### PR TITLE
fix(comments): verify Turnstile tokens server-side on comment submission

### DIFF
--- a/.changeset/comments-turnstile-verification.md
+++ b/.changeset/comments-turnstile-verification.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes comment submissions bypassing Turnstile: when the `EMDASH_TURNSTILE_SECRET_KEY` (or `TURNSTILE_SECRET_KEY`) environment variable is set, the public comment endpoint now verifies the submitted Turnstile token server-side and rejects submissions without a valid one. Sites without a configured secret key are unaffected.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -646,6 +646,7 @@ EmDash respects these environment variables:
 | `EMDASH_PREVIEW_SECRET`   | Optional override for preview HMAC secret. When unset, a stable per-site value is generated and stored in the database. |
 | `EMDASH_IP_SALT`          | Optional override for the commenter-IP hash salt. When unset, a stable per-site value is generated and stored in the database. |
 | `EMDASH_AUTH_SECRET`      | Legacy. Used as the IP-salt source if set; existing installs should keep this to preserve stable commenter-IP hashes across upgrade. |
+| `EMDASH_TURNSTILE_SECRET_KEY` | Cloudflare Turnstile secret key (falls back to `TURNSTILE_SECRET_KEY`). When set, comment submissions must include a valid Turnstile token — pair it with the `turnstileSiteKey` prop on `<CommentForm>`. |
 | `EMDASH_URL`              | Remote EmDash URL for schema sync         |
 
 Generate an encryption key with the following command:

--- a/packages/core/src/api/schemas/comments.ts
+++ b/packages/core/src/api/schemas/comments.ts
@@ -12,6 +12,12 @@ export const createCommentBody = z
 		parentId: z.string().optional(),
 		/** Honeypot field — hidden in the form, filled only by bots */
 		website_url: z.string().optional(),
+		/**
+		 * Turnstile response token from the form widget. Verified
+		 * server-side when a Turnstile secret key is configured.
+		 * Turnstile tokens can be up to 2048 characters.
+		 */
+		turnstileToken: z.string().max(2048).optional(),
 	})
 	.meta({ id: "CreateCommentBody" });
 

--- a/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
+++ b/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
@@ -14,6 +14,7 @@ import { createCommentBody } from "#api/schemas.js";
 import { getSiteBaseUrl } from "#api/site-url.js";
 import { sendCommentNotification } from "#comments/notifications.js";
 import { createComment, type CommentHookRunner } from "#comments/service.js";
+import { getTurnstileSecretKey, verifyTurnstileToken } from "#comments/turnstile.js";
 import { resolveSecretsCached } from "#config/secrets.js";
 import { CommentRepository } from "#db/repositories/comment.js";
 import { validateIdentifier } from "#db/validate.js";
@@ -161,6 +162,18 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		const rateLimited = await checkRateLimit(emdash.db, ipHash, unknownBucketLimit);
 		if (rateLimited) {
 			return apiError("RATE_LIMITED", "Too many comments. Please try again later.", 429);
+		}
+
+		// Anti-spam: Turnstile — enforced only when the operator configured a
+		// secret key. Runs after the free checks (honeypot, rate limit) so
+		// obvious spam never triggers a siteverify subrequest. Fails closed:
+		// missing token, failed verification, and siteverify errors all reject.
+		const turnstileSecretKey = getTurnstileSecretKey();
+		if (turnstileSecretKey) {
+			const verified = await verifyTurnstileToken(body.turnstileToken, turnstileSecretKey, meta.ip);
+			if (!verified) {
+				return apiError("TURNSTILE_FAILED", "CAPTCHA verification failed", 403);
+			}
 		}
 
 		// Build collection settings

