### PR TITLE
fix(ci): allow fork checkout in query-counts-apply workflow

### DIFF
--- a/.github/workflows/query-counts-apply.yml
+++ b/.github/workflows/query-counts-apply.yml
@@ -154,6 +154,12 @@ jobs:
           repository: ${{ steps.pr.outputs.full_name }}
           ref: ${{ steps.pr.outputs.sha }}
           persist-credentials: false
+          # Safe here: this job never executes the fork's code, it only
+          # checks out the tree to apply the inert JSON snapshot artifact
+          # and push it back (see "Apply snapshots" / "Commit and push
+          # (fork)" below). actions/checkout added this opt-in requirement
+          # for workflow_run checkouts of fork PRs; see gh.io/securely-using-pull_request_target.
+          allow-unsafe-pr-checkout: true
 
       - name: Apply snapshots
         if: steps.download.outputs.found == 'true'


### PR DESCRIPTION
## What does this PR do?

`Query Counts — Apply` has been failing for every fork PR since `actions/checkout` started refusing fork checkouts inside a `workflow_run` trigger unless `allow-unsafe-pr-checkout: true` is set (failing run: https://github.com/emdash-cms/emdash/actions/runs/28683600625).

This job never executes the fork's code -- it only applies an inert JSON snapshot artifact and pushes back via an app token, matching the existing zizmor.yml threat-model note already on file for this workflow. Added the opt-in flag with a comment explaining why it's safe.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes -- n/a, no package code changed (workflow YAML only)
- [ ] `pnpm lint` passes -- n/a, no package code changed
- [ ] `pnpm test` passes -- n/a, no package code changed
- [ ] `pnpm format` has been run -- n/a, YAML not covered by oxfmt
- [ ] I have added/updated tests for my changes -- n/a, GitHub Actions workflow, no test harness for CI config
- [ ] User-visible strings -- n/a, no admin UI touched
- [ ] Changeset -- n/a, no published package changed
- [ ] New features link to an approved Discussion -- n/a, bug fix not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Sonnet 5

## Screenshots / test output

Failing run this fixes: https://github.com/emdash-cms/emdash/actions/runs/28683600625