### PR TITLE
feat(templates): migrate portfolio to the semantic theme-token architecture

### DIFF
--- a/templates/portfolio-cloudflare/AGENTS.md
+++ b/templates/portfolio-cloudflare/AGENTS.md
@@ -71,30 +71,34 @@ The `gallery` field on `projects` is a JSON field, not an EmDash image field. It
 
 ## Visual character
 
-Typography is the design. The display face is **Playfair Display** (serif) on the `--font-serif` CSS variable; the body face is the system sans stack on `--font-sans`. The serif is used for the site title, hero titles, project titles, page titles, and contact column labels. Everything else is the sans.
+Typography is the design. The display face is **Playfair Display** (serif) on the `--font-heading` CSS variable; the body face is the system sans stack on `--font-body`. The serif is used for the site title, hero titles, project titles, page titles, and contact column labels. Everything else is the sans. Serif weight is calm on purpose (`--font-weight-heading` and `--font-weight-display` both default to 500).
 
-The accent colour is barely visible by design -- the only saturated colour on the page should be inside images. The default `--color-accent` (`#7c3aed`) is used sparingly for link hover and focus states.
+The brand colour is barely visible by design -- the only saturated colour on the page should be inside images. The default `--color-brand` (`#7c3aed`) is used sparingly for link hover and focus states.
 
 Whitespace is generous. Sections breathe. Don't fight that.
 
 ## Customisation
 
-`src/styles/theme.css` is the only file to edit for visual changes. Every CSS variable from `Base.astro` is listed there as a commented default -- uncomment and change to override. The dark mode palette is defined inside `Base.astro` itself; light-mode overrides in `theme.css` won't affect dark mode. To customise dark mode, add `@media (prefers-color-scheme: dark)` and `:root.dark` rules in `theme.css`.
+Design tokens live in `src/styles/tokens.css` with their default values. To restyle the site, override tokens in `src/styles/theme.css` -- declarations there are unlayered, so they always beat the `@layer base` defaults. Don't edit `tokens.css` or `Base.astro` for visual changes.
 
-Fonts are configured in `astro.config.mjs` under `fonts:` (the Astro Fonts API). To change the display face, swap the `name:` for any Google Fonts serif and keep `cssVariable: "--font-serif"`. Good pairings: Cormorant Garamond, Fraunces, EB Garamond, DM Serif Display. Avoid changing the body font unless you have a reason -- system sans is deliberately quiet here.
+Colours are defined with `light-dark(<light>, <dark>)`, so each token carries both modes. Overriding with a plain colour changes light and dark at once; use `light-dark()` in the override to keep them distinct. There is no separate dark palette to maintain.
 
-CSS variables worth knowing:
+The display face is configured in `astro.config.mjs` under `fonts:` (the Astro Fonts API). To change it, swap the `name:` for any Google Fonts serif and keep `cssVariable: "--font-heading"`. Good pairings: Cormorant Garamond, Fraunces, EB Garamond, DM Serif Display. The body face (`--font-body`) is a plain token in `tokens.css` -- system sans, deliberately quiet; override it in `theme.css` only if you have a reason.
 
-- `--color-accent` / `--color-accent-muted` -- the single accent, used very sparingly
+CSS variables worth knowing (see `tokens.css` for the full list):
+
+- `--color-brand`, `--color-on-brand`, `--color-brand-ring` -- the single accent, used very sparingly
 - `--color-bg`, `--color-surface`, `--color-text`, `--color-muted`, `--color-border` -- neutral palette
-- `--font-serif`, `--font-sans` -- bound to the Fonts API entries in `astro.config.mjs`
+- `--color-danger` -- form errors
+- `--font-heading` (Fonts API entry in `astro.config.mjs`), `--font-body` (token)
+- `--font-weight-heading` / `--font-weight-display` (both 500) -- raise for a heavier serif voice
 - `--font-size-4xl` -- the size of the homepage title and project titles
 - `--max-width` (720px), `--wide-width` (1200px) -- column widths
 
 ## What not to do
 
 - Don't introduce gradients, drop shadows on cards, or coloured section backgrounds. The template's voice is calm and editorial; those break it.
-- Don't change `--font-sans` to a display font. Two display faces fight each other.
+- Don't change `--font-body` to a display font. Two display faces fight each other.
 - Don't add more than one accent colour.
 - Don't write generic copy like "Welcome to my portfolio" or "Crafting beautiful experiences". The work should speak; the words should be specific (a client name, a discipline, a year).
 - Don't pack the home page with every project. The "Selected Work" framing is intentional -- 3-6 is plenty.

