### PR TITLE
Harden media usage repair behavior

### DIFF
--- a/.changeset/media-usage-repair-hardening.md
+++ b/.changeset/media-usage-repair-hardening.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes internal media usage repair so partial draft failures, concurrent content deletes, and fresher usage writes keep repair coverage non-complete without discarding valid indexed usage.

--- a/packages/core/src/database/repositories/media-usage.ts
+++ b/packages/core/src/database/repositories/media-usage.ts
@@ -496,7 +496,7 @@ export class MediaUsageRepository {
 				.executeTakeFirst();
 			deleted = Number(result.numDeletedRows ?? 0) > 0;
 			if (!deleted) return;
-			await trx.deleteFrom("_emdash_media_usage").where("source_key", "=", sourceKey).execute();
+			await this.deleteSourceGenerationOccurrences(trx, sourceKey, expectedCurrentGeneration);
 		});
 
 		return {
@@ -518,7 +518,11 @@ export class MediaUsageRepository {
 				.executeTakeFirst();
 			deleted = Number(result.numDeletedRows ?? 0) > 0;
 			if (!deleted) return;
-			await trx.deleteFrom("_emdash_media_usage").where("source_key", "=", sourceKey).execute();
+			await this.deleteSourceGenerationOccurrences(
+				trx,
+				sourceKey,
+				expectedSource.currentGeneration,
+			);
 		});
 
 		return {
@@ -547,7 +551,11 @@ export class MediaUsageRepository {
 				.executeTakeFirst();
 			deleted = Number(result.numDeletedRows ?? 0) > 0;
 			if (!deleted) return;
-			await trx.deleteFrom("_emdash_media_usage").where("source_key", "=", sourceKey).execute();
+			await this.deleteSourceGenerationOccurrences(
+				trx,
+				sourceKey,
+				expectedSource.currentGeneration,
+			);
 		});
 		const contentPresent = deleted ? false : await this.contentRowExists(tableName, contentId);
 
@@ -901,6 +909,18 @@ export class MediaUsageRepository {
 			}
 			return deleted;
 		});
