### PR TITLE
fix(media): refine media library and asset details UX

### DIFF
--- a/.changeset/media-library-refinements.md
+++ b/.changeset/media-library-refinements.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Updates the media library controls, empty states, and asset details dialog for clearer media management, including provider asset deletion when supported.

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -8,6 +8,8 @@
 import { writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
+import type { Page } from "@playwright/test";
+
 import { test, expect } from "../fixtures";
 
 // Create a test image for uploads
@@ -39,6 +41,16 @@ function ensureTestAssets(): string {
 	return testImagePath;
 }
 
+async function uploadTestImage(page: Page) {
+	const testImagePath = ensureTestAssets();
+	const fileInput = page.locator('input[type="file"]');
+	await fileInput.setInputFiles(testImagePath);
+	await page.waitForResponse(
+		(res) => MEDIA_API_RESPONSE_PATTERN.test(res.url()) && res.status() === 200,
+		{ timeout: 10000 },
+	);
+}
+
 test.describe("Media Library", () => {
 	test.beforeAll(() => {
 		ensureTestAssets();
@@ -62,23 +74,24 @@ test.describe("Media Library", () => {
 			).toBeVisible();
 		});
 
-		test("shows grid view by default", async ({ admin }) => {
+		test("shows grid view by default", async ({ admin, page }) => {
 			await admin.goToMedia();
 			await admin.waitForLoading();
+			await uploadTestImage(page);
 
-			// Grid view button should be active
-			const gridButton = admin.page.locator('button[aria-label="Grid view"]');
-			await expect(gridButton).toBeVisible();
+			// Grid view tab should be active
+			const gridTab = admin.page.getByRole("tab", { name: "Grid view" });
+			await expect(gridTab).toBeVisible();
+			await expect(gridTab).toHaveAttribute("aria-selected", "true");
 		});
 
-		test("shows view toggle buttons", async ({ admin }) => {
+		test("shows view toggle tabs", async ({ admin, page }) => {
 			await admin.goToMedia();
 			await admin.waitForLoading();
+			await uploadTestImage(page);
 
-			// View toggle buttons should be visible (grid and list icons)
-			const buttons = admin.page.locator("button").filter({ has: admin.page.locator("svg") });
-			const count = await buttons.count();
-			expect(count).toBeGreaterThan(0);
+			await expect(admin.page.getByRole("tab", { name: "Grid view" })).toBeVisible();
+			await expect(admin.page.getByRole("tab", { name: "List view" })).toBeVisible();
 		});
 	});
 
@@ -88,15 +101,7 @@ test.describe("Media Library", () => {
 			await admin.waitForLoading();
 
 			// Upload file
-			const testImagePath = ensureTestAssets();
-			const fileInput = page.locator('input[type="file"]');
-			await fileInput.setInputFiles(testImagePath);
-
-			// Wait for upload
-			await page.waitForResponse(
-				(res) => MEDIA_API_RESPONSE_PATTERN.test(res.url()) && res.status() === 200,
-				{ timeout: 10000 },
-			);
+			await uploadTestImage(page);
 
 			// Wait for the uploaded image to appear in the media grid
 			const mediaGrid = page.locator(".grid.gap-4");
@@ -115,18 +120,12 @@ test.describe("Media Library", () => {
 			await admin.goToMedia();
 			await admin.waitForLoading();
 
-			const testImagePath = ensureTestAssets();
-			const fileInput = page.locator('input[type="file"]');
-			await fileInput.setInputFiles(testImagePath);
-			await page.waitForResponse(
-				(res) => MEDIA_API_RESPONSE_PATTERN.test(res.url()) && res.status() === 200,
-				{ timeout: 10000 },
-			);
+			await uploadTestImage(page);
 			await page.reload();
 			await admin.waitForLoading();
 
 			// Switch to list view
-			await page.click('button[aria-label="List view"]');
+			await page.getByRole("tab", { name: "List view" }).click();
 
 			// Should show table with columns
 			await expect(page.locator("th:has-text('Filename')")).toBeVisible();

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -66,6 +66,10 @@ export function MediaDetailPanel({
 
 	React.useEffect(() => {
 		if (!open) return;
+		if (closeFallbackTimerRef.current !== null) {
+			window.clearTimeout(closeFallbackTimerRef.current);
+			closeFallbackTimerRef.current = null;
+		}
 		closeFinishedRef.current = false;
 		restoreFocusAfterDeleteRef.current = false;
 		setFilename(item.filename);

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -135,9 +135,10 @@ export function MediaDetailPanel({
 		mutationFn: () =>
 			item.provider ? deleteFromProvider(item.provider, item.id) : deleteMedia(item.id),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["media"] });
 			if (item.provider) {
 				void queryClient.invalidateQueries({ queryKey: ["provider-media", item.provider] });
+			} else {
+				void queryClient.invalidateQueries({ queryKey: ["media"] });
 			}
 			restoreFocusAfterDeleteRef.current = true;
 			setShowDeleteConfirm(false);

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -1,262 +1,441 @@
 /**
- * Media Detail Panel
+ * Media Detail Dialog
  *
- * A slide-out panel for viewing and editing media item metadata.
+ * A centered dialog for viewing and editing media item metadata.
  * Opens when clicking an item in the MediaLibrary.
  */
 
-import { Button, ClipboardText, Input, InputArea } from "@cloudflare/kumo";
+import { Button, ClipboardText, Dialog, Input, InputArea, Tooltip } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { X, Trash, Calendar, HardDrive, LinkSimple, Ruler } from "@phosphor-icons/react";
+import { X, Trash, Calendar, HardDrive, LinkSimple, Ruler, Info } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
-import { updateMedia, deleteMedia, type MediaItem } from "../lib/api";
+import { updateMedia, deleteMedia, deleteFromProvider, type MediaItem } from "../lib/api";
 import { useStableCallback } from "../lib/hooks";
 import { getFileIcon, formatFileSize } from "../lib/media-utils";
-import { cn } from "../lib/utils";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { DialogError, getMutationError } from "./DialogError.js";
+
+const CLOSE_FALLBACK_MS = 500;
 
 export interface MediaDetailPanelProps {
-	item: MediaItem | null;
+	open: boolean;
+	item: MediaItem;
+	providerName?: string;
+	canDelete?: boolean;
+	restoreFocusTargetRef?: React.RefObject<HTMLElement | null>;
 	onClose: () => void;
+	onClosed?: () => void;
+	onUpdated?: () => void;
 	onDeleted?: () => void;
 }
 
 /**
- * Slide-out panel for viewing and editing media metadata
+ * Centered dialog for viewing and editing media metadata.
  */
-export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelProps) {
+export function MediaDetailPanel({
+	open,
+	item,
+	providerName,
+	canDelete: canDeleteProp,
+	restoreFocusTargetRef,
+	onClose,
+	onClosed,
+	onUpdated,
+	onDeleted,
+}: MediaDetailPanelProps) {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const restoreFocusAfterDeleteRef = React.useRef(false);
+	const closeFallbackTimerRef = React.useRef<number | null>(null);
+	const closeFinishedRef = React.useRef(false);
 
-	// Form state - controlled inputs
-	const [filename, setFilename] = React.useState(item?.filename ?? "");
-	const [alt, setAlt] = React.useState(item?.alt ?? "");
-	const [caption, setCaption] = React.useState(item?.caption ?? "");
+	const isProviderAsset = Boolean(item.provider);
+	const isImage = item.mimeType.startsWith("image/");
+	const isVideo = item.mimeType.startsWith("video/");
+	const isAudio = item.mimeType.startsWith("audio/");
+	const canEditMetadata = !isProviderAsset && isImage;
+	const canDelete = !isProviderAsset || Boolean(canDeleteProp);
 
-	// Reset form when item changes
+	const [filename, setFilename] = React.useState(item.filename);
+	const [alt, setAlt] = React.useState(item.alt ?? "");
+	const [caption, setCaption] = React.useState(item.caption ?? "");
+	const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
+	const [showDiscardConfirm, setShowDiscardConfirm] = React.useState(false);
+
 	React.useEffect(() => {
-		if (item) {
-			setFilename(item.filename);
-			setAlt(item.alt ?? "");
-			setCaption(item.caption ?? "");
+		if (!open) return;
+		closeFinishedRef.current = false;
+		restoreFocusAfterDeleteRef.current = false;
+		setFilename(item.filename);
+		setAlt(item.alt ?? "");
+		setCaption(item.caption ?? "");
+		setShowDeleteConfirm(false);
+		setShowDiscardConfirm(false);
+	}, [item.id, open]);
+
+	React.useEffect(() => {
+		return () => {
+			if (closeFallbackTimerRef.current !== null) {
+				window.clearTimeout(closeFallbackTimerRef.current);
+			}
+		};
+	}, []);
+
+	const finishClose = React.useCallback(() => {
+		if (closeFinishedRef.current) return;
+		closeFinishedRef.current = true;
+		if (closeFallbackTimerRef.current !== null) {
+			window.clearTimeout(closeFallbackTimerRef.current);
+			closeFallbackTimerRef.current = null;
 		}
-	}, [item]);
+		const shouldRestoreFocus = restoreFocusAfterDeleteRef.current;
+		restoreFocusAfterDeleteRef.current = false;
+		onClosed?.();
+		if (shouldRestoreFocus) {
+			window.setTimeout(() => {
+				restoreFocusTargetRef?.current?.focus();
+			}, 0);
+		}
+	}, [onClosed, restoreFocusTargetRef]);
 
-	// Public file URL — absolute so it can be pasted anywhere (relative API
-	// paths from local storage are resolved against the current origin).
-	const fileUrl = item ? new URL(item.url, window.location.origin).href : "";
+	const closeDialog = React.useCallback(() => {
+		onClose();
+		if (closeFallbackTimerRef.current !== null) {
+			window.clearTimeout(closeFallbackTimerRef.current);
+		}
+		closeFallbackTimerRef.current = window.setTimeout(finishClose, CLOSE_FALLBACK_MS);
+	}, [finishClose, onClose]);
 
-	// Track if form has unsaved changes
-	const hasChanges = React.useMemo(() => {
-		if (!item) return false;
-		return (
-			filename !== item.filename || alt !== (item.alt ?? "") || caption !== (item.caption ?? "")
-		);
-	}, [item, filename, alt, caption]);
+	const hasChanges =
+		canEditMetadata && (alt !== (item.alt ?? "") || caption !== (item.caption ?? ""));
+	const isConfirmOpen = showDeleteConfirm || showDiscardConfirm;
+	const publicFileUrl =
+		!isProviderAsset && item.url ? new URL(item.url, window.location.origin).href : "";
+	const filenameHelp = t`Filename cannot be changed after upload`;
+	const filenameHelpLabel = t`Why can't this be changed?`;
+	const altTextHelp = t`Used by screen readers and when image fails to load`;
+	const altTextHelpLabel = t`Why is this important?`;
 
-	// Update mutation
 	const updateMutation = useMutation({
-		mutationFn: (data: { alt?: string; caption?: string }) => {
-			if (!item) throw new Error("No item selected");
-			return updateMedia(item.id, data);
-		},
+		mutationFn: (data: { alt?: string; caption?: string }) => updateMedia(item.id, data),
 		onSuccess: () => {
-			// Invalidate to refresh the list
 			void queryClient.invalidateQueries({ queryKey: ["media"] });
+			onUpdated?.();
+			closeDialog();
 		},
 	});
 
-	// Delete mutation
 	const deleteMutation = useMutation({
-		mutationFn: () => {
-			if (!item) throw new Error("No item selected");
-			return deleteMedia(item.id);
-		},
+		mutationFn: () =>
+			item.provider ? deleteFromProvider(item.provider, item.id) : deleteMedia(item.id),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["media"] });
+			if (item.provider) {
+				void queryClient.invalidateQueries({ queryKey: ["provider-media", item.provider] });
+			}
+			restoreFocusAfterDeleteRef.current = true;
+			setShowDeleteConfirm(false);
 			onDeleted?.();
-			onClose();
+			closeDialog();
 		},
 	});
+	const isSaving = updateMutation.isPending;
+	const isDeleting = deleteMutation.isPending;
+	const isBusy = isSaving || isDeleting;
+
+	const requestClose = React.useCallback(() => {
+		if (isBusy) return;
+		if (isConfirmOpen) return;
+		if (hasChanges) {
+			setShowDiscardConfirm(true);
+			return;
+		}
+		closeDialog();
+	}, [closeDialog, hasChanges, isBusy, isConfirmOpen]);
 
 	const handleSave = () => {
-		if (!item || !hasChanges) return;
+		if (!canEditMetadata || !hasChanges || isSaving) return;
 		updateMutation.mutate({
-			alt: alt || undefined,
-			caption: caption || undefined,
+			alt,
+			caption,
 		});
 	};
 
-	const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
-
 	const handleDelete = () => {
-		if (!item) return;
+		if (!canDelete || isBusy) return;
 		setShowDeleteConfirm(true);
 	};
 
-	const stableOnClose = useStableCallback(onClose);
-	const stableHandleSave = useStableCallback(handleSave);
+	const handleDiscardConfirm = () => {
+		setShowDiscardConfirm(false);
+		closeDialog();
+	};
 
-	// Handle keyboard shortcuts
+	const stableHandleSave = useStableCallback(handleSave);
 	React.useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				stableOnClose();
-			}
-			if ((e.metaKey || e.ctrlKey) && e.key === "s") {
-				e.preventDefault();
+		if (!open) return;
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (isConfirmOpen) return;
+			if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+				if (!canEditMetadata || !hasChanges || isSaving) return;
+				event.preventDefault();
 				stableHandleSave();
 			}
 		};
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [stableOnClose, stableHandleSave]);
-
-	if (!item) return null;
-
-	const isImage = item.mimeType.startsWith("image/");
-	const isVideo = item.mimeType.startsWith("video/");
-	const isAudio = item.mimeType.startsWith("audio/");
+	}, [canEditMetadata, hasChanges, isConfirmOpen, isSaving, open, stableHandleSave]);
 
 	return (
 		<>
-			<div
-				className={cn(
-					"fixed inset-y-0 end-0 w-96 bg-kumo-base border-s shadow-xl z-50",
-					"flex flex-col",
-				)}
+			<Dialog.Root
+				open={open}
+				onOpenChange={(nextOpen) => {
+					if (!nextOpen && !isConfirmOpen) requestClose();
+				}}
+				onOpenChangeComplete={(nextOpen) => {
+					if (nextOpen) return;
+					finishClose();
+				}}
 			>
-				{/* Header */}
-				<div className="flex items-center justify-between p-4 border-b">
-					<h2 className="font-semibold truncate pe-2">{t`Media Details`}</h2>
-					<Button variant="ghost" shape="square" aria-label={t`Close`} onClick={onClose}>
-						<X className="h-4 w-4" />
-						<span className="sr-only">{t`Close`}</span>
-					</Button>
-				</div>
+				<Dialog
+					size="xl"
+					className="flex flex-col overflow-hidden p-0"
+					style={{ width: "min(94vw, 72rem)", maxHeight: "min(88dvh, 48rem)" }}
+				>
+					<div
+						className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line"
+						style={{ padding: "1.25rem 2rem" }}
+						data-testid="media-detail-dialog-header"
+					>
+						<div className="min-w-0 flex-1">
+							<Dialog.Title className="truncate text-lg font-semibold leading-none tracking-tight">
+								{t`Media Details`}
+							</Dialog.Title>
+							<p className="mt-1 truncate text-sm text-kumo-subtle">{item.filename}</p>
+						</div>
+						<Button
+							variant="ghost"
+							shape="square"
+							aria-label={t`Close`}
+							onClick={requestClose}
+							disabled={isBusy}
+						>
+							<X className="h-4 w-4" aria-hidden="true" />
+						</Button>
+					</div>
 
-				{/* Content */}
-				<div className="flex-1 overflow-y-auto">
-					{/* Preview */}
-					<div className="p-4 border-b">
-						<div className="aspect-video bg-kumo-tint rounded-lg overflow-hidden flex items-center justify-center">
-							{isImage ? (
-								<img
-									src={item.url}
-									alt={item.alt || item.filename}
-									className="max-h-full max-w-full object-contain"
-								/>
-							) : isVideo ? (
-								<video
-									src={item.url}
-									controls
-									preload="metadata"
-									className="max-h-full max-w-full"
-								/>
-							) : isAudio ? (
-								<audio src={item.url} controls preload="metadata" className="w-full" />
-							) : (
-								<div className="text-center p-4">
-									<span className="text-4xl">{getFileIcon(item.mimeType)}</span>
-									<p className="mt-2 text-sm text-kumo-subtle">{item.mimeType}</p>
+					<div
+						className="grid min-h-0 flex-1 grid-cols-1 overflow-y-auto md:grid-cols-2 md:overflow-hidden"
+						data-testid="media-detail-dialog-body"
+					>
+						<div
+							className="space-y-5 border-b border-kumo-line p-6 md:min-h-0 md:overflow-y-auto md:border-e md:border-b-0 md:p-8"
+							data-testid="media-detail-dialog-preview-column"
+						>
+							<div className="flex h-64 items-center justify-center overflow-hidden rounded-xl border border-kumo-line bg-kumo-tint md:h-80">
+								{isImage ? (
+									<img
+										src={item.url}
+										alt={item.alt || item.filename}
+										className="max-h-full max-w-full object-contain"
+									/>
+								) : isVideo ? (
+									<video
+										src={item.url}
+										controls
+										preload="metadata"
+										className="max-h-full max-w-full"
+									/>
+								) : isAudio ? (
+									<audio src={item.url} controls preload="metadata" className="w-full" />
+								) : (
+									<div className="p-4 text-center">
+										<span className="text-5xl" aria-hidden="true">
+											{getFileIcon(item.mimeType)}
+										</span>
+										<p className="mt-3 text-sm text-kumo-subtle">{item.mimeType}</p>
+									</div>
+								)}
+							</div>
+
+							<div className="space-y-3" data-testid="media-detail-dialog-file-facts">
+								<div className="flex items-center gap-2 text-sm">
+									<HardDrive className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
+									<span className="text-kumo-subtle">{t`Size:`}</span>
+									<span>{formatFileSize(item.size)}</span>
 								</div>
+								{item.width && item.height && (
+									<div className="flex items-center gap-2 text-sm">
+										<Ruler className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
+										<span className="text-kumo-subtle">{t`Dimensions:`}</span>
+										<span>
+											{item.width} × {item.height}
+										</span>
+									</div>
+								)}
+								{!isProviderAsset && (
+									<div className="flex items-center gap-2 text-sm">
+										<Calendar className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
+										<span className="text-kumo-subtle">{t`Uploaded:`}</span>
+										<span>{formatDate(item.createdAt)}</span>
+									</div>
+								)}
+								<div className="flex items-center gap-2 text-sm">
+									<LinkSimple className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
+									<span className="shrink-0 text-kumo-subtle">{t`URL:`}</span>
+									{publicFileUrl ? (
+										<ClipboardText
+											text={publicFileUrl}
+											size="sm"
+											className="min-w-0 flex-1"
+											labels={{ copyAction: t`Copy URL` }}
+										/>
+									) : (
+										<span className="min-w-0 text-kumo-subtle">{t`No public URL available`}</span>
+									)}
+								</div>
+							</div>
+						</div>
+
+						<div
+							className="space-y-5 p-6 md:min-h-0 md:overflow-y-auto md:p-8"
+							data-testid="media-detail-dialog-details-column"
+						>
+							{isProviderAsset && (
+								<p className="rounded-lg bg-kumo-tint p-3 text-sm text-kumo-subtle">
+									{providerName
+										? t`Managed by ${providerName}`
+										: t`Managed by an external media provider`}
+								</p>
+							)}
+
+							<div className="space-y-4">
+								<div className="w-full space-y-2">
+									<div className="flex items-center gap-1.5">
+										<span className="text-sm font-medium text-kumo-default">{t`Filename`}</span>
+										<Tooltip
+											content={filenameHelp}
+											delay={0}
+											closeDelay={0}
+											render={
+												<button
+													type="button"
+													className="inline-flex cursor-help rounded-full text-kumo-subtle hover:text-kumo-default focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-brand"
+													aria-label={filenameHelpLabel}
+												>
+													<Info className="h-4 w-4" aria-hidden="true" />
+												</button>
+											}
+										/>
+									</div>
+									<Input
+										aria-label={t`Filename`}
+										value={filename}
+										onChange={(event) => setFilename(event.target.value)}
+										disabled
+										className="w-full bg-kumo-tint text-kumo-subtle"
+									/>
+								</div>
+
+								{canEditMetadata && (
+									<>
+										<div className="w-full space-y-2">
+											<div className="flex items-center gap-1.5">
+												<span className="text-sm font-medium text-kumo-default">{t`Alt Text`}</span>
+												<Tooltip
+													content={altTextHelp}
+													delay={0}
+													closeDelay={0}
+													render={
+														<button
+															type="button"
+															className="inline-flex cursor-help rounded-full text-kumo-subtle hover:text-kumo-default focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-brand"
+															aria-label={altTextHelpLabel}
+														>
+															<Info className="h-4 w-4" aria-hidden="true" />
+														</button>
+													}
+												/>
+											</div>
+											<Input
+												aria-label={t`Alt Text`}
+												value={alt}
+												onChange={(event) => setAlt(event.target.value)}
+												placeholder={t`Describe this image for accessibility`}
+												disabled={isSaving}
+												className="w-full"
+											/>
+										</div>
+
+										<InputArea
+											label={t`Caption`}
+											value={caption}
+											onChange={(event) => setCaption(event.target.value)}
+											placeholder={t`Optional caption for display`}
+											rows={2}
+											disabled={isSaving}
+										/>
+									</>
+								)}
+							</div>
+
+							<DialogError message={getMutationError(updateMutation.error)} />
+						</div>
+					</div>
+
+					<div
+						className="flex shrink-0 items-center justify-between gap-3 border-t border-kumo-line"
+						style={{ padding: "1.25rem 2rem" }}
+						data-testid="media-detail-dialog-footer"
+					>
+						<div>
+							{canDelete && (
+								<Button
+									variant="destructive"
+									size="sm"
+									icon={<Trash />}
+									onClick={handleDelete}
+									disabled={isBusy}
+								>
+									{isDeleting ? t`Deleting...` : t`Delete`}
+								</Button>
+							)}
+						</div>
+						<div className="flex gap-2">
+							<Button variant="outline" size="sm" onClick={requestClose} disabled={isBusy}>
+								{canEditMetadata ? t`Cancel` : t`Close`}
+							</Button>
+							{canEditMetadata && (
+								<Button
+									variant="primary"
+									size="sm"
+									onClick={handleSave}
+									disabled={!hasChanges || isBusy}
+								>
+									{isSaving ? t`Saving...` : t`Save`}
+								</Button>
 							)}
 						</div>
 					</div>
+				</Dialog>
+			</Dialog.Root>
 
-					{/* File Info */}
-					<div className="p-4 border-b space-y-3">
-						<div className="flex items-center gap-2 text-sm">
-							<HardDrive className="h-4 w-4 text-kumo-subtle" />
-							<span className="text-kumo-subtle">{t`Size:`}</span>
-							<span>{formatFileSize(item.size)}</span>
-						</div>
-						{item.width && item.height && (
-							<div className="flex items-center gap-2 text-sm">
-								<Ruler className="h-4 w-4 text-kumo-subtle" />
-								<span className="text-kumo-subtle">{t`Dimensions:`}</span>
-								<span>
-									{item.width} × {item.height}
-								</span>
-							</div>
-						)}
-						<div className="flex items-center gap-2 text-sm">
-							<Calendar className="h-4 w-4 text-kumo-subtle" />
-							<span className="text-kumo-subtle">{t`Uploaded:`}</span>
-							<span>{formatDate(item.createdAt)}</span>
-						</div>
-						<div className="flex items-center gap-2 text-sm">
-							<LinkSimple className="h-4 w-4 text-kumo-subtle shrink-0" />
-							<span className="text-kumo-subtle shrink-0">{t`URL:`}</span>
-							<ClipboardText
-								text={fileUrl}
-								size="sm"
-								className="min-w-0 flex-1"
-								labels={{ copyAction: t`Copy URL` }}
-							/>
-						</div>
-					</div>
-
-					{/* Editable Fields */}
-					<div className="p-4 space-y-4">
-						<Input
-							label={t`Filename`}
-							value={filename}
-							onChange={(e) => setFilename(e.target.value)}
-							disabled // Filename editing needs backend support
-							description={t`Filename cannot be changed after upload`}
-						/>
-
-						{isImage && (
-							<>
-								<Input
-									label={t`Alt Text`}
-									value={alt}
-									onChange={(e) => setAlt(e.target.value)}
-									placeholder={t`Describe this image for accessibility`}
-									description={t`Used by screen readers and when image fails to load`}
-								/>
-
-								<InputArea
-									label={t`Caption`}
-									value={caption}
-									onChange={(e) => setCaption(e.target.value)}
-									placeholder={t`Optional caption for display`}
-									rows={2}
-								/>
-							</>
-						)}
-					</div>
-				</div>
-
-				{/* Footer */}
-				<div className="p-4 border-t flex items-center justify-between gap-2">
-					<Button
-						variant="destructive"
-						size="sm"
-						icon={<Trash />}
-						onClick={handleDelete}
-						disabled={deleteMutation.isPending}
-					>
-						{deleteMutation.isPending ? t`Deleting...` : t`Delete`}
-					</Button>
-					<div className="flex gap-2">
-						<Button variant="outline" size="sm" onClick={onClose}>
-							{t`Cancel`}
-						</Button>
-						<Button
-							size="sm"
-							onClick={handleSave}
-							disabled={!hasChanges || updateMutation.isPending}
-						>
-							{updateMutation.isPending ? t`Saving...` : t`Save`}
-						</Button>
-					</div>
-				</div>
-			</div>
+			<ConfirmDialog
+				open={showDiscardConfirm}
+				onClose={() => setShowDiscardConfirm(false)}
+				title={t`Discard changes?`}
+				description={t`Your unsaved media changes will be lost.`}
+				confirmLabel={t`Discard`}
+				pendingLabel={t`Discarding...`}
+				isPending={false}
+				error={null}
+				onConfirm={handleDiscardConfirm}
+			/>
 
 			<ConfirmDialog
 				open={showDeleteConfirm}

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -298,7 +298,8 @@ export function MediaLibrary({
 		resultCount > 0 && !hasMoreCurrentItems
 			? plural(resultCount, { one: "# item", other: "# items" })
 			: "";
-	const hasActiveQuery = searchQuery.trim() !== "" || localTypeFilter !== "all";
+	const hasActiveQuery =
+		searchQuery.trim() !== "" || (activeProvider === "local" && localTypeFilter !== "all");
 	const clearLocalQuery = () => {
 		setSearchQuery("");
 		onLocalSearchChange?.("");

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -407,7 +407,10 @@ export function MediaLibrary({
 					<div className="flex min-w-0 items-center gap-3">
 						{(canSearch || activeProvider === "local") && (
 							<div className="relative min-w-0 flex-1 sm:w-72 sm:flex-none">
-								<MagnifyingGlass className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-kumo-subtle" />
+								<MagnifyingGlass
+									className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-kumo-subtle"
+									aria-hidden="true"
+								/>
 								<Input
 									type="search"
 									placeholder={activeProvider === "local" ? t`Search by filename...` : t`Search...`}
@@ -646,7 +649,7 @@ export function MediaLibrary({
 					onClose={closeDetail}
 					onClosed={handleDetailClosed}
 					onUpdated={onItemUpdated}
-					onDeleted={onItemUpdated}
+					onDeleted={detailItem.provider ? undefined : onItemUpdated}
 				/>
 			)}
 		</div>

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -1,7 +1,16 @@
-import { Button, Input, Loader, Select } from "@cloudflare/kumo";
+import { Button, Input, Loader, Select, Tabs } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import { Upload, Image, SquaresFour, List, MagnifyingGlass, Check, X } from "@phosphor-icons/react";
+import {
+	Upload,
+	Images,
+	SquaresFour,
+	List,
+	MagnifyingGlass,
+	Check,
+	X,
+} from "@phosphor-icons/react";
+import type { Icon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -47,7 +56,6 @@ export interface MediaLibraryProps {
 	isLoading?: boolean;
 	onUpload?: (file: File) => Promise<void> | void;
 	onSelect?: (item: MediaItem) => void;
-	onDelete?: (id: string) => void;
 	onItemUpdated?: () => void;
 	/** True when more local-library items can be fetched via cursor pagination */
 	hasMore?: boolean;
@@ -66,7 +74,6 @@ export function MediaLibrary({
 	items = [],
 	isLoading,
 	onUpload,
-	onDelete,
 	onItemUpdated,
 	hasMore,
 	onLoadMore,
@@ -75,10 +82,13 @@ export function MediaLibrary({
 }: MediaLibraryProps) {
 	const { t } = useLingui();
 	const [viewMode, setViewMode] = React.useState<"grid" | "list">("grid");
-	const [selectedItem, setSelectedItem] = React.useState<MediaItem | null>(null);
+	const [detailItem, setDetailItem] = React.useState<MediaItem | null>(null);
+	const [isDetailOpen, setIsDetailOpen] = React.useState(false);
 	const [activeProvider, setActiveProvider] = React.useState<string>("local");
 	const [searchQuery, setSearchQuery] = React.useState("");
 	const [localTypeFilter, setLocalTypeFilter] = React.useState("all");
+	const mediaHeadingRef = React.useRef<HTMLHeadingElement>(null);
+	const detailOpenFrameRef = React.useRef<number | null>(null);
 	// Debounced filename search reported up for the local library's server query.
 	const debouncedSearch = useDebouncedValue(searchQuery, 300);
 	React.useEffect(() => {
@@ -131,18 +141,35 @@ export function MediaLibrary({
 		return providers?.find((p) => p.id === activeProvider);
 	}, [activeProvider, providers, t]);
 
-	// Update selected item when items change (e.g., after metadata update)
-	React.useEffect(() => {
-		if (selectedItem && activeProvider === "local") {
-			const updated = items.find((i) => i.id === selectedItem.id);
-			if (updated) {
-				setSelectedItem(updated);
-			} else {
-				// Item was deleted
-				setSelectedItem(null);
-			}
-		}
-	}, [items, selectedItem?.id, activeProvider]);
+	const cancelPendingDetailOpen = React.useCallback(() => {
+		if (detailOpenFrameRef.current === null) return;
+		window.cancelAnimationFrame(detailOpenFrameRef.current);
+		detailOpenFrameRef.current = null;
+	}, []);
+
+	React.useEffect(() => cancelPendingDetailOpen, [cancelPendingDetailOpen]);
+
+	const openDetail = React.useCallback(
+		(item: MediaItem) => {
+			cancelPendingDetailOpen();
+			setIsDetailOpen(false);
+			setDetailItem(item);
+			detailOpenFrameRef.current = window.requestAnimationFrame(() => {
+				detailOpenFrameRef.current = null;
+				setIsDetailOpen(true);
+			});
+		},
+		[cancelPendingDetailOpen],
+	);
+
+	const closeDetail = React.useCallback(() => {
+		cancelPendingDetailOpen();
+		setIsDetailOpen(false);
+	}, [cancelPendingDetailOpen]);
+
+	const handleDetailClosed = React.useCallback(() => {
+		setDetailItem(null);
+	}, []);
 
 	// Clear success/error message after a delay
 	React.useEffect(() => {
@@ -263,68 +290,38 @@ export function MediaLibrary({
 
 	const canUpload = activeProviderInfo?.capabilities.upload ?? false;
 	const canSearch = activeProviderInfo?.capabilities.search ?? false;
+	const resultCount =
+		activeProvider === "local" ? currentItems.length : currentProviderItems.length;
+	const hasMoreCurrentItems =
+		activeProvider === "local" ? Boolean(hasMore) : Boolean(providerData?.nextCursor);
+	const resultCountText =
+		resultCount > 0 && !hasMoreCurrentItems
+			? plural(resultCount, { one: "# item", other: "# items" })
+			: "";
+	const hasActiveQuery = searchQuery.trim() !== "" || localTypeFilter !== "all";
+	const clearLocalQuery = () => {
+		setSearchQuery("");
+		onLocalSearchChange?.("");
+		setLocalTypeFilter("all");
+		onLocalMimeFilterChange?.(mimeForTypeFilter("all"));
+	};
+	const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const next = e.target.value;
+		setSearchQuery(next);
+		if (activeProvider === "local" && next.trim() === "") {
+			onLocalSearchChange?.("");
+		}
+	};
+	const showToolbar = resultCount > 0 || hasActiveQuery;
 
 	return (
-		<div className="space-y-6">
-			{/* Header */}
-			<div className="flex items-center justify-between">
-				<h1 className="text-2xl font-bold">{t`Media Library`}</h1>
-				<div className="flex rounded-md border" role="group" aria-label={t`View mode`}>
-					<Button
-						variant={viewMode === "grid" ? "secondary" : "ghost"}
-						shape="square"
-						onClick={() => setViewMode("grid")}
-						aria-label={t`Grid view`}
-						aria-pressed={viewMode === "grid"}
-					>
-						<SquaresFour className="h-4 w-4" aria-hidden="true" />
-					</Button>
-					<Button
-						variant={viewMode === "list" ? "secondary" : "ghost"}
-						shape="square"
-						onClick={() => setViewMode("list")}
-						aria-label={t`List view`}
-						aria-pressed={viewMode === "list"}
-					>
-						<List className="h-4 w-4" aria-hidden="true" />
-					</Button>
-				</div>
-			</div>
-
-			{/* Provider Tabs + Upload */}
-			<div className="flex items-center justify-between gap-4 border-b pb-3">
-				{providerTabs.length > 1 && (
-					<div className="flex gap-2 overflow-x-auto">
-						{providerTabs.map((tab) => (
-							<button
-								key={tab.id}
-								type="button"
-								onClick={() => {
-									setActiveProvider(tab.id);
-									setSelectedItem(null);
-									setSearchQuery("");
-								}}
-								className={cn(
-									"flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors whitespace-nowrap",
-									activeProvider === tab.id
-										? "bg-kumo-brand text-white"
-										: "bg-kumo-tint hover:bg-kumo-tint/80 text-kumo-subtle",
-								)}
-							>
-								{tab.icon &&
-									(tab.icon.startsWith("data:") ? (
-										<img src={tab.icon} alt="" className="h-4 w-4" aria-hidden="true" />
-									) : (
-										<span aria-hidden="true">{tab.icon}</span>
-									))}
-								{tab.name}
-							</button>
-						))}
-					</div>
-				)}
-
-				{/* Upload button + status */}
-				<div className="flex items-center gap-3 flex-shrink-0">
+		<div className="space-y-4">
+			{/* Header: page title (start) + primary upload action (end) */}
+			<div className="flex flex-wrap items-center justify-between gap-4">
+				<h1 ref={mediaHeadingRef} tabIndex={-1} className="text-2xl font-bold">
+					{t`Media Library`}
+				</h1>
+				<div className="flex items-center gap-3">
 					{/* Upload status feedback */}
 					{uploadState.status === "uploading" && (
 						<div className="flex items-center gap-2 text-sm text-kumo-subtle">
@@ -337,14 +334,14 @@ export function MediaLibrary({
 						</div>
 					)}
 					{uploadState.status === "success" && (
-						<div className="flex items-center gap-2 text-sm text-green-600">
-							<Check className="h-4 w-4" />
+						<div className="flex items-center gap-2 text-sm text-kumo-success">
+							<Check className="h-4 w-4" aria-hidden="true" />
 							<span>{uploadState.message}</span>
 						</div>
 					)}
 					{uploadState.status === "error" && (
 						<div className="flex items-center gap-2 text-sm text-kumo-danger">
-							<X className="h-4 w-4" />
+							<X className="h-4 w-4" aria-hidden="true" />
 							<span>{uploadState.message}</span>
 						</div>
 					)}
@@ -372,77 +369,174 @@ export function MediaLibrary({
 				</div>
 			</div>
 
-			{/* Search — providers that support it, plus the local library
-			    (filename/extension search + type filter, handled server-side). */}
-			{(canSearch || activeProvider === "local") && (
-				<div className="flex flex-wrap items-center gap-3">
-					<div className="relative max-w-sm flex-1">
-						<MagnifyingGlass className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
-						<Input
-							type="search"
-							placeholder={activeProvider === "local" ? t`Search by filename...` : t`Search...`}
-							aria-label={t`Search media`}
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-							maxLength={MEDIA_SEARCH_MAX_LENGTH}
-							className="ps-9"
-						/>
+			{/* Provider tabs (only when an external provider is configured) */}
+			{providerTabs.length > 1 && (
+				<Tabs
+					variant="underline"
+					value={activeProvider}
+					onValueChange={(v) => {
+						if (!v) return;
+						cancelPendingDetailOpen();
+						setActiveProvider(v);
+						setIsDetailOpen(false);
+						setDetailItem(null);
+						setSearchQuery("");
+					}}
+					tabs={providerTabs.map((tab) => ({
+						value: tab.id,
+						label: (
+							<span className="flex items-center gap-2">
+								{tab.icon &&
+									(tab.icon.startsWith("data:") ? (
+										<img src={tab.icon} alt="" className="h-4 w-4" aria-hidden="true" />
+									) : (
+										<span aria-hidden="true">{tab.icon}</span>
+									))}
+								{tab.name}
+							</span>
+						),
+					}))}
+				/>
+			)}
+
+			{/* Toolbar: search + type filter (start) · result count + view toggle (end).
+			    Local library search/filter is handled server-side. */}
+			{showToolbar && (
+				<div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+					<div className="flex min-w-0 items-center gap-3">
+						{(canSearch || activeProvider === "local") && (
+							<div className="relative min-w-0 flex-1 sm:w-72 sm:flex-none">
+								<MagnifyingGlass className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-kumo-subtle" />
+								<Input
+									type="search"
+									placeholder={activeProvider === "local" ? t`Search by filename...` : t`Search...`}
+									aria-label={t`Search media`}
+									value={searchQuery}
+									onChange={handleSearchChange}
+									maxLength={MEDIA_SEARCH_MAX_LENGTH}
+									className="w-full ps-9"
+								/>
+							</div>
+						)}
+						{activeProvider === "local" && (
+							<Select
+								value={localTypeFilter}
+								onValueChange={(v) => {
+									const next = v ?? "all";
+									setLocalTypeFilter(next);
+									onLocalMimeFilterChange?.(mimeForTypeFilter(next));
+								}}
+								items={{
+									all: t`All types`,
+									image: t`Images`,
+									video: t`Video`,
+									audio: t`Audio`,
+									document: t`Documents`,
+								}}
+								aria-label={t`Filter by type`}
+							/>
+						)}
 					</div>
-					{activeProvider === "local" && (
-						<Select
-							value={localTypeFilter}
-							onValueChange={(v) => {
-								const next = v ?? "all";
-								setLocalTypeFilter(next);
-								onLocalMimeFilterChange?.(mimeForTypeFilter(next));
-							}}
-							items={{
-								all: t`All types`,
-								image: t`Images`,
-								video: t`Video`,
-								audio: t`Audio`,
-								document: t`Documents`,
-							}}
-							aria-label={t`Filter by type`}
-						/>
-					)}
+					<div className="flex flex-shrink-0 items-center justify-between gap-3 sm:justify-end">
+						<span className="text-sm text-kumo-subtle" aria-live="polite">
+							{resultCountText}
+						</span>
+						<div role="group" aria-label={t`View mode`}>
+							<Tabs
+								variant="segmented"
+								value={viewMode}
+								onValueChange={(v) => {
+									if (v === "grid" || v === "list") setViewMode(v);
+								}}
+								tabs={[
+									{
+										value: "grid",
+										label: (
+											<>
+												<SquaresFour className="h-4 w-4" aria-hidden="true" />
+												<span className="sr-only">{t`Grid view`}</span>
+											</>
+										),
+									},
+									{
+										value: "list",
+										label: (
+											<>
+												<List className="h-4 w-4" aria-hidden="true" />
+												<span className="sr-only">{t`List view`}</span>
+											</>
+										),
+									},
+								]}
+							/>
+						</div>
+					</div>
 				</div>
 			)}
 
 			{/* Content */}
-			{/*
-			 * Gate the full-area loader on items being empty so that "Load More"
-			 * (which sets isLoading=true while fetching the next page) does not
-			 * blank out the already-rendered grid. Mirrors the ContentList
-			 * pattern from #135.
-			 */}
 			{currentLoading && currentItems.length === 0 && currentProviderItems.length === 0 ? (
 				<div className="flex items-center justify-center py-12">
 					<Loader />
 				</div>
 			) : activeProvider === "local" && currentItems.length === 0 ? (
-				<div className="rounded-lg border bg-kumo-base p-12 text-center">
-					<Image className="mx-auto h-12 w-12 text-kumo-subtle" aria-hidden="true" />
-					<h2 className="mt-4 text-lg font-medium">{t`No media yet`}</h2>
-					<p className="mt-2 text-sm text-kumo-subtle">
-						{t`Upload images, videos, and documents to get started.`}
-					</p>
-					<Button className="mt-4" onClick={() => fileInputRef.current?.click()} icon={<Upload />}>
-						{t`Upload Files`}
-					</Button>
-				</div>
+				hasActiveQuery ? (
+					<MediaEmptyState
+						hero={MagnifyingGlass}
+						title={t`No matching media`}
+						description={
+							searchQuery.trim()
+								? t`Try another filename, or clear your search and filters.`
+								: t`Try a broader media type or clear your filters.`
+						}
+						action={
+							<Button variant="outline" onClick={clearLocalQuery}>
+								{searchQuery.trim() ? t`Clear search` : t`Clear filters`}
+							</Button>
+						}
+					/>
+				) : (
+					<MediaEmptyState
+						hero={Images}
+						title={t`Your media library is empty`}
+						description={t`Upload images, videos, and documents to keep reusable assets in one place.`}
+						action={
+							<Button onClick={() => fileInputRef.current?.click()} icon={<Upload />}>
+								{t`Upload Files`}
+							</Button>
+						}
+					/>
+				)
 			) : activeProvider !== "local" && currentProviderItems.length === 0 ? (
-				<div className="rounded-lg border bg-kumo-base p-12 text-center">
-					<Image className="mx-auto h-12 w-12 text-kumo-subtle" aria-hidden="true" />
-					<h2 className="mt-4 text-lg font-medium">{t`No media found`}</h2>
-					<p className="mt-2 text-sm text-kumo-subtle">
-						{canSearch && searchQuery
-							? t`Try a different search term`
-							: canUpload
-								? t`Upload media to get started`
-								: t`No media available from this provider`}
-					</p>
-				</div>
+				canSearch && searchQuery.trim() ? (
+					<MediaEmptyState
+						hero={MagnifyingGlass}
+						title={t`No matching media`}
+						description={t`Try another filename or clear your search.`}
+						action={
+							<Button variant="outline" onClick={() => setSearchQuery("")}>
+								{t`Clear search`}
+							</Button>
+						}
+					/>
+				) : canUpload ? (
+					<MediaEmptyState
+						hero={Images}
+						title={t`Your media library is empty`}
+						description={t`Upload media to keep reusable assets in one place.`}
+						action={
+							<Button onClick={() => fileInputRef.current?.click()} icon={<Upload />}>
+								{t`Upload Files`}
+							</Button>
+						}
+					/>
+				) : (
+					<MediaEmptyState
+						hero={Images}
+						title={t`No media found`}
+						description={t`No media available from this provider.`}
+					/>
+				)
 			) : viewMode === "grid" ? (
 				<div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(160px,1fr))]">
 					{activeProvider === "local"
@@ -450,16 +544,15 @@ export function MediaLibrary({
 								<MediaGridItem
 									key={item.id}
 									item={item}
-									selected={selectedItem?.id === item.id}
-									onClick={() => setSelectedItem(item)}
-									onDelete={() => onDelete?.(item.id)}
+									selected={detailItem?.id === item.id}
+									onClick={() => openDetail(item)}
 								/>
 							))
 						: currentProviderItems.map((item) => (
 								<ProviderGridItem
 									key={item.id}
 									item={item}
-									selected={selectedItem?.id === item.id}
+									selected={detailItem?.id === item.id}
 									onClick={() => {
 										// Merge loaded dimensions if provider didn't return them
 										const dims = loadedDimensions[item.id];
@@ -470,7 +563,7 @@ export function MediaLibrary({
 													height: item.height ?? dims.height,
 												}
 											: item;
-										setSelectedItem(providerItemToMediaItem(activeProvider, itemWithDims));
+										openDetail(providerItemToMediaItem(activeProvider, itemWithDims));
 									}}
 									onDimensionsLoaded={(width, height) => {
 										setLoadedDimensions((prev) => ({
@@ -490,7 +583,7 @@ export function MediaLibrary({
 								<th className="px-4 py-3 text-start text-sm font-medium">{t`Filename`}</th>
 								<th className="px-4 py-3 text-start text-sm font-medium">{t`Type`}</th>
 								<th className="px-4 py-3 text-start text-sm font-medium">{t`Size`}</th>
-								<th className="px-4 py-3 text-end text-sm font-medium">{t`Actions`}</th>
+								<th className="px-4 py-3 text-end text-sm font-medium">{t`Alt text`}</th>
 							</tr>
 						</thead>
 						<tbody className="divide-y divide-kumo-line">
@@ -499,16 +592,15 @@ export function MediaLibrary({
 										<MediaListItem
 											key={item.id}
 											item={item}
-											selected={selectedItem?.id === item.id}
-											onClick={() => setSelectedItem(item)}
-											onDelete={() => onDelete?.(item.id)}
+											selected={detailItem?.id === item.id}
+											onClick={() => openDetail(item)}
 										/>
 									))
 								: currentProviderItems.map((item) => (
 										<ProviderListItem
 											key={item.id}
 											item={item}
-											selected={selectedItem?.id === item.id}
+											selected={detailItem?.id === item.id}
 											onClick={() => {
 												const dims = loadedDimensions[item.id];
 												const itemWithDims = dims
@@ -518,7 +610,7 @@ export function MediaLibrary({
 															height: item.height ?? dims.height,
 														}
 													: item;
-												setSelectedItem(providerItemToMediaItem(activeProvider, itemWithDims));
+												openDetail(providerItemToMediaItem(activeProvider, itemWithDims));
 											}}
 											onDimensionsLoaded={(width, height) => {
 												setLoadedDimensions((prev) => ({
@@ -542,21 +634,64 @@ export function MediaLibrary({
 				</div>
 			)}
 
-			{/* Detail Panel */}
-			{selectedItem && (
+			{/* Detail Dialog */}
+			{detailItem && (
 				<MediaDetailPanel
-					item={selectedItem}
-					onClose={() => setSelectedItem(null)}
-					onDeleted={() => {
-						if (activeProvider === "local") {
-							onDelete?.(selectedItem.id);
-							onItemUpdated?.();
-						} else {
-							void refetchProviderMedia();
-						}
-					}}
+					open={isDetailOpen}
+					item={detailItem}
+					providerName={detailItem.provider ? activeProviderInfo?.name : undefined}
+					canDelete={detailItem.provider ? activeProviderInfo?.capabilities.delete : undefined}
+					restoreFocusTargetRef={mediaHeadingRef}
+					onClose={closeDetail}
+					onClosed={handleDetailClosed}
+					onUpdated={onItemUpdated}
+					onDeleted={onItemUpdated}
 				/>
 			)}
+		</div>
+	);
+}
+
+/** Single-chip illustration: solid tinted circle + darker icon, decorative. */
+function MediaEmptyIllustration({ hero: Hero }: { hero: Icon }) {
+	return (
+		<div
+			className="flex items-center justify-center"
+			style={{
+				width: "5rem",
+				height: "5rem",
+				minWidth: "5rem",
+				minHeight: "5rem",
+				borderRadius: "9999px",
+				backgroundColor: "var(--color-kumo-info-tint)",
+			}}
+			aria-hidden="true"
+		>
+			<Hero size={36} className="text-kumo-brand" aria-hidden="true" />
+		</div>
+	);
+}
+
+interface MediaEmptyStateProps {
+	hero: Icon;
+	title: string;
+	description: string;
+	action?: React.ReactNode;
+}
+
+/** Centered empty / no-results panel with the media illustration. */
+function MediaEmptyState({ hero, title, description, action }: MediaEmptyStateProps) {
+	return (
+		<div
+			className="flex flex-col items-center rounded-lg border bg-kumo-base px-6 py-20 text-center"
+			style={{ gap: "1.5rem" }}
+		>
+			<MediaEmptyIllustration hero={hero} />
+			<div className="flex flex-col items-center" style={{ gap: "0.75rem" }}>
+				<h2 className="text-2xl font-semibold leading-none tracking-tight">{title}</h2>
+				<p className="max-w-md text-base leading-6 text-kumo-subtle">{description}</p>
+			</div>
+			{action && <div style={{ marginTop: "0.25rem" }}>{action}</div>}
 		</div>
 	);
 }
@@ -565,7 +700,6 @@ interface MediaGridItemProps {
 	item: MediaItem;
 	selected?: boolean;
 	onClick?: () => void;
-	onDelete: () => void;
 }
 
 function MediaGridItem({ item, selected, onClick }: MediaGridItemProps) {
@@ -658,7 +792,6 @@ interface MediaListItemProps {
 	item: MediaItem;
 	selected?: boolean;
 	onClick?: () => void;
-	onDelete: () => void;
 }
 
 function MediaListItem({ item, selected, onClick }: MediaListItemProps) {

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -77,7 +77,6 @@ import {
 	fetchTranslations,
 	fetchMediaList,
 	uploadMedia,
-	deleteMedia,
 	fetchCollections,
 	fetchCollection,
 	createCollection,
@@ -1131,13 +1130,6 @@ function MediaPage() {
 		},
 	});
 
-	const deleteMutation = useMutation({
-		mutationFn: (id: string) => deleteMedia(id),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["media"] });
-		},
-	});
-
 	const items = React.useMemo(() => {
 		return data?.pages.flatMap((page) => page.items) || [];
 	}, [data]);
@@ -1153,7 +1145,6 @@ function MediaPage() {
 			hasMore={!!hasNextPage}
 			onLoadMore={() => void fetchNextPage()}
 			onUpload={(file) => uploadMutation.mutate(file)}
-			onDelete={(id) => deleteMutation.mutate(id)}
 			onLocalSearchChange={setSearch}
 			onLocalMimeFilterChange={setMimeFilter}
 		/>

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -388,6 +388,49 @@ describe("MediaDetailPanel", () => {
 		expect(onClose).toHaveBeenCalled();
 	});
 
+	it("cancels the close fallback when reopened before the fallback timer fires", async () => {
+		vi.useFakeTimers();
+		try {
+			const onClose = vi.fn();
+			const onClosed = vi.fn();
+			const firstItem = makeImageItem({ id: "media-1", filename: "first.jpg" });
+			const secondItem = makeImageItem({ id: "media-2", filename: "second.jpg" });
+
+			const screen = await render(
+				<QueryWrapper>
+					<MediaDetailPanel
+						open
+						item={firstItem}
+						onClose={onClose}
+						onClosed={onClosed}
+						onDeleted={vi.fn()}
+					/>
+				</QueryWrapper>,
+			);
+
+			screen.getByRole("button", { name: "Close" }).element().click();
+			expect(onClose).toHaveBeenCalled();
+
+			await screen.rerender(
+				<QueryWrapper>
+					<MediaDetailPanel
+						open
+						item={secondItem}
+						onClose={onClose}
+						onClosed={onClosed}
+						onDeleted={vi.fn()}
+					/>
+				</QueryWrapper>,
+			);
+			await vi.advanceTimersByTimeAsync(500);
+
+			expect(onClosed).not.toHaveBeenCalled();
+			await expect.element(screen.getByLabelText("Filename")).toHaveValue("second.jpg");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("form fields reset when item prop changes", async () => {
 		const item1 = makeImageItem({ id: "m1", alt: "Alt one", caption: "Cap one" });
 		const item2 = makeImageItem({ id: "m2", alt: "Alt two", caption: "Cap two" });

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -12,31 +12,18 @@ vi.mock("../../src/lib/api", async () => {
 		...actual,
 		updateMedia: vi.fn().mockResolvedValue({}),
 		deleteMedia: vi.fn().mockResolvedValue({}),
+		deleteFromProvider: vi.fn().mockResolvedValue({}),
 	};
 });
 
 // Import the mocked functions for assertions
-import { updateMedia, deleteMedia } from "../../src/lib/api";
+import { updateMedia, deleteMedia, deleteFromProvider } from "../../src/lib/api";
 
 function QueryWrapper({ children }: { children: React.ReactNode }) {
 	const qc = new QueryClient({
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	});
 	return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-}
-
-function renderPanel(props: Partial<React.ComponentProps<typeof MediaDetailPanel>> = {}) {
-	const defaultProps = {
-		item: null as MediaItem | null,
-		onClose: vi.fn(),
-		onDeleted: vi.fn(),
-		...props,
-	};
-	return render(
-		<QueryWrapper>
-			<MediaDetailPanel {...defaultProps} />
-		</QueryWrapper>,
-	);
 }
 
 function makeImageItem(overrides: Partial<MediaItem> = {}): MediaItem {
@@ -67,14 +54,28 @@ function makePdfItem(overrides: Partial<MediaItem> = {}): MediaItem {
 	};
 }
 
+function renderPanel(props: Partial<React.ComponentProps<typeof MediaDetailPanel>> = {}) {
+	const defaultProps: React.ComponentProps<typeof MediaDetailPanel> = {
+		open: true,
+		item: makeImageItem(),
+		onClose: vi.fn(),
+		onDeleted: vi.fn(),
+		...props,
+	};
+	return render(
+		<QueryWrapper>
+			<MediaDetailPanel {...defaultProps} />
+		</QueryWrapper>,
+	);
+}
+
 describe("MediaDetailPanel", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("renders nothing when item is null", async () => {
-		const screen = await renderPanel({ item: null });
-		// The component returns null, so "Media Details" heading shouldn't exist
+	it("does not render dialog contents when closed", async () => {
+		const screen = await renderPanel({ open: false });
 		await expect
 			.element(screen.getByText("Media Details"), { timeout: 100 })
 			.not.toBeInTheDocument();
@@ -94,6 +95,42 @@ describe("MediaDetailPanel", () => {
 		const item = makeImageItem({ width: 1920, height: 1080 });
 		const screen = await renderPanel({ item });
 		await expect.element(screen.getByText("1920 × 1080")).toBeInTheDocument();
+	});
+
+	it("renders the responsive two-column viewport-bounded dialog layout", async () => {
+		const screen = await renderPanel();
+		const dialog = screen.getByRole("dialog", { name: "Media Details" }).element();
+		const header = screen.getByTestId("media-detail-dialog-header").element();
+		const body = screen.getByTestId("media-detail-dialog-body").element();
+		const previewColumn = screen.getByTestId("media-detail-dialog-preview-column").element();
+		const detailsColumn = screen.getByTestId("media-detail-dialog-details-column").element();
+		const fileFacts = screen.getByTestId("media-detail-dialog-file-facts").element();
+		const footer = screen.getByTestId("media-detail-dialog-footer").element();
+
+		expect(body.className).toContain("grid-cols-1");
+		expect(body.className).toContain("md:grid-cols-2");
+		expect(dialog.style.height).toBe("");
+		expect(dialog.style.maxHeight).toBe("min(88dvh, 48rem)");
+		expect(dialog.className).toContain("data-starting-style:scale-90");
+		expect(dialog.className).toContain("data-starting-style:opacity-0");
+		expect(dialog.style.transitionProperty).toBe("scale, opacity");
+		expect(header.style.padding).toBe("1.25rem 2rem");
+		expect(previewColumn.contains(fileFacts)).toBe(true);
+		expect(detailsColumn.contains(fileFacts)).toBe(false);
+		expect(previewColumn.className).toContain("md:p-8");
+		expect(detailsColumn.className).toContain("md:p-8");
+		// Columns only constrain/scroll at md+; on mobile the body scrolls as one
+		// column so collapsed columns can't compress and overlap their content.
+		expect(body.className).toContain("overflow-y-auto");
+		expect(body.className).toContain("md:overflow-hidden");
+		expect(previewColumn.className).toContain("md:min-h-0");
+		expect(previewColumn.className).toContain("md:overflow-y-auto");
+		expect(previewColumn.className).not.toContain(" min-h-0");
+		expect(detailsColumn.className).toContain("md:min-h-0");
+		expect(detailsColumn.className).toContain("md:overflow-y-auto");
+		expect(detailsColumn.className).not.toContain(" min-h-0");
+		expect(fileFacts.className).toContain("space-y-3");
+		expect(footer.style.padding).toBe("1.25rem 2rem");
 	});
 
 	it("shows image preview for image mimeTypes", async () => {
@@ -116,6 +153,10 @@ describe("MediaDetailPanel", () => {
 		const screen = await renderPanel({ item });
 		const altInput = screen.getByLabelText("Alt Text");
 		await expect.element(altInput).toBeInTheDocument();
+		expect(altInput.element().className).toContain("w-full");
+		await expect
+			.element(screen.getByRole("button", { name: "Why is this important?" }))
+			.toBeInTheDocument();
 		await altInput.fill("New alt text");
 		await expect.element(altInput).toHaveValue("New alt text");
 	});
@@ -140,11 +181,16 @@ describe("MediaDetailPanel", () => {
 			.not.toBeInTheDocument();
 	});
 
-	it("filename input is disabled", async () => {
+	it("filename input is disabled with tooltip help", async () => {
 		const item = makeImageItem();
 		const screen = await renderPanel({ item });
 		const filenameInput = screen.getByLabelText("Filename");
 		await expect.element(filenameInput).toBeDisabled();
+		expect(filenameInput.element().className).toContain("bg-kumo-tint");
+		expect(filenameInput.element().className).toContain("w-full");
+		await expect
+			.element(screen.getByRole("button", { name: "Why can't this be changed?" }))
+			.toBeInTheDocument();
 	});
 
 	it("save button is disabled when no changes", async () => {
@@ -164,19 +210,97 @@ describe("MediaDetailPanel", () => {
 	});
 
 	it("save calls updateMedia with correct payload", async () => {
+		const onClose = vi.fn();
 		const item = makeImageItem({ alt: "Old alt", caption: "Old caption" });
-		const screen = await renderPanel({ item });
+		const screen = await renderPanel({ item, onClose });
 
 		const altInput = screen.getByLabelText("Alt Text");
 		await altInput.fill("New alt");
 
 		const saveBtn = screen.getByRole("button", { name: "Save" });
-		await saveBtn.click();
+		await expect.element(saveBtn).toBeEnabled();
+		saveBtn.element().click();
 
-		expect(updateMedia).toHaveBeenCalledWith("media-1", {
-			alt: "New alt",
-			caption: "Old caption",
+		await vi.waitFor(() => {
+			expect(updateMedia).toHaveBeenCalledWith("media-1", {
+				alt: "New alt",
+				caption: "Old caption",
+			});
+			expect(onClose).toHaveBeenCalled();
 		});
+	});
+
+	it("saves empty strings when clearing alt text and caption", async () => {
+		const item = makeImageItem({ alt: "Old alt", caption: "Old caption" });
+		const screen = await renderPanel({ item });
+
+		await screen.getByLabelText("Alt Text").fill("");
+		await screen.getByLabelText("Caption").fill("");
+		screen.getByRole("button", { name: "Save" }).element().click();
+
+		await vi.waitFor(() => {
+			expect(updateMedia).toHaveBeenCalledWith("media-1", {
+				alt: "",
+				caption: "",
+			});
+		});
+	});
+
+	it("disables editing and closing while a save is pending", async () => {
+		let resolveUpdate!: (item: MediaItem) => void;
+		vi.mocked(updateMedia).mockImplementationOnce(
+			() => new Promise<MediaItem>((resolve) => (resolveUpdate = resolve)),
+		);
+		const onClose = vi.fn();
+		const item = makeImageItem({ alt: "Old alt", caption: "Old caption" });
+		const screen = await renderPanel({ item, onClose });
+
+		const altInput = screen.getByLabelText("Alt Text");
+		await altInput.fill("New alt");
+		screen.getByRole("button", { name: "Save" }).element().click();
+
+		await expect.element(altInput).toBeDisabled();
+		await expect.element(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+		await expect.element(screen.getByRole("button", { name: "Close" })).toBeDisabled();
+		await expect.element(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+
+		screen.getByRole("button", { name: "Close" }).element().click();
+		expect(onClose).not.toHaveBeenCalled();
+
+		resolveUpdate({ ...item, alt: "New alt" });
+		await vi.waitFor(() => {
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	it("saves dirty metadata with the keyboard shortcut", async () => {
+		const onClose = vi.fn();
+		const item = makeImageItem({ alt: "Old alt", caption: "Old caption" });
+		const screen = await renderPanel({ item, onClose });
+
+		await screen.getByLabelText("Alt Text").fill("Shortcut alt");
+		window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true }));
+
+		await vi.waitFor(() => {
+			expect(updateMedia).toHaveBeenCalledWith("media-1", {
+				alt: "Shortcut alt",
+				caption: "Old caption",
+			});
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	it("does not consume the keyboard save shortcut when nothing can be saved", async () => {
+		await renderPanel({
+			item: makeImageItem({ provider: "cloudflare-images" }),
+			providerName: "Cloudflare Images",
+		});
+
+		const event = new KeyboardEvent("keydown", { key: "s", ctrlKey: true, cancelable: true });
+		window.dispatchEvent(event);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(updateMedia).not.toHaveBeenCalled();
 	});
 
 	it("delete with confirm calls deleteMedia and onClose + onDeleted", async () => {
@@ -186,7 +310,7 @@ describe("MediaDetailPanel", () => {
 
 		const screen = await renderPanel({ item, onClose, onDeleted });
 		const deleteBtn = screen.getByRole("button", { name: "Delete" });
-		await deleteBtn.click();
+		deleteBtn.element().click();
 
 		// ConfirmDialog should appear
 		await expect.element(screen.getByText("Delete Media?")).toBeInTheDocument();
@@ -203,32 +327,64 @@ describe("MediaDetailPanel", () => {
 		});
 	});
 
+	it("deletes provider assets through the provider API when deletion is supported", async () => {
+		const onDeleted = vi.fn();
+		const screen = await renderPanel({
+			item: makeImageItem({ id: "provider-1", provider: "cloudflare-images" }),
+			providerName: "Cloudflare Images",
+			canDelete: true,
+			onDeleted,
+		});
+
+		screen.getByRole("button", { name: "Delete" }).element().click();
+		await expect.element(screen.getByText("Delete Media?")).toBeInTheDocument();
+		screen.getByRole("button", { name: "Delete" }).all().at(-1)!.element().click();
+
+		await vi.waitFor(() => {
+			expect(deleteFromProvider).toHaveBeenCalledWith("cloudflare-images", "provider-1");
+			expect(deleteMedia).not.toHaveBeenCalled();
+			expect(onDeleted).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	it("delete cancelled does not call deleteMedia", async () => {
 		const item = makeImageItem();
 
 		const screen = await renderPanel({ item });
 		const deleteBtn = screen.getByRole("button", { name: "Delete" });
-		await deleteBtn.click();
+		deleteBtn.element().click();
 
 		// ConfirmDialog should appear
 		await expect.element(screen.getByText("Delete Media?")).toBeInTheDocument();
 
 		// Direct DOM click to bypass Base UI inert overlay
-		screen.getByRole("button", { name: "Cancel" }).element().click();
+		screen.getByRole("button", { name: "Cancel" }).all().at(-1)!.element().click();
 
 		expect(deleteMedia).not.toHaveBeenCalled();
 	});
 
-	it("escape key calls onClose", async () => {
+	it("close button calls onClose when clean", async () => {
 		const onClose = vi.fn();
 		const item = makeImageItem();
-		await renderPanel({ item, onClose });
+		const screen = await renderPanel({ item, onClose });
 
-		await new Promise<void>((resolve) => {
-			window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-			resolve();
-		});
+		screen.getByRole("button", { name: "Close" }).element().click();
 
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it("close button opens discard confirmation when dirty", async () => {
+		const onClose = vi.fn();
+		const item = makeImageItem({ alt: "Original" });
+		const screen = await renderPanel({ item, onClose });
+
+		await screen.getByLabelText("Alt Text").fill("Changed alt");
+		screen.getByRole("button", { name: "Close" }).element().click();
+
+		await expect.element(screen.getByText("Discard changes?")).toBeInTheDocument();
+		expect(onClose).not.toHaveBeenCalled();
+
+		screen.getByRole("button", { name: "Discard" }).element().click();
 		expect(onClose).toHaveBeenCalled();
 	});
 
@@ -245,7 +401,7 @@ describe("MediaDetailPanel", () => {
 		// Rerender with item2
 		await screen.rerender(
 			<QueryWrapper>
-				<MediaDetailPanel item={item2} onClose={vi.fn()} onDeleted={vi.fn()} />
+				<MediaDetailPanel open item={item2} onClose={vi.fn()} onDeleted={vi.fn()} />
 			</QueryWrapper>,
 		);
 
@@ -266,5 +422,36 @@ describe("MediaDetailPanel file URL", () => {
 		const absolute = new URL("/_emdash/api/media/file/01ABC.jpg", window.location.origin).href;
 		await expect.element(screen.getByText(absolute)).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: /Copy URL/ })).toBeVisible();
+	});
+
+	it("does not expose provider preview URLs as public URLs", async () => {
+		const screen = await renderPanel({
+			item: makeImageItem({ provider: "cloudflare-images", url: "https://preview.example/image" }),
+			providerName: "Cloudflare Images",
+		});
+
+		await expect.element(screen.getByText("Managed by Cloudflare Images")).toBeVisible();
+		await expect.element(screen.getByText("No public URL available")).toBeVisible();
+		await expect
+			.element(screen.getByRole("button", { name: /Copy URL/ }), { timeout: 100 })
+			.not.toBeInTheDocument();
+	});
+
+	it("renders provider assets read-only", async () => {
+		const screen = await renderPanel({
+			item: makeImageItem({ provider: "cloudflare-images" }),
+			providerName: "Cloudflare Images",
+		});
+
+		await expect
+			.element(screen.getByRole("button", { name: "Delete" }), { timeout: 100 })
+			.not.toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "Save" }), { timeout: 100 })
+			.not.toBeInTheDocument();
+		await expect
+			.element(screen.getByLabelText("Alt Text"), { timeout: 100 })
+			.not.toBeInTheDocument();
+		await expect.element(screen.getByText("Uploaded:"), { timeout: 100 }).not.toBeInTheDocument();
 	});
 });

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -4,13 +4,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { MediaLibrary } from "../../src/components/MediaLibrary";
 import type { MediaItem } from "../../src/lib/api";
+import { deleteMedia } from "../../src/lib/api";
 import { render } from "../utils/render.tsx";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const UPLOAD_CTA_PATTERN = /Upload images, videos, and documents/;
+const UPLOAD_CTA_PATTERN = /Upload images, videos, and documents to keep reusable assets/;
 const UPLOAD_TO_LIBRARY_PATTERN = /Upload to Library/;
 const UPLOAD_FILES_PATTERN = /Upload Files/;
 
@@ -39,7 +40,6 @@ function renderLibrary(props: Partial<React.ComponentProps<typeof MediaLibrary>>
 		isLoading: false,
 		onUpload: vi.fn(),
 		onSelect: vi.fn(),
-		onDelete: vi.fn(),
 		onItemUpdated: vi.fn(),
 		...props,
 	};
@@ -77,7 +77,7 @@ describe("MediaLibrary", () => {
 			];
 			const screen = await renderLibrary({ items });
 			// Grid view is default — items render as buttons with alt text
-			await expect.element(screen.getByRole("button", { name: "Grid view" })).toBeInTheDocument();
+			await expect.element(screen.getByRole("tab", { name: "Grid view" })).toBeInTheDocument();
 			// Images should be present via their img alt attributes
 			await expect.element(screen.getByAltText("image1.jpg")).toBeInTheDocument();
 			await expect.element(screen.getByAltText("image2.jpg")).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe("MediaLibrary", () => {
 			const screen = await renderLibrary({ items });
 
 			// Default is grid
-			const listBtn = screen.getByRole("button", { name: "List view" });
+			const listBtn = screen.getByRole("tab", { name: "List view" });
 			await listBtn.click();
 
 			// In list view, filename appears in table cell
@@ -124,7 +124,7 @@ describe("MediaLibrary", () => {
 	});
 
 	describe("item selection", () => {
-		it("clicking an item opens detail panel", async () => {
+		it("clicking an item opens detail dialog", async () => {
 			const items = [makeMediaItem({ id: "1", filename: "photo.jpg", alt: "A photo" })];
 			const screen = await renderLibrary({ items });
 
@@ -134,12 +134,106 @@ describe("MediaLibrary", () => {
 			// MediaDetailPanel should open showing the item details
 			await expect.element(screen.getByText("Media Details")).toBeInTheDocument();
 		});
+
+		it("opens the detail dialog on an animation frame so Kumo entry animation runs", async () => {
+			let openFrame: FrameRequestCallback | undefined;
+			const requestAnimationFrameSpy = vi
+				.spyOn(window, "requestAnimationFrame")
+				.mockImplementation((callback) => {
+					openFrame = callback;
+					return 1;
+				});
+			const cancelAnimationFrameSpy = vi
+				.spyOn(window, "cancelAnimationFrame")
+				.mockImplementation(() => undefined);
+
+			try {
+				const items = [makeMediaItem({ id: "1", filename: "photo.jpg", alt: "A photo" })];
+				const screen = await renderLibrary({ items });
+
+				await screen.getByRole("button", { name: "photo.jpg" }).click();
+
+				expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+				await expect
+					.element(screen.getByText("Media Details"), { timeout: 100 })
+					.not.toBeInTheDocument();
+
+				openFrame?.(performance.now());
+
+				await expect.element(screen.getByText("Media Details")).toBeInTheDocument();
+			} finally {
+				requestAnimationFrameSpy.mockRestore();
+				cancelAnimationFrameSpy.mockRestore();
+			}
+		});
+
+		it("preserves unsaved alt text when the media list refetches the same item", async () => {
+			const item = makeMediaItem({ id: "1", filename: "photo.jpg", alt: "Server alt" });
+			const screen = await renderLibrary({ items: [item] });
+
+			await screen.getByRole("button", { name: "photo.jpg" }).click();
+			await screen.getByLabelText("Alt Text").fill("Unsaved alt");
+
+			await screen.rerender(
+				<QueryWrapper>
+					<MediaLibrary
+						items={[makeMediaItem({ id: "1", filename: "photo.jpg", alt: "Refetched alt" })]}
+						isLoading={false}
+					/>
+				</QueryWrapper>,
+			);
+
+			await expect.element(screen.getByLabelText("Alt Text")).toHaveValue("Unsaved alt");
+		});
+
+		it("deletes from the detail dialog with one local delete call", async () => {
+			const onItemUpdated = vi.fn();
+			const items = [makeMediaItem({ id: "1", filename: "photo.jpg" })];
+			const screen = await renderLibrary({ items, onItemUpdated });
+
+			await screen.getByRole("button", { name: "photo.jpg" }).click();
+			screen.getByRole("button", { name: "Delete" }).element().click();
+			await expect.element(screen.getByText("Delete Media?")).toBeInTheDocument();
+			screen.getByRole("button", { name: "Delete" }).all().at(-1)!.element().click();
+
+			await vi.waitFor(() => {
+				expect(deleteMedia).toHaveBeenCalledTimes(1);
+				expect(deleteMedia).toHaveBeenCalledWith("1");
+				expect(onItemUpdated).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it("focuses the persistent heading after deleting the last asset", async () => {
+			function Harness() {
+				const [items, setItems] = React.useState([
+					makeMediaItem({ id: "1", filename: "photo.jpg" }),
+				]);
+				return <MediaLibrary items={items} isLoading={false} onItemUpdated={() => setItems([])} />;
+			}
+
+			const screen = await render(
+				<QueryWrapper>
+					<Harness />
+				</QueryWrapper>,
+			);
+
+			await screen.getByRole("button", { name: "photo.jpg" }).click();
+			screen.getByRole("button", { name: "Delete" }).element().click();
+			await expect.element(screen.getByText("Delete Media?")).toBeInTheDocument();
+			screen.getByRole("button", { name: "Delete" }).all().at(-1)!.element().click();
+
+			await vi.waitFor(() => {
+				expect(document.activeElement).toBe(
+					screen.getByRole("heading", { name: "Media Library", exact: true }).element(),
+				);
+			});
+		});
 	});
 
 	describe("empty state", () => {
 		it("shows upload CTA when no items", async () => {
 			const screen = await renderLibrary({ items: [] });
-			await expect.element(screen.getByText("No media yet")).toBeInTheDocument();
+			await expect.element(screen.getByText("Your media library is empty")).toBeInTheDocument();
 			await expect.element(screen.getByText(UPLOAD_CTA_PATTERN)).toBeInTheDocument();
 			await expect
 				.element(screen.getByRole("button", { name: UPLOAD_FILES_PATTERN }))
@@ -151,7 +245,7 @@ describe("MediaLibrary", () => {
 		it("displays loading state", async () => {
 			const screen = await renderLibrary({ isLoading: true });
 			// When loading, neither empty state nor items are shown
-			expect(screen.getByText("No media yet").query()).toBeNull();
+			expect(screen.getByText("Your media library is empty").query()).toBeNull();
 		});
 	});
 
@@ -168,7 +262,7 @@ describe("MediaLibrary", () => {
 			const screen = await renderLibrary({ items });
 
 			// Switch to list view
-			await screen.getByRole("button", { name: "List view" }).click();
+			await screen.getByRole("tab", { name: "List view" }).click();
 
 			await expect.element(screen.getByText("document.pdf")).toBeInTheDocument();
 			await expect.element(screen.getByText("application/pdf")).toBeInTheDocument();
@@ -179,7 +273,9 @@ describe("MediaLibrary", () => {
 	describe("header", () => {
 		it("shows Media Library heading", async () => {
 			const screen = await renderLibrary();
-			await expect.element(screen.getByText("Media Library")).toBeInTheDocument();
+			await expect
+				.element(screen.getByRole("heading", { name: "Media Library", exact: true }))
+				.toBeInTheDocument();
 		});
 	});
 
@@ -188,6 +284,7 @@ describe("MediaLibrary", () => {
 			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
 			const screen = await renderLibrary({ items, hasMore: true, onLoadMore: vi.fn() });
 			await expect.element(screen.getByRole("button", { name: "Load More" })).toBeInTheDocument();
+			expect(screen.getByText("1 item").query()).toBeNull();
 		});
 
 		it("does not render Load More button when hasMore is false", async () => {
@@ -243,6 +340,29 @@ describe("MediaLibrary", () => {
 			await screen.getByRole("option", { name: "Images" }).click();
 
 			expect(onLocalMimeFilterChange).toHaveBeenCalledWith("image/");
+		});
+
+		it("does not flash the empty-library state while clearing a zero-result search", async () => {
+			function Harness() {
+				const [search, setSearch] = React.useState("");
+				const items = search ? [] : [makeMediaItem({ id: "1", filename: "restored.jpg" })];
+
+				return <MediaLibrary items={items} onLocalSearchChange={setSearch} isLoading={false} />;
+			}
+
+			const screen = await render(
+				<QueryWrapper>
+					<Harness />
+				</QueryWrapper>,
+			);
+
+			await screen.getByRole("searchbox", { name: "Search media" }).fill("missing");
+			await expect.element(screen.getByText("No matching media")).toBeInTheDocument();
+
+			await screen.getByRole("searchbox", { name: "Search media" }).fill("");
+
+			expect(screen.getByText("Your media library is empty").query()).toBeNull();
+			await expect.element(screen.getByAltText("restored.jpg")).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -364,5 +364,28 @@ describe("MediaLibrary", () => {
 			expect(screen.getByText("Your media library is empty").query()).toBeNull();
 			await expect.element(screen.getByAltText("restored.jpg")).toBeInTheDocument();
 		});
+
+		it("does not keep the local filter toolbar visible on empty provider tabs", async () => {
+			const api = await import("../../src/lib/api");
+			(api.fetchMediaProviders as any).mockResolvedValueOnce([
+				{
+					id: "cloudflare-images",
+					name: "Cloudflare Images",
+					capabilities: { browse: true, search: false, upload: false, delete: false },
+				},
+			]);
+
+			const screen = await renderLibrary({
+				items: [makeMediaItem({ id: "1", filename: "a.jpg" })],
+			});
+
+			await screen.getByRole("combobox", { name: "Filter by type" }).click();
+			await screen.getByRole("option", { name: "Images" }).click();
+			await screen.getByRole("tab", { name: "Cloudflare Images" }).click();
+
+			await expect.element(screen.getByText("No media found")).toBeInTheDocument();
+			expect(screen.getByRole("tab", { name: "Grid view" }).query()).toBeNull();
+			expect(screen.getByRole("tab", { name: "List view" }).query()).toBeNull();
+		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Refines the admin media library and asset details flow: the library uses Kumo tabs for view switching, has clearer empty/no-results states, opens asset details in a centered responsive dialog, and routes provider asset deletion through the provider API when supported.

Closes: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (verified with `pnpm --filter @emdash-cms/admin typecheck`)
- [x] `pnpm lint` passes (verified with `pnpm --silent lint:json | jq '.diagnostics | length'` -> `0`)
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs -- a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, no new feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: OpenCode with GPT-5.5

## Screenshots / test output

<img width="3023" height="1532" alt="image" src="https://github.com/user-attachments/assets/b95da39f-3fef-4911-b93a-138331fb2205" />
<img width="3023" height="1198" alt="image" src="https://github.com/user-attachments/assets/69bf59a3-1feb-4295-8d3c-5f2aa2912794" />
<img width="3024" height="1537" alt="image" src="https://github.com/user-attachments/assets/6d7a3eb3-9aac-47cc-b9ce-07c9d84710e7" />


- `pnpm --silent lint:json | jq '.diagnostics | length'` -> `0`
- `pnpm --filter @emdash-cms/admin typecheck` -> passed
- `pnpm --filter @emdash-cms/admin test -- tests/components/MediaLibrary.test.tsx tests/components/MediaDetailPanel.test.tsx` -> `83` test files passed, `1041` tests passed

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://pr-media-library-refinements-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `pr/media-library-refinements`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
