### PR TITLE
fix(core): send Cache-Control private, no-store on the admin shell

### DIFF
--- a/.changeset/admin-shell-no-store.md
+++ b/.changeset/admin-shell-no-store.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Sets `Cache-Control: private, no-store` on the admin shell response so shared caches never store the admin HTML. Without an explicit header, caches that apply RFC 9111 heuristic freshness (for example Cloudflare's Workers Cache) could store an authenticated 200 and replay it to anonymous visitors instead of the login redirect.

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -125,6 +125,18 @@ emdash({
 
 See [Object Cache](/deployment/object-cache/) for KV setup, options, and invalidation behavior.
 
+## Workers Cache
+
+Cloudflare's [Workers Cache](https://developers.cloudflare.com/workers/cache/) (`"cache": { "enabled": true }` in `wrangler.jsonc`) puts an edge cache **in front of** your Worker: matching requests are served without running your Worker at all. This works well with EmDash:
+
+- EmDash admin and API responses send `Cache-Control: private, no-store` and are never stored.
+- Your public pages control their own caching through the `Cache-Control` headers they return.
+
+Two things to know before enabling it:
+
+1. **Responses without a `Cache-Control` header are still cached.** Workers Cache applies RFC 9111 heuristic freshness — a `200` without any header is cached for 2 hours. Give every custom route an explicit `Cache-Control` (use `private, no-store` for anything session-dependent).
+2. **Cached pages are shared with logged-in editors.** The cache runs before your Worker, so it cannot bypass based on request cookies. A logged-in editor may receive the cached anonymous variant of a public page — without the visual editing toolbar — until the entry expires. Editor-rendered responses themselves are never stored (they carry `private, no-store`), so nothing leaks in the other direction.
+
 ## Custom Domain
 
 Add a custom domain in the Cloudflare dashboard:

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -43,6 +43,16 @@ test.describe("Authentication", () => {
 			// No allowed domains are seeded, so signup should not be visible
 			await expect(admin.page.locator('a:has-text("Sign up")')).not.toBeVisible();
 		});
+
+		test("admin shell is not storable by shared caches", async ({ request }) => {
+			// Regression: the admin shell had no Cache-Control header, so shared
+			// caches applying RFC 9111 heuristic freshness (e.g. Cloudflare's
+			// Workers Cache) could store an authenticated 200 and replay it to
+			// anonymous visitors instead of the login redirect.
+			const res = await request.get("/_emdash/admin/login");
+			expect(res.status()).toBe(200);
+			expect(res.headers()["cache-control"]).toBe("private, no-store");
+		});
 	});
 
 	test.describe("Protected Routes", () => {

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -24,6 +24,15 @@ const messages = await loadMessages(resolvedLocale);
 
 const adminConfig = Astro.locals.emdash?.config?.admin;
 const pageTitle = adminConfig?.siteName ? `${adminConfig.siteName} Admin` : "EmDash Admin";
+
+// The admin shell must never be stored by a shared cache. Without an explicit
+// Cache-Control, caches fall back to RFC 9111 heuristic freshness — e.g.
+// Cloudflare's Workers Cache stores header-less 200s for 2 hours — so an
+// authenticated editor's 200 could be replayed to anonymous visitors instead
+// of the login redirect. The shell is also personalized per request (locale
+// via cookie/Accept-Language). API routes already send `private, no-store`
+// (API_CACHE_HEADERS); this closes the same gap for the admin HTML.
+Astro.response.headers.set("Cache-Control", "private, no-store");
 ---
 
 <!doctype html>


### PR DESCRIPTION
## What does this PR do?

The admin shell response (`/_emdash/admin/[...path]`, `admin.astro`) is served without any `Cache-Control` header. Shared caches that apply RFC 9111 heuristic freshness will store it — for example, Cloudflare's new [Workers Cache](https://developers.cloudflare.com/workers/cache/) (`"cache": { "enabled": true }`) caches header-less `200`s for 2 hours. In that setup an authenticated editor's `200` shell can be replayed to anonymous visitors instead of the login redirect, and since the shell is personalized per request (locale via cookie / `Accept-Language`), the cached variant can also be wrong for the requester.

The API layer already guards against this (`API_CACHE_HEADERS` sends `private, no-store` on every API response); this closes the same gap for the admin HTML by setting `Cache-Control: private, no-store` on the shell response.

Also adds a short "Workers Cache" section to the Cloudflare deployment docs describing how EmDash behaves with the feature enabled and what to watch out for (heuristic freshness on header-less custom routes, visual-editing toolbar on cached public pages).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude

## Screenshots / test output

Added an e2e regression test (`e2e/tests/auth.spec.ts`) that requests `/_emdash/admin/login` and asserts the `cache-control: private, no-store` response header.

Verified on a deployed Cloudflare Worker with Workers Cache enabled: before the change `GET /_emdash/admin/login` returned `200` with no `Cache-Control`; after the change it returns `cache-control: private, no-store` and Workers Cache reports `BYPASS` instead of storing the shell.

`pnpm --filter emdash typecheck` and the core test suite pass locally (4269 passed; the 8 failures in `tests/unit/astro/vite-config.test.ts` are environment-only — they require a built `@emdash-cms/admin/dist`, whose build currently fails on Node 24.1.0 with `ERR_INTERNAL_ASSERTION` in lingui, unrelated to this change).
