### PR TITLE
i18n(ca): add Catalan translations

### DIFF
--- a/.changeset/add-catalan-locale.md
+++ b/.changeset/add-catalan-locale.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Adds a Catalan (ca) locale catalog to the admin UI (disabled by default)
+Adds a Catalan (ca) locale catalog to the admin UI

--- a/.changeset/add-catalan-locale.md
+++ b/.changeset/add-catalan-locale.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds a Catalan (ca) locale catalog to the admin UI (disabled by default)

--- a/packages/admin/src/locales/ca/messages.po
+++ b/packages/admin/src/locales/ca/messages.po
@@ -1,0 +1,8107 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-04 12:28+0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ca\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: packages/admin/src/routes/bylines.tsx:447
+msgid " - Guest"
+msgstr " - Convidat"
+
+#: packages/admin/src/routes/bylines.tsx:447
+msgid " - Linked"
+msgstr " - Enllaçat"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:76
+msgid " (default)"
+msgstr " (per defecte)"
+
+#: packages/admin/src/components/MenuEditor.tsx:435
+msgid " (opens in new window)"
+msgstr " (s'obre en una finestra nova)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:803
+#: packages/admin/src/components/MediaPickerModal.tsx:886
+msgid " (selected)"
+msgstr " (seleccionat)"
+
+#: packages/admin/src/routes/bylines.tsx:707
+msgid "-- Select --"
+msgstr "-- Selecciona --"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", o obre l'administració a"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": utilitza"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:737
+msgid "(from {0})"
+msgstr "(de {0})"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:520
+msgid "(pre-release)"
+msgstr "(preversió)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr "(sincronitzat)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:523
+msgid "(too new)"
+msgstr "(massa nou)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(amb el teu port de desenvolupament)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# element)} other {(# elements)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# col·lecció} other {# col·leccions}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1268
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr "{0, plural, one {# comentari actualitzat} other {# comentaris actualitzats}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:344
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# comentari} other {# comentaris}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2080
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {# error de contingut} other {# errors de contingut}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2056
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {# element de contingut importat} other {# elements de contingut importats}}"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:588
+#: packages/admin/src/components/MenuList.tsx:217
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# element} other {# elements}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2085
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {# error multimèdia} other {# errors multimèdia}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {# fitxer multimèdia importat} other {# fitxers multimèdia importats}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:123
+msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr "{0, plural, one {# fitxer multimèdia} other {# fitxers multimèdia}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1739
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {S'importarà # menú} other {S'importaran # menús}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:399
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# permís} other {# permisos}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2292
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# entrada} other {# entrades}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:444
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {# redirecció forma part d'un bucle.} other {# redireccions formen part d'un bucle.}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:228
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {# seleccionat} other {# seleccionats}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2064
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {# omès (ja existeix)} other {# omesos (ja existeixen)}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:128
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr "{0, plural, one {# usuari} other {# usuaris}}"
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:576
+msgid "{0, plural, one {field} other {fields}}"
+msgstr "{0, plural, one {camp} other {camps}}"
+
+#. placeholder {0}: envLabel(m.key)
+#. placeholder {1}: m.required
+#. placeholder {2}: m.host
+#: packages/admin/src/components/RegistryPluginDetail.tsx:623
+msgid "{0} {1} required — you have {2}."
+msgstr "Cal {0} {1}: tens {2}."
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:215
+msgid "{0} • {1}"
+msgstr ""
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:412
+msgid "{0} banner"
+msgstr "Bàner {0}"
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1142
+msgid "{0} detected"
+msgstr "S'ha detectat {0}"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:111
+msgid "{0} has been deactivated"
+msgstr "S'ha desactivat {0}"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:306
+msgid "{0} has been removed"
+msgstr "S'ha eliminat {0}"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:424
+msgid "{0} icon"
+msgstr "Icona {0}"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:202
+msgid "{0} installs"
+msgstr "{0} instal·lacions"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:92
+msgid "{0} is now active"
+msgstr "{0} ja és actiu"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1809
+msgid "{0} items → {1}"
+msgstr "{0} elements → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "{0} items will be imported"
+msgstr "S'importaran {0} elements"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "{0} plugins"
+msgstr "{0} connectors"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:210
+msgid "{0} preview"
+msgstr "Previsualització de {0}"
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && ( <span className="ms-2 text-purple-600 dark:text-purple-400">{t`Defined in code`}</span> )} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" /> <p className="text-sm text-purple-700 dark:text-purple-300"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && ( <Button type="submit" disabled={!hasChanges || !urlPatternValid || isSaving} className="w-full" > {isSaving ? t`Saving...` : isNew ? t`Create Content Type` : t`Save Changes`} </Button> )} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:574
+msgid "{0} system + {1} custom {2}"
+msgstr "{0} del sistema + {1} personalitzats {2}"
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:345
+msgid "{0} updated"
+msgstr "S'ha actualitzat {0}"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "{0} updated to v{1}"
+msgstr "{0} actualitzat a la v{1}"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:803
+#: packages/admin/src/components/MediaPickerModal.tsx:886
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:173
+msgid "{0}/160 characters"
+msgstr "{0}/160 caràcters"
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:255
+msgid "{base} to: {0}"
+msgstr "{base} a: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# canvi respecte de la revisió següent} other {# canvis respecte de la revisió següent}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1908
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# fitxer} other {# fitxers}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2157
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# element} other {# elements}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1979
+msgid "{current} of {total}"
+msgstr "{current} de {total}"
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:747
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr "{filteredCount, plural, one {#{0} element} other {#{1} elements}}"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — sense traducció"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — mostra la traducció"
+
+#: packages/admin/src/components/ContentList.tsx:736
+msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{matchCount, plural, one {# element que coincideix amb \"{searchQuery}\"} other {# elements que coincideixen amb \"{searchQuery}\"}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "{matchedCount} de {totalCount} assignats"
+
+#: packages/admin/src/components/WordPressImport.tsx:2267
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "{matchedCount} de {totalCount} autors coincidents per correu electrònic"
+
+#: packages/admin/src/components/WordPressImport.tsx:1715
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {Es crearà # col·lecció nova} other {Es crearan # col·leccions noves}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1724
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {S'afegiran camps a # col·lecció existent} other {S'afegiran camps a # col·leccions existents}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} sol·licita permisos addicionals:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:80
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} requereix els permisos següents:"
+
+#: packages/admin/src/components/MediaLibrary.tsx:299
+msgid "{resultCount, plural, one {# item} other {# items}}"
+msgstr "{resultCount, plural, one {# element} other {# elements}}"
+
+#: packages/admin/src/components/ContentList.tsx:742
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr "{total, plural, one {# element} other {# elements}}"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:149
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {# en total} other {# en total}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:212
+#: packages/admin/src/components/MediaLibrary.tsx:248
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {S'ha pujat el fitxer} other {S'han pujat # fitxers}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:217
+#: packages/admin/src/components/MediaLibrary.tsx:253
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {Ha fallat la pujada} other {Han fallat les # pujades}}"
+
+#: packages/admin/src/components/Dashboard.tsx:113
+msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
+msgstr "{totalDrafts, plural, one {# esborrany} other {# esborranys}}"
+
+#: packages/admin/src/components/Dashboard.tsx:118
+msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr "{totalScheduled, plural, one {# programat} other {# programats}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {Amaga'n # sense canvis} other {Amaga'n # sense canvis}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {Mostra'n # sense canvis} other {Mostra'n # sense canvis}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:222
+#: packages/admin/src/components/MediaLibrary.tsx:258
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "{uploaded} pujats, {failed} fallits"
+
+#: packages/admin/src/components/Redirects.tsx:141
+msgid "/new-page or /articles/[slug]"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:132
+msgid "/old-page or /blog/[slug]"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1929
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• Els fitxers es baixen del teu lloc de WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1930
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• Pujats al teu emmagatzematge multimèdia d'EmDash"
+
+#: packages/admin/src/components/WordPressImport.tsx:1931
+msgid "• URLs in your content are updated automatically"
+msgstr "• Els URL del teu contingut s'actualitzen automàticament"
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1440
+msgid "← Back"
+msgstr "← Enrere"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "1 year"
+msgstr "1 any"
+
+#: packages/admin/src/components/WordPressImport.tsx:1361
+msgid "1. Log into your WordPress admin"
+msgstr "1. Inicia la sessió a l'administració de WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. Inicia la sessió al tauler d'administració de WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "2. Go to"
+msgstr "2. Ves a"
+
+#: packages/admin/src/components/WordPressImport.tsx:1362
+msgid "2. Go to Users → Profile"
+msgstr "2. Ves a Usuaris → Perfil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1363
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. Desplaça't fins a «Contrasenyes d'aplicació»"
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "3. Select \"All content\""
+msgstr "3. Selecciona «Tot el contingut»"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "30 days"
+msgstr "30 dies"
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "301 Permanent"
+msgstr "301 Permanent"
+
+#: packages/admin/src/components/Redirects.tsx:156
+msgid "302 Temporary"
+msgstr "302 Temporal"
+
+#: packages/admin/src/components/Redirects.tsx:157
+msgid "307 Temporary (Strict)"
+msgstr "307 Temporal (estricte)"
+
+#: packages/admin/src/components/Redirects.tsx:158
+msgid "308 Permanent (Strict)"
+msgstr "308 Permanent (estricte)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "4. Click \"Download Export File\""
+msgstr "4. Fes clic a «Baixa el fitxer d'exportació»"
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. Introdueix «EmDash» i fes clic a «Afegeix-ne un de nou»"
+
+#: packages/admin/src/components/Redirects.tsx:394
+msgid "404 Errors"
+msgstr "Errors 404"
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "410 Content Deleted (Gone)"
+msgstr "410 Contingut suprimit (Gone)"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "451 Unavailable for legal reasons"
+msgstr "451 No disponible per motius legals"
+
+#: packages/admin/src/components/WordPressImport.tsx:1365
+msgid "5. Copy the generated password"
+msgstr "5. Copia la contrasenya generada"
+
+#: packages/admin/src/components/WordPressImport.tsx:1120
+msgid "5. Upload the file here"
+msgstr "5. Puja el fitxer aquí"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "7 days"
+msgstr "7 dies"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "90 days"
+msgstr "90 dies"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:418
+msgid "A brief description of this content type"
+msgstr "Una breu descripció d'aquest tipus de contingut"
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr "Un bàner destacat d'amplada completa amb encapçalament, text i botó de crida a l'acció"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:142
+msgid "A short description of your site"
+msgstr "Una breu descripció del teu lloc"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:170
+msgid "Accept & Install"
+msgstr "Accepta i instal·la"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:169
+msgid "Accept & Update"
+msgstr "Accepta i actualitza"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:206
+msgid "Accept Invite"
+msgstr "Accepta la invitació"
+
+#: packages/admin/src/routes/byline-schema.tsx:174
+msgid "Access denied"
+msgstr "Accés denegat"
+
+#: packages/admin/src/router.tsx:1288
+msgid "Access Denied"
+msgstr "Accés denegat"
+
+#: packages/admin/src/lib/api/marketplace.ts:224
+#: packages/admin/src/lib/api/marketplace.ts:232
+msgid "Access your media library"
+msgstr "Accedeix a la teva biblioteca multimèdia"
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr "Compte"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:121
+msgid "Account already exists"
+msgstr "El compte ja existeix"
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Account exists"
+msgstr "El compte existeix"
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr "Informació del compte"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:299
+#: packages/admin/src/components/ContentList.tsx:345
+#: packages/admin/src/components/ContentList.tsx:463
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/TaxonomyManager.tsx:823
+#: packages/admin/src/routes/byline-schema.tsx:249
+msgid "Actions"
+msgstr "Accions"
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr "Actiu"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentEditor.tsx:1915
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/TaxonomySidebar.tsx:476
+msgid "Add"
+msgstr "Afegeix"
+
+#. placeholder {0}: field.item_label
+#. placeholder {0}: taxonomyDef.labelSingular || t`Term`
+#: packages/admin/src/components/PortableTextEditor.tsx:1657
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Add {0}"
+msgstr "Afegeix {0}"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:263
+msgid "Add {label}"
+msgstr "Afegeix {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+msgid "Add a new passkey"
+msgstr "Afegeix una clau d'accés nova"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Add an allowed domain"
+msgstr "Afegeix un domini permès"
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "Afegeix com a mínim un subcamp per definir l'estructura del repetidor."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2783
+msgid "Add column after"
+msgstr "Afegeix una columna després"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2776
+msgid "Add column before"
+msgstr "Afegeix una columna abans"
+
+#: packages/admin/src/components/MenuEditor.tsx:299
+#: packages/admin/src/components/MenuEditor.tsx:414
+msgid "Add Content"
+msgstr "Afegeix contingut"
+
+#: packages/admin/src/components/MenuEditor.tsx:311
+#: packages/admin/src/components/MenuEditor.tsx:318
+#: packages/admin/src/components/MenuEditor.tsx:417
+msgid "Add Custom Link"
+msgstr "Afegeix un enllaç personalitzat"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:316
+msgid "Add Domain"
+msgstr "Afegeix un domini"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:582
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Add Field"
+msgstr "Afegeix un camp"
+
+#: packages/admin/src/components/WordPressImport.tsx:1820
+msgid "Add fields"
+msgstr "Afegeix camps"
+
+#: packages/admin/src/routes/byline-schema.tsx:293
+msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+msgstr "Afegeix camps com «Càrrec» o «Pronoms» per enriquir cada signatura."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:604
+msgid "Add fields to define the structure of your content"
+msgstr "Afegeix camps per definir l'estructura del teu contingut"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:607
+msgid "Add First Field"
+msgstr "Afegeix el primer camp"
+
+#: packages/admin/src/components/RepeaterField.tsx:174
+msgid "Add First Item"
+msgstr "Afegeix el primer element"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1657
+msgid "Add item"
+msgstr "Afegeix un element"
+
+#: packages/admin/src/components/RepeaterField.tsx:158
+msgid "Add Item"
+msgstr "Afegeix un element"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2743
+msgid "Add link"
+msgstr "Afegeix un enllaç"
+
+#: packages/admin/src/components/MenuEditor.tsx:407
+msgid "Add links to build your navigation menu"
+msgstr "Afegeix enllaços per construir el teu menú de navegació"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr "Afegeix un tipus MIME o una extensió"
+
+#: packages/admin/src/components/ContentList.tsx:256
+msgid "Add New"
+msgstr "Afegeix-ne un de nou"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:486
+msgid "Add new {0}"
+msgstr "Afegeix {0}"
+
+#: packages/admin/src/components/SeoPanel.tsx:197
+msgid "Add noindex meta tag"
+msgstr "Afegeix l'etiqueta meta noindex"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:200
+msgid "Add Passkey"
+msgstr "Afegeix una clau d'accés"
+
+#: packages/admin/src/components/PluginManager.tsx:206
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "Afegeix connectors al teu astro.config.mjs per ampliar les funcions d'EmDash."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2806
+msgid "Add row after"
+msgstr "Afegeix una fila després"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2799
+msgid "Add row before"
+msgstr "Afegeix una fila abans"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:476
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr "Afegeix camps de metadades SEO (títol, descripció, imatge) i inclou-los al mapa del lloc"
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr "Afegeix un subcamp"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:262
+msgid "Add tags..."
+msgstr "Afegeix etiquetes..."
+
+#: packages/admin/src/components/Widgets.tsx:338
+msgid "Add Widget Area"
+msgstr "Afegeix una àrea de ginys"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:102
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "Afegeix els teus perfils de xarxes socials. Estan disponibles per al tema del teu lloc i es poden mostrar a les capçaleres, els peus de pàgina o les biografies dels autors."
+
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+msgid "Adding..."
+msgstr "S'està afegint..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1592
+msgid "Additional data to import."
+msgstr "Dades addicionals per importar."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
+#: packages/admin/src/components/Sidebar.tsx:469
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "Administració"
+
+#: packages/admin/src/components/Sidebar.tsx:419
+msgid "Admin navigation"
+msgstr "Navegació d'administració"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "Administrador"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:198
+msgid "After send:"
+msgstr "Després d'enviar:"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3133
+msgid "Align Center"
+msgstr "Alinea al centre"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3126
+msgid "Align Left"
+msgstr "Alinea a l'esquerra"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3140
+msgid "Align Right"
+msgstr "Alinea a la dreta"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
+msgid "Alignment"
+msgstr "Alineació"
+
+#: packages/admin/src/components/ContentList.tsx:283
+msgid "All"
+msgstr "Tots"
+
+#: packages/admin/src/components/ContentList.tsx:587
+#: packages/admin/src/components/ContentList.tsx:591
+msgid "All authors"
+msgstr "Tots els autors"
+
+#: packages/admin/src/routes/bylines.tsx:413
+msgid "All bylines"
+msgstr "Totes les signatures"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr "Totes les capacitats"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:133
+msgid "All collections"
+msgstr "Totes les col·leccions"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr "Tots els comentaris requereixen aprovació"
+
+#: packages/admin/src/components/WordPressImport.tsx:2324
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "Tot el contingut importat quedarà sense assignar. Pots reassignar els autors més tard des de l'editor de contingut."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "Tots els idiomes"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "Tots els rols"
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "Totes les fonts"
+
+#: packages/admin/src/components/ContentList.tsx:542
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "All statuses"
+msgstr "Tots els estats"
+
+#: packages/admin/src/components/MediaLibrary.tsx:434
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "All types"
+msgstr "Tots els tipus"
+
+#: packages/admin/src/components/Settings.tsx:99
+msgid "Allow users from specific domains to sign up"
+msgstr "Permet que els usuaris de dominis específics es registrin"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:497
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr "Permet que els visitants deixin comentaris al contingut d'aquesta col·lecció"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Allowed Domains"
+msgstr "Dominis permesos"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr "Tipus permesos"
+
+#: packages/admin/src/components/SignupPage.tsx:437
+msgid "Already have an account?"
+msgstr "Ja tens un compte?"
+
+#: packages/admin/src/components/PluginManager.tsx:634
+msgid "Also delete plugin storage data"
+msgstr "Elimina també les dades d'emmagatzematge del connector"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:231
+#: packages/admin/src/components/MediaLibrary.tsx:590
+msgid "Alt text"
+msgstr "Text alternatiu"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
+#: packages/admin/src/components/MediaDetailPanel.tsx:354
+#: packages/admin/src/components/MediaDetailPanel.tsx:371
+msgid "Alt Text"
+msgstr "Text alternatiu"
+
+#: packages/admin/src/components/MediaLibrary.tsx:834
+#: packages/admin/src/components/MediaLibrary.tsx:891
+msgid "Alt text set"
+msgstr "Text alternatiu definit"
+
+#: packages/admin/src/components/WordPressImport.tsx:1234
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "Com a alternativa, pots exportar des de WordPress (Eines → Exporta) i pujar el fitxer."
+
+#: packages/admin/src/components/DialogError.tsx:14
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:98
+#: packages/admin/src/components/PluginManager.tsx:117
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:71
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:95
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+#: packages/admin/src/components/settings/EmailSettings.tsx:51
+#: packages/admin/src/components/settings/GeneralSettings.tsx:51
+#: packages/admin/src/components/settings/SecuritySettings.tsx:54
+#: packages/admin/src/components/settings/SecuritySettings.tsx:71
+#: packages/admin/src/components/settings/SeoSettings.tsx:45
+#: packages/admin/src/components/settings/SocialSettings.tsx:43
+#: packages/admin/src/components/TaxonomySidebar.tsx:350
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:398
+#: packages/admin/src/router.tsx:413
+#: packages/admin/src/router.tsx:427
+#: packages/admin/src/router.tsx:441
+#: packages/admin/src/router.tsx:817
+#: packages/admin/src/router.tsx:855
+#: packages/admin/src/router.tsx:873
+#: packages/admin/src/router.tsx:891
+#: packages/admin/src/router.tsx:912
+#: packages/admin/src/router.tsx:933
+#: packages/admin/src/router.tsx:954
+#: packages/admin/src/router.tsx:985
+#: packages/admin/src/router.tsx:1005
+#: packages/admin/src/router.tsx:1233
+#: packages/admin/src/router.tsx:1249
+#: packages/admin/src/router.tsx:1274
+#: packages/admin/src/router.tsx:1756
+#: packages/admin/src/routes/byline-schema.tsx:103
+#: packages/admin/src/routes/byline-schema.tsx:123
+#: packages/admin/src/routes/byline-schema.tsx:139
+#: packages/admin/src/routes/byline-schema.tsx:153
+msgid "An error occurred"
+msgstr "S'ha produït un error"
+
+#: packages/admin/src/routes/byline-schema.tsx:272
+msgid "An unexpected error occurred."
+msgstr "S'ha produït un error inesperat."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:217
+msgid "An unknown error occurred"
+msgstr "S'ha produït un error desconegut"
+
+#: packages/admin/src/components/WordPressImport.tsx:1414
+msgid "Analyzing export file..."
+msgstr "S'està analitzant el fitxer d'exportació..."
+
+#: packages/admin/src/components/WordPressImport.tsx:735
+msgid "Analyzing WordPress site..."
+msgstr "S'està analitzant el lloc de WordPress..."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr "S'accepta qualsevol tipus de fitxer multimèdia (subjecte als límits globals)."
+
+#: packages/admin/src/components/Settings.tsx:109
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
+msgid "API Tokens"
+msgstr "Testimonis d'API"
+
+#: packages/admin/src/components/Widgets.tsx:375
+msgid "Appears on posts and pages"
+msgstr "Apareix a les entrades i les pàgines"
+
+#: packages/admin/src/components/WordPressImport.tsx:1329
+msgid "Application Password"
+msgstr "Contrasenya d'aplicació"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3200
+msgid "Apply"
+msgstr "Aplica"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:181
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:182
+msgid "Apply language"
+msgstr "Aplica l'idioma"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2683
+#: packages/admin/src/components/PortableTextEditor.tsx:2684
+msgid "Apply link"
+msgstr "Aplica l'enllaç"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:237
+#: packages/admin/src/components/comments/CommentInbox.tsx:489
+msgid "Approve"
+msgstr "Aprova"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "aprovat"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:202
+msgid "Approved"
+msgstr "Aprovat"
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr "Dades JSON arbitràries"
+
+#: packages/admin/src/components/ContentList.tsx:963
+msgid "archived"
+msgstr "arxivat"
+
+#: packages/admin/src/components/ContentList.tsx:546
+msgid "Archived"
+msgstr "Arxivat"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+msgid "Archives"
+msgstr "Arxius"
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:375
+msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+msgstr "Segur que vols eliminar «{0}»? Cap valor emmagatzemat fa referència a aquest camp."
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "Segur que vols eliminar «{0}»? Això també eliminarà tot el contingut d'aquesta col·lecció."
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:660
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr "Segur que vols eliminar el camp «{0}»?"
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "Segur que vols eliminar aquest menú? Això també eliminarà tots els elements del menú. Aquesta acció no es pot desfer."
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "Com a administrador, pots convidar altres usuaris des de la secció Usuaris."
+
+#: packages/admin/src/components/WordPressImport.tsx:2262
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "Assigna els autors de WordPress a usuaris d'EmDash. Les entrades s'atribuiran a l'usuari seleccionat."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:28
+msgid "Astro"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+#: packages/admin/src/components/MediaLibrary.tsx:437
+msgid "Audio"
+msgstr "Àudio"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "Error d'autenticació: {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:195
+msgid "Authentication error: {error}"
+msgstr "Error d'autenticació: {error}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:256
+msgid "Authentication failed"
+msgstr "Ha fallat l'autenticació"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:120
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "L'autenticació la gestiona un proveïdor extern ({0}). La configuració de claus d'accés no està disponible quan s'utilitza autenticació externa."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "L'autenticació s'ha cancel·lat o ha excedit el temps d'espera. Torna-ho a provar."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:287
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "Autor"
+
+#: packages/admin/src/components/WordPressImport.tsx:2277
+msgid "Author Mapping"
+msgstr "Assignació d'autors"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "Autorització denegada"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr "Ha fallat l'autorització"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "Autoritza"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "Autoritza el dispositiu"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "S'està autoritzant..."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:672
+msgid "Authors"
+msgstr "Autors"
+
+#: packages/admin/src/components/Redirects.tsx:521
+msgid "auto"
+msgstr "automàtic"
+
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "Auto (slug change)"
+msgstr "Automàtic (canvi de slug)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:541
+msgid "Auto-approve authenticated users"
+msgstr "Aprova automàticament els usuaris autenticats"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:408
+msgid "Auto-generated from name (you can edit)"
+msgstr "Generat automàticament a partir del nom (el pots editar)"
+
+#: packages/admin/src/router.tsx:854
+msgid "Autosave failed"
+msgstr "Ha fallat el desament automàtic"
+
+#: packages/admin/src/components/ContentEditor.tsx:644
+msgid "Autosave status"
+msgstr "Estat del desament automàtic"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:662
+msgid "Available media"
+msgstr "Fitxers multimèdia disponibles"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:207
+msgid "Available Providers"
+msgstr "Proveïdors disponibles"
+
+#: packages/admin/src/components/Widgets.tsx:401
+msgid "Available Widgets"
+msgstr "Ginys disponibles"
+
+#: packages/admin/src/components/BylineAvatarField.tsx:46
+#: packages/admin/src/components/BylineAvatarField.tsx:71
+msgid "Avatar"
+msgstr "Avatar"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:257
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/WordPressImport.tsx:1349
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Back"
+msgstr "Enrere"
+
+#: packages/admin/src/components/ContentEditor.tsx:613
+msgid "Back to {collectionLabel} list"
+msgstr "Torna a la llista {collectionLabel}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr "Torna als tipus de contingut"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:139
+#: packages/admin/src/components/LoginPage.tsx:117
+#: packages/admin/src/components/LoginPage.tsx:153
+#: packages/admin/src/components/LoginPage.tsx:311
+#: packages/admin/src/components/SignupPage.tsx:281
+msgid "Back to login"
+msgstr "Torna a l'inici de sessió"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:115
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:391
+msgid "Back to marketplace"
+msgstr "Torna al mercat"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:805
+msgid "Back to plugins"
+msgstr "Torna als connectors"
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+#: packages/admin/src/components/SectionEditor.tsx:174
+msgid "Back to sections"
+msgstr "Torna a les seccions"
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr "Torna a la configuració"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr "Torna als temes"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:29
+msgid "Bash"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Before send:"
+msgstr "Abans d'enviar:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Bing Verification"
+msgstr "Verificació de Bing"
+
+#: packages/admin/src/routes/bylines.tsx:497
+msgid "Bio"
+msgstr "Biografia"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
+msgid "Block actions - drag to reorder, click for menu"
+msgstr "Accions del bloc: arrossega per reordenar, fes clic per al menú"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2707
+#: packages/admin/src/components/PortableTextEditor.tsx:3015
+msgid "Bold"
+msgstr "Negreta"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:55
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr "Booleà"
+
+#: packages/admin/src/components/SeoPanel.tsx:174
+msgid "Brief summary shown below the title in search results"
+msgstr "Resum breu que es mostra sota el títol als resultats de cerca"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr "Explora i instal·la connectors publicats al registre descentralitzat."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr "Explora i instal·la connectors per ampliar el teu lloc."
+
+#: packages/admin/src/components/WordPressImport.tsx:966
+#: packages/admin/src/components/WordPressImport.tsx:1433
+msgid "Browse Files"
+msgstr "Explora els fitxers"
+
+#: packages/admin/src/components/PluginManager.tsx:199
+msgid "Browse the"
+msgstr "Explora el"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr "Explora temes i previsualitza'ls amb el teu propi contingut."
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:102
+#: packages/admin/src/components/PortableTextEditor.tsx:1040
+#: packages/admin/src/components/PortableTextEditor.tsx:3083
+msgid "Bullet List"
+msgstr "Llista de vinyetes"
+
+#: packages/admin/src/routes/byline-schema.tsx:218
+#: packages/admin/src/routes/bylines.tsx:384
+msgid "Byline schema"
+msgstr "Esquema de signatures"
+
+#: packages/admin/src/components/Sidebar.tsx:347
+msgid "Byline Schema"
+msgstr "Esquema de signatures"
+
+#: packages/admin/src/components/ContentEditor.tsx:993
+#: packages/admin/src/components/Sidebar.tsx:342
+#: packages/admin/src/routes/bylines.tsx:376
+msgid "Bylines"
+msgstr "Signatures"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:30
+msgid "C"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:32
+msgid "C#"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:31
+msgid "C++"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "Pot crear contingut"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "Pot gestionar tot el contingut"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "Pot publicar contingut propi"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "Pot veure el contingut"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:315
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:161
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentEditor.tsx:706
+#: packages/admin/src/components/ContentEditor.tsx:907
+#: packages/admin/src/components/ContentEditor.tsx:959
+#: packages/admin/src/components/ContentEditor.tsx:2029
+#: packages/admin/src/components/ContentEditor.tsx:2082
+#: packages/admin/src/components/ContentList.tsx:851
+#: packages/admin/src/components/ContentList.tsx:922
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:193
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:194
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:586
+#: packages/admin/src/components/editor/ImageNode.tsx:252
+#: packages/admin/src/components/editor/ImageNode.tsx:253
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:649
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:744
+#: packages/admin/src/components/MenuEditor.tsx:359
+#: packages/admin/src/components/MenuEditor.tsx:530
+#: packages/admin/src/components/MenuList.tsx:172
+#: packages/admin/src/components/PluginManager.tsx:640
+#: packages/admin/src/components/PortableTextEditor.tsx:3184
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:280
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:390
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:325
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:453
+#: packages/admin/src/components/settings/SecuritySettings.tsx:179
+#: packages/admin/src/components/TaxonomyManager.tsx:187
+#: packages/admin/src/components/TaxonomyManager.tsx:472
+#: packages/admin/src/components/TaxonomyManager.tsx:686
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/Widgets.tsx:386
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr "Cancel·la (Esc)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "Cancel·la el canvi de nom"
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr "No es poden eliminar les seccions del tema"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:413
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr "No es pot determinar el tipus MIME a partir de l'URL. Utilitza un URL acabat en una extensió d'imatge reconeguda (p. ex. .jpg, .png, .webp)."
+
+#: packages/admin/src/components/SeoPanel.tsx:186
+msgid "Canonical URL"
+msgstr "URL canònic"
+
+#: packages/admin/src/components/PluginManager.tsx:473
+msgid "Capabilities"
+msgstr "Capacitats"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:65
+msgid "Capability consent"
+msgstr "Consentiment de capacitats"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:352
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:541
+#: packages/admin/src/components/MediaDetailPanel.tsx:381
+msgid "Caption"
+msgstr "Llegenda"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr "Llegendes / Subtítols"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+msgid "Categories"
+msgstr "Categories"
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1621
+msgid "Categories ({0})"
+msgstr "Categories ({0})"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
+msgid "Center"
+msgstr "Centre"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1699
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/ImageFieldRenderer.tsx:122
+#: packages/admin/src/components/ImageFieldRenderer.tsx:151
+#: packages/admin/src/components/SeoImageField.tsx:47
+msgid "Change"
+msgstr "Canvia"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr "Vols canviar <0>{0}</0> de <1>{1}</1> a <2>{2}</2>? Perdrà l'accés a les funcions de nivell superior."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:239
+msgid "Change Favicon"
+msgstr "Canvia la icona del lloc"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:167
+msgid "Change Image"
+msgstr "Canvia la imatge"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:185
+msgid "Change Logo"
+msgstr "Canvia el logotip"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:793
+msgid "Changelog"
+msgstr "Registre de canvis"
+
+#: packages/admin/src/router.tsx:905
+msgid "Changes discarded"
+msgstr "Canvis descartats"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:129
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "Caràcter entre el títol de la pàgina i el nom del lloc (p. ex. «La meva entrada | El meu lloc»)"
+
+#: packages/admin/src/components/PluginManager.tsx:162
+msgid "Check for updates"
+msgstr "Comprova si hi ha actualitzacions"
+
+#: packages/admin/src/components/WordPressImport.tsx:937
+msgid "Check Site"
+msgstr "Comprova el lloc"
+
+#: packages/admin/src/components/LoginPage.tsx:101
+#: packages/admin/src/components/SignupPage.tsx:130
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Check your email"
+msgstr "Comprova el teu correu electrònic"
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+msgid "Checking {urlInput}..."
+msgstr "S'està comprovant {urlInput}..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "S'està comprovant l'autenticació..."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:362
+msgid "Checking how many stored values reference \"{0}\"…"
+msgstr "S'està comprovant quants valors emmagatzemats fan referència a «{0}»…"
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr "Tria com iniciar la sessió"
+
+#: packages/admin/src/components/Settings.tsx:130
+msgid "Choose your preferred admin language"
+msgstr "Tria el teu idioma preferit per a l'administració"
+
+#: packages/admin/src/components/ContentList.tsx:639
+#: packages/admin/src/components/MediaLibrary.tsx:498
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr "Neteja els filtres"
+
+#: packages/admin/src/components/MediaLibrary.tsx:498
+#: packages/admin/src/components/MediaLibrary.tsx:522
+msgid "Clear search"
+msgstr "Neteja la cerca"
+
+#: packages/admin/src/components/SignupPage.tsx:138
+msgid "Click the link in the email to continue setting up your account."
+msgstr "Fes clic a l'enllaç del correu electrònic per continuar configurant el teu compte."
+
+#: packages/admin/src/components/LoginPage.tsx:112
+msgid "Click the link in the email to sign in."
+msgstr "Fes clic a l'enllaç del correu electrònic per iniciar la sessió."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:212
+#: packages/admin/src/components/BylineFieldEditor.tsx:218
+#: packages/admin/src/components/BylineFieldEditor.tsx:222
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:227
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:229
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:414
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:436
+#: packages/admin/src/components/MediaDetailPanel.tsx:229
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:482
+#: packages/admin/src/components/MediaPickerModal.tsx:488
+#: packages/admin/src/components/MediaPickerModal.tsx:492
+#: packages/admin/src/components/MenuEditor.tsx:321
+#: packages/admin/src/components/MenuEditor.tsx:327
+#: packages/admin/src/components/MenuEditor.tsx:331
+#: packages/admin/src/components/MenuEditor.tsx:489
+#: packages/admin/src/components/MenuEditor.tsx:495
+#: packages/admin/src/components/MenuEditor.tsx:499
+#: packages/admin/src/components/MenuList.tsx:136
+#: packages/admin/src/components/MenuList.tsx:142
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/PortableTextEditor.tsx:1441
+#: packages/admin/src/components/PortableTextEditor.tsx:1447
+#: packages/admin/src/components/PortableTextEditor.tsx:1451
+#: packages/admin/src/components/Redirects.tsx:114
+#: packages/admin/src/components/Redirects.tsx:120
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:338
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:348
+#: packages/admin/src/components/TaxonomyManager.tsx:164
+#: packages/admin/src/components/TaxonomyManager.tsx:371
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/components/TaxonomyManager.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:605
+#: packages/admin/src/components/TaxonomyManager.tsx:611
+#: packages/admin/src/components/TaxonomyManager.tsx:615
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:348
+#: packages/admin/src/components/Widgets.tsx:354
+#: packages/admin/src/components/Widgets.tsx:358
+msgid "Close"
+msgstr "Tanca"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:520
+msgid "Close comments after (days)"
+msgstr "Tanca els comentaris al cap de (dies)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr "Tanca el tauler"
+
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/PortableTextEditor.tsx:2735
+#: packages/admin/src/components/Redirects.tsx:469
+msgid "Code"
+msgstr "Codi"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:94
+#: packages/admin/src/components/PortableTextEditor.tsx:1070
+#: packages/admin/src/components/PortableTextEditor.tsx:3104
+msgid "Code Block"
+msgstr "Bloc de codi"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Collapse"
+msgstr "Replega"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Collapse details"
+msgstr "Replega els detalls"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr "Col·lecció"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "Col·lecció:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Collections"
+msgstr "Col·leccions"
+
+#: packages/admin/src/components/WordPressImport.tsx:2133
+msgid "Collections created:"
+msgstr "Col·leccions creades:"
+
+#: packages/admin/src/components/SectionEditor.tsx:273
+msgid "Comma-separated keywords for search."
+msgstr "Paraules clau separades per comes per a la cerca."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Comment"
+msgstr "Comentari"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "Detall del comentari"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:146
+#: packages/admin/src/components/ContentTypeEditor.tsx:487
+#: packages/admin/src/components/Sidebar.tsx:326
+msgid "Comments"
+msgstr "Comentaris"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:544
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr "Els comentaris dels usuaris del CMS amb sessió iniciada s'aproven automàticament"
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Complete signup"
+msgstr "Completa el registre"
+
+#: packages/admin/src/components/Widgets.tsx:851
+msgid "Component"
+msgstr "Component"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr "Configura el camp"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Confirm"
+msgstr "Confirma"
+
+#: packages/admin/src/components/WordPressImport.tsx:627
+msgid "Connect"
+msgstr "Connecta"
+
+#: packages/admin/src/components/WordPressImport.tsx:1346
+msgid "Connect & Analyze"
+msgstr "Connecta i analitza"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1296
+msgid "Connect to {0}"
+msgstr "Connecta't a {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1212
+msgid "Connect with WordPress"
+msgstr "Connecta amb WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr "{0} connectat"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:293
+#: packages/admin/src/components/Dashboard.tsx:164
+#: packages/admin/src/components/PortableTextEditor.tsx:2211
+#: packages/admin/src/components/SectionEditor.tsx:194
+#: packages/admin/src/components/Sidebar.tsx:451
+#: packages/admin/src/components/Widgets.tsx:819
+msgid "Content"
+msgstr "Contingut"
+
+#: packages/admin/src/components/Widgets.tsx:96
+msgid "Content Block"
+msgstr "Bloc de contingut"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2188
+msgid "Content Errors ({0})"
+msgstr "Errors de contingut ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1156
+msgid "Content found:"
+msgstr "Contingut trobat:"
+
+#: packages/admin/src/router.tsx:927
+msgid "Content has been scheduled for publishing"
+msgstr "S'ha programat la publicació del contingut"
+
+#: packages/admin/src/components/RevisionHistory.tsx:131
+msgid "Content has been updated to the selected revision."
+msgstr "El contingut s'ha actualitzat a la revisió seleccionada."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "ID del contingut:"
+
+#: packages/admin/src/router.tsx:868
+msgid "Content is now live"
+msgstr "El contingut ja és en línia"
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "content items"
+msgstr "elements de contingut"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
+msgid "Content Read"
+msgstr "Lectura de contingut"
+
+#: packages/admin/src/router.tsx:886
+msgid "Content removed from public view"
+msgstr "S'ha retirat el contingut de la vista pública"
+
+#: packages/admin/src/router.tsx:948
+msgid "Content reverted to draft"
+msgstr "El contingut s'ha revertit a esborrany"
+
+#: packages/admin/src/components/RevisionHistory.tsx:296
+msgid "Content snapshot:"
+msgstr "Instantània del contingut:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1570
+msgid "Content to Import"
+msgstr "Contingut per importar"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:346
+msgid "Content Types"
+msgstr "Tipus de contingut"
+
+#: packages/admin/src/components/WordPressImport.tsx:2116
+msgid "Content was skipped because it already exists"
+msgstr "S'ha omès el contingut perquè ja existeix"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
+msgid "Content Write"
+msgstr "Escriptura de contingut"
+
+#: packages/admin/src/components/SignupPage.tsx:91
+msgid "Continue"
+msgstr "Continua"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr "Continua →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2335
+msgid "Continue Import"
+msgstr "Continua la importació"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "Col·laborador"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:225
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
+msgid "Copied to clipboard"
+msgstr "Copiat al porta-retalls"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr "Copia {0} al porta-retalls"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "Copia l'enllaç d'invitació"
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr "Copia el slug"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
+msgid "Copy this token now — it won't be shown again."
+msgstr "Copia aquest testimoni ara: no es tornarà a mostrar."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copy token"
+msgstr "Copia el testimoni"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+#: packages/admin/src/components/MediaDetailPanel.tsx:301
+msgid "Copy URL"
+msgstr "Copia l'URL"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "No s'ha pogut copiar automàticament. Selecciona l'URL de dalt i copia'l manualment."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Could not load image from URL"
+msgstr "No s'ha pogut carregar la imatge des de l'URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Couldn't detect WordPress"
+msgstr "No s'ha pogut detectar WordPress"
+
+#: packages/admin/src/routes/byline-schema.tsx:268
+msgid "Couldn't load byline fields."
+msgstr "No s'han pogut carregar els camps de signatura."
+
+#: packages/admin/src/routes/bylines.tsx:548
+msgid "Couldn't load custom fields."
+msgstr "No s'han pogut carregar els camps personalitzats."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr "No s'ha pogut associar «{draft}» a cap tipus MIME. Escriu el MIME directament."
+
+#: packages/admin/src/components/ContentEditor.tsx:1921
+msgid "Couldn't search bylines. Please try again."
+msgstr "No s'han pogut cercar les signatures. Torna-ho a provar."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:369
+msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+msgstr "No s'ha pogut verificar quants valors fan referència a «{0}». En eliminar-lo, se suprimiran igualment tots els valors emmagatzemats d'aquest camp, però el recompte anterior no s'ha pogut comprovar."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:822
+msgid "Count"
+msgstr "Recompte"
+
+#: packages/admin/src/components/ContentEditor.tsx:2053
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:191
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:479
+#: packages/admin/src/components/Widgets.tsx:389
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Create"
+msgstr "Crea"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:290
+msgid "Create \"{trimmedInput}\""
+msgstr "Crea «{trimmedInput}»"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1041
+msgid "Create a bullet list"
+msgstr "Crea una llista de vinyetes"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:367
+msgid "Create a new {0}"
+msgstr "Crea {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1051
+msgid "Create a numbered list"
+msgstr "Crea una llista numerada"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:81
+#: packages/admin/src/components/SignupPage.tsx:220
+msgid "Create Account"
+msgstr "Crea un compte"
+
+#: packages/admin/src/components/SignupPage.tsx:399
+msgid "Create an account"
+msgstr "Crea un compte"
+
+#: packages/admin/src/components/ContentEditor.tsx:2001
+#: packages/admin/src/routes/bylines.tsx:477
+msgid "Create byline"
+msgstr "Crea una signatura"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr "Crea un tipus de contingut"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Create field"
+msgstr "Crea un camp"
+
+#: packages/admin/src/components/MenuList.tsx:126
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "Create Menu"
+msgstr "Crea un menú"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "Create New Menu"
+msgstr "Crea un menú nou"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:396
+msgid "Create New Token"
+msgstr "Crea un testimoni nou"
+
+#: packages/admin/src/components/WordPressImport.tsx:1340
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "Crea'n una a WordPress: Usuaris → Perfil → Contrasenyes d'aplicació"
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr "Crea una clau d'accés"
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
+msgid "Create personal access tokens for programmatic API access"
+msgstr "Crea testimonis d'accés personals per a l'accés programàtic a l'API"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:247
+msgid "Create redirect for {0}"
+msgstr "Crea una redirecció per a {0}"
+
+#: packages/admin/src/components/Redirects.tsx:246
+msgid "Create redirect for this path"
+msgstr "Crea una redirecció per a aquesta ruta"
+
+#: packages/admin/src/components/Redirects.tsx:461
+msgid "Create redirect rules to manage URL changes."
+msgstr "Crea regles de redirecció per gestionar els canvis d'URL."
+
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "Create Schema & Import"
+msgstr "Crea l'esquema i importa"
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr "Crea una secció"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr "Crea seccions a la biblioteca de seccions per utilitzar-les aquí"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:598
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+msgid "Create Taxonomy"
+msgstr "Crea una taxonomia"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:258
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+msgid "Create Token"
+msgstr "Crea un testimoni"
+
+#: packages/admin/src/components/Widgets.tsx:345
+msgid "Create Widget Area"
+msgstr "Crea una àrea de ginys"
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr "Crea el teu compte"
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "Create your first navigation menu to get started"
+msgstr "Crea el teu primer menú de navegació per començar"
+
+#: packages/admin/src/components/ContentList.tsx:373
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr "Crea'n el primer"
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr "Crea la teva primera secció de contingut reutilitzable per començar."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:72
+#: packages/admin/src/components/SignupPage.tsx:211
+msgid "Create your passkey"
+msgstr "Crea la teva clau d'accés"
+
+#: packages/admin/src/lib/api/marketplace.ts:223
+#: packages/admin/src/lib/api/marketplace.ts:231
+msgid "Create, update, and delete content"
+msgstr "Crea, actualitza i elimina contingut"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Create, update, and delete navigation menus"
+msgstr "Crea, actualitza i elimina menús de navegació"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Create, update, and delete taxonomy terms"
+msgstr "Crea, actualitza i elimina termes de taxonomia"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Create, update, delete content"
+msgstr "Crea, actualitza i elimina contingut"
+
+#: packages/admin/src/components/ContentList.tsx:550
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr "Creat"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:96
+msgid "Created \"{0}\"."
+msgstr "S'ha creat «{0}»."
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:297
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr "S'ha creat {0}"
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:979
+msgid "Created {0} translation"
+msgstr "S'ha creat la traducció {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr "Data de creació"
+
+#. placeholder {0}: new Date(item.createdAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:927
+msgid "Created: {0}"
+msgstr "Creat: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "Creating collections and fields..."
+msgstr "S'estan creant les col·leccions i els camps..."
+
+#: packages/admin/src/components/ContentEditor.tsx:2053
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:188
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+#: packages/admin/src/components/TaxonomySidebar.tsx:290
+msgid "Creating..."
+msgstr "S'està creant..."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:33
+msgid "CSS"
+msgstr ""
+
+#: packages/admin/src/components/TranslationsPanel.tsx:78
+msgid "current"
+msgstr "actual"
+
+#: packages/admin/src/components/RevisionHistory.tsx:264
+msgid "Current"
+msgstr "Actual"
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:614
+msgid "Custom Fields"
+msgstr "Camps personalitzats"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:210
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "Contingut personalitzat del robots.txt. Deixa-ho buit per utilitzar el valor per defecte."
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Custom Section"
+msgstr "Secció personalitzada"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "fosc"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "Fosc"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:246
+#: packages/admin/src/components/Dashboard.tsx:42
+#: packages/admin/src/components/Sidebar.tsx:312
+#: packages/admin/src/components/Sidebar.tsx:442
+msgid "Dashboard"
+msgstr "Tauler"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:296
+#: packages/admin/src/components/ContentList.tsx:342
+msgid "Date"
+msgstr "Data"
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr "Data i hora"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr "Selector de data i hora"
+
+#: packages/admin/src/components/ContentList.tsx:604
+msgid "Date field to filter on"
+msgstr "Camp de data per filtrar"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:281
+msgid "Date Format"
+msgstr "Format de data"
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr "Nombre decimal"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:737
+msgid "Declared permissions"
+msgstr "Permisos declarats"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:294
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:356
+msgid "Default Role"
+msgstr "Rol per defecte"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:233
+msgid "Default role:"
+msgstr "Rol per defecte:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:147
+msgid "Default social image"
+msgstr "Imatge social per defecte"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:138
+msgid "Default Social Image"
+msgstr "Imatge social per defecte"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:601
+msgid "Define a new taxonomy for classifying content"
+msgstr "Defineix una taxonomia nova per classificar el contingut"
+
+#: packages/admin/src/routes/byline-schema.tsx:220
+msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+msgstr "Defineix camps personalitzats emmagatzemats a cada signatura: càrrec, pronoms, identificadors socials i més."
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr "Defineix l'estructura del teu contingut"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:361
+msgid "Defined in code"
+msgstr "Definit al codi"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:267
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+#: packages/admin/src/components/ContentTypeEditor.tsx:663
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:301
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:130
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:453
+#: packages/admin/src/components/MenuEditor.tsx:463
+#: packages/admin/src/components/MenuList.tsx:255
+#: packages/admin/src/components/Redirects.tsx:582
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/TaxonomyManager.tsx:886
+#: packages/admin/src/components/Widgets.tsx:636
+#: packages/admin/src/routes/byline-schema.tsx:378
+#: packages/admin/src/routes/bylines.tsx:589
+#: packages/admin/src/routes/bylines.tsx:625
+msgid "Delete"
+msgstr "Elimina"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:452
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "Vols eliminar «{0}»? Aquesta acció no es pot desfer."
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeList.tsx:229
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:252
+#: packages/admin/src/components/TaxonomyManager.tsx:97
+#: packages/admin/src/components/Widgets.tsx:737
+#: packages/admin/src/routes/byline-schema.tsx:458
+msgid "Delete {0}"
+msgstr "Elimina {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:740
+msgid "Delete {0} field"
+msgstr "Elimina el camp {0}"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:237
+msgid "Delete {0} menu"
+msgstr "Elimina el menú {0}"
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:584
+msgid "Delete {0} widget area"
+msgstr "Elimina l'àrea de ginys {0}"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:882
+msgid "Delete {0}?"
+msgstr "Vols eliminar {0}?"
+
+#: packages/admin/src/routes/byline-schema.tsx:358
+msgid "Delete byline field?"
+msgstr "Vols eliminar el camp de signatura?"
+
+#: packages/admin/src/routes/bylines.tsx:623
+msgid "Delete Byline?"
+msgstr "Vols eliminar la signatura?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2790
+msgid "Delete column"
+msgstr "Elimina la columna"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:405
+msgid "Delete Comment?"
+msgstr "Vols eliminar el comentari?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr "Vols eliminar el tipus de contingut?"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr "Elimina la incrustació"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:657
+msgid "Delete Field?"
+msgstr "Vols eliminar el camp?"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
+msgid "Delete HTML block"
+msgstr "Elimina el bloc HTML"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:220
+#: packages/admin/src/components/editor/ImageNode.tsx:221
+msgid "Delete image"
+msgstr "Elimina la imatge"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:451
+msgid "Delete Media?"
+msgstr "Vols eliminar el fitxer multimèdia?"
+
+#: packages/admin/src/components/MenuList.tsx:253
+msgid "Delete Menu"
+msgstr "Elimina el menú"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:525
+msgid "Delete permanently"
+msgstr "Elimina permanentment"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:933
+msgid "Delete Permanently"
+msgstr "Elimina permanentment"
+
+#: packages/admin/src/components/ContentList.tsx:913
+msgid "Delete Permanently?"
+msgstr "Vols eliminar-ho permanentment?"
+
+#: packages/admin/src/components/Redirects.tsx:535
+msgid "Delete redirect"
+msgstr "Elimina la redirecció"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:536
+msgid "Delete redirect {0}"
+msgstr "Elimina la redirecció {0}"
+
+#: packages/admin/src/components/Redirects.tsx:580
+msgid "Delete Redirect?"
+msgstr "Vols eliminar la redirecció?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2811
+msgid "Delete row"
+msgstr "Elimina la fila"
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr "Vols eliminar la secció?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2826
+msgid "Delete table"
+msgstr "Elimina la taula"
+
+#: packages/admin/src/components/Widgets.tsx:634
+msgid "Delete Widget Area?"
+msgstr "Vols eliminar l'àrea de ginys?"
+
+#: packages/admin/src/components/ContentList.tsx:460
+msgid "Deleted"
+msgstr "Eliminat"
+
+#. placeholder {0}: deletingField.label
+#. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
+#: packages/admin/src/routes/byline-schema.tsx:371
+msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+msgstr "En eliminar «{0}» també se suprimirà {1, plural, one {# valor emmagatzemat} other {# valors emmagatzemats}} de totes les signatures. Aquesta acció no es pot desfer."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:664
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:454
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:583
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/TaxonomyManager.tsx:887
+#: packages/admin/src/components/Widgets.tsx:637
+#: packages/admin/src/routes/bylines.tsx:626
+msgid "Deleting..."
+msgstr "S'està eliminant..."
+
+#: packages/admin/src/routes/byline-schema.tsx:379
+msgid "Deleting…"
+msgstr "S'està eliminant…"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr "Demostració"
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr "Degrada l'usuari"
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr "Vols degradar l'usuari?"
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr "S'està degradant..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "Denega"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:238
+msgid "Describe the image..."
+msgstr "Descriu la imatge..."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
+#: packages/admin/src/components/MediaDetailPanel.tsx:374
+msgid "Describe this image for accessibility"
+msgstr "Descriu aquesta imatge per a l'accessibilitat"
+
+#: packages/admin/src/components/SectionEditor.tsx:262
+msgid "Describe what this section is for..."
+msgstr "Descriu per a què serveix aquesta secció..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:415
+#: packages/admin/src/components/RegistryPluginDetail.tsx:790
+#: packages/admin/src/components/SectionEditor.tsx:259
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:373
+msgid "Description"
+msgstr "Descripció"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:434
+msgid "Description (optional)"
+msgstr "Descripció (opcional)"
+
+#: packages/admin/src/components/Redirects.tsx:468
+msgid "Destination"
+msgstr "Destinació"
+
+#: packages/admin/src/components/Redirects.tsx:140
+msgid "Destination path"
+msgstr "Ruta de destinació"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "details"
+msgstr "detalls"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "Dispositiu autoritzat"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "Codi del dispositiu"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr "Vinculat al dispositiu"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Clau d'accés vinculada al dispositiu"
+
+#: packages/admin/src/components/SignupPage.tsx:143
+msgid "Didn't receive the email?"
+msgstr "No has rebut el correu electrònic?"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:34
+msgid "Diff"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:280
+msgid "Dimensions:"
+msgstr "Dimensions:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr "Desactiva"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Disable plugin"
+msgstr "Desactiva el connector"
+
+#: packages/admin/src/components/Redirects.tsx:504
+msgid "Disable redirect"
+msgstr "Desactiva la redirecció"
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr "Desactiva l'usuari"
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr "Vols desactivar l'usuari?"
+
+#: packages/admin/src/components/PluginManager.tsx:354
+#: packages/admin/src/components/Redirects.tsx:418
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: packages/admin/src/components/PluginManager.tsx:531
+msgid "Disabled:"
+msgstr "Desactivat:"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr "Si desactives <0>{0}</0>, no podrà iniciar la sessió fins que es torni a activar. El seu contingut es conservarà."
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr "S'està desactivant..."
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:438
+msgid "Discard"
+msgstr "Descarta"
+
+#: packages/admin/src/components/ContentEditor.tsx:691
+#: packages/admin/src/components/ContentEditor.tsx:713
+msgid "Discard changes"
+msgstr "Descarta els canvis"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:436
+msgid "Discard changes?"
+msgstr "Vols descartar els canvis?"
+
+#: packages/admin/src/components/ContentEditor.tsx:697
+msgid "Discard draft changes?"
+msgstr "Vols descartar els canvis de l'esborrany?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:439
+msgid "Discarding..."
+msgstr "S'està descartant..."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
+msgid "Dismiss"
+msgstr "Descarta"
+
+#: packages/admin/src/components/Widgets.tsx:103
+msgid "Display a navigation menu"
+msgstr "Mostra un menú de navegació"
+
+#: packages/admin/src/components/ContentEditor.tsx:2004
+#: packages/admin/src/components/ContentEditor.tsx:2066
+#: packages/admin/src/routes/bylines.tsx:482
+msgid "Display name"
+msgstr "Nom visible"
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Display name for admin interface"
+msgstr "Nom visible per a la interfície d'administració"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:269
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:458
+msgid "Display Size"
+msgstr "Mida de visualització"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
+msgid "Displayed below the image as a visible caption."
+msgstr "Es mostra sota la imatge com a llegenda visible."
+
+#: packages/admin/src/components/ContentEditor.tsx:667
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "Mode sense distraccions (⌘⇧\\)"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1095
+msgid "Divider"
+msgstr "Separador"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:35
+msgid "Dockerfile"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+#: packages/admin/src/components/MediaLibrary.tsx:438
+msgid "Documents"
+msgstr "Documents"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:286
+msgid "Domain"
+msgstr "Domini"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:66
+msgid "Domain added successfully"
+msgstr "S'ha afegit el domini correctament"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain removed"
+msgstr "S'ha eliminat el domini"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Domain updated"
+msgstr "S'ha actualitzat el domini"
+
+#: packages/admin/src/components/LoginPage.tsx:332
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "No tens cap compte? <0>Registra't</0>"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1964
+msgid "Done"
+msgstr "Fet"
+
+#: packages/admin/src/components/ContentEditor.tsx:1947
+msgid "Down"
+msgstr "Avall"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:479
+msgid "Download SBOM"
+msgstr "Baixa l'SBOM"
+
+#: packages/admin/src/components/WordPressImport.tsx:1962
+msgid "Downloading"
+msgstr "S'està baixant"
+
+#: packages/admin/src/components/ContentList.tsx:959
+msgid "draft"
+msgstr "esborrany"
+
+#: packages/admin/src/components/ContentEditor.tsx:858
+#: packages/admin/src/components/ContentList.tsx:544
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+msgid "Draft"
+msgstr "Esborrany"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr "esborrany, publicat o arxivat"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:188
+msgid "Drafts"
+msgstr "Esborranys"
+
+#: packages/admin/src/components/WordPressImport.tsx:961
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "Arrossega i deixa anar o fes clic per explorar (.xml)"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drag here to add"
+msgstr "Arrossega aquí per afegir"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1833
+msgid "Drag to reorder"
+msgstr "Arrossega per reordenar"
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:707
+#: packages/admin/src/components/Widgets.tsx:722
+msgid "Drag to reorder {0}"
+msgstr "Arrossega per reordenar {0}"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:338
+msgid "Drag to reorder block"
+msgstr "Arrossega per reordenar el bloc"
+
+#: packages/admin/src/components/Widgets.tsx:624
+msgid "Drag widgets here to add them"
+msgstr "Arrossega ginys aquí per afegir-los"
+
+#: packages/admin/src/components/Widgets.tsx:402
+msgid "Drag widgets into an area to add them"
+msgstr "Arrossega ginys a una àrea per afegir-los"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drop to add widget"
+msgstr "Deixa anar per afegir el giny"
+
+#: packages/admin/src/components/WordPressImport.tsx:1427
+msgid "Drop your WordPress export file here"
+msgstr "Deixa anar aquí el teu fitxer d'exportació de WordPress"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:292
+msgid "Duplicate"
+msgstr "Duplica"
+
+#: packages/admin/src/components/ContentList.tsx:824
+msgid "Duplicate {title}"
+msgstr "Duplica {title}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr "p. ex. application/zip o .pdf"
+
+#: packages/admin/src/components/Redirects.tsx:167
+msgid "e.g. import, blog"
+msgstr "p. ex. import, blog"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
+msgid "e.g., CI/CD Pipeline"
+msgstr "p. ex. canalització CI/CD"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "p. ex. MacBook Pro, iPhone"
+
+#: packages/admin/src/components/ContentEditor.tsx:1956
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:458
+#: packages/admin/src/components/MenuList.tsx:231
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TranslationsPanel.tsx:88
+msgid "Edit"
+msgstr "Edita"
+
+#. placeholder {0}: block?.label || ""
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:1438
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:243
+#: packages/admin/src/components/TaxonomyManager.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/routes/byline-schema.tsx:449
+#: packages/admin/src/routes/bylines.tsx:477
+msgid "Edit {0}"
+msgstr "Edita {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+msgid "Edit {0} field"
+msgstr "Edita el camp {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:630
+msgid "Edit {collectionLabel}"
+msgstr "Edita {collectionLabel}"
+
+#: packages/admin/src/components/ContentList.tsx:816
+msgid "Edit {title}"
+msgstr "Edita {title}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2063
+msgid "Edit byline"
+msgstr "Edita la signatura"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "Edit byline field"
+msgstr "Edita el camp de signatura"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:331
+msgid "Edit Domain"
+msgstr "Edita el domini"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr "Edita el camp"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2743
+msgid "Edit link"
+msgstr "Edita l'enllaç"
+
+#: packages/admin/src/components/MenuEditor.tsx:486
+msgid "Edit Menu Item"
+msgstr "Edita l'element del menú"
+
+#: packages/admin/src/components/MenuEditor.tsx:290
+msgid "Edit menu items"
+msgstr "Edita els elements del menú"
+
+#: packages/admin/src/components/Redirects.tsx:527
+msgid "Edit redirect"
+msgstr "Edita la redirecció"
+
+#: packages/admin/src/components/Redirects.tsx:105
+msgid "Edit Redirect"
+msgstr "Edita la redirecció"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:528
+msgid "Edit redirect {0}"
+msgstr "Edita la redirecció {0}"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr "Edita l'URL"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "Editor"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr "Editor\nRedactor\nFotògraf"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:59
+#: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:197
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr "Correu electrònic"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr "Correu electrònic (opcional)"
+
+#: packages/admin/src/components/LoginPage.tsx:126
+#: packages/admin/src/components/SignupPage.tsx:66
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
+msgid "Email address"
+msgstr "Adreça electrònica"
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:49
+msgid "Email is required"
+msgstr "El correu electrònic és obligatori"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:189
+msgid "Email Middleware"
+msgstr "Programari intermediari de correu"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:99
+msgid "Email Pipeline"
+msgstr "Canalització de correu"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:173
+msgid "Email provider active"
+msgstr "Proveïdor de correu actiu"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:77
+#: packages/admin/src/components/settings/EmailSettings.tsx:92
+msgid "Email Settings"
+msgstr "Configuració de correu"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr "Correu electrònic verificat"
+
+#: packages/admin/src/components/SignupPage.tsx:189
+msgid "Email verified!"
+msgstr "Correu electrònic verificat!"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2224
+msgid "Embed a {0}"
+msgstr "Incrusta {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2227
+msgid "Embeds"
+msgstr "Incrustacions"
+
+#: packages/admin/src/components/WordPressImport.tsx:1047
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "S'ha detectat el connector EmDash Exporter. Pots importar directament."
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr "Activa"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Enable comments"
+msgstr "Activa els comentaris"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr "Activa la cerca de text complet en aquesta col·lecció"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Enable plugin"
+msgstr "Activa el connector"
+
+#: packages/admin/src/components/Redirects.tsx:504
+msgid "Enable redirect"
+msgstr "Activa la redirecció"
+
+#: packages/admin/src/components/Redirects.tsx:175
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "Enabled"
+msgstr "Activat"
+
+#. placeholder {0}: label.toLowerCase()
+#: packages/admin/src/components/ContentEditor.tsx:1229
+msgid "Enter {0}..."
+msgstr "Introdueix {0}..."
+
+#: packages/admin/src/components/MenuEditor.tsx:344
+#: packages/admin/src/components/MenuEditor.tsx:514
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "Introdueix un URL (https://…) o una ruta relativa (/…)"
+
+#: packages/admin/src/components/ContentEditor.tsx:1477
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr "Introdueix un URL vàlid (p. ex. https://example.com)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1219
+msgid "Enter credentials manually"
+msgstr "Introdueix les credencials manualment"
+
+#: packages/admin/src/components/ContentEditor.tsx:666
+msgid "Enter distraction-free mode"
+msgstr "Entra al mode sense distraccions"
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr "Introdueix el correu electrònic"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
+msgid "Enter HTML..."
+msgstr "Introdueix HTML..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1251
+msgid "Enter markdown content..."
+msgstr "Introdueix contingut en Markdown..."
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr "Introdueix el nom"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "Introdueix el codi del teu terminal"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr "Introdueix un URL..."
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "Enter your handle to sign in."
+msgstr "Introdueix el teu identificador per iniciar la sessió."
+
+#: packages/admin/src/components/WordPressImport.tsx:1298
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "Introdueix les teves credencials de WordPress per importar contingut directament."
+
+#: packages/admin/src/components/WordPressImport.tsx:924
+msgid "Enter your WordPress site URL"
+msgstr "Introdueix l'URL del teu lloc de WordPress"
+
+#: packages/admin/src/components/MenuEditor.tsx:101
+#: packages/admin/src/components/MenuEditor.tsx:139
+#: packages/admin/src/components/MenuEditor.tsx:179
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:689
+#: packages/admin/src/router.tsx:1938
+msgid "Error"
+msgstr "Error"
+
+#: packages/admin/src/components/Widgets.tsx:174
+msgid "Error adding widget"
+msgstr "Error en afegir el giny"
+
+#: packages/admin/src/components/Widgets.tsx:235
+msgid "Error reordering widgets"
+msgstr "Error en reordenar els ginys"
+
+#: packages/admin/src/components/SectionEditor.tsx:52
+msgid "Error saving section"
+msgstr "Error en desar la secció"
+
+#: packages/admin/src/components/Widgets.tsx:704
+msgid "Error updating widget"
+msgstr "Error en actualitzar el giny"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:583
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr "Totes les versions publicades d'aquest connector s'han retirat o no s'han pogut verificar. Torna-ho a comprovar més tard o contacta amb l'editor."
+
+#: packages/admin/src/components/WordPressImport.tsx:1846
+msgid "Exists"
+msgstr "Existeix"
+
+#: packages/admin/src/components/ContentEditor.tsx:624
+msgid "Exit distraction-free mode"
+msgstr "Surt del mode sense distraccions"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3258
+msgid "Exit Spotlight Mode"
+msgstr "Surt del mode focus"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Expand"
+msgstr "Desplega"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Expand details"
+msgstr "Desplega els detalls"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:287
+msgid "Expires {0}"
+msgstr "Caduca {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:436
+msgid "Expiry"
+msgstr "Caducitat"
+
+#: packages/admin/src/components/WordPressImport.tsx:1112
+msgid "Export from WordPress manually"
+msgstr "Exporta des de WordPress manualment"
+
+#: packages/admin/src/components/WordPressImport.tsx:1236
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "Exporta el teu contingut des de WordPress per importar-ho tot, inclosos els esborranys."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:118
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr "Ha fallat"
+
+#: packages/admin/src/components/WordPressImport.tsx:1966
+msgid "Failed"
+msgstr "Ha fallat"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:188
+msgid "Failed security audit"
+msgstr "No ha superat l'auditoria de seguretat"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:70
+msgid "Failed to add domain"
+msgstr "No s'ha pogut afegir el domini"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:188
+msgid "Failed to add passkey"
+msgstr "No s'ha pogut afegir la clau d'accés"
+
+#: packages/admin/src/components/WordPressImport.tsx:367
+msgid "Failed to analyze WordPress site"
+msgstr "No s'ha pogut analitzar el lloc de WordPress"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr "No s'ha pogut comunicar amb el connector"
+
+#: packages/admin/src/lib/api/media.ts:155
+msgid "Failed to confirm upload"
+msgstr "No s'ha pogut confirmar la pujada"
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr "No s'ha pogut crear l'administrador"
+
+#: packages/admin/src/components/ContentEditor.tsx:2047
+msgid "Failed to create byline"
+msgstr "No s'ha pogut crear la signatura"
+
+#: packages/admin/src/lib/api/byline-fields.ts:120
+msgid "Failed to create byline field"
+msgstr "No s'ha pogut crear el camp de signatura"
+
+#: packages/admin/src/routes/byline-schema.tsx:102
+msgid "Failed to create field"
+msgstr "No s'ha pogut crear el camp"
+
+#: packages/admin/src/lib/api/sections.ts:88
+msgid "Failed to create section"
+msgstr "No s'ha pogut crear la secció"
+
+#: packages/admin/src/components/WordPressImport.tsx:1553
+msgid "Failed to create some collections"
+msgstr "No s'han pogut crear algunes col·leccions"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:493
+msgid "Failed to create term"
+msgstr "No s'ha pogut crear el terme"
+
+#: packages/admin/src/router.tsx:984
+msgid "Failed to create translation"
+msgstr "No s'ha pogut crear la traducció"
+
+#: packages/admin/src/router.tsx:397
+#: packages/admin/src/router.tsx:426
+#: packages/admin/src/router.tsx:1004
+msgid "Failed to delete"
+msgstr "No s'ha pogut eliminar"
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr "No s'ha pogut eliminar el domini permès"
+
+#: packages/admin/src/lib/api/bylines.ts:143
+msgid "Failed to delete byline"
+msgstr "No s'ha pogut eliminar la signatura"
+
+#: packages/admin/src/lib/api/byline-fields.ts:143
+msgid "Failed to delete byline field"
+msgstr "No s'ha pogut eliminar el camp de signatura"
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr "No s'ha pogut eliminar la col·lecció"
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1248
+msgid "Failed to delete comment"
+msgstr "No s'ha pogut eliminar el comentari"
+
+#: packages/admin/src/lib/api/content.ts:279
+msgid "Failed to delete content"
+msgstr "No s'ha pogut eliminar el contingut"
+
+#: packages/admin/src/lib/api/schema.ts:278
+#: packages/admin/src/routes/byline-schema.tsx:138
+msgid "Failed to delete field"
+msgstr "No s'ha pogut eliminar el camp"
+
+#: packages/admin/src/lib/api/media.ts:389
+msgid "Failed to delete from provider"
+msgstr "No s'ha pogut eliminar del proveïdor"
+
+#: packages/admin/src/lib/api/media.ts:259
+msgid "Failed to delete media"
+msgstr "No s'ha pogut eliminar el fitxer multimèdia"
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr "No s'ha pogut eliminar el menú"
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr "No s'ha pogut eliminar l'element del menú"
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr "No s'ha pogut eliminar la clau d'accés"
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr "No s'ha pogut eliminar la redirecció"
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr "No s'ha pogut eliminar la secció"
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr "No s'ha pogut eliminar el terme"
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr "No s'ha pogut eliminar el giny"
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr "No s'ha pogut eliminar l'àrea de ginys"
+
+#: packages/admin/src/components/PluginManager.tsx:116
+#: packages/admin/src/lib/api/plugins.ts:91
+msgid "Failed to disable plugin"
+msgstr "No s'ha pogut desactivar el connector"
+
+#: packages/admin/src/lib/api/search.ts:32
+msgid "Failed to disable search"
+msgstr "No s'ha pogut desactivar la cerca"
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr "No s'ha pogut desactivar l'usuari"
+
+#: packages/admin/src/router.tsx:911
+msgid "Failed to discard changes"
+msgstr "No s'han pogut descartar els canvis"
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr "No s'ha pogut descartar la benvinguda"
+
+#: packages/admin/src/router.tsx:440
+msgid "Failed to duplicate"
+msgstr "No s'ha pogut duplicar"
+
+#: packages/admin/src/components/PluginManager.tsx:97
+#: packages/admin/src/lib/api/plugins.ts:77
+msgid "Failed to enable plugin"
+msgstr "No s'ha pogut activar el connector"
+
+#: packages/admin/src/lib/api/search.ts:31
+msgid "Failed to enable search"
+msgstr "No s'ha pogut activar la cerca"
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr "No s'ha pogut activar l'usuari"
+
+#: packages/admin/src/components/WordPressImport.tsx:295
+msgid "Failed to execute import"
+msgstr "No s'ha pogut executar la importació"
+
+#: packages/admin/src/lib/api/client.ts:227
+msgid "Failed to fetch auth mode"
+msgstr "No s'ha pogut obtenir el mode d'autenticació"
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr "No s'ha pogut obtenir la col·lecció"
+
+#: packages/admin/src/lib/api/dashboard.ts:41
+msgid "Failed to fetch dashboard stats"
+msgstr "No s'han pogut obtenir les estadístiques del tauler"
+
+#: packages/admin/src/lib/api/email-settings.ts:34
+msgid "Failed to fetch email settings"
+msgstr "No s'ha pogut obtenir la configuració de correu"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:90
+msgid "Failed to fetch entry terms"
+msgstr "No s'han pogut obtenir els termes de l'entrada"
+
+#: packages/admin/src/lib/api/client.ts:210
+msgid "Failed to fetch manifest"
+msgstr "No s'ha pogut obtenir el manifest"
+
+#: packages/admin/src/lib/api/media.ts:76
+msgid "Failed to fetch media"
+msgstr "No s'han pogut obtenir els fitxers multimèdia"
+
+#: packages/admin/src/lib/api/media.ts:89
+msgid "Failed to fetch media item"
+msgstr "No s'ha pogut obtenir l'element multimèdia"
+
+#: packages/admin/src/lib/api/media.ts:325
+msgid "Failed to fetch media providers"
+msgstr "No s'han pogut obtenir els proveïdors multimèdia"
+
+#: packages/admin/src/lib/api/plugins.ts:59
+#: packages/admin/src/lib/api/plugins.ts:63
+msgid "Failed to fetch plugin"
+msgstr "No s'ha pogut obtenir el connector"
+
+#: packages/admin/src/lib/api/plugins.ts:45
+msgid "Failed to fetch plugins"
+msgstr "No s'han pogut obtenir els connectors"
+
+#: packages/admin/src/lib/api/media.ts:355
+msgid "Failed to fetch provider media"
+msgstr "No s'han pogut obtenir els fitxers multimèdia del proveïdor"
+
+#: packages/admin/src/lib/api/content.ts:556
+#: packages/admin/src/lib/api/content.ts:561
+msgid "Failed to fetch revision"
+msgstr "No s'ha pogut obtenir la revisió"
+
+#: packages/admin/src/lib/api/sections.ts:76
+msgid "Failed to fetch section"
+msgstr "No s'ha pogut obtenir la secció"
+
+#: packages/admin/src/lib/api/sections.ts:68
+msgid "Failed to fetch sections"
+msgstr "No s'han pogut obtenir les seccions"
+
+#: packages/admin/src/lib/api/settings.ts:50
+msgid "Failed to fetch settings"
+msgstr "No s'ha pogut obtenir la configuració"
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr "No s'ha pogut obtenir l'estat de configuració"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:71
+msgid "Failed to fetch terms"
+msgstr "No s'han pogut obtenir els termes"
+
+#: packages/admin/src/lib/api/current-user.ts:22
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:741
+#: packages/admin/src/router.tsx:1179
+msgid "Failed to fetch user"
+msgstr "No s'ha pogut obtenir l'usuari"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
+msgid "Failed to generate preview"
+msgstr "No s'ha pogut generar la previsualització"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr "No s'ha pogut generar l'URL de previsualització"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr "No s'han pogut obtenir les opcions d'autenticació"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr "No s'han pogut obtenir les opcions de registre"
+
+#: packages/admin/src/lib/api/media.ts:131
+msgid "Failed to get upload URL"
+msgstr "No s'ha pogut obtenir l'URL de pujada"
+
+#: packages/admin/src/components/WordPressImport.tsx:386
+msgid "Failed to import from WordPress"
+msgstr "No s'ha pogut importar des de WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:319
+#: packages/admin/src/lib/api/import.ts:256
+msgid "Failed to import media"
+msgstr "No s'han pogut importar els fitxers multimèdia"
+
+#: packages/admin/src/lib/api/marketplace.ts:160
+#: packages/admin/src/lib/api/registry.ts:692
+msgid "Failed to install plugin"
+msgstr "No s'ha pogut instal·lar el connector"
+
+#: packages/admin/src/lib/api/byline-fields.ts:98
+msgid "Failed to list byline fields"
+msgstr "No s'han pogut llistar els camps de signatura"
+
+#: packages/admin/src/router.tsx:257
+msgid "Failed to load admin"
+msgstr "No s'ha pogut carregar l'administració"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "Failed to load allowed domains"
+msgstr "No s'han pogut carregar els dominis permesos"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:366
+msgid "Failed to load bylines: {0}"
+msgstr "No s'han pogut carregar les signatures: {0}"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:81
+msgid "Failed to load email settings"
+msgstr "No s'ha pogut carregar la configuració de correu"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:422
+msgid "Failed to load image"
+msgstr "No s'ha pogut carregar la imatge"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:135
+msgid "Failed to load passkeys"
+msgstr "No s'han pogut carregar les claus d'accés"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:110
+msgid "Failed to load plugin"
+msgstr "No s'ha pogut carregar el connector"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:145
+msgid "Failed to load plugins: {0}"
+msgstr "No s'han pogut carregar els connectors: {0}"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:95
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr "No s'han pogut carregar els connectors. Pot ser que l'agregador del registre no sigui accessible."
+
+#: packages/admin/src/components/RevisionHistory.tsx:180
+msgid "Failed to load revisions"
+msgstr "No s'han pogut carregar les revisions"
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr "No s'ha pogut carregar la configuració inicial"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr "No s'ha pogut carregar el tema"
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr "No s'han pogut carregar els usuaris: {0}"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr "No s'ha pogut carregar el giny"
+
+#: packages/admin/src/router.tsx:1273
+msgid "Failed to perform bulk action"
+msgstr "No s'ha pogut dur a terme l'acció massiva"
+
+#: packages/admin/src/lib/api/content.ts:322
+msgid "Failed to permanently delete content"
+msgstr "No s'ha pogut eliminar permanentment el contingut"
+
+#: packages/admin/src/components/WordPressImport.tsx:276
+msgid "Failed to prepare import"
+msgstr "No s'ha pogut preparar la importació"
+
+#: packages/admin/src/router.tsx:872
+msgid "Failed to publish"
+msgstr "No s'ha pogut publicar"
+
+#: packages/admin/src/lib/api/byline-fields.ts:106
+msgid "Failed to read byline field usage"
+msgstr "No s'ha pogut llegir l'ús del camp de signatura"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:112
+msgid "Failed to remove domain"
+msgstr "No s'ha pogut eliminar el domini"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:70
+msgid "Failed to remove passkey"
+msgstr "No s'ha pogut eliminar la clau d'accés"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:53
+msgid "Failed to rename passkey"
+msgstr "No s'ha pogut canviar el nom de la clau d'accés"
+
+#: packages/admin/src/lib/api/byline-fields.ts:156
+msgid "Failed to reorder byline fields"
+msgstr "No s'han pogut reordenar els camps de signatura"
+
+#: packages/admin/src/lib/api/schema.ts:293
+#: packages/admin/src/routes/byline-schema.tsx:152
+msgid "Failed to reorder fields"
+msgstr "No s'han pogut reordenar els camps"
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr "No s'han pogut reordenar els ginys"
+
+#: packages/admin/src/router.tsx:412
+msgid "Failed to restore"
+msgstr "No s'ha pogut restaurar"
+
+#: packages/admin/src/lib/api/content.ts:311
+msgid "Failed to restore content"
+msgstr "No s'ha pogut restaurar el contingut"
+
+#: packages/admin/src/lib/api/content.ts:578
+#: packages/admin/src/lib/api/content.ts:583
+msgid "Failed to restore revision"
+msgstr "No s'ha pogut restaurar la revisió"
+
+#: packages/admin/src/lib/api/api-tokens.ts:98
+msgid "Failed to revoke API token"
+msgstr "No s'ha pogut revocar el testimoni d'API"
+
+#: packages/admin/src/components/WordPressImport.tsx:332
+msgid "Failed to rewrite URLs"
+msgstr "No s'han pogut reescriure els URL"
+
+#: packages/admin/src/router.tsx:816
+#: packages/admin/src/router.tsx:1755
+msgid "Failed to save"
+msgstr "No s'ha pogut desar"
+
+#: packages/admin/src/routes/byline-schema.tsx:122
+msgid "Failed to save field"
+msgstr "No s'ha pogut desar el camp"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:50
+#: packages/admin/src/components/settings/SeoSettings.tsx:44
+#: packages/admin/src/components/settings/SocialSettings.tsx:42
+msgid "Failed to save settings"
+msgstr "No s'ha pogut desar la configuració"
+
+#: packages/admin/src/router.tsx:932
+msgid "Failed to schedule"
+msgstr "No s'ha pogut programar"
+
+#: packages/admin/src/components/LoginPage.tsx:70
+#: packages/admin/src/components/LoginPage.tsx:75
+msgid "Failed to send magic link"
+msgstr "No s'ha pogut enviar l'enllaç màgic"
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr "No s'ha pogut enviar l'enllaç de recuperació"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:50
+#: packages/admin/src/lib/api/email-settings.ts:45
+msgid "Failed to send test email"
+msgstr "No s'ha pogut enviar el correu de prova"
+
+#: packages/admin/src/components/SignupPage.tsx:349
+msgid "Failed to send verification email"
+msgstr "No s'ha pogut enviar el correu de verificació"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:113
+msgid "Failed to set entry terms"
+msgstr "No s'han pogut definir els termes de l'entrada"
+
+#: packages/admin/src/lib/api/marketplace.ts:192
+#: packages/admin/src/lib/api/registry.ts:831
+msgid "Failed to uninstall plugin"
+msgstr "No s'ha pogut desinstal·lar el connector"
+
+#: packages/admin/src/router.tsx:890
+msgid "Failed to unpublish"
+msgstr "No s'ha pogut anul·lar la publicació"
+
+#: packages/admin/src/router.tsx:953
+msgid "Failed to unschedule"
+msgstr "No s'ha pogut anul·lar la programació"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:349
+msgid "Failed to update {0}"
+msgstr "No s'ha pogut actualitzar {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2097
+msgid "Failed to update byline"
+msgstr "No s'ha pogut actualitzar la signatura"
+
+#: packages/admin/src/lib/api/byline-fields.ts:135
+msgid "Failed to update byline field"
+msgstr "No s'ha pogut actualitzar el camp de signatura"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:94
+msgid "Failed to update domain"
+msgstr "No s'ha pogut actualitzar el domini"
+
+#: packages/admin/src/lib/api/media.ts:276
+msgid "Failed to update media"
+msgstr "No s'ha pogut actualitzar el fitxer multimèdia"
+
+#: packages/admin/src/lib/api/marketplace.ts:176
+#: packages/admin/src/lib/api/registry.ts:763
+msgid "Failed to update plugin"
+msgstr "No s'ha pogut actualitzar el connector"
+
+#: packages/admin/src/lib/api/sections.ts:100
+msgid "Failed to update section"
+msgstr "No s'ha pogut actualitzar la secció"
+
+#: packages/admin/src/lib/api/settings.ts:64
+msgid "Failed to update settings"
+msgstr "No s'ha pogut actualitzar la configuració"
+
+#: packages/admin/src/router.tsx:1232
+msgid "Failed to update status"
+msgstr "No s'ha pogut actualitzar l'estat"
+
+#: packages/admin/src/lib/api/media.ts:173
+msgid "Failed to upload file"
+msgstr "No s'ha pogut pujar el fitxer"
+
+#: packages/admin/src/lib/api/media.ts:218
+msgid "Failed to upload media"
+msgstr "No s'han pogut pujar els fitxers multimèdia"
+
+#: packages/admin/src/lib/api/media.ts:377
+msgid "Failed to upload to provider"
+msgstr "No s'ha pogut pujar al proveïdor"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:250
+msgid "Failed to verify authentication"
+msgstr "No s'ha pogut verificar l'autenticació"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr "No s'ha pogut verificar el registre"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:792
+msgid "FAQ"
+msgstr "PMF"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:213
+#: packages/admin/src/components/settings/GeneralSettings.tsx:219
+msgid "Favicon"
+msgstr "Icona del lloc"
+
+#: packages/admin/src/components/WordPressImport.tsx:1022
+msgid "Feature"
+msgstr "Funció"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:442
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr "Funcions"
+
+#: packages/admin/src/components/WordPressImport.tsx:736
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "S'està obtenint el contingut de l'API d'EmDash Exporter."
+
+#: packages/admin/src/routes/byline-schema.tsx:95
+msgid "Field created"
+msgstr "S'ha creat el camp"
+
+#: packages/admin/src/routes/byline-schema.tsx:133
+msgid "Field deleted"
+msgstr "S'ha eliminat el camp"
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr "Etiqueta del camp"
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr "Etiqueta del camp"
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr "Els slugs dels camps no es poden canviar després de la creació"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:268
+msgid "Field type cannot be changed after creation."
+msgstr "El tipus de camp no es pot canviar després de la creació."
+
+#: packages/admin/src/routes/byline-schema.tsx:115
+msgid "Field updated"
+msgstr "S'ha actualitzat el camp"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:572
+msgid "Fields"
+msgstr "Camps"
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Fields created:"
+msgstr "Camps creats:"
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr "Fitxer"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:1994
+msgid "File {0}"
+msgstr "Fitxer {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr "Fitxer de la biblioteca multimèdia"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:325
+#: packages/admin/src/components/MediaDetailPanel.tsx:342
+#: packages/admin/src/components/MediaLibrary.tsx:587
+msgid "Filename"
+msgstr "Nom del fitxer"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:120
+msgid "Filename cannot be changed after upload"
+msgstr "El nom del fitxer no es pot canviar després de la pujada"
+
+#: packages/admin/src/components/WordPressImport.tsx:2172
+msgid "files imported"
+msgstr "fitxers importats"
+
+#: packages/admin/src/components/ContentList.tsx:583
+msgid "Filter by author"
+msgstr "Filtra per autor"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr "Filtra per capacitat"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:177
+msgid "Filter by collection"
+msgstr "Filtra per col·lecció"
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr "Filtra per rol"
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr "Filtra per font"
+
+#: packages/admin/src/components/ContentList.tsx:568
+#: packages/admin/src/components/Redirects.tsx:419
+msgid "Filter by status"
+msgstr "Filtra per estat"
+
+#: packages/admin/src/components/MediaLibrary.tsx:440
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "Filter by type"
+msgstr "Filtra per tipus"
+
+#: packages/admin/src/routes/bylines.tsx:409
+msgid "Filter byline type"
+msgstr "Filtra per tipus de signatura"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr "Només els qui comenten per primera vegada"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr "Tipus de lletra"
+
+#: packages/admin/src/components/WordPressImport.tsx:1237
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "Per fer una importació completa, inclosos els esborranys i tot el contingut, exporta des de WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1046
+msgid "For the best import experience, install the"
+msgstr "Per obtenir la millor experiència d'importació, instal·la el"
+
+#: packages/admin/src/components/ContentList.tsx:620
+msgid "From date"
+msgstr "Data d'inici"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
+msgid "Full"
+msgstr "Complet"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "Accés complet"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Full admin access"
+msgstr "Accés d'administració complet"
+
+#: packages/admin/src/components/Settings.tsx:69
+msgid "General"
+msgstr "General"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:96
+#: packages/admin/src/components/settings/GeneralSettings.tsx:124
+msgid "General Settings"
+msgstr "Configuració general"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "Genres"
+msgstr "Gèneres"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "Comença"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:112
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "Posa un nom a aquesta clau d'accés per identificar-la més fàcilment després."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:36
+msgid "Go"
+msgstr "Ves"
+
+#: packages/admin/src/components/WordPressImport.tsx:2224
+#: packages/admin/src/router.tsx:1958
+msgid "Go to Dashboard"
+msgstr "Ves al tauler"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:194
+msgid "Google Verification"
+msgstr "Verificació de Google"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:37
+msgid "GraphQL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:461
+msgid "Grid view"
+msgstr "Vista de graella"
+
+#: packages/admin/src/components/Redirects.tsx:166
+msgid "Group (optional)"
+msgstr "Grup (opcional)"
+
+#: packages/admin/src/routes/bylines.tsx:556
+msgid "Guest byline"
+msgstr "Signatura de convidat"
+
+#: packages/admin/src/routes/bylines.tsx:414
+msgid "Guest only"
+msgstr "Només convidats"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:62
+#: packages/admin/src/components/PortableTextEditor.tsx:1010
+#: packages/admin/src/components/PortableTextEditor.tsx:3056
+msgid "Heading 1"
+msgstr "Encapçalament 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:70
+#: packages/admin/src/components/PortableTextEditor.tsx:1020
+#: packages/admin/src/components/PortableTextEditor.tsx:3063
+msgid "Heading 2"
+msgstr "Encapçalament 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:78
+#: packages/admin/src/components/PortableTextEditor.tsx:1030
+#: packages/admin/src/components/PortableTextEditor.tsx:3070
+msgid "Heading 3"
+msgstr "Encapçalament 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
+msgid "Height"
+msgstr "Alçada"
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr "Bàner destacat"
+
+#: packages/admin/src/components/SectionEditor.tsx:271
+msgid "hero, banner, cta"
+msgstr "destacat, bàner, cta"
+
+#: packages/admin/src/components/SeoPanel.tsx:196
+msgid "Hide from search engines"
+msgstr "Amaga als motors de cerca"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Hide token"
+msgstr "Amaga el testimoni"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:649
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "Jeràrquic (com les categories, amb relacions pare/fill)"
+
+#: packages/admin/src/components/Redirects.tsx:225
+#: packages/admin/src/components/Redirects.tsx:470
+msgid "Hits"
+msgstr "Coincidències"
+
+#: packages/admin/src/components/MenuEditor.tsx:337
+msgid "Home"
+msgstr "Inici"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr "Pàgina d'inici"
+
+#: packages/admin/src/components/PluginManager.tsx:385
+msgid "Hooks"
+msgstr "Ganxos"
+
+#: packages/admin/src/components/WordPressImport.tsx:1359
+msgid "How to create an Application Password"
+msgstr "Com crear una contrasenya d'aplicació"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:38
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
+#: packages/admin/src/components/PortableTextEditor.tsx:1080
+msgid "HTML"
+msgstr ""
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
+msgid "HTML source"
+msgstr "Codi font HTML"
+
+#: packages/admin/src/components/MenuEditor.tsx:345
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:508
+msgid "https://example.com/image.jpg"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:142
+msgid "Icon blurred due to image audit"
+msgstr "Icona difuminada a causa de l'auditoria d'imatges"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:103
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "Si existeix un compte per a <0>{email}</0>, t'hem enviat un enllaç d'inici de sessió."
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/FieldEditor.tsx:587
+#: packages/admin/src/components/PortableTextEditor.tsx:2193
+msgid "Image"
+msgstr "Imatge"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr "Imatge de la biblioteca multimèdia"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ImageFieldRenderer.tsx:113
+msgid "Image not found"
+msgstr "No s'ha trobat la imatge"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:208
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Image settings"
+msgstr "Configuració de la imatge"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
+msgid "Image Settings"
+msgstr "Configuració de la imatge"
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr "Imatge que es mostra quan es comparteix aquesta pàgina a les xarxes socials"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:509
+msgid "Image URL"
+msgstr "URL de la imatge"
+
+#: packages/admin/src/components/WordPressImport.tsx:2176
+msgid "image URLs updated in"
+msgstr "URL d'imatge actualitzats a"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+#: packages/admin/src/components/MediaLibrary.tsx:435
+msgid "Images"
+msgstr "Imatges"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:378
+#: packages/admin/src/components/WordPressImport.tsx:664
+msgid "Import"
+msgstr "Importa"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1794
+msgid "Import {0}"
+msgstr "Importa {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1205
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "Importa tot el contingut directament, inclosos els esborranys, els tipus d'entrada personalitzats, els camps ACF i les dades SEO. No cal baixar cap fitxer."
+
+#: packages/admin/src/components/WordPressImport.tsx:2222
+msgid "Import Another File"
+msgstr "Importa un altre fitxer"
+
+#: packages/admin/src/components/WordPressImport.tsx:1016
+msgid "Import Capabilities"
+msgstr "Capacitats d'importació"
+
+#: packages/admin/src/components/WordPressImport.tsx:2110
+msgid "Import Complete"
+msgstr "Importació completada"
+
+#: packages/admin/src/components/WordPressImport.tsx:2111
+msgid "Import Completed with Errors"
+msgstr "Importació completada amb errors"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Import failed"
+msgstr "Ha fallat la importació"
+
+#: packages/admin/src/components/WordPressImport.tsx:617
+msgid "Import from WordPress"
+msgstr "Importa des de WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1943
+msgid "Import Media"
+msgstr "Importa fitxers multimèdia"
+
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "Import Media Files"
+msgstr "Importa fitxers multimèdia"
+
+#: packages/admin/src/components/WordPressImport.tsx:619
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "Importa entrades, pàgines i tipus d'entrada personalitzats des de WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1650
+msgid "Import site configuration from WordPress."
+msgstr "Importa la configuració del lloc des de WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Import via EmDash Exporter"
+msgstr "Importa mitjançant EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr "Importat"
+
+#: packages/admin/src/components/WordPressImport.tsx:2150
+msgid "Imported by Collection"
+msgstr "Importat per col·lecció"
+
+#: packages/admin/src/components/WordPressImport.tsx:820
+msgid "Importing content..."
+msgstr "S'està important el contingut..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1975
+msgid "Importing Media"
+msgstr "S'estan important els fitxers multimèdia"
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr "Inclou contingut d'exemple (recomanat per a llocs nous)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1816
+msgid "Incompatible"
+msgstr "Incompatible"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:493
+msgid "Indexed"
+msgstr "Indexat"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3043
+msgid "Inline Code"
+msgstr "Codi en línia"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:520
+#: packages/admin/src/components/MediaPickerModal.tsx:747
+msgid "Insert"
+msgstr "Insereix"
+
+#. placeholder {0}: block?.label || ""
+#: packages/admin/src/components/PortableTextEditor.tsx:1438
+msgid "Insert {0}"
+msgstr "Insereix {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1061
+msgid "Insert a blockquote"
+msgstr "Insereix una cita"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1071
+msgid "Insert a code block"
+msgstr "Insereix un bloc de codi"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1096
+msgid "Insert a horizontal rule"
+msgstr "Insereix una línia horitzontal"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2208
+msgid "Insert a reusable section"
+msgstr "Insereix una secció reutilitzable"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1106
+msgid "Insert a table"
+msgstr "Insereix una taula"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2194
+msgid "Insert an image"
+msgstr "Insereix una imatge"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:502
+msgid "Insert from URL"
+msgstr "Insereix des d'un URL"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3225
+msgid "Insert Horizontal Rule"
+msgstr "Insereix una línia horitzontal"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3219
+msgid "Insert HTML"
+msgstr "Insereix HTML"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3208
+msgid "Insert Image"
+msgstr "Insereix una imatge"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3155
+msgid "Insert Link"
+msgstr "Insereix un enllaç"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1081
+msgid "Insert raw HTML"
+msgstr "Insereix HTML pur"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr "Insereix una secció"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3113
+msgid "Insert Table"
+msgstr "Insereix una taula"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:192
+#: packages/admin/src/components/RegistryPluginDetail.tsx:541
+msgid "Install"
+msgstr "Instal·la"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:155
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "Instal·la i activa un connector de proveïdor de correu per habilitar funcions com les invitacions, els enllaços màgics i la recuperació de contrasenya."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:186
+msgid "Install blocked"
+msgstr "Instal·lació bloquejada"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:791
+msgid "Installation"
+msgstr "Instal·lació"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:173
+#: packages/admin/src/components/RegistryBrowse.tsx:198
+#: packages/admin/src/components/RegistryPluginDetail.tsx:533
+msgid "Installed"
+msgstr "Instal·lat"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:500
+msgid "Installed from marketplace (v{0})"
+msgstr "Instal·lat des del mercat (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:519
+msgid "Installed:"
+msgstr "Instal·lat:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:167
+msgid "Installing..."
+msgstr "S'està instal·lant..."
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr "Enter"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:119
+msgid "Invalid invite link"
+msgstr "Enllaç d'invitació no vàlid"
+
+#: packages/admin/src/components/ContentEditor.tsx:1546
+msgid "Invalid JSON"
+msgstr "JSON no vàlid"
+
+#: packages/admin/src/components/SignupPage.tsx:259
+msgid "Invalid link"
+msgstr "Enllaç no vàlid"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:207
+msgid "Invite Error"
+msgstr "Error d'invitació"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:117
+msgid "Invite expired"
+msgstr "La invitació ha caducat"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "S'ha creat l'enllaç d'invitació"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr "Convida un usuari"
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr "Convida el primer membre del teu equip"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2714
+#: packages/admin/src/components/PortableTextEditor.tsx:3022
+msgid "Italic"
+msgstr "Cursiva"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1819
+#: packages/admin/src/components/RepeaterField.tsx:239
+msgid "Item {0}"
+msgstr "Element {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Item added"
+msgstr "S'ha afegit l'element"
+
+#: packages/admin/src/components/MenuEditor.tsx:133
+msgid "Item deleted"
+msgstr "S'ha eliminat l'element"
+
+#: packages/admin/src/components/MenuEditor.tsx:158
+msgid "Item updated"
+msgstr "S'ha actualitzat l'element"
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:205
+msgid "Jane Doe"
+msgstr "Jana Puig"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:39
+msgid "Java"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:40
+msgid "JavaScript"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:235
+msgid "Job title"
+msgstr "Càrrec"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:246
+msgid "job_title"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:41
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:42
+msgid "JSX"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1926
+msgid "Keep typing to narrow down more bylines."
+msgstr "Continua escrivint per acotar més les signatures."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:293
+#: packages/admin/src/components/SectionEditor.tsx:268
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr "Paraules clau"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:43
+msgid "Kotlin"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:232
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:337
+#: packages/admin/src/components/MenuEditor.tsx:506
+#: packages/admin/src/components/MenuList.tsx:166
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+#: packages/admin/src/components/Widgets.tsx:371
+#: packages/admin/src/routes/byline-schema.tsx:234
+msgid "Label"
+msgstr "Etiqueta"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:394
+msgid "Label (Plural)"
+msgstr "Etiqueta (plural)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:386
+msgid "Label (Singular)"
+msgstr "Etiqueta (singular)"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:162
+#: packages/admin/src/components/LoginPage.tsx:345
+#: packages/admin/src/components/Settings.tsx:129
+#: packages/admin/src/components/Settings.tsx:134
+msgid "Language"
+msgstr "Idioma"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1011
+msgid "Large section heading"
+msgstr "Encapçalament de secció gran"
+
+#: packages/admin/src/components/PluginManager.tsx:525
+msgid "Last enabled:"
+msgstr "Última activació:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr "Últim inici de sessió"
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr "Últim inici de sessió"
+
+#: packages/admin/src/components/Redirects.tsx:226
+msgid "Last seen"
+msgstr "Vist per última vegada"
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr "Última actualització"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr "Últim ús"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:292
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr "Últim ús {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr "Deixa-ho en blanc per utilitzar una clau d'accés detectable."
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Leave unassigned"
+msgstr "Deixa sense assignar"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
+msgid "Left"
+msgstr "Esquerra"
+
+#: packages/admin/src/components/MediaLibrary.tsx:137
+#: packages/admin/src/components/MediaLibrary.tsx:274
+#: packages/admin/src/components/MediaLibrary.tsx:357
+#: packages/admin/src/components/MediaPickerModal.tsx:203
+#: packages/admin/src/components/MediaPickerModal.tsx:462
+msgid "Library"
+msgstr "Biblioteca"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr "Llicència"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "clar"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "Clar"
+
+#: packages/admin/src/components/SignupPage.tsx:257
+msgid "Link expired"
+msgstr "L'enllaç ha caducat"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr "Enllaça amb un altre element de contingut"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr "Comptes enllaçats ({0})"
+
+#: packages/admin/src/routes/bylines.tsx:415
+msgid "Linked only"
+msgstr "Només enllaçats"
+
+#: packages/admin/src/routes/bylines.tsx:507
+msgid "Linked user"
+msgstr "Usuari enllaçat"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:130
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr "Enllaços"
+
+#: packages/admin/src/components/MediaLibrary.tsx:470
+msgid "List view"
+msgstr "Vista de llista"
+
+#: packages/admin/src/components/ContentEditor.tsx:745
+msgid "Live View"
+msgstr "Vista en directe"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:469
+msgid "Load more"
+msgstr "Carrega'n més"
+
+#: packages/admin/src/components/ContentList.tsx:444
+#: packages/admin/src/components/ContentList.tsx:501
+#: packages/admin/src/components/MediaLibrary.tsx:636
+#: packages/admin/src/components/MediaPickerModal.tsx:723
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr "Carrega'n més"
+
+#: packages/admin/src/routes/byline-schema.tsx:257
+msgid "Loading byline fields…"
+msgstr "S'estan carregant els camps de signatura…"
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr "S'estan carregant les col·leccions..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:307
+msgid "Loading comments..."
+msgstr "S'estan carregant els comentaris..."
+
+#: packages/admin/src/router.tsx:1927
+msgid "Loading configuration..."
+msgstr "S'està carregant la configuració..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr "S'està carregant el contingut..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2541
+msgid "Loading editor..."
+msgstr "S'està carregant l'editor..."
+
+#: packages/admin/src/components/MenuEditor.tsx:263
+msgid "Loading menu..."
+msgstr "S'està carregant el menú..."
+
+#: packages/admin/src/components/MenuList.tsx:94
+msgid "Loading menus..."
+msgstr "S'estan carregant els menús..."
+
+#: packages/admin/src/components/PluginManager.tsx:136
+msgid "Loading plugins..."
+msgstr "S'estan carregant els connectors..."
+
+#: packages/admin/src/components/Redirects.tsx:456
+msgid "Loading redirects..."
+msgstr "S'estan carregant les redireccions..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr "S'estan carregant les seccions..."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:99
+#: packages/admin/src/components/settings/SeoSettings.tsx:93
+#: packages/admin/src/components/settings/SocialSettings.tsx:73
+msgid "Loading settings..."
+msgstr "S'està carregant la configuració..."
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr "S'està carregant la configuració inicial..."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:827
+msgid "Loading terms..."
+msgstr "S'estan carregant els termes..."
+
+#: packages/admin/src/components/Widgets.tsx:310
+msgid "Loading widgets..."
+msgstr "S'estan carregant els ginys..."
+
+#: packages/admin/src/components/ContentList.tsx:355
+#: packages/admin/src/components/ContentList.tsx:444
+#: packages/admin/src/components/ContentList.tsx:473
+#: packages/admin/src/components/ContentList.tsx:501
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MediaLibrary.tsx:636
+#: packages/admin/src/components/MediaPickerModal.tsx:723
+#: packages/admin/src/components/PortableTextEditor.tsx:1946
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:161
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/TaxonomyManager.tsx:779
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:469
+msgid "Loading..."
+msgstr "S'està carregant..."
+
+#: packages/admin/src/components/ContentList.tsx:335
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "Idioma"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Lock aspect ratio"
+msgstr "Bloqueja la relació d'aspecte"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:291
+msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
+msgstr "Bloquejat perquè aquest camp té valors emmagatzemats. Elimina els valors (o el camp) per canviar-ho."
+
+#: packages/admin/src/components/Header.tsx:101
+msgid "Log out"
+msgstr "Tanca la sessió"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "Logo"
+msgstr "Logotip"
+
+#: packages/admin/src/components/WordPressImport.tsx:1668
+msgid "Logo & favicon"
+msgstr "Logotip i icona del lloc"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:53
+msgid "Long text"
+msgstr "Text llarg"
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr "Text llarg"
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "Només lletres minúscules, números i guions"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:641
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "Només lletres minúscules, números i guions baixos, començant per una lletra"
+
+#: packages/admin/src/components/Widgets.tsx:371
+msgid "Main Sidebar"
+msgstr "Barra lateral principal"
+
+#: packages/admin/src/lib/api/marketplace.ts:227
+#: packages/admin/src/lib/api/marketplace.ts:235
+msgid "Make network requests"
+msgstr "Fes sol·licituds de xarxa"
+
+#: packages/admin/src/lib/api/marketplace.ts:228
+#: packages/admin/src/lib/api/marketplace.ts:236
+msgid "Make network requests to any host (unrestricted)"
+msgstr "Fes sol·licituds de xarxa a qualsevol amfitrió (sense restriccions)"
+
+#: packages/admin/src/components/Sidebar.tsx:461
+msgid "Manage"
+msgstr "Gestiona"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:798
+msgid "Manage {0} for {1}"
+msgstr "Gestiona {0} per a {1}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1889
+msgid "Manage bylines in {entryLocale}"
+msgstr "Gestiona les signatures en {entryLocale}"
+
+#: packages/admin/src/components/Widgets.tsx:326
+msgid "Manage content widgets in your widget areas"
+msgstr "Gestiona els ginys de contingut de les teves àrees de ginys"
+
+#: packages/admin/src/components/PluginManager.tsx:175
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "Gestiona els connectors instal·lats. Activa o desactiva connectors per controlar-ne les funcions."
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Manage navigation menus for your site"
+msgstr "Gestiona els menús de navegació del teu lloc"
+
+#: packages/admin/src/components/Redirects.tsx:359
+msgid "Manage URL redirects and view 404 errors."
+msgstr "Gestiona les redireccions d'URL i consulta els errors 404."
+
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Manage your passkeys and authentication"
+msgstr "Gestiona les teves claus d'accés i l'autenticació"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:317
+msgid "Managed by {providerName}"
+msgstr "Gestionat per {providerName}"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:318
+msgid "Managed by an external media provider"
+msgstr "Gestionat per un proveïdor multimèdia extern"
+
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "Manual"
+msgstr "Manual"
+
+#: packages/admin/src/components/WordPressImport.tsx:2260
+msgid "Map Authors"
+msgstr "Assigna els autors"
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2308
+msgid "Map WordPress user {0} to EmDash user"
+msgstr "Assigna l'usuari {0} de WordPress a un usuari d'EmDash"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:255
+msgid "Mark {0} as Gone (410)"
+msgstr "Marca {0} com a Gone (410)"
+
+#: packages/admin/src/components/Redirects.tsx:254
+msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
+msgstr "Marca com a Gone (410): indica als motors de cerca que s'ha eliminat permanentment"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:501
+msgid "Mark as spam"
+msgstr "Marca com a brossa"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:44
+msgid "Markdown"
+msgstr "Markdown"
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "marketplace"
+msgstr "mercat"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:167
+#: packages/admin/src/components/PluginManager.tsx:355
+#: packages/admin/src/components/Sidebar.tsx:362
+msgid "Marketplace"
+msgstr "Mercat"
+
+#: packages/admin/src/components/FieldEditor.tsx:627
+msgid "Max Items"
+msgstr "Elements màxims"
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr "Longitud màxima"
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr "Valor màxim"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:45
+msgid "MDX"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2197
+#: packages/admin/src/components/Sidebar.tsx:321
+#: packages/admin/src/components/WordPressImport.tsx:678
+#: packages/admin/src/components/WordPressImport.tsx:1173
+msgid "Media"
+msgstr "Multimèdia"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:222
+msgid "Media Details"
+msgstr "Detalls del fitxer multimèdia"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2206
+msgid "Media Errors ({0})"
+msgstr "Errors multimèdia ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2168
+msgid "Media Import"
+msgstr "Importació multimèdia"
+
+#: packages/admin/src/components/WordPressImport.tsx:2109
+msgid "Media Import Complete"
+msgstr "Importació multimèdia completada"
+
+#: packages/admin/src/components/WordPressImport.tsx:2120
+msgid "Media import was skipped"
+msgstr "S'ha omès la importació multimèdia"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Media Library"
+msgstr "Biblioteca multimèdia"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Media Read"
+msgstr "Lectura de fitxers multimèdia"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Media Write"
+msgstr "Escriptura de fitxers multimèdia"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1021
+msgid "Medium section heading"
+msgstr "Encapçalament de secció mitjà"
+
+#: packages/admin/src/components/Widgets.tsx:102
+#: packages/admin/src/components/Widgets.tsx:834
+msgid "Menu"
+msgstr "Menú"
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:90
+msgid "Menu \"{0}\" ({1}) created."
+msgstr "S'ha creat el menú «{0}» ({1})."
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu \"{0}\" has been created."
+msgstr "S'ha creat el menú «{0}»."
+
+#: packages/admin/src/components/MenuList.tsx:54
+msgid "Menu created"
+msgstr "S'ha creat el menú"
+
+#: packages/admin/src/components/MenuList.tsx:74
+msgid "Menu deleted"
+msgstr "S'ha eliminat el menú"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Menu item has been added."
+msgstr "S'ha afegit l'element del menú."
+
+#: packages/admin/src/components/MenuEditor.tsx:134
+msgid "Menu item has been deleted."
+msgstr "S'ha eliminat l'element del menú."
+
+#: packages/admin/src/components/MenuEditor.tsx:159
+msgid "Menu item has been updated."
+msgstr "S'ha actualitzat l'element del menú."
+
+#: packages/admin/src/components/MenuEditor.tsx:271
+msgid "Menu not found"
+msgstr "No s'ha trobat el menú"
+
+#: packages/admin/src/components/MenuEditor.tsx:174
+msgid "Menu order has been updated."
+msgstr "S'ha actualitzat l'ordre del menú."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:103
+#: packages/admin/src/components/Sidebar.tsx:331
+msgid "Menus"
+msgstr "Menús"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1604
+msgid "Menus ({0})"
+msgstr "Menús ({0})"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Menus Manage"
+msgstr "Gestió de menús"
+
+#: packages/admin/src/components/SeoPanel.tsx:170
+msgid "Meta Description"
+msgstr "Meta descripció"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:203
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "Contingut de l'etiqueta meta per a la verificació de Bing Webmaster Tools"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:197
+msgid "Meta tag content for Google Search Console verification"
+msgstr "Contingut de l'etiqueta meta per a la verificació de Google Search Console"
+
+#: packages/admin/src/components/WordPressImport.tsx:1681
+msgid "Meta titles, descriptions, and social images"
+msgstr "Meta títols, descripcions i imatges socials"
+
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Min Items"
+msgstr "Elements mínims"
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr "Longitud mínima"
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr "Valor mínim"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:506
+msgid "Moderation"
+msgstr "Moderació"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "Senyals de moderació"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr "Modificat"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Modify collection schemas"
+msgstr "Modifica els esquemes de col·lecció"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr "Més populars"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:439
+msgid "Move \"{0}\" down"
+msgstr "Mou «{0}» avall"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:429
+msgid "Move \"{0}\" up"
+msgstr "Mou «{0}» amunt"
+
+#: packages/admin/src/components/ContentList.tsx:845
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "Vols moure «{title}» a la paperera? El podràs restaurar més tard."
+
+#: packages/admin/src/components/ContentList.tsx:836
+msgid "Move {title} to trash"
+msgstr "Mou {title} a la paperera"
+
+#: packages/admin/src/components/MenuEditor.tsx:451
+msgid "Move down"
+msgstr "Mou avall"
+
+#: packages/admin/src/components/ContentEditor.tsx:944
+#: packages/admin/src/components/ContentEditor.tsx:966
+#: packages/admin/src/components/ContentList.tsx:858
+msgid "Move to Trash"
+msgstr "Mou a la paperera"
+
+#: packages/admin/src/components/ContentEditor.tsx:950
+#: packages/admin/src/components/ContentList.tsx:843
+msgid "Move to Trash?"
+msgstr "Vols moure-ho a la paperera?"
+
+#: packages/admin/src/components/MenuEditor.tsx:442
+msgid "Move up"
+msgstr "Mou amunt"
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr "Selecció múltiple"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr "Text sense format multilínia"
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr "Diverses opcions triades"
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr "El meu blog"
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:154
+#: packages/admin/src/components/TaxonomyManager.tsx:389
+#: packages/admin/src/components/TaxonomyManager.tsx:632
+#: packages/admin/src/components/TaxonomyManager.tsx:821
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:365
+msgid "Name"
+msgstr "Nom"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:558
+msgid "Name and label are required"
+msgstr "El nom i l'etiqueta són obligatoris"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "El nom ha de començar per una lletra i contenir només lletres minúscules, números i guions baixos"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "Navegació"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr "Mai"
+
+#: packages/admin/src/router.tsx:979
+msgid "new"
+msgstr "nou"
+
+#: packages/admin/src/routes/bylines.tsx:427
+msgid "New"
+msgstr "Nou"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:106
+msgid "NEW"
+msgstr "NOU"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:464
+msgid "New {0}"
+msgstr "{0} nou"
+
+#: packages/admin/src/components/ContentEditor.tsx:630
+msgid "New {collectionLabel}"
+msgstr "{collectionLabel} nou"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "New byline field"
+msgstr "Camp de signatura nou"
+
+#: packages/admin/src/components/WordPressImport.tsx:1818
+msgid "New collection"
+msgstr "Col·lecció nova"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr "Tipus de contingut nou"
+
+#: packages/admin/src/routes/byline-schema.tsx:224
+msgid "New field"
+msgstr "Camp nou"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:116
+msgid "New public routes"
+msgstr "Rutes públiques noves"
+
+#: packages/admin/src/components/Redirects.tsx:105
+#: packages/admin/src/components/Redirects.tsx:362
+msgid "New Redirect"
+msgstr "Redirecció nova"
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr "Secció nova"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "pestanya nova"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:811
+msgid "New Taxonomy"
+msgstr "Taxonomia nova"
+
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:354
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuEditor.tsx:525
+msgid "New window"
+msgstr "Finestra nova"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr "Més recents"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:392
+msgid "News"
+msgstr "Notícies"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr "Següent"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:371
+#: packages/admin/src/components/ContentList.tsx:432
+msgid "Next page"
+msgstr "Pàgina següent"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:463
+msgid "Next screenshot"
+msgstr "Captura de pantalla següent"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "No"
+msgstr "No"
+
+#: packages/admin/src/routes/byline-schema.tsx:420
+msgid "No (shared across translations)"
+msgstr "No (compartit entre traduccions)"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:434
+msgid "No {0} available."
+msgstr "No hi ha cap {0} disponible."
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:366
+msgid "No {0} yet."
+msgstr "Encara no hi ha cap {0}."
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:830
+msgid "No {0} yet. Create one to get started."
+msgstr "Encara no hi ha cap {0}. Crea'n un per començar."
+
+#: packages/admin/src/components/Redirects.tsx:217
+msgid "No 404 errors recorded yet."
+msgstr "Encara no s'ha registrat cap error 404."
+
+#: packages/admin/src/components/MediaLibrary.tsx:834
+#: packages/admin/src/components/MediaLibrary.tsx:891
+msgid "No alt text"
+msgstr "Sense text alternatiu"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
+msgid "No API tokens yet. Create one to get started."
+msgstr "Encara no hi ha cap testimoni d'API. Crea'n un per començar."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No approved comments yet."
+msgstr "Encara no hi ha cap comentari aprovat."
+
+#: packages/admin/src/routes/byline-schema.tsx:291
+msgid "No byline fields yet."
+msgstr "Encara no hi ha cap camp de signatura."
+
+#: packages/admin/src/components/ContentEditor.tsx:1881
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr "No hi ha cap signatura disponible en {entryLocale}. Crea una variant des de la pàgina de signatures abans d'atribuir-ne una en aquesta entrada."
+
+#: packages/admin/src/routes/bylines.tsx:453
+msgid "No bylines found"
+msgstr "No s'ha trobat cap signatura"
+
+#: packages/admin/src/components/ContentEditor.tsx:1988
+msgid "No bylines selected."
+msgstr "No s'ha seleccionat cap signatura."
+
+#: packages/admin/src/components/Dashboard.tsx:172
+msgid "No collections configured"
+msgstr "No hi ha cap col·lecció configurada"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:546
+msgid "No comments awaiting moderation."
+msgstr "No hi ha cap comentari pendent de moderació."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:542
+msgid "No comments match your search."
+msgstr "Cap comentari coincideix amb la teva cerca."
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:80
+msgid "No content"
+msgstr "Sense contingut"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr "No s'ha trobat cap contingut"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr "No hi ha contingut en aquesta col·lecció"
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr "Encara no hi ha cap tipus de contingut."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:603
+msgid "No custom fields yet"
+msgstr "Encara no hi ha cap camp personalitzat"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:264
+msgid "No detailed description available."
+msgstr "No hi ha cap descripció detallada disponible."
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:262
+msgid "No domains configured. Users must be invited individually."
+msgstr "No hi ha cap domini configurat. Els usuaris s'han de convidar individualment."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:152
+msgid "No email provider configured"
+msgstr "No hi ha cap proveïdor de correu configurat"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "No hi ha cap proveïdor de correu configurat. Comparteix aquest enllaç manualment."
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "No EmDash users found"
+msgstr "No s'ha trobat cap usuari d'EmDash"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
+msgid "No expiry"
+msgstr "Sense caducitat"
+
+#: packages/admin/src/components/RevisionHistory.tsx:327
+msgid "No fields to compare"
+msgstr "No hi ha camps per comparar"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:189
+msgid "No headings in document"
+msgstr "No hi ha encapçalaments al document"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:581
+msgid "No installable releases"
+msgstr "No hi ha versions instal·lables"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:159
+msgid "No invite token provided"
+msgstr "No s'ha proporcionat cap testimoni d'invitació"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1742
+#: packages/admin/src/components/RepeaterField.tsx:165
+msgid "No items yet"
+msgstr "Encara no hi ha cap element"
+
+#: packages/admin/src/components/FieldEditor.tsx:631
+msgid "No limit"
+msgstr "Sense límit"
+
+#: packages/admin/src/routes/bylines.tsx:518
+msgid "No linked user"
+msgstr "Cap usuari enllaçat"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "No matches"
+msgstr "Cap coincidència"
+
+#: packages/admin/src/components/ContentEditor.tsx:1923
+msgid "No matching bylines."
+msgstr "Cap signatura coincident."
+
+#: packages/admin/src/components/MediaLibrary.tsx:490
+#: packages/admin/src/components/MediaLibrary.tsx:518
+msgid "No matching media"
+msgstr "Cap fitxer multimèdia coincident"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr "No s'ha trobat cap clau d'accés coincident per a aquest compte."
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr "Sense màxim"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:646
+msgid "No media available from this provider"
+msgstr "No hi ha cap fitxer multimèdia disponible d'aquest proveïdor"
+
+#: packages/admin/src/components/MediaLibrary.tsx:541
+msgid "No media available from this provider."
+msgstr "No hi ha cap fitxer multimèdia disponible d'aquest proveïdor."
+
+#: packages/admin/src/components/MediaLibrary.tsx:540
+#: packages/admin/src/components/MediaPickerModal.tsx:640
+msgid "No media found"
+msgstr "No s'ha trobat cap fitxer multimèdia"
+
+#: packages/admin/src/components/MenuEditor.tsx:406
+msgid "No menu items yet"
+msgstr "Encara no hi ha cap element del menú"
+
+#: packages/admin/src/components/MenuList.tsx:186
+msgid "No menus yet"
+msgstr "Encara no hi ha cap menú"
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr "Sense mínim"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr "Sense moderació (aprova-ho tot automàticament)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr "No hi ha cap clau d'accés registrada"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:168
+msgid "No passkeys registered yet."
+msgstr "Encara no hi ha cap clau d'accés registrada."
+
+#: packages/admin/src/components/PluginManager.tsx:195
+msgid "No plugins configured"
+msgstr "No hi ha cap connector configurat"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "No s'ha trobat cap connector"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:117
+msgid "No plugins have been published to this registry yet."
+msgstr "Encara no s'ha publicat cap connector en aquest registre."
+
+#: packages/admin/src/components/RegistryBrowse.tsx:116
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr "Cap connector coincideix amb «{debouncedQuery}»."
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr "Sense previsualització"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:304
+msgid "No public URL available"
+msgstr "No hi ha cap URL públic disponible"
+
+#: packages/admin/src/components/Dashboard.tsx:236
+msgid "No recent activity"
+msgstr "No hi ha activitat recent"
+
+#: packages/admin/src/components/Redirects.tsx:460
+msgid "No redirects yet"
+msgstr "Encara no hi ha cap redirecció"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1300
+#: packages/admin/src/components/RepeaterField.tsx:374
+msgid "No results"
+msgstr "Cap resultat"
+
+#: packages/admin/src/components/ContentList.tsx:363
+#: packages/admin/src/components/ContentList.tsx:382
+msgid "No results for \"{activeSearch}\""
+msgstr "Cap resultat per a «{activeSearch}»"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "Cap resultat per a «{debouncedQuery}». Prova un altre terme de cerca."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "No s'ha trobat cap resultat"
+
+#: packages/admin/src/components/RevisionHistory.tsx:183
+msgid "No revisions yet"
+msgstr "Encara no hi ha cap revisió"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr "No hi ha cap secció disponible"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr "No s'ha trobat cap secció"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr "Encara no hi ha cap secció"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No spam comments."
+msgstr "No hi ha comentaris de brossa."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr "No s'ha trobat cap tema"
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr "No s'ha trobat cap usuari que coincideixi amb els teus filtres."
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr "Encara no hi ha cap usuari."
+
+#: packages/admin/src/components/Widgets.tsx:434
+msgid "No widget areas yet. Create one to get started."
+msgstr "Encara no hi ha cap àrea de ginys. Crea'n una per començar."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
+msgid "None"
+msgstr "Cap"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:418
+#: packages/admin/src/components/TaxonomyManager.tsx:424
+msgid "None (top level)"
+msgstr "Cap (nivell superior)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:616
+msgid "Not compatible with this environment"
+msgstr "No és compatible amb aquest entorn"
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr "Nombre"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:278
+msgid "Number of posts to show per page on list views"
+msgstr "Nombre d'entrades que es mostren per pàgina a les vistes de llista"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:110
+#: packages/admin/src/components/PortableTextEditor.tsx:1050
+#: packages/admin/src/components/PortableTextEditor.tsx:3090
+msgid "Numbered List"
+msgstr "Llista numerada"
+
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr "Imatge OG"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "en un nom d'amfitrió personalitzat no es considera segur, ni tan sols en loopback."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "Autoritza només els codis que reconeguis."
+
+#: packages/admin/src/components/SignupPage.tsx:96
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "Només es poden registrar les adreces electròniques de dominis permesos."
+
+#: packages/admin/src/components/MenuList.tsx:159
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "Només lletres minúscules, números i guions"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr "Només s'acceptaran els tipus MIME llistats per a aquest camp."
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Oops!"
+msgstr "Vaja!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:379
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:380
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:568
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:569
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr "Obre en una pestanya nova"
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Open WordPress Profile"
+msgstr "Obre el perfil de WordPress"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr "Opció 1\nOpció 2\nOpció 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
+msgid "Optional caption displayed below the image"
+msgstr "Llegenda opcional que es mostra sota la imatge"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:384
+msgid "Optional caption for display"
+msgstr "Llegenda opcional per mostrar"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+msgid "Optional description"
+msgstr "Descripció opcional"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:553
+msgid "Optional tooltip on hover"
+msgstr "Descripció emergent opcional en passar-hi per sobre"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:302
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr "Opcions (una per línia)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:532
+msgid "or choose from library"
+msgstr "o tria'n un de la biblioteca"
+
+#: packages/admin/src/components/WordPressImport.tsx:1429
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "O fes clic per explorar. Accepta fitxers .xml exportats de WordPress."
+
+#: packages/admin/src/components/LoginPage.tsx:261
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr "O continua amb"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Or upload an export file"
+msgstr "O puja un fitxer d'exportació"
+
+#: packages/admin/src/components/WordPressImport.tsx:949
+msgid "or upload directly"
+msgstr "o puja'l directament"
+
+#: packages/admin/src/components/MenuEditor.tsx:173
+msgid "Order saved"
+msgstr "S'ha desat l'ordre"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
+msgid "Original:"
+msgstr "Original:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:181
+msgid "Outline"
+msgstr "Esquema"
+
+#: packages/admin/src/components/SeoPanel.tsx:160
+msgid "Overrides the page title in search engine results"
+msgstr "Substitueix el títol de la pàgina als resultats dels motors de cerca"
+
+#: packages/admin/src/components/ContentEditor.tsx:981
+msgid "Ownership"
+msgstr "Propietat"
+
+#: packages/admin/src/components/PluginManager.tsx:509
+msgid "Package"
+msgstr "Paquet"
+
+#: packages/admin/src/router.tsx:1953
+msgid "Page Not Found"
+msgstr "No s'ha trobat la pàgina"
+
+#: packages/admin/src/components/PluginManager.tsx:373
+#: packages/admin/src/components/WordPressImport.tsx:1167
+msgid "Pages"
+msgstr "Pàgines"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:54
+msgid "Paragraph"
+msgstr "Paràgraf"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:414
+msgid "Parent"
+msgstr "Pare"
+
+#: packages/admin/src/components/Redirects.tsx:509
+#: packages/admin/src/components/Redirects.tsx:515
+msgid "Part of a redirect loop"
+msgstr "Forma part d'un bucle de redirecció"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr "Correcte"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:89
+msgid "Passkey added successfully"
+msgstr "S'ha afegit la clau d'accés correctament"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "Nom de la clau d'accés"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "Nom de la clau d'accés (opcional)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "S'ha registrat la clau d'accés correctament!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Passkey removed"
+msgstr "S'ha eliminat la clau d'accés"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:49
+msgid "Passkey renamed"
+msgstr "S'ha canviat el nom de la clau d'accés"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:150
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr "Claus d'accés"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr "Claus d'accés ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:154
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Les claus d'accés són una manera segura i sense contrasenya d'iniciar la sessió al teu compte. Pots registrar diverses claus d'accés per a diferents dispositius."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:74
+#: packages/admin/src/components/SignupPage.tsx:213
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Les claus d'accés són una manera segura i sense contrasenya d'iniciar la sessió amb la biometria, el PIN o la clau de seguretat del teu dispositiu."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "Les claus d'accés no estan disponibles aquí"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Les claus d'accés requereixen un"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Les claus d'accés requereixen HTTPS o http://localhost (amb el teu port); aquest nom d'amfitrió no és un context de navegador segur."
+
+#: packages/admin/src/components/Redirects.tsx:224
+msgid "Path"
+msgstr "Ruta"
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr "Patró (expressió regular)"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:437
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr "Patró per generar URL, p. ex. /blog/{0}"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:433
+msgid "Pattern must include a {0} placeholder"
+msgstr "El patró ha d'incloure un marcador de posició {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:982
+msgid "pending"
+msgstr "pendent"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:197
+msgid "Pending"
+msgstr "Pendent"
+
+#: packages/admin/src/components/ContentEditor.tsx:856
+msgid "Pending changes"
+msgstr "Canvis pendents"
+
+#: packages/admin/src/components/ContentList.tsx:916
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "Vols eliminar permanentment «{title}»? Aquesta acció no es pot desfer."
+
+#: packages/admin/src/components/ContentList.tsx:905
+msgid "Permanently delete {title}"
+msgstr "Elimina permanentment {title}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:273
+msgid "Permissions"
+msgstr "Permisos"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:46
+msgid "PHP"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr "Tria qualsevol mètode per crear el teu compte d'administrador."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "Simple"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:27
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:120
+msgid "Plain text"
+msgstr "Text sense format"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:133
+msgid "Please ask your administrator to send a new invite."
+msgstr "Demana a l'administrador que enviï una invitació nova."
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr "Introdueix un correu electrònic vàlid"
+
+#: packages/admin/src/components/SignupPage.tsx:54
+msgid "Please enter a valid email address"
+msgstr "Introdueix una adreça electrònica vàlida"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:399
+msgid "Please enter a valid URL"
+msgstr "Introdueix un URL vàlid"
+
+#: packages/admin/src/components/WordPressImport.tsx:1024
+msgid "Plugin"
+msgstr "Connector"
+
+#: packages/admin/src/lib/api/plugins.ts:57
+msgid "Plugin \"{pluginId}\" not found"
+msgstr "No s'ha trobat el connector «{pluginId}»"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:749
+msgid "Plugin details"
+msgstr "Detalls del connector"
+
+#: packages/admin/src/components/PluginManager.tsx:110
+msgid "Plugin disabled"
+msgstr "S'ha desactivat el connector"
+
+#: packages/admin/src/components/PluginManager.tsx:91
+msgid "Plugin enabled"
+msgstr "S'ha activat el connector"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr "Error del connector"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr "Error del connector ({0})"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:112
+msgid "Plugin not found"
+msgstr "No s'ha trobat el connector"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:398
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr "No s'ha trobat el connector. Pot ser que l'identificador de l'editor o el slug siguin incorrectes."
+
+#: packages/admin/src/components/WordPressImport.tsx:1048
+msgid "plugin on your WordPress site."
+msgstr "connector al teu lloc de WordPress."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Plugin Permissions"
+msgstr "Permisos del connector"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:70
+msgid "Plugin Registry"
+msgstr "Registre de connectors"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr "El connector ha respost amb {0}: {text}"
+
+#: packages/admin/src/components/PluginManager.tsx:305
+msgid "Plugin uninstalled"
+msgstr "S'ha desinstal·lat el connector"
+
+#: packages/admin/src/lib/api/registry.ts:783
+msgid "Plugin update requires re-consent"
+msgstr "L'actualització del connector requereix tornar a donar consentiment"
+
+#: packages/admin/src/components/PluginManager.tsx:258
+msgid "Plugin updated"
+msgstr "S'ha actualitzat el connector"
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
+msgid "Plugin widget error"
+msgstr "Error del giny del connector"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:135
+#: packages/admin/src/components/PluginManager.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:153
+#: packages/admin/src/components/Sidebar.tsx:349
+#: packages/admin/src/components/Sidebar.tsx:477
+msgid "Plugins"
+msgstr "Connectors"
+
+#: packages/admin/src/components/SeoPanel.tsx:187
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "Indica als motors de cerca la versió original d'aquesta pàgina, si està duplicada d'un altre URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:389
+msgid "Post"
+msgstr "Entrada"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:397
+#: packages/admin/src/components/WordPressImport.tsx:1161
+msgid "Posts"
+msgstr "Entrades"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:272
+msgid "Posts Per Page"
+msgstr "Entrades per pàgina"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:465
+msgid "Pre-release"
+msgstr "Preversió"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "S'està preparant el registre..."
+
+#: packages/admin/src/components/WordPressImport.tsx:2020
+msgid "Preparing to download files from WordPress..."
+msgstr "S'està preparant la baixada de fitxers des de WordPress..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr "S'està preparant..."
+
+#: packages/admin/src/components/ContentEditor.tsx:680
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:586
+msgid "Preview"
+msgstr "Previsualitza"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr "Previsualitza el contingut abans de publicar-lo"
+
+#: packages/admin/src/components/ContentEditor.tsx:680
+msgid "Preview draft"
+msgstr "Previsualitza l'esborrany"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr "Anterior"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:352
+#: packages/admin/src/components/ContentList.tsx:420
+msgid "Previous page"
+msgstr "Pàgina anterior"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:445
+msgid "Previous screenshot"
+msgstr "Captura de pantalla anterior"
+
+#: packages/admin/src/components/MenuList.tsx:166
+msgid "Primary Navigation"
+msgstr "Navegació principal"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:176
+msgid "Provider:"
+msgstr "Proveïdor:"
+
+#: packages/admin/src/components/ContentEditor.tsx:735
+#: packages/admin/src/components/ContentEditor.tsx:841
+msgid "Publish"
+msgstr "Publica"
+
+#: packages/admin/src/components/ContentEditor.tsx:725
+msgid "Publish changes"
+msgstr "Publica els canvis"
+
+#: packages/admin/src/components/ContentList.tsx:957
+msgid "published"
+msgstr "publicat"
+
+#: packages/admin/src/components/ContentEditor.tsx:854
+#: packages/admin/src/components/ContentList.tsx:543
+#: packages/admin/src/components/ContentList.tsx:552
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/Dashboard.tsx:187
+#: packages/admin/src/router.tsx:868
+msgid "Published"
+msgstr "Publicat"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:326
+msgid "Published {0}"
+msgstr "Publicat {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr "Data de publicació"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:459
+msgid "Published by"
+msgstr "Publicat per"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:47
+msgid "Python"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1996
+msgid "Quick create byline"
+msgstr "Crea ràpidament una signatura"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:196
+#: packages/admin/src/components/editor/ImageNode.tsx:197
+msgid "Quick edit alt text"
+msgstr "Edita ràpidament el text alternatiu"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:86
+#: packages/admin/src/components/PortableTextEditor.tsx:1060
+#: packages/admin/src/components/PortableTextEditor.tsx:3097
+msgid "Quote"
+msgstr "Cita"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Read collection schemas"
+msgstr "Llegeix els esquemes de col·lecció"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Read content entries"
+msgstr "Llegeix les entrades de contingut"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Read media files"
+msgstr "Llegeix els fitxers multimèdia"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Read site settings"
+msgstr "Llegeix la configuració del lloc"
+
+#: packages/admin/src/lib/api/marketplace.ts:226
+#: packages/admin/src/lib/api/marketplace.ts:234
+msgid "Read user accounts"
+msgstr "Llegeix els comptes d'usuari"
+
+#: packages/admin/src/lib/api/marketplace.ts:222
+#: packages/admin/src/lib/api/marketplace.ts:230
+msgid "Read your content"
+msgstr "Llegeix el teu contingut"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:269
+msgid "Reading"
+msgstr "Lectura"
+
+#: packages/admin/src/components/WordPressImport.tsx:1822
+msgid "Ready"
+msgstr "A punt"
+
+#: packages/admin/src/components/Dashboard.tsx:228
+msgid "Recent Activity"
+msgstr "Activitat recent"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr "Actualitzat recentment"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:118
+msgid "Recipient email"
+msgstr "Correu electrònic del destinatari"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr "S'ha enviat l'enllaç de recuperació a {0}"
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Redirect loop detected"
+msgstr "S'ha detectat un bucle de redirecció"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "S'està redirigint a l'inici de sessió..."
+
+#: packages/admin/src/components/Redirects.tsx:358
+#: packages/admin/src/components/Redirects.tsx:377
+#: packages/admin/src/components/Sidebar.tsx:332
+msgid "Redirects"
+msgstr "Redireccions"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3245
+msgid "Redo"
+msgstr "Refés"
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr "Referència"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:228
+msgid "Referenced favicon unavailable."
+msgstr "La icona del lloc referenciada no està disponible."
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr "Registra't"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "Register Passkey"
+msgstr "Registra una clau d'accés"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "Usuari registrat"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr "Ha fallat el registre"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "El registre s'ha cancel·lat o ha excedit el temps d'espera. Torna-ho a provar."
+
+#: packages/admin/src/components/Sidebar.tsx:355
+msgid "Registry"
+msgstr "Registre"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:597
+msgid "Release is too new to install"
+msgstr "La versió és massa nova per instal·lar-la"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentEditor.tsx:1965
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:199
+#: packages/admin/src/components/PortableTextEditor.tsx:3196
+#: packages/admin/src/components/settings/GeneralSettings.tsx:194
+#: packages/admin/src/components/settings/GeneralSettings.tsx:248
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
+#: packages/admin/src/components/settings/SeoSettings.tsx:176
+msgid "Remove"
+msgstr "Treu"
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:243
+msgid "Remove {0}"
+msgstr "Treu {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr "Treu {entry}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1707
+msgid "Remove {label}"
+msgstr "Treu {label}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:397
+msgid "Remove Domain"
+msgstr "Elimina el domini"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+msgid "Remove Domain?"
+msgstr "Vols eliminar el domini?"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:130
+#: packages/admin/src/components/ImageFieldRenderer.tsx:159
+#: packages/admin/src/components/SeoImageField.tsx:55
+msgid "Remove image"
+msgstr "Treu la imatge"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:392
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:582
+msgid "Remove Image"
+msgstr "Treu la imatge"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
+msgid "Remove Image?"
+msgstr "Vols treure la imatge?"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1858
+#: packages/admin/src/components/RepeaterField.tsx:275
+msgid "Remove item {0}"
+msgstr "Treu l'element {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2695
+#: packages/admin/src/components/PortableTextEditor.tsx:2696
+msgid "Remove link"
+msgstr "Treu l'enllaç"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
+msgstr "Elimina la clau d'accés"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr "Vols eliminar la clau d'accés?"
+
+#: packages/admin/src/components/FieldEditor.tsx:611
+msgid "Remove sub-field"
+msgstr "Treu el subcamp"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:198
+msgid "Remove this image from the document?"
+msgstr "Vols treure aquesta imatge del document?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:200
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
+msgid "Removing..."
+msgstr "S'està traient..."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr "Canvia el nom"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr "Canvia el nom de {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
+msgstr "Canvia el nom de la clau d'accés"
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr "Repetidor"
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr "Grup de camps repetible"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:435
+msgid "Replace Image"
+msgstr "Substitueix la imatge"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "Respon a:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr "Dipòsit"
+
+#: packages/admin/src/components/SignupPage.tsx:273
+msgid "Request a new link"
+msgstr "Sol·licita un enllaç nou"
+
+#: packages/admin/src/lib/api/client.ts:198
+msgid "Request failed"
+msgstr "Ha fallat la sol·licitud"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:280
+#: packages/admin/src/components/ContentTypeEditor.tsx:721
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:593
+#: packages/admin/src/routes/byline-schema.tsx:246
+msgid "Required"
+msgstr "Obligatori"
+
+#: packages/admin/src/components/WordPressImport.tsx:1835
+msgid "Required fields:"
+msgstr "Camps obligatoris:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "Obligatori per a l'accessibilitat. Descriu la imatge per als lectors de pantalla."
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:324
+msgid "Requires EmDash {0}"
+msgstr "Requereix EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend email"
+msgstr "Torna a enviar el correu"
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend in {resendCooldown}s"
+msgstr "Torna a enviar-lo d'aquí a {resendCooldown} s"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:277
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+msgid "Reset to original"
+msgstr "Restableix a l'original"
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restore"
+msgstr "Restaura"
+
+#: packages/admin/src/components/ContentList.tsx:893
+msgid "Restore {title}"
+msgstr "Restaura {title}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:136
+msgid "Restore failed"
+msgstr "Ha fallat la restauració"
+
+#: packages/admin/src/components/RevisionHistory.tsx:214
+msgid "Restore Revision?"
+msgstr "Vols restaurar la revisió?"
+
+#: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
+msgid "Restore this version"
+msgstr "Restaura aquesta versió"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:217
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "Vols restaurar aquesta versió de {0}? Això actualitzarà el contingut actual amb les dades d'aquesta revisió."
+
+#: packages/admin/src/components/RevisionHistory.tsx:221
+msgid "Restoring..."
+msgstr "S'està restaurant..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:1941
+#: packages/admin/src/routes/byline-schema.tsx:280
+msgid "Retry"
+msgstr "Reintenta"
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr "Blocs de contingut reutilitzables que pots inserir en qualsevol contingut"
+
+#: packages/admin/src/router.tsx:906
+msgid "Reverted to published version"
+msgstr "S'ha revertit a la versió publicada"
+
+#: packages/admin/src/components/WordPressImport.tsx:650
+msgid "Review"
+msgstr "Revisa"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Review New Permissions"
+msgstr "Revisa els permisos nous"
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Revision restored"
+msgstr "S'ha restaurat la revisió"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:161
+msgid "Revisions"
+msgstr "Revisions"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:333
+msgid "Revoke token"
+msgstr "Revoca el testimoni"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Revoke?"
+msgstr "Vols revocar-lo?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Revoking..."
+msgstr "S'està revocant..."
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr "Text enriquit"
+
+#: packages/admin/src/components/Widgets.tsx:97
+msgid "Rich text content"
+msgstr "Contingut de text enriquit"
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr "Editor de text enriquit"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
+msgid "Right"
+msgstr "Dreta"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:311
+msgid "Risk score: {0}/100"
+msgstr "Puntuació de risc: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr "Rol"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "Rol {role}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1970
+msgid "Role label"
+msgstr "Etiqueta del rol"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:48
+msgid "Ruby"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:49
+msgid "Rust"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:353
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuEditor.tsx:524
+msgid "Same window"
+msgstr "Mateixa finestra"
+
+#: packages/admin/src/components/ContentEditor.tsx:2103
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:395
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:589
+#: packages/admin/src/components/editor/ImageNode.tsx:264
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:533
+#: packages/admin/src/components/Redirects.tsx:190
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Save"
+msgstr "Desa"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr "Desa (Retorn)"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:265
+msgid "Save alt text"
+msgstr "Desa el text alternatiu"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Save changes"
+msgstr "Desa els canvis"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr "Desa els canvis"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr "Desa el contingut com a esborrany abans de publicar-lo"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "Desa el nom"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+msgid "Save SEO Settings"
+msgstr "Desa la configuració de SEO"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+msgid "Save Settings"
+msgstr "Desa la configuració"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Save Social Links"
+msgstr "Desa els enllaços socials"
+
+#: packages/admin/src/components/ContentEditor.tsx:655
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Saved"
+msgstr "Desat"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:116
+msgid "Saved \"{0}\"."
+msgstr "S'ha desat «{0}»."
+
+#: packages/admin/src/components/ContentEditor.tsx:650
+#: packages/admin/src/components/ContentEditor.tsx:2103
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/FieldEditor.tsx:660
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:533
+#: packages/admin/src/components/Redirects.tsx:187
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Saving..."
+msgstr "S'està desant..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Saving…"
+msgstr "S'està desant…"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:469
+msgid "SBOM"
+msgstr ""
+
+#. placeholder {0}: sbom.format
+#: packages/admin/src/components/RegistryPluginDetail.tsx:467
+msgid "SBOM · {0}"
+msgstr "SBOM · {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:896
+msgid "Schedule"
+msgstr "Programa"
+
+#: packages/admin/src/components/ContentEditor.tsx:882
+msgid "Schedule for"
+msgstr "Programa per a"
+
+#: packages/admin/src/components/ContentEditor.tsx:919
+msgid "Schedule for later"
+msgstr "Programa per a més tard"
+
+#: packages/admin/src/components/ContentList.tsx:961
+msgid "scheduled"
+msgstr "programat"
+
+#: packages/admin/src/components/ContentEditor.tsx:859
+#: packages/admin/src/components/ContentList.tsx:545
+#: packages/admin/src/router.tsx:926
+msgid "Scheduled"
+msgstr "Programat"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentEditor.tsx:869
+msgid "Scheduled for: {0}"
+msgstr "Programat per a: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Schema Changes"
+msgstr "Canvis d'esquema"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Schema preparation failed"
+msgstr "Ha fallat la preparació de l'esquema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Schema Read"
+msgstr "Lectura d'esquema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Schema Write"
+msgstr "Escriptura d'esquema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:416
+msgid "Scopes"
+msgstr "Àmbits"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:284
+msgid "Scopes: {0}"
+msgstr "Àmbits: {0}"
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:243
+#: packages/admin/src/components/RegistryPluginDetail.tsx:642
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr "Captura de pantalla {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:453
+msgid "Screenshot {0} of {1}"
+msgstr "Captura de pantalla {0} de {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:246
+msgid "Screenshot blurred due to image audit"
+msgstr "Captura de pantalla difuminada a causa de l'auditoria d'imatges"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:431
+msgid "Screenshot viewer"
+msgstr "Visualitzador de captures de pantalla"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:233
+#: packages/admin/src/components/RegistryPluginDetail.tsx:636
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr "Captures de pantalla"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:50
+msgid "SCSS"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+msgid "Search"
+msgstr "Cerca"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:267
+msgid "Search {0}"
+msgstr "Cerca {0}"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:266
+msgid "Search {0}..."
+msgstr "Cerca {0}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:578
+msgid "Search by filename..."
+msgstr "Cerca per nom de fitxer..."
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr "Cerca per nom o correu electrònic..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1898
+#: packages/admin/src/routes/bylines.tsx:402
+msgid "Search bylines"
+msgstr "Cerca signatures"
+
+#: packages/admin/src/components/ContentEditor.tsx:1897
+msgid "Search bylines to add..."
+msgstr "Cerca signatures per afegir..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments"
+msgstr "Cerca comentaris"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:162
+msgid "Search comments..."
+msgstr "Cerca comentaris..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "Cerca contingut..."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:122
+msgid "Search Engine Optimization"
+msgstr "Optimització per a motors de cerca"
+
+#: packages/admin/src/components/Settings.tsx:82
+msgid "Search engine optimization and verification"
+msgstr "Optimització i verificació per a motors de cerca"
+
+#: packages/admin/src/components/MediaLibrary.tsx:417
+#: packages/admin/src/components/MediaPickerModal.tsx:579
+msgid "Search media"
+msgstr "Cerca fitxers multimèdia"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "Cerca pàgines i contingut..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+#: packages/admin/src/components/RegistryBrowse.tsx:84
+msgid "Search plugins"
+msgstr "Cerca connectors"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+#: packages/admin/src/components/RegistryBrowse.tsx:80
+msgid "Search plugins..."
+msgstr "Cerca connectors..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr "Cerca seccions..."
+
+#: packages/admin/src/components/Redirects.tsx:409
+msgid "Search source or destination..."
+msgstr "Cerca origen o destinació..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr "Cerca temes"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr "Cerca temes..."
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr "Cerca usuaris"
+
+#: packages/admin/src/components/MediaLibrary.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:578
+msgid "Search..."
+msgstr "Cerca..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:723
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr "Cercable"
+
+#: packages/admin/src/components/ContentEditor.tsx:1901
+msgid "Searching..."
+msgstr "S'està cercant..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2207
+msgid "Section"
+msgstr "Secció"
+
+#: packages/admin/src/components/SectionEditor.tsx:82
+msgid "Section \"{slug}\" could not be found."
+msgstr "No s'ha pogut trobar la secció «{slug}»."
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr "S'ha creat la secció"
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr "S'ha eliminat la secció"
+
+#: packages/admin/src/components/SectionEditor.tsx:233
+msgid "Section Details"
+msgstr "Detalls de la secció"
+
+#: packages/admin/src/components/SectionEditor.tsx:78
+msgid "Section Not Found"
+msgstr "No s'ha trobat la secció"
+
+#: packages/admin/src/components/SectionEditor.tsx:44
+msgid "Section saved"
+msgstr "S'ha desat la secció"
+
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "Section title"
+msgstr "Títol de la secció"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:334
+msgid "Sections"
+msgstr "Seccions"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "context segur"
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr "Assegura el teu compte"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:794
+#: packages/admin/src/components/Settings.tsx:92
+msgid "Security"
+msgstr "Seguretat"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:307
+msgid "Security Audit"
+msgstr "Auditoria de seguretat"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr "Ha fallat l'auditoria de seguretat"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr "L'auditoria de seguretat ha detectat problemes"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "L'auditoria de seguretat ha detectat possibles problemes amb aquest connector."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:149
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "L'auditoria de seguretat ha marcat aquest connector com a potencialment insegur."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr "S'ha superat l'auditoria de seguretat"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:705
+msgid "Security contacts"
+msgstr "Contactes de seguretat"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "Error de seguretat. Assegura't que estàs en una connexió segura."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:95
+msgid "Security Settings"
+msgstr "Configuració de seguretat"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:56
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr "Selecciona"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1719
+#: packages/admin/src/components/ContentEditor.tsx:1735
+#: packages/admin/src/components/ImageFieldRenderer.tsx:187
+msgid "Select {label}"
+msgstr "Selecciona {label}"
+
+#: packages/admin/src/components/Widgets.tsx:871
+msgid "Select a component..."
+msgstr "Selecciona un component..."
+
+#: packages/admin/src/components/Widgets.tsx:839
+msgid "Select a menu..."
+msgstr "Selecciona un menú..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:283
+msgid "Select all"
+msgstr "Selecciona-ho tot"
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:456
+msgid "Select comment by {0}"
+msgstr "Selecciona el comentari de {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "Selecciona contingut"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:235
+msgid "Select Default Social Image"
+msgstr "Selecciona la imatge social per defecte"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:260
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Select Favicon"
+msgstr "Selecciona la icona del lloc"
+
+#: packages/admin/src/components/ContentEditor.tsx:1723
+msgid "Select file"
+msgstr "Selecciona un fitxer"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:145
+msgid "Select File"
+msgstr "Selecciona un fitxer"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:175
+msgid "Select image"
+msgstr "Selecciona una imatge"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:145
+#: packages/admin/src/components/PortableTextEditor.tsx:2583
+#: packages/admin/src/components/PortableTextEditor.tsx:3270
+#: packages/admin/src/components/settings/SeoSettings.tsx:188
+msgid "Select Image"
+msgstr "Selecciona una imatge"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:206
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Select Logo"
+msgstr "Selecciona el logotip"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr "Selecciona un fitxer multimèdia"
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr "Selecciona la imatge OG"
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr "Selecciona la imatge OG"
+
+#: packages/admin/src/components/WordPressImport.tsx:1571
+msgid "Select which content types to import."
+msgstr "Selecciona quins tipus de contingut vols importar."
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:1953
+#: packages/admin/src/components/RepeaterField.tsx:372
+msgid "Select..."
+msgstr "Selecciona..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:734
+msgid "Selected:"
+msgstr "Seleccionat:"
+
+#: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:152
+msgid "Self-Signup Domains"
+msgstr "Dominis d'autoregistre"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:113
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "Envia un correu de prova a través de tota la canalització per verificar la teva configuració de correu."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "Envia un correu d'invitació a un membre nou de l'equip."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr "Envia la invitació"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+msgid "Send magic link"
+msgstr "Envia l'enllaç màgic"
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr "Envia l'enllaç de recuperació"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+msgid "Send Test"
+msgstr "Envia una prova"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:110
+msgid "Send Test Email"
+msgstr "Envia un correu de prova"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+#: packages/admin/src/components/SignupPage.tsx:88
+#: packages/admin/src/components/SignupPage.tsx:151
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr "S'està enviant..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1046
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+#: packages/admin/src/components/Settings.tsx:81
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SeoSettings.tsx:115
+msgid "SEO Settings"
+msgstr "Configuració de SEO"
+
+#: packages/admin/src/components/WordPressImport.tsx:1679
+msgid "SEO settings (Yoast)"
+msgstr "Configuració de SEO (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:40
+msgid "SEO settings saved"
+msgstr "S'ha desat la configuració de SEO"
+
+#: packages/admin/src/components/SeoPanel.tsx:159
+msgid "SEO Title"
+msgstr "Títol SEO"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
+msgid "Set a custom display size for this image instance."
+msgstr "Defineix una mida de visualització personalitzada per a aquesta instància de la imatge."
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:146
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:150
+msgid "Set language"
+msgstr "Defineix l'idioma"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:147
+msgid "Set language (current: {label})"
+msgstr "Defineix l'idioma (actual: {label})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:531
+msgid "Set to 0 to never close comments automatically."
+msgstr "Defineix-ho a 0 per no tancar mai els comentaris automàticament."
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr "Configura el teu lloc"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr "S'està configurant..."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/ContentTypeEditor.tsx:383
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:437
+#: packages/admin/src/components/Settings.tsx:62
+#: packages/admin/src/components/Sidebar.tsx:379
+#: packages/admin/src/components/WordPressImport.tsx:1647
+msgid "Settings"
+msgstr "Configuració"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
+msgid "Settings Manage"
+msgstr "Gestió de la configuració"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Settings Read"
+msgstr "Lectura de la configuració"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:43
+msgid "Settings saved successfully"
+msgstr "S'ha desat la configuració correctament"
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr "Ha fallat la configuració"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "Comparteix aquest enllaç amb l'usuari convidat"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:294
+msgid "Shared across all translations of the same byline."
+msgstr "Compartit entre totes les traduccions de la mateixa signatura."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:52
+msgid "Short text"
+msgstr "Text curt"
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr "Text curt"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Show token"
+msgstr "Mostra el testimoni"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:365
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:554
+msgid "Shown when hovering over the image."
+msgstr "Es mostra en passar el cursor per sobre de la imatge."
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Sign in"
+msgstr "Inicia la sessió"
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr "Inicia la sessió"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr "Inicia la sessió"
+
+#: packages/admin/src/components/LoginPage.tsx:232
+msgid "Sign in to your site"
+msgstr "Inicia la sessió al teu lloc"
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:231
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr "Inicia la sessió amb {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:229
+msgid "Sign in with email"
+msgstr "Inicia la sessió amb correu electrònic"
+
+#: packages/admin/src/components/LoginPage.tsx:290
+msgid "Sign in with email link"
+msgstr "Inicia la sessió amb un enllaç per correu electrònic"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:252
+msgid "Sign in with Passkey"
+msgstr "Inicia la sessió amb una clau d'accés"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "Sessió iniciada com a {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr "Una sola opció triada"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr "Entrada de text d'una sola línia"
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr "Lloc"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:130
+msgid "Site Identity"
+msgstr "Identitat del lloc"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "Identitat del lloc, logotip, icona del lloc i preferències de lectura"
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+msgid "Site Settings"
+msgstr "Configuració del lloc"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:133
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr "Títol del lloc"
+
+#: packages/admin/src/components/WordPressImport.tsx:1659
+msgid "Site title & tagline"
+msgstr "Títol i eslògan del lloc"
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr "El títol del lloc és obligatori"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:145
+msgid "Site URL"
+msgstr "URL del lloc"
+
+#: packages/admin/src/components/MediaLibrary.tsx:589
+msgid "Size"
+msgstr "Mida"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:274
+msgid "Size:"
+msgstr "Mida:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1940
+msgid "Skip Media Import"
+msgstr "Omet la importació multimèdia"
+
+#: packages/admin/src/components/WordPressImport.tsx:1965
+msgid "Skipped"
+msgstr "Omès"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:239
+#: packages/admin/src/components/ContentEditor.tsx:844
+#: packages/admin/src/components/ContentEditor.tsx:2012
+#: packages/admin/src/components/ContentEditor.tsx:2074
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:404
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:244
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:398
+#: packages/admin/src/routes/byline-schema.tsx:237
+#: packages/admin/src/routes/bylines.tsx:487
+msgid "Slug"
+msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr "Slug copiat al porta-retalls"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:251
+msgid "Slugs cannot be changed after the field is created."
+msgstr "Els slugs no es poden canviar després de crear el camp."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1031
+msgid "Small section heading"
+msgstr "Encapçalament de secció petit"
+
+#: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:70
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
+msgid "Social Links"
+msgstr "Enllaços socials"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:38
+msgid "Social links saved"
+msgstr "S'han desat els enllaços socials"
+
+#: packages/admin/src/components/Settings.tsx:76
+msgid "Social media profile links"
+msgstr "Enllaços als perfils de xarxes socials"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:100
+msgid "Social Profiles"
+msgstr "Perfils socials"
+
+#: packages/admin/src/components/WordPressImport.tsx:1696
+msgid "Some content types cannot be imported"
+msgstr "Alguns tipus de contingut no es poden importar"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:122
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Something went wrong"
+msgstr "Alguna cosa ha anat malament"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr "Ordena els connectors"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr "Ordena els temes"
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:560
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:214
+#: packages/admin/src/components/PluginManager.tsx:497
+#: packages/admin/src/components/Redirects.tsx:466
+#: packages/admin/src/components/SectionEditor.tsx:279
+msgid "Source"
+msgstr "Origen"
+
+#: packages/admin/src/components/Redirects.tsx:131
+msgid "Source path"
+msgstr "Ruta d'origen"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "brossa"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:207
+#: packages/admin/src/components/comments/CommentInbox.tsx:247
+msgid "Spam"
+msgstr "Brossa"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3258
+msgid "Spotlight Mode"
+msgstr "Mode focus"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr "Fulls de càlcul"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:51
+msgid "SQL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1758
+msgid "Start Import"
+msgstr "Inicia la importació"
+
+#: packages/admin/src/components/ContentEditor.tsx:850
+#: packages/admin/src/components/ContentList.tsx:328
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:471
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr "Estat"
+
+#: packages/admin/src/components/Redirects.tsx:151
+msgid "Status code"
+msgstr "Codi d'estat"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:293
+msgid "Stored per locale — each translation of a byline gets its own value."
+msgstr "S'emmagatzema per idioma: cada traducció d'una signatura té el seu propi valor."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2728
+#: packages/admin/src/components/PortableTextEditor.tsx:3036
+msgid "Strikethrough"
+msgstr "Ratllat"
+
+#: packages/admin/src/components/WordPressImport.tsx:1591
+msgid "Structure"
+msgstr "Estructura"
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr "Subcamps"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "Subscriptor"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:52
+msgid "Svelte"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:53
+msgid "Swift"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr "Sincronitzat"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Clau d'accés sincronitzada"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:768
+msgid "System"
+msgstr "Sistema"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "Sistema ({resolvedLabel})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:590
+msgid "System Fields"
+msgstr "Camps del sistema"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1105
+msgid "Table"
+msgstr "Taula"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:139
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr "Eslògan"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+msgid "Tags"
+msgstr "Etiquetes"
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1633
+msgid "Tags ({0})"
+msgstr "Etiquetes ({0})"
+
+#: packages/admin/src/components/MenuEditor.tsx:348
+#: packages/admin/src/components/MenuEditor.tsx:519
+msgid "Target"
+msgstr "Destinació"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:172
+msgid "Target locale"
+msgstr "Idioma de destinació"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:537
+msgid "Taxonomies"
+msgstr "Taxonomies"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Taxonomies Manage"
+msgstr "Gestió de taxonomies"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:898
+msgid "Taxonomy created"
+msgstr "S'ha creat la taxonomia"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:785
+msgid "Taxonomy not found:"
+msgstr "No s'ha trobat la taxonomia:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:159
+msgid "Taxonomy: {taxonomyName}"
+msgstr "Taxonomia: {taxonomyName}"
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr "Plantilla:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Term"
+msgstr "Terme"
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:759
+msgid "Term \"{0}\" created in {1}."
+msgstr "S'ha creat el terme «{0}» a {1}."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:741
+msgid "Term deleted"
+msgstr "S'ha eliminat el terme"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:122
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3006
+msgid "Text formatting"
+msgstr "Format del text"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "No es concedirà accés al dispositiu."
+
+#: packages/admin/src/components/WordPressImport.tsx:1698
+msgid "The existing collection has fields with incompatible types."
+msgstr "La col·lecció existent té camps amb tipus incompatibles."
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "Les taules següents contenen contingut però no estan registrades com a col·leccions. Registra-les per gestionar aquest contingut a l'administració."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr "L'usuari convidat tindrà aquest rol un cop completi el registre."
+
+#: packages/admin/src/components/LoginPage.tsx:113
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "The link will expire in 15 minutes."
+msgstr "L'enllaç caducarà d'aquí a 15 minuts."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "El mercat és buit. Torna-hi més tard per veure connectors nous."
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "The menu has been deleted."
+msgstr "S'ha eliminat el menú."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:136
+msgid "The name of your site, used in the header and metadata"
+msgstr "El nom del teu lloc, utilitzat a la capçalera i les metadades"
+
+#: packages/admin/src/router.tsx:1955
+msgid "The page you're looking for doesn't exist."
+msgstr "La pàgina que cerques no existeix."
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
+msgid "The plugin field widget failed to render."
+msgstr "El giny de camp del connector no s'ha pogut renderitzar."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:149
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "L'URL públic del teu lloc (utilitzat per als enllaços canònics i els mapes del lloc)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr "La imatge referenciada ja no està disponible. Tria'n una de nova o treu la referència."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:174
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr "El logotip referenciat ja no està disponible. Tria'n un de nou o treu la referència."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr "El mercat de temes és buit. Torna-hi més tard."
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr "Tema"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:292
+msgid "Theme ID: {0}"
+msgstr "ID del tema: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr "No s'ha trobat el tema"
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Theme Section"
+msgstr "Secció del tema"
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "Les seccions proporcionades pel tema no es poden eliminar. Edita la secció per crear-ne una còpia personalitzada i elimina aquesta."
+
+#: packages/admin/src/components/ThemeToggle.tsx:32
+msgid "Theme: {label}"
+msgstr "Tema: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:371
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr "Temes"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:372
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr "Aquesta col·lecció està definida al codi. Algunes opcions no es poden canviar aquí. Edita el fitxer live.config.ts per modificar l'esquema."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:418
+msgid "This field does not accept {sniffedMime} files."
+msgstr "Aquest camp no accepta fitxers {sniffedMime}."
+
+#: packages/admin/src/components/ContentEditor.tsx:1738
+#: packages/admin/src/components/ImageFieldRenderer.tsx:191
+msgid "This field is required"
+msgstr "Aquest camp és obligatori"
+
+#: packages/admin/src/components/SectionEditor.tsx:286
+msgid "This is a custom section."
+msgstr "Aquesta és una secció personalitzada."
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "This is a WordPress site."
+msgstr "Aquest és un lloc de WordPress."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "Aquest enllaç caduca al cap de 7 dies i només es pot utilitzar una vegada."
+
+#: packages/admin/src/components/WordPressImport.tsx:821
+msgid "This may take a while for large exports."
+msgstr "Això pot trigar una estona en exportacions grans."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "Aquesta clau d'accés ja està registrada en aquest dispositiu."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:276
+msgid "This plugin requires no special permissions."
+msgstr "Aquest connector no requereix cap permís especial."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:566
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr "Aquest editor reclama un nom que no ha pogut demostrar que li pertany, possiblement suplantant algú altre. La instal·lació està desactivada. Si coneixes l'editor i hi confies, demana-li que arregli la configuració de la seva identitat abans de tornar-ho a provar."
+
+#: packages/admin/src/components/Redirects.tsx:581
+msgid "This redirect rule will be permanently removed."
+msgstr "Aquesta regla de redirecció s'eliminarà permanentment."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:618
+msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
+msgstr "Aquesta versió requereix un entorn més nou del que executa actualment el teu lloc. Actualitza'l abans d'instal·lar-la."
+
+#: packages/admin/src/routes/bylines.tsx:624
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr "Això elimina el perfil de signatura. S'eliminen els enllaços de signatura del contingut i s'esborren els punters principals."
+
+#: packages/admin/src/components/SectionEditor.tsx:283
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "Aquesta secció la proporciona el tema. En editar-la, es crearà una còpia personalitzada que substituirà la versió del tema."
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "This section was imported from another system."
+msgstr "Aquesta secció s'ha importat d'un altre sistema."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:119
+msgid "This update exposes the following routes without authentication:"
+msgstr "Aquesta actualització exposa les rutes següents sense autenticació:"
+
+#: packages/admin/src/components/Widgets.tsx:635
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr "Això eliminarà l'àrea de ginys i tots els seus ginys. Aquesta acció no es pot desfer."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "Això concedirà accés per CLI amb els teus permisos."
+
+#: packages/admin/src/components/ContentEditor.tsx:953
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "Això mourà l'element a la paperera. El podràs restaurar més tard des de la paperera."
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:884
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "Això eliminarà permanentment «{0}» i el traurà de tot el contingut."
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "Això eliminarà permanentment «{0}». Aquesta acció no es pot desfer."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "Això eliminarà permanentment aquest comentari. Aquesta acció no es pot desfer."
+
+#: packages/admin/src/components/PluginManager.tsx:629
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "Això traurà el connector i el seu paquet del teu lloc."
+
+#: packages/admin/src/components/ContentEditor.tsx:700
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "Això revertirà a la versió publicada. Es perdran els canvis del teu esborrany."
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr "Reflexions, tutorials i més"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:287
+msgid "Timezone"
+msgstr "Fus horari"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:290
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "Fus horari per mostrar les dates (p. ex. Europe/Madrid)"
+
+#: packages/admin/src/components/ContentList.tsx:322
+#: packages/admin/src/components/ContentList.tsx:457
+#: packages/admin/src/components/SectionEditor.tsx:236
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:811
+msgid "Title"
+msgstr "Títol"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:361
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:550
+msgid "Title (Tooltip)"
+msgstr "Títol (descripció emergent)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+msgid "Title Separator"
+msgstr "Separador del títol"
+
+#: packages/admin/src/components/ContentList.tsx:625
+msgid "to"
+msgstr "a"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "per tancar"
+
+#: packages/admin/src/components/ContentList.tsx:629
+msgid "To date"
+msgstr "Data final"
+
+#: packages/admin/src/components/PluginManager.tsx:203
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "per instal·lar connectors, o afegeix-los al teu astro.config.mjs."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "per seleccionar"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2820
+msgid "Toggle header row"
+msgstr "Commuta la fila de capçalera"
+
+#: packages/admin/src/components/ThemeToggle.tsx:30
+#: packages/admin/src/components/ThemeToggle.tsx:41
+msgid "Toggle theme (current: {label})"
+msgstr "Commuta el tema (actual: {label})"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
+msgid "Token created: {0}"
+msgstr "S'ha creat el testimoni: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:407
+msgid "Token Name"
+msgstr "Nom del testimoni"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:54
+msgid "TOML"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "Tools → Export"
+msgstr "Eines → Exporta"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr "Fes un seguiment de l'historial del contingut"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:287
+#: packages/admin/src/routes/byline-schema.tsx:243
+msgid "Translatable"
+msgstr "Traduïble"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:83
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translate"
+msgstr "Tradueix"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:156
+msgid "Translate \"{0}\""
+msgstr "Tradueix «{0}»"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:80
+msgid "Translate {0}"
+msgstr "Tradueix {0}"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translating..."
+msgstr "S'està traduint..."
+
+#: packages/admin/src/components/MenuEditor.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:758
+#: packages/admin/src/router.tsx:978
+msgid "Translation created"
+msgstr "S'ha creat la traducció"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:56
+msgid "Translations"
+msgstr "Traduccions"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "paperera"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:216
+#: packages/admin/src/components/comments/CommentInbox.tsx:257
+#: packages/admin/src/components/comments/CommentInbox.tsx:513
+#: packages/admin/src/components/ContentList.tsx:289
+msgid "Trash"
+msgstr "Paperera"
+
+#: packages/admin/src/components/ContentList.tsx:480
+msgid "Trash is empty"
+msgstr "La paperera és buida"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "Trash is empty."
+msgstr "La paperera és buida."
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr "Commutador cert/fals"
+
+#: packages/admin/src/components/MediaLibrary.tsx:494
+msgid "Try a broader media type or clear your filters."
+msgstr "Prova un tipus de fitxer més ampli o neteja els filtres."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:643
+msgid "Try a different search term"
+msgstr "Prova un altre terme de cerca"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr "Prova d'ajustar la teva cerca"
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr "Prova d'ajustar la teva cerca o els filtres."
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr "Torna-ho a provar"
+
+#: packages/admin/src/components/WordPressImport.tsx:1421
+msgid "Try Again"
+msgstr "Torna-ho a provar"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "Prova un altre codi"
+
+#: packages/admin/src/components/MediaLibrary.tsx:519
+msgid "Try another filename or clear your search."
+msgstr "Prova un altre nom de fitxer o neteja la cerca."
+
+#: packages/admin/src/components/MediaLibrary.tsx:493
+msgid "Try another filename, or clear your search and filters."
+msgstr "Prova un altre nom de fitxer, o neteja la cerca i els filtres."
+
+#: packages/admin/src/components/WordPressImport.tsx:1125
+#: packages/admin/src/components/WordPressImport.tsx:1247
+msgid "Try Another URL"
+msgstr "Prova un altre URL"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr "Prova amb les meves dades"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:55
+msgid "TSX"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:282
+msgid "Turn into"
+msgstr "Converteix en"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:106
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:260
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:588
+#: packages/admin/src/routes/byline-schema.tsx:240
+msgid "Type"
+msgstr "Tipus"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1854
+msgid "Type mismatch ({0})"
+msgstr "Discrepància de tipus ({0})"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:56
+msgid "TypeScript"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr "No s'ha pogut arribar al mercat"
+
+#: packages/admin/src/components/ContentEditor.tsx:2117
+#: packages/admin/src/components/ContentEditor.tsx:2132
+msgid "Unassigned"
+msgstr "Sense assignar"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2721
+#: packages/admin/src/components/PortableTextEditor.tsx:3029
+msgid "Underline"
+msgstr "Subratllat"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3238
+msgid "Undo"
+msgstr "Desfés"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:180
+#: packages/admin/src/components/PluginManager.tsx:547
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstall"
+msgstr "Desinstal·la"
+
+#: packages/admin/src/components/PluginManager.tsx:627
+msgid "Uninstall {pluginName}?"
+msgstr "Vols desinstal·lar {pluginName}?"
+
+#: packages/admin/src/components/PluginManager.tsx:622
+msgid "Uninstall confirmation"
+msgstr "Confirmació de la desinstal·lació"
+
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstalling..."
+msgstr "S'està desinstal·lant..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:722
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr "Únic"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr "Identificador únic (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "Rol desconegut"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Unlock aspect ratio"
+msgstr "Desbloqueja la relació d'aspecte"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr "Clau d'accés sense nom"
+
+#: packages/admin/src/components/ContentEditor.tsx:729
+msgid "Unpublish"
+msgstr "Anul·la la publicació"
+
+#: packages/admin/src/router.tsx:886
+msgid "Unpublished"
+msgstr "Publicació anul·lada"
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr "S'han trobat taules de contingut no registrades"
+
+#: packages/admin/src/components/ContentEditor.tsx:871
+msgid "Unschedule"
+msgstr "Anul·la la programació"
+
+#: packages/admin/src/router.tsx:947
+msgid "Unscheduled"
+msgstr "Programació anul·lada"
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr "Tipus d'element de giny no admès: {0}"
+
+#: packages/admin/src/components/Dashboard.tsx:249
+msgid "Untitled"
+msgstr "Sense títol"
+
+#: packages/admin/src/components/ContentEditor.tsx:1641
+msgid "Untitled file"
+msgstr "Fitxer sense títol"
+
+#: packages/admin/src/components/Widgets.tsx:466
+#: packages/admin/src/components/Widgets.tsx:729
+msgid "Untitled Widget"
+msgstr "Giny sense títol"
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr "Editor no verificat"
+
+#: packages/admin/src/components/ContentEditor.tsx:1944
+msgid "Up"
+msgstr "Amunt"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:478
+msgid "Update"
+msgstr "Actualitza"
+
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Update Field"
+msgstr "Actualitza el camp"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:334
+msgid "Update settings for {0}"
+msgstr "Actualitza la configuració de {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Update site settings"
+msgstr "Actualitza la configuració del lloc"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:366
+msgid "Update the {0} details"
+msgstr "Actualitza els detalls de {0}"
+
+#: packages/admin/src/components/Redirects.tsx:109
+msgid "Update this redirect rule."
+msgstr "Actualitza aquesta regla de redirecció."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Update to v{0}"
+msgstr "Actualitza a la v{0}"
+
+#: packages/admin/src/components/ContentList.tsx:551
+#: packages/admin/src/components/RegistryPluginDetail.tsx:488
+msgid "Updated"
+msgstr "Actualitzat"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr "Data d'actualització"
+
+#. placeholder {0}: new Date(item.updatedAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:928
+msgid "Updated: {0}"
+msgstr "Actualitzat: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:844
+msgid "Updating content URLs..."
+msgstr "S'estan actualitzant els URL del contingut..."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:166
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Updating..."
+msgstr "S'està actualitzant..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:601
+msgid "Upload"
+msgstr "Puja"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:147
+msgid "Upload a file to get started"
+msgstr "Puja un fitxer per començar"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Upload an export file"
+msgstr "Puja un fitxer d'exportació"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:148
+msgid "Upload an image to get started"
+msgstr "Puja una imatge per començar"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Upload and delete media"
+msgstr "Puja i elimina fitxers multimèdia"
+
+#: packages/admin/src/lib/api/marketplace.ts:225
+#: packages/admin/src/lib/api/marketplace.ts:233
+msgid "Upload and manage media"
+msgstr "Puja i gestiona fitxers multimèdia"
+
+#: packages/admin/src/components/WordPressImport.tsx:1123
+#: packages/admin/src/components/WordPressImport.tsx:1244
+msgid "Upload Export File"
+msgstr "Puja el fitxer d'exportació"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:621
+msgid "Upload failed: {uploadError}"
+msgstr "Ha fallat la pujada: {uploadError}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:613
+msgid "Upload file"
+msgstr "Puja un fitxer"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:149
+msgid "Upload File"
+msgstr "Puja un fitxer"
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+msgid "Upload files"
+msgstr "Puja fitxers"
+
+#: packages/admin/src/components/MediaLibrary.tsx:509
+#: packages/admin/src/components/MediaLibrary.tsx:533
+msgid "Upload Files"
+msgstr "Puja fitxers"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:149
+msgid "Upload Image"
+msgstr "Puja una imatge"
+
+#: packages/admin/src/components/MediaLibrary.tsx:506
+msgid "Upload images, videos, and documents to keep reusable assets in one place."
+msgstr "Puja imatges, vídeos i documents per tenir els recursos reutilitzables en un sol lloc."
+
+#: packages/admin/src/components/Dashboard.tsx:89
+msgid "Upload Media"
+msgstr "Puja fitxers multimèdia"
+
+#: packages/admin/src/components/MediaLibrary.tsx:530
+msgid "Upload media to keep reusable assets in one place."
+msgstr "Puja fitxers multimèdia per tenir els recursos reutilitzables en un sol lloc."
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload to {0}"
+msgstr "Puja a {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:960
+msgid "Upload WordPress export file"
+msgstr "Puja el fitxer d'exportació de WordPress"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:289
+msgid "Uploaded:"
+msgstr "Pujat:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1963
+msgid "Uploading"
+msgstr "S'està pujant"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:332
+msgid "Uploading {0}/{1}..."
+msgstr "S'està pujant {0}/{1}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:333
+#: packages/admin/src/components/MediaPickerModal.tsx:601
+msgid "Uploading..."
+msgstr "S'està pujant..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:54
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:339
+#: packages/admin/src/components/MenuEditor.tsx:509
+#: packages/admin/src/components/PortableTextEditor.tsx:3162
+msgid "URL"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:425
+msgid "URL Pattern"
+msgstr "Patró d'URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr "Identificador apte per a URL"
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "Identificador apte per a URL (p. ex. «primary», «footer»)"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:295
+msgid "URL:"
+msgstr "URL:"
+
+#: packages/admin/src/components/Redirects.tsx:110
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "Utilitza [param] o [...rest] a les rutes per fer coincidència de patrons."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "Utilitza l'autenticació biomètrica, la clau de seguretat o el PIN del teu dispositiu per iniciar la sessió."
+
+#: packages/admin/src/components/LoginPage.tsx:326
+msgid "Use your registered passkey to sign in securely."
+msgstr "Utilitza la teva clau d'accés registrada per iniciar la sessió de manera segura."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr "S'utilitza com a imatge Open Graph alternativa quan una pàgina no en té. Mida recomanada: 1200×630."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:644
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "S'utilitza com a identificador. Només lletres minúscules, números i guions baixos."
+
+#: packages/admin/src/components/ContentEditor.tsx:1328
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "S'utilitza com a element visual principal d'aquesta entrada a les pàgines de llista i a la part superior de l'entrada"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:122
+msgid "Used by screen readers and when image fails to load"
+msgstr "L'utilitzen els lectors de pantalla i quan la imatge no es pot carregar"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:410
+msgid "Used in URLs and API endpoints"
+msgstr "S'utilitza als URL i als extrems d'API"
+
+#: packages/admin/src/components/SectionEditor.tsx:254
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "S'utilitza per identificar aquesta secció. Només lletres minúscules, números i guions."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:37
+#: packages/admin/src/components/Header.tsx:75
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr "Usuari"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:177
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "L'accés dels usuaris el gestiona un proveïdor extern ({0}). La configuració de dominis d'autoregistre no està disponible quan s'utilitza autenticació externa."
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr "Detalls de l'usuari"
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr "No s'ha trobat l'usuari"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:348
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr "Usuaris"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:383
+msgid "Users from"
+msgstr "Usuaris de"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:211
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "Els usuaris amb adreces electròniques d'aquests dominis es poden registrar sense invitació. Se'ls assignarà automàticament el rol especificat."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:358
+msgid "v{0} available"
+msgstr "v{0} disponible"
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr "Validació"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:186
+#: packages/admin/src/components/RegistryPluginDetail.tsx:449
+msgid "Verified publisher"
+msgstr "Editor verificat"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:448
+msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
+msgstr "Editor verificat, confirmat per l'etiquetador {verifiedLabeller}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:439
+msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+msgstr "Editor verificat. Un etiquetador ({verifiedLabeller}) ha confirmat la identitat d'aquest editor."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:440
+msgid "Verified publisher. A labeller has confirmed this publisher's identity."
+msgstr "Editor verificat. Un etiquetador ha confirmat la identitat d'aquest editor."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:194
+msgid "Verifying your invite..."
+msgstr "S'està verificant la teva invitació..."
+
+#: packages/admin/src/components/SignupPage.tsx:386
+msgid "Verifying your link..."
+msgstr "S'està verificant el teu enllaç..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "S'està verificant..."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:320
+#: packages/admin/src/components/RegistryPluginDetail.tsx:502
+msgid "Version"
+msgstr "Versió"
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:464
+msgid "Version {0}"
+msgstr "Versió {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+#: packages/admin/src/components/MediaLibrary.tsx:436
+msgid "Video"
+msgstr "Vídeo"
+
+#: packages/admin/src/components/Settings.tsx:116
+msgid "View email provider status and send test emails"
+msgstr "Consulta l'estat del proveïdor de correu i envia correus de prova"
+
+#: packages/admin/src/components/PluginManager.tsx:429
+msgid "View in Marketplace"
+msgstr "Mostra al mercat"
+
+#: packages/admin/src/components/MediaLibrary.tsx:448
+msgid "View mode"
+msgstr "Mode de visualització"
+
+#: packages/admin/src/components/ContentList.tsx:808
+msgid "View published {title}"
+msgstr "Mostra {title} publicat"
+
+#: packages/admin/src/components/Header.tsx:51
+msgid "View Site"
+msgstr "Mostra el lloc"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:663
+msgid "View source"
+msgstr "Mostra el codi font"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:916
+msgid "View the {license} license on spdx.org"
+msgstr "Mostra la llicència {license} a spdx.org"
+
+#: packages/admin/src/components/Redirects.tsx:448
+msgid "Visitors hitting these paths will see an error."
+msgstr "Els visitants que accedeixin a aquestes rutes veuran un error."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:57
+msgid "Vue"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "S'està esperant la clau d'accés..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr "Advertència"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "No ens hem pogut connectar a cap lloc de WordPress a {0}. Això pot significar que el lloc no és WordPress, que l'API REST està desactivada o que el lloc no és accessible."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:564
+msgid "We couldn't verify this publisher's identity"
+msgstr "No hem pogut verificar la identitat d'aquest editor"
+
+#: packages/admin/src/components/WordPressImport.tsx:926
+msgid "We'll check what import options are available for your site."
+msgstr "Comprovarem quines opcions d'importació hi ha disponibles per al teu lloc."
+
+#: packages/admin/src/components/LoginPage.tsx:323
+msgid "We'll send you a link to sign in without a password."
+msgstr "T'enviarem un enllaç per iniciar la sessió sense contrasenya."
+
+#: packages/admin/src/components/SignupPage.tsx:132
+msgid "We've sent a verification link to"
+msgstr "Hem enviat un enllaç de verificació a"
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr "Adreça web"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "Aquest navegador no admet WebAuthn"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/RegistryPluginDetail.tsx:688
+msgid "Website"
+msgstr "Lloc web"
+
+#: packages/admin/src/routes/bylines.tsx:492
+msgid "Website URL"
+msgstr "URL del lloc web"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "Us donem la benvinguda a EmDash, {firstName}!"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "Us donem la benvinguda a EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:1927
+msgid "What happens when you import:"
+msgstr "Què passa quan importes:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1710
+msgid "What will happen when you import"
+msgstr "Què passarà quan importis"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr "Quan es va crear l'entrada"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr "Quan es va modificar l'entrada per última vegada"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr "Quan es va publicar l'entrada"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:658
+msgid "Which content types can use this taxonomy"
+msgstr "Quins tipus de contingut poden utilitzar aquesta taxonomia"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr "Nombre enter"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:121
+msgid "Why can't this be changed?"
+msgstr "Per què no es pot canviar això?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:123
+msgid "Why is this important?"
+msgstr "Per què és important això?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
+msgid "Wide"
+msgstr "Ample"
+
+#: packages/admin/src/components/Widgets.tsx:722
+#: packages/admin/src/components/Widgets.tsx:737
+msgid "widget"
+msgstr "giny"
+
+#: packages/admin/src/components/Widgets.tsx:170
+msgid "Widget added"
+msgstr "S'ha afegit el giny"
+
+#: packages/admin/src/components/Widgets.tsx:158
+msgid "Widget area created"
+msgstr "S'ha creat l'àrea de ginys"
+
+#: packages/admin/src/components/Widgets.tsx:565
+msgid "Widget area deleted"
+msgstr "S'ha eliminat l'àrea de ginys"
+
+#: packages/admin/src/components/Widgets.tsx:685
+msgid "Widget deleted"
+msgstr "S'ha eliminat el giny"
+
+#: packages/admin/src/components/Widgets.tsx:814
+msgid "Widget title"
+msgstr "Títol del giny"
+
+#: packages/admin/src/components/Widgets.tsx:700
+msgid "Widget updated"
+msgstr "S'ha actualitzat el giny"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:379
+#: packages/admin/src/components/Sidebar.tsx:333
+#: packages/admin/src/components/Widgets.tsx:325
+msgid "Widgets"
+msgstr "Ginys"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:284
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:473
+msgid "Width"
+msgstr "Amplada"
+
+#: packages/admin/src/components/WordPressImport.tsx:1850
+msgid "Will create"
+msgstr "Es crearà"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:384
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "ja no es podran registrar sense invitació. Els usuaris existents no es veuen afectats."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:158
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "Sense un proveïdor de correu, els enllaços d'invitació s'han de compartir manualment."
+
+#: packages/admin/src/components/WordPressImport.tsx:1315
+msgid "WordPress Username"
+msgstr "Nom d'usuari de WordPress"
+
+#: packages/admin/src/components/Widgets.tsx:824
+msgid "Write widget content..."
+msgstr "Escriu el contingut del giny..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1023
+msgid "WXR File"
+msgstr "Fitxer WXR"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:58
+msgid "XML"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:59
+msgid "YAML"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:420
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "Yes"
+msgstr "Sí"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "Pots tancar aquesta pàgina i tornar al teu terminal."
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "Pots crear i editar el teu propi contingut."
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "Pots gestionar contingut, fitxers multimèdia, menús i taxonomies."
+
+#: packages/admin/src/routes/bylines.tsx:550
+msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+msgstr "Encara pots editar els camps fixos de dalt. En desar, no es modificarà cap valor de camp personalitzat emmagatzemat."
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "Pots veure el lloc i contribuir-hi."
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr "No pots canviar el teu propi rol"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "Tens accés complet per gestionar aquest lloc, inclosos els usuaris, la configuració i tot el contingut."
+
+#: packages/admin/src/routes/byline-schema.tsx:175
+msgid "You need admin permissions to manage byline schema."
+msgstr "Necessites permisos d'administrador per gestionar l'esquema de signatures."
+
+#: packages/admin/src/router.tsx:1289
+msgid "You need Editor permissions to moderate comments."
+msgstr "Necessites permisos d'editor per moderar els comentaris."
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "Ja no podràs utilitzar «{0}» per iniciar la sessió. Aquesta acció no es pot desfer."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "Ja no podràs utilitzar aquesta clau d'accés per iniciar la sessió. Aquesta acció no es pot desfer."
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:52
+msgid "You'll be joining as <0>{0}</0>"
+msgstr "T'uniràs com a <0>{0}</0>"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "Se't demanarà que utilitzis l'autenticació biomètrica, la clau de seguretat o el PIN del teu dispositiu."
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "Se't redirigirà a WordPress per autoritzar la connexió."
+
+#: packages/admin/src/components/SignupPage.tsx:191
+msgid "You'll be signing up as"
+msgstr "Et registraràs com a"
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr "Has iniciat la sessió mitjançant Cloudflare Access"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:50
+msgid "You've been invited!"
+msgstr "T'han convidat!"
+
+#: packages/admin/src/components/SignupPage.tsx:70
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "El teu compte s'ha creat correctament."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "El teu navegador no admet claus d'accés. Utilitza un navegador modern com Chrome, Safari, Firefox o Edge."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "El teu dispositiu no admet les funcions de seguretat necessàries."
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr "El teu correu electrònic"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:121
+msgid "Your Facebook page or profile username"
+msgstr "El nom de la teva pàgina o perfil de Facebook"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:115
+msgid "Your GitHub username"
+msgstr "El teu nom d'usuari de GitHub"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:127
+msgid "Your Instagram username"
+msgstr "El teu nom d'usuari d'Instagram"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:133
+msgid "Your LinkedIn profile username"
+msgstr "El nom d'usuari del teu perfil de LinkedIn"
+
+#: packages/admin/src/components/MediaLibrary.tsx:505
+#: packages/admin/src/components/MediaLibrary.tsx:529
+msgid "Your media library is empty"
+msgstr "La teva biblioteca multimèdia és buida"
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr "El teu nom"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:62
+#: packages/admin/src/components/SignupPage.tsx:201
+msgid "Your name (optional)"
+msgstr "El teu nom (opcional)"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "El teu rol"
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:599
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr "El teu lloc requereix que les versions tinguin com a mínim {0} d'antiguitat abans de poder-se instal·lar. Aquesta versió es podrà instal·lar més tard."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:109
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "El teu identificador de Twitter/X (p. ex. @nomusuari)"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:437
+msgid "Your unsaved media changes will be lost."
+msgstr "Es perdran els canvis multimèdia no desats."
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1898
+msgid "Your WordPress export contains {0} media files."
+msgstr "La teva exportació de WordPress conté {0} fitxers multimèdia."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:139
+msgid "Your YouTube channel ID or handle"
+msgstr "L'ID o l'identificador del teu canal de YouTube"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:136
+msgid "YouTube"
+msgstr ""

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -34,7 +34,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "en", label: "English", enabled: true },
 	{ code: "ar", label: "العربية", enabled: true, dir: "rtl" }, // Arabic
 	{ code: "eu", label: "Euskara", enabled: true }, // Basque
-	{ code: "ca", label: "Català", enabled: false }, // Catalan
+	{ code: "ca", label: "Català", enabled: true }, // Catalan
 	{ code: "zh-CN", label: "简体中文", enabled: true }, // Chinese (Simplified)
 	{ code: "zh-TW", label: "繁體中文", enabled: true }, // Chinese (Traditional)
 	{ code: "en-GB", label: "English (UK)", enabled: true }, // English (United Kingdom)

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -34,6 +34,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "en", label: "English", enabled: true },
 	{ code: "ar", label: "العربية", enabled: true, dir: "rtl" }, // Arabic
 	{ code: "eu", label: "Euskara", enabled: true }, // Basque
+	{ code: "ca", label: "Català", enabled: false }, // Catalan
 	{ code: "zh-CN", label: "简体中文", enabled: true }, // Chinese (Simplified)
 	{ code: "zh-TW", label: "繁體中文", enabled: true }, // Chinese (Traditional)
 	{ code: "en-GB", label: "English (UK)", enabled: true }, // English (United Kingdom)


### PR DESCRIPTION
## What does this PR do?

Adds a **Catalan (`ca`)** locale to the admin UI.

- Registers `ca` in `packages/admin/src/locales/locales.ts` with `enabled: false`
  (a maintainer flips it on once coverage/review is confirmed).
- Adds `packages/admin/src/locales/ca/messages.po` — **1731 / 1778 strings** translated.

The ~47 untranslated entries are intentional: language/code names, proper nouns,
pure `{token}` placeholders, and example emails/URLs. They fall back to English by
design. ICU plural forms (`one`/`other`) and interpolations are translated with
placeholders preserved.

Terminology follows Softcatalà conventions (e.g. *giny* = widget, *clau d'accés* =
passkey, *signatura* = byline, *esborrany* = draft, *paperera* = trash), with
imperative second-person-singular button labels.

No linked issue.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- not run locally yet — please run before merge -->
- [ ] `pnpm lint` passes <!-- not run locally yet -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: translation-only -->
- [ ] `pnpm format` has been run <!-- please run before merge -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no source changes; this is a translation PR, so messages.po is included intentionally -->
- [x] I have added a changeset (if this PR changes a published package) <!-- translation catalogs are extracted on merge; no changeset added -->
- [ ] New features link to an approved Discussion <!-- n/a: not a feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

> AI-assisted **first pass**. Per EmDash's translation policy, this still needs a
> fluent Catalan speaker to review every string and preview it in the running admin
> before `enabled` is set to `true`. Untranslated strings fall back to English.

## Screenshots / test output

<!-- Add an admin screenshot in Català once previewed in context. -->