### PR TITLE
fix(core): auto-select FTS5 snippet column instead of hardcoding title

### DIFF
--- a/.changeset/search-snippet-auto-column.md
+++ b/.changeset/search-snippet-auto-column.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+---
+
+Fixes search results always showing the title as the "snippet," even when the
+search term only appeared in the body. The snippet now reflects whichever field
+actually matched.

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -290,7 +290,9 @@ async function searchSingleCollection(
 	// Using raw SQL because Kysely doesn't have FTS5 support
 	const bm25Expr = bm25Args ? `bm25("${ftsTable}", ${bm25Args})` : `bm25("${ftsTable}")`;
 
-	// Snippet column index is 2 (after id=0, locale=1, first searchable field=2)
+	// Negative column index tells FTS5 to scan every indexed column and
+	// extract the snippet from whichever one has the most matching
+	// tokens, instead of always the first searchable field (title).
 	let results;
 	try {
 		results = await sql<{
@@ -306,7 +308,7 @@ async function searchSingleCollection(
 			c.slug,
 			c.locale,
 			${titleExpr} as title,
-			snippet("${sql.raw(ftsTable)}", 2, '<mark>', '</mark>', '...', 32) as snippet,
+			snippet("${sql.raw(ftsTable)}", -1, '<mark>', '</mark>', '...', 32) as snippet,
 			${sql.raw(bm25Expr)} as score
 		FROM "${sql.raw(ftsTable)}" f
 		JOIN "${sql.raw(contentTable)}" c ON f.id = c.id

--- a/packages/core/tests/integration/search/snippet-sanitization.test.ts
+++ b/packages/core/tests/integration/search/snippet-sanitization.test.ts
@@ -92,12 +92,14 @@ describe("search snippet sanitization", () => {
 	});
 
 	it("does not crash when the snippet column is NULL", async () => {
-		// FTS triggers insert raw column values with no COALESCE, so any
-		// row whose title (the column the snippet() call targets) is
-		// NULL produces a NULL snippet from SQLite — even when the row
-		// matched via a different searchable column. A regression that
-		// drops the null-guard throws "Cannot read properties of null
-		// (reading 'replace')" before these assertions can run.
+		// FTS triggers insert raw column values with no COALESCE, so a
+		// snippet column that is NULL for a given row produces a NULL
+		// snippet from SQLite. With automatic column selection (-1) this
+		// is rare in practice — SQLite only picks a column that has a
+		// match, and a matched row always has a match in *some* column —
+		// but the guard stays cheap insurance. A regression that drops it
+		// throws "Cannot read properties of null (reading 'replace')"
+		// before these assertions can run.
 		const registry = new SchemaRegistry(db);
 		await registry.updateField("post", "content", { searchable: true });
 		const ftsManager = new FTSManager(db);
@@ -130,6 +132,45 @@ describe("search snippet sanitization", () => {
 		// Whether the snippet ends up as a string or undefined doesn't
 		// matter — the contract is "the search call must not throw".
 		expect(typeof items[0]!.snippet === "string" || items[0]!.snippet === undefined).toBe(true);
+	});
+
+	it("snippet reflects the field that actually matched, not always the title", async () => {
+		// Title never mentions the query term; only the body does. With the
+		// hardcoded column-2 (title) snippet, this row's snippet would be
+		// the title text and would NOT contain the matched word. With
+		// automatic column selection it must.
+		const registry = new SchemaRegistry(db);
+		await registry.updateField("post", "content", { searchable: true });
+		const ftsManager = new FTSManager(db);
+		await ftsManager.enableSearch("post");
+
+		await repo.create(
+			createPostFixture({
+				slug: "houston-mention",
+				status: "published",
+				data: {
+					title: "Weekend Roundup",
+					content: [
+						{
+							_type: "block",
+							style: "normal",
+							children: [{ _type: "span", text: "The team drove to Houston for the game." }],
+						},
+					],
+				},
+			}),
+		);
+
+		const { items } = await searchWithDb(db, "Houston", {
+			collections: ["post"],
+		});
+
+		expect(items).toHaveLength(1);
+		const snippet = items[0]!.snippet ?? "";
+
+		expect(snippet).not.toBe("Weekend Roundup");
+		expect(snippet.toLowerCase()).toContain("houston");
+		expect(snippet).toMatch(/<mark>Houston<\/mark>/i);
 	});
 
 	it("preserves `<mark>` highlight tags as live HTML", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes search snippets always showing the title verbatim, even when the search term
only matched in the body. `searchSingleCollection` called FTS5's `snippet()` with a
hardcoded column index of `2` (always the first searchable field / title). Switches
to FTS5's automatic column-selection mode (`-1`), so the snippet is drawn from
whichever indexed column actually contains the match.

Closes #1817

Note: if a query only matches a rich-text (Portable Text) body field, the
auto-selected snippet may show raw Portable Text JSON tokens rather than
clean prose — plain-text extraction isn't wired into indexing yet (tracked
as follow-up in #1817). Title/plain-text-field matches are unaffected.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: `packages/core/tests/integration/search`, `packages/core/tests/unit/search` — 14/14)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no admin UI strings touched)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion (n/a — bug fix, not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5

## Screenshots / test output

```
RUN  v4.1.5
 Test Files  4 passed (4)
      Tests  14 passed (14)
```

