### PR TITLE
i18n(fr): translate 79 missing keys

### DIFF
--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -456,11 +456,11 @@ msgstr "Erreurs 404"
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "410 Content Deleted (Gone)"
-msgstr ""
+msgstr "410 Contenu supprimé (Disparu)"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "451 Unavailable for legal reasons"
-msgstr ""
+msgstr "451 Indisponible pour raisons légales"
 
 #: packages/admin/src/components/WordPressImport.tsx:1365
 msgid "5. Copy the generated password"
@@ -738,7 +738,7 @@ msgstr "Aligner à droite"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
 msgid "Alignment"
-msgstr ""
+msgstr "Alignement"
 
 #: packages/admin/src/components/ContentList.tsx:283
 msgid "All"
@@ -747,7 +747,7 @@ msgstr "Tous"
 #: packages/admin/src/components/ContentList.tsx:587
 #: packages/admin/src/components/ContentList.tsx:591
 msgid "All authors"
-msgstr ""
+msgstr "Tous les auteurs"
 
 #: packages/admin/src/routes/bylines.tsx:413
 msgid "All bylines"
@@ -936,7 +936,7 @@ msgstr "archivé"
 
 #: packages/admin/src/components/ContentList.tsx:546
 msgid "Archived"
-msgstr ""
+msgstr "Archivé"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 msgid "Archives"
@@ -971,7 +971,7 @@ msgstr "Attribuez des auteurs WordPress aux utilisateurs d'EmDash. Les publicati
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:28
 msgid "Astro"
-msgstr ""
+msgstr "Astro"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 #: packages/admin/src/components/MediaLibrary.tsx:403
@@ -1075,7 +1075,7 @@ msgstr "Widgets disponibles"
 #: packages/admin/src/components/BylineAvatarField.tsx:46
 #: packages/admin/src/components/BylineAvatarField.tsx:71
 msgid "Avatar"
-msgstr ""
+msgstr "Avatar"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:257
 #: packages/admin/src/components/MenuEditor.tsx:283
@@ -1125,7 +1125,7 @@ msgstr "Retour aux thèmes"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:29
 msgid "Bash"
-msgstr ""
+msgstr "Bash"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:219
 msgid "Before send:"
@@ -1192,7 +1192,7 @@ msgstr "Schéma des auteurs"
 
 #: packages/admin/src/components/Sidebar.tsx:347
 msgid "Byline Schema"
-msgstr ""
+msgstr "Schéma des auteurs"
 
 #: packages/admin/src/components/ContentEditor.tsx:993
 #: packages/admin/src/components/Sidebar.tsx:342
@@ -1202,15 +1202,15 @@ msgstr "Auteurs"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
-msgstr ""
+msgstr "C"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:32
 msgid "C#"
-msgstr ""
+msgstr "C#"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:31
 msgid "C++"
-msgstr ""
+msgstr "C++"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -1319,7 +1319,7 @@ msgstr "Catégories ({0})"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
 msgid "Center"
-msgstr ""
+msgstr "Centré"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
@@ -1946,7 +1946,7 @@ msgstr "Création en cours..."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:33
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:78
 msgid "current"
@@ -2004,7 +2004,7 @@ msgstr "Sélecteur de date et d'heure"
 
 #: packages/admin/src/components/ContentList.tsx:604
 msgid "Date field to filter on"
-msgstr ""
+msgstr "Champ de date sur lequel filtrer"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:304
 msgid "Date Format"
@@ -2306,7 +2306,7 @@ msgstr "Vous n'avez pas reçu l'e-mail ?"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:34
 msgid "Diff"
-msgstr ""
+msgstr "Diff"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:180
 msgid "Dimensions:"
@@ -2400,7 +2400,7 @@ msgstr "Séparateur"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:35
 msgid "Dockerfile"