+	}
+
+	private async deleteSourceGenerationOccurrences(
+		db: DatabaseExecutor,
+		sourceKey: string,
+		generation: string,
+	): Promise<void> {
+		await db
+			.deleteFrom("_emdash_media_usage")
+			.where("source_key", "=", sourceKey)
+			.where("generation", "=", generation)
+			.execute();
 	}
 
 	private async insertOccurrences(

--- a/packages/core/src/database/repositories/media-usage.ts
+++ b/packages/core/src/database/repositories/media-usage.ts
@@ -916,6 +916,8 @@ export class MediaUsageRepository {
 		sourceKey: string,
 		generation: string,
 	): Promise<void> {
+		// Guarded source deletes remove only the generation that won the source CAS;
+		// unmatched generations become invisible orphans reclaimed by age-gated cleanup.
 		await db
 			.deleteFrom("_emdash_media_usage")
 			.where("source_key", "=", sourceKey)

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -155,7 +155,6 @@ async function repairContentMediaUsageCollectionUnlocked(
 		}
 		const counts = await repairScannedContentSources(db, repo, scan);
 		const finalScan = await scanContentMediaUsageCollection(db, collectionSlug);
-		const scannedContentCount = finalScan?.contentIds.length ?? scan.contentIds.length;
 		if (!finalScan) {
 			counts.failedSourceCount++;
 			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.COLLECTION_NOT_FOUND;
@@ -164,7 +163,7 @@ async function repairContentMediaUsageCollectionUnlocked(
 			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 		}
 		const completedAt = new Date().toISOString();
-		const status = determineRepairStatus(counts, scannedContentCount);
+		const status = determineRepairStatus(counts);
 		return await finalizeRepairStatus(repo, {
 			...scope,
 			runToken,
@@ -439,11 +438,12 @@ async function finalizeRepairStatus(
 
 function determineRepairStatus(
 	counts: RepairCounts,
-	scannedContentCount: number,
 ): Exclude<ContentMediaUsageRepairStatus, "stale"> {
 	if (counts.failedSourceCount === 0 && counts.skippedSourceCount === 0) return "complete";
 	const trustedProgress = counts.indexedSourceCount + counts.deletedSourceCount;
-	if (trustedProgress === 0 && scannedContentCount > 0) return "failed";
+	if (counts.failedSourceCount > 0 && trustedProgress === 0) {
+		return "failed";
+	}
 	return "partial";
 }
 

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -20,6 +20,7 @@ import {
 } from "./content-refresh.js";
 import {
 	CONTENT_SOURCE_SCHEMA_VERSION,
+	type ContentMediaUsageSnapshot,
 	loadContentMediaUsageSnapshots,
 } from "./content-snapshots.js";
 import {
@@ -147,6 +148,7 @@ async function repairContentMediaUsageCollectionUnlocked(
 					skippedSourceCount: 0,
 					deletedSourceCount: 0,
 					lastErrorCode: CONTENT_MEDIA_USAGE_REPAIR_ERROR.COLLECTION_NOT_FOUND,
+					missingContentIds: new Set(),
 				},
 				status: "failed",
 				startedAt,
@@ -158,7 +160,7 @@ async function repairContentMediaUsageCollectionUnlocked(
 		if (!finalScan) {
 			counts.failedSourceCount++;
 			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.COLLECTION_NOT_FOUND;
-		} else if (!sameContentIds(scan.contentIds, finalScan.contentIds)) {
+		} else if (!sameContentIds(repairedContentIds(scan.contentIds, counts), finalScan.contentIds)) {
 			counts.skippedSourceCount++;
 			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 		}
@@ -190,6 +192,7 @@ async function repairContentMediaUsageCollectionUnlocked(
 				skippedSourceCount: 0,
 				deletedSourceCount: 0,
 				lastErrorCode,
+				missingContentIds: new Set(),
 			},
 			status: "failed",
 			startedAt,
@@ -204,6 +207,7 @@ interface RepairCounts {
 	skippedSourceCount: number;
 	deletedSourceCount: number;
 	lastErrorCode: ContentMediaUsageRepairErrorCode | null;
+	missingContentIds: Set<string>;
 }
 
 async function repairScannedContentSources(
@@ -217,6 +221,7 @@ async function repairScannedContentSources(
 		skippedSourceCount: 0,
 		deletedSourceCount: 0,
 		lastErrorCode: null,
+		missingContentIds: new Set(),
 	};
 
 	const fieldDiscovery = await loadContentMediaUsageFields(db, scan.collectionSlug);
@@ -256,6 +261,15 @@ async function repairContentSource(
 	);
 	if (!snapshotsResult.success) {
 		counts.lastErrorCode = snapshotsResult.error;
+		if (snapshotsResult.error === CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_NOT_FOUND) {
+			counts.skippedSourceCount++;
+			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
+			counts.missingContentIds.add(contentId);
+			return;
+		}
+		if (snapshotsResult.snapshots) {
+			await repairSnapshotSources(repo, snapshotsResult.snapshots, observedSources, counts);
+		}
 		if (snapshotsResult.source) {
 			const result = await repo.markSourceAttemptedIfMatching(
 				{
@@ -278,8 +292,29 @@ async function repairContentSource(
 		return;
 	}
 
+	const expectedSourceKeys = await repairSnapshotSources(
+		repo,
+		snapshotsResult.snapshots,
+		observedSources,
+		counts,
+	);
+
+	for (const sourceKey of sourceKeys) {
+		if (expectedSourceKeys.has(sourceKey)) continue;
+		const observedSource = observedSources.get(sourceKey);
+		if (!observedSource) continue;
+		await deleteObservedSource(repo, sourceKey, observedSource, counts);
+	}
+}
+
+async function repairSnapshotSources(
+	repo: MediaUsageRepository,
+	snapshots: readonly ContentMediaUsageSnapshot[],
+	observedSources: Map<string, MediaUsageSource>,
+	counts: RepairCounts,
+): Promise<Set<string>> {
 	const expectedSourceKeys = new Set<string>();
-	for (const snapshot of snapshotsResult.snapshots) {
+	for (const snapshot of snapshots) {
 		expectedSourceKeys.add(snapshot.source.sourceKey);
 		const result = await repo.replaceSourceIfMatching(
 			snapshot.source,
@@ -293,13 +328,7 @@ async function repairContentSource(
 			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 		}
 	}
-
-	for (const sourceKey of sourceKeys) {
-		if (expectedSourceKeys.has(sourceKey)) continue;
-		const observedSource = observedSources.get(sourceKey);
-		if (!observedSource) continue;
-		await deleteObservedSource(repo, sourceKey, observedSource, counts);
-	}
+	return expectedSourceKeys;
 }
 
 async function reconcileOrphanedContentSources(
@@ -475,6 +504,14 @@ function sameContentIds(left: readonly string[], right: readonly string[]): bool
 	if (left.length !== right.length) return false;
 	const rightIds = new Set(right);
 	return left.every((id) => rightIds.has(id));
+}
+
+function repairedContentIds(
+	contentIds: readonly string[],
+	counts: Pick<RepairCounts, "missingContentIds">,
+): string[] {
+	if (counts.missingContentIds.size === 0) return [...contentIds];
+	return contentIds.filter((contentId) => !counts.missingContentIds.has(contentId));
 }
 
 function contentMediaUsageCollectionScope(collectionSlug: string): ContentMediaUsageRepairScope {

--- a/packages/core/src/media/usage/content-repair.ts
+++ b/packages/core/src/media/usage/content-repair.ts
@@ -161,8 +161,7 @@ async function repairContentMediaUsageCollectionUnlocked(
 			counts.failedSourceCount++;
 			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.COLLECTION_NOT_FOUND;
 		} else if (!sameContentIds(repairedContentIds(scan.contentIds, counts), finalScan.contentIds)) {
-			counts.skippedSourceCount++;
-			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
+			markRepairConflict(counts);
 		}
 		const completedAt = new Date().toISOString();
 		const status = determineRepairStatus(counts);
@@ -260,14 +259,14 @@ async function repairContentSource(
 		fieldDiscovery,
 	);
 	if (!snapshotsResult.success) {
-		counts.lastErrorCode = snapshotsResult.error;
 		if (snapshotsResult.error === CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_NOT_FOUND) {
-			counts.skippedSourceCount++;
-			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
+			markRepairConflict(counts);
 			counts.missingContentIds.add(contentId);
 			return;
 		}
+		counts.lastErrorCode = snapshotsResult.error;
 		if (snapshotsResult.snapshots) {
+			// Partial snapshot failures keep absent variants in place; the attempted source is marked below.
 			await repairSnapshotSources(repo, snapshotsResult.snapshots, observedSources, counts);
 		}
 		if (snapshotsResult.source) {
@@ -282,8 +281,7 @@ async function repairContentSource(
 			if (result.attempted) {
 				counts.failedSourceCount++;
 			} else {
-				counts.skippedSourceCount++;
-				counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
+				markRepairConflict(counts);
 			}
 			return;
 		}
@@ -324,11 +322,15 @@ async function repairSnapshotSources(
 		if (result.replaced) {
 			counts.indexedSourceCount++;
 		} else {
-			counts.skippedSourceCount++;
-			counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
+			markRepairConflict(counts);
 		}
 	}
 	return expectedSourceKeys;
+}
+
+function markRepairConflict(counts: RepairCounts): void {
+	counts.skippedSourceCount++;
+	counts.lastErrorCode ??= CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
 }
 
 async function reconcileOrphanedContentSources(
@@ -398,8 +400,7 @@ async function deleteObservedSourceIfContentAbsent(
 	}
 	if (result.contentPresent) return;
 	if (result.source) {
-		counts.skippedSourceCount++;
-		counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
+		markRepairConflict(counts);
 	}
 }
 
@@ -415,8 +416,7 @@ async function deleteObservedSource(
 		return;
 	}
 	if (result.source) {
-		counts.skippedSourceCount++;
-		counts.lastErrorCode = CONTENT_MEDIA_USAGE_REPAIR_ERROR.CONTENT_USAGE_REPAIR_CONFLICT;
+		markRepairConflict(counts);
 	}
 }
 

--- a/packages/core/src/media/usage/content-snapshots.ts
+++ b/packages/core/src/media/usage/content-snapshots.ts
@@ -46,6 +46,7 @@ export type LoadContentMediaUsageSnapshotsResult =
 				| "DRAFT_REVISION_MISMATCH"
 				| "DRAFT_REVISION_INVALID";
 			source?: MediaUsageSourceInput;
+			snapshots?: ContentMediaUsageSnapshot[];
 	  };
 
 export interface ContentMediaUsageSnapshot {
@@ -116,6 +117,7 @@ export async function loadContentMediaUsageSnapshots(
 				success: false,
 				error: "DRAFT_REVISION_NOT_FOUND",
 				source: attemptedDraftSource,
+				snapshots,
 			};
 		}
 		if (!revisionResult.success) {
@@ -123,6 +125,7 @@ export async function loadContentMediaUsageSnapshots(
 				success: false,
 				error: "DRAFT_REVISION_INVALID",
 				source: attemptedDraftSource,
+				snapshots,
 			};
 		}
 		const revision = revisionResult.revision;
@@ -131,6 +134,7 @@ export async function loadContentMediaUsageSnapshots(
 				success: false,
 				error: "DRAFT_REVISION_MISMATCH",
 				source: attemptedDraftSource,
+				snapshots,
 			};
 		}
 

--- a/packages/core/tests/integration/database/media-usage-content-repair.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-repair.test.ts
@@ -175,6 +175,66 @@ describeEachDialect("content media usage repair", (dialect) => {
 		);
 	});
 
+	it("keeps per-source failures without trusted progress failed", async () => {
+		const item = await insertPost(ctx, {
+			id: "post_failed_source",
+			slug: "failed-source-post",
+			status: "published",
+			data: {
+				title: "Failed Source Post",
+				hero: { id: "media-unindexed", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await ctx.db
+			.insertInto("revisions")
+			.values({
+				id: "mismatched_revision",
+				collection: "pages",
+				entry_id: item.id,
+				data: JSON.stringify({ hero: { id: "media-draft", provider: "local" } }),
+			})
+			.execute();
+		await sql`
+			UPDATE ${sql.ref("ec_posts")}
+			SET draft_revision_id = ${"mismatched_revision"}
+			WHERE id = ${item.id}
+		`.execute(ctx.db);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "failed",
+				indexedSourceCount: 0,
+				failedSourceCount: 1,
+				skippedSourceCount: 0,
+				deletedSourceCount: 0,
+				lastErrorCode: "DRAFT_REVISION_MISMATCH",
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toBeNull();
+		expect(await usageRepo.findSource(sourceKey(item.id, "draft_overlay"))).toEqual(
+			expect.objectContaining({
+				sourceCompleteness: "failed",
+				lastErrorCode: "DRAFT_REVISION_MISMATCH",
+			}),
+		);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				status: "failed",
+				indexedSourceCount: 0,
+				failedSourceCount: 1,
+				lastErrorCode: "DRAFT_REVISION_MISMATCH",
+			}),
+		);
+	});
+
 	it("scans deleted content rows during repair", async () => {
 		const deletedAt = "2026-01-01T00:00:00.000Z";
 		const item = await insertPost(ctx, {
@@ -283,7 +343,7 @@ describeEachDialect("content media usage repair", (dialect) => {
 		);
 	});
 
-	it("does not delete draft sources that become fresher during absent-source cleanup", async () => {
+	it("does not delete stale observed draft sources that become fresher during repair", async () => {
 		const item = await insertPost(ctx, {
 			id: "post_draft_conflict",
 			slug: "draft-conflict-post",

--- a/packages/core/tests/integration/database/media-usage-content-repair.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-repair.test.ts
@@ -234,6 +234,94 @@ describeEachDialect("content media usage repair", (dialect) => {
 		);
 	});
 
+	it("reports skipped-only repair source conflicts as partial", async () => {
+		await insertPost(ctx, {
+			id: "post_conflict",
+			slug: "conflicted-post",
+			status: "published",
+			data: {
+				title: "Conflicted Post",
+				hero: { id: "media-repair", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await installFresherColumnsSourceDuringRepairTrigger(ctx);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				indexedSourceCount: 0,
+				failedSourceCount: 0,
+				skippedSourceCount: 1,
+				deletedSourceCount: 0,
+				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey("post_conflict", "columns"))).toEqual(
+			expect.objectContaining({
+				currentGeneration: "trigger_columns_generation",
+				contentTitle: "Runtime Fresh Columns",
+				sourceFingerprint: "runtime-fresher-columns",
+			}),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-fresher-columns")).toHaveLength(1);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-repair")).toHaveLength(0);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				indexedSourceCount: 0,
+				failedSourceCount: 0,
+				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
+			}),
+		);
+	});
+
+	it("does not delete draft sources that become fresher during absent-source cleanup", async () => {
+		const item = await insertPost(ctx, {
+			id: "post_draft_conflict",
+			slug: "draft-conflict-post",
+			status: "published",
+			data: {
+				title: "Draft Conflict Post",
+				hero: { id: "media-columns", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await usageRepo.replaceSource(contentSource(item.id, "draft_overlay"), [
+			occurrence("hero", "media-stale-draft"),
+		]);
+		await installFresherDraftSourceDuringRepairTrigger(ctx);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				indexedSourceCount: 1,
+				failedSourceCount: 0,
+				skippedSourceCount: 1,
+				deletedSourceCount: 0,
+				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "draft_overlay"))).toEqual(
+			expect.objectContaining({
+				currentGeneration: "trigger_draft_generation",
+				contentTitle: "Runtime Fresh Draft",
+				sourceFingerprint: "runtime-fresher-draft",
+			}),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-columns")).toHaveLength(1);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-fresher-draft")).toHaveLength(1);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-stale-draft")).toHaveLength(0);
+	});
+
 	it("returns the winning stale error when final status CAS loses", async () => {
 		await insertPost(ctx, {
 			slug: "stale-status-post",
@@ -533,6 +621,303 @@ async function installStaleStatusTrigger(ctx: DialectTestContext): Promise<void>
 			WHERE adapter_id = 'content-media'
 			AND scope_type = 'collection'
 			AND scope_key = 'posts';
+		END
+	`.execute(ctx.db);
+}
+
+async function installFresherColumnsSourceDuringRepairTrigger(
+	ctx: DialectTestContext,
+): Promise<void> {
+	if (ctx.dialect === "postgres") {
+		await sql`
+			CREATE FUNCTION media_usage_insert_fresher_columns_source()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				IF NEW.media_id = 'media-repair' THEN
+					INSERT INTO _emdash_media_usage_sources (
+						source_key,
+						source_type,
+						collection_slug,
+						content_id,
+						source_variant,
+						locale,
+						translation_group,
+						content_slug,
+						content_title,
+						content_status,
+						current_generation,
+						schema_version,
+						source_updated_at,
+						source_version,
+						source_fingerprint,
+						source_completeness,
+						last_attempted_at,
+						indexed_at,
+						created_at,
+						updated_at
+					) VALUES (
+						'content:posts:post_conflict:columns',
+						'content',
+						'posts',
+						'post_conflict',
+						'columns',
+						'en',
+						'post_conflict',
+						'runtime-fresh-columns',
+						'Runtime Fresh Columns',
+						'published',
+						'trigger_columns_generation',
+						1,
+						'2099-01-01T00:00:01.000Z',
+						2,
+						'runtime-fresher-columns',
+						'complete',
+						'2099-01-01T00:00:01.000Z',
+						'2099-01-01T00:00:01.000Z',
+						'2099-01-01T00:00:01.000Z',
+						'2099-01-01T00:00:01.000Z'
+					)
+					ON CONFLICT (source_key) DO NOTHING;
+
+					INSERT INTO _emdash_media_usage (
+						id,
+						source_key,
+						generation,
+						field_slug,
+						field_path,
+						occurrence_index,
+						reference_type,
+						media_id,
+						provider,
+						provider_asset_id,
+						media_kind,
+						mime_type,
+						created_at
+					) VALUES (
+						'usage_trigger_columns',
+						'content:posts:post_conflict:columns',
+						'trigger_columns_generation',
+						'hero',
+						'hero',
+						0,
+						'image_field',
+						'media-fresher-columns',
+						'local',
+						'media-fresher-columns',
+						'image',
+						'image/webp',
+						'2099-01-01T00:00:01.000Z'
+					)
+					ON CONFLICT (id) DO NOTHING;
+				END IF;
+				RETURN NEW;
+			END;
+			$$
+		`.execute(ctx.db);
+		await sql`
+			CREATE TRIGGER media_usage_insert_fresher_columns_source
+			AFTER INSERT ON _emdash_media_usage
+			FOR EACH ROW
+			EXECUTE FUNCTION media_usage_insert_fresher_columns_source()
+		`.execute(ctx.db);
+		return;
+	}
+
+	await sql`
+		CREATE TRIGGER media_usage_insert_fresher_columns_source
+		AFTER INSERT ON _emdash_media_usage
+		WHEN NEW.media_id = 'media-repair'
+		BEGIN
+			INSERT OR IGNORE INTO _emdash_media_usage_sources (
+				source_key,
+				source_type,
+				collection_slug,
+				content_id,
+				source_variant,
+				locale,
+				translation_group,
+				content_slug,
+				content_title,
+				content_status,
+				current_generation,
+				schema_version,
+				source_updated_at,
+				source_version,
+				source_fingerprint,
+				source_completeness,
+				last_attempted_at,
+				indexed_at,
+				created_at,
+				updated_at
+			) VALUES (
+				'content:posts:post_conflict:columns',
+				'content',
+				'posts',
+				'post_conflict',
+				'columns',
+				'en',
+				'post_conflict',
+				'runtime-fresh-columns',
+				'Runtime Fresh Columns',
+				'published',
+				'trigger_columns_generation',
+				1,
+				'2099-01-01T00:00:01.000Z',
+				2,
+				'runtime-fresher-columns',
+				'complete',
+				'2099-01-01T00:00:01.000Z',
+				'2099-01-01T00:00:01.000Z',
+				'2099-01-01T00:00:01.000Z',
+				'2099-01-01T00:00:01.000Z'
+			);
+
+			INSERT OR IGNORE INTO _emdash_media_usage (
+				id,
+				source_key,
+				generation,
+				field_slug,
+				field_path,
+				occurrence_index,
+				reference_type,
+				media_id,
+				provider,
+				provider_asset_id,
+				media_kind,
+				mime_type,
+				created_at
+			) VALUES (
+				'usage_trigger_columns',
+				'content:posts:post_conflict:columns',
+				'trigger_columns_generation',
+				'hero',
+				'hero',
+				0,
+				'image_field',
+				'media-fresher-columns',
+				'local',
+				'media-fresher-columns',
+				'image',
+				'image/webp',
+				'2099-01-01T00:00:01.000Z'
+			);
+		END
+	`.execute(ctx.db);
+}
+
+async function installFresherDraftSourceDuringRepairTrigger(
+	ctx: DialectTestContext,
+): Promise<void> {
+	if (ctx.dialect === "postgres") {
+		await sql`
+			CREATE FUNCTION media_usage_update_fresher_draft_source()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				IF NEW.media_id = 'media-columns' THEN
+					INSERT INTO _emdash_media_usage (
+						id,
+						source_key,
+						generation,
+						field_slug,
+						field_path,
+						occurrence_index,
+						reference_type,
+						media_id,
+						provider,
+						provider_asset_id,
+						media_kind,
+						mime_type,
+						created_at
+					) VALUES (
+						'usage_trigger_draft',
+						'content:posts:post_draft_conflict:draft_overlay',
+						'trigger_draft_generation',
+						'hero',
+						'hero',
+						0,
+						'image_field',
+						'media-fresher-draft',
+						'local',
+						'media-fresher-draft',
+						'image',
+						'image/webp',
+						'2099-01-01T00:00:01.000Z'
+					)
+					ON CONFLICT (id) DO NOTHING;
+
+					UPDATE _emdash_media_usage_sources
+					SET current_generation = 'trigger_draft_generation',
+						source_updated_at = '2099-01-01T00:00:01.000Z',
+						source_version = 2,
+						source_fingerprint = 'runtime-fresher-draft',
+						content_title = 'Runtime Fresh Draft',
+						last_attempted_at = '2099-01-01T00:00:01.000Z',
+						indexed_at = '2099-01-01T00:00:01.000Z',
+						updated_at = '2099-01-01T00:00:01.000Z'
+					WHERE source_key = 'content:posts:post_draft_conflict:draft_overlay';
+				END IF;
+				RETURN NEW;
+			END;
+			$$
+		`.execute(ctx.db);
+		await sql`
+			CREATE TRIGGER media_usage_update_fresher_draft_source
+			AFTER INSERT ON _emdash_media_usage
+			FOR EACH ROW
+			EXECUTE FUNCTION media_usage_update_fresher_draft_source()
+		`.execute(ctx.db);
+		return;
+	}
+
+	await sql`
+		CREATE TRIGGER media_usage_update_fresher_draft_source
+		AFTER INSERT ON _emdash_media_usage
+		WHEN NEW.media_id = 'media-columns'
+		BEGIN
+			INSERT OR IGNORE INTO _emdash_media_usage (
+				id,
+				source_key,
+				generation,
+				field_slug,
+				field_path,
+				occurrence_index,
+				reference_type,
+				media_id,
+				provider,
+				provider_asset_id,
+				media_kind,
+				mime_type,
+				created_at
+			) VALUES (
+				'usage_trigger_draft',
+				'content:posts:post_draft_conflict:draft_overlay',
+				'trigger_draft_generation',
+				'hero',
+				'hero',
+				0,
+				'image_field',
+				'media-fresher-draft',
+				'local',
+				'media-fresher-draft',
+				'image',
+				'image/webp',
+				'2099-01-01T00:00:01.000Z'
+			);
+
+			UPDATE _emdash_media_usage_sources
+			SET current_generation = 'trigger_draft_generation',
+				source_updated_at = '2099-01-01T00:00:01.000Z',
+				source_version = 2,
+				source_fingerprint = 'runtime-fresher-draft',
+				content_title = 'Runtime Fresh Draft',
+				last_attempted_at = '2099-01-01T00:00:01.000Z',
+				indexed_at = '2099-01-01T00:00:01.000Z',
+				updated_at = '2099-01-01T00:00:01.000Z'
+			WHERE source_key = 'content:posts:post_draft_conflict:draft_overlay';
 		END
 	`.execute(ctx.db);
 }

--- a/packages/core/tests/integration/database/media-usage-content-repair.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-repair.test.ts
@@ -352,6 +352,7 @@ describeEachDialect("content media usage repair", (dialect) => {
 				failedSourceCount: 1,
 				skippedSourceCount: 1,
 				deletedSourceCount: 0,
+				lastErrorCode: "DRAFT_REVISION_MISMATCH",
 			}),
 		);
 		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toEqual(

--- a/packages/core/tests/integration/database/media-usage-content-repair.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-repair.test.ts
@@ -317,6 +317,42 @@ describeEachDialect("content media usage repair", (dialect) => {
 		);
 	});
 
+	it("indexes valid columns when draft revision is missing", async () => {
+		const item = await insertPost(ctx, {
+			id: "post_missing_draft_revision",
+			slug: "missing-draft-revision-post",
+			status: "published",
+			data: {
+				title: "Missing Draft Revision Post",
+				hero: { id: "media-missing-draft", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await setMissingDraftRevision(ctx, item.id, "missing_revision");
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				indexedSourceCount: 1,
+				failedSourceCount: 1,
+				skippedSourceCount: 0,
+				deletedSourceCount: 0,
+				lastErrorCode: "DRAFT_REVISION_NOT_FOUND",
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toEqual(
+			expect.objectContaining({ sourceCompleteness: "complete" }),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "draft_overlay"))).toEqual(
+			expect.objectContaining({
+				sourceCompleteness: "failed",
+				lastErrorCode: "DRAFT_REVISION_NOT_FOUND",
+			}),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-missing-draft")).toHaveLength(1);
+	});
+
 	it("keeps draft failures without trusted source progress failed", async () => {
 		const item = await insertPost(ctx, {
 			id: "post_conflict",
@@ -725,6 +761,27 @@ function contentSource(
 		contentDeletedAt: null,
 		revisionId: null,
 	};
+}
+
+async function setMissingDraftRevision(
+	ctx: DialectTestContext,
+	contentId: string,
+	revisionId: string,
+): Promise<void> {
+	if (ctx.dialect === "postgres") {
+		await sql`
+			ALTER TABLE ${sql.ref("ec_posts")}
+			DROP CONSTRAINT IF EXISTS ec_posts_draft_revision_id_fkey
+		`.execute(ctx.db);
+	} else {
+		await sql`PRAGMA foreign_keys = OFF`.execute(ctx.db);
+	}
+
+	await sql`
+		UPDATE ${sql.ref("ec_posts")}
+		SET draft_revision_id = ${revisionId}
+		WHERE id = ${contentId}
+	`.execute(ctx.db);
 }
 
 function occurrence(

--- a/packages/core/tests/integration/database/media-usage-content-repair.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-repair.test.ts
@@ -144,6 +144,51 @@ describeEachDialect("content media usage repair", (dialect) => {
 		).toEqual(expect.objectContaining({ status: "complete", indexedSourceCount: 0 }));
 	});
 
+	it("repairs stale no-media content rows as complete coverage", async () => {
+		const item = await insertPost(ctx, {
+			slug: "no-media-post",
+			status: "published",
+			data: { title: "No Media Post" },
+		});
+		await usageRepo.upsertIndexStatus({
+			adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+			scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+			scopeKey: "posts",
+			status: "stale",
+			lastErrorCode: "CONTENT_USAGE_STALE",
+		});
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "complete",
+				indexedSourceCount: 1,
+				failedSourceCount: 0,
+				skippedSourceCount: 0,
+				lastErrorCode: null,
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toEqual(
+			expect.objectContaining({ sourceCompleteness: "complete", lastErrorCode: null }),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-missing")).toEqual([]);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				status: "complete",
+				indexedSourceCount: 1,
+				failedSourceCount: 0,
+				lastErrorCode: null,
+			}),
+		);
+	});
+
 	it("does not mark empty collections complete when field discovery fails", async () => {
 		await registry.createField("posts", { slug: "sections", label: "Sections", type: "repeater" });
 		await ctx.db
@@ -175,7 +220,41 @@ describeEachDialect("content media usage repair", (dialect) => {
 		);
 	});
 
-	it("keeps per-source failures without trusted progress failed", async () => {
+	it("treats repeater fields with non-array subfields as unsupported during repair", async () => {
+		await registry.createField("posts", { slug: "sections", label: "Sections", type: "repeater" });
+		await ctx.db
+			.updateTable("_emdash_fields")
+			.set({ validation: JSON.stringify({ subFields: "not-an-array" }) })
+			.where("slug", "=", "sections")
+			.execute();
+		const item = await insertPost(ctx, {
+			slug: "unsupported-repeater-post",
+			status: "published",
+			data: { title: "Unsupported Repeater Post" },
+		});
+		await sql`
+			UPDATE ${sql.ref("ec_posts")}
+			SET sections = ${JSON.stringify([{ image: { id: "media-repeater", provider: "local" } }])}
+			WHERE id = ${item.id}
+		`.execute(ctx.db);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "complete",
+				indexedSourceCount: 1,
+				failedSourceCount: 0,
+				lastErrorCode: null,
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toEqual(
+			expect.objectContaining({ sourceCompleteness: "complete" }),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-repeater")).toEqual([]);
+	});
+
+	it("indexes valid columns when draft source repair fails", async () => {
 		const item = await insertPost(ctx, {
 			id: "post_failed_source",
 			slug: "failed-source-post",
@@ -204,21 +283,24 @@ describeEachDialect("content media usage repair", (dialect) => {
 
 		expect(result).toEqual(
 			expect.objectContaining({
-				status: "failed",
-				indexedSourceCount: 0,
+				status: "partial",
+				indexedSourceCount: 1,
 				failedSourceCount: 1,
 				skippedSourceCount: 0,
 				deletedSourceCount: 0,
 				lastErrorCode: "DRAFT_REVISION_MISMATCH",
 			}),
 		);
-		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toBeNull();
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toEqual(
+			expect.objectContaining({ sourceCompleteness: "complete" }),
+		);
 		expect(await usageRepo.findSource(sourceKey(item.id, "draft_overlay"))).toEqual(
 			expect.objectContaining({
 				sourceCompleteness: "failed",
 				lastErrorCode: "DRAFT_REVISION_MISMATCH",
 			}),
 		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-unindexed")).toHaveLength(1);
 		expect(
 			await usageRepo.findIndexStatus({
 				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
@@ -227,12 +309,66 @@ describeEachDialect("content media usage repair", (dialect) => {
 			}),
 		).toEqual(
 			expect.objectContaining({
-				status: "failed",
-				indexedSourceCount: 0,
+				status: "partial",
+				indexedSourceCount: 1,
 				failedSourceCount: 1,
 				lastErrorCode: "DRAFT_REVISION_MISMATCH",
 			}),
 		);
+	});
+
+	it("keeps draft failures without trusted source progress failed", async () => {
+		const item = await insertPost(ctx, {
+			id: "post_conflict",
+			slug: "failed-conflicted-source-post",
+			status: "published",
+			data: {
+				title: "Failed Conflicted Source Post",
+				hero: { id: "media-repair", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await ctx.db
+			.insertInto("revisions")
+			.values({
+				id: "mismatched_revision",
+				collection: "pages",
+				entry_id: item.id,
+				data: JSON.stringify({ hero: { id: "media-draft", provider: "local" } }),
+			})
+			.execute();
+		await sql`
+			UPDATE ${sql.ref("ec_posts")}
+			SET draft_revision_id = ${"mismatched_revision"}
+			WHERE id = ${item.id}
+		`.execute(ctx.db);
+		await installFresherColumnsSourceDuringRepairTrigger(ctx);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "failed",
+				indexedSourceCount: 0,
+				failedSourceCount: 1,
+				skippedSourceCount: 1,
+				deletedSourceCount: 0,
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "columns"))).toEqual(
+			expect.objectContaining({
+				currentGeneration: "trigger_columns_generation",
+				contentTitle: "Runtime Fresh Columns",
+				sourceFingerprint: "runtime-fresher-columns",
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey(item.id, "draft_overlay"))).toEqual(
+			expect.objectContaining({
+				sourceCompleteness: "failed",
+				lastErrorCode: "DRAFT_REVISION_MISMATCH",
+			}),
+		);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-fresher-columns")).toHaveLength(1);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-repair")).toHaveLength(0);
 	});
 
 	it("scans deleted content rows during repair", async () => {
@@ -289,6 +425,58 @@ describeEachDialect("content media usage repair", (dialect) => {
 		).toEqual(
 			expect.objectContaining({
 				status: "partial",
+				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
+			}),
+		);
+	});
+
+	it("treats content deleted during repair as a skipped conflict", async () => {
+		await insertPost(ctx, {
+			id: "post_a",
+			slug: "first-post",
+			status: "published",
+			data: {
+				title: "First Post",
+				hero: { id: "media-first", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await insertPost(ctx, {
+			id: "post_deleted",
+			slug: "deleted-during-repair",
+			status: "published",
+			data: {
+				title: "Deleted During Repair",
+				hero: { id: "media-deleted", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await installConcurrentPostDeleteTrigger(ctx);
+
+		const result = await repairContentMediaUsageCollection(ctx.db, { collectionSlug: "posts" });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				indexedSourceCount: 1,
+				failedSourceCount: 0,
+				skippedSourceCount: 1,
+				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
+			}),
+		);
+		expect(await usageRepo.findSource(sourceKey("post_a", "columns"))).not.toBeNull();
+		expect(await usageRepo.findSource(sourceKey("post_deleted", "columns"))).toBeNull();
+		expect(await usageRepo.findCurrentUsageByMediaId("media-first")).toHaveLength(1);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-deleted")).toEqual([]);
+		expect(
+			await usageRepo.findIndexStatus({
+				adapterId: CONTENT_MEDIA_USAGE_ADAPTER_ID,
+				scopeType: CONTENT_MEDIA_USAGE_COLLECTION_SCOPE,
+				scopeKey: "posts",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				status: "partial",
+				indexedSourceCount: 1,
+				failedSourceCount: 0,
 				lastErrorCode: "CONTENT_USAGE_REPAIR_CONFLICT",
 			}),
 		);
@@ -638,6 +826,40 @@ async function installConcurrentPostInsertTrigger(ctx: DialectTestContext): Prom
 				'Concurrent Post',
 				'{"id":"media-concurrent","provider":"local","mimeType":"image/webp"}'
 			);
+		END
+	`.execute(ctx.db);
+}
+
+async function installConcurrentPostDeleteTrigger(ctx: DialectTestContext): Promise<void> {
+	if (ctx.dialect === "postgres") {
+		await sql`
+			CREATE FUNCTION media_usage_delete_concurrent_post()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				IF NEW.media_id = 'media-first' THEN
+					DELETE FROM ec_posts WHERE id = 'post_deleted';
+				END IF;
+				RETURN NEW;
+			END;
+			$$
+		`.execute(ctx.db);
+		await sql`
+			CREATE TRIGGER media_usage_delete_concurrent_post
+			AFTER INSERT ON _emdash_media_usage
+			FOR EACH ROW
+			EXECUTE FUNCTION media_usage_delete_concurrent_post()
+		`.execute(ctx.db);
+		return;
+	}
+
+	await sql`
+		CREATE TRIGGER media_usage_delete_concurrent_post
+		AFTER INSERT ON _emdash_media_usage
+		WHEN NEW.media_id = 'media-first'
+		BEGIN
+			DELETE FROM ec_posts WHERE id = 'post_deleted';
 		END
 	`.execute(ctx.db);
 }

--- a/packages/core/tests/integration/database/media-usage-content-snapshots.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-snapshots.test.ts
@@ -339,6 +339,35 @@ describeEachDialect("content media usage snapshots", (dialect) => {
 		);
 	});
 
+	it("fails with a columns snapshot when draft_revision_id is missing", async () => {
+		const item = await insertPost(ctx, {
+			slug: "live-post",
+			status: "published",
+			data: {
+				title: "Live Title",
+				hero: { id: "media-live", provider: "local", mimeType: "image/webp" },
+			},
+		});
+		await setDraftRevision(ctx, item.id, "missing_revision", { allowMissing: true });
+
+		const result = await loadContentMediaUsageSnapshots(ctx.db, "posts", item.id);
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: false,
+				error: "DRAFT_REVISION_NOT_FOUND",
+				source: expect.objectContaining({ sourceVariant: "draft_overlay" }),
+				snapshots: [
+					expect.objectContaining({
+						source: expect.objectContaining({ sourceVariant: "columns" }),
+						occurrences: [expect.objectContaining({ mediaId: "media-live" })],
+					}),
+				],
+			}),
+		);
+		expect(result.source).not.toHaveProperty("sourceFingerprint");
+	});
+
 	it("fails when draft revision data is invalid JSON", async () => {
 		const item = await insertPost(ctx, {
 			slug: "live-post",
@@ -553,13 +582,27 @@ async function setDraftRevision(
 	ctx: DialectTestContext,
 	contentId: string,
 	revisionId: string,
+	options: { allowMissing?: boolean } = {},
 ): Promise<void> {
+	if (options.allowMissing) await allowMissingDraftRevision(ctx);
 	await sql`
 		UPDATE ${sql.ref("ec_posts")}
 		SET draft_revision_id = ${revisionId},
 			updated_at = ${new Date().toISOString()}
 		WHERE id = ${contentId}
 	`.execute(ctx.db);
+}
+
+async function allowMissingDraftRevision(ctx: DialectTestContext): Promise<void> {
+	if (ctx.dialect === "postgres") {
+		await sql`
+			ALTER TABLE ${sql.ref("ec_posts")}
+			DROP CONSTRAINT IF EXISTS ec_posts_draft_revision_id_fkey
+		`.execute(ctx.db);
+		return;
+	}
+
+	await sql`PRAGMA foreign_keys = OFF`.execute(ctx.db);
 }
 
 async function updatePostHero(

--- a/packages/core/tests/integration/database/media-usage-content-snapshots.test.ts
+++ b/packages/core/tests/integration/database/media-usage-content-snapshots.test.ts
@@ -330,6 +330,11 @@ describeEachDialect("content media usage snapshots", (dialect) => {
 				success: false,
 				error: "DRAFT_REVISION_MISMATCH",
 				source: expect.objectContaining({ sourceVariant: "draft_overlay" }),
+				snapshots: [
+					expect.objectContaining({
+						source: expect.objectContaining({ sourceVariant: "columns" }),
+					}),
+				],
 			}),
 		);
 	});
@@ -354,6 +359,11 @@ describeEachDialect("content media usage snapshots", (dialect) => {
 				success: false,
 				error: "DRAFT_REVISION_INVALID",
 				source: expect.objectContaining({ sourceVariant: "draft_overlay" }),
+				snapshots: [
+					expect.objectContaining({
+						source: expect.objectContaining({ sourceVariant: "columns" }),
+					}),
+				],
 			}),
 		);
 		expect(result.source).not.toHaveProperty("sourceFingerprint");

--- a/packages/core/tests/integration/database/media-usage-repository.test.ts
+++ b/packages/core/tests/integration/database/media-usage-repository.test.ts
@@ -346,6 +346,36 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 		expect(await repo.findCurrentUsageByMediaId("media-preserved-delete")).toHaveLength(1);
 	});
 
+	it("does not delete content-absent sources when source metadata changed", async () => {
+		await sql`CREATE TABLE ${sql.ref("ec_posts")} (id text primary key)`.execute(ctx.db);
+		const observed = await repo.replaceSource(
+			contentSource("orphan-entry", "columns", { sourceFingerprint: "fingerprint-observed" }),
+			[occurrence("hero", "media-orphan-observed")],
+		);
+		const concurrent = await repo.replaceSource(
+			contentSource("orphan-entry", "columns", { sourceFingerprint: "fingerprint-concurrent" }),
+			[occurrence("hero", "media-orphan-concurrent")],
+		);
+
+		const stale = await repo.deleteSourceIfMatchingContentAbsent(
+			observed.sourceKey,
+			observed,
+			"posts",
+			"orphan-entry",
+		);
+
+		expect(stale.deleted).toBe(false);
+		expect(stale.contentPresent).toBe(false);
+		expect(stale.source).toEqual(
+			expect.objectContaining({
+				currentGeneration: concurrent.currentGeneration,
+				sourceFingerprint: "fingerprint-concurrent",
+			}),
+		);
+		expect(await repo.findCurrentUsageByMediaId("media-orphan-observed")).toEqual([]);
+		expect(await repo.findCurrentUsageByMediaId("media-orphan-concurrent")).toHaveLength(1);
+	});
+
 	it("writes ISO occurrence timestamps for safe cleanup cutoffs", async () => {
 		await repo.replaceSource(contentSource("entry1", "columns"), [
 			occurrence("hero", "media-live"),

--- a/packages/core/tests/integration/database/media-usage-repository.test.ts
+++ b/packages/core/tests/integration/database/media-usage-repository.test.ts
@@ -323,6 +323,29 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 		expect(await repo.findCurrentUsageByMediaId("media-delete")).toEqual([]);
 	});
 
+	it("deletes only the matched generation when guarded source delete wins", async () => {
+		const observed = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-delete-generation"),
+		]);
+		await insertOccurrenceGeneration(
+			ctx,
+			observed.sourceKey,
+			"preserved_generation_delete",
+			"media-preserved-generation-delete",
+		);
+
+		const deleted = await repo.deleteSourceIfMatching(observed.sourceKey, observed);
+
+		expect(deleted.deleted).toBe(true);
+		expect(deleted.source).toBeNull();
+		expect(await mediaUsageRows(ctx, observed.sourceKey)).toEqual([
+			expect.objectContaining({
+				generation: "preserved_generation_delete",
+				media_id: "media-preserved-generation-delete",
+			}),
+		]);
+	});
+
 	it("does not delete a source when source metadata changed despite the same generation", async () => {
 		const observed = await repo.replaceSource(contentSource("entry1", "columns"), [
 			occurrence("hero", "media-preserved-delete"),
@@ -374,6 +397,36 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 		);
 		expect(await repo.findCurrentUsageByMediaId("media-orphan-observed")).toEqual([]);
 		expect(await repo.findCurrentUsageByMediaId("media-orphan-concurrent")).toHaveLength(1);
+	});
+
+	it("deletes only the matched generation when content-absent guarded delete wins", async () => {
+		await sql`CREATE TABLE ${sql.ref("ec_posts")} (id text primary key)`.execute(ctx.db);
+		const observed = await repo.replaceSource(contentSource("orphan-entry", "columns"), [
+			occurrence("hero", "media-delete-orphan-generation"),
+		]);
+		await insertOccurrenceGeneration(
+			ctx,
+			observed.sourceKey,
+			"preserved_generation_orphan",
+			"media-preserved-generation-orphan",
+		);
+
+		const deleted = await repo.deleteSourceIfMatchingContentAbsent(
+			observed.sourceKey,
+			observed,
+			"posts",
+			"orphan-entry",
+		);
+
+		expect(deleted.deleted).toBe(true);
+		expect(deleted.contentPresent).toBe(false);
+		expect(deleted.source).toBeNull();
+		expect(await mediaUsageRows(ctx, observed.sourceKey)).toEqual([
+			expect.objectContaining({
+				generation: "preserved_generation_orphan",
+				media_id: "media-preserved-generation-orphan",
+			}),
+		]);
 	});
 
 	it("writes ISO occurrence timestamps for safe cleanup cutoffs", async () => {
@@ -1293,6 +1346,40 @@ function occurrence(
 		mimeType: null,
 		...overrides,
 	};
+}
+
+async function insertOccurrenceGeneration(
+	ctx: DialectTestContext,
+	sourceKey: string,
+	generation: string,
+	mediaId: string,
+): Promise<void> {
+	await ctx.db
+		.insertInto("_emdash_media_usage")
+		.values({
+			id: `${generation}-usage`,
+			source_key: sourceKey,
+			generation,
+			field_slug: "hero",
+			field_path: `hero-${generation}`,
+			occurrence_index: 0,
+			reference_type: "image_field",
+			media_id: mediaId,
+			provider: "local",
+			provider_asset_id: mediaId,
+			media_kind: "image",
+			mime_type: null,
+		})
+		.execute();
+}
+
+async function mediaUsageRows(ctx: DialectTestContext, sourceKey: string) {
+	return ctx.db
+		.selectFrom("_emdash_media_usage")
+		.select(["generation", "media_id"])
+		.where("source_key", "=", sourceKey)
+		.orderBy("generation", "asc")
+		.execute();
 }
 
 function withoutTransactions(db: DialectTestContext["db"]): DialectTestContext["db"] {

--- a/packages/core/tests/integration/database/media-usage-repository.test.ts
+++ b/packages/core/tests/integration/database/media-usage-repository.test.ts
@@ -311,6 +311,41 @@ describeEachDialect("MediaUsageRepository", (dialect) => {
 		expect(await repo.findCurrentUsageByMediaId("media-concurrent-draft")).toHaveLength(1);
 	});
 
+	it("leaves unmatched generations for orphan cleanup when current-generation delete wins", async () => {
+		const observed = await repo.replaceSource(contentSource("entry1", "draft_overlay"), [
+			occurrence("hero", "media-current-delete-generation"),
+		]);
+		await insertOccurrenceGeneration(
+			ctx,
+			observed.sourceKey,
+			"preserved_generation_current_delete",
+			"media-preserved-current-delete",
+		);
+		await ctx.db
+			.updateTable("_emdash_media_usage")
+			.set({ created_at: "2026-01-01T00:00:00.000Z" })
+			.where("source_key", "=", observed.sourceKey)
+			.execute();
+
+		const deleted = await repo.deleteSourceIfCurrent(
+			observed.sourceKey,
+			observed.currentGeneration,
+		);
+
+		expect(deleted.deleted).toBe(true);
+		expect(deleted.source).toBeNull();
+		expect(await mediaUsageRows(ctx, observed.sourceKey)).toEqual([
+			expect.objectContaining({
+				generation: "preserved_generation_current_delete",
+				media_id: "media-preserved-current-delete",
+			}),
+		]);
+		expect(await repo.findCurrentUsageByMediaId("media-preserved-current-delete")).toEqual([]);
+
+		expect(await repo.deleteOrphanOccurrencesOlderThan("2026-01-02T00:00:00.000Z", 10)).toBe(1);
+		expect(await mediaUsageRows(ctx, observed.sourceKey)).toEqual([]);
+	});
+
 	it("deletes a source only when nullable source metadata still matches", async () => {
 		const observed = await repo.replaceSource(contentSource("entry1", "columns"), [
 			occurrence("hero", "media-delete"),


### PR DESCRIPTION
## What does this PR do?

Hardens collection-scope content media usage repair before the operator entry point ships.

- Preserves valid `columns` usage when `draft_overlay` snapshot loading fails.
- Treats content rows deleted during repair as repair conflicts/skips instead of source failures.
- Preserves fresher runtime usage during guarded repair deletes and final status races.
- Adds regression coverage for missing draft revisions, malformed repeater metadata, no-media scopes, concurrent writes/deletes, and stale status races.

Related: Discussion #1503.
Builds on merged repair foundation PR #1846.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). N/a: no admin UI or user-facing strings changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1503. N/a: this is hardening for the existing media usage repair work, not a new feature surface.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.5 via OpenCode

## Screenshots / test output

No screenshots; backend repair hardening only.

Verified on `media-usage-repair-hardening-main`:

```text
pnpm format
pnpm lint
pnpm typecheck
pnpm --dir packages/core exec vitest run tests/integration/database/media-usage-repository.test.ts tests/integration/database/media-usage-content-repair.test.ts tests/integration/database/media-usage-content-refresh.test.ts tests/integration/database/media-usage-content-snapshots.test.ts  # 85 passed
pnpm lint:json | jq '.diagnostics | length'  # 0
pnpm changeset status --since origin/main  # emdash patch bump found
second-opinion review cycle 3  # No findings.
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://media-usage-repair-hardening-main-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `media-usage-repair-hardening-main`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
