### PR TITLE
fix(settings): use Kumo toasts for save feedback

### DIFF
--- a/.changeset/settings-notice-styling.md
+++ b/.changeset/settings-notice-styling.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Updates admin settings success and error feedback to use Kumo toasts across settings pages.

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -67,7 +67,8 @@ export function AllowedDomainsSettings() {
 		},
 		onError: (mutationError) => {
 			toastManager.add({
-				title: mutationError instanceof Error ? mutationError.message : t`Failed to add domain`,
+				title: t`Failed to add domain`,
+				description: mutationError instanceof Error ? mutationError.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});
@@ -90,7 +91,8 @@ export function AllowedDomainsSettings() {
 		},
 		onError: (mutationError) => {
 			toastManager.add({
-				title: mutationError instanceof Error ? mutationError.message : t`Failed to update domain`,
+				title: t`Failed to update domain`,
+				description: mutationError instanceof Error ? mutationError.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});
@@ -107,7 +109,8 @@ export function AllowedDomainsSettings() {
 		},
 		onError: (mutationError) => {
 			toastManager.add({
-				title: mutationError instanceof Error ? mutationError.message : t`Failed to remove domain`,
+				title: t`Failed to remove domain`,
+				description: mutationError instanceof Error ? mutationError.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -5,17 +5,9 @@
  * is configured, this page shows an informational message instead.
  */
 
-import { Button, Dialog, Input, Select, Switch } from "@cloudflare/kumo";
+import { Button, Dialog, Input, Select, Switch, useKumoToastManager } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import {
-	Globe,
-	Plus,
-	CheckCircle,
-	WarningCircle,
-	Trash,
-	Pencil,
-	Info,
-} from "@phosphor-icons/react";
+import { Globe, Plus, Trash, Pencil, Info } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -35,13 +27,10 @@ export function AllowedDomainsSettings() {
 	const { t } = useLingui();
 	const { getRoleLabel, signupRoles, signupRoleItems } = useAllowedDomainsRolesConfig();
 	const queryClient = useQueryClient();
+	const toastManager = useKumoToastManager();
 	const [isAddingDomain, setIsAddingDomain] = React.useState(false);
 	const [editingDomain, setEditingDomain] = React.useState<AllowedDomain | null>(null);
 	const [deletingDomain, setDeletingDomain] = React.useState<string | null>(null);
-	const [saveStatus, setSaveStatus] = React.useState<{
-		type: "success" | "error";
-		message: string;
-	} | null>(null);
 
 	// Form state
 	const [newDomain, setNewDomain] = React.useState("");
@@ -66,14 +55,6 @@ export function AllowedDomainsSettings() {
 		enabled: !isExternalAuth && !manifestLoading,
 	});
 
-	// Clear status message after 3 seconds
-	React.useEffect(() => {
-		if (saveStatus) {
-			const timer = setTimeout(setSaveStatus, 3000, null);
-			return () => clearTimeout(timer);
-		}
-	}, [saveStatus]);
-
 	// Create mutation
 	const createMutation = useMutation({
 		mutationFn: createAllowedDomain,
@@ -82,12 +63,13 @@ export function AllowedDomainsSettings() {
 			setIsAddingDomain(false);
 			setNewDomain("");
 			setNewRole(30);
-			setSaveStatus({ type: "success", message: t`Domain added successfully` });
+			toastManager.add({ title: t`Domain added successfully`, variant: "success", timeout: 3000 });
 		},
 		onError: (mutationError) => {
-			setSaveStatus({
-				type: "error",
-				message: mutationError instanceof Error ? mutationError.message : t`Failed to add domain`,
+			toastManager.add({
+				title: mutationError instanceof Error ? mutationError.message : t`Failed to add domain`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -104,13 +86,13 @@ export function AllowedDomainsSettings() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["allowed-domains"] });
 			setEditingDomain(null);
-			setSaveStatus({ type: "success", message: t`Domain updated` });
+			toastManager.add({ title: t`Domain updated`, variant: "success", timeout: 3000 });
 		},
 		onError: (mutationError) => {
-			setSaveStatus({
-				type: "error",
-				message:
-					mutationError instanceof Error ? mutationError.message : t`Failed to update domain`,
+			toastManager.add({
+				title: mutationError instanceof Error ? mutationError.message : t`Failed to update domain`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -121,13 +103,13 @@ export function AllowedDomainsSettings() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["allowed-domains"] });
 			setDeletingDomain(null);
-			setSaveStatus({ type: "success", message: t`Domain removed` });
+			toastManager.add({ title: t`Domain removed`, variant: "success", timeout: 3000 });
 		},
 		onError: (mutationError) => {
-			setSaveStatus({
-				type: "error",
-				message:
-					mutationError instanceof Error ? mutationError.message : t`Failed to remove domain`,
+			toastManager.add({
+				title: mutationError instanceof Error ? mutationError.message : t`Failed to remove domain`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -214,24 +196,6 @@ export function AllowedDomainsSettings() {
 	return (
 		<div className="space-y-6">
 			{settingsHeader}
-
-			{/* Status message */}
-			{saveStatus && (
-				<div
-					className={`flex items-center gap-2 rounded-lg border p-3 text-sm ${
-						saveStatus.type === "success"
-							? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950/30 dark:text-green-200"
-							: "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200"
-					}`}
-				>
-					{saveStatus.type === "success" ? (
-						<CheckCircle className="h-4 w-4 flex-shrink-0" />
-					) : (
-						<WarningCircle className="h-4 w-4 flex-shrink-0" />
-					)}
-					{saveStatus.message}
-				</div>
-			)}
 
 			{/* Domains Section */}
 			<div className="rounded-lg border bg-kumo-base p-6">

--- a/packages/admin/src/components/settings/EmailSettings.tsx
+++ b/packages/admin/src/components/settings/EmailSettings.tsx
@@ -5,7 +5,7 @@
  * sending a test email through the full pipeline.
  */
 
-import { Button, Input, Loader } from "@cloudflare/kumo";
+import { Button, Input, Loader, useKumoToastManager } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	CheckCircle,
@@ -27,18 +27,8 @@ import { BackToSettingsLink } from "./BackToSettingsLink.js";
 
 export function EmailSettings() {
 	const { t } = useLingui();
+	const toastManager = useKumoToastManager();
 	const [testEmail, setTestEmail] = React.useState("");
-	const [status, setStatus] = React.useState<{
-		type: "success" | "error";
-		message: string;
-	} | null>(null);
-
-	// Clear status after 5 seconds
-	React.useEffect(() => {
-		if (!status) return;
-		const timer = setTimeout(setStatus, 5000, null);
-		return () => clearTimeout(timer);
-	}, [status]);
 
 	const {
 		data: settings,
@@ -52,13 +42,14 @@ export function EmailSettings() {
 	const testMutation = useMutation({
 		mutationFn: (to: string) => sendTestEmail(to),
 		onSuccess: (result) => {
-			setStatus({ type: "success", message: result.message });
+			toastManager.add({ title: result.message, variant: "success", timeout: 5000 });
 			setTestEmail("");
 		},
 		onError: (error) => {
-			setStatus({
-				type: "error",
-				message: getMutationError(error) || t`Failed to send test email`,
+			toastManager.add({
+				title: getMutationError(error) || t`Failed to send test email`,
+				variant: "error",
+				timeout: 5000,
 			});
 		},
 	});
@@ -99,24 +90,6 @@ export function EmailSettings() {
 				<BackToSettingsLink />
 				<h1 className="text-2xl font-bold">{t`Email Settings`}</h1>
 			</div>
-
-			{/* Status banner */}
-			{status && (
-				<div
-					className={`flex items-center gap-2 rounded-lg border p-3 text-sm ${
-						status.type === "success"
-							? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950/30 dark:text-green-200"
-							: "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200"
-					}`}
-				>
-					{status.type === "success" ? (
-						<CheckCircle className="h-4 w-4 flex-shrink-0" />
-					) : (
-						<WarningCircle className="h-4 w-4 flex-shrink-0" />
-					)}
-					{status.message}
-				</div>
-			)}
 
 			{/* Pipeline status */}
 			<div className="rounded-lg border bg-kumo-base p-6">

--- a/packages/admin/src/components/settings/EmailSettings.tsx
+++ b/packages/admin/src/components/settings/EmailSettings.tsx
@@ -47,7 +47,8 @@ export function EmailSettings() {
 		},
 		onError: (error) => {
 			toastManager.add({
-				title: getMutationError(error) || t`Failed to send test email`,
+				title: t`Failed to send test email`,
+				description: getMutationError(error) || t`An error occurred`,
 				variant: "error",
 				timeout: 5000,
 			});

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -47,7 +47,8 @@ export function GeneralSettings() {
 		},
 		onError: (error) => {
 			toastManager.add({
-				title: error instanceof Error ? error.message : t`Failed to save settings`,
+				title: t`Failed to save settings`,
+				description: error instanceof Error ? error.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -5,9 +5,9 @@
  * (posts per page, date format, timezone).
  */
 
-import { Button, Input, Label } from "@cloudflare/kumo";
+import { Button, Input, Label, useKumoToastManager } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { FloppyDisk, CheckCircle, WarningCircle, Upload, X } from "@phosphor-icons/react";
+import { FloppyDisk, WarningCircle, Upload, X } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -19,6 +19,7 @@ import { BackToSettingsLink } from "./BackToSettingsLink.js";
 export function GeneralSettings() {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const toastManager = useKumoToastManager();
 
 	const { data: settings, isLoading } = useQuery({
 		queryKey: ["settings"],
@@ -27,11 +28,6 @@ export function GeneralSettings() {
 	});
 
 	const [formData, setFormData] = React.useState<Partial<SiteSettings>>({});
-	const [saveStatus, setSaveStatus] = React.useState<{
-		type: "success" | "error";
-		message: string;
-	} | null>(null);
-
 	const [logoPickerOpen, setLogoPickerOpen] = React.useState(false);
 	const [faviconPickerOpen, setFaviconPickerOpen] = React.useState(false);
 
@@ -39,23 +35,21 @@ export function GeneralSettings() {
 		if (settings) setFormData(settings);
 	}, [settings]);
 
-	React.useEffect(() => {
-		if (saveStatus) {
-			const timer = setTimeout(setSaveStatus, 3000, null);
-			return () => clearTimeout(timer);
-		}
-	}, [saveStatus]);
-
 	const saveMutation = useMutation({
 		mutationFn: (data: Partial<SiteSettings>) => updateSettings(data),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["settings"] });
-			setSaveStatus({ type: "success", message: t`Settings saved successfully` });
+			toastManager.add({
+				title: t`Settings saved successfully`,
+				variant: "success",
+				timeout: 3000,
+			});
 		},
 		onError: (error) => {
-			setSaveStatus({
-				type: "error",
-				message: error instanceof Error ? error.message : t`Failed to save settings`,
+			toastManager.add({
+				title: error instanceof Error ? error.message : t`Failed to save settings`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -128,24 +122,6 @@ export function GeneralSettings() {
 			>
 				<h1 className="text-2xl font-bold truncate">{t`General Settings`}</h1>
 			</EditorHeader>
-
-			{/* Status banner */}
-			{saveStatus && (
-				<div
-					className={`flex items-center gap-2 rounded-lg border p-3 text-sm ${
-						saveStatus.type === "success"
-							? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950/30 dark:text-green-200"
-							: "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200"
-					}`}
-				>
-					{saveStatus.type === "success" ? (
-						<CheckCircle className="h-4 w-4 flex-shrink-0" />
-					) : (
-						<WarningCircle className="h-4 w-4 flex-shrink-0" />
-					)}
-					{saveStatus.message}
-				</div>
-			)}
 
 			<form id="general-settings-form" onSubmit={handleSubmit} className="space-y-6">
 				{/* Site Identity */}

--- a/packages/admin/src/components/settings/SecuritySettings.tsx
+++ b/packages/admin/src/components/settings/SecuritySettings.tsx
@@ -50,7 +50,8 @@ export function SecuritySettings() {
 		},
 		onError: (mutationError) => {
 			toastManager.add({
-				title: mutationError instanceof Error ? mutationError.message : t`Failed to rename passkey`,
+				title: t`Failed to rename passkey`,
+				description: mutationError instanceof Error ? mutationError.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});
@@ -66,7 +67,8 @@ export function SecuritySettings() {
 		},
 		onError: (mutationError) => {
 			toastManager.add({
-				title: mutationError instanceof Error ? mutationError.message : t`Failed to remove passkey`,
+				title: t`Failed to remove passkey`,
+				description: mutationError instanceof Error ? mutationError.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});
@@ -183,7 +185,8 @@ export function SecuritySettings() {
 								onSuccess={handleAddSuccess}
 								onError={(registrationError) =>
 									toastManager.add({
-										title: registrationError.message,
+										title: t`Failed to add passkey`,
+										description: registrationError.message,
 										variant: "error",
 										timeout: 3000,
 									})

--- a/packages/admin/src/components/settings/SecuritySettings.tsx
+++ b/packages/admin/src/components/settings/SecuritySettings.tsx
@@ -5,9 +5,9 @@
  * is configured, this page shows an informational message instead.
  */
 
-import { Button } from "@cloudflare/kumo";
+import { Button, useKumoToastManager } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { Shield, Plus, CheckCircle, WarningCircle, Info } from "@phosphor-icons/react";
+import { Shield, Plus, Info } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -19,11 +19,8 @@ import { PasskeyList } from "./PasskeyList";
 export function SecuritySettings() {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const toastManager = useKumoToastManager();
 	const [isAdding, setIsAdding] = React.useState(false);
-	const [saveStatus, setSaveStatus] = React.useState<{
-		type: "success" | "error";
-		message: string;
-	} | null>(null);
 
 	// Fetch manifest for auth mode
 	const { data: manifest, isLoading: manifestLoading } = useQuery({
@@ -44,26 +41,18 @@ export function SecuritySettings() {
 		enabled: !isExternalAuth && !manifestLoading,
 	});
 
-	// Clear status message after 3 seconds
-	React.useEffect(() => {
-		if (saveStatus) {
-			const timer = setTimeout(setSaveStatus, 3000, null);
-			return () => clearTimeout(timer);
-		}
-	}, [saveStatus]);
-
 	// Rename mutation
 	const renameMutation = useMutation({
 		mutationFn: ({ id, name }: { id: string; name: string }) => renamePasskey(id, name),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
-			setSaveStatus({ type: "success", message: t`Passkey renamed` });
+			toastManager.add({ title: t`Passkey renamed`, variant: "success", timeout: 3000 });
 		},
 		onError: (mutationError) => {
-			setSaveStatus({
-				type: "error",
-				message:
-					mutationError instanceof Error ? mutationError.message : t`Failed to rename passkey`,
+			toastManager.add({
+				title: mutationError instanceof Error ? mutationError.message : t`Failed to rename passkey`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -73,13 +62,13 @@ export function SecuritySettings() {
 		mutationFn: (id: string) => deletePasskey(id),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
-			setSaveStatus({ type: "success", message: t`Passkey removed` });
+			toastManager.add({ title: t`Passkey removed`, variant: "success", timeout: 3000 });
 		},
 		onError: (mutationError) => {
-			setSaveStatus({
-				type: "error",
-				message:
-					mutationError instanceof Error ? mutationError.message : t`Failed to remove passkey`,
+			toastManager.add({
+				title: mutationError instanceof Error ? mutationError.message : t`Failed to remove passkey`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -95,7 +84,7 @@ export function SecuritySettings() {
 	const handleAddSuccess = () => {
 		void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
 		setIsAdding(false);
-		setSaveStatus({ type: "success", message: t`Passkey added successfully` });
+		toastManager.add({ title: t`Passkey added successfully`, variant: "success", timeout: 3000 });
 	};
 
 	const settingsHeader = (
@@ -152,24 +141,6 @@ export function SecuritySettings() {
 		<div className="space-y-6">
 			{settingsHeader}
 
-			{/* Status message */}
-			{saveStatus && (
-				<div
-					className={`flex items-center gap-2 rounded-lg border p-3 text-sm ${
-						saveStatus.type === "success"
-							? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950/30 dark:text-green-200"
-							: "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200"
-					}`}
-				>
-					{saveStatus.type === "success" ? (
-						<CheckCircle className="h-4 w-4 flex-shrink-0" />
-					) : (
-						<WarningCircle className="h-4 w-4 flex-shrink-0" />
-					)}
-					{saveStatus.message}
-				</div>
-			)}
-
 			{/* Passkeys Section */}
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<div className="flex items-center gap-2 mb-4">
@@ -211,9 +182,10 @@ export function SecuritySettings() {
 								verifyEndpoint="/_emdash/api/auth/passkey/register/verify"
 								onSuccess={handleAddSuccess}
 								onError={(registrationError) =>
-									setSaveStatus({
-										type: "error",
-										message: registrationError.message,
+									toastManager.add({
+										title: registrationError.message,
+										variant: "error",
+										timeout: 3000,
 									})
 								}
 								showNameInput

--- a/packages/admin/src/components/settings/SeoSettings.tsx
+++ b/packages/admin/src/components/settings/SeoSettings.tsx
@@ -4,16 +4,9 @@
  * Title separator, search engine verification codes, and robots.txt.
  */
 
-import { Button, Input, InputArea, Label } from "@cloudflare/kumo";
+import { Button, Input, InputArea, Label, useKumoToastManager } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import {
-	FloppyDisk,
-	CheckCircle,
-	WarningCircle,
-	MagnifyingGlass,
-	Upload,
-	X,
-} from "@phosphor-icons/react";
+import { FloppyDisk, WarningCircle, MagnifyingGlass, Upload, X } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -25,6 +18,7 @@ import { BackToSettingsLink } from "./BackToSettingsLink.js";
 export function SeoSettings() {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const toastManager = useKumoToastManager();
 
 	const { data: settings, isLoading } = useQuery({
 		queryKey: ["settings"],
@@ -33,33 +27,23 @@ export function SeoSettings() {
 	});
 
 	const [formData, setFormData] = React.useState<Partial<SiteSettings>>({});
-	const [saveStatus, setSaveStatus] = React.useState<{
-		type: "success" | "error";
-		message: string;
-	} | null>(null);
 	const [ogImagePickerOpen, setOgImagePickerOpen] = React.useState(false);
 
 	React.useEffect(() => {
 		if (settings) setFormData(settings);
 	}, [settings]);
 
-	React.useEffect(() => {
-		if (saveStatus) {
-			const timer = setTimeout(setSaveStatus, 3000, null);
-			return () => clearTimeout(timer);
-		}
-	}, [saveStatus]);
-
 	const saveMutation = useMutation({
 		mutationFn: (data: Partial<SiteSettings>) => updateSettings(data),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["settings"] });
-			setSaveStatus({ type: "success", message: t`SEO settings saved` });
+			toastManager.add({ title: t`SEO settings saved`, variant: "success", timeout: 3000 });
 		},
 		onError: (error) => {
-			setSaveStatus({
-				type: "error",
-				message: error instanceof Error ? error.message : t`Failed to save settings`,
+			toastManager.add({
+				title: error instanceof Error ? error.message : t`Failed to save settings`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -129,24 +113,6 @@ export function SeoSettings() {
 			>
 				<h1 className="text-2xl font-bold truncate">{t`SEO Settings`}</h1>
 			</EditorHeader>
-
-			{/* Status banner */}
-			{saveStatus && (
-				<div
-					className={`flex items-center gap-2 rounded-lg border p-3 text-sm ${
-						saveStatus.type === "success"
-							? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950/30 dark:text-green-200"
-							: "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200"
-					}`}
-				>
-					{saveStatus.type === "success" ? (
-						<CheckCircle className="h-4 w-4 flex-shrink-0" />
-					) : (
-						<WarningCircle className="h-4 w-4 flex-shrink-0" />
-					)}
-					{saveStatus.message}
-				</div>
-			)}
 
 			<form id="seo-settings-form" onSubmit={handleSubmit} className="space-y-6">
 				<div className="rounded-lg border bg-kumo-base p-6">

--- a/packages/admin/src/components/settings/SeoSettings.tsx
+++ b/packages/admin/src/components/settings/SeoSettings.tsx
@@ -41,7 +41,8 @@ export function SeoSettings() {
 		},
 		onError: (error) => {
 			toastManager.add({
-				title: error instanceof Error ? error.message : t`Failed to save settings`,
+				title: t`Failed to save settings`,
+				description: error instanceof Error ? error.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});

--- a/packages/admin/src/components/settings/SocialSettings.tsx
+++ b/packages/admin/src/components/settings/SocialSettings.tsx
@@ -39,7 +39,8 @@ export function SocialSettings() {
 		},
 		onError: (error) => {
 			toastManager.add({
-				title: error instanceof Error ? error.message : t`Failed to save settings`,
+				title: t`Failed to save settings`,
+				description: error instanceof Error ? error.message : t`An error occurred`,
 				variant: "error",
 				timeout: 3000,
 			});

--- a/packages/admin/src/components/settings/SocialSettings.tsx
+++ b/packages/admin/src/components/settings/SocialSettings.tsx
@@ -4,9 +4,9 @@
  * Social media profile links (Twitter, GitHub, Facebook, Instagram, LinkedIn, YouTube).
  */
 
-import { Button, Input } from "@cloudflare/kumo";
+import { Button, Input, useKumoToastManager } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { FloppyDisk, CheckCircle, WarningCircle } from "@phosphor-icons/react";
+import { FloppyDisk } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -17,6 +17,7 @@ import { BackToSettingsLink } from "./BackToSettingsLink.js";
 export function SocialSettings() {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const toastManager = useKumoToastManager();
 
 	const { data: settings, isLoading } = useQuery({
 		queryKey: ["settings"],
@@ -25,32 +26,22 @@ export function SocialSettings() {
 	});
 
 	const [formData, setFormData] = React.useState<Partial<SiteSettings>>({});
-	const [saveStatus, setSaveStatus] = React.useState<{
-		type: "success" | "error";
-		message: string;
-	} | null>(null);
 
 	React.useEffect(() => {
 		if (settings) setFormData(settings);
 	}, [settings]);
 
-	React.useEffect(() => {
-		if (saveStatus) {
-			const timer = setTimeout(setSaveStatus, 3000, null);
-			return () => clearTimeout(timer);
-		}
-	}, [saveStatus]);
-
 	const saveMutation = useMutation({
 		mutationFn: (data: Partial<SiteSettings>) => updateSettings(data),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["settings"] });
-			setSaveStatus({ type: "success", message: t`Social links saved` });
+			toastManager.add({ title: t`Social links saved`, variant: "success", timeout: 3000 });
 		},
 		onError: (error) => {
-			setSaveStatus({
-				type: "error",
-				message: error instanceof Error ? error.message : t`Failed to save settings`,
+			toastManager.add({
+				title: error instanceof Error ? error.message : t`Failed to save settings`,
+				variant: "error",
+				timeout: 3000,
 			});
 		},
 	});
@@ -102,24 +93,6 @@ export function SocialSettings() {
 			>
 				<h1 className="text-2xl font-bold truncate">{t`Social Links`}</h1>
 			</EditorHeader>
-
-			{/* Status banner */}
-			{saveStatus && (
-				<div
-					className={`flex items-center gap-2 rounded-lg border p-3 text-sm ${
-						saveStatus.type === "success"
-							? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950/30 dark:text-green-200"
-							: "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200"
-					}`}
-				>
-					{saveStatus.type === "success" ? (
-						<CheckCircle className="h-4 w-4 flex-shrink-0" />
-					) : (
-						<WarningCircle className="h-4 w-4 flex-shrink-0" />
-					)}
-					{saveStatus.message}
-				</div>
-			)}
 
 			<form id="social-settings-form" onSubmit={handleSubmit} className="space-y-6">
 				<div className="rounded-lg border bg-kumo-base p-6">

--- a/packages/admin/tests/components/settings/AllowedDomainsSettings.test.tsx
+++ b/packages/admin/tests/components/settings/AllowedDomainsSettings.test.tsx
@@ -167,6 +167,7 @@ describe("AllowedDomainsSettings", () => {
 		const submitButton = screen.getByText("Add Domain").element().closest("button")!;
 		await userEvent.click(submitButton);
 
+		await expect.element(screen.getByText("Failed to add domain")).toBeInTheDocument();
 		await expect.element(screen.getByText("Domain is already allowed")).toBeInTheDocument();
 	});
 

--- a/packages/admin/tests/components/settings/AllowedDomainsSettings.test.tsx
+++ b/packages/admin/tests/components/settings/AllowedDomainsSettings.test.tsx
@@ -1,3 +1,4 @@
+import { Toasty } from "@cloudflare/kumo";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { userEvent } from "@vitest/browser/context";
 import * as React from "react";
@@ -42,7 +43,11 @@ function QueryWrapper({ children }: { children: React.ReactNode }) {
 			mutations: { retry: false },
 		},
 	});
-	return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+	return (
+		<Toasty>
+			<QueryClientProvider client={qc}>{children}</QueryClientProvider>
+		</Toasty>
+	);
 }
 
 beforeEach(() => {
@@ -138,10 +143,31 @@ describe("AllowedDomainsSettings", () => {
 		await vi.waitFor(() => {
 			expect(mockCreateAllowedDomain).toHaveBeenCalled();
 		});
+		await expect.element(screen.getByText("Domain added successfully")).toBeInTheDocument();
 		expect(mockCreateAllowedDomain.mock.calls[0]![0]).toEqual({
 			domain: "example.com",
 			defaultRole: 30,
 		});
+	});
+
+	it("add domain: failed submit shows an error toast", async () => {
+		mockCreateAllowedDomain.mockRejectedValue(new Error("Domain is already allowed"));
+		const screen = await render(
+			<QueryWrapper>
+				<AllowedDomainsSettings />
+			</QueryWrapper>,
+		);
+
+		await expect.element(screen.getByText("Add Domain")).toBeInTheDocument();
+		const addButton = screen.getByText("Add Domain").element().closest("button")!;
+		await userEvent.click(addButton);
+
+		const domainInput = screen.getByLabelText("Domain");
+		await userEvent.type(domainInput, "example.com");
+		const submitButton = screen.getByText("Add Domain").element().closest("button")!;
+		await userEvent.click(submitButton);
+
+		await expect.element(screen.getByText("Domain is already allowed")).toBeInTheDocument();
 	});
 
 	it("delete domain: confirmation dialog, confirm calls deleteAllowedDomain", async () => {

--- a/packages/admin/tests/components/settings/SecuritySettings.test.tsx
+++ b/packages/admin/tests/components/settings/SecuritySettings.test.tsx
@@ -1,0 +1,90 @@
+import { Toasty } from "@cloudflare/kumo";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { SecuritySettings } from "../../../src/components/settings/SecuritySettings";
+import { render } from "../../utils/render";
+
+const mockFetchManifest = vi.fn();
+const mockFetchPasskeys = vi.fn();
+const mockRenamePasskey = vi.fn();
+const mockDeletePasskey = vi.fn();
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...actual,
+		Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+	};
+});
+
+vi.mock("../../../src/lib/api", async () => {
+	const actual = await vi.importActual("../../../src/lib/api");
+	return {
+		...actual,
+		fetchManifest: (...args: unknown[]) => mockFetchManifest(...args),
+		fetchPasskeys: (...args: unknown[]) => mockFetchPasskeys(...args),
+		renamePasskey: (...args: unknown[]) => mockRenamePasskey(...args),
+		deletePasskey: (...args: unknown[]) => mockDeletePasskey(...args),
+	};
+});
+
+vi.mock("../../../src/components/auth/PasskeyRegistration", () => ({
+	PasskeyRegistration: ({ onError }: { onError?: (error: Error) => void }) => (
+		<button
+			type="button"
+			onClick={() => onError?.(new Error("Authenticator rejected registration"))}
+		>
+			Simulate registration error
+		</button>
+	),
+}));
+
+function QueryWrapper({ children }: { children: React.ReactNode }) {
+	const qc = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	return (
+		<Toasty>
+			<QueryClientProvider client={qc}>{children}</QueryClientProvider>
+		</Toasty>
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockFetchManifest.mockResolvedValue({
+		authMode: "passkey",
+		collections: {},
+		plugins: {},
+		version: "1",
+		hash: "",
+	});
+	mockFetchPasskeys.mockResolvedValue([]);
+	mockRenamePasskey.mockResolvedValue({});
+	mockDeletePasskey.mockResolvedValue({});
+});
+
+describe("SecuritySettings", () => {
+	it("passkey registration errors show a stable title and detail toast", async () => {
+		const screen = await render(
+			<QueryWrapper>
+				<SecuritySettings />
+			</QueryWrapper>,
+		);
+
+		await expect.element(screen.getByText("Add Passkey")).toBeInTheDocument();
+		await userEvent.click(screen.getByText("Add Passkey"));
+		await userEvent.click(screen.getByText("Simulate registration error"));
+
+		await expect.element(screen.getByText("Failed to add passkey")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("Authenticator rejected registration"))
+			.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Replaces inline admin settings success/error banners with Kumo toasts across the settings pages. This keeps feedback consistent with the admin design system and removes bespoke raw-color/dark-mode banner styling.

Closes: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (verified with `pnpm --filter @emdash-cms/admin typecheck`)
- [x] `pnpm lint` passes (verified with `pnpm --silent lint:json | jq '.diagnostics | length'` -> `0`)
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs -- a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, no new feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: OpenCode with GPT-5.5

## Screenshots / test output

<img width="2488" height="813" alt="image" src="https://github.com/user-attachments/assets/96a125fc-1360-48df-b391-03747c031c24" />


- `pnpm --silent lint:json | jq '.diagnostics | length'` -> `0`
- `pnpm --filter @emdash-cms/admin typecheck` -> passed
- `pnpm --filter @emdash-cms/admin test -- tests/components/settings/AllowedDomainsSettings.test.tsx` -> `83` test files passed, `1028` tests passed


<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://pr-settings-toast-feedback-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `pr/settings-toast-feedback`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