-msgstr ""
+msgstr "Dockerfile"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 #: packages/admin/src/components/MediaLibrary.tsx:404
@@ -2867,7 +2867,7 @@ msgstr "Échec lors de la communication avec le module d'extension"
 
 #: packages/admin/src/lib/api/media.ts:155
 msgid "Failed to confirm upload"
-msgstr ""
+msgstr "Échec lors de la confirmation du téléversement"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
@@ -2887,7 +2887,7 @@ msgstr "Échec lors de la création du champ"
 
 #: packages/admin/src/lib/api/sections.ts:88
 msgid "Failed to create section"
-msgstr ""
+msgstr "Échec lors de la création de la section"
 
 #: packages/admin/src/components/WordPressImport.tsx:1553
 msgid "Failed to create some collections"
@@ -2984,7 +2984,7 @@ msgstr "Échec lors de la désactivation du module d'extension"
 
 #: packages/admin/src/lib/api/search.ts:32
 msgid "Failed to disable search"
-msgstr ""
+msgstr "Échec lors de la désactivation de la recherche"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
@@ -3009,7 +3009,7 @@ msgstr "Échec lors de l'activation du module d'extension"
 
 #: packages/admin/src/lib/api/search.ts:31
 msgid "Failed to enable search"
-msgstr ""
+msgstr "Échec lors de l'activation de la recherche"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
@@ -3021,7 +3021,7 @@ msgstr "Échec lors de l'exécution de l'importation"
 
 #: packages/admin/src/lib/api/client.ts:227
 msgid "Failed to fetch auth mode"
-msgstr ""
+msgstr "Échec lors de la récupération du mode d'authentification"
 
 #: packages/admin/src/lib/api/schema.ts:170
 #: packages/admin/src/lib/api/schema.ts:174
@@ -3030,11 +3030,11 @@ msgstr "Échec lors de la récupération de la collection"
 
 #: packages/admin/src/lib/api/dashboard.ts:41
 msgid "Failed to fetch dashboard stats"
-msgstr ""
+msgstr "Échec lors de la récupération des statistiques du tableau de bord"
 
 #: packages/admin/src/lib/api/email-settings.ts:34
 msgid "Failed to fetch email settings"
-msgstr ""
+msgstr "Échec lors de la récupération des paramètres de messagerie"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:90
 msgid "Failed to fetch entry terms"
@@ -3046,15 +3046,15 @@ msgstr "Échec lors de la récupération du manifeste"
 
 #: packages/admin/src/lib/api/media.ts:76
 msgid "Failed to fetch media"
-msgstr ""
+msgstr "Échec lors de la récupération des fichiers multimédias"
 
 #: packages/admin/src/lib/api/media.ts:89
 msgid "Failed to fetch media item"
-msgstr ""
+msgstr "Échec lors de la récupération du fichier multimédia"
 
 #: packages/admin/src/lib/api/media.ts:325
 msgid "Failed to fetch media providers"
-msgstr ""
+msgstr "Échec lors de la récupération des fournisseurs de médias"
 
 #: packages/admin/src/lib/api/plugins.ts:59
 #: packages/admin/src/lib/api/plugins.ts:63
@@ -3063,11 +3063,11 @@ msgstr "Échec lors de la récupération du module d'extension"
 
 #: packages/admin/src/lib/api/plugins.ts:45
 msgid "Failed to fetch plugins"
-msgstr ""
+msgstr "Échec lors de la récupération des modules d'extension"
 
 #: packages/admin/src/lib/api/media.ts:355
 msgid "Failed to fetch provider media"
-msgstr ""
+msgstr "Échec lors de la récupération des fichiers multimédias du fournisseur"
 
 #: packages/admin/src/lib/api/content.ts:556
 #: packages/admin/src/lib/api/content.ts:561
@@ -3076,15 +3076,15 @@ msgstr "Échec lors de la récupération de la révision"
 
 #: packages/admin/src/lib/api/sections.ts:76
 msgid "Failed to fetch section"
