### PR TITLE
fix(menus): resolve content-picker collection items to the entry URL, not the archive

### DIFF
--- a/.changeset/menu-collection-entry-links.md
+++ b/.changeset/menu-collection-entry-links.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes menu items added via the admin content picker from a custom collection linking to the collection archive (`/projects/`) instead of the selected entry (`/projects/widget-co`). Entry references now resolve like page and post items, including `urlPattern` support and per-locale resolution; items whose referenced entry no longer exists are hidden instead of pointing at the archive. Archive links (collection items without an entry reference) are unchanged.

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -235,7 +235,23 @@ async function resolveMenuItem(
 				break;
 
 			case "collection":
-				url = `/${item.reference_collection}/`;
+				// Two shapes share this type: the admin content picker stores
+				// entries from custom collections as "collection" with a
+				// reference_id, while archive links carry only the collection
+				// slug. Entry references resolve like page/post items.
+				if (!item.reference_collection) return null;
+				if (item.reference_id) {
+					url = await resolveContentUrl(
+						item.reference_collection,
+						item.reference_id,
+						db,
+						urlPatterns,
+						locale,
+					);
+					if (url === null) return null;
+				} else {
+					url = `/${item.reference_collection}/`;
+				}
 				break;
 
 			default:

--- a/packages/core/tests/unit/menus/menus.test.ts
+++ b/packages/core/tests/unit/menus/menus.test.ts
@@ -8,6 +8,7 @@ import { createDatabase } from "../../../src/database/connection.js";
 import { runMigrations } from "../../../src/database/migrations/runner.js";
 import type { Database } from "../../../src/database/types.js";
 import { getMenuWithDb, getMenusWithDb } from "../../../src/menus/index.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { sanitizeHref } from "../../../src/utils/url.js";
 
 describe("Navigation Menus", () => {
@@ -394,6 +395,117 @@ describe("Navigation Menus", () => {
 			expect(menu!.items[0].label).toBe("Home");
 			expect(menu!.items[1].label).toBe("About");
 			expect(menu!.items[2].label).toBe("Contact");
+		});
+	});
+
+	describe("collection menu items", () => {
+		// The admin content picker stores entries from custom collections
+		// (anything that isn't pages/posts) as type "collection" with
+		// referenceCollection + referenceId. The resolver used to ignore the
+		// reference_id for this type and emit the archive URL, so picking
+		// "Widget Co" from a "projects" collection produced a menu link to
+		// /projects/ instead of the entry.
+
+		async function setupProjectsCollection(urlPattern?: string): Promise<void> {
+			const registry = new SchemaRegistry(db);
+			await registry.createCollection({
+				slug: "projects",
+				label: "Projects",
+				labelSingular: "Project",
+				urlPattern,
+			});
+		}
+
+		async function insertMenuWithCollectionItem(item: {
+			referenceCollection?: string | null;
+			referenceId?: string | null;
+		}): Promise<void> {
+			const menuId = ulid();
+			await db
+				.insertInto("_emdash_menus")
+				.values({ id: menuId, name: "primary", label: "Primary" })
+				.execute();
+			await db
+				.insertInto("_emdash_menu_items")
+				.values({
+					id: ulid(),
+					menu_id: menuId,
+					sort_order: 0,
+					type: "collection",
+					reference_collection: item.referenceCollection ?? null,
+					reference_id: item.referenceId ?? null,
+					label: "Projects",
+				})
+				.execute();
+		}
+
+		it("resolves entry references from the content picker to the entry URL", async () => {
+			await setupProjectsCollection();
+			await sql`
+				INSERT INTO ec_projects (id, slug, locale, translation_group)
+				VALUES ('proj-1', 'widget-co', 'en', 'group-proj-1')
+			`.execute(db);
+			await insertMenuWithCollectionItem({
+				referenceCollection: "projects",
+				referenceId: "group-proj-1",
+			});
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(1);
+			expect(menu!.items[0].url).toBe("/projects/widget-co");
+		});
+
+		it("applies the collection url_pattern to entry references", async () => {
+			await setupProjectsCollection("/work/{slug}");
+			await sql`
+				INSERT INTO ec_projects (id, slug, locale, translation_group)
+				VALUES ('proj-1', 'widget-co', 'en', 'group-proj-1')
+			`.execute(db);
+			await insertMenuWithCollectionItem({
+				referenceCollection: "projects",
+				referenceId: "group-proj-1",
+			});
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(1);
+			expect(menu!.items[0].url).toBe("/work/widget-co");
+		});
+
+		it("resolves items without a reference_id to the collection archive URL", async () => {
+			// Archive links (no entry reference) keep their root-relative
+			// /{collection}/ shape — the same URL shape as every other
+			// same-site item type.
+			await setupProjectsCollection();
+			await insertMenuWithCollectionItem({ referenceCollection: "projects" });
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(1);
+			expect(menu!.items[0].url).toBe("/projects/");
+		});
+
+		it("skips entry references whose content row no longer exists", async () => {
+			// Same contract as page/post items: an unresolvable reference
+			// hides the item instead of rendering a dead link.
+			await setupProjectsCollection();
+			await insertMenuWithCollectionItem({
+				referenceCollection: "projects",
+				referenceId: "group-gone",
+			});
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(0);
+		});
+
+		it("skips items with no reference_collection instead of linking /null/", async () => {
+			await insertMenuWithCollectionItem({});
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(0);
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

Menu items added through the admin content picker from a custom collection (anything that isn't `pages`/`posts`) link to the collection archive instead of the picked entry.

The admin's `MenuEditor` maps those picks to `type: "collection"` with `referenceCollection` + `referenceId`, and the API schema documents that non-custom types "resolve a URL from `referenceCollection` + `referenceId`" — but `resolveMenuItem()`'s `case "collection"` ignored `reference_id` entirely and always returned `/{collection}/`. Picking "Widget Co" from a `projects` collection produced a nav link to `/projects/`.

This PR makes entry references resolve the same way `page`/`post` items do (shared `resolveContentUrl`, so `urlPattern` interpolation and per-locale resolution apply), while archive links keep their current behavior:

- `type: "collection"` + `reference_id` → entry URL (`/projects/widget-co`, or the collection's `urlPattern`); the item is hidden if the referenced entry no longer exists, matching the page/post contract.
- `type: "collection"` without `reference_id` → archive URL `/{collection}/`, unchanged.
- `type: "collection"` with no `reference_collection` → item hidden (previously rendered `href="/null/"`).

Found while building a theme on EmDash and auditing how each menu item type resolves. Tests cover all five shapes above; the entry-reference and url_pattern tests fail on `main` (`expected '/projects/' to be '/projects/widget-co'`).

Issue: none filed.

Two small related observations from the same audit — happy to open a Discussion for either:

- `getMenu(name)` is an exact-match lookup, so `getMenu("primary")` misses a menu saved as `Primary`. Would you take a documented lowercase-name convention in the docs, or a case-insensitive lookup?
- The admin has no first-class way to add a collection-archive link (the picker only picks entries), so archive nav items end up as hand-typed custom links — often pasted as absolute URLs, which bakes the deployment origin into nav data.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI strings changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

- Failing test on `main` before the fix: `AssertionError: expected '/projects/' to be '/projects/widget-co'`
- `pnpm --filter emdash exec vitest run tests/unit/menus/` → 52 passed
- Full core suite after the fix: 314 test files, 4282 tests, all passed
- `pnpm lint:json | jq '.diagnostics | length'` → `0` (clean before and after)
- `pnpm typecheck` → pass (workspace)
- `pnpm format` → ran
- Changeset added (`emdash`, patch)
