### PR TITLE
fix(admin): surface field-level validation messages instead of a generic error

### DIFF
--- a/.changeset/surface-validation-issue-messages.md
+++ b/.changeset/surface-validation-issue-messages.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes admin forms (e.g. Create Taxonomy) showing a generic "Invalid request data" error instead of the actual validation problem. Field-level validation messages from the server are now shown to the user.

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -18,20 +18,48 @@ export function apiFetch(input: string | URL | Request, init?: RequestInit): Pro
 	return fetch(input, { ...init, headers });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/**
+ * Extract per-field validation issue messages from a `VALIDATION_ERROR`
+ * response's `error.details.issues` array (see `packages/core/src/api/parse.ts`).
+ * Returns undefined when the shape doesn't match, so callers can fall back
+ * to the generic top-level message.
+ */
+function formatValidationIssues(error: Record<string, unknown>): string | undefined {
+	if (error.code !== "VALIDATION_ERROR") return undefined;
+	if (!isRecord(error.details)) return undefined;
+	const issues = error.details.issues;
+	if (!Array.isArray(issues) || issues.length === 0) return undefined;
+
+	const messages = issues
+		.map((issue: unknown) => {
+			if (!isRecord(issue)) return undefined;
+			const { path, message } = issue;
+			if (typeof message !== "string") return undefined;
+			return typeof path === "string" && path.length > 0 ? `${path}: ${message}` : message;
+		})
+		.filter((m): m is string => m !== undefined);
+
+	return messages.length > 0 ? messages.join("; ") : undefined;
+}
+
 /**
  * Throw an error with the message from the API response body if available,
  * falling back to a generic message. All API error responses use the shape
- * `{ error: { code, message } }`.
+ * `{ error: { code, message, details? } }`. For validation errors, the
+ * field-level messages in `error.details.issues` are surfaced instead of
+ * the generic "Invalid request data" top-level message.
  */
 export async function throwResponseError(res: Response, fallback: string): Promise<never> {
 	const body: unknown = await res.json().catch(() => ({}));
 	let message: string | undefined;
-	if (typeof body === "object" && body !== null && "error" in body) {
+	if (isRecord(body) && isRecord(body.error)) {
 		const { error } = body;
-		if (typeof error === "object" && error !== null && "message" in error) {
-			const { message: errorMessage } = error;
-			if (typeof errorMessage === "string") message = errorMessage;
-		}
+		message = formatValidationIssues(error);
+		if (!message && typeof error.message === "string") message = error.message;
 	}
 	throw new Error(message || `${fallback}: ${res.statusText}`);
 }

--- a/packages/admin/tests/lib/api-client.test.ts
+++ b/packages/admin/tests/lib/api-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { apiFetch, fetchManifest } from "../../src/lib/api/client";
+import { apiFetch, fetchManifest, throwResponseError } from "../../src/lib/api/client";
 
 describe("apiFetch", () => {
 	let fetchSpy: ReturnType<typeof vi.fn>;
@@ -67,5 +67,75 @@ describe("fetchManifest", () => {
 			.fn()
 			.mockResolvedValue(new Response("", { status: 500, statusText: "Internal Server Error" }));
 		await expect(fetchManifest()).rejects.toThrow("Failed to fetch manifest");
+	});
+});
+
+describe("throwResponseError", () => {
+	it("includes the field-level message for a validation error", async () => {
+		const response = new Response(
+			JSON.stringify({
+				error: {
+					code: "VALIDATION_ERROR",
+					message: "Invalid request data",
+					details: {
+						issues: [{ path: "name", message: "Too big: expected string to have <=63 characters" }],
+					},
+				},
+			}),
+			{ status: 400 },
+		);
+		await expect(throwResponseError(response, "Failed to create taxonomy")).rejects.toThrow(
+			"name: Too big: expected string to have <=63 characters",
+		);
+	});
+
+	it("joins multiple validation issues", async () => {
+		const response = new Response(
+			JSON.stringify({
+				error: {
+					code: "VALIDATION_ERROR",
+					message: "Invalid request data",
+					details: {
+						issues: [
+							{ path: "name", message: "Required" },
+							{ path: "slug", message: "Invalid format" },
+						],
+					},
+				},
+			}),
+			{ status: 400 },
+		);
+		await expect(throwResponseError(response, "fallback")).rejects.toThrow(
+			"name: Required; slug: Invalid format",
+		);
+	});
+
+	it("omits the empty path prefix for top-level issues", async () => {
+		const response = new Response(
+			JSON.stringify({
+				error: {
+					code: "VALIDATION_ERROR",
+					message: "Invalid request data",
+					details: { issues: [{ path: "", message: "Expected an object" }] },
+				},
+			}),
+			{ status: 400 },
+		);
+		await expect(throwResponseError(response, "fallback")).rejects.toThrow("Expected an object");
+	});
+
+	it("falls back to the plain message when there are no issues", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "NOT_FOUND", message: "Not found" } }),
+			{ status: 404 },
+		);
+		await expect(throwResponseError(response, "fallback")).rejects.toThrow("Not found");
+	});
+
+	it("falls back to the generic fallback when the body has no error", async () => {
+		const response = new Response("", { status: 500, statusText: "Internal Server Error" });
+		await expect(throwResponseError(response, "fallback")).rejects.toThrow(
+			"fallback: Internal Server Error",
+		);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

`throwResponseError()` only read `error.message`, which the API always sets to the generic "Invalid request data" for `VALIDATION_ERROR` responses — the actual per-field problems live in `error.details.issues` and were silently discarded. This surfaces the real field-level messages to the user instead of the generic error, fixed once in the shared helper so every caller routed through `parseApiResponse` benefits (createTaxonomy and 20+ others), not just the reported taxonomy-creation case.

Closes #255

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no new user-visible strings, this surfaces existing API-provided messages)
- [x] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5

## Screenshots / test output

`packages/admin/tests/lib/api-client.test.ts` — 1050/1050 admin tests pass; `pnpm lint:quick` clean; `pnpm typecheck` clean.