-msgstr ""
+msgstr "Échec lors de la récupération de la section"
 
 #: packages/admin/src/lib/api/sections.ts:68
 msgid "Failed to fetch sections"
-msgstr ""
+msgstr "Échec lors de la récupération des sections"
 
 #: packages/admin/src/lib/api/settings.ts:50
 msgid "Failed to fetch settings"
-msgstr ""
+msgstr "Échec lors de la récupération des paramètres"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
@@ -3120,7 +3120,7 @@ msgstr "Échec lors de l'obtention des options d'inscription"
 
 #: packages/admin/src/lib/api/media.ts:131
 msgid "Failed to get upload URL"
-msgstr ""
+msgstr "Échec lors de l'obtention de l'URL de téléversement"
 
 #: packages/admin/src/components/WordPressImport.tsx:386
 msgid "Failed to import from WordPress"
@@ -3339,7 +3339,7 @@ msgstr "Échec lors de la mise à jour du domaine"
 
 #: packages/admin/src/lib/api/media.ts:276
 msgid "Failed to update media"
-msgstr ""
+msgstr "Échec lors de la mise à jour du média"
 
 #: packages/admin/src/lib/api/marketplace.ts:176
 #: packages/admin/src/lib/api/registry.ts:763
@@ -3348,11 +3348,11 @@ msgstr "Échec lors de la mise à jour du module d'extension"
 
 #: packages/admin/src/lib/api/sections.ts:100
 msgid "Failed to update section"
-msgstr ""
+msgstr "Échec lors de la mise à jour de la section"
 
 #: packages/admin/src/lib/api/settings.ts:64
 msgid "Failed to update settings"
-msgstr ""
+msgstr "Échec lors de la mise à jour des paramètres"
 
 #: packages/admin/src/router.tsx:1241
 msgid "Failed to update status"
@@ -3364,11 +3364,11 @@ msgstr "Échec lors du téléchargement du fichier"
 
 #: packages/admin/src/lib/api/media.ts:218
 msgid "Failed to upload media"
-msgstr ""
+msgstr "Échec lors du téléversement du média"
 
 #: packages/admin/src/lib/api/media.ts:377
 msgid "Failed to upload to provider"
-msgstr ""
+msgstr "Échec lors du téléversement vers le fournisseur"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:250
 msgid "Failed to verify authentication"
@@ -3464,7 +3464,7 @@ msgstr "fichiers importés"
 
 #: packages/admin/src/components/ContentList.tsx:583
 msgid "Filter by author"
-msgstr ""
+msgstr "Filtrer par auteur"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
@@ -3514,11 +3514,11 @@ msgstr "Pour une expérience d'importation optimale, installez le"
 
 #: packages/admin/src/components/ContentList.tsx:620
 msgid "From date"
-msgstr ""
+msgstr "Date de début"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
 msgid "Full"
-msgstr ""
+msgstr "Pleine largeur"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -3555,7 +3555,7 @@ msgstr "Donnez un nom à cette clé d'accès pour vous aider à l'identifier plu
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:36
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: packages/admin/src/components/WordPressImport.tsx:2224
 #: packages/admin/src/router.tsx:1967
@@ -3568,7 +3568,7 @@ msgstr "Vérification Google"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:37
 msgid "GraphQL"
-msgstr ""
+msgstr "GraphQL"
 
 #: packages/admin/src/components/MediaLibrary.tsx:277
 msgid "Grid view"
@@ -3858,7 +3858,7 @@ msgstr "Insérer une règle horizontale"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3219
 msgid "Insert HTML"
-msgstr ""
+msgstr "Insérer du HTML"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3208
 msgid "Insert Image"
@@ -3989,11 +3989,11 @@ msgstr "Jane Doe"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:39
 msgid "Java"
-msgstr ""
+msgstr "Java"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:40
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:235
 msgid "Job title"
@@ -4010,7 +4010,7 @@ msgstr "JSON"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:42
 msgid "JSX"
