### PR TITLE
docs: add Edge Caching guide (Workers Cache + tag purge)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -222,6 +222,7 @@ export default defineConfig({
 						{ label: "Database Options", slug: "deployment/database" },
 						{ label: "Storage Options", slug: "deployment/storage" },
 						{ label: "Object Cache", slug: "deployment/object-cache" },
+						{ label: "Edge Caching", slug: "deployment/edge-cache" },
 					],
 				},
 				{

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -159,6 +159,8 @@ Two things to know before enabling it:
 1. **Responses without a `Cache-Control` header are still cached.** Workers Cache applies RFC 9111 heuristic freshness — a `200` without any header is cached for 2 hours. Give every custom route an explicit `Cache-Control` (use `private, no-store` for anything session-dependent).
 2. **Cached pages are shared with logged-in editors.** The cache runs before your Worker, so it cannot bypass based on request cookies. A logged-in editor may receive the cached anonymous variant of a public page — without the visual editing toolbar — until the entry expires. Editor-rendered responses themselves are never stored (they carry `private, no-store`), so nothing leaks in the other direction.
 
+To cache rendered HTML with route rules and purge it by tag when content changes, see [Edge Caching](/deployment/edge-cache/).
+
 ## Custom Domain
 
 Add a custom domain in the Cloudflare dashboard:

--- a/docs/src/content/docs/deployment/edge-cache.mdx
+++ b/docs/src/content/docs/deployment/edge-cache.mdx
@@ -1,0 +1,146 @@
+---
+title: Edge Caching
+description: Cache rendered HTML in the Cloudflare Workers Cache and purge it by tag when content changes.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The [object cache](/deployment/object-cache/) stores query results, but every request still renders HTML inside the Worker. Edge caching stores the rendered HTML response itself in the [Cloudflare Workers Cache](https://developers.cloudflare.com/workers/configuration/workers-cache/), so a cache hit is served at the edge and never invokes the Worker. Combined with cache tags and a purge hook, pages stay cached for days while a publish becomes visible within seconds.
+
+This guide uses [Astro's route caching](https://docs.astro.build/en/guides/caching/) with the Cloudflare cache provider, and applies to Cloudflare deployments only. The two caches are complementary: the edge cache serves repeat requests, the object cache makes the remaining renders cheap.
+
+<Aside type="caution">
+	The Workers Cache and its tag-based purge API (`cache.purge` from
+	`cloudflare:workers`) are in beta and not available on every account. Check
+	whether the **Cache** toggle appears on your Worker in the Cloudflare
+	dashboard. Without purge access, keep `maxAge` short and rely on
+	`swr` instead of purging.
+</Aside>
+
+## Enable the Workers Cache
+
+Enable the cache for your Worker in the Wrangler configuration:
+
+```jsonc title="wrangler.jsonc"
+{
+	"cache": { "enabled": true },
+}
+```
+
+## Configure route caching
+
+Register the Cloudflare cache provider and declare which routes may be cached, for how long, and under which tags:
+
+```js title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import cloudflare from "@astrojs/cloudflare";
+import { cacheCloudflare } from "@astrojs/cloudflare/cache";
+import emdash from "emdash/astro";
+import { d1, r2 } from "@emdash-cms/cloudflare";
+
+export default defineConfig({
+	output: "server",
+	adapter: cloudflare(),
+	cache: {
+		provider: cacheCloudflare(),
+	},
+	routeRules: {
+		"/": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
+		"/blog": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
+		"/blog/[slug]": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
+		"/sitemap.xml": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
+	},
+	integrations: [
+		emdash({
+			database: d1({ binding: "DB" }),
+			storage: r2({ binding: "MEDIA" }),
+		}),
+	],
+});
+```
+
+- `maxAge` is how long the edge serves the entry without contacting the Worker. It can be generous when a purge hook (below) removes stale entries on publish.
+- `swr` lets the edge keep serving a stale entry while it revalidates in the background, so visitors never wait on a cold render.
+- `tags` name the entry for purging. A useful convention is one broad tag on every cached route (`pages`, the emergency switch that clears everything) plus one tag per collection the page renders.
+
+The provider turns these rules into `Cloudflare-CDN-Cache-Control` and `Cache-Tag` response headers. The edge consumes both; clients never see them, and any `Cache-Control` header your pages set for browsers is unaffected.
+
+Routes without a matching rule are stamped `Cloudflare-CDN-Cache-Control: no-store`, so the admin panel, authenticated routes, and mutating API endpoints stay uncached without extra configuration. Only list routes that are safe to serve identically to every visitor.
+
+## Purge on publish
+
+Content lifecycle hooks can purge the affected tags whenever an entry is saved or deleted, so a publish reaches visitors in seconds even with a long `maxAge`. The following native plugin purges the tags for the saved entry's collection (see [Hook Reference](/reference/hooks/) for the hook surface):
+
+```ts title="src/plugins/edge-cache-purge.ts"
+import { definePlugin } from "emdash";
+
+const TAGS: Record<string, string[]> = {
+	posts: ["posts"],
+	pages: ["pages"],
+};
+
+async function purgeEdgeCache(collection: string, ctx) {
+	const tags = TAGS[collection] ?? ["pages"];
+	try {
+		// `cloudflare:workers` exists only at Worker runtime; a top-level
+		// import would break `astro dev` and the build.
+		const { cache } = await import("cloudflare:workers");
+		if (!cache?.purge) return;
+		await cache.purge({ tags });
+		ctx.log.info("edge cache purged", { collection, tags });
+	} catch (error) {
+		ctx.log.warn("edge cache purge failed", { collection, error: String(error) });
+	}
+}
+
+export default definePlugin({
+	id: "edge-cache-purge",
+	version: "1.0.0",
+	hooks: {
+		"content:afterSave": (event, ctx) => purgeEdgeCache(event.collection, ctx),
+		"content:afterDelete": (event, ctx) => purgeEdgeCache(event.collection, ctx),
+	},
+});
+```
+
+Purging on every save — including drafts — is a reasonable default: an unnecessary purge costs one cold render, while a missed purge serves stale content for up to `maxAge`. Keep the handler best-effort so a purge failure never blocks a save.
+
+## Keep responses out of the cache
+
+Route rules match the request path, so they also apply to responses you do not want cached under a long TTL. Opt out per request with `Astro.cache.set()`.
+
+### Preview links
+
+Preview URLs carry a signed token as a query parameter, and each query variant is cached separately — a preview response would otherwise sit in the edge cache under its token URL after the token expires. Disable caching when draft content is served:
+
+```astro title="src/pages/blog/[slug].astro"
+---
+const { entry, isPreview } = await getEmDashEntry("posts", Astro.params.slug);
+if (isPreview) Astro.cache.set(false);
+---
+```
+
+### Error responses
+
+A 404 or 500 rendered on a cached route would inherit the rule's TTL. Setting `Astro.cache.set(false)` keeps errors out of the cache entirely. For 404s on high-traffic dynamic routes, a short TTL is often better than no caching — it absorbs bot and retry traffic to dead slugs without invoking the Worker each time:
+
+```astro title="src/pages/blog/[slug].astro"
+if (!entry) {
+	Astro.cache.set({ maxAge: 60, tags: ["pages", "posts"] });
+	Astro.response.status = 404;
+}
+```
+
+The tags matter here: if the slug is published within those 60 seconds, the purge hook also removes the cached 404.
+
+### Redirects in middleware
+
+Middleware that short-circuits with a redirect (for example, host canonicalization) must opt out with `context.cache.set(false)`. When several hostnames route to the same Worker, a cached redirect can otherwise be served to requests for the canonical hostname as well — an instant redirect loop.
+
+## Editors and cached pages
+
+The edge cache stores one shared variant per URL. The editor toolbar is injected only into responses rendered for an authenticated editor, and those responses are marked `private, no-store` — they are never stored in a shared cache. An editor browsing the public site is therefore usually served the cached anonymous variant, without the toolbar. Preview links and edit mode force uncached renders and are unaffected. Improving the toolbar experience behind shared caches is tracked in [discussion #1742](https://github.com/emdash-cms/emdash/discussions/1742).
+
+## Browser caching is separate
+
+The edge cache can afford long TTLs because it is purgeable; browser caches are not. Keep the `Cache-Control` header your pages send to clients short (minutes, not days), so a publish also reaches returning visitors quickly. `stale-while-revalidate` in that header gives returning visitors instant loads while their browser revalidates in the background.

--- a/docs/src/content/docs/deployment/edge-cache.mdx
+++ b/docs/src/content/docs/deployment/edge-cache.mdx
@@ -3,7 +3,7 @@ title: Edge Caching
 description: Cache rendered HTML in the Cloudflare Workers Cache and purge it by tag when content changes.
 ---
 
-The [object cache](/deployment/object-cache/) stores query results, but every request still renders HTML inside the Worker. Edge caching stores the rendered HTML response itself in the [Cloudflare Workers Cache](https://developers.cloudflare.com/workers/configuration/workers-cache/), so a cache hit is served at the edge and never invokes the Worker. Combined with cache tags and EmDash's built-in purging, pages stay cached for days while a publish becomes visible within seconds.
+The [object cache](/deployment/object-cache/) stores query results, but every request still renders HTML inside the Worker. Edge caching stores the rendered HTML response itself in the [Cloudflare Workers Cache](https://developers.cloudflare.com/workers/cache/), so a cache hit is served at the edge and never invokes the Worker. Combined with cache tags and EmDash's built-in purging, pages stay cached for days while a publish becomes visible within seconds.
 
 This guide uses [Astro's route caching](https://docs.astro.build/en/guides/caching/) with the Cloudflare cache provider, and applies to Cloudflare deployments only. The two caches are complementary: the edge cache serves repeat requests, the object cache makes the remaining renders cheap.
 

--- a/docs/src/content/docs/deployment/edge-cache.mdx
+++ b/docs/src/content/docs/deployment/edge-cache.mdx
@@ -3,29 +3,9 @@ title: Edge Caching
 description: Cache rendered HTML in the Cloudflare Workers Cache and purge it by tag when content changes.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
-
-The [object cache](/deployment/object-cache/) stores query results, but every request still renders HTML inside the Worker. Edge caching stores the rendered HTML response itself in the [Cloudflare Workers Cache](https://developers.cloudflare.com/workers/configuration/workers-cache/), so a cache hit is served at the edge and never invokes the Worker. Combined with cache tags and a purge hook, pages stay cached for days while a publish becomes visible within seconds.
+The [object cache](/deployment/object-cache/) stores query results, but every request still renders HTML inside the Worker. Edge caching stores the rendered HTML response itself in the [Cloudflare Workers Cache](https://developers.cloudflare.com/workers/configuration/workers-cache/), so a cache hit is served at the edge and never invokes the Worker. Combined with cache tags and EmDash's built-in purging, pages stay cached for days while a publish becomes visible within seconds.
 
 This guide uses [Astro's route caching](https://docs.astro.build/en/guides/caching/) with the Cloudflare cache provider, and applies to Cloudflare deployments only. The two caches are complementary: the edge cache serves repeat requests, the object cache makes the remaining renders cheap.
-
-<Aside type="caution">
-	The Workers Cache and its tag-based purge API (`cache.purge` from
-	`cloudflare:workers`) are in beta and not available on every account. Check
-	whether the **Cache** toggle appears on your Worker in the Cloudflare
-	dashboard. Without purge access, keep `maxAge` short and rely on
-	`swr` instead of purging.
-</Aside>
-
-## Enable the Workers Cache
-
-Enable the cache for your Worker in the Wrangler configuration:
-
-```jsonc title="wrangler.jsonc"
-{
-	"cache": { "enabled": true },
-}
-```
 
 ## Configure route caching
 
@@ -45,10 +25,10 @@ export default defineConfig({
 		provider: cacheCloudflare(),
 	},
 	routeRules: {
-		"/": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
-		"/blog": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
-		"/blog/[slug]": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
-		"/sitemap.xml": { maxAge: 86_400, swr: 604_800, tags: ["pages", "posts"] },
+		"/": { maxAge: 86_400, swr: 604_800, tags: ["posts", "pages"] },
+		"/blog": { maxAge: 86_400, swr: 604_800, tags: ["posts"] },
+		"/blog/[slug]": { maxAge: 86_400, swr: 604_800, tags: ["posts"] },
+		"/sitemap.xml": { maxAge: 86_400, swr: 604_800, tags: ["posts", "pages"] },
 	},
 	integrations: [
 		emdash({
@@ -59,51 +39,23 @@ export default defineConfig({
 });
 ```
 
-- `maxAge` is how long the edge serves the entry without contacting the Worker. It can be generous when a purge hook (below) removes stale entries on publish.
+- `maxAge` is how long the edge serves the entry without contacting the Worker. It can be generous because EmDash purges stale entries on publish (below).
 - `swr` lets the edge keep serving a stale entry while it revalidates in the background, so visitors never wait on a cold render.
-- `tags` name the entry for purging. A useful convention is one broad tag on every cached route (`pages`, the emergency switch that clears everything) plus one tag per collection the page renders.
+- `tags` name the entry for purging. Tag each route with the collections it renders, using the collection names — EmDash's built-in invalidation purges by collection name, so matching tags are purged automatically. A broad extra tag on every cached route (here `pages`) works as an emergency switch that clears everything at once.
 
 The provider turns these rules into `Cloudflare-CDN-Cache-Control` and `Cache-Tag` response headers. The edge consumes both; clients never see them, and any `Cache-Control` header your pages set for browsers is unaffected.
 
 Routes without a matching rule are stamped `Cloudflare-CDN-Cache-Control: no-store`, so the admin panel, authenticated routes, and mutating API endpoints stay uncached without extra configuration. Only list routes that are safe to serve identically to every visitor.
 
-## Purge on publish
+When a cache provider is configured, the `@astrojs/cloudflare` adapter enables the Workers Cache automatically: the build writes `"cache": { "enabled": true }` into the generated Wrangler configuration that `wrangler deploy` picks up. No manual Wrangler changes are needed.
 
-Content lifecycle hooks can purge the affected tags whenever an entry is saved or deleted, so a publish reaches visitors in seconds even with a long `maxAge`. The following native plugin purges the tags for the saved entry's collection (see [Hook Reference](/reference/hooks/) for the hook surface):
+EmDash's own `cloudflareCache()` provider from `@emdash-cms/cloudflare` predates Astro's route caching and is deprecated in favor of the setup shown here.
 
-```ts title="src/plugins/edge-cache-purge.ts"
-import { definePlugin } from "emdash";
+## Purge on publish is built-in
 
-const TAGS: Record<string, string[]> = {
-	posts: ["posts"],
-	pages: ["pages"],
-};
+No plugin or hook is required. EmDash's content API routes invalidate the route cache whenever an entry changes: saving, publishing, unpublishing, deleting, restoring, or duplicating an entry purges the tags `[collection, id]`, and scheduled publishing purges the same tags from the cron sweep. Any route rule tagged with the collection name (as above) is therefore refreshed within seconds of a publish, even with a long `maxAge`.
 
-async function purgeEdgeCache(collection: string, ctx) {
-	const tags = TAGS[collection] ?? ["pages"];
-	try {
-		// `cloudflare:workers` exists only at Worker runtime; a top-level
-		// import would break `astro dev` and the build.
-		const { cache } = await import("cloudflare:workers");
-		if (!cache?.purge) return;
-		await cache.purge({ tags });
-		ctx.log.info("edge cache purged", { collection, tags });
-	} catch (error) {
-		ctx.log.warn("edge cache purge failed", { collection, error: String(error) });
-	}
-}
-
-export default definePlugin({
-	id: "edge-cache-purge",
-	version: "1.0.0",
-	hooks: {
-		"content:afterSave": (event, ctx) => purgeEdgeCache(event.collection, ctx),
-		"content:afterDelete": (event, ctx) => purgeEdgeCache(event.collection, ctx),
-	},
-});
-```
-
-Purging on every save — including drafts — is a reasonable default: an unnecessary purge costs one cold render, while a missed purge serves stale content for up to `maxAge`. Keep the handler best-effort so a purge failure never blocks a save.
+This is also why the tag convention matters: EmDash purges the *collection name* as a tag. If your route rules use other tag names, the built-in purge will not match them and stale entries survive until `maxAge` expires.
 
 ## Keep responses out of the cache
 
@@ -111,7 +63,7 @@ Route rules match the request path, so they also apply to responses you do not w
 
 ### Preview links
 
-Preview URLs carry a signed token as a query parameter, and each query variant is cached separately — a preview response would otherwise sit in the edge cache under its token URL after the token expires. Disable caching when draft content is served:
+Preview URLs carry a signed token as a query parameter (`?_preview=…`), and each query variant is cached separately. EmDash marks preview responses `Cache-Control: private, no-store`, but that header governs browsers and downstream CDNs — it does not opt a response out of the Workers Cache, which follows the route rule. Without an opt-out, the preview variant is stored at the edge under its token URL; once cached, it is served without invoking the Worker, so no token verification runs and the draft content remains reachable after the token expires. Disable caching when draft content is served:
 
 ```astro title="src/pages/blog/[slug].astro"
 ---
@@ -131,7 +83,7 @@ if (!entry) {
 }
 ```
 
-The tags matter here: if the slug is published within those 60 seconds, the purge hook also removes the cached 404.
+The tags matter here: if the slug is published within those 60 seconds, the built-in purge also removes the cached 404.
 
 ### Redirects in middleware
 

--- a/docs/src/content/docs/deployment/object-cache.mdx
+++ b/docs/src/content/docs/deployment/object-cache.mdx
@@ -113,7 +113,7 @@ The object cache covers the reads that run on a typical page render:
 - Content queries: `getEmDashCollection`, `getEmDashEntry`, and `resolveEmDashPath`.
 - Site settings, navigation menus, and taxonomy terms.
 
-Admin API requests, media files, and full HTML responses are not handled here. To cache rendered HTML at the edge, see [Deploy to Cloudflare](/deployment/cloudflare/).
+Admin API requests, media files, and full HTML responses are not handled here. To cache rendered HTML at the edge, see [Edge Caching](/deployment/edge-cache/).
 
 ## Freshness
 


### PR DESCRIPTION
## What does this PR do?

Adds a deployment guide (`/deployment/edge-cache/`) for caching rendered HTML in the Cloudflare Workers Cache via Astro route caching: the `cacheCloudflare` provider + `routeRules`, tag-based purge-on-publish through `content:afterSave`/`content:afterDelete` hooks, and the responses that must opt out of the edge cache (preview-token requests, error responses, middleware redirects).

It also registers the page in the docs sidebar (after Object Cache), adds an "Edge Caching" section to `deployment/cloudflare.mdx` pointing to the new page, and fixes the cross-link in `object-cache.mdx`, which sent readers to `/deployment/cloudflare/` for edge HTML caching although that page had no such section.

This grew out of the context around discussion #1742 (editors behind shared caches seeing stale content): the page documents the shared-cache behavior editors will encounter and links back to that discussion.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Note: docs-only change (MDX + sidebar entry), no package code touched, so the full typecheck/lint/test suites were not run locally — relying on repo CI. The docs site itself builds locally: `pnpm --filter docs build` completes successfully and renders `/deployment/edge-cache/`.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Fable 5

## Screenshots / test output

Local docs build:

```
[build] Server built in 19.76s
[build] Complete!
```