--- a/templates/portfolio-cloudflare/astro.config.mjs
+++ b/templates/portfolio-cloudflare/astro.config.mjs
@@ -22,7 +22,7 @@ export default defineConfig({
 		{
 			provider: fontProviders.google(),
 			name: "Playfair Display",
-			cssVariable: "--font-serif",
+			cssVariable: "--font-heading",
 			weights: [400, 500, 600, 700],
 			fallbacks: ["serif"],
 		},

--- a/templates/portfolio-cloudflare/src/components/ProjectCard.astro
+++ b/templates/portfolio-cloudflare/src/components/ProjectCard.astro
@@ -56,7 +56,7 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-link {
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-lg, 1.5rem);
+		gap: var(--spacing-lg);
 		text-decoration: none;
 		color: inherit;
 	}
@@ -64,7 +64,7 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-image {
 		position: relative;
 		overflow: hidden;
-		border-radius: var(--radius, 4px);
+		border-radius: var(--radius);
 	}
 
 	.card-image img {
@@ -72,7 +72,7 @@ const allTags = [...(categories || []), ...(tags || [])];
 		height: auto;
 		aspect-ratio: 4 / 3;
 		object-fit: cover;
-		transition: transform var(--transition-slow, 300ms ease);
+		transition: transform var(--transition-slow);
 	}
 
 	.card-overlay {
@@ -82,21 +82,22 @@ const allTags = [...(categories || []), ...(tags || [])];
 		align-items: center;
 		justify-content: center;
 		background: rgba(0, 0, 0, 0);
-		transition: background var(--transition-base, 200ms ease);
+		transition: background var(--transition-base);
 	}
 
+	/* Over-image chip: white regardless of theme */
 	.card-view {
-		font-family: var(--font-serif, Georgia, serif);
-		font-size: var(--font-size-sm, 0.875rem);
+		font-family: var(--font-heading);
+		font-size: var(--font-size-sm);
 		color: white;
-		padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+		padding: var(--spacing-sm) var(--spacing-md);
 		border: 1px solid white;
-		border-radius: var(--radius, 4px);
+		border-radius: var(--radius);
 		opacity: 0;
 		transform: translateY(10px);
 		transition:
-			opacity var(--transition-base, 200ms ease),
-			transform var(--transition-base, 200ms ease);
+			opacity var(--transition-base),
+			transform var(--transition-base);
 	}
 
 	.project-card:hover .card-image img {
@@ -115,33 +116,33 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-content {
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-xs, 0.25rem);
+		gap: var(--spacing-xs);
 	}
 
 	.card-title {
-		font-family: var(--font-serif, Georgia, serif);
-		font-size: var(--font-size-xl, 1.5rem);
-		font-weight: 500;
-		transition: color var(--transition-fast, 150ms ease);
+		font-family: var(--font-heading);
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-heading);
+		transition: color var(--transition-fast);
 	}
 
 	.project-card:hover .card-title {
-		color: var(--color-accent, #7c3aed);
+		color: var(--color-brand);
 	}
 
 	.card-meta {
-		font-size: var(--font-size-sm, 0.875rem);
-		color: var(--color-muted, #6b7280);
+		font-size: var(--font-size-sm);
+		color: var(--color-muted);
 	}
 
 	.card-separator {
-		margin: 0 var(--spacing-xs, 0.25rem);
+		margin: 0 var(--spacing-xs);
 	}
 
 	.card-summary {
-		font-size: var(--font-size-sm, 0.875rem);
-		color: var(--color-muted, #6b7280);
-		line-height: 1.6;
+		font-size: var(--font-size-sm);
+		color: var(--color-muted);
+		line-height: var(--leading-normal);
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical;
@@ -151,17 +152,17 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-categories {
 		display: flex;
 		flex-wrap: wrap;
-		gap: var(--spacing-sm, 0.5rem);
-		margin-top: var(--spacing-sm, 0.5rem);
+		gap: var(--spacing-sm);
+		margin-top: var(--spacing-sm);
 	}
 
 	.card-category {
-		font-size: 0.75rem;
+		font-size: var(--font-size-xs);
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--color-muted, #6b7280);
-		padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
-		border: 1px solid var(--color-border, #e5e7eb);
-		border-radius: var(--radius, 4px);
+		letter-spacing: var(--tracking-wide);
+		color: var(--color-muted);
+		padding: var(--spacing-xs) var(--spacing-sm);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius);
 	}
 </style>

--- a/templates/portfolio-cloudflare/src/layouts/Base.astro
+++ b/templates/portfolio-cloudflare/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import { Font } from "astro:assets";
+import "../styles/tokens.css";
 import "../styles/theme.css";
 
 interface Props {
@@ -43,7 +44,7 @@ const pageCtx = createPublicPageContext({
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />
-		<Font cssVariable="--font-serif" preload />
+		<Font cssVariable="--font-heading" preload />
 		<link
 			rel="alternate"
 			type="application/rss+xml"
@@ -51,15 +52,14 @@ const pageCtx = createPublicPageContext({
 			href="/rss.xml"
 		/>
 		<script is:inline>
-			// Apply theme immediately to prevent flash
+			// Apply an explicit theme choice immediately to prevent flash.
+			// With no cookie, color-scheme: light dark follows the OS.
 			(function () {
 				var c = document.cookie;
 				var i = c.indexOf("theme=");
 				var theme = i >= 0 ? c.slice(i + 6).split(";")[0] : null;
 				if (theme === "dark" || theme === "light") {
 					document.documentElement.classList.add(theme);
-				} else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-					document.documentElement.classList.add("dark");
 				}
 			})();
 		</script>
@@ -143,9 +143,6 @@ const pageCtx = createPublicPageContext({
 				if (theme === "system") {
 					document.cookie = `theme=; path=/; max-age=0; SameSite=Lax${secure}`;
 					root.classList.remove("light", "dark");
-					if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-						root.classList.add("dark");
-					}
 				} else {
 					document.cookie = `theme=${theme}; path=/; max-age=31536000; SameSite=Lax${secure}`;
 					root.classList.remove("light", "dark");
@@ -174,15 +171,6 @@ const pageCtx = createPublicPageContext({
 					setTheme(btn.dataset.theme || "system");
 				});
 			});
-
-			// Listen for system preference changes
-			window
-				.matchMedia("(prefers-color-scheme: dark)")
-				.addEventListener("change", (e) => {
-					if (getStoredTheme() === "system") {
-						root.classList.toggle("dark", e.matches);
-					}
-				});
 		</script>
 
 		<style is:global>
@@ -202,71 +190,18 @@ const pageCtx = createPublicPageContext({
 					padding: 0;
 				}
 
-				:root {
-					/* Colors - Elegant/Minimal palette */
-					--color-bg: #fafafa;
-					--color-text: #1a1a1a;
-					--color-muted: #6b7280;
-					--color-border: #e5e7eb;
-					--color-surface: #ffffff;
-					--color-accent: #7c3aed;
-					--color-accent-muted: #a78bfa;
-
-					/* Typography */
-					--font-sans: system-ui, -apple-system, sans-serif;
-					--font-mono: ui-monospace, monospace;
-
-					--font-size-sm: 0.875rem;
-					--font-size-base: 1.0625rem;
-					--font-size-lg: 1.25rem;
-					--font-size-xl: 1.5rem;
-					--font-size-2xl: 2rem;
-					--font-size-3xl: 2.75rem;
-					--font-size-4xl: 3.5rem;
-
-					/* Spacing */
-					--spacing-xs: 0.25rem;
-					--spacing-sm: 0.5rem;
-					--spacing-md: 1rem;
-					--spacing-lg: 1.5rem;
-					--spacing-xl: 2rem;
-					--spacing-2xl: 3rem;
-					--spacing-3xl: 4rem;
-					--spacing-4xl: 6rem;
-
-					/* Layout */
-					--max-width: 720px;
-					--wide-width: 1200px;
-					--radius: 4px;
-
-					/* Transitions */
-					--transition-fast: 150ms ease;
-					--transition-base: 200ms ease;
-					--transition-slow: 300ms ease;
+				/*
+				 * Design tokens live in src/styles/tokens.css. Colors are
+				 * defined with light-dark(); these rules pin the scheme when
+				 * the footer switcher sets an explicit choice. With no class,
+				 * color-scheme: light dark follows the OS preference.
+				 */
+				:root.light {
+					color-scheme: light;
 				}
 
-				/* Dark mode via system preference (when no explicit class) */
-				@media (prefers-color-scheme: dark) {
-					:root:not(.light) {
-						--color-bg: #0a0a0a;
-						--color-text: #f5f5f5;
-						--color-muted: #a1a1aa;
-						--color-border: #27272a;
-						--color-surface: #18181b;
-						--color-accent: #a78bfa;
-						--color-accent-muted: #7c3aed;
-					}
-				}
-
-				/* Explicit dark mode */
 				:root.dark {
-					--color-bg: #0a0a0a;
-					--color-text: #f5f5f5;
-					--color-muted: #a1a1aa;
-					--color-border: #27272a;
-					--color-surface: #18181b;
-					--color-accent: #a78bfa;
-					--color-accent-muted: #7c3aed;
+					color-scheme: dark;
 				}
 
 				html {
@@ -274,9 +209,9 @@ const pageCtx = createPublicPageContext({
 				}
 
 				body {
-					font-family: var(--font-sans);
+					font-family: var(--font-body);
 					font-size: var(--font-size-base);
-					line-height: 1.6;
+					line-height: var(--leading-normal);
 					color: var(--color-text);
 					background: var(--color-bg);
 					-webkit-font-smoothing: antialiased;
@@ -297,9 +232,9 @@ const pageCtx = createPublicPageContext({
 				h2,
 				h3,
 				h4 {
-					font-family: var(--font-serif);
-					font-weight: 500;
-					line-height: 1.2;
+					font-family: var(--font-heading);
+					font-weight: var(--font-weight-heading);
+					line-height: var(--leading-snug);
 				}
 
 				h1 {
@@ -330,11 +265,11 @@ const pageCtx = createPublicPageContext({
 			}
 
 			.site-title {
-				font-family: var(--font-serif);
+				font-family: var(--font-heading);
 				font-size: var(--font-size-lg);
 				font-weight: 600;
 				text-decoration: none;
-				letter-spacing: -0.02em;
+				letter-spacing: var(--tracking-tight);
 			}
 
 			.site-logo-img {
@@ -386,7 +321,7 @@ const pageCtx = createPublicPageContext({
 			}
 
 			.footer-logo {
-				font-family: var(--font-serif);
+				font-family: var(--font-heading);
 				font-size: var(--font-size-lg);
 				font-weight: 600;
 			}
@@ -397,7 +332,7 @@ const pageCtx = createPublicPageContext({
 			}
 
 			.footer-tagline {
-				font-family: var(--font-serif);
+				font-family: var(--font-heading);
 				font-style: italic;
 				font-size: var(--font-size-sm);
 				color: var(--color-muted);
@@ -420,7 +355,7 @@ const pageCtx = createPublicPageContext({
 				background: transparent;
 				border: 1px solid var(--color-border);
 				color: var(--color-muted);
-				font-family: var(--font-sans);
+				font-family: var(--font-body);
 				font-size: var(--font-size-sm);
 				padding: var(--spacing-xs) var(--spacing-sm);
 				border-radius: var(--radius);
@@ -436,7 +371,7 @@ const pageCtx = createPublicPageContext({
 			.theme-btn.active {
 				background: var(--color-surface);
 				color: var(--color-text);
-				border-color: var(--color-accent);
+				border-color: var(--color-brand);
 			}
 
 			.footer-powered {

--- a/templates/portfolio-cloudflare/src/layouts/Base.astro
+++ b/templates/portfolio-cloudflare/src/layouts/Base.astro
@@ -194,14 +194,18 @@ const pageCtx = createPublicPageContext({
 				 * Design tokens live in src/styles/tokens.css. Colors are
 				 * defined with light-dark(); these rules pin the scheme when
 				 * the footer switcher sets an explicit choice. With no class,
-				 * color-scheme: light dark follows the OS preference.
+				 * color-scheme: light dark follows the OS preference. The
+				 * @supports guard keeps the toggle from forcing dark UA form
+				 * controls on browsers stuck on the plain-light fallback.
 				 */
-				:root.light {
-					color-scheme: light;
-				}
+				@supports (color: light-dark(#000, #fff)) {
+					:root.light {
+						color-scheme: light;
+					}
 
-				:root.dark {
-					color-scheme: dark;
+					:root.dark {
+						color-scheme: dark;
+					}
 				}
 
 				html {

--- a/templates/portfolio-cloudflare/src/pages/404.astro
+++ b/templates/portfolio-cloudflare/src/pages/404.astro
@@ -24,18 +24,18 @@ import Base from "../layouts/Base.astro";
 
 	.not-found-code {
 		display: block;
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: 8rem;
-		font-weight: 500;
+		font-weight: var(--font-weight-display);
 		line-height: 1;
 		color: var(--color-border);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.not-found h1 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-sm);
 	}
 
@@ -63,8 +63,8 @@ import Base from "../layouts/Base.astro";
 	}
 
 	.link-primary:hover {
-		background: var(--color-accent);
-		color: white;
+		background: var(--color-brand);
+		color: var(--color-on-brand);
 		transform: translateY(-1px);
 	}
 

--- a/templates/portfolio-cloudflare/src/pages/about.astro
+++ b/templates/portfolio-cloudflare/src/pages/about.astro
@@ -66,15 +66,15 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.about-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
-		line-height: 1.1;
+		font-weight: var(--font-weight-display);
+		line-height: var(--leading-tight);
 	}
 
 	.about-content {
 		font-size: var(--font-size-base);
-		line-height: 1.7;
+		line-height: var(--leading-relaxed);
 	}
 
 	.about-content :global(p) {
@@ -82,17 +82,17 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.about-content :global(h2) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2.5em;
 		margin-bottom: 0.75em;
 	}
 
 	.about-content :global(h3) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2em;
 		margin-bottom: 0.5em;
 	}
@@ -108,9 +108,9 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.sidebar-section h3 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-lg);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-md);
 	}
 
@@ -137,7 +137,7 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.sidebar-section a:hover {
-		color: var(--color-accent);
+		color: var(--color-brand);
 	}
 
 	@media (max-width: 768px) {

--- a/templates/portfolio-cloudflare/src/pages/contact.astro
+++ b/templates/portfolio-cloudflare/src/pages/contact.astro
@@ -142,17 +142,17 @@ if (Astro.request.method === "POST") {
 	}
 
 	.contact-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
-		line-height: 1.1;
+		font-weight: var(--font-weight-display);
+		line-height: var(--leading-tight);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.contact-intro {
 		font-size: var(--font-size-lg);
 		color: var(--color-muted);
-		line-height: 1.6;
+		line-height: var(--leading-normal);
 	}
 
 	.contact-grid {
@@ -195,8 +195,8 @@ if (Astro.request.method === "POST") {
 	.form-field input:focus,
 	.form-field textarea:focus {
 		outline: none;
-		border-color: var(--color-accent);
-		box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+		border-color: var(--color-brand);
+		box-shadow: 0 0 0 3px var(--color-brand-ring);
 	}
 
 	.form-field input::placeholder,
@@ -226,8 +226,8 @@ if (Astro.request.method === "POST") {
 	}
 
 	.form-submit:hover {
-		background: var(--color-accent);
-		color: white;
+		background: var(--color-brand);
+		color: var(--color-on-brand);
 		transform: translateY(-1px);
 	}
 
@@ -237,19 +237,11 @@ if (Astro.request.method === "POST") {
 
 	.form-error {
 		padding: var(--spacing-md);
-		background: #fef2f2;
-		border: 1px solid #fecaca;
+		background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
 		border-radius: var(--radius);
-		color: #dc2626;
+		color: var(--color-danger);
 		font-size: var(--font-size-sm);
-	}
-
-	@media (prefers-color-scheme: dark) {
-		.form-error {
-			background: rgba(239, 68, 68, 0.1);
-			border-color: rgba(239, 68, 68, 0.3);
-			color: #f87171;
-		}
 	}
 
 	.form-success {
@@ -261,9 +253,9 @@ if (Astro.request.method === "POST") {
 	}
 
 	.form-success h2 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-sm);
 	}
 
@@ -274,7 +266,7 @@ if (Astro.request.method === "POST") {
 
 	.form-reset {
 		font-size: var(--font-size-sm);
-		color: var(--color-accent);
+		color: var(--color-brand);
 		text-decoration: none;
 	}
 
@@ -293,9 +285,9 @@ if (Astro.request.method === "POST") {
 	}
 
 	.info-section h3 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-lg);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-sm);
 	}
 

--- a/templates/portfolio-cloudflare/src/pages/index.astro
+++ b/templates/portfolio-cloudflare/src/pages/index.astro
@@ -67,15 +67,15 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 	.hero-title {
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-display);
 		margin-bottom: var(--spacing-md);
-		letter-spacing: -0.02em;
+		letter-spacing: var(--tracking-tight);
 	}
 
 	.hero-tagline {
 		font-size: var(--font-size-xl);
 		color: var(--color-muted);
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-style: italic;
 	}
 
@@ -96,7 +96,7 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 	.section-title {
 		font-size: var(--font-size-lg);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 	}
 
 	.section-link {

--- a/templates/portfolio-cloudflare/src/pages/work/[slug].astro
+++ b/templates/portfolio-cloudflare/src/pages/work/[slug].astro
@@ -156,7 +156,7 @@ function getImageSrc(img: unknown): string | undefined {
 		color: var(--color-muted);
 		margin-bottom: var(--spacing-sm);
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
+		letter-spacing: var(--tracking-wide);
 	}
 
 	.meta-separator {
@@ -164,24 +164,24 @@ function getImageSrc(img: unknown): string | undefined {
 	}
 
 	.project-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
-		line-height: 1.1;
+		font-weight: var(--font-weight-display);
+		line-height: var(--leading-tight);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.project-summary {
 		font-size: var(--font-size-lg);
 		color: var(--color-muted);
-		line-height: 1.6;
+		line-height: var(--leading-normal);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.project-link {
 		display: inline-block;
 		font-size: var(--font-size-sm);
-		color: var(--color-accent);
+		color: var(--color-brand);
 		text-decoration: none;
 		transition: color var(--transition-fast);
 	}
@@ -202,7 +202,7 @@ function getImageSrc(img: unknown): string | undefined {
 
 	.project-content {
 		font-size: var(--font-size-base);
-		line-height: 1.7;
+		line-height: var(--leading-relaxed);
 	}
 
 	.project-content :global(p) {
@@ -210,17 +210,17 @@ function getImageSrc(img: unknown): string | undefined {
 	}
 
 	.project-content :global(h2) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2.5em;
 		margin-bottom: 0.75em;
 	}
 
 	.project-content :global(h3) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2em;
 		margin-bottom: 0.5em;
 	}
@@ -228,9 +228,9 @@ function getImageSrc(img: unknown): string | undefined {
 	.project-content :global(blockquote) {
 		margin: 2em 0;
 		padding-left: var(--spacing-xl);
-		border-left: 2px solid var(--color-accent);
+		border-left: 2px solid var(--color-brand);
 		color: var(--color-muted);
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-style: italic;
 		font-size: var(--font-size-lg);
 	}
@@ -276,9 +276,9 @@ function getImageSrc(img: unknown): string | undefined {
 	}
 
 	.more-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-2xl);
 	}
 

--- a/templates/portfolio-cloudflare/src/styles/theme.css
+++ b/templates/portfolio-cloudflare/src/styles/theme.css
@@ -1,62 +1,28 @@
 /*
-  theme.css -- override any :root variable here to retheme the site.
+  theme.css -- your theme overrides. This is the file to edit to
+  retheme the site.
 
-  This is the only file you need to edit to customize the site's visual
-  appearance. All defaults are listed below as comments. Uncomment and
-  change any value to override it.
+  Every design token lives in src/styles/tokens.css (colors, type
+  scale, spacing, layout) with its default value. Override any of them
+  here: declarations in this file are unlayered, so they always beat
+  the @layer base defaults in tokens.css.
 
-  Base.astro puts its defaults inside @layer base, so declarations here
-  (which are unlayered) always take priority -- no specificity tricks needed.
+  Colors are defined with light-dark(). Overriding with a plain color
+  changes light and dark mode at once; use light-dark(<light>, <dark>)
+  to set different values per mode.
 
-  Note: this template defines explicit dark mode colors in Base.astro.
-  Overriding light-mode --color-* variables here won't affect dark mode.
-  To customize dark mode, also override --color-* variables inside a
-  @media (prefers-color-scheme: dark) block and/or in the :root.dark rule.
+  The serif display face (--font-heading) is loaded in astro.config.mjs.
+  Swap the loaded font there; use overrides here for system fonts or to
+  change the quiet system-sans body face (--font-body).
+
+  Example:
+
+  :root {
+    --color-brand: light-dark(#0f766e, #2dd4bf);
+    --font-body: "Avenir Next", system-ui, sans-serif;
+    --font-size-4xl: 4rem;
+  }
 */
 
 :root {
-	/* --- Colors ---
-	--color-bg: #fafafa;
-	--color-text: #1a1a1a;
-	--color-muted: #6b7280;
-	--color-border: #e5e7eb;
-	--color-surface: #ffffff;
-	--color-accent: #7c3aed;
-	--color-accent-muted: #a78bfa;
-	*/
-
-	/* --- Typography ---
-	--font-sans: system-ui, -apple-system, sans-serif;
-	--font-mono: ui-monospace, monospace;
-	--font-size-sm: 0.875rem;
-	--font-size-base: 1.0625rem;
-	--font-size-lg: 1.25rem;
-	--font-size-xl: 1.5rem;
-	--font-size-2xl: 2rem;
-	--font-size-3xl: 2.75rem;
-	--font-size-4xl: 3.5rem;
-	*/
-
-	/* --- Spacing ---
-	--spacing-xs: 0.25rem;
-	--spacing-sm: 0.5rem;
-	--spacing-md: 1rem;
-	--spacing-lg: 1.5rem;
-	--spacing-xl: 2rem;
-	--spacing-2xl: 3rem;
-	--spacing-3xl: 4rem;
-	--spacing-4xl: 6rem;
-	*/
-
-	/* --- Layout ---
-	--max-width: 720px;
-	--wide-width: 1200px;
-	--radius: 4px;
-	*/
-
-	/* --- Transitions ---
-	--transition-fast: 150ms ease;
-	--transition-base: 200ms ease;
-	--transition-slow: 300ms ease;
-	*/
 }

--- a/templates/portfolio-cloudflare/src/styles/tokens.css
+++ b/templates/portfolio-cloudflare/src/styles/tokens.css
@@ -1,0 +1,96 @@
+/*
+  tokens.css -- the design tokens for this template. These are the
+  defaults; to customize the site, override any variable in
+  src/styles/theme.css rather than editing this file. Declarations in
+  theme.css are unlayered, so they always beat these @layer base
+  defaults -- no specificity tricks needed.
+
+  Colors use light-dark(): the first value applies in light mode, the
+  second in dark mode. Overriding a color with a plain value changes
+  both modes at once; use light-dark(<light>, <dark>) in an override to
+  keep them distinct.
+
+  --font-heading (the serif display face) is defined by the font
+  pipeline in astro.config.mjs, not here. To swap it, edit the fonts
+  entry there. --font-body is the deliberately quiet system sans stack
+  below.
+*/
+
+@layer base {
+	:root {
+		color-scheme: light dark;
+
+		/* Colors */
+		--color-bg: light-dark(#fafafa, #0a0a0a);
+		--color-text: light-dark(#1a1a1a, #f5f5f5);
+		--color-muted: light-dark(#6b7280, #a1a1aa);
+		--color-border: light-dark(#e5e7eb, #27272a);
+		--color-surface: light-dark(#ffffff, #18181b);
+		--color-brand: light-dark(#7c3aed, #a78bfa); /* the single accent, used sparingly */
+		--color-on-brand: white; /* text on brand-colored surfaces */
+		--color-brand-ring: color-mix(in srgb, var(--color-brand) 10%, transparent);
+		--color-danger: light-dark(#dc2626, #f87171);
+
+		/* Typography */
+		--font-body: system-ui, -apple-system, sans-serif;
+		--font-weight-heading: 500; /* serif headings and titles */
+		--font-weight-display: 500; /* hero and page titles */
+
+		/* Type scale */
+		--font-size-xs: 0.75rem;
+		--font-size-sm: 0.875rem;
+		--font-size-base: 1.0625rem;
+		--font-size-lg: 1.25rem;
+		--font-size-xl: 1.5rem;
+		--font-size-2xl: 2rem;
+		--font-size-3xl: 2.75rem;
+		--font-size-4xl: 3.5rem;
+
+		/* Line heights */
+		--leading-tight: 1.1; /* hero and project titles */
+		--leading-snug: 1.2; /* headings */
+		--leading-normal: 1.6; /* body copy */
+		--leading-relaxed: 1.7; /* long-form content */
+
+		/* Letter spacing */
+		--tracking-tight: -0.02em; /* site title, hero title */
+		--tracking-wide: 0.05em; /* uppercase meta lines, tag chips */
+
+		/* Spacing */
+		--spacing-xs: 0.25rem;
+		--spacing-sm: 0.5rem;
+		--spacing-md: 1rem;
+		--spacing-lg: 1.5rem;
+		--spacing-xl: 2rem;
+		--spacing-2xl: 3rem;
+		--spacing-3xl: 4rem;
+		--spacing-4xl: 6rem;
+
+		/* Layout */
+		--max-width: 720px;
+		--wide-width: 1200px;
+		--radius: 4px;
+
+		/* Transitions */
+		--transition-fast: 150ms ease;
+		--transition-base: 200ms ease;
+		--transition-slow: 300ms ease;
+	}
+
+	/*
+	 * Light-mode values for browsers without light-dark() (Safari < 17.5,
+	 * Chrome < 123). Must mirror the light values above.
+	 */
+	@supports not (color: light-dark(#000, #fff)) {
+		:root {
+			color-scheme: light;
+			--color-bg: #fafafa;
+			--color-text: #1a1a1a;
+			--color-muted: #6b7280;
+			--color-border: #e5e7eb;
+			--color-surface: #ffffff;
+			--color-brand: #7c3aed;
+			--color-danger: #dc2626;
+		}
+	}
+}

--- a/templates/portfolio/AGENTS-template.md
+++ b/templates/portfolio/AGENTS-template.md
@@ -27,30 +27,34 @@ The `gallery` field on `projects` is a JSON field, not an EmDash image field. It
 
 ## Visual character
 
-Typography is the design. The display face is **Playfair Display** (serif) on the `--font-serif` CSS variable; the body face is the system sans stack on `--font-sans`. The serif is used for the site title, hero titles, project titles, page titles, and contact column labels. Everything else is the sans.
+Typography is the design. The display face is **Playfair Display** (serif) on the `--font-heading` CSS variable; the body face is the system sans stack on `--font-body`. The serif is used for the site title, hero titles, project titles, page titles, and contact column labels. Everything else is the sans. Serif weight is calm on purpose (`--font-weight-heading` and `--font-weight-display` both default to 500).
 
-The accent colour is barely visible by design -- the only saturated colour on the page should be inside images. The default `--color-accent` (`#7c3aed`) is used sparingly for link hover and focus states.
+The brand colour is barely visible by design -- the only saturated colour on the page should be inside images. The default `--color-brand` (`#7c3aed`) is used sparingly for link hover and focus states.
 
 Whitespace is generous. Sections breathe. Don't fight that.
 
 ## Customisation
 
-`src/styles/theme.css` is the only file to edit for visual changes. Every CSS variable from `Base.astro` is listed there as a commented default -- uncomment and change to override. The dark mode palette is defined inside `Base.astro` itself; light-mode overrides in `theme.css` won't affect dark mode. To customise dark mode, add `@media (prefers-color-scheme: dark)` and `:root.dark` rules in `theme.css`.
+Design tokens live in `src/styles/tokens.css` with their default values. To restyle the site, override tokens in `src/styles/theme.css` -- declarations there are unlayered, so they always beat the `@layer base` defaults. Don't edit `tokens.css` or `Base.astro` for visual changes.
 
-Fonts are configured in `astro.config.mjs` under `fonts:` (the Astro Fonts API). To change the display face, swap the `name:` for any Google Fonts serif and keep `cssVariable: "--font-serif"`. Good pairings: Cormorant Garamond, Fraunces, EB Garamond, DM Serif Display. Avoid changing the body font unless you have a reason -- system sans is deliberately quiet here.
+Colours are defined with `light-dark(<light>, <dark>)`, so each token carries both modes. Overriding with a plain colour changes light and dark at once; use `light-dark()` in the override to keep them distinct. There is no separate dark palette to maintain.
 
-CSS variables worth knowing:
+The display face is configured in `astro.config.mjs` under `fonts:` (the Astro Fonts API). To change it, swap the `name:` for any Google Fonts serif and keep `cssVariable: "--font-heading"`. Good pairings: Cormorant Garamond, Fraunces, EB Garamond, DM Serif Display. The body face (`--font-body`) is a plain token in `tokens.css` -- system sans, deliberately quiet; override it in `theme.css` only if you have a reason.
 
-- `--color-accent` / `--color-accent-muted` -- the single accent, used very sparingly
+CSS variables worth knowing (see `tokens.css` for the full list):
+
+- `--color-brand`, `--color-on-brand`, `--color-brand-ring` -- the single accent, used very sparingly
 - `--color-bg`, `--color-surface`, `--color-text`, `--color-muted`, `--color-border` -- neutral palette
-- `--font-serif`, `--font-sans` -- bound to the Fonts API entries in `astro.config.mjs`
+- `--color-danger` -- form errors
+- `--font-heading` (Fonts API entry in `astro.config.mjs`), `--font-body` (token)
+- `--font-weight-heading` / `--font-weight-display` (both 500) -- raise for a heavier serif voice
 - `--font-size-4xl` -- the size of the homepage title and project titles
 - `--max-width` (720px), `--wide-width` (1200px) -- column widths
 
 ## What not to do
 
 - Don't introduce gradients, drop shadows on cards, or coloured section backgrounds. The template's voice is calm and editorial; those break it.
-- Don't change `--font-sans` to a display font. Two display faces fight each other.
+- Don't change `--font-body` to a display font. Two display faces fight each other.
 - Don't add more than one accent colour.
 - Don't write generic copy like "Welcome to my portfolio" or "Crafting beautiful experiences". The work should speak; the words should be specific (a client name, a discipline, a year).
 - Don't pack the home page with every project. The "Selected Work" framing is intentional -- 3-6 is plenty.

--- a/templates/portfolio/AGENTS.md
+++ b/templates/portfolio/AGENTS.md
@@ -71,30 +71,34 @@ The `gallery` field on `projects` is a JSON field, not an EmDash image field. It
 
 ## Visual character
 
-Typography is the design. The display face is **Playfair Display** (serif) on the `--font-serif` CSS variable; the body face is the system sans stack on `--font-sans`. The serif is used for the site title, hero titles, project titles, page titles, and contact column labels. Everything else is the sans.
+Typography is the design. The display face is **Playfair Display** (serif) on the `--font-heading` CSS variable; the body face is the system sans stack on `--font-body`. The serif is used for the site title, hero titles, project titles, page titles, and contact column labels. Everything else is the sans. Serif weight is calm on purpose (`--font-weight-heading` and `--font-weight-display` both default to 500).
 
-The accent colour is barely visible by design -- the only saturated colour on the page should be inside images. The default `--color-accent` (`#7c3aed`) is used sparingly for link hover and focus states.
+The brand colour is barely visible by design -- the only saturated colour on the page should be inside images. The default `--color-brand` (`#7c3aed`) is used sparingly for link hover and focus states.
 
 Whitespace is generous. Sections breathe. Don't fight that.
 
 ## Customisation
 
-`src/styles/theme.css` is the only file to edit for visual changes. Every CSS variable from `Base.astro` is listed there as a commented default -- uncomment and change to override. The dark mode palette is defined inside `Base.astro` itself; light-mode overrides in `theme.css` won't affect dark mode. To customise dark mode, add `@media (prefers-color-scheme: dark)` and `:root.dark` rules in `theme.css`.
+Design tokens live in `src/styles/tokens.css` with their default values. To restyle the site, override tokens in `src/styles/theme.css` -- declarations there are unlayered, so they always beat the `@layer base` defaults. Don't edit `tokens.css` or `Base.astro` for visual changes.
 
-Fonts are configured in `astro.config.mjs` under `fonts:` (the Astro Fonts API). To change the display face, swap the `name:` for any Google Fonts serif and keep `cssVariable: "--font-serif"`. Good pairings: Cormorant Garamond, Fraunces, EB Garamond, DM Serif Display. Avoid changing the body font unless you have a reason -- system sans is deliberately quiet here.
+Colours are defined with `light-dark(<light>, <dark>)`, so each token carries both modes. Overriding with a plain colour changes light and dark at once; use `light-dark()` in the override to keep them distinct. There is no separate dark palette to maintain.
 
-CSS variables worth knowing:
+The display face is configured in `astro.config.mjs` under `fonts:` (the Astro Fonts API). To change it, swap the `name:` for any Google Fonts serif and keep `cssVariable: "--font-heading"`. Good pairings: Cormorant Garamond, Fraunces, EB Garamond, DM Serif Display. The body face (`--font-body`) is a plain token in `tokens.css` -- system sans, deliberately quiet; override it in `theme.css` only if you have a reason.
 
-- `--color-accent` / `--color-accent-muted` -- the single accent, used very sparingly
+CSS variables worth knowing (see `tokens.css` for the full list):
+
+- `--color-brand`, `--color-on-brand`, `--color-brand-ring` -- the single accent, used very sparingly
 - `--color-bg`, `--color-surface`, `--color-text`, `--color-muted`, `--color-border` -- neutral palette
-- `--font-serif`, `--font-sans` -- bound to the Fonts API entries in `astro.config.mjs`
+- `--color-danger` -- form errors
+- `--font-heading` (Fonts API entry in `astro.config.mjs`), `--font-body` (token)
+- `--font-weight-heading` / `--font-weight-display` (both 500) -- raise for a heavier serif voice
 - `--font-size-4xl` -- the size of the homepage title and project titles
 - `--max-width` (720px), `--wide-width` (1200px) -- column widths
 
 ## What not to do
 
 - Don't introduce gradients, drop shadows on cards, or coloured section backgrounds. The template's voice is calm and editorial; those break it.
-- Don't change `--font-sans` to a display font. Two display faces fight each other.
+- Don't change `--font-body` to a display font. Two display faces fight each other.
 - Don't add more than one accent colour.
 - Don't write generic copy like "Welcome to my portfolio" or "Crafting beautiful experiences". The work should speak; the words should be specific (a client name, a discipline, a year).
 - Don't pack the home page with every project. The "Selected Work" framing is intentional -- 3-6 is plenty.

--- a/templates/portfolio/astro.config.mjs
+++ b/templates/portfolio/astro.config.mjs
@@ -27,7 +27,7 @@ export default defineConfig({
 		{
 			provider: fontProviders.google(),
 			name: "Playfair Display",
-			cssVariable: "--font-serif",
+			cssVariable: "--font-heading",
 			weights: [400, 500, 600, 700],
 			fallbacks: ["serif"],
 		},

--- a/templates/portfolio/src/components/ProjectCard.astro
+++ b/templates/portfolio/src/components/ProjectCard.astro
@@ -56,7 +56,7 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-link {
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-lg, 1.5rem);
+		gap: var(--spacing-lg);
 		text-decoration: none;
 		color: inherit;
 	}
@@ -64,7 +64,7 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-image {
 		position: relative;
 		overflow: hidden;
-		border-radius: var(--radius, 4px);
+		border-radius: var(--radius);
 	}
 
 	.card-image img {
@@ -72,7 +72,7 @@ const allTags = [...(categories || []), ...(tags || [])];
 		height: auto;
 		aspect-ratio: 4 / 3;
 		object-fit: cover;
-		transition: transform var(--transition-slow, 300ms ease);
+		transition: transform var(--transition-slow);
 	}
 
 	.card-overlay {
@@ -82,21 +82,22 @@ const allTags = [...(categories || []), ...(tags || [])];
 		align-items: center;
 		justify-content: center;
 		background: rgba(0, 0, 0, 0);
-		transition: background var(--transition-base, 200ms ease);
+		transition: background var(--transition-base);
 	}
 
+	/* Over-image chip: white regardless of theme */
 	.card-view {
-		font-family: var(--font-serif, Georgia, serif);
-		font-size: var(--font-size-sm, 0.875rem);
+		font-family: var(--font-heading);
+		font-size: var(--font-size-sm);
 		color: white;
-		padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+		padding: var(--spacing-sm) var(--spacing-md);
 		border: 1px solid white;
-		border-radius: var(--radius, 4px);
+		border-radius: var(--radius);
 		opacity: 0;
 		transform: translateY(10px);
 		transition:
-			opacity var(--transition-base, 200ms ease),
-			transform var(--transition-base, 200ms ease);
+			opacity var(--transition-base),
+			transform var(--transition-base);
 	}
 
 	.project-card:hover .card-image img {
@@ -115,33 +116,33 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-content {
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-xs, 0.25rem);
+		gap: var(--spacing-xs);
 	}
 
 	.card-title {
-		font-family: var(--font-serif, Georgia, serif);
-		font-size: var(--font-size-xl, 1.5rem);
-		font-weight: 500;
-		transition: color var(--transition-fast, 150ms ease);
+		font-family: var(--font-heading);
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-heading);
+		transition: color var(--transition-fast);
 	}
 
 	.project-card:hover .card-title {
-		color: var(--color-accent, #7c3aed);
+		color: var(--color-brand);
 	}
 
 	.card-meta {
-		font-size: var(--font-size-sm, 0.875rem);
-		color: var(--color-muted, #6b7280);
+		font-size: var(--font-size-sm);
+		color: var(--color-muted);
 	}
 
 	.card-separator {
-		margin: 0 var(--spacing-xs, 0.25rem);
+		margin: 0 var(--spacing-xs);
 	}
 
 	.card-summary {
-		font-size: var(--font-size-sm, 0.875rem);
-		color: var(--color-muted, #6b7280);
-		line-height: 1.6;
+		font-size: var(--font-size-sm);
+		color: var(--color-muted);
+		line-height: var(--leading-normal);
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical;
@@ -151,17 +152,17 @@ const allTags = [...(categories || []), ...(tags || [])];
 	.card-categories {
 		display: flex;
 		flex-wrap: wrap;
-		gap: var(--spacing-sm, 0.5rem);
-		margin-top: var(--spacing-sm, 0.5rem);
+		gap: var(--spacing-sm);
+		margin-top: var(--spacing-sm);
 	}
 
 	.card-category {
-		font-size: 0.75rem;
+		font-size: var(--font-size-xs);
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: var(--color-muted, #6b7280);
-		padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
-		border: 1px solid var(--color-border, #e5e7eb);
-		border-radius: var(--radius, 4px);
+		letter-spacing: var(--tracking-wide);
+		color: var(--color-muted);
+		padding: var(--spacing-xs) var(--spacing-sm);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius);
 	}
 </style>

--- a/templates/portfolio/src/layouts/Base.astro
+++ b/templates/portfolio/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import { Font } from "astro:assets";
+import "../styles/tokens.css";
 import "../styles/theme.css";
 
 interface Props {
@@ -43,7 +44,7 @@ const pageCtx = createPublicPageContext({
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />
-		<Font cssVariable="--font-serif" preload />
+		<Font cssVariable="--font-heading" preload />
 		<link
 			rel="alternate"
 			type="application/rss+xml"
@@ -51,15 +52,14 @@ const pageCtx = createPublicPageContext({
 			href="/rss.xml"
 		/>
 		<script is:inline>
-			// Apply theme immediately to prevent flash
+			// Apply an explicit theme choice immediately to prevent flash.
+			// With no cookie, color-scheme: light dark follows the OS.
 			(function () {
 				var c = document.cookie;
 				var i = c.indexOf("theme=");
 				var theme = i >= 0 ? c.slice(i + 6).split(";")[0] : null;
 				if (theme === "dark" || theme === "light") {
 					document.documentElement.classList.add(theme);
-				} else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-					document.documentElement.classList.add("dark");
 				}
 			})();
 		</script>
@@ -143,9 +143,6 @@ const pageCtx = createPublicPageContext({
 				if (theme === "system") {
 					document.cookie = `theme=; path=/; max-age=0; SameSite=Lax${secure}`;
 					root.classList.remove("light", "dark");
-					if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-						root.classList.add("dark");
-					}
 				} else {
 					document.cookie = `theme=${theme}; path=/; max-age=31536000; SameSite=Lax${secure}`;
 					root.classList.remove("light", "dark");
@@ -174,15 +171,6 @@ const pageCtx = createPublicPageContext({
 					setTheme(btn.dataset.theme || "system");
 				});
 			});
-
-			// Listen for system preference changes
-			window
-				.matchMedia("(prefers-color-scheme: dark)")
-				.addEventListener("change", (e) => {
-					if (getStoredTheme() === "system") {
-						root.classList.toggle("dark", e.matches);
-					}
-				});
 		</script>
 
 		<style is:global>
@@ -202,71 +190,18 @@ const pageCtx = createPublicPageContext({
 					padding: 0;
 				}
 
-				:root {
-					/* Colors - Elegant/Minimal palette */
-					--color-bg: #fafafa;
-					--color-text: #1a1a1a;
-					--color-muted: #6b7280;
-					--color-border: #e5e7eb;
-					--color-surface: #ffffff;
-					--color-accent: #7c3aed;
-					--color-accent-muted: #a78bfa;
-
-					/* Typography */
-					--font-sans: system-ui, -apple-system, sans-serif;
-					--font-mono: ui-monospace, monospace;
-
-					--font-size-sm: 0.875rem;
-					--font-size-base: 1.0625rem;
-					--font-size-lg: 1.25rem;
-					--font-size-xl: 1.5rem;
-					--font-size-2xl: 2rem;
-					--font-size-3xl: 2.75rem;
-					--font-size-4xl: 3.5rem;
-
-					/* Spacing */
-					--spacing-xs: 0.25rem;
-					--spacing-sm: 0.5rem;
-					--spacing-md: 1rem;
-					--spacing-lg: 1.5rem;
-					--spacing-xl: 2rem;
-					--spacing-2xl: 3rem;
-					--spacing-3xl: 4rem;
-					--spacing-4xl: 6rem;
-
-					/* Layout */
-					--max-width: 720px;
-					--wide-width: 1200px;
-					--radius: 4px;
-
-					/* Transitions */
-					--transition-fast: 150ms ease;
-					--transition-base: 200ms ease;
-					--transition-slow: 300ms ease;
+				/*
+				 * Design tokens live in src/styles/tokens.css. Colors are
+				 * defined with light-dark(); these rules pin the scheme when
+				 * the footer switcher sets an explicit choice. With no class,
+				 * color-scheme: light dark follows the OS preference.
+				 */
+				:root.light {
+					color-scheme: light;
 				}
 
-				/* Dark mode via system preference (when no explicit class) */
-				@media (prefers-color-scheme: dark) {
-					:root:not(.light) {
-						--color-bg: #0a0a0a;
-						--color-text: #f5f5f5;
-						--color-muted: #a1a1aa;
-						--color-border: #27272a;
-						--color-surface: #18181b;
-						--color-accent: #a78bfa;
-						--color-accent-muted: #7c3aed;
-					}
-				}
-
-				/* Explicit dark mode */
 				:root.dark {
-					--color-bg: #0a0a0a;
-					--color-text: #f5f5f5;
-					--color-muted: #a1a1aa;
-					--color-border: #27272a;
-					--color-surface: #18181b;
-					--color-accent: #a78bfa;
-					--color-accent-muted: #7c3aed;
+					color-scheme: dark;
 				}
 
 				html {
@@ -274,9 +209,9 @@ const pageCtx = createPublicPageContext({
 				}
 
 				body {
-					font-family: var(--font-sans);
+					font-family: var(--font-body);
 					font-size: var(--font-size-base);
-					line-height: 1.6;
+					line-height: var(--leading-normal);
 					color: var(--color-text);
 					background: var(--color-bg);
 					-webkit-font-smoothing: antialiased;
@@ -297,9 +232,9 @@ const pageCtx = createPublicPageContext({
 				h2,
 				h3,
 				h4 {
-					font-family: var(--font-serif);
-					font-weight: 500;
-					line-height: 1.2;
+					font-family: var(--font-heading);
+					font-weight: var(--font-weight-heading);
+					line-height: var(--leading-snug);
 				}
 
 				h1 {
@@ -330,11 +265,11 @@ const pageCtx = createPublicPageContext({
 			}
 
 			.site-title {
-				font-family: var(--font-serif);
+				font-family: var(--font-heading);
 				font-size: var(--font-size-lg);
 				font-weight: 600;
 				text-decoration: none;
-				letter-spacing: -0.02em;
+				letter-spacing: var(--tracking-tight);
 			}
 
 			.site-logo-img {
@@ -386,7 +321,7 @@ const pageCtx = createPublicPageContext({
 			}
 
 			.footer-logo {
-				font-family: var(--font-serif);
+				font-family: var(--font-heading);
 				font-size: var(--font-size-lg);
 				font-weight: 600;
 			}
@@ -397,7 +332,7 @@ const pageCtx = createPublicPageContext({
 			}
 
 			.footer-tagline {
-				font-family: var(--font-serif);
+				font-family: var(--font-heading);
 				font-style: italic;
 				font-size: var(--font-size-sm);
 				color: var(--color-muted);
@@ -420,7 +355,7 @@ const pageCtx = createPublicPageContext({
 				background: transparent;
 				border: 1px solid var(--color-border);
 				color: var(--color-muted);
-				font-family: var(--font-sans);
+				font-family: var(--font-body);
 				font-size: var(--font-size-sm);
 				padding: var(--spacing-xs) var(--spacing-sm);
 				border-radius: var(--radius);
@@ -436,7 +371,7 @@ const pageCtx = createPublicPageContext({
 			.theme-btn.active {
 				background: var(--color-surface);
 				color: var(--color-text);
-				border-color: var(--color-accent);
+				border-color: var(--color-brand);
 			}
 
 			.footer-powered {

--- a/templates/portfolio/src/layouts/Base.astro
+++ b/templates/portfolio/src/layouts/Base.astro
@@ -194,14 +194,18 @@ const pageCtx = createPublicPageContext({
 				 * Design tokens live in src/styles/tokens.css. Colors are
 				 * defined with light-dark(); these rules pin the scheme when
 				 * the footer switcher sets an explicit choice. With no class,
-				 * color-scheme: light dark follows the OS preference.
+				 * color-scheme: light dark follows the OS preference. The
+				 * @supports guard keeps the toggle from forcing dark UA form
+				 * controls on browsers stuck on the plain-light fallback.
 				 */
-				:root.light {
-					color-scheme: light;
-				}
+				@supports (color: light-dark(#000, #fff)) {
+					:root.light {
+						color-scheme: light;
+					}
 
-				:root.dark {
-					color-scheme: dark;
+					:root.dark {
+						color-scheme: dark;
+					}
 				}
 
 				html {

--- a/templates/portfolio/src/pages/404.astro
+++ b/templates/portfolio/src/pages/404.astro
@@ -24,18 +24,18 @@ import Base from "../layouts/Base.astro";
 
 	.not-found-code {
 		display: block;
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: 8rem;
-		font-weight: 500;
+		font-weight: var(--font-weight-display);
 		line-height: 1;
 		color: var(--color-border);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.not-found h1 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-sm);
 	}
 
@@ -63,8 +63,8 @@ import Base from "../layouts/Base.astro";
 	}
 
 	.link-primary:hover {
-		background: var(--color-accent);
-		color: white;
+		background: var(--color-brand);
+		color: var(--color-on-brand);
 		transform: translateY(-1px);
 	}
 

--- a/templates/portfolio/src/pages/about.astro
+++ b/templates/portfolio/src/pages/about.astro
@@ -66,15 +66,15 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.about-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
-		line-height: 1.1;
+		font-weight: var(--font-weight-display);
+		line-height: var(--leading-tight);
 	}
 
 	.about-content {
 		font-size: var(--font-size-base);
-		line-height: 1.7;
+		line-height: var(--leading-relaxed);
 	}
 
 	.about-content :global(p) {
@@ -82,17 +82,17 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.about-content :global(h2) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2.5em;
 		margin-bottom: 0.75em;
 	}
 
 	.about-content :global(h3) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2em;
 		margin-bottom: 0.5em;
 	}
@@ -108,9 +108,9 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.sidebar-section h3 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-lg);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-md);
 	}
 
@@ -137,7 +137,7 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 	}
 
 	.sidebar-section a:hover {
-		color: var(--color-accent);
+		color: var(--color-brand);
 	}
 
 	@media (max-width: 768px) {

--- a/templates/portfolio/src/pages/contact.astro
+++ b/templates/portfolio/src/pages/contact.astro
@@ -142,17 +142,17 @@ if (Astro.request.method === "POST") {
 	}
 
 	.contact-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
-		line-height: 1.1;
+		font-weight: var(--font-weight-display);
+		line-height: var(--leading-tight);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.contact-intro {
 		font-size: var(--font-size-lg);
 		color: var(--color-muted);
-		line-height: 1.6;
+		line-height: var(--leading-normal);
 	}
 
 	.contact-grid {
@@ -195,8 +195,8 @@ if (Astro.request.method === "POST") {
 	.form-field input:focus,
 	.form-field textarea:focus {
 		outline: none;
-		border-color: var(--color-accent);
-		box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+		border-color: var(--color-brand);
+		box-shadow: 0 0 0 3px var(--color-brand-ring);
 	}
 
 	.form-field input::placeholder,
@@ -226,8 +226,8 @@ if (Astro.request.method === "POST") {
 	}
 
 	.form-submit:hover {
-		background: var(--color-accent);
-		color: white;
+		background: var(--color-brand);
+		color: var(--color-on-brand);
 		transform: translateY(-1px);
 	}
 
@@ -237,19 +237,11 @@ if (Astro.request.method === "POST") {
 
 	.form-error {
 		padding: var(--spacing-md);
-		background: #fef2f2;
-		border: 1px solid #fecaca;
+		background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
 		border-radius: var(--radius);
-		color: #dc2626;
+		color: var(--color-danger);
 		font-size: var(--font-size-sm);
-	}
-
-	@media (prefers-color-scheme: dark) {
-		.form-error {
-			background: rgba(239, 68, 68, 0.1);
-			border-color: rgba(239, 68, 68, 0.3);
-			color: #f87171;
-		}
 	}
 
 	.form-success {
@@ -261,9 +253,9 @@ if (Astro.request.method === "POST") {
 	}
 
 	.form-success h2 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-sm);
 	}
 
@@ -274,7 +266,7 @@ if (Astro.request.method === "POST") {
 
 	.form-reset {
 		font-size: var(--font-size-sm);
-		color: var(--color-accent);
+		color: var(--color-brand);
 		text-decoration: none;
 	}
 
@@ -293,9 +285,9 @@ if (Astro.request.method === "POST") {
 	}
 
 	.info-section h3 {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-lg);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-sm);
 	}
 

--- a/templates/portfolio/src/pages/index.astro
+++ b/templates/portfolio/src/pages/index.astro
@@ -67,15 +67,15 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 	.hero-title {
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-display);
 		margin-bottom: var(--spacing-md);
-		letter-spacing: -0.02em;
+		letter-spacing: var(--tracking-tight);
 	}
 
 	.hero-tagline {
 		font-size: var(--font-size-xl);
 		color: var(--color-muted);
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-style: italic;
 	}
 
@@ -96,7 +96,7 @@ if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 	.section-title {
 		font-size: var(--font-size-lg);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 	}
 
 	.section-link {

--- a/templates/portfolio/src/pages/work/[slug].astro
+++ b/templates/portfolio/src/pages/work/[slug].astro
@@ -156,7 +156,7 @@ function getImageSrc(img: unknown): string | undefined {
 		color: var(--color-muted);
 		margin-bottom: var(--spacing-sm);
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
+		letter-spacing: var(--tracking-wide);
 	}
 
 	.meta-separator {
@@ -164,24 +164,24 @@ function getImageSrc(img: unknown): string | undefined {
 	}
 
 	.project-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-4xl);
-		font-weight: 500;
-		line-height: 1.1;
+		font-weight: var(--font-weight-display);
+		line-height: var(--leading-tight);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.project-summary {
 		font-size: var(--font-size-lg);
 		color: var(--color-muted);
-		line-height: 1.6;
+		line-height: var(--leading-normal);
 		margin-bottom: var(--spacing-lg);
 	}
 
 	.project-link {
 		display: inline-block;
 		font-size: var(--font-size-sm);
-		color: var(--color-accent);
+		color: var(--color-brand);
 		text-decoration: none;
 		transition: color var(--transition-fast);
 	}
@@ -202,7 +202,7 @@ function getImageSrc(img: unknown): string | undefined {
 
 	.project-content {
 		font-size: var(--font-size-base);
-		line-height: 1.7;
+		line-height: var(--leading-relaxed);
 	}
 
 	.project-content :global(p) {
@@ -210,17 +210,17 @@ function getImageSrc(img: unknown): string | undefined {
 	}
 
 	.project-content :global(h2) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2.5em;
 		margin-bottom: 0.75em;
 	}
 
 	.project-content :global(h3) {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-top: 2em;
 		margin-bottom: 0.5em;
 	}
@@ -228,9 +228,9 @@ function getImageSrc(img: unknown): string | undefined {
 	.project-content :global(blockquote) {
 		margin: 2em 0;
 		padding-left: var(--spacing-xl);
-		border-left: 2px solid var(--color-accent);
+		border-left: 2px solid var(--color-brand);
 		color: var(--color-muted);
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-style: italic;
 		font-size: var(--font-size-lg);
 	}
@@ -276,9 +276,9 @@ function getImageSrc(img: unknown): string | undefined {
 	}
 
 	.more-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-heading);
 		font-size: var(--font-size-2xl);
-		font-weight: 500;
+		font-weight: var(--font-weight-heading);
 		margin-bottom: var(--spacing-2xl);
 	}
 

--- a/templates/portfolio/src/styles/theme.css
+++ b/templates/portfolio/src/styles/theme.css
@@ -1,62 +1,28 @@
 /*
-  theme.css -- override any :root variable here to retheme the site.
+  theme.css -- your theme overrides. This is the file to edit to
+  retheme the site.
 
-  This is the only file you need to edit to customize the site's visual
-  appearance. All defaults are listed below as comments. Uncomment and
-  change any value to override it.
+  Every design token lives in src/styles/tokens.css (colors, type
+  scale, spacing, layout) with its default value. Override any of them
+  here: declarations in this file are unlayered, so they always beat
+  the @layer base defaults in tokens.css.
 
-  Base.astro puts its defaults inside @layer base, so declarations here
-  (which are unlayered) always take priority -- no specificity tricks needed.
+  Colors are defined with light-dark(). Overriding with a plain color
+  changes light and dark mode at once; use light-dark(<light>, <dark>)
+  to set different values per mode.
 
-  Note: this template defines explicit dark mode colors in Base.astro.
-  Overriding light-mode --color-* variables here won't affect dark mode.
-  To customize dark mode, also override --color-* variables inside a
-  @media (prefers-color-scheme: dark) block and/or in the :root.dark rule.
+  The serif display face (--font-heading) is loaded in astro.config.mjs.
+  Swap the loaded font there; use overrides here for system fonts or to
+  change the quiet system-sans body face (--font-body).
+
+  Example:
+
+  :root {
+    --color-brand: light-dark(#0f766e, #2dd4bf);
+    --font-body: "Avenir Next", system-ui, sans-serif;
+    --font-size-4xl: 4rem;
+  }
 */
 
 :root {
-	/* --- Colors ---
-	--color-bg: #fafafa;
-	--color-text: #1a1a1a;
-	--color-muted: #6b7280;
-	--color-border: #e5e7eb;
-	--color-surface: #ffffff;
-	--color-accent: #7c3aed;
-	--color-accent-muted: #a78bfa;
-	*/
-
-	/* --- Typography ---
-	--font-sans: system-ui, -apple-system, sans-serif;
-	--font-mono: ui-monospace, monospace;
-	--font-size-sm: 0.875rem;
-	--font-size-base: 1.0625rem;
-	--font-size-lg: 1.25rem;
-	--font-size-xl: 1.5rem;
-	--font-size-2xl: 2rem;
-	--font-size-3xl: 2.75rem;
-	--font-size-4xl: 3.5rem;
-	*/
-
-	/* --- Spacing ---
-	--spacing-xs: 0.25rem;
-	--spacing-sm: 0.5rem;
-	--spacing-md: 1rem;
-	--spacing-lg: 1.5rem;
-	--spacing-xl: 2rem;
-	--spacing-2xl: 3rem;
-	--spacing-3xl: 4rem;
-	--spacing-4xl: 6rem;
-	*/
-
-	/* --- Layout ---
-	--max-width: 720px;
-	--wide-width: 1200px;
-	--radius: 4px;
-	*/
-
-	/* --- Transitions ---
-	--transition-fast: 150ms ease;
-	--transition-base: 200ms ease;
-	--transition-slow: 300ms ease;
-	*/
 }

--- a/templates/portfolio/src/styles/tokens.css
+++ b/templates/portfolio/src/styles/tokens.css
@@ -1,0 +1,96 @@
+/*
+  tokens.css -- the design tokens for this template. These are the
+  defaults; to customize the site, override any variable in
+  src/styles/theme.css rather than editing this file. Declarations in
+  theme.css are unlayered, so they always beat these @layer base
+  defaults -- no specificity tricks needed.
+
+  Colors use light-dark(): the first value applies in light mode, the
+  second in dark mode. Overriding a color with a plain value changes
+  both modes at once; use light-dark(<light>, <dark>) in an override to
+  keep them distinct.
+
+  --font-heading (the serif display face) is defined by the font
+  pipeline in astro.config.mjs, not here. To swap it, edit the fonts
+  entry there. --font-body is the deliberately quiet system sans stack
+  below.
+*/
+
+@layer base {
+	:root {
+		color-scheme: light dark;
+
+		/* Colors */
+		--color-bg: light-dark(#fafafa, #0a0a0a);
+		--color-text: light-dark(#1a1a1a, #f5f5f5);
+		--color-muted: light-dark(#6b7280, #a1a1aa);
+		--color-border: light-dark(#e5e7eb, #27272a);
+		--color-surface: light-dark(#ffffff, #18181b);
+		--color-brand: light-dark(#7c3aed, #a78bfa); /* the single accent, used sparingly */
+		--color-on-brand: white; /* text on brand-colored surfaces */
+		--color-brand-ring: color-mix(in srgb, var(--color-brand) 10%, transparent);
+		--color-danger: light-dark(#dc2626, #f87171);
+
+		/* Typography */
+		--font-body: system-ui, -apple-system, sans-serif;
+		--font-weight-heading: 500; /* serif headings and titles */
+		--font-weight-display: 500; /* hero and page titles */
+
+		/* Type scale */
+		--font-size-xs: 0.75rem;
+		--font-size-sm: 0.875rem;
+		--font-size-base: 1.0625rem;
+		--font-size-lg: 1.25rem;
+		--font-size-xl: 1.5rem;
+		--font-size-2xl: 2rem;
+		--font-size-3xl: 2.75rem;
+		--font-size-4xl: 3.5rem;
+
+		/* Line heights */
+		--leading-tight: 1.1; /* hero and project titles */
+		--leading-snug: 1.2; /* headings */
+		--leading-normal: 1.6; /* body copy */
+		--leading-relaxed: 1.7; /* long-form content */
+
+		/* Letter spacing */
+		--tracking-tight: -0.02em; /* site title, hero title */
+		--tracking-wide: 0.05em; /* uppercase meta lines, tag chips */
+
+		/* Spacing */
+		--spacing-xs: 0.25rem;
+		--spacing-sm: 0.5rem;
+		--spacing-md: 1rem;
+		--spacing-lg: 1.5rem;
+		--spacing-xl: 2rem;
+		--spacing-2xl: 3rem;
+		--spacing-3xl: 4rem;
+		--spacing-4xl: 6rem;
+
+		/* Layout */
+		--max-width: 720px;
+		--wide-width: 1200px;
+		--radius: 4px;
+
+		/* Transitions */
+		--transition-fast: 150ms ease;
+		--transition-base: 200ms ease;
+		--transition-slow: 300ms ease;
+	}
+
+	/*
+	 * Light-mode values for browsers without light-dark() (Safari < 17.5,
+	 * Chrome < 123). Must mirror the light values above.
+	 */
+	@supports not (color: light-dark(#000, #fff)) {
+		:root {
+			color-scheme: light;
+			--color-bg: #fafafa;
+			--color-text: #1a1a1a;
+			--color-muted: #6b7280;
+			--color-border: #e5e7eb;
+			--color-surface: #ffffff;
+			--color-brand: #7c3aed;
+			--color-danger: #dc2626;
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Migrates the portfolio template (and its `-cloudflare` variant) to the theme-token architecture introduced for blog and marketing in #1731, so a portfolio site can be rethemed entirely from `src/styles/theme.css`. Best reviewed/merged after #1731 (no file overlap — this touches only `templates/portfolio*`).

- **Real tokens file.** Tokens move from `Base.astro` into `src/styles/tokens.css` as `@layer base` defaults; `theme.css` becomes a pure unlayered override file. Colors are defined once with `light-dark()` (one override rethemes both modes), the switcher pins `color-scheme`, and a `@supports not (light-dark)` block gives pre-Safari-17.5/Chrome-123 browsers the plain light palette.
- **Semantic tokens.** `--font-heading` replaces `--font-serif` (Playfair, `cssVariable` renamed in both variants' `astro.config.mjs` — the cloudflare config isn't script-synced, edited by hand) and `--font-body` replaces `--font-sans` (the quiet system stack, now a plain token). `--color-brand` replaces `--color-accent`, with new `--color-on-brand` (was hardcoded `white` on hover states), `--color-brand-ring` (was a frozen `rgba(124,58,237,0.1)` violet that ignored brand overrides), and `--color-danger` (was hardcoded reds with a `prefers-color-scheme` block that ignored the cookie theme toggle — same bug fixed in marketing).
- **Typography tokens.** `--font-weight-heading`/`--font-weight-display` (both 500 — the calm serif voice is now one knob), leading and tracking tokens replacing inline literals, and `--font-size-xs` replacing a hardcoded chip size.
- **Dead weight removed.** `--color-accent-muted` and `--font-mono` had zero consumers (verified on main) and are dropped. `ProjectCard.astro`'s inline `var(--x, fallback)` defaults are stripped — they duplicated token values and would silently mask a broken token reference.

Known accepted degradations, consistent with #1731: `color-mix()` consumers (focus ring, error tint) degrade gracefully on Safari < 16.2, and browsers without `light-dark()` become light-only (previously they had media-query dark mode). The form-error tint is compositionally close to, not pixel-identical with, the old opaque `#fef2f2` — it now derives from `--color-danger` like marketing's.

Starter remains on the old architecture and needs separate work.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [x] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Tests
- [ ] Performance improvement
- [ ] Chore (dependencies, CI, tooling)

Rendered output is intentionally unchanged (verified in browser, both modes); the theming API changes deliberately, matching #1731. Maintainer-requested work, so no prior Discussion.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`pnpm typecheck:templates` — all templates)
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a: templates have no test suite; CSS/markup only, verified in-browser (see below)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, no template test infrastructure
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no admin UI changes
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) — n/a: template packages are private and in the changesets ignore list, so they are never released
- [ ] New features link to an approved Discussion — n/a, maintainer-requested refactor

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code + Claude Fable 5

## Screenshots / test output

Verified by running the template with `emdash dev` and driving it with agent-browser:

- Home and contact render pixel-equivalent to `main` in light and dark mode (Playfair serif, near-monochrome palette intact).
- Dark mode works with no `.dark` class (pure `color-scheme`), and pinning `.light` under a dark OS flips `background` `rgb(10,10,10)` → `rgb(250,250,250)`.
- Retheme exercised from `theme.css` alone: `--color-brand: light-dark(#0d9488, #2dd4bf)` + `--font-weight-display: 700` — the page title visibly bolds and the focus ring computes to `color(srgb 0.176 0.831 0.749 / 0.1)`, i.e. the overridden dark-mode teal at the ring's 10% alpha.
- An adversarial-review pass over the diff found no correctness bugs: all light-dark() pairs byte-match the old light+dark palettes, no stale or unresolved variable references in either variant, the cloudflare src tree is byte-identical except `worker.ts`, and the dropped tokens had zero consumers on main.
