### PR TITLE
Add media usage repair foundation

### DIFF
--- a/.changeset/media-usage-repair-foundation.md
+++ b/.changeset/media-usage-repair-foundation.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds internal media usage repair foundations for future usage-aware media workflows.

--- a/packages/core/src/database/repositories/media-usage.ts
+++ b/packages/core/src/database/repositories/media-usage.ts
@@ -19,6 +19,7 @@ import type {
 	MediaUsageSourceTable,
 	MediaUsageTable,
 } from "../types.js";
+import { validateIdentifier } from "../validate.js";
 import { decodeCursor, encodeCursor, type FindManyResult } from "./types.js";
 
 type DatabaseExecutor = Kysely<Database> | Transaction<Database>;
@@ -107,6 +108,10 @@ export interface MediaUsageGuardedReplaceResult {
 export interface MediaUsageGuardedDeleteResult {
 	deleted: boolean;
 	source: MediaUsageSource | null;
+}
+
+export interface MediaUsageGuardedAbsentDeleteResult extends MediaUsageGuardedDeleteResult {
+	contentPresent: boolean;
 }
 
 export interface MediaUsageGuardedAttemptResult {
@@ -522,6 +527,37 @@ export class MediaUsageRepository {
 		};
 	}
 
+	async deleteSourceIfMatchingContentAbsent(
+		sourceKey: string,
+		expectedSource: MediaUsageSource,
+		collectionSlug: string,
+		contentId: string,
+	): Promise<MediaUsageGuardedAbsentDeleteResult> {
+		validateIdentifier(collectionSlug, "collection slug");
+		const tableName = `ec_${collectionSlug}`;
+		let deleted = false;
+		await withTransaction(this.db, async (trx) => {
+			const result = await trx
+				.deleteFrom("_emdash_media_usage_sources")
+				.where("source_key", "=", sourceKey)
+				.where(this.sourceMatchExpression(expectedSource))
+				.where(
+					sql<boolean>`NOT EXISTS (SELECT 1 FROM ${sql.ref(tableName)} WHERE id = ${contentId})`,
+				)
+				.executeTakeFirst();
+			deleted = Number(result.numDeletedRows ?? 0) > 0;
+			if (!deleted) return;
+			await trx.deleteFrom("_emdash_media_usage").where("source_key", "=", sourceKey).execute();
+		});
+		const contentPresent = deleted ? false : await this.contentRowExists(tableName, contentId);
+
+		return {
+			deleted,
+			contentPresent,
+			source: deleted || contentPresent ? null : await this.findSource(sourceKey),
+		};
+	}
+
 	async deleteSources(sourceKeys: readonly string[]): Promise<number> {
 		return this.deleteSourceKeys(sourceKeys);
 	}
@@ -554,6 +590,17 @@ export class MediaUsageRepository {
 			deleted += await this.deleteSourceKeys(sourceRows.map((row) => row.source_key));
 		}
 		return deleted;
+	}
+
+	async findCollectionContentSources(collectionSlug: string): Promise<MediaUsageSource[]> {
+		const rows = await this.db
+			.selectFrom("_emdash_media_usage_sources")
+			.selectAll()
+			.where("source_type", "=", "content")
+			.where("collection_slug", "=", collectionSlug)
+			.orderBy("source_key", "asc")
+			.execute();
+		return rows.map((row) => rowToSource(row));
 	}
 
 	async deleteOrphanOccurrencesOlderThan(cutoff: string, limit: number): Promise<number> {
@@ -985,6 +1032,16 @@ export class MediaUsageRepository {
 		value: number | null,
 	) {
 		return value === null ? eb(column, "is", null) : eb(column, "=", value);
+	}
+
+	private async contentRowExists(tableName: string, contentId: string): Promise<boolean> {
+		const result = await sql<{ id: string }>`
+			SELECT id
+			FROM ${sql.ref(tableName)}
+			WHERE id = ${contentId}
+			LIMIT 1
+		`.execute(this.db);
+		return result.rows.length > 0;
 	}
 
 	private buildSourceRow(source: MediaUsageSourceInput, generation: string, now: string) {

--- a/packages/core/src/database/repositories/media-usage.ts
+++ b/packages/core/src/database/repositories/media-usage.ts
@@ -1,4 +1,12 @@
-import { sql, type Kysely, type Selectable, type Transaction, type Updateable } from "kysely";
+import {
+	sql,
+	type ExpressionBuilder,
+	type Insertable,
+	type Kysely,
+	type Selectable,
+	type Transaction,
+	type Updateable,
+} from "kysely";
 import { ulid } from "ulidx";
 
 import type { MediaUsageContentSourceVariant } from "../../media/usage/source-key.js";
@@ -14,6 +22,13 @@ import type {
 import { decodeCursor, encodeCursor, type FindManyResult } from "./types.js";
 
 type DatabaseExecutor = Kysely<Database> | Transaction<Database>;
+type MediaUsageSourceNullableStringColumn =
+	| "source_fingerprint"
+	| "source_updated_at"
+	| "revision_id"
+	| "updated_at"
+	| "last_attempted_at"
+	| "last_error_code";
 
 const OCCURRENCE_BIND_COLUMNS = 13;
 const OCCURRENCE_INSERT_BATCH_SIZE = Math.max(
@@ -92,6 +107,35 @@ export interface MediaUsageGuardedReplaceResult {
 export interface MediaUsageGuardedDeleteResult {
 	deleted: boolean;
 	source: MediaUsageSource | null;
+}
+
+export interface MediaUsageGuardedAttemptResult {
+	attempted: boolean;
+	/** Populated only when a guarded attempted mark did not win the current source row. */
+	source: MediaUsageSource | null;
+}
+
+export interface MediaUsageIndexStatusRepairInput extends MediaUsageIndexStatusIdentity {
+	runToken: string;
+	schemaVersion?: number;
+	startedAt: string;
+	updatedAt?: string;
+}
+
+export interface MediaUsageIndexStatusFinalizeInput extends MediaUsageIndexStatusIdentity {
+	runToken: string;
+	status: Exclude<MediaUsageIndexStatusValue, "never" | "running" | "stale">;
+	schemaVersion?: number;
+	completedAt: string;
+	indexedSourceCount?: number;
+	failedSourceCount?: number;
+	lastErrorCode?: string | null;
+	updatedAt?: string;
+}
+
+export interface MediaUsageGuardedIndexStatusResult {
+	finalized: boolean;
+	status: MediaUsageIndexStatus | null;
 }
 
 export type MediaUsageSourceCompleteness =
@@ -288,62 +332,55 @@ export class MediaUsageRepository {
 		return row ? rowToSource(row) : null;
 	}
 
+	async findSources(sourceKeys: readonly string[]): Promise<Map<string, MediaUsageSource>> {
+		const uniqueSourceKeys = [...new Set(sourceKeys)];
+		const sources = new Map<string, MediaUsageSource>();
+		if (uniqueSourceKeys.length === 0) return sources;
+
+		for (const sourceKeyBatch of chunks(uniqueSourceKeys, SQL_BATCH_SIZE)) {
+			const rows = await this.db
+				.selectFrom("_emdash_media_usage_sources")
+				.selectAll()
+				.where("source_key", "in", sourceKeyBatch)
+				.execute();
+			for (const row of rows) {
+				const source = rowToSource(row);
+				sources.set(source.sourceKey, source);
+			}
+		}
+
+		return sources;
+	}
+
+	async replaceSourceIfMatching(
+		source: MediaUsageSourceInput,
+		occurrences: readonly MediaUsageOccurrenceInput[],
+		expectedSource: MediaUsageSource | null,
+	): Promise<MediaUsageGuardedReplaceResult> {
+		const generation = ulid();
+		const now = new Date().toISOString();
+		const row = this.buildSourceRow(source, generation, now);
+		let replaced = false;
+
+		await withTransaction(this.db, async (trx) => {
+			await this.insertOccurrences(trx, source.sourceKey, generation, occurrences, now);
+			if (expectedSource === null) {
+				replaced = await this.insertSourceIfAbsent(trx, row);
+				return;
+			}
+			replaced = await this.updateSourceIfMatching(trx, row, expectedSource);
+		});
+
+		return {
+			replaced,
+			source: replaced ? null : await this.findSource(source.sourceKey),
+		};
+	}
+
 	async markSourceAttempted(source: MediaUsageSourceInput): Promise<MediaUsageSource> {
 		const now = new Date().toISOString();
-		const attemptedAt = source.lastAttemptedAt ?? now;
-		const row = {
-			source_key: source.sourceKey,
-			source_type: source.sourceType,
-			collection_slug: source.collectionSlug ?? null,
-			content_id: source.contentId ?? null,
-			source_variant: source.sourceVariant,
-			locale: source.locale ?? null,
-			translation_group: source.translationGroup ?? null,
-			content_slug: source.contentSlug ?? null,
-			content_title: source.contentTitle ?? null,
-			content_status: source.contentStatus ?? null,
-			content_scheduled_at: source.contentScheduledAt ?? null,
-			content_deleted_at: source.contentDeletedAt ?? null,
-			revision_id: source.revisionId ?? null,
-			current_generation: ulid(),
-			schema_version: source.schemaVersion ?? 1,
-			source_updated_at: source.sourceUpdatedAt ?? null,
-			source_version: source.sourceVersion ?? null,
-			source_fingerprint: source.sourceFingerprint ?? null,
-			source_completeness:
-				source.sourceCompleteness ?? (source.lastErrorCode ? "failed" : "unknown"),
-			last_attempted_at: attemptedAt,
-			last_error_code: source.lastErrorCode ?? null,
-			indexed_at: now,
-			updated_at: now,
-		};
-		const updates: Updateable<MediaUsageSourceTable> = {
-			source_type: row.source_type,
-			source_variant: row.source_variant,
-			source_completeness: row.source_completeness,
-			last_attempted_at: row.last_attempted_at,
-			last_error_code: row.last_error_code,
-			updated_at: row.updated_at,
-		};
-
-		if (source.collectionSlug !== undefined) updates.collection_slug = row.collection_slug;
-		if (source.contentId !== undefined) updates.content_id = row.content_id;
-		if (source.locale !== undefined) updates.locale = row.locale;
-		if (source.translationGroup !== undefined) updates.translation_group = row.translation_group;
-		if (source.contentSlug !== undefined) updates.content_slug = row.content_slug;
-		if (source.contentTitle !== undefined) updates.content_title = row.content_title;
-		if (source.contentStatus !== undefined) updates.content_status = row.content_status;
-		if (source.contentScheduledAt !== undefined) {
-			updates.content_scheduled_at = row.content_scheduled_at;
-		}
-		if (source.contentDeletedAt !== undefined) updates.content_deleted_at = row.content_deleted_at;
-		if (source.revisionId !== undefined) updates.revision_id = row.revision_id;
-		if (source.schemaVersion !== undefined) updates.schema_version = row.schema_version;
-		if (source.sourceUpdatedAt !== undefined) updates.source_updated_at = row.source_updated_at;
-		if (source.sourceVersion !== undefined) updates.source_version = row.source_version;
-		if (source.sourceFingerprint !== undefined) {
-			updates.source_fingerprint = row.source_fingerprint;
-		}
+		const row = this.buildAttemptedSourceRow(source, now);
+		const updates = this.attemptedSourceUpdateSet(source, row);
 
 		await this.db
 			.insertInto("_emdash_media_usage_sources")
@@ -356,6 +393,26 @@ export class MediaUsageRepository {
 			throw new Error(`Media usage source ${source.sourceKey} was not persisted`);
 		}
 		return attempted;
+	}
+
+	async markSourceAttemptedIfMatching(
+		source: MediaUsageSourceInput,
+		expectedSource: MediaUsageSource | null,
+	): Promise<MediaUsageGuardedAttemptResult> {
+		const now = new Date().toISOString();
+		const row = this.buildAttemptedSourceRow(source, now);
+		let attempted = false;
+
+		if (expectedSource === null) {
+			attempted = await this.insertSourceIfAbsent(this.db, row);
+		} else {
+			attempted = await this.updateAttemptedSourceIfMatching(this.db, source, row, expectedSource);
+		}
+
+		return {
+			attempted,
+			source: attempted ? null : await this.findSource(source.sourceKey),
+		};
 	}
 
 	async findCurrentUsageByMediaId(mediaId: string): Promise<MediaUsageRecord[]> {
@@ -431,6 +488,28 @@ export class MediaUsageRepository {
 				.deleteFrom("_emdash_media_usage_sources")
 				.where("source_key", "=", sourceKey)
 				.where("current_generation", "=", expectedCurrentGeneration)
+				.executeTakeFirst();
+			deleted = Number(result.numDeletedRows ?? 0) > 0;
+			if (!deleted) return;
+			await trx.deleteFrom("_emdash_media_usage").where("source_key", "=", sourceKey).execute();
+		});
+
+		return {
+			deleted,
+			source: await this.findSource(sourceKey),
+		};
+	}
+
+	async deleteSourceIfMatching(
+		sourceKey: string,
+		expectedSource: MediaUsageSource,
+	): Promise<MediaUsageGuardedDeleteResult> {
+		let deleted = false;
+		await withTransaction(this.db, async (trx) => {
+			const result = await trx
+				.deleteFrom("_emdash_media_usage_sources")
+				.where("source_key", "=", sourceKey)
+				.where(this.sourceMatchExpression(expectedSource))
 				.executeTakeFirst();
 			deleted = Number(result.numDeletedRows ?? 0) > 0;
 			if (!deleted) return;
@@ -642,6 +721,56 @@ export class MediaUsageRepository {
 		return status;
 	}
 
+	async beginIndexStatusRepair(
+		input: MediaUsageIndexStatusRepairInput,
+	): Promise<MediaUsageIndexStatus> {
+		return this.upsertIndexStatus({
+			adapterId: input.adapterId,
+			scopeType: input.scopeType,
+			scopeKey: input.scopeKey,
+			status: "running",
+			schemaVersion: input.schemaVersion,
+			startedAt: input.startedAt,
+			completedAt: null,
+			cursor: input.runToken,
+			indexedSourceCount: 0,
+			failedSourceCount: 0,
+			lastErrorCode: null,
+			updatedAt: input.updatedAt,
+		});
+	}
+
+	async finalizeIndexStatusRepairIfRunning(
+		input: MediaUsageIndexStatusFinalizeInput,
+	): Promise<MediaUsageGuardedIndexStatusResult> {
+		const updates: Updateable<MediaUsageIndexStatusTable> = {
+			status: input.status,
+			completed_at: input.completedAt,
+			cursor: null,
+			indexed_source_count: input.indexedSourceCount ?? 0,
+			failed_source_count: input.failedSourceCount ?? 0,
+			last_error_code: input.lastErrorCode ?? null,
+			updated_at: input.updatedAt ?? new Date().toISOString(),
+		};
+		if (input.schemaVersion !== undefined) updates.schema_version = input.schemaVersion;
+
+		const result = await this.db
+			.updateTable("_emdash_media_usage_index_status")
+			.set(updates)
+			.where("adapter_id", "=", input.adapterId)
+			.where("scope_type", "=", input.scopeType)
+			.where("scope_key", "=", input.scopeKey)
+			.where("status", "=", "running")
+			.where("cursor", "=", input.runToken)
+			.executeTakeFirst();
+		const finalized = Number(result.numUpdatedRows ?? 0) > 0;
+
+		return {
+			finalized,
+			status: await this.findIndexStatus(input),
+		};
+	}
+
 	async findIndexStatus(
 		identity: MediaUsageIndexStatusIdentity,
 	): Promise<MediaUsageIndexStatus | null> {
@@ -774,7 +903,7 @@ export class MediaUsageRepository {
 
 	private async insertSourceIfAbsent(
 		db: DatabaseExecutor,
-		row: ReturnType<MediaUsageRepository["buildSourceRow"]>,
+		row: Insertable<MediaUsageSourceTable>,
 	): Promise<boolean> {
 		const result = await db
 			.insertInto("_emdash_media_usage_sources")
@@ -796,6 +925,66 @@ export class MediaUsageRepository {
 			.where("current_generation", "=", expectedCurrentGeneration)
 			.executeTakeFirst();
 		return Number(result.numUpdatedRows ?? 0) > 0;
+	}
+
+	private async updateSourceIfMatching(
+		db: DatabaseExecutor,
+		row: ReturnType<MediaUsageRepository["buildSourceRow"]>,
+		expectedSource: MediaUsageSource,
+	): Promise<boolean> {
+		const result = await db
+			.updateTable("_emdash_media_usage_sources")
+			.set(this.sourceUpdateSet(row))
+			.where("source_key", "=", row.source_key)
+			.where(this.sourceMatchExpression(expectedSource))
+			.executeTakeFirst();
+		return Number(result.numUpdatedRows ?? 0) > 0;
+	}
+
+	private async updateAttemptedSourceIfMatching(
+		db: DatabaseExecutor,
+		source: MediaUsageSourceInput,
+		row: ReturnType<MediaUsageRepository["buildAttemptedSourceRow"]>,
+		expectedSource: MediaUsageSource,
+	): Promise<boolean> {
+		const result = await db
+			.updateTable("_emdash_media_usage_sources")
+			.set(this.attemptedSourceUpdateSet(source, row))
+			.where("source_key", "=", row.source_key)
+			.where(this.sourceMatchExpression(expectedSource))
+			.executeTakeFirst();
+		return Number(result.numUpdatedRows ?? 0) > 0;
+	}
+
+	private sourceMatchExpression(expectedSource: MediaUsageSource) {
+		return (eb: ExpressionBuilder<Database, "_emdash_media_usage_sources">) =>
+			eb.and([
+				eb("current_generation", "=", expectedSource.currentGeneration),
+				eb("source_completeness", "=", expectedSource.sourceCompleteness),
+				this.nullableStringExpression(eb, "updated_at", expectedSource.updatedAt),
+				this.nullableStringExpression(eb, "source_fingerprint", expectedSource.sourceFingerprint),
+				this.nullableStringExpression(eb, "source_updated_at", expectedSource.sourceUpdatedAt),
+				this.nullableNumberExpression(eb, "source_version", expectedSource.sourceVersion),
+				this.nullableStringExpression(eb, "revision_id", expectedSource.revisionId),
+				this.nullableStringExpression(eb, "last_attempted_at", expectedSource.lastAttemptedAt),
+				this.nullableStringExpression(eb, "last_error_code", expectedSource.lastErrorCode),
+			]);
+	}
+
+	private nullableStringExpression(
+		eb: ExpressionBuilder<Database, "_emdash_media_usage_sources">,
+		column: MediaUsageSourceNullableStringColumn,
+		value: string | null,
+	) {
+		return value === null ? eb(column, "is", null) : eb(column, "=", value);
+	}
+
+	private nullableNumberExpression(
+		eb: ExpressionBuilder<Database, "_emdash_media_usage_sources">,
+		column: "source_version",
+		value: number | null,
+	) {
+		return value === null ? eb(column, "is", null) : eb(column, "=", value);
 	}
 
 	private buildSourceRow(source: MediaUsageSourceInput, generation: string, now: string) {
@@ -826,6 +1015,70 @@ export class MediaUsageRepository {
 			indexed_at: now,
 			updated_at: now,
 		};
+	}
+
+	private buildAttemptedSourceRow(source: MediaUsageSourceInput, now: string) {
+		return {
+			source_key: source.sourceKey,
+			source_type: source.sourceType,
+			collection_slug: source.collectionSlug ?? null,
+			content_id: source.contentId ?? null,
+			source_variant: source.sourceVariant,
+			locale: source.locale ?? null,
+			translation_group: source.translationGroup ?? null,
+			content_slug: source.contentSlug ?? null,
+			content_title: source.contentTitle ?? null,
+			content_status: source.contentStatus ?? null,
+			content_scheduled_at: source.contentScheduledAt ?? null,
+			content_deleted_at: source.contentDeletedAt ?? null,
+			revision_id: source.revisionId ?? null,
+			current_generation: ulid(),
+			schema_version: source.schemaVersion ?? 1,
+			source_updated_at: source.sourceUpdatedAt ?? null,
+			source_version: source.sourceVersion ?? null,
+			source_fingerprint: source.sourceFingerprint ?? null,
+			source_completeness:
+				source.sourceCompleteness ?? (source.lastErrorCode ? "failed" : "unknown"),
+			last_attempted_at: source.lastAttemptedAt ?? now,
+			last_error_code: source.lastErrorCode ?? null,
+			indexed_at: now,
+			updated_at: now,
+		};
+	}
+
+	private attemptedSourceUpdateSet(
+		source: MediaUsageSourceInput,
+		row: ReturnType<MediaUsageRepository["buildAttemptedSourceRow"]>,
+	): Updateable<MediaUsageSourceTable> {
+		const updates: Updateable<MediaUsageSourceTable> = {
+			source_type: row.source_type,
+			source_variant: row.source_variant,
+			source_completeness: row.source_completeness,
+			last_attempted_at: row.last_attempted_at,
+			last_error_code: row.last_error_code,
+			updated_at: row.updated_at,
+		};
+
+		if (source.collectionSlug !== undefined) updates.collection_slug = row.collection_slug;
+		if (source.contentId !== undefined) updates.content_id = row.content_id;
+		if (source.locale !== undefined) updates.locale = row.locale;
+		if (source.translationGroup !== undefined) updates.translation_group = row.translation_group;
+		if (source.contentSlug !== undefined) updates.content_slug = row.content_slug;
+		if (source.contentTitle !== undefined) updates.content_title = row.content_title;
+		if (source.contentStatus !== undefined) updates.content_status = row.content_status;
+		if (source.contentScheduledAt !== undefined) {
+			updates.content_scheduled_at = row.content_scheduled_at;
+		}
+		if (source.contentDeletedAt !== undefined) updates.content_deleted_at = row.content_deleted_at;
+		if (source.revisionId !== undefined) updates.revision_id = row.revision_id;
+		if (source.schemaVersion !== undefined) updates.schema_version = row.schema_version;
+		if (source.sourceUpdatedAt !== undefined) updates.source_updated_at = row.source_updated_at;
+		if (source.sourceVersion !== undefined) updates.source_version = row.source_version;
+		if (source.sourceFingerprint !== undefined) {
+			updates.source_fingerprint = row.source_fingerprint;
+		}
+
+		return updates;
 	}
 
 	private sourceUpdateSet(

--- a/packages/core/src/media/usage/content-refresh.ts
+++ b/packages/core/src/media/usage/content-refresh.ts
@@ -247,8 +247,10 @@ export async function deleteContentMediaUsage(
 	contentId: string,
 ): Promise<ContentMediaUsageRefreshResult> {
 	validateIdentifier(collectionSlug, "collection slug");
-	return withContentUsageLock(collectionSlug, contentId, () =>
-		deleteContentMediaUsageUnlocked(db, collectionSlug, contentId),
+	return withContentUsageCollectionLock(collectionSlug, () =>
+		withContentUsageLock(collectionSlug, contentId, () =>
+			deleteContentMediaUsageUnlocked(db, collectionSlug, contentId),
+		),
 	);
 }
 

--- a/packages/core/src/media/usage/content-refresh.ts
+++ b/packages/core/src/media/usage/content-refresh.ts
@@ -478,7 +478,7 @@ async function withContentUsageLock<T>(
 	}
 }
 
-async function withContentUsageCollectionLock<T>(
+export async function withContentUsageCollectionLock<T>(
 	collectionSlug: string,
 	fn: () => Promise<T>,
 ): Promise<T> {

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -1,0 +1,424 @@
+import { sql, type Kysely } from "kysely";
+import { ulid } from "ulidx";
+
+import {
+	MediaUsageRepository,
+	type MediaUsageSource,
+} from "../../database/repositories/media-usage.js";
+import type { Database } from "../../database/types.js";
+import { validateIdentifier } from "../../database/validate.js";
+import { loadContentMediaUsageFields, MediaUsageFieldDiscoveryError } from "./content-fields.js";
+import {
+	CONTENT_MEDIA_USAGE_ADAPTER_ID,
+	CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+	withContentUsageCollectionLock,
+} from "./content-refresh.js";
+import {
+	CONTENT_SOURCE_SCHEMA_VERSION,
+	loadContentMediaUsageSnapshots,
+} from "./content-snapshots.js";
+import {
+	buildContentMediaUsageSourceKey,
+	MEDIA_USAGE_CONTENT_SOURCE_VARIANTS,
+} from "./source-key.js";
+
+export type ContentMediaUsageRepairStatus = "complete" | "partial" | "failed" | "stale";
+
+export type ContentMediaUsageRepairErrorCode =
+	| "COLLECTION_NOT_FOUND"
+	| "CONTENT_NOT_FOUND"
+	| "DRAFT_REVISION_NOT_FOUND"
+	| "DRAFT_REVISION_MISMATCH"
+	| "DRAFT_REVISION_INVALID"
+	| "CONTENT_USAGE_REPAIR_ERROR"
+	| "CONTENT_USAGE_REPAIR_CONFLICT"
+	| "INVALID_REPEATER_VALIDATION";
+
+export interface ContentMediaUsageRepairCollectionInput {
+	collectionSlug: string;
+}
+
+export interface ContentMediaUsageRepairScope {
+	adapterId: typeof CONTENT_MEDIA_USAGE_ADAPTER_ID;
+	scopeType: typeof CONTENT_MEDIA_USAGE_COLLECTION_SCOPE;
+	scopeKey: string;
+}
+
+export interface ContentMediaUsageRepairCollectionResult {
+	scope: ContentMediaUsageRepairScope;
+	status: ContentMediaUsageRepairStatus;
+	indexedSourceCount: number;
+	failedSourceCount: number;
+	skippedSourceCount: number;
+	deletedSourceCount: number;
+	lastErrorCode: ContentMediaUsageRepairErrorCode | null;
+	startedAt: string;
+	completedAt: string | null;
+}
+
+export interface ContentMediaUsageCollectionScan {
+	collectionSlug: string;
+	contentIds: string[];
+}
+
+export async function scanContentMediaUsageCollection(
+	db: Kysely<Database>,
+	collectionSlug: string,
+): Promise<ContentMediaUsageCollectionScan | null> {
+	validateIdentifier(collectionSlug, "collection slug");
+	const collection = await db
+		.selectFrom("_emdash_collections")
+		.select("id")
+		.where("slug", "=", collectionSlug)
+		.executeTakeFirst();
+	if (!collection) return null;
+
+	const tableName = getContentTableName(collectionSlug);
+	const rows = await sql<{ id: string }>`
+		SELECT id
+		FROM ${sql.ref(tableName)}
+		ORDER BY id ASC
+	`.execute(db);
+
+	return {
+		collectionSlug,
+		contentIds: rows.rows.map((row) => row.id),
+	};
+}
+
+export async function repairContentMediaUsageCollection(
+	db: Kysely<Database>,
+	input: ContentMediaUsageRepairCollectionInput,
+): Promise<ContentMediaUsageRepairCollectionResult> {
+	validateIdentifier(input.collectionSlug, "collection slug");
+	return withContentUsageCollectionLock(input.collectionSlug, () =>
+		repairContentMediaUsageCollectionUnlocked(db, input.collectionSlug),
+	);
+}
+
+async function repairContentMediaUsageCollectionUnlocked(
+	db: Kysely<Database>,
+	collectionSlug: string,
+): Promise<ContentMediaUsageRepairCollectionResult> {
+	const startedAt = new Date().toISOString();
+	const scope = contentMediaUsageCollectionScope(collectionSlug);
+	if (!(await contentCollectionExists(db, collectionSlug))) {
+		return {
+			scope,
+			status: "failed",
+			indexedSourceCount: 0,
+			failedSourceCount: 0,
+			skippedSourceCount: 0,
+			deletedSourceCount: 0,
+			lastErrorCode: "COLLECTION_NOT_FOUND",
+			startedAt,
+			completedAt: startedAt,
+		};
+	}
+
+	const repo = new MediaUsageRepository(db);
+	const runToken = ulid();
+	await repo.beginIndexStatusRepair({
+		...scope,
+		runToken,
+		schemaVersion: CONTENT_SOURCE_SCHEMA_VERSION,
+		startedAt,
+	});
+
+	try {
+		const scan = await scanContentMediaUsageCollection(db, collectionSlug);
+		if (!scan) {
+			const completedAt = new Date().toISOString();
+			return await finalizeRepairStatus(repo, {
+				...scope,
+				runToken,
+				counts: {
+					indexedSourceCount: 0,
+					failedSourceCount: 0,
+					skippedSourceCount: 0,
+					deletedSourceCount: 0,
+					lastErrorCode: "COLLECTION_NOT_FOUND",
+				},
+				status: "failed",
+				startedAt,
+				completedAt,
+			});
+		}
+		const counts = await repairScannedContentSources(db, repo, scan);
+		const finalScan = await scanContentMediaUsageCollection(db, collectionSlug);
+		const scannedContentCount = finalScan?.contentIds.length ?? scan.contentIds.length;
+		if (!finalScan) {
+			counts.failedSourceCount++;
+			counts.lastErrorCode = "COLLECTION_NOT_FOUND";
+		} else if (!sameContentIds(scan.contentIds, finalScan.contentIds)) {
+			counts.skippedSourceCount++;
+			counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+		}
+		const completedAt = new Date().toISOString();
+		const status = determineRepairStatus(counts, scannedContentCount);
+		return await finalizeRepairStatus(repo, {
+			...scope,
+			runToken,
+			counts,
+			status,
+			startedAt,
+			completedAt,
+		});
+	} catch (error) {
+		if (!(error instanceof MediaUsageFieldDiscoveryError)) {
+			console.error(`[media-usage] Failed to repair collection ${collectionSlug}:`, error);
+		}
+		const completedAt = new Date().toISOString();
+		const lastErrorCode =
+			error instanceof MediaUsageFieldDiscoveryError ? error.code : "CONTENT_USAGE_REPAIR_ERROR";
+		return finalizeRepairStatus(repo, {
+			...scope,
+			runToken,
+			counts: {
+				indexedSourceCount: 0,
+				failedSourceCount: 0,
+				skippedSourceCount: 0,
+				deletedSourceCount: 0,
+				lastErrorCode,
+			},
+			status: "failed",
+			startedAt,
+			completedAt,
+		});
+	}
+}
+
+interface RepairCounts {
+	indexedSourceCount: number;
+	failedSourceCount: number;
+	skippedSourceCount: number;
+	deletedSourceCount: number;
+	lastErrorCode: ContentMediaUsageRepairErrorCode | null;
+}
+
+async function repairScannedContentSources(
+	db: Kysely<Database>,
+	repo: MediaUsageRepository,
+	scan: ContentMediaUsageCollectionScan,
+): Promise<RepairCounts> {
+	const counts: RepairCounts = {
+		indexedSourceCount: 0,
+		failedSourceCount: 0,
+		skippedSourceCount: 0,
+		deletedSourceCount: 0,
+		lastErrorCode: null,
+	};
+
+	await loadContentMediaUsageFields(db, scan.collectionSlug);
+
+	for (const contentId of scan.contentIds) {
+		await repairContentSource(db, repo, scan.collectionSlug, contentId, counts);
+	}
+
+	await reconcileOrphanedContentSources(db, repo, scan.collectionSlug, counts);
+	return counts;
+}
+
+async function repairContentSource(
+	db: Kysely<Database>,
+	repo: MediaUsageRepository,
+	collectionSlug: string,
+	contentId: string,
+	counts: RepairCounts,
+): Promise<void> {
+	const sourceKeys = buildContentSourceKeys(collectionSlug, contentId);
+	const observedSources = await repo.findSources(sourceKeys);
+	const snapshotsResult = await loadContentMediaUsageSnapshots(db, collectionSlug, contentId);
+	if (!snapshotsResult.success) {
+		counts.lastErrorCode = snapshotsResult.error;
+		if (snapshotsResult.source) {
+			const result = await repo.markSourceAttemptedIfMatching(
+				{
+					...snapshotsResult.source,
+					sourceCompleteness: "failed",
+					lastErrorCode: snapshotsResult.error,
+				},
+				observedSources.get(snapshotsResult.source.sourceKey) ?? null,
+			);
+			if (result.attempted) {
+				counts.failedSourceCount++;
+			} else {
+				counts.skippedSourceCount++;
+				counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+			}
+			return;
+		}
+
+		counts.failedSourceCount++;
+		return;
+	}
+
+	const expectedSourceKeys = new Set<string>();
+	for (const snapshot of snapshotsResult.snapshots) {
+		expectedSourceKeys.add(snapshot.source.sourceKey);
+		const result = await repo.replaceSourceIfMatching(
+			snapshot.source,
+			snapshot.occurrences,
+			observedSources.get(snapshot.source.sourceKey) ?? null,
+		);
+		if (result.replaced) {
+			counts.indexedSourceCount++;
+		} else {
+			counts.skippedSourceCount++;
+			counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+		}
+	}
+
+	for (const sourceKey of sourceKeys) {
+		if (expectedSourceKeys.has(sourceKey)) continue;
+		const observedSource = observedSources.get(sourceKey);
+		if (!observedSource) continue;
+		await deleteObservedSource(repo, sourceKey, observedSource, counts);
+	}
+}
+
+async function reconcileOrphanedContentSources(
+	db: Kysely<Database>,
+	repo: MediaUsageRepository,
+	collectionSlug: string,
+	counts: RepairCounts,
+): Promise<void> {
+	const sources = await repo.findCollectionContentSources(collectionSlug);
+	for (const source of sources) {
+		if (!source.contentId) {
+			await deleteObservedSource(repo, source.sourceKey, source, counts);
+			continue;
+		}
+		await deleteObservedSourceIfContentAbsent(repo, collectionSlug, source, counts);
+	}
+}
+
+async function deleteObservedSourceIfContentAbsent(
+	repo: MediaUsageRepository,
+	collectionSlug: string,
+	observedSource: MediaUsageSource,
+	counts: RepairCounts,
+): Promise<void> {
+	if (!observedSource.contentId) return;
+	const result = await repo.deleteSourceIfMatchingContentAbsent(
+		observedSource.sourceKey,
+		observedSource,
+		collectionSlug,
+		observedSource.contentId,
+	);
+	if (result.deleted) {
+		counts.deletedSourceCount++;
+		return;
+	}
+	if (result.contentPresent) return;
+	if (result.source) {
+		counts.skippedSourceCount++;
+		counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+	}
+}
+
+async function deleteObservedSource(
+	repo: MediaUsageRepository,
+	sourceKey: string,
+	observedSource: MediaUsageSource,
+	counts: RepairCounts,
+): Promise<void> {
+	const result = await repo.deleteSourceIfMatching(sourceKey, observedSource);
+	if (result.deleted) {
+		counts.deletedSourceCount++;
+		return;
+	}
+	if (result.source) {
+		counts.skippedSourceCount++;
+		counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+	}
+}
+
+interface FinalizeInput extends ContentMediaUsageRepairScope {
+	runToken: string;
+	counts: RepairCounts;
+	status: Exclude<ContentMediaUsageRepairStatus, "stale">;
+	startedAt: string;
+	completedAt: string;
+}
+
+async function finalizeRepairStatus(
+	repo: MediaUsageRepository,
+	input: FinalizeInput,
+): Promise<ContentMediaUsageRepairCollectionResult> {
+	const result = await repo.finalizeIndexStatusRepairIfRunning({
+		adapterId: input.adapterId,
+		scopeType: input.scopeType,
+		scopeKey: input.scopeKey,
+		runToken: input.runToken,
+		status: input.status,
+		schemaVersion: CONTENT_SOURCE_SCHEMA_VERSION,
+		completedAt: input.completedAt,
+		indexedSourceCount: input.counts.indexedSourceCount,
+		failedSourceCount: input.counts.failedSourceCount,
+		lastErrorCode: input.counts.lastErrorCode,
+	});
+
+	return {
+		scope: {
+			adapterId: input.adapterId,
+			scopeType: input.scopeType,
+			scopeKey: input.scopeKey,
+		},
+		status: result.finalized ? input.status : "stale",
+		indexedSourceCount: input.counts.indexedSourceCount,
+		failedSourceCount: input.counts.failedSourceCount,
+		skippedSourceCount: input.counts.skippedSourceCount,
+		deletedSourceCount: input.counts.deletedSourceCount,
+		lastErrorCode: input.counts.lastErrorCode,
+		startedAt: input.startedAt,
+		completedAt: result.finalized ? input.completedAt : null,
+	};
+}
+
+function determineRepairStatus(
+	counts: RepairCounts,
+	scannedContentCount: number,
+): Exclude<ContentMediaUsageRepairStatus, "stale"> {
+	if (counts.failedSourceCount === 0 && counts.skippedSourceCount === 0) return "complete";
+	const trustedProgress = counts.indexedSourceCount + counts.deletedSourceCount;
+	if (trustedProgress === 0 && scannedContentCount > 0) return "failed";
+	return "partial";
+}
+
+function buildContentSourceKeys(collectionSlug: string, contentId: string): string[] {
+	return MEDIA_USAGE_CONTENT_SOURCE_VARIANTS.map((sourceVariant) =>
+		buildContentMediaUsageSourceKey({ collectionSlug, contentId, sourceVariant }),
+	);
+}
+
+async function contentCollectionExists(
+	db: Kysely<Database>,
+	collectionSlug: string,
+): Promise<boolean> {
+	const row = await db
+		.selectFrom("_emdash_collections")
+		.select("id")
+		.where("slug", "=", collectionSlug)
+		.executeTakeFirst();
+	return row !== undefined;
+}
+
+function sameContentIds(left: readonly string[], right: readonly string[]): boolean {
+	if (left.length !== right.length) return false;
+	const rightIds = new Set(right);
+	return left.every((id) => rightIds.has(id));
+}
+
+function contentMediaUsageCollectionScope(collectionSlug: string): ContentMediaUsageRepairScope {
+	return {
+		adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+		scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+		scopeKey: collectionSlug,
+	};
+}
+
+function getContentTableName(collectionSlug: string): string {
+	validateIdentifier(collectionSlug, "collection slug");
+	return `ec_${collectionSlug}`;
+}

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -7,7 +7,11 @@ import {
 } from "../../database/repositories/media-usage.js";
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
-import { loadContentMediaUsageFields, MediaUsageFieldDiscoveryError } from "./content-fields.js";
+import {
+	loadContentMediaUsageFields,
+	MediaUsageFieldDiscoveryError,
+	type ContentMediaUsageFieldDiscovery,
+} from "./content-fields.js";
 import {
 	CONTENT_MEDIA_USAGE_ADAPTER_ID,
 	CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
@@ -209,10 +213,10 @@ async function repairScannedContentSources(
 		lastErrorCode: null,
 	};
 
-	await loadContentMediaUsageFields(db, scan.collectionSlug);
+	const fieldDiscovery = await loadContentMediaUsageFields(db, scan.collectionSlug);
 
 	for (const contentId of scan.contentIds) {
-		await repairContentSource(db, repo, scan.collectionSlug, contentId, counts);
+		await repairContentSource(db, repo, scan.collectionSlug, contentId, fieldDiscovery, counts);
 	}
 
 	await reconcileOrphanedContentSources(db, repo, scan.collectionSlug, counts);
@@ -224,11 +228,17 @@ async function repairContentSource(
 	repo: MediaUsageRepository,
 	collectionSlug: string,
 	contentId: string,
+	fieldDiscovery: ContentMediaUsageFieldDiscovery,
 	counts: RepairCounts,
 ): Promise<void> {
 	const sourceKeys = buildContentSourceKeys(collectionSlug, contentId);
 	const observedSources = await repo.findSources(sourceKeys);
-	const snapshotsResult = await loadContentMediaUsageSnapshots(db, collectionSlug, contentId);
+	const snapshotsResult = await loadContentMediaUsageSnapshots(
+		db,
+		collectionSlug,
+		contentId,
+		fieldDiscovery,
+	);
 	if (!snapshotsResult.success) {
 		counts.lastErrorCode = snapshotsResult.error;
 		if (snapshotsResult.source) {

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -60,7 +60,7 @@ export interface ContentMediaUsageRepairCollectionResult {
 	failedSourceCount: number;
 	skippedSourceCount: number;
 	deletedSourceCount: number;
-	lastErrorCode: ContentMediaUsageRepairErrorCode | null;
+	lastErrorCode: string | null;
 	startedAt: string;
 	completedAt: string | null;
 }
@@ -428,7 +428,10 @@ async function finalizeRepairStatus(
 		failedSourceCount: input.counts.failedSourceCount,
 		skippedSourceCount: input.counts.skippedSourceCount,
 		deletedSourceCount: input.counts.deletedSourceCount,
-		lastErrorCode: input.counts.lastErrorCode,
+		lastErrorCode: result.finalized
+			? input.counts.lastErrorCode
+			: (result.status?.lastErrorCode ??
+				CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT),
 		startedAt: input.startedAt,
 		completedAt: result.finalized ? input.completedAt : null,
 	};

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -28,15 +28,19 @@ import {
 
 export type ContentMediaUsageRepairStatus = "complete" | "partial" | "failed" | "stale";
 
+export const CONTENT_MEDIA_USAGE_REPAIR_ERROR = {
+	COLLECTION_NOT_FOUND: "COLLECTION_NOT_FOUND",
+	CONTENT_NOT_FOUND: "CONTENT_NOT_FOUND",
+	DRAFT_REVISION_NOT_FOUND: "DRAFT_REVISION_NOT_FOUND",
+	DRAFT_REVISION_MISMATCH: "DRAFT_REVISION_MISMATCH",
+	DRAFT_REVISION_INVALID: "DRAFT_REVISION_INVALID",
+	CONTENT_USAGE_REPAIR_ERROR: "CONTENT_USAGE_REPAIR_ERROR",
+	CONTENT_USAGE_REPAIR_CONFLICT: "CONTENT_USAGE_REPAIR_CONFLICT",
+	INVALID_REPEATER_VALIDATION: "INVALID_REPEATER_VALIDATION",
+} as const;
+
 export type ContentMediaUsageRepairErrorCode =
-	| "COLLECTION_NOT_FOUND"
-	| "CONTENT_NOT_FOUND"
-	| "DRAFT_REVISION_NOT_FOUND"
-	| "DRAFT_REVISION_MISMATCH"
-	| "DRAFT_REVISION_INVALID"
-	| "CONTENT_USAGE_REPAIR_ERROR"
-	| "CONTENT_USAGE_REPAIR_CONFLICT"
-	| "INVALID_REPEATER_VALIDATION";
+	(typeof CONTENT_MEDIA_USAGE_REPAIR_ERROR)[keyof typeof CONTENT_MEDIA_USAGE_REPAIR_ERROR];
 
 export interface ContentMediaUsageRepairCollectionInput {
 	collectionSlug: string;
@@ -114,7 +118,7 @@ async function repairContentMediaUsageCollectionUnlocked(
 			failedSourceCount: 0,
 			skippedSourceCount: 0,
 			deletedSourceCount: 0,
-			lastErrorCode: "COLLECTION_NOT_FOUND",
+			lastErrorCode: CONTENT_MEDIA_USAGE_REPAIR_ERROR.COLLECTION_NOT_FOUND,
 			startedAt,
 			completedAt: startedAt,
 		};
@@ -141,7 +145,7 @@ async function repairContentMediaUsageCollectionUnlocked(
 					failedSourceCount: 0,
 					skippedSourceCount: 0,
 					deletedSourceCount: 0,
-					lastErrorCode: "COLLECTION_NOT_FOUND",
+					lastErrorCode: CONTENT_MEDIA_USAGE_REPAIR_ERROR.COLLECTION_NOT_FOUND,
 				},
 				status: "failed",
 				startedAt,
@@ -153,10 +157,10 @@ async function repairContentMediaUsageCollectionUnlocked(
 		const scannedContentCount = finalScan?.contentIds.length ?? scan.contentIds.length;
 		if (!finalScan) {
 			counts.failedSourceCount++;
-			counts.lastErrorCode = "COLLECTION_NOT_FOUND";
+			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.COLLECTION_NOT_FOUND;
 		} else if (!sameContentIds(scan.contentIds, finalScan.contentIds)) {
 			counts.skippedSourceCount++;
-			counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 		}
 		const completedAt = new Date().toISOString();
 		const status = determineRepairStatus(counts, scannedContentCount);
@@ -174,7 +178,9 @@ async function repairContentMediaUsageCollectionUnlocked(
 		}
 		const completedAt = new Date().toISOString();
 		const lastErrorCode =
-			error instanceof MediaUsageFieldDiscoveryError ? error.code : "CONTENT_USAGE_REPAIR_ERROR";
+			error instanceof MediaUsageFieldDiscoveryError
+				? error.code
+				: CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_ERROR;
 		return finalizeRepairStatus(repo, {
 			...scope,
 			runToken,
@@ -254,7 +260,7 @@ async function repairContentSource(
 				counts.failedSourceCount++;
 			} else {
 				counts.skippedSourceCount++;
-				counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+				counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 			}
 			return;
 		}
@@ -275,7 +281,7 @@ async function repairContentSource(
 			counts.indexedSourceCount++;
 		} else {
 			counts.skippedSourceCount++;
-			counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 		}
 	}
 
@@ -323,7 +329,7 @@ async function deleteObservedSourceIfContentAbsent(
 	if (result.contentPresent) return;
 	if (result.source) {
 		counts.skippedSourceCount++;
-		counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+		counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 	}
 }
 
@@ -340,7 +346,7 @@ async function deleteObservedSource(
 	}
 	if (result.source) {
 		counts.skippedSourceCount++;
-		counts.lastErrorCode = "CONTENT_USAGE_REPAIR_CONFLICT";
+		counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 	}
 }
 

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -7,6 +7,7 @@ import {
 } from "../../database/repositories/media-usage.js";
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
+import { chunks, SQL_BATCH_SIZE } from "../../utils/chunks.js";
 import {
 	loadContentMediaUsageFields,
 	MediaUsageFieldDiscoveryError,
@@ -220,9 +221,18 @@ async function repairScannedContentSources(
 	};
 
 	const fieldDiscovery = await loadContentMediaUsageFields(db, scan.collectionSlug);
+	const observedSources = await repo.findSources(buildContentSourceKeysForScan(scan));
 
 	for (const contentId of scan.contentIds) {
-		await repairContentSource(db, repo, scan.collectionSlug, contentId, fieldDiscovery, counts);
+		await repairContentSource(
+			db,
+			repo,
+			scan.collectionSlug,
+			contentId,
+			fieldDiscovery,
+			observedSources,
+			counts,
+		);
 	}
 
 	await reconcileOrphanedContentSources(db, repo, scan.collectionSlug, counts);
@@ -235,10 +245,10 @@ async function repairContentSource(
 	collectionSlug: string,
 	contentId: string,
 	fieldDiscovery: ContentMediaUsageFieldDiscovery,
+	observedSources: Map<string, MediaUsageSource>,
 	counts: RepairCounts,
 ): Promise<void> {
 	const sourceKeys = buildContentSourceKeys(collectionSlug, contentId);
-	const observedSources = await repo.findSources(sourceKeys);
 	const snapshotsResult = await loadContentMediaUsageSnapshots(
 		db,
 		collectionSlug,
@@ -300,13 +310,45 @@ async function reconcileOrphanedContentSources(
 	counts: RepairCounts,
 ): Promise<void> {
 	const sources = await repo.findCollectionContentSources(collectionSlug);
+	const existingContentIds = await findExistingContentIds(
+		db,
+		collectionSlug,
+		sources.flatMap((source) => (source.contentId ? [source.contentId] : [])),
+	);
+
 	for (const source of sources) {
 		if (!source.contentId) {
 			await deleteObservedSource(repo, source.sourceKey, source, counts);
 			continue;
 		}
+		if (existingContentIds.has(source.contentId)) continue;
 		await deleteObservedSourceIfContentAbsent(repo, collectionSlug, source, counts);
 	}
+}
+
+async function findExistingContentIds(
+	db: Kysely<Database>,
+	collectionSlug: string,
+	contentIds: readonly string[],
+): Promise<Set<string>> {
+	validateIdentifier(collectionSlug, "collection slug");
+	const existingContentIds = new Set<string>();
+	const uniqueContentIds = [...new Set(contentIds)];
+	if (uniqueContentIds.length === 0) return existingContentIds;
+
+	const tableName = getContentTableName(collectionSlug);
+	for (const contentIdBatch of chunks(uniqueContentIds, SQL_BATCH_SIZE)) {
+		const result = await sql<{ id: string }>`
+			SELECT id
+			FROM ${sql.ref(tableName)}
+			WHERE id IN (${sql.join(contentIdBatch)})
+		`.execute(db);
+		for (const row of result.rows) {
+			existingContentIds.add(row.id);
+		}
+	}
+
+	return existingContentIds;
 }
 
 async function deleteObservedSourceIfContentAbsent(
@@ -405,6 +447,12 @@ function determineRepairStatus(
 function buildContentSourceKeys(collectionSlug: string, contentId: string): string[] {
 	return MEDIA_USAGE_CONTENT_SOURCE_VARIANTS.map((sourceVariant) =>
 		buildContentMediaUsageSourceKey({ collectionSlug, contentId, sourceVariant }),
+	);
+}
+
+function buildContentSourceKeysForScan(scan: ContentMediaUsageCollectionScan): string[] {
+	return scan.contentIds.flatMap((contentId) =>
+		buildContentSourceKeys(scan.collectionSlug, contentId),
 	);
 }
 

--- a/packages/core/src/media/usage/content-snapshots.ts
+++ b/packages/core/src/media/usage/content-snapshots.ts
@@ -7,7 +7,11 @@ import type {
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
 import { hashString } from "../../utils/hash.js";
-import { loadContentMediaUsageFields, type ContentMediaUsageField } from "./content-fields.js";
+import {
+	loadContentMediaUsageFields,
+	type ContentMediaUsageField,
+	type ContentMediaUsageFieldDiscovery,
+} from "./content-fields.js";
 import { extractMediaUsageOccurrences } from "./extractor.js";
 import {
 	buildContentMediaUsageSourceKey,
@@ -54,9 +58,10 @@ export async function loadContentMediaUsageSnapshots(
 	db: Kysely<Database>,
 	collectionSlug: string,
 	contentId: string,
+	fieldDiscovery?: ContentMediaUsageFieldDiscovery,
 ): Promise<LoadContentMediaUsageSnapshotsResult> {
 	validateIdentifier(collectionSlug, "collection slug");
-	const discovery = await loadContentMediaUsageFields(db, collectionSlug);
+	const discovery = fieldDiscovery ?? (await loadContentMediaUsageFields(db, collectionSlug));
 	const row = await loadContentRow(db, collectionSlug, contentId, [
 		...discovery.extractionFields.map((field) => field.slug),
 		...discovery.displayFieldSlugs,

--- a/packages/core/tests/integration/database/media-usage-content-repair.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-repair.test.ts
@@ -1,0 +1,472 @@
+import { sql } from "kysely";
+import { ulid } from "ulidx";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { MediaUsageRepository } from "../../../src/database/repositories/media-usage.js";
+import {
+	CONTENT_MEDIA_USAGE_ADAPTER_ID,
+	CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+} from "../../../src/media/usage/content-refresh.js";
+import {
+	repairContentMediaUsageCollection,
+	scanContentMediaUsageCollection,
+} from "../../../src/media/usage/content-repair.js";
+import {
+	buildContentMediaUsageSourceKey,
+	type MediaUsageContentSourceVariant,
+} from "../../../src/media/usage/source-key.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("content media usage repair", (dialect) => {
+	let ctx: DialectTestContext;
+	let registry: SchemaRegistry;
+	let usageRepo: MediaUsageRepository;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		registry = new SchemaRegistry(ctx.db);
+		usageRepo = new MediaUsageRepository(ctx.db);
+
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		await registry.createField("posts", { slug: "hero", label: "Hero", type: "image" });
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("scans collection content IDs in deterministic order", async () => {
+		const later = await insertPost(ctx, {
+			id: "post_z",
+			slug: "later",
+			status: "published",
+			data: { title: "Later" },
+		});
+		const earlier = await insertPost(ctx, {
+			id: "post_a",
+			slug: "earlier",
+			status: "published",
+			data: { title: "Earlier" },
+		});
+
+		const scan = await scanContentMediaUsageCollection(ctx.db, "posts");
+
+		expect(scan).toEqual({ collectionSlug: "posts", contentIds: [earlier.id, later.id] });
+	});
+
+	it("repairs collection sources and finalizes complete coverage", async () => {
+		const first = await insertPost(ctx, {
+			slug: "first-post",
+			status: "published",
+			data: {
+				title: "First Post",
+				hero: { id: "media-first", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		const second = await insertPost(ctx, {
+			slug: "second-post",
+			status: "published",
+			data: {
+				title: "Second Post",
+				hero: { id: "media-second", provider: "local", mimeType: "image/webp" },
+			},
+		});
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				scope: {
+					adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+					scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+					scopeKey: "posts",
+				},
+				status: "complete",
+				indexedSourceCount: 2,
+				failedSourceCount: 0,
+				skippedSourceCount: 0,
+				deletedSourceCount: 0,
+				lastErrorCode: null,
+				completedAt: expect.any(String),
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(first.id, "columns"))).toEqual(
+			expect.objectContaining({ contentTitle: "First Post", sourceCompleteness: "complete" }),
+		);
+		expect(await usageRepo.findSource(sourceKey(second.id, "columns"))).toEqual(
+			expect.objectContaining({ contentTitle: "Second Post", sourceCompleteness: "complete" }),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-first")).toHaveLength(1);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-second")).toHaveLength(1);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				status: "complete",
+				cursor: null,
+				indexedSourceCount: 2,
+				failedSourceCount: 0,
+				lastErrorCode: null,
+			}),
+		);
+	});
+
+	it("repairs empty collection scopes as complete", async () => {
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "complete",
+				indexedSourceCount: 0,
+				failedSourceCount: 0,
+				skippedSourceCount: 0,
+				deletedSourceCount: 0,
+				lastErrorCode: null,
+			}),
+		);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(expect.objectContaining({ status: "complete", indexedSourceCount: 0 }));
+	});
+
+	it("does not mark empty collections complete when field discovery fails", async () => {
+		await registry.createField("posts", { slug: "sections", label: "Sections", type: "repeater" });
+		await ctx.db
+			.updateTable("_emdash_fields")
+			.set({ validation: "{" })
+			.where("slug", "=", "sections")
+			.execute();
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "failed",
+				lastErrorCode: "INVALID_REPEATER_VALIDATION",
+				indexedSourceCount: 0,
+			}),
+		);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				status: "failed",
+				lastErrorCode: "INVALID_REPEATER_VALIDATION",
+			}),
+		);
+	});
+
+	it("scans deleted content rows during repair", async () => {
+		const deletedAt = "2026-01-01T00:00:00.000Z";
+		const item = await insertPost(ctx, {
+			slug: "trash-post",
+			status: "published",
+			deletedAt,
+			data: {
+				title: "Trash Post",
+				hero: { id: "media-trash", provider: "local", mimeType: "image/webp" },
+			},
+		});
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result.status).toBe("complete");
+		expect(result.indexedSourceCount).toBe(1);
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toEqual(
+			expect.objectContaining({ contentDeletedAt: deletedAt }),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-trash")).toHaveLength(1);
+	});
+
+	it("does not finalize complete when content IDs change during repair", async () => {
+		await insertPost(ctx, {
+			id: "post_existing",
+			slug: "existing-post",
+			status: "published",
+			data: {
+				title: "Existing Post",
+				hero: { id: "media-first", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await installConcurrentPostInsertTrigger(ctx);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				indexedSourceCount: 1,
+				skippedSourceCount: 1,
+				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey("post_concurrent", "columns"))).toBeNull();
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
+			}),
+		);
+	});
+
+	it("deletes observed draft and orphan sources that repair proves absent", async () => {
+		const item = await insertPost(ctx, {
+			slug: "columns-only-post",
+			status: "published",
+			data: {
+				title: "Columns Only",
+				hero: { id: "media-live", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await usageRepo.replaceSource(contentSource(item.id, "draft_overlay"), [
+			occurrence("hero", "media-stale-draft"),
+		]);
+		await usageRepo.replaceSource(contentSource("missing-post", "columns"), [
+			occurrence("hero", "media-orphan"),
+		]);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "complete",
+				indexedSourceCount: 1,
+				deletedSourceCount: 2,
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).not.toBeNull();
+		expect(await usageRepo.findSource(sourceKey(item.id, "draft_overlay"))).toBeNull();
+		expect(await usageRepo.findSource(sourceKey("missing-post", "columns"))).toBeNull();
+		expect(await usageRepo.findCurrentUsageByMediaId("media-stale-draft")).toEqual([]);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-orphan")).toEqual([]);
+	});
+
+	it("returns failed without writing status for missing collections", async () => {
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "missing" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				scope: {
+					adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+					scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+					scopeKey: "missing",
+				},
+				status: "failed",
+				lastErrorCode: "COLLECTION_NOT_FOUND",
+				indexedSourceCount: 0,
+				failedSourceCount: 0,
+				skippedSourceCount: 0,
+				deletedSourceCount: 0,
+			}),
+		);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "missing",
+			}),
+		).toBeNull();
+	});
+});
+
+interface TestPostInput {
+	id?: string;
+	slug: string;
+	status: string;
+	deletedAt?: string | null;
+	data: Record<string, unknown>;
+}
+
+interface TestPost {
+	id: string;
+}
+
+async function insertPost(ctx: DialectTestContext, input: TestPostInput): Promise<TestPost> {
+	const id = input.id ?? ulid();
+	const now = new Date().toISOString();
+	await sql`
+		INSERT INTO ${sql.ref("ec_posts")} (
+			id,
+			slug,
+			status,
+			created_at,
+			updated_at,
+			deleted_at,
+			version,
+			locale,
+			translation_group,
+			title,
+			hero
+		) VALUES (
+			${id},
+			${input.slug},
+			${input.status},
+			${now},
+			${now},
+			${input.deletedAt ?? null},
+			${1},
+			${"en"},
+			${id},
+			${serializeFieldValue(input.data.title)},
+			${serializeFieldValue(input.data.hero)}
+		)
+	`.execute(ctx.db);
+
+	return { id };
+}
+
+function contentSource(
+	contentId: string,
+	variant: MediaUsageContentSourceVariant,
+): Parameters<MediaUsageRepository["replaceSource"]>[0] {
+	return {
+		sourceKey: sourceKey(contentId, variant),
+		sourceType: "content",
+		collectionSlug: "posts",
+		contentId,
+		sourceVariant: variant,
+		locale: "en",
+		translationGroup: `tg-${contentId}`,
+		contentSlug: contentId,
+		contentTitle: contentId,
+		contentStatus: "published",
+		contentScheduledAt: null,
+		contentDeletedAt: null,
+		revisionId: null,
+	};
+}
+
+function occurrence(
+	fieldSlug: string,
+	mediaId: string,
+): Parameters<MediaUsageRepository["replaceSource"]>[1][number] {
+	return {
+		fieldSlug,
+		fieldPath: fieldSlug,
+		occurrenceIndex: 0,
+		referenceType: "image_field",
+		mediaId,
+		provider: "local",
+		providerAssetId: mediaId,
+		mediaKind: "image",
+		mimeType: null,
+	};
+}
+
+function sourceKey(contentId: string, sourceVariant: MediaUsageContentSourceVariant): string {
+	return buildContentMediaUsageSourceKey({
+		collectionSlug: "posts",
+		contentId,
+		sourceVariant,
+	});
+}
+
+async function installConcurrentPostInsertTrigger(ctx: DialectTestContext): Promise<void> {
+	if (ctx.dialect === "postgres") {
+		await sql`
+			CREATE FUNCTION media_usage_insert_concurrent_post()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				IF NEW.media_id = 'media-first' THEN
+					INSERT INTO ec_posts (
+						id,
+						slug,
+						status,
+						created_at,
+						updated_at,
+						version,
+						locale,
+						translation_group,
+						title,
+						hero
+					) VALUES (
+						'post_concurrent',
+						'concurrent-post',
+						'published',
+						'2026-01-01T00:00:00.000Z',
+						'2026-01-01T00:00:00.000Z',
+						1,
+						'en',
+						'post_concurrent',
+						'Concurrent Post',
+						'{"id":"media-concurrent","provider":"local","mimeType":"image/webp"}'
+					)
+					ON CONFLICT (id) DO NOTHING;
+				END IF;
+				RETURN NEW;
+			END;
+			$$
+		`.execute(ctx.db);
+		await sql`
+			CREATE TRIGGER media_usage_insert_concurrent_post
+			AFTER INSERT ON _emdash_media_usage
+			FOR EACH ROW
+			EXECUTE FUNCTION media_usage_insert_concurrent_post()
+		`.execute(ctx.db);
+		return;
+	}
+
+	await sql`
+		CREATE TRIGGER media_usage_insert_concurrent_post
+		AFTER INSERT ON _emdash_media_usage
+		WHEN NEW.media_id = 'media-first'
+		BEGIN
+			INSERT OR IGNORE INTO ec_posts (
+				id,
+				slug,
+				status,
+				created_at,
+				updated_at,
+				version,
+				locale,
+				translation_group,
+				title,
+				hero
+			) VALUES (
+				'post_concurrent',
+				'concurrent-post',
+				'published',
+				'2026-01-01T00:00:00.000Z',
+				'2026-01-01T00:00:00.000Z',
+				1,
+				'en',
+				'post_concurrent',
+				'Concurrent Post',
+				'{"id":"media-concurrent","provider":"local","mimeType":"image/webp"}'
+			);
+		END
+	`.execute(ctx.db);
+}
+
+function serializeFieldValue(value: unknown): unknown {
+	if (value === null || value === undefined) return null;
+	if (typeof value === "object") return JSON.stringify(value);
+	return value;
+}

--- a/packages/core/tests/integration/database/media-usage-content-repair.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-repair.test.ts
@@ -234,6 +234,35 @@ describeEachDialect("content media usage repair", (dialect) => {
 		);
 	});
 
+	it("returns the winning stale error when final status CAS loses", async () => {
+		await insertPost(ctx, {
+			slug: "stale-status-post",
+			status: "published",
+			data: {
+				title: "Stale Status Post",
+				hero: { id: "media-stale-status", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await installStaleStatusTrigger(ctx);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "stale",
+				lastErrorCode: "CONTENT_USAGE_STALE",
+				completedAt: null,
+			}),
+		);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(expect.objectContaining({ status: "stale", lastErrorCode: "CONTENT_USAGE_STALE" }));
+	});
+
 	it("deletes observed draft and orphan sources that repair proves absent", async () => {
 		const item = await insertPost(ctx, {
 			slug: "columns-only-post",
@@ -461,6 +490,49 @@ async function installConcurrentPostInsertTrigger(ctx: DialectTestContext): Prom
 				'Concurrent Post',
 				'{"id":"media-concurrent","provider":"local","mimeType":"image/webp"}'
 			);
+		END
+	`.execute(ctx.db);
+}
+
+async function installStaleStatusTrigger(ctx: DialectTestContext): Promise<void> {
+	if (ctx.dialect === "postgres") {
+		await sql`
+			CREATE FUNCTION media_usage_mark_status_stale()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				UPDATE _emdash_media_usage_index_status
+				SET status = 'stale',
+					last_error_code = 'CONTENT_USAGE_STALE',
+					updated_at = '2026-01-01T00:00:01.000Z'
+				WHERE adapter_id = 'content-media'
+				AND scope_type = 'collection'
+				AND scope_key = 'posts';
+				RETURN NEW;
+			END;
+			$$
+		`.execute(ctx.db);
+		await sql`
+			CREATE TRIGGER media_usage_mark_status_stale
+			AFTER INSERT ON _emdash_media_usage
+			FOR EACH ROW
+			EXECUTE FUNCTION media_usage_mark_status_stale()
+		`.execute(ctx.db);
+		return;
+	}
+
+	await sql`
+		CREATE TRIGGER media_usage_mark_status_stale
+		AFTER INSERT ON _emdash_media_usage
+		BEGIN
+			UPDATE _emdash_media_usage_index_status
+			SET status = 'stale',
+				last_error_code = 'CONTENT_USAGE_STALE',
+				updated_at = '2026-01-01T00:00:01.000Z'
+			WHERE adapter_id = 'content-media'
+			AND scope_type = 'collection'
+			AND scope_key = 'posts';
 		END
 	`.execute(ctx.db);
 }

--- a/packages/core/tests/integration/database/media-usage-repository.test.ts
+++ b/packages/core/tests/integration/database/media-usage-repository.test.ts
@@ -164,6 +164,130 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 		expect(await repo.findCurrentUsageByMediaId("media-stale")).toEqual([]);
 	});
 
+	it("finds source rows by key in a deduplicated map", async () => {
+		const columns = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-columns"),
+		]);
+		const draft = await repo.replaceSource(contentSource("entry1", "draft_overlay"), [
+			occurrence("hero", "media-draft"),
+		]);
+
+		const sources = await repo.findSources([
+			columns.sourceKey,
+			draft.sourceKey,
+			columns.sourceKey,
+			"content:posts:missing:columns",
+		]);
+
+		expect([...sources.keys()].toSorted()).toEqual([columns.sourceKey, draft.sourceKey].toSorted());
+		expect(sources.get(columns.sourceKey)).toEqual(
+			expect.objectContaining({ currentGeneration: columns.currentGeneration }),
+		);
+		expect(sources.get(draft.sourceKey)).toEqual(
+			expect.objectContaining({ currentGeneration: draft.currentGeneration }),
+		);
+	});
+
+	it("replaces a source only when nullable source metadata still matches", async () => {
+		const observed = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-old"),
+		]);
+
+		const replaced = await repo.replaceSourceIfMatching(
+			contentSource("entry1", "columns", {
+				sourceUpdatedAt: "2026-01-01T00:00:00.000Z",
+				sourceVersion: 2,
+				sourceFingerprint: "fingerprint-new",
+			}),
+			[occurrence("hero", "media-new")],
+			observed,
+		);
+
+		expect(replaced.replaced).toBe(true);
+		expect(replaced.source).toBeNull();
+		expect(await repo.findCurrentUsageByMediaId("media-old")).toEqual([]);
+		expect(await repo.findCurrentUsageByMediaId("media-new")).toHaveLength(1);
+		expect(await repo.findSource(observed.sourceKey)).toEqual(
+			expect.objectContaining({
+				sourceUpdatedAt: "2026-01-01T00:00:00.000Z",
+				sourceVersion: 2,
+				sourceFingerprint: "fingerprint-new",
+			}),
+		);
+	});
+
+	it("replaces a source when nullable row timestamps still match", async () => {
+		const source = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-old-null-updated"),
+		]);
+		await sql`
+			UPDATE _emdash_media_usage_sources
+			SET updated_at = ${null}
+			WHERE source_key = ${source.sourceKey}
+		`.execute(ctx.db);
+		const observed = await repo.findSource(source.sourceKey);
+
+		const replaced = await repo.replaceSourceIfMatching(
+			contentSource("entry1", "columns"),
+			[occurrence("hero", "media-new-null-updated")],
+			observed,
+		);
+
+		expect(observed?.updatedAt).toBeNull();
+		expect(replaced.replaced).toBe(true);
+		expect(replaced.source).toBeNull();
+		expect(await repo.findCurrentUsageByMediaId("media-old-null-updated")).toEqual([]);
+		expect(await repo.findCurrentUsageByMediaId("media-new-null-updated")).toHaveLength(1);
+	});
+
+	it("does not replace a source when source metadata changed despite the same generation", async () => {
+		const observed = await repo.replaceSource(
+			contentSource("entry1", "columns", { sourceFingerprint: "fingerprint-observed" }),
+			[occurrence("hero", "media-current")],
+		);
+
+		await ctx.db
+			.updateTable("_emdash_media_usage_sources")
+			.set({ source_fingerprint: "fingerprint-concurrent" })
+			.where("source_key", "=", observed.sourceKey)
+			.execute();
+
+		const stale = await repo.replaceSourceIfMatching(
+			contentSource("entry1", "columns", { sourceFingerprint: "fingerprint-stale" }),
+			[occurrence("hero", "media-stale")],
+			observed,
+		);
+
+		expect(stale.replaced).toBe(false);
+		expect(stale.source).toEqual(
+			expect.objectContaining({
+				currentGeneration: observed.currentGeneration,
+				sourceFingerprint: "fingerprint-concurrent",
+			}),
+		);
+		expect(await repo.findCurrentUsageByMediaId("media-current")).toHaveLength(1);
+		expect(await repo.findCurrentUsageByMediaId("media-stale")).toEqual([]);
+	});
+
+	it("does not insert a matching replacement when an observed-absent source was created", async () => {
+		const concurrent = await repo.replaceSource(contentSource("entry-new", "columns"), [
+			occurrence("hero", "media-concurrent-matching"),
+		]);
+
+		const stale = await repo.replaceSourceIfMatching(
+			contentSource("entry-new", "columns"),
+			[occurrence("hero", "media-stale-matching")],
+			null,
+		);
+
+		expect(stale.replaced).toBe(false);
+		expect(stale.source).toEqual(
+			expect.objectContaining({ currentGeneration: concurrent.currentGeneration }),
+		);
+		expect(await repo.findCurrentUsageByMediaId("media-concurrent-matching")).toHaveLength(1);
+		expect(await repo.findCurrentUsageByMediaId("media-stale-matching")).toEqual([]);
+	});
+
 	it("does not delete a source when the expected generation is stale", async () => {
 		const first = await repo.replaceSource(contentSource("entry1", "draft_overlay"), [
 			occurrence("hero", "media-old-draft"),
@@ -185,6 +309,41 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 			expect.objectContaining({ currentGeneration: second.currentGeneration }),
 		);
 		expect(await repo.findCurrentUsageByMediaId("media-concurrent-draft")).toHaveLength(1);
+	});
+
+	it("deletes a source only when nullable source metadata still matches", async () => {
+		const observed = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-delete"),
+		]);
+
+		const deleted = await repo.deleteSourceIfMatching(observed.sourceKey, observed);
+
+		expect(deleted.deleted).toBe(true);
+		expect(deleted.source).toBeNull();
+		expect(await repo.findCurrentUsageByMediaId("media-delete")).toEqual([]);
+	});
+
+	it("does not delete a source when source metadata changed despite the same generation", async () => {
+		const observed = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-preserved-delete"),
+		]);
+
+		await ctx.db
+			.updateTable("_emdash_media_usage_sources")
+			.set({ source_version: 3 })
+			.where("source_key", "=", observed.sourceKey)
+			.execute();
+
+		const stale = await repo.deleteSourceIfMatching(observed.sourceKey, observed);
+
+		expect(stale.deleted).toBe(false);
+		expect(stale.source).toEqual(
+			expect.objectContaining({
+				currentGeneration: observed.currentGeneration,
+				sourceVersion: 3,
+			}),
+		);
+		expect(await repo.findCurrentUsageByMediaId("media-preserved-delete")).toHaveLength(1);
 	});
 
 	it("writes ISO occurrence timestamps for safe cleanup cutoffs", async () => {
@@ -462,6 +621,124 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 			}),
 		);
 		expect(await repo.findCurrentUsageByMediaId("media-live")).toHaveLength(1);
+	});
+
+	it("marks failed source attempts only when source metadata still matches", async () => {
+		const observed = await repo.replaceSource(
+			contentSource("entry1", "columns", {
+				sourceUpdatedAt: "2026-01-01T00:00:00.000Z",
+				sourceVersion: 7,
+				sourceFingerprint: "fingerprint-observed",
+			}),
+			[occurrence("hero", "media-live-matching-attempt")],
+		);
+
+		const attempted = await repo.markSourceAttemptedIfMatching(
+			{
+				sourceKey: observed.sourceKey,
+				sourceType: "content",
+				sourceVariant: "columns",
+				lastAttemptedAt: "2026-01-01T00:00:01.000Z",
+				lastErrorCode: "LOAD_FAILED",
+			},
+			observed,
+		);
+
+		expect(attempted.attempted).toBe(true);
+		expect(attempted.source).toBeNull();
+		expect(await repo.findSource(observed.sourceKey)).toEqual(
+			expect.objectContaining({
+				sourceUpdatedAt: "2026-01-01T00:00:00.000Z",
+				sourceVersion: 7,
+				sourceFingerprint: "fingerprint-observed",
+				sourceCompleteness: "failed",
+				lastErrorCode: "LOAD_FAILED",
+			}),
+		);
+		expect(await repo.findCurrentUsageByMediaId("media-live-matching-attempt")).toHaveLength(1);
+	});
+
+	it("does not mark failed source attempts when source metadata changed", async () => {
+		const observed = await repo.replaceSource(
+			contentSource("entry1", "columns", { sourceFingerprint: "fingerprint-observed" }),
+			[occurrence("hero", "media-preserved-attempt")],
+		);
+		await ctx.db
+			.updateTable("_emdash_media_usage_sources")
+			.set({ source_fingerprint: "fingerprint-concurrent" })
+			.where("source_key", "=", observed.sourceKey)
+			.execute();
+
+		const stale = await repo.markSourceAttemptedIfMatching(
+			{
+				sourceKey: observed.sourceKey,
+				sourceType: "content",
+				sourceVariant: "columns",
+				lastAttemptedAt: "2026-01-01T00:00:01.000Z",
+				lastErrorCode: "LOAD_FAILED",
+			},
+			observed,
+		);
+
+		expect(stale.attempted).toBe(false);
+		expect(stale.source).toEqual(
+			expect.objectContaining({
+				sourceFingerprint: "fingerprint-concurrent",
+				sourceCompleteness: "complete",
+				lastErrorCode: null,
+			}),
+		);
+		expect(await repo.findCurrentUsageByMediaId("media-preserved-attempt")).toHaveLength(1);
+	});
+
+	it("does not mark failed source attempts when attempt metadata changed", async () => {
+		const observed = await repo.markSourceAttempted(
+			contentSource("entry1", "columns", {
+				lastAttemptedAt: "2026-01-01T00:00:00.000Z",
+				lastErrorCode: "OLD_FAILURE",
+			}),
+		);
+		await repo.markSourceAttempted(
+			contentSource("entry1", "columns", {
+				lastAttemptedAt: "2026-01-01T00:00:01.000Z",
+				lastErrorCode: "NEW_FAILURE",
+			}),
+		);
+
+		const stale = await repo.markSourceAttemptedIfMatching(
+			contentSource("entry1", "columns", {
+				lastAttemptedAt: "2026-01-01T00:00:02.000Z",
+				lastErrorCode: "STALE_FAILURE",
+			}),
+			observed,
+		);
+
+		expect(stale.attempted).toBe(false);
+		expect(stale.source).toEqual(
+			expect.objectContaining({
+				lastAttemptedAt: "2026-01-01T00:00:01.000Z",
+				lastErrorCode: "NEW_FAILURE",
+			}),
+		);
+	});
+
+	it("inserts a failed source attempt only when an observed-absent source stays absent", async () => {
+		const attempted = await repo.markSourceAttemptedIfMatching(
+			contentSource("entry-missing", "draft_overlay", {
+				lastAttemptedAt: "2026-01-01T00:00:01.000Z",
+				lastErrorCode: "DRAFT_REVISION_INVALID",
+			}),
+			null,
+		);
+
+		expect(attempted.attempted).toBe(true);
+		expect(attempted.source).toBeNull();
+		expect(await repo.findSource("content:posts:entry-missing:draft_overlay")).toEqual(
+			expect.objectContaining({
+				sourceCompleteness: "failed",
+				lastErrorCode: "DRAFT_REVISION_INVALID",
+			}),
+		);
 	});
 
 	it("supports empty replacement while preserving the source row", async () => {
@@ -768,6 +1045,158 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 				scopeKey: "posts",
 			}),
 		).toEqual(complete);
+	});
+
+	it("begins repair status with a cursor run token and zeroed counts", async () => {
+		await repo.upsertIndexStatus({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			status: "partial",
+			startedAt: "2026-01-01T00:00:00.000Z",
+			completedAt: "2026-01-01T00:00:02.000Z",
+			cursor: "old-cursor",
+			indexedSourceCount: 12,
+			failedSourceCount: 2,
+			lastErrorCode: "OLD_ERROR",
+		});
+
+		const running = await repo.beginIndexStatusRepair({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-1",
+			schemaVersion: 5,
+			startedAt: "2026-01-02T00:00:00.000Z",
+			updatedAt: "2026-01-02T00:00:01.000Z",
+		});
+
+		expect(running).toEqual(
+			expect.objectContaining({
+				status: "running",
+				schemaVersion: 5,
+				startedAt: "2026-01-02T00:00:00.000Z",
+				completedAt: null,
+				cursor: "repair-run-1",
+				indexedSourceCount: 0,
+				failedSourceCount: 0,
+				lastErrorCode: null,
+				updatedAt: "2026-01-02T00:00:01.000Z",
+			}),
+		);
+	});
+
+	it("finalizes repair status only when status and run token still match", async () => {
+		await repo.beginIndexStatusRepair({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-1",
+			startedAt: "2026-01-01T00:00:00.000Z",
+		});
+
+		const finalized = await repo.finalizeIndexStatusRepairIfRunning({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-1",
+			status: "complete",
+			schemaVersion: 4,
+			completedAt: "2026-01-01T00:00:02.000Z",
+			indexedSourceCount: 3,
+			failedSourceCount: 0,
+			updatedAt: "2026-01-01T00:00:03.000Z",
+		});
+
+		expect(finalized.finalized).toBe(true);
+		expect(finalized.status).toEqual(
+			expect.objectContaining({
+				status: "complete",
+				schemaVersion: 4,
+				startedAt: "2026-01-01T00:00:00.000Z",
+				completedAt: "2026-01-01T00:00:02.000Z",
+				cursor: null,
+				indexedSourceCount: 3,
+				failedSourceCount: 0,
+				lastErrorCode: null,
+				updatedAt: "2026-01-01T00:00:03.000Z",
+			}),
+		);
+	});
+
+	it("does not finalize repair status after a stale mark wins the race", async () => {
+		await repo.beginIndexStatusRepair({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-1",
+			startedAt: "2026-01-01T00:00:00.000Z",
+		});
+		await repo.upsertIndexStatus({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			status: "stale",
+			startedAt: "2026-01-01T00:00:00.000Z",
+			cursor: "repair-run-1",
+			lastErrorCode: "CONTENT_USAGE_STALE",
+			updatedAt: "2026-01-01T00:00:01.000Z",
+		});
+
+		const stale = await repo.finalizeIndexStatusRepairIfRunning({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-1",
+			status: "complete",
+			completedAt: "2026-01-01T00:00:02.000Z",
+			indexedSourceCount: 3,
+		});
+
+		expect(stale.finalized).toBe(false);
+		expect(stale.status).toEqual(
+			expect.objectContaining({
+				status: "stale",
+				cursor: "repair-run-1",
+				lastErrorCode: "CONTENT_USAGE_STALE",
+			}),
+		);
+	});
+
+	it("does not finalize repair status after a newer running repair wins the race", async () => {
+		await repo.beginIndexStatusRepair({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-1",
+			startedAt: "2026-01-01T00:00:00.000Z",
+		});
+		await repo.beginIndexStatusRepair({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-2",
+			startedAt: "2026-01-01T00:00:01.000Z",
+		});
+
+		const stale = await repo.finalizeIndexStatusRepairIfRunning({
+			adapterId: "content-media",
+			scopeType: "collection",
+			scopeKey: "posts",
+			runToken: "repair-run-1",
+			status: "complete",
+			completedAt: "2026-01-01T00:00:02.000Z",
+			indexedSourceCount: 3,
+		});
+
+		expect(stale.finalized).toBe(false);
+		expect(stale.status).toEqual(
+			expect.objectContaining({
+				status: "running",
+				startedAt: "2026-01-01T00:00:01.000Z",
+				cursor: "repair-run-2",
+			}),
+		);
 	});
 
 	it("replaces more occurrences than one D1 insert batch", async () => {


### PR DESCRIPTION
## What does this PR do?

Adds the internal media usage repair foundation for future Used In workflows.

This PR adds repository CAS/status primitives, a deterministic collection scanner, and a collection-level repair service foundation that can rebuild content-media usage rows and prove complete coverage for the happy path. It also tightens in-process delete/repair serialization and avoids repeated field-discovery queries during a repair run.

Out of scope for this PR: admin REST/client entry points, CLI, MCP, and admin UI. Those are planned follow-up PRs.

Closes: n/a

Related Discussion: https://github.com/emdash-cms/emdash/discussions/1503

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1503

i18n note: n/a, this PR adds no admin UI or user-facing strings.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.5; second-opinion review with Claude Opus 4.8

## Screenshots / test output

No screenshots; no UI changes.

Verified:

```bash
pnpm --filter emdash exec vitest run tests/integration/database/media-usage-repository.test.ts tests/integration/database/media-usage-content-repair.test.ts tests/integration/database/media-usage-content-refresh.test.ts
pnpm typecheck
pnpm format
pnpm lint
pnpm lint:json | jq '.diagnostics | length'
```

Targeted tests passed: 58 tests.

Final lint-json diagnostic count: 0.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://media-usage-repair-rebuild-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `media-usage-repair-rebuild`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
