### PR TITLE
fix(admin): support nested menu items in the menu editor

### DIFF
--- a/.changeset/menu-editor-nesting.md
+++ b/.changeset/menu-editor-nesting.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds nested (parent/child) menu items to the admin menu editor. Items can now be assigned a parent via the edit dialog, are shown indented under their parent, and reorder buttons move an item relative to its siblings instead of the whole flat list.

--- a/.changeset/menu-editor-nesting.md
+++ b/.changeset/menu-editor-nesting.md
@@ -1,5 +1,5 @@
 ---
-"emdash": patch
+"@emdash-cms/admin": patch
 ---
 
 Adds nested (parent/child) menu items to the admin menu editor. Items can now be assigned a parent via the edit dialog, are shown indented under their parent, and reorder buttons move an item relative to its siblings instead of the whole flat list.

--- a/packages/admin/src/components/MenuEditor.tsx
+++ b/packages/admin/src/components/MenuEditor.tsx
@@ -36,6 +36,60 @@ import { DialogError, getMutationError } from "./DialogError.js";
 import { useI18nConfig } from "./LocaleSwitcher.js";
 import { TranslationsPanel } from "./TranslationsPanel.js";
 
+/** A menu item with its nesting depth, in parent-then-children display order. */
+interface DisplayItem {
+	item: MenuItem;
+	depth: number;
+}
+
+/**
+ * Flattens items into parent-then-children display order. Guards against
+ * cyclic parentId data (not currently possible via this UI, but the API
+ * doesn't validate against it either) with a visited set.
+ */
+function buildDisplayList(items: MenuItem[]): DisplayItem[] {
+	const childrenByParent = new Map<string | null, MenuItem[]>();
+	for (const item of items) {
+		const siblings = childrenByParent.get(item.parentId) ?? [];
+		siblings.push(item);
+		childrenByParent.set(item.parentId, siblings);
+	}
+
+	const result: DisplayItem[] = [];
+	const visited = new Set<string>();
+	function visit(parentId: string | null, depth: number) {
+		for (const item of childrenByParent.get(parentId) ?? []) {
+			if (visited.has(item.id)) continue;
+			visited.add(item.id);
+			result.push({ item, depth });
+			visit(item.id, depth + 1);
+		}
+	}
+	visit(null, 0);
+	return result;
+}
+
+/** IDs of `rootId` and everything nested under it, so it can't become its own descendant's child. */
+function getSelfAndDescendantIds(items: MenuItem[], rootId: string): Set<string> {
+	const childrenByParent = new Map<string | null, MenuItem[]>();
+	for (const item of items) {
+		const siblings = childrenByParent.get(item.parentId) ?? [];
+		siblings.push(item);
+		childrenByParent.set(item.parentId, siblings);
+	}
+
+	const ids = new Set<string>([rootId]);
+	function visit(parentId: string) {
+		for (const child of childrenByParent.get(parentId) ?? []) {
+			if (ids.has(child.id)) continue;
+			ids.add(child.id);
+			visit(child.id);
+		}
+	}
+	visit(rootId);
+	return ids;
+}
+
 export function MenuEditor() {
 	const { t } = useLingui();
 	const { name } = useParams({ from: "/_admin/menus/$name" });
@@ -223,6 +277,7 @@ export function MenuEditor() {
 		const uLabelVal = formData.get("label");
 		const uUrlVal = formData.get("url");
 		const uTargetVal = formData.get("target");
+		const uParentIdVal = formData.get("parentId");
 		updateMutation.mutate({
 			itemId: editingItem.id,
 			input: {
@@ -230,21 +285,29 @@ export function MenuEditor() {
 				customUrl:
 					editingItem.type === "custom" ? (typeof uUrlVal === "string" ? uUrlVal : "") : undefined,
 				target: (typeof uTargetVal === "string" ? uTargetVal : "") || undefined,
+				parentId: typeof uParentIdVal === "string" && uParentIdVal !== "" ? uParentIdVal : null,
 			},
 		});
 	};
 
-	const moveItem = (index: number, direction: "up" | "down") => {
+	// Moves an item relative to its siblings (same parentId) only, so reordering
+	// can't accidentally move an item into a different parent's children.
+	const moveItem = (itemId: string, direction: "up" | "down") => {
+		const currentItem = localItems.find((i) => i.id === itemId);
+		if (!currentItem) return;
+
+		const siblings = localItems.filter((i) => i.parentId === currentItem.parentId);
+		const siblingIndex = siblings.findIndex((i) => i.id === itemId);
+		const targetSiblingIndex = direction === "up" ? siblingIndex - 1 : siblingIndex + 1;
+		if (targetSiblingIndex < 0 || targetSiblingIndex >= siblings.length) return;
+		const targetItem = siblings[targetSiblingIndex];
+		if (!targetItem) return;
+
+		const currentPos = localItems.findIndex((i) => i.id === currentItem.id);
+		const targetPos = localItems.findIndex((i) => i.id === targetItem.id);
 		const newItems = [...localItems];
-		const targetIndex = direction === "up" ? index - 1 : index + 1;
-		if (targetIndex < 0 || targetIndex >= newItems.length) return;
-
-		const currentItem = newItems[index];
-		const targetItem = newItems[targetIndex];
-		if (!currentItem || !targetItem) return;
-
-		newItems[index] = targetItem;
-		newItems[targetIndex] = currentItem;
+		newItems[currentPos] = targetItem;
+		newItems[targetPos] = currentItem;
 
 		// Update sort orders
 		const reorderedItems = newItems.map((item, i) => ({
@@ -256,6 +319,22 @@ export function MenuEditor() {
 		setLocalItems(newItems);
 		reorderMutation.mutate({ items: reorderedItems });
 	};
+
+	const displayList = React.useMemo(() => buildDisplayList(localItems), [localItems]);
+
+	const parentOptions = React.useMemo(() => {
+		if (!editingItem) return [];
+		const excluded = getSelfAndDescendantIds(localItems, editingItem.id);
+		return [
+			{ value: "", label: t`No parent (top level)` },
+			...buildDisplayList(localItems)
+				.filter(({ item }) => !excluded.has(item.id))
+				.map(({ item, depth }) => ({
+					value: item.id,
+					label: `${"— ".repeat(depth)}${item.label}`,
+				})),
+		];
+	}, [editingItem, localItems, t]);
 
 	if (isLoading) {
 		return (
@@ -420,54 +499,62 @@ export function MenuEditor() {
 				</div>
 			) : (
 				<div className="space-y-2">
-					{localItems.map((item, index) => (
-						<div key={item.id} className="border rounded-lg p-4 flex items-center justify-between">
-							<div className="flex-1">
-								<div className="font-medium">{item.label}</div>
-								<div className="text-sm text-kumo-subtle">
-									{item.type === "custom" ? (
-										item.customUrl
-									) : (
-										<span className="inline-flex items-center rounded-full bg-kumo-brand/10 px-2 py-0.5 text-xs font-medium text-kumo-brand">
-											{item.referenceCollection ?? item.type}
-										</span>
-									)}
-									{item.target === "_blank" && t` (opens in new window)`}
+					{displayList.map(({ item, depth }) => {
+						const siblings = localItems.filter((i) => i.parentId === item.parentId);
+						const siblingIndex = siblings.findIndex((i) => i.id === item.id);
+						return (
+							<div
+								key={item.id}
+								className="border rounded-lg p-4 flex items-center justify-between"
+								style={{ marginInlineStart: `${depth * 1.5}rem` }}
+							>
+								<div className="flex-1">
+									<div className="font-medium">{item.label}</div>
+									<div className="text-sm text-kumo-subtle">
+										{item.type === "custom" ? (
+											item.customUrl
+										) : (
+											<span className="inline-flex items-center rounded-full bg-kumo-brand/10 px-2 py-0.5 text-xs font-medium text-kumo-brand">
+												{item.referenceCollection ?? item.type}
+											</span>
+										)}
+										{item.target === "_blank" && t` (opens in new window)`}
+									</div>
+								</div>
+								<div className="flex gap-2">
+									<Button
+										variant="ghost"
+										size="sm"
+										aria-label={t`Move up`}
+										onClick={() => moveItem(item.id, "up")}
+										disabled={siblingIndex === 0}
+									>
+										<CaretUp className="h-4 w-4" />
+									</Button>
+									<Button
+										variant="ghost"
+										size="sm"
+										aria-label={t`Move down`}
+										onClick={() => moveItem(item.id, "down")}
+										disabled={siblingIndex === siblings.length - 1}
+									>
+										<CaretDown className="h-4 w-4" />
+									</Button>
+									<Button variant="outline" size="sm" onClick={() => setEditingItem(item)}>
+										{t`Edit`}
+									</Button>
+									<Button
+										variant="outline"
+										size="sm"
+										aria-label={t`Delete`}
+										onClick={() => deleteMutation.mutate(item.id)}
+									>
+										<Trash className="h-4 w-4" />
+									</Button>
 								</div>
 							</div>
-							<div className="flex gap-2">
-								<Button
-									variant="ghost"
-									size="sm"
-									aria-label={t`Move up`}
-									onClick={() => moveItem(index, "up")}
-									disabled={index === 0}
-								>
-									<CaretUp className="h-4 w-4" />
-								</Button>
-								<Button
-									variant="ghost"
-									size="sm"
-									aria-label={t`Move down`}
-									onClick={() => moveItem(index, "down")}
-									disabled={index === localItems.length - 1}
-								>
-									<CaretDown className="h-4 w-4" />
-								</Button>
-								<Button variant="outline" size="sm" onClick={() => setEditingItem(item)}>
-									{t`Edit`}
-								</Button>
-								<Button
-									variant="outline"
-									size="sm"
-									aria-label={t`Delete`}
-									onClick={() => deleteMutation.mutate(item.id)}
-								>
-									<Trash className="h-4 w-4" />
-								</Button>
-							</div>
-						</div>
-					))}
+						);
+					})}
 				</div>
 			)}
 
@@ -524,6 +611,12 @@ export function MenuEditor() {
 								<Select.Option value="">{t`Same window`}</Select.Option>
 								<Select.Option value="_blank">{t`New window`}</Select.Option>
 							</Select>
+							<Select
+								label={t`Parent`}
+								name="parentId"
+								defaultValue={editingItem.parentId ?? ""}
+								items={parentOptions}
+							/>
 							<DialogError message={editError || getMutationError(updateMutation.error)} />
 							<div className="flex justify-end gap-2">
 								<Button type="button" variant="outline" onClick={() => setEditingItem(null)}>

--- a/packages/admin/src/components/MenuEditor.tsx
+++ b/packages/admin/src/components/MenuEditor.tsx
@@ -331,7 +331,7 @@ export function MenuEditor() {
 				.filter(({ item }) => !excluded.has(item.id))
 				.map(({ item, depth }) => ({
 					value: item.id,
-					label: `${"— ".repeat(depth)}${item.label}`,
+					label: <span style={{ marginInlineStart: `${depth * 1.5}rem` }}>{item.label}</span>,
 				})),
 		];
 	}, [editingItem, localItems, t]);

--- a/packages/admin/tests/components/MenuEditor.test.tsx
+++ b/packages/admin/tests/components/MenuEditor.test.tsx
@@ -233,7 +233,16 @@ describe("MenuEditor", () => {
 		await expect.element(screen.getByText("Home")).toBeInTheDocument();
 		await screen.getByRole("button", { name: "Edit" }).first().click();
 
-		await screen.getByRole("combobox", { name: "Parent" }).click();
+		await expect
+			.element(screen.getByRole("heading", { name: "Edit Menu Item" }))
+			.toBeInTheDocument();
+		// Use a native DOM click rather than a Playwright locator click: this
+		// env doesn't load Tailwind CSS, so the Dialog's `fixed` positioning
+		// class has no effect and Base UI's outside-click-capture layer (styled
+		// via inline `position: fixed`) stacks on top per normal paint order,
+		// failing Playwright's pointer-event hit test on the trigger.
+		screen.getByRole("combobox", { name: "Parent" }).element().click();
+
 		await expect.element(screen.getByRole("option", { name: "About" })).toBeInTheDocument();
 		expect(screen.getByRole("option", { name: "Home", exact: true }).query()).toBeNull();
 	});
@@ -265,8 +274,11 @@ describe("MenuEditor", () => {
 
 		const screen = await render(<MenuEditor />, { wrapper: Wrapper });
 
-		await expect.element(screen.getByText("Services")).toBeInTheDocument();
-		const servicesRow = screen.getByText("Services").element().closest("div.border");
+		await expect.element(screen.getByText("Services", { exact: true })).toBeInTheDocument();
+		const servicesRow = screen
+			.getByText("Services", { exact: true })
+			.element()
+			.closest("div.border");
 		expect((servicesRow as HTMLElement | null)?.style.marginInlineStart).toBe("1.5rem");
 	});
 
@@ -297,10 +309,13 @@ describe("MenuEditor", () => {
 
 		const screen = await render(<MenuEditor />, { wrapper: Wrapper });
 
-		await expect.element(screen.getByText("Services")).toBeInTheDocument();
+		await expect.element(screen.getByText("Services", { exact: true })).toBeInTheDocument();
 		// "Services" is Home's only child, so both its up and down buttons are
 		// disabled even though it isn't the first/last item in the flat list.
-		const servicesRow = screen.getByText("Services").element().closest("div.border") as HTMLElement;
+		const servicesRow = screen
+			.getByText("Services", { exact: true })
+			.element()
+			.closest("div.border") as HTMLElement;
 		const upBtn = servicesRow.querySelector('button[aria-label="Move up"]') as HTMLButtonElement;
 		const downBtn = servicesRow.querySelector(
 			'button[aria-label="Move down"]',

--- a/packages/admin/tests/components/MenuEditor.test.tsx
+++ b/packages/admin/tests/components/MenuEditor.test.tsx
@@ -226,4 +226,86 @@ describe("MenuEditor", () => {
 		const inputEl = urlInput.element() as HTMLInputElement;
 		expect(inputEl.validity.valid).toBe(false);
 	});
+
+	it("edit dialog shows a Parent select that excludes the item itself", async () => {
+		const screen = await render(<MenuEditor />, { wrapper: Wrapper });
+
+		await expect.element(screen.getByText("Home")).toBeInTheDocument();
+		await screen.getByRole("button", { name: "Edit" }).first().click();
+
+		await screen.getByRole("combobox", { name: "Parent" }).click();
+		await expect.element(screen.getByRole("option", { name: "About" })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "Home", exact: true }).query()).toBeNull();
+	});
+
+	it("renders nested items indented under their parent", async () => {
+		vi.mocked(api.fetchMenu).mockResolvedValue({
+			...defaultMenu,
+			items: [
+				...defaultMenu.items,
+				{
+					id: "3",
+					menuId: "menu1",
+					parentId: "1",
+					sortOrder: 0,
+					type: "custom",
+					referenceCollection: null,
+					referenceId: null,
+					customUrl: "/services",
+					label: "Services",
+					titleAttr: null,
+					target: "_self",
+					cssClasses: null,
+					createdAt: "",
+					locale: "en",
+					translationGroup: "3",
+				},
+			],
+		});
+
+		const screen = await render(<MenuEditor />, { wrapper: Wrapper });
+
+		await expect.element(screen.getByText("Services")).toBeInTheDocument();
+		const servicesRow = screen.getByText("Services").element().closest("div.border");
+		expect((servicesRow as HTMLElement | null)?.style.marginInlineStart).toBe("1.5rem");
+	});
+
+	it("reorder buttons only compare against siblings, not the whole flat list", async () => {
+		vi.mocked(api.fetchMenu).mockResolvedValue({
+			...defaultMenu,
+			items: [
+				...defaultMenu.items,
+				{
+					id: "3",
+					menuId: "menu1",
+					parentId: "1",
+					sortOrder: 0,
+					type: "custom",
+					referenceCollection: null,
+					referenceId: null,
+					customUrl: "/services",
+					label: "Services",
+					titleAttr: null,
+					target: "_self",
+					cssClasses: null,
+					createdAt: "",
+					locale: "en",
+					translationGroup: "3",
+				},
+			],
+		});
+
+		const screen = await render(<MenuEditor />, { wrapper: Wrapper });
+
+		await expect.element(screen.getByText("Services")).toBeInTheDocument();
+		// "Services" is Home's only child, so both its up and down buttons are
+		// disabled even though it isn't the first/last item in the flat list.
+		const servicesRow = screen.getByText("Services").element().closest("div.border") as HTMLElement;
+		const upBtn = servicesRow.querySelector('button[aria-label="Move up"]') as HTMLButtonElement;
+		const downBtn = servicesRow.querySelector(
+			'button[aria-label="Move down"]',
+		) as HTMLButtonElement;
+		expect(upBtn.disabled).toBe(true);
+		expect(downBtn.disabled).toBe(true);
+	});
 });

--- a/packages/admin/tests/components/MenuEditor.test.tsx
+++ b/packages/admin/tests/components/MenuEditor.test.tsx
@@ -247,6 +247,48 @@ describe("MenuEditor", () => {
 		expect(screen.getByRole("option", { name: "Home", exact: true }).query()).toBeNull();
 	});
 
+	it("edit dialog's Parent select excludes descendants to prevent cycles", async () => {
+		vi.mocked(api.fetchMenu).mockResolvedValue({
+			...defaultMenu,
+			items: [
+				...defaultMenu.items,
+				{
+					id: "3",
+					menuId: "menu1",
+					parentId: "1",
+					sortOrder: 0,
+					type: "custom",
+					referenceCollection: null,
+					referenceId: null,
+					customUrl: "/services",
+					label: "Services",
+					titleAttr: null,
+					target: "_self",
+					cssClasses: null,
+					createdAt: "",
+					locale: "en",
+					translationGroup: "3",
+				},
+			],
+		});
+
+		const screen = await render(<MenuEditor />, { wrapper: Wrapper });
+
+		await expect.element(screen.getByText("Home")).toBeInTheDocument();
+		// Home is the first row; editing it must exclude its own child (Services)
+		// from the Parent options, not just itself.
+		await screen.getByRole("button", { name: "Edit" }).first().click();
+
+		await expect
+			.element(screen.getByRole("heading", { name: "Edit Menu Item" }))
+			.toBeInTheDocument();
+		screen.getByRole("combobox", { name: "Parent" }).element().click();
+
+		await expect.element(screen.getByRole("option", { name: "About" })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "Home", exact: true }).query()).toBeNull();
+		expect(screen.getByRole("option", { name: "Services", exact: true }).query()).toBeNull();
+	});
+
 	it("renders nested items indented under their parent", async () => {
 		vi.mocked(api.fetchMenu).mockResolvedValue({
 			...defaultMenu,


### PR DESCRIPTION
## What does this PR do?

`MenuItem.parentId` was already supported end-to-end by the API and admin API client, but the MenuEditor UI never exposed it, so there was no way to build a nested menu from the admin. Adds a Parent select to the edit dialog (excluding the item itself and its descendants, to prevent cycles), renders items indented by nesting depth, and makes the up/down reorder buttons operate on siblings only instead of the whole flat list.

Closes #208

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: `packages/admin/tests/components/MenuEditor.test.tsx`, 14/14)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude (Claude Code CLI)