-msgstr ""
+msgstr "JSX"
 
 #: packages/admin/src/components/ContentEditor.tsx:1926
 msgid "Keep typing to narrow down more bylines."
@@ -4024,7 +4024,7 @@ msgstr "Mots-clés"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:43
 msgid "Kotlin"
-msgstr ""
+msgstr "Kotlin"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:232
 #: packages/admin/src/components/FieldEditor.tsx:411
@@ -4098,7 +4098,7 @@ msgstr "Laisser non attribué"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
 msgid "Left"
-msgstr ""
+msgstr "Gauche"
 
 #: packages/admin/src/components/MediaLibrary.tsx:127
 #: packages/admin/src/components/MediaLibrary.tsx:247
@@ -4368,11 +4368,11 @@ msgstr "Associer l'utilisateur WordPress {0} à l'utilisateur EmDash"
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark {0} as Gone (410)"
-msgstr ""
+msgstr "Marquer {0} comme disparu (410)"
 
 #: packages/admin/src/components/Redirects.tsx:254
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr ""
+msgstr "Marquer comme disparu (410) — indique aux moteurs de recherche que le contenu a été définitivement supprimé"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:501
 msgid "Mark as spam"
@@ -4380,7 +4380,7 @@ msgstr "Marquer comme indésirable"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:44
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 #: packages/admin/src/components/PluginManager.tsx:201
 msgid "marketplace"
@@ -4407,7 +4407,7 @@ msgstr "Valeur maximale"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:45
 msgid "MDX"
-msgstr ""
+msgstr "MDX"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2197
 #: packages/admin/src/components/Sidebar.tsx:321
@@ -5015,7 +5015,7 @@ msgstr "Aucune zone de widget pour l'instant. Créez-en une pour commencer."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
 msgid "None"
-msgstr ""
+msgstr "Aucun"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:418
 #: packages/admin/src/components/TaxonomyManager.tsx:424
@@ -5294,7 +5294,7 @@ msgstr "Autorisations"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:46
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
@@ -5308,7 +5308,7 @@ msgstr "Un simple"
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:27
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:120
 msgid "Plain text"
-msgstr ""
+msgstr "Texte brut"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:133
 msgid "Please ask your administrator to send a new invite."
@@ -5332,7 +5332,7 @@ msgstr "Module d'extension"
 
 #: packages/admin/src/lib/api/plugins.ts:57
 msgid "Plugin \"{pluginId}\" not found"
-msgstr ""
+msgstr "Module d’extension « {pluginId} » introuvable"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:749
 msgid "Plugin details"
@@ -5394,7 +5394,7 @@ msgstr "Module d'extension mis à jour"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
 msgid "Plugin widget error"
-msgstr ""
+msgstr "Erreur de widget de module d'extension"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
 #: packages/admin/src/components/PluginManager.tsx:135
@@ -5411,7 +5411,7 @@ msgstr "Dirige les moteurs de recherche vers la version originale de cette page,
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:389
 msgid "Post"
-msgstr ""
+msgstr "Article"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:397
 #: packages/admin/src/components/WordPressImport.tsx:1161
@@ -5511,7 +5511,7 @@ msgstr "Publié par"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
-msgstr ""
+msgstr "Python"
 
 #: packages/admin/src/components/ContentEditor.tsx:1996
 msgid "Quick create byline"
@@ -5759,7 +5759,7 @@ msgstr "Demander un nouveau lien"
 
 #: packages/admin/src/lib/api/client.ts:198
 msgid "Request failed"
-msgstr ""
+msgstr "La requête a échoué"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:280
 #: packages/admin/src/components/ContentTypeEditor.tsx:721
@@ -5885,7 +5885,7 @@ msgstr "Éditeur de texte enrichi"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
 msgid "Right"
-msgstr ""
+msgstr "Droite"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:311
@@ -5909,11 +5909,11 @@ msgstr "Libellé du rôle"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
-msgstr ""
+msgstr "Ruby"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:49
 msgid "Rust"
