### PR TITLE
fix(e2e): dismiss the first-login welcome modal deterministically in devBypassAuth

### DIFF
--- a/e2e/fixtures/admin.ts
+++ b/e2e/fixtures/admin.ts
@@ -28,11 +28,34 @@ export class AdminPage {
 	 * Navigates through the bypass URLs which sets cookies in the browser context.
 	 */
 	async devBypassAuth(): Promise<void> {
-		// Navigate to setup bypass - this sets up the site AND creates a session
-		// The redirect param sends us to auth bypass to ensure cookies are set
-		await this.page.goto("/_emdash/api/setup/dev-bypass?redirect=/_emdash/admin/");
+		// Set up the site and establish a session, landing on the shell-free
+		// auth/me JSON endpoint instead of the admin shell. The shell opens
+		// the first-login welcome modal whenever its currentUser query
+		// resolves with isFirstLogin — on a cold workerd start that can be
+		// seconds after the sidebar renders, after dismissOnboardingModal()'s
+		// 2s visibility window has passed, leaving the modal covering the
+		// page (actions run 28678460523, E2E Cloudflare shard 3/8). Clearing
+		// the flag before the shell ever loads removes the race instead of
+		// retiming it.
+		// The bypass redirects via meta refresh, and its ?redirect= query
+		// contains the auth/me path — so match on pathname, not the full URL,
+		// or the wait resolves on the bypass page itself and the next goto
+		// races the pending redirect.
+		await this.page.goto("/_emdash/api/setup/dev-bypass?redirect=/_emdash/api/auth/me");
+		await this.page.waitForURL((url) => url.pathname === "/_emdash/api/auth/me", {
+			timeout: 30000,
+		});
 
-		// Wait for the redirect to complete and admin shell to appear
+		// page.request shares the session cookie; X-EmDash-Request is the
+		// CSRF header the auth middleware requires on state-changing routes.
+		const dismissed = await this.page.request.post("/_emdash/api/auth/me", {
+			headers: { "X-EmDash-Request": "1" },
+			data: { action: "dismissWelcome" },
+		});
+		expect(dismissed.status()).toBe(200);
+
+		// Load the admin shell with the first-login flag already cleared.
+		await this.page.goto(`${this.baseUrl}/`);
 		await this.page.waitForURL(ADMIN_URL_PATTERN, { timeout: 30000 });
 
 		// Wait for page to be usable. Race networkidle (Vite dep re-optimization) against


### PR DESCRIPTION
## What does this PR do?

Removes a timing race in the E2E auth fixture that intermittently fails unrelated PRs on the Cloudflare suite.

The admin shell opens the first-login "Welcome to EmDash" modal whenever its `currentUser` query resolves with `isFirstLogin` — on a cold workerd start that can be several seconds after the sidebar renders. `AdminPage.waitForShell()` only dismisses the modal if it is visible within a 2-second window, so when the query resolves late the modal survives and swallows the test's clicks/assertions.

Observed in the wild on [actions run 28678460523, E2E Cloudflare (3/8)](https://github.com/emdash-cms/emdash/actions/runs/28678460523/job/85056808697) (failing #1810, whose diff touches only the menus resolver): `content-types.spec.ts › displays seeded collections in a table` failed with `element(s) not found` for the table links, and the Playwright error context shows the page covered by `dialog "Welcome to EmDash, Dev!"`. The equivalent SQLite shard and the other seven Cloudflare shards passed.

The fix makes the standard auth path deterministic instead of retiming the race:

- `devBypassAuth()` now lands the bypass redirect on the shell-free `/_emdash/api/auth/me` JSON endpoint, clears the flag server-side (`POST /_emdash/api/auth/me` with `action: "dismissWelcome"`, via `page.request` so the session cookie and CSRF header are supplied), and only then loads the admin shell — so the shell's first `currentUser` fetch already reports `isFirstLogin: false` and the modal can never mount.
- The existing UI-side `dismissOnboardingModal()` fallback in `waitForShell()` is left in place for flows that authenticate outside the bypass (e.g. the setup-wizard spec's real first-run path).

No product code changes; the fixture ends in the same post-condition as before (authenticated, dashboard loaded, shell hydrated).

Issue: none filed — happy to open one instead if you prefer tracking flakes that way.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable) — the change is itself test infrastructure; affected specs run green on both targets (output below)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). N/A: E2E fixture only.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package). N/A: test-only change, no published package touched.
- [ ] New features link to an approved Discussion: N/A, test fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

- `pnpm exec playwright test e2e/tests/content-types.spec.ts e2e/tests/setup-wizard.spec.ts` → **17 passed** (42.0s)
- `EMDASH_E2E_TARGET=cloudflare pnpm exec playwright test e2e/tests/content-types.spec.ts e2e/tests/setup-wizard.spec.ts` → **17 passed** (52.7s)
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm format` → ran
