### PR TITLE
fix(core): allow the configured storage endpoint origin in connect-src

### DIFF
--- a/.changeset/csp-connect-src-storage-endpoint.md
+++ b/.changeset/csp-connect-src-storage-endpoint.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes admin media uploads to S3-compatible storage (R2, S3, Minio, etc.) being blocked by the Content-Security-Policy when the storage endpoint is a different origin than the site. The signed upload URL's origin is now allowed in `connect-src`.

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -34,7 +34,7 @@ import { getAuthMode, type ExternalAuthMode } from "../../auth/mode.js";
 import type { ExternalAuthConfig } from "../../auth/types.js";
 import { resolveSessionUser } from "../session-user.js";
 import type { EmDashHandlers } from "../types.js";
-import { buildEmDashCsp } from "./csp.js";
+import { buildEmDashCsp, getConfiguredStorageEndpoint } from "./csp.js";
 
 declare global {
 	namespace App {
@@ -306,7 +306,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		if (!import.meta.env.DEV) {
 			response.headers.set(
 				"Content-Security-Policy",
-				buildEmDashCsp(context.locals.emdash?.config.experimental?.registry),
+				buildEmDashCsp(
+					context.locals.emdash?.config.experimental?.registry,
+					getConfiguredStorageEndpoint(context.locals.emdash?.config.storage),
+				),
 			);
 		}
 		return response;
@@ -318,7 +321,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	if (!import.meta.env.DEV) {
 		response.headers.set(
 			"Content-Security-Policy",
-			buildEmDashCsp(context.locals.emdash?.config.experimental?.registry),
+			buildEmDashCsp(
+				context.locals.emdash?.config.experimental?.registry,
+				getConfiguredStorageEndpoint(context.locals.emdash?.config.storage),
+			),
 		);
 	}
 

--- a/packages/core/src/astro/middleware/csp.ts
+++ b/packages/core/src/astro/middleware/csp.ts
@@ -9,9 +9,26 @@
  * may reference external images (migrations, external hosting, embeds).
  * Plugin security does not rely on img-src -- plugins run in V8 isolates with
  * no DOM access. connect-src stays at 'self' unless the experimental registry
- * is configured, in which case the configured aggregator origin is allowed.
+ * and/or the configured storage endpoint (for direct-to-S3 signed uploads)
+ * are configured, in which case those origins are allowed too.
  */
 import type { RegistryConfigInput } from "../../registry/types.js";
+import type { StorageDescriptor } from "../storage/types.js";
+
+/**
+ * Storage entrypoints are free to shape their config however they like, so
+ * `endpoint` isn't a known field on `StorageDescriptor["config"]` -- only
+ * S3-compatible adapters (R2, S3, Minio, ...) set it. Anything else (e.g.
+ * local filesystem storage) simply has no `endpoint` to allow.
+ */
+export function getConfiguredStorageEndpoint(
+	storage: StorageDescriptor | undefined,
+): string | undefined {
+	const config = storage?.config;
+	if (typeof config !== "object" || config === null) return undefined;
+	const endpoint = (config as Record<string, unknown>).endpoint;
+	return typeof endpoint === "string" ? endpoint : undefined;
+}
 
 function getRegistryAggregatorOrigin(
 	registry: RegistryConfigInput | undefined,
@@ -28,10 +45,26 @@ function getRegistryAggregatorOrigin(
 	}
 }
 
-export function buildEmDashCsp(registry?: RegistryConfigInput): string {
+function getHttpOrigin(rawUrl: string | undefined): string | undefined {
+	if (!rawUrl) return undefined;
+
+	try {
+		const url = new URL(rawUrl);
+		if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+		return url.origin;
+	} catch {
+		return undefined;
+	}
+}
+
+export function buildEmDashCsp(registry?: RegistryConfigInput, storageEndpoint?: string): string {
 	const connectSrc = ["connect-src 'self'"];
+	const origins = new Set<string>();
 	const registryAggregatorOrigin = getRegistryAggregatorOrigin(registry);
-	if (registryAggregatorOrigin) connectSrc.push(registryAggregatorOrigin);
+	if (registryAggregatorOrigin) origins.add(registryAggregatorOrigin);
+	const storageOrigin = getHttpOrigin(storageEndpoint);
+	if (storageOrigin) origins.add(storageOrigin);
+	connectSrc.push(...origins);
 
 	return [
 		"default-src 'self'",

--- a/packages/core/src/astro/middleware/csp.ts
+++ b/packages/core/src/astro/middleware/csp.ts
@@ -25,8 +25,8 @@ export function getConfiguredStorageEndpoint(
 	storage: StorageDescriptor | undefined,
 ): string | undefined {
 	const config = storage?.config;
-	if (typeof config !== "object" || config === null) return undefined;
-	const endpoint = (config as Record<string, unknown>).endpoint;
+	if (typeof config !== "object" || config === null || !("endpoint" in config)) return undefined;
+	const endpoint = config.endpoint;
 	return typeof endpoint === "string" ? endpoint : undefined;
 }
 

--- a/packages/core/src/astro/middleware/csp.ts
+++ b/packages/core/src/astro/middleware/csp.ts
@@ -15,19 +15,37 @@
 import type { RegistryConfigInput } from "../../registry/types.js";
 import type { StorageDescriptor } from "../storage/types.js";
 
+/** Entrypoint constant used by the `s3()` adapter (see `astro/storage/adapters.ts`). */
+const S3_ADAPTER_ENTRYPOINT = "emdash/storage/s3";
+
 /**
  * Storage entrypoints are free to shape their config however they like, so
  * `endpoint` isn't a known field on `StorageDescriptor["config"]` -- only
  * S3-compatible adapters (R2, S3, Minio, ...) set it. Anything else (e.g.
  * local filesystem storage) simply has no `endpoint` to allow.
+ *
+ * The `s3()` adapter resolves any field omitted from its config -- including
+ * `endpoint` -- from the matching `S3_*` env var at runtime (see
+ * `storage/s3.ts`'s `resolveS3Config`). A site configured as `s3({ ... })`
+ * with only `S3_ENDPOINT` set has no `endpoint` in the descriptor's config,
+ * so fall back to that env var for S3-adapter storage before giving up.
  */
 export function getConfiguredStorageEndpoint(
 	storage: StorageDescriptor | undefined,
 ): string | undefined {
 	const config = storage?.config;
-	if (typeof config !== "object" || config === null || !("endpoint" in config)) return undefined;
-	const endpoint = config.endpoint;
-	return typeof endpoint === "string" ? endpoint : undefined;
+	if (typeof config === "object" && config !== null && "endpoint" in config) {
+		const endpoint = config.endpoint;
+		if (typeof endpoint === "string") return endpoint;
+	}
+
+	if (storage?.entrypoint === S3_ADAPTER_ENTRYPOINT) {
+		const envEndpoint =
+			typeof process !== "undefined" && process.env ? process.env.S3_ENDPOINT : undefined;
+		if (envEndpoint) return envEndpoint;
+	}
+
+	return undefined;
 }
 
 function getRegistryAggregatorOrigin(

--- a/packages/core/tests/unit/middleware/csp.test.ts
+++ b/packages/core/tests/unit/middleware/csp.test.ts
@@ -35,6 +35,41 @@ describe("buildEmDashCsp", () => {
 		expect(connectSrc).toBe("connect-src 'self' https://registry.emdashcms.com");
 	});
 
+	it("allows the configured storage endpoint origin in connect-src", () => {
+		const csp = buildEmDashCsp(undefined, "https://xxx.r2.cloudflarestorage.com");
+		const connectSrc = csp.split("; ").find((d) => d.startsWith("connect-src"));
+		expect(connectSrc).toBe("connect-src 'self' https://xxx.r2.cloudflarestorage.com");
+	});
+
+	it("ignores a storage endpoint that isn't http(s)", () => {
+		const csp = buildEmDashCsp(undefined, "file:///tmp/uploads");
+		const connectSrc = csp.split("; ").find((d) => d.startsWith("connect-src"));
+		expect(connectSrc).toBe("connect-src 'self'");
+	});
+
+	it("ignores a malformed storage endpoint", () => {
+		const csp = buildEmDashCsp(undefined, "not a url");
+		const connectSrc = csp.split("; ").find((d) => d.startsWith("connect-src"));
+		expect(connectSrc).toBe("connect-src 'self'");
+	});
+
+	it("allows both the registry and storage endpoint origins together", () => {
+		const csp = buildEmDashCsp(
+			"https://registry.emdashcms.com",
+			"https://xxx.r2.cloudflarestorage.com",
+		);
+		const connectSrc = csp.split("; ").find((d) => d.startsWith("connect-src"));
+		expect(connectSrc).toBe(
+			"connect-src 'self' https://registry.emdashcms.com https://xxx.r2.cloudflarestorage.com",
+		);
+	});
+
+	it("does not duplicate the origin when storage endpoint and registry share it", () => {
+		const csp = buildEmDashCsp("https://shared.example.com", "https://shared.example.com/bucket");
+		const connectSrc = csp.split("; ").find((d) => d.startsWith("connect-src"));
+		expect(connectSrc).toBe("connect-src 'self' https://shared.example.com");
+	});
+
 	it("blocks framing with frame-ancestors none", () => {
 		const csp = buildEmDashCsp();
 		expect(csp).toContain("frame-ancestors 'none'");

--- a/packages/core/tests/unit/middleware/csp.test.ts
+++ b/packages/core/tests/unit/middleware/csp.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
-import { buildEmDashCsp } from "../../../src/astro/middleware/csp.js";
+import { buildEmDashCsp, getConfiguredStorageEndpoint } from "../../../src/astro/middleware/csp.js";
 
 describe("buildEmDashCsp", () => {
 	it("includes https: in img-src to allow external images", () => {
@@ -73,5 +73,63 @@ describe("buildEmDashCsp", () => {
 	it("blocks framing with frame-ancestors none", () => {
 		const csp = buildEmDashCsp();
 		expect(csp).toContain("frame-ancestors 'none'");
+	});
+});
+
+describe("getConfiguredStorageEndpoint", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("returns undefined for undefined storage", () => {
+		expect(getConfiguredStorageEndpoint(undefined)).toBeUndefined();
+	});
+
+	it("returns undefined for storage config without an endpoint field", () => {
+		expect(
+			getConfiguredStorageEndpoint({
+				entrypoint: "emdash/storage/local",
+				config: { directory: "./uploads" },
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns the explicit endpoint from config when present", () => {
+		expect(
+			getConfiguredStorageEndpoint({
+				entrypoint: "emdash/storage/s3",
+				config: { endpoint: "https://xxx.r2.cloudflarestorage.com" },
+			}),
+		).toBe("https://xxx.r2.cloudflarestorage.com");
+	});
+
+	it("falls back to S3_ENDPOINT when the s3 adapter's config omits endpoint", () => {
+		vi.stubEnv("S3_ENDPOINT", "https://from-env.example.com");
+		expect(getConfiguredStorageEndpoint({ entrypoint: "emdash/storage/s3", config: {} })).toBe(
+			"https://from-env.example.com",
+		);
+	});
+
+	it("explicit config endpoint wins over S3_ENDPOINT", () => {
+		vi.stubEnv("S3_ENDPOINT", "https://from-env.example.com");
+		expect(
+			getConfiguredStorageEndpoint({
+				entrypoint: "emdash/storage/s3",
+				config: { endpoint: "https://from-config.example.com" },
+			}),
+		).toBe("https://from-config.example.com");
+	});
+
+	it("does not fall back to S3_ENDPOINT for a non-s3 adapter", () => {
+		vi.stubEnv("S3_ENDPOINT", "https://from-env.example.com");
+		expect(
+			getConfiguredStorageEndpoint({ entrypoint: "emdash/storage/local", config: {} }),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when S3_ENDPOINT is unset and config has no endpoint", () => {
+		expect(
+			getConfiguredStorageEndpoint({ entrypoint: "emdash/storage/s3", config: {} }),
+		).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Media uploads for S3-compatible storage (R2, S3, Minio, etc.) do a direct browser PUT to the storage endpoint's origin. The admin's strict CSP `connect-src` only allowed `'self'` (and, if configured, the registry aggregator origin), so it blocked these signed uploads whenever the storage endpoint was a different origin than the site. `buildEmDashCsp()` now also accepts the configured storage endpoint and adds its origin to `connect-src`.

Closes #205

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: `packages/core/tests/unit/middleware/csp.test.ts`)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude (Claude Code CLI)