-msgstr ""
+msgstr "Rust"
 
 #: packages/admin/src/components/MenuEditor.tsx:351
 #: packages/admin/src/components/MenuEditor.tsx:353
@@ -6103,7 +6103,7 @@ msgstr "Captures d'écran"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:50
 msgid "SCSS"
-msgstr ""
+msgstr "SCSS"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 msgid "Search"
@@ -6735,7 +6735,7 @@ msgstr "Feuilles de calcul"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:51
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1758
 msgid "Start Import"
@@ -6777,11 +6777,11 @@ msgstr "Abonné"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:52
 msgid "Svelte"
-msgstr ""
+msgstr "Svelte"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:53
 msgid "Swift"
-msgstr ""
+msgstr "Swift"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
@@ -6917,7 +6917,7 @@ msgstr "La page que vous recherchez n'existe pas."
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
 msgid "The plugin field widget failed to render."
-msgstr ""
+msgstr "Le widget de champ du module d'extension n'a pas pu s'afficher."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:172
 msgid "The public URL of your site (used for canonical links and sitemaps)"
@@ -7095,7 +7095,7 @@ msgstr "Séparateur de titre"
 
 #: packages/admin/src/components/ContentList.tsx:625
 msgid "to"
-msgstr ""
+msgstr "au"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
@@ -7103,7 +7103,7 @@ msgstr "pour fermer"
 
 #: packages/admin/src/components/ContentList.tsx:629
 msgid "To date"
-msgstr ""
+msgstr "Date de fin"
 
 #: packages/admin/src/components/PluginManager.tsx:203
 msgid "to install plugins, or add them to your astro.config.mjs."
@@ -7133,7 +7133,7 @@ msgstr "Nom du jeton"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:54
 msgid "TOML"
-msgstr ""
+msgstr "TOML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 msgid "Tools → Export"
@@ -7241,7 +7241,7 @@ msgstr "Essayez avec mes données"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:55
 msgid "TSX"
-msgstr ""
+msgstr "TSX"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:282
 msgid "Turn into"
@@ -7265,7 +7265,7 @@ msgstr "Incompatibilité de type ({0})"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:56
 msgid "TypeScript"
-msgstr ""
+msgstr "TypeScript"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:131
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
@@ -7551,7 +7551,7 @@ msgstr "Identifiant adapté aux URL (p. ex. « principal », « pied-de-page
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:193
 msgid "URL:"
-msgstr ""
+msgstr "URL :"
 
 #: packages/admin/src/components/Redirects.tsx:110
 msgid "Use [param] or [...rest] in paths for pattern matching."
@@ -7713,7 +7713,7 @@ msgstr "Les visiteurs qui empruntent ces chemins verront une erreur."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:57
 msgid "Vue"
-msgstr ""
+msgstr "Vue"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
@@ -7801,7 +7801,7 @@ msgstr "Nombre entier"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
 msgid "Wide"
-msgstr ""
+msgstr "Large"
 
 #: packages/admin/src/components/Widgets.tsx:722
 #: packages/admin/src/components/Widgets.tsx:737
@@ -7870,11 +7870,11 @@ msgstr "Fichier WXR"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:58
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:59
 msgid "YAML"
-msgstr ""
+msgstr "YAML"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:420

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -7551,7 +7551,7 @@ msgstr "Identifiant adapté aux URL (p. ex. « principal », « pied-de-page
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:193
 msgid "URL:"
-msgstr "URL :"
+msgstr "URL :"
 
 #: packages/admin/src/components/Redirects.tsx:110
 msgid "Use [param] or [...rest] in paths for pattern matching."


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Update the French translation to translate the 79 missing keys.

Edit: I never know what is the policy for translations regarding changeset... I can see some i18n PR use changesets, but not all... So please let me know if I should add a changeset, so that I don't forget next time! 😄 Because in a way it "affects a published package"...

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

N/A

<!-- Optional. Include if the change is visual or if you want to show test results. -->