--- a/packages/core/src/comments/turnstile.ts
+++ b/packages/core/src/comments/turnstile.ts
@@ -45,6 +45,9 @@ export async function verifyTurnstileToken(
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
+			// Fail closed *quickly* if siteverify is slow — without a timeout
+			// the comment POST would hang until the runtime kills it
+			signal: AbortSignal.timeout(10_000),
 		});
 		const data: { success?: boolean; "error-codes"?: string[] } = await res.json();
 		if (!data.success) {

--- a/packages/core/src/comments/turnstile.ts
+++ b/packages/core/src/comments/turnstile.ts
@@ -1,0 +1,61 @@
+/**
+ * Server-side Turnstile verification for public comment submissions.
+ *
+ * The comment form widget (`CommentForm.astro`) submits a `turnstileToken`;
+ * this verifies it against Cloudflare's siteverify API. Enforcement is
+ * opt-in: it only runs when the operator configures the Turnstile secret
+ * key (`EMDASH_TURNSTILE_SECRET_KEY` or `TURNSTILE_SECRET_KEY`), so
+ * existing non-Turnstile sites are unaffected.
+ *
+ * Mirrors `verifyTurnstile` in `@emdash-cms/plugin-forms` (not imported —
+ * core doesn't depend on plugin packages).
+ */
+
+const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Resolve the configured Turnstile secret key, or `""` when Turnstile
+ * enforcement is not configured.
+ */
+export function getTurnstileSecretKey(): string {
+	return import.meta.env.EMDASH_TURNSTILE_SECRET_KEY || import.meta.env.TURNSTILE_SECRET_KEY || "";
+}
+
+/**
+ * Verify a Turnstile response token via siteverify.
+ *
+ * Fails closed: a missing token, a failed verification, and a siteverify
+ * transport error all return `false` — when the operator has configured a
+ * secret, an unverifiable submission must not be persisted.
+ */
+export async function verifyTurnstileToken(
+	token: string | undefined,
+	secretKey: string,
+	remoteIp?: string | null,
+): Promise<boolean> {
+	if (!token) return false;
+
+	const body: Record<string, string> = { secret: secretKey, response: token };
+	if (remoteIp) {
+		body.remoteip = remoteIp;
+	}
+
+	try {
+		const res = await fetch(SITEVERIFY_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+		const data: { success?: boolean; "error-codes"?: string[] } = await res.json();
+		if (!data.success) {
+			console.warn("[comments] Turnstile verification failed:", data["error-codes"] ?? []);
+		}
+		return data.success === true;
+	} catch (error) {
+		console.error(
+			"[comments] Turnstile siteverify request failed:",
+			error instanceof Error ? error.message : error,
+		);
+		return false;
+	}
+}

--- a/packages/core/src/components/CommentForm.astro
+++ b/packages/core/src/components/CommentForm.astro
@@ -22,7 +22,12 @@ interface Props {
 	contentId: string;
 	parentId?: string | null;
 	class?: string;
-	/** Turnstile site key. If provided, the widget is rendered. */
+	/**
+	 * Turnstile site key. If provided, the widget is rendered and its
+	 * token is submitted. Set the matching secret key on the server
+	 * (EMDASH_TURNSTILE_SECRET_KEY) so submissions are actually verified —
+	 * without it the token is ignored.
+	 */
 	turnstileSiteKey?: string;
 }
 
@@ -174,6 +179,12 @@ const endpoint = `/_emdash/api/comments/${encodeURIComponent(collection)}/${enco
 
 			const result = await res.json();
 
+			// Reset Turnstile on success and failure — tokens are single-use,
+			// so a retry after a server rejection needs a fresh challenge
+			if (typeof window.turnstile !== "undefined") {
+				window.turnstile.reset();
+			}
+
 			if (res.ok) {
 				statusEl.textContent = result.message || "Comment submitted!";
 				statusEl.classList.add("ec-comment-form-success");
@@ -182,10 +193,6 @@ const endpoint = `/_emdash/api/comments/${encodeURIComponent(collection)}/${enco
 					"textarea[name='body']"
 				);
 				if (textarea) textarea.value = "";
-				// Reset Turnstile if present
-				if (typeof window.turnstile !== "undefined") {
-					window.turnstile.reset();
-				}
 			} else {
 				statusEl.textContent =
 					result.error?.message ||

--- a/packages/core/src/components/CommentForm.astro
+++ b/packages/core/src/components/CommentForm.astro
@@ -179,12 +179,6 @@ const endpoint = `/_emdash/api/comments/${encodeURIComponent(collection)}/${enco
 
 			const result = await res.json();
 
-			// Reset Turnstile on success and failure — tokens are single-use,
-			// so a retry after a server rejection needs a fresh challenge
-			if (typeof window.turnstile !== "undefined") {
-				window.turnstile.reset();
-			}
-
 			if (res.ok) {
 				statusEl.textContent = result.message || "Comment submitted!";
 				statusEl.classList.add("ec-comment-form-success");
@@ -204,6 +198,12 @@ const endpoint = `/_emdash/api/comments/${encodeURIComponent(collection)}/${enco
 			statusEl.textContent = "Network error. Please try again.";
 			statusEl.classList.add("ec-comment-form-error");
 		} finally {
+			// Reset Turnstile on success and failure alike (incl. network
+			// errors) — tokens are single-use, so any retry needs a fresh
+			// challenge
+			if (typeof window.turnstile !== "undefined") {
+				window.turnstile.reset();
+			}
 			submitBtn.disabled = false;
 			submitBtn.textContent = "Post Comment";
 		}

--- a/packages/core/tests/integration/astro/comments-turnstile.test.ts
+++ b/packages/core/tests/integration/astro/comments-turnstile.test.ts
@@ -20,22 +20,26 @@ import type { Database } from "../../../src/database/types.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
 
-function buildRequest(body: Record<string, unknown>): Request {
+function buildRequest(body: Record<string, unknown>, headers?: Record<string, string>): Request {
 	return new Request("http://localhost/_emdash/api/comments/post/post-1", {
 		method: "POST",
-		headers: { "content-type": "application/json" },
+		headers: { "content-type": "application/json", ...headers },
 		body: JSON.stringify(body),
 	});
 }
 
-function buildContext(db: Kysely<Database>, request: Request): APIContext {
+function buildContext(
+	db: Kysely<Database>,
+	request: Request,
+	config: Record<string, unknown> = {},
+): APIContext {
 	return {
 		params: { collection: "post", contentId: "post-1" },
 		request,
 		locals: {
 			emdash: {
 				db,
-				config: {},
+				config,
 				hooks: {
 					runCommentBeforeCreate: async (event: unknown) => event,
 					invokeExclusiveHook: async () => null,
@@ -143,6 +147,29 @@ describe("POST /comments — Turnstile verification", () => {
 			response: "valid-token",
 		});
 		expect(await commentCount()).toBe(1);
+	});
+
+	it("forwards the trusted remote IP to siteverify", async () => {
+		vi.stubEnv("EMDASH_TURNSTILE_SECRET_KEY", "test-secret");
+		const fetchSpy = stubSiteverify(true);
+
+		const request = buildRequest(
+			{ ...VALID_BODY, turnstileToken: "valid-token" },
+			{ "x-forwarded-for": "203.0.113.45" },
+		);
+		const res = await postComment(
+			buildContext(db, request, { trustedProxyHeaders: ["x-forwarded-for"] }),
+		);
+
+		expect(res.status).toBe(201);
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- shape fixed by the code under test
+		const [, init] = fetchSpy.mock.calls[0] as unknown as [string, { body: string }];
+		expect(JSON.parse(init.body)).toMatchObject({
+			secret: "test-secret",
+			response: "valid-token",
+			remoteip: "203.0.113.45",
+		});
 	});
 
 	it("fails closed when siteverify itself errors", async () => {

--- a/packages/core/tests/integration/astro/comments-turnstile.test.ts
+++ b/packages/core/tests/integration/astro/comments-turnstile.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Server-side Turnstile enforcement on
+ * POST /_emdash/api/comments/:collection/:contentId (issue #1589).
+ *
+ * The form widget submits a `turnstileToken`, but the route previously
+ * never verified it — a bot POSTing directly to the API bypassed
+ * Turnstile entirely. When a secret key is configured
+ * (EMDASH_TURNSTILE_SECRET_KEY / TURNSTILE_SECRET_KEY), the route must
+ * verify the token via Cloudflare's siteverify before persisting, and
+ * reject submissions without a valid token. Without a configured secret
+ * the behavior is unchanged (backward compatible).
+ */
+
+import type { APIContext } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as postComment } from "../../../src/astro/routes/api/comments/[collection]/[contentId]/index.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+function buildRequest(body: Record<string, unknown>): Request {
+	return new Request("http://localhost/_emdash/api/comments/post/post-1", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function buildContext(db: Kysely<Database>, request: Request): APIContext {
+	return {
+		params: { collection: "post", contentId: "post-1" },
+		request,
+		locals: {
+			emdash: {
+				db,
+				config: {},
+				hooks: {
+					runCommentBeforeCreate: async (event: unknown) => event,
+					invokeExclusiveHook: async () => null,
+					runCommentAfterCreate: async () => undefined,
+				},
+			},
+			user: null,
+		},
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- minimal stub for tests
+	} as unknown as APIContext;
+}
+
+const VALID_BODY = {
+	authorName: "Alice",
+	authorEmail: "alice@example.com",
+	body: "Nice post!",
+};
+
+/** Stub global fetch for the siteverify call; returns the spy. */
+function stubSiteverify(success: boolean) {
+	const fetchSpy = vi.fn(async () =>
+		Response.json(success ? { success: true } : { success: false, "error-codes": ["bad-token"] }),
+	);
+	vi.stubGlobal("fetch", fetchSpy);
+	return fetchSpy;
+}
+
+describe("POST /comments — Turnstile verification", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({
+			slug: "post",
+			label: "Posts",
+			labelSingular: "Post",
+			commentsEnabled: true,
+		});
+		await registry.createField("post", { slug: "title", label: "Title", type: "string" });
+		await db
+			.insertInto("ec_post" as never)
+			.values({
+				id: "post-1",
+				slug: "post-1",
+				status: "published",
+				published_at: new Date().toISOString(),
+				title: "Test post",
+			} as never)
+			.execute();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	});
+
+	async function commentCount(): Promise<number> {
+		const rows = await db.selectFrom("_emdash_comments").select("id").execute();
+		return rows.length;
+	}
+
+	it("rejects a submission without a token when a secret is configured", async () => {
+		vi.stubEnv("EMDASH_TURNSTILE_SECRET_KEY", "test-secret");
+		const fetchSpy = stubSiteverify(true);
+
+		const res = await postComment(buildContext(db, buildRequest(VALID_BODY)));
+
+		expect(res.status).toBe(403);
+		// No siteverify subrequest for a missing token
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(await commentCount()).toBe(0);
+	});
+
+	it("rejects a submission whose token fails siteverify", async () => {
+		vi.stubEnv("EMDASH_TURNSTILE_SECRET_KEY", "test-secret");
+		const fetchSpy = stubSiteverify(false);
+
+		const res = await postComment(
+			buildContext(db, buildRequest({ ...VALID_BODY, turnstileToken: "forged" })),
+		);
+
+		expect(res.status).toBe(403);
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		expect(await commentCount()).toBe(0);
+	});
+
+	it("accepts a submission whose token passes siteverify", async () => {
+		vi.stubEnv("EMDASH_TURNSTILE_SECRET_KEY", "test-secret");
+		const fetchSpy = stubSiteverify(true);
+
+		const res = await postComment(
+			buildContext(db, buildRequest({ ...VALID_BODY, turnstileToken: "valid-token" })),
+		);
+
+		expect(res.status).toBe(201);
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		// The secret and token must reach siteverify
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- shape fixed by the code under test
+		const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, { body: string }];
+		expect(url).toBe("https://challenges.cloudflare.com/turnstile/v0/siteverify");
+		expect(JSON.parse(init.body)).toMatchObject({
+			secret: "test-secret",
+			response: "valid-token",
+		});
+		expect(await commentCount()).toBe(1);
+	});
+
+	it("fails closed when siteverify itself errors", async () => {
+		vi.stubEnv("EMDASH_TURNSTILE_SECRET_KEY", "test-secret");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error("network down");
+			}),
+		);
+
+		const res = await postComment(
+			buildContext(db, buildRequest({ ...VALID_BODY, turnstileToken: "valid-token" })),
+		);
+
+		expect(res.status).toBe(403);
+		expect(await commentCount()).toBe(0);
+	});
+
+	it("ignores the token when no secret is configured (backward compatible)", async () => {
+		const fetchSpy = stubSiteverify(true);
+
+		const res = await postComment(
+			buildContext(db, buildRequest({ ...VALID_BODY, turnstileToken: "anything" })),
+		);
+
+		expect(res.status).toBe(201);
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(await commentCount()).toBe(1);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The `CommentForm` component renders the Turnstile widget and submits its token as `turnstileToken`, but the public `POST /_emdash/api/comments/:collection/:contentId` endpoint never verified it — a bot POSTing directly to the API bypassed Turnstile entirely. The widget was decorative.

This PR adds server-side verification, opt-in via configuration (mirroring how the secret side of Turnstile has to be operator-provided):

- When `EMDASH_TURNSTILE_SECRET_KEY` (fallback: `TURNSTILE_SECRET_KEY`) is set, the comment route verifies the submitted token against Cloudflare's siteverify API before persisting, forwarding the trusted client IP when available.
- Verification fails closed: a missing token, a failed verification, and a siteverify transport error all reject with `403 TURNSTILE_FAILED`. The check runs after the free anti-spam checks (honeypot, rate limit) so obvious spam never triggers a siteverify subrequest.
- Without a configured secret key the behavior is unchanged (backward compatible) — the token is ignored as before.
- `createCommentBody` now accepts the `turnstileToken` field the form was already sending (it was previously stripped by the schema).
- The form now resets the Turnstile widget after failed submissions too, not just successful ones — tokens are single-use, so a retry after a server rejection needs a fresh challenge.
- Documents the new env var in the configuration reference and on the `turnstileSiteKey` prop.

New integration test covers: missing token rejected without a siteverify call, forged token rejected, valid token accepted (secret + token + remote IP reach siteverify), siteverify transport error fails closed, and no-secret backward compatibility.

Closes #1589

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. *(n/a — no admin UI changes; server error messages are English-only by convention)*
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: *(n/a — bug fix)*

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

```
✓ tests/integration/astro/comments-turnstile.test.ts (5 tests)
  ✓ rejects a submission without a token when a secret is configured
  ✓ rejects a submission whose token fails siteverify
  ✓ accepts a submission whose token passes siteverify
  ✓ fails closed when siteverify itself errors
  ✓ ignores the token when no secret is configured (backward compatible)

Test Files  1 passed (1)
     Tests  5 passed (5)
```