### PR TITLE
fix(core): reclaim object-cache epoch reads orphaned by cancelled requests

### DIFF
--- a/.changeset/object-cache-epoch-cancelled-owner.md
+++ b/.changeset/object-cache-epoch-cancelled-owner.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes object-cache reads hanging indefinitely after a request was cancelled mid-read. A namespace epoch read started by a request that disconnects (for example a bot aborting on a 404) could leave a never-settling shared promise behind, wedging every later read of that namespace until the isolate was recycled. Waiting requests now bound the shared read with their own timer, dead reads are reclaimed after a deadline, and in-flight reads survive the originating request's cancellation where the platform allows.

--- a/packages/core/src/object-cache/index.ts
+++ b/packages/core/src/object-cache/index.ts
@@ -77,6 +77,55 @@ interface EpochEntry {
 	at: number;
 	/** In-flight read, so concurrent callers share one backend round-trip. */
 	promise?: Promise<number>;
+	/**
+	 * `Date.now()` at which the in-flight read started. Callers use it to
+	 * decide whether the read's owner can still be alive (see
+	 * {@link epochReadDeadline}) — past the deadline the promise is presumed
+	 * dead and the next caller reclaims by starting a fresh read.
+	 */
+	promiseAt?: number;
+}
+
+/**
+ * Extra time past the configured read timeout before an in-flight epoch read
+ * is presumed dead. A live owner's read settles within `timeout` (enforced by
+ * {@link withTimeout}), so the grace only needs to absorb scheduling jitter.
+ */
+const EPOCH_READ_GRACE_MS = 1_000;
+
+/**
+ * How long an in-flight epoch read may be trusted. A read older than this can
+ * only exist because its owning request was cancelled mid-await — on workerd
+ * a cancelled request's continuations never run, *including the timeout's own
+ * `setTimeout` callback*, so the shared promise never settles and is never
+ * replaced. With the timeout disabled (`timeout: 0`) the default is used as
+ * the deadline; the worst case of guessing too short is one duplicate
+ * backend read.
+ */
+function epochReadDeadline(): number {
+	const timeout = holder.config.timeout > 0 ? holder.config.timeout : DEFAULT_TIMEOUT_MS;
+	return timeout + EPOCH_READ_GRACE_MS;
+}
+
+/**
+ * Await another request's in-flight epoch read, bounded by the waiter's own
+ * timer. The bare promise must never be awaited across requests: if the
+ * owning request is cancelled, the promise never settles (see
+ * {@link epochReadDeadline}) and an unguarded waiter hangs until the isolate
+ * is evicted. The race timer below belongs to the *waiter's* request context
+ * and therefore always fires; on timeout the waiter degrades to `fallback`
+ * (the last known epoch), the same contract as a failed backend read.
+ */
+function raceInFlightEpochRead(
+	promise: Promise<number>,
+	ms: number,
+	fallback: number,
+): Promise<number> {
+	let timer: ReturnType<typeof setTimeout>;
+	const timeout = new Promise<number>((resolve) => {
+		timer = setTimeout(resolve, Math.max(ms, 1), fallback);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 const BACKEND_KEY = Symbol.for("emdash:object-cache:backend");
@@ -263,7 +312,17 @@ async function getEpoch(namespace: string, backend: ObjectCacheBackend): Promise
 	if (cached && now - cached.at < holder.config.revalidate) {
 		return cached.value;
 	}
-	if (cached?.promise) return cached.promise;
+	if (cached?.promise) {
+		// Share the in-flight read only while its owner can still be alive,
+		// and never await it bare (a cancelled owner's promise never settles;
+		// see epochReadDeadline). Past the deadline, fall through and reclaim
+		// with a fresh read — the dead entry is overwritten below.
+		const age = now - (cached.promiseAt ?? 0);
+		const deadline = epochReadDeadline();
+		if (age < deadline) {
+			return raceInFlightEpochRead(cached.promise, deadline - age, cached.value);
+		}
+	}
 
 	const promise = (async () => {
 		let value: number;
@@ -287,12 +346,28 @@ async function getEpoch(namespace: string, backend: ObjectCacheBackend): Promise
 		return merged;
 	})();
 
-	// Concurrent callers share this in-flight read (dedup). The timeout above
-	// guarantees `promise` settles — its success/catch handler then replaces
-	// this entry with a fresh, promise-free one — so a stalled backend can no
-	// longer pin the namespace to a never-settling promise (the bug that
-	// poisoned an isolate until it was recycled).
-	epochCache.set(namespace, { value: cached?.value ?? 0, at: cached?.at ?? 0, promise });
+	// Anchor the read on the host's lifetime extender: if the owning request
+	// is cancelled mid-await, the anchored copy keeps the read alive so it
+	// still settles and its handler replaces this entry with a fresh,
+	// promise-free one. Where no extender exists, the deadline reclaim above
+	// recovers instead.
+	after(() =>
+		promise.then(
+			() => undefined,
+			() => undefined,
+		),
+	);
+
+	// Concurrent callers share this in-flight read (dedup) — bounded by their
+	// own timers via raceInFlightEpochRead, never awaited bare. The timeout
+	// above makes a live owner's read settle; `promiseAt` lets callers detect
+	// a dead one (cancelled owner) and reclaim.
+	epochCache.set(namespace, {
+		value: cached?.value ?? 0,
+		at: cached?.at ?? 0,
+		promise,
+		promiseAt: now,
+	});
 	return promise;
 }
 

--- a/packages/core/tests/unit/object-cache.test.ts
+++ b/packages/core/tests/unit/object-cache.test.ts
@@ -317,6 +317,93 @@ describe("cachedQuery", () => {
 		expect(load).toHaveBeenCalledTimes(1);
 	});
 
+	it("reclaims an epoch read whose owner was cancelled and never settles", async () => {
+		// On workerd a cancelled request's continuations never run — including
+		// the epoch read's own timeout timer — so the shared in-flight promise
+		// neither settles nor gets replaced. Simulated here with a get that
+		// never settles and a timeout too long to fire during the test; the
+		// deadline check is driven by Date.now, not timers.
+		const store = new Map<string, string>();
+		let stallEpoch = true;
+		const backend: ObjectCacheBackend = {
+			get: (key) => {
+				if (stallEpoch && key.includes(":epoch:")) return new Promise<string | null>(() => {});
+				return Promise.resolve(store.get(key) ?? null);
+			},
+			set: (key, value) => {
+				store.set(key, value);
+				return Promise.resolve();
+			},
+			delete: (key) => {
+				store.delete(key);
+				return Promise.resolve();
+			},
+		};
+		__setObjectCacheBackendForTests(backend, { revalidate: 0, defaultTtl: 3600, timeout: 5000 });
+
+		const load = vi.fn(() => Promise.resolve({ n: 1 }));
+
+		// The cancelled owner: parks on the epoch read and is never awaited.
+		void cachedQuery({ namespace: "posts", key: "k", load }).catch(() => {});
+		await flush();
+
+		// Past the read deadline (timeout + grace) the owner is presumed dead:
+		// the next caller must start a fresh read instead of joining the dead
+		// promise — which, on a recovered backend, settles normally.
+		const realNow = Date.now();
+		vi.spyOn(Date, "now").mockReturnValue(realNow + 6001);
+		stallEpoch = false;
+
+		await expect(cachedQuery({ namespace: "posts", key: "k", load })).resolves.toEqual({
+			n: 1,
+		});
+		expect(load).toHaveBeenCalledTimes(1);
+		vi.restoreAllMocks();
+	});
+
+	it("bounds a waiter on a foreign in-flight epoch read with its own timer", async () => {
+		// A waiter must never await another request's epoch-read promise bare:
+		// if the owner was cancelled the promise never settles. The waiter's
+		// race timer belongs to the waiter's own (live) request, so the query
+		// degrades to the last-known epoch instead of hanging.
+		const store = new Map<string, string>();
+		const backend: ObjectCacheBackend = {
+			get: (key) => {
+				if (key.includes(":epoch:")) return new Promise<string | null>(() => {}); // never settles
+				return Promise.resolve(store.get(key) ?? null);
+			},
+			set: (key, value) => {
+				store.set(key, value);
+				return Promise.resolve();
+			},
+			delete: (key) => {
+				store.delete(key);
+				return Promise.resolve();
+			},
+		};
+		__setObjectCacheBackendForTests(backend, {
+			revalidate: 0,
+			defaultTtl: 3600,
+			timeout: 20_000,
+		});
+
+		const load = vi.fn(() => Promise.resolve({ n: 1 }));
+
+		// The cancelled owner parks on the epoch read.
+		void cachedQuery({ namespace: "posts", key: "k", load }).catch(() => {});
+		await flush();
+
+		// A waiter arriving late in the share window: its remaining bound is
+		// short, so its own timer fires and the query settles. (Unfixed, the
+		// waiter awaits the dead promise and hangs past the test timeout.)
+		const realNow = Date.now();
+		vi.spyOn(Date, "now").mockReturnValue(realNow + 20_900);
+		await expect(cachedQuery({ namespace: "posts", key: "k", load })).resolves.toEqual({
+			n: 1,
+		});
+		vi.restoreAllMocks();
+	});
+
 	it("self-heals after a stalled read instead of poisoning the namespace", async () => {
 		// First the backend stalls (epoch + value reads hang); after the timeout
 		// the namespace must recover and serve from cache on a healthy backend.


### PR DESCRIPTION
## What does this PR do?

Fixes #1821

`getEpoch` stores the in-flight namespace epoch read in the isolate-global `epochCache`, and later callers awaited that shared promise bare. On workerd, a request cancelled mid-await never runs its continuations — including the read's own timeout timer — so the shared promise never settles and every later read of that namespace hangs until the isolate is evicted. Observed in production as repeat requests to the same 404 slug hanging >30 s with `outcome: canceled` and ~0 CPU. This is the same hazard class as the session-store fix in #1538 and the documented init-lock/single-flight-cache contract ("never await a promise created by another request").

The fix keeps the dedup but makes it cancellation-safe:

1. **Bounded waiters** — a caller that finds a foreign in-flight read races it against its *own* timer (which belongs to the waiter's request context and therefore always fires) and degrades to the last-known epoch on timeout, matching the existing "backend errors are non-fatal" semantics.
2. **Deadline reclaim** — the cache entry records when the read started; a read older than the timeout plus grace means the owner is dead, and the next caller reclaims the entry with a fresh read instead of joining the dead one.
3. **Anchored read** — the owner's read is anchored via `after()`/waitUntil, so where the platform allows, a cancelled originator's read still settles and publishes instead of wedging.

Includes two regression tests and a changeset.

Verified failing-test-first: with the `index.ts` fix stashed, both new tests fail (time out awaiting the never-settling shared promise); with the fix restored, all 23 tests in `tests/unit/object-cache.test.ts` pass.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Fable 5

## Screenshots / test output

Targeted file (`pnpm --filter emdash test run tests/unit/object-cache.test.ts`): 23/23 passed.

Full core suite (`pnpm --filter emdash test run`): 4271 passed, 8 failed — all 8 failures are pre-existing and unrelated (`tests/unit/astro/vite-config.test.ts` cannot resolve `@emdash-cms/admin/dist`, whose build crashes locally on a Node 24.1.0 internal ESM bug, `ERR_INTERNAL_ASSERTION: Unexpected module status 3`).
