### PR TITLE
fix(core): exclude unpublished entries from taxonomy term counts

### DIFF
--- a/.changeset/taxonomy-counts-exclude-unpublished.md
+++ b/.changeset/taxonomy-counts-exclude-unpublished.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes taxonomy term counts (e.g. the "Categories" sidebar widget) including unpublished draft posts. Counts now only reflect published (or scheduled-and-due) content.

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -521,7 +521,7 @@ export type OrderBySpec = Record<string, SortDirection>;
  * whose scheduled_at time has passed (treating it as effectively published).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
-function buildStatusCondition(
+export function buildStatusCondition(
 	db: Kysely<any>,
 	status: string,
 	tablePrefix?: string,

--- a/packages/core/src/taxonomies/index.ts
+++ b/packages/core/src/taxonomies/index.ts
@@ -11,8 +11,11 @@
  * the right per-locale term.
  */
 
+import { sql } from "kysely";
+
+import { validateIdentifier } from "../database/validate.js";
 import { resolveLocale, resolveLocaleChain } from "../i18n/resolve.js";
-import { getDb, resetTaxonomyNamesCache } from "../loader.js";
+import { buildStatusCondition, getDb, resetTaxonomyNamesCache } from "../loader.js";
 import {
 	cachedQuery,
 	CacheNamespace,
@@ -282,22 +285,55 @@ async function loadTaxonomyTerms(
 }
 
 /**
- * Per-translation-group usage counts across all taxonomies, in one aggregate
- * scan of `content_taxonomies`. Counts are locale-independent (the pivot stores
+ * Per-translation-group usage counts across all taxonomies, counting only
+ * published (or scheduled-and-past-due) entries so unpublished drafts don't
+ * inflate the counts shown in term widgets (#581). `content_taxonomies` has
+ * no FK to the per-collection `ec_*` tables that hold `status`, so this joins
+ * against each distinct collection present in the pivot separately and sums
+ * the results. Counts are locale-independent (the pivot stores
  * translation_group), so a single request-cached entry serves every taxonomy
  * that renders during the request.
  */
 function getTaxonomyTermCounts(): Promise<Map<string, number>> {
 	return requestCached("taxonomy-term-counts", async () => {
 		const db = await getDb();
-		const countsResult = await db
-			.selectFrom("content_taxonomies")
-			.select(["taxonomy_id"])
-			.select((eb) => eb.fn.count<number>("entry_id").as("count"))
-			.groupBy("taxonomy_id")
-			.execute();
 		const counts = new Map<string, number>();
-		for (const row of countsResult) counts.set(row.taxonomy_id, row.count);
+
+		const collectionRows = await db
+			.selectFrom("content_taxonomies")
+			.select("collection")
+			.distinct()
+			.execute();
+
+		await Promise.all(
+			collectionRows.map(async ({ collection }) => {
+				try {
+					validateIdentifier(collection, "content_taxonomies collection");
+				} catch {
+					return;
+				}
+
+				const statusCondition = buildStatusCondition(db, "published", "c");
+				let rows;
+				try {
+					rows = await sql<{ taxonomy_id: string; count: number }>`
+						SELECT ct.taxonomy_id AS taxonomy_id, COUNT(*) AS count
+						FROM content_taxonomies ct
+						JOIN ${sql.ref(`ec_${collection}`)} c ON c.id = ct.entry_id
+						WHERE ct.collection = ${collection} AND ${statusCondition}
+						GROUP BY ct.taxonomy_id
+					`.execute(db);
+				} catch (error) {
+					if (isMissingTableError(error)) return;
+					throw error;
+				}
+
+				for (const row of rows.rows) {
+					counts.set(row.taxonomy_id, (counts.get(row.taxonomy_id) ?? 0) + Number(row.count));
+				}
+			}),
+		);
+
 		return counts;
 	});
 }

--- a/packages/core/tests/unit/taxonomies/get-taxonomy-terms.test.ts
+++ b/packages/core/tests/unit/taxonomies/get-taxonomy-terms.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
+import { ContentRepository } from "../../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../../src/database/repositories/taxonomy.js";
 import {
 	describeEachDialect,
@@ -9,9 +10,12 @@ import {
 } from "../../utils/test-db.js";
 
 // Mock loader.getDb so the runtime taxonomy functions read from our test db.
-vi.mock("../../../src/loader.js", () => ({
-	getDb: vi.fn(),
-}));
+// buildStatusCondition is the real implementation -- only getDb needs stubbing.
+vi.mock("../../../src/loader.js", async () => {
+	const actual =
+		await vi.importActual<typeof import("../../../src/loader.js")>("../../../src/loader.js");
+	return { ...actual, getDb: vi.fn() };
+});
 
 import { getDb } from "../../../src/loader.js";
 import { getTaxonomyTerms, invalidateTermCache } from "../../../src/taxonomies/index.js";
@@ -19,10 +23,12 @@ import { getTaxonomyTerms, invalidateTermCache } from "../../../src/taxonomies/i
 describeEachDialect("getTaxonomyTerms", (dialect) => {
 	let ctx: DialectTestContext;
 	let taxRepo: TaxonomyRepository;
+	let contentRepo: ContentRepository;
 
 	beforeEach(async () => {
 		ctx = await setupForDialectWithCollections(dialect);
 		taxRepo = new TaxonomyRepository(ctx.db);
+		contentRepo = new ContentRepository(ctx.db);
 		vi.mocked(getDb).mockResolvedValue(ctx.db);
 		invalidateTermCache();
 	});
@@ -63,5 +69,30 @@ describeEachDialect("getTaxonomyTerms", (dialect) => {
 
 		expect(terms).toHaveLength(1);
 		expect(terms[0].description).toBe("All things tech");
+	});
+
+	it("excludes draft entries from the term count (#581)", async () => {
+		const term = await taxRepo.create({ name: "category", slug: "tech", label: "Technology" });
+
+		const published = await contentRepo.create({
+			type: "post",
+			slug: "published-post",
+			status: "published",
+			data: { title: "Published" },
+		});
+		await taxRepo.attachToEntry("post", published.id, term.id);
+
+		const draft = await contentRepo.create({
+			type: "post",
+			slug: "draft-post",
+			status: "draft",
+			data: { title: "Draft" },
+		});
+		await taxRepo.attachToEntry("post", draft.id, term.id);
+
+		const terms = await getTaxonomyTerms("category");
+
+		expect(terms).toHaveLength(1);
+		expect(terms[0].count).toBe(1);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

`getTaxonomyTermCounts()` aggregated `content_taxonomies` with no status filter, so a draft post attached to a term inflated that term's count in widgets like the "Categories" sidebar even though the draft never renders publicly.

`content_taxonomies` has no FK to the per-collection `ec_*` tables that hold status, so the fix joins against each distinct collection present in the pivot and applies the same published-or-scheduled-and-due condition `loader.ts` already uses for content queries (`buildStatusCondition`, now exported for reuse here).

Closes #581

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no new strings, count values only)
- [x] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5

## Screenshots / test output

`packages/core/tests/unit/taxonomies/get-taxonomy-terms.test.ts` — 3/3 pass; `pnpm lint:quick` clean; `pnpm typecheck` clean. (Full-suite run also shows 4 pre-existing failures in `tests/unit/cli/bundle-utils.test.ts` unrelated to this change — Windows/Git-Bash `tar` path mangling in the local dev environment, reproduces identically on `main`.)

Opened as draft: fork already has several open PRs against this repo (non-collaborator open-PR limit).