### PR TITLE
fix(preview): opt preview and toolbar responses out of the route cache

### DIFF
--- a/.changeset/preview-route-cache-optout.md
+++ b/.changeset/preview-route-cache-optout.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes preview and editor-toolbar responses being stored in the shared edge cache when route caching is enabled: requests with a `_preview` token and toolbar-injected editor pages now opt out of the route cache, so draft content is no longer served from the cache without token verification and toolbar markup no longer leaks to anonymous visitors.

--- a/packages/core/src/astro/middleware/request-context.ts
+++ b/packages/core/src/astro/middleware/request-context.ts
@@ -19,10 +19,36 @@ import { getRequestContext, runWithContext } from "../../request-context.js";
 import { renderToolbar } from "../../visual-editing/toolbar.js";
 
 /**
+ * The subset of Astro's route-cache API the middleware needs. `context.cache`
+ * ships with Astro's route caching; typed structurally (and called
+ * optionally) so the middleware stays compatible with Astro versions that
+ * predate it.
+ */
+interface RouteCacheLike {
+	set(input: false): void;
+}
+
+/**
+ * Opt the current request out of Astro's route cache (e.g. Workers Cache on
+ * Cloudflare). `Cache-Control` headers do NOT cover this: the adapter derives
+ * the shared-cache TTL from the route-cache options (on Cloudflare via
+ * `Cloudflare-CDN-Cache-Control`), so session-specific responses must
+ * explicitly disable it or they get stored in the shared cache and served to
+ * anonymous visitors without ever invoking the middleware again.
+ */
+function optOutOfRouteCache(cache: RouteCacheLike | undefined): void {
+	cache?.set(false);
+}
+
+/**
  * Inject toolbar HTML into a response if it's an HTML page.
  * Returns the original response if not HTML.
  */
-async function injectToolbar(response: Response, toolbarHtml: string): Promise<Response> {
+async function injectToolbar(
+	response: Response,
+	toolbarHtml: string,
+	routeCache: RouteCacheLike | undefined,
+): Promise<Response> {
 	const contentType = response.headers.get("content-type");
 	if (!contentType?.includes("text/html")) return response;
 
@@ -37,7 +63,10 @@ async function injectToolbar(response: Response, toolbarHtml: string): Promise<R
 	// Toolbar-injected HTML is session-specific (its presence reveals an active
 	// editor session); it must never be stored in a shared CDN cache and served
 	// to anonymous visitors. Mirrors the preview branch's guard (#1398).
+	// `Cache-Control` covers browsers/downstream proxies; the route-cache
+	// opt-out covers the shared edge cache, which ignores `Cache-Control`.
 	result.headers.set("Cache-Control", "private, no-store");
+	optOutOfRouteCache(routeCache);
 	return result;
 }
 
@@ -86,6 +115,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Astro context includes currentLocale when i18n is configured
 	const locale = (context as { currentLocale?: string }).currentLocale;
 
+	// Astro's route-cache handle. Read defensively — absent on Astro
+	// versions that predate route caching.
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- structural read, see RouteCacheLike
+	const routeCache = (context as { cache?: RouteCacheLike }).cache;
+
 	// Verify preview token if present.
 	// The preview secret is resolved via `resolveSecretsCached`: env wins,
 	// otherwise a DB-stored value is read (or generated on first need).
@@ -122,6 +156,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 			// Preview responses must not be cached -- draft content could leak past token expiry.
 			// Clone the response before modifying headers — the original may be immutable.
+			// `Cache-Control` only governs browsers/downstream proxies; the shared
+			// edge cache follows the route-cache options, so opt out of those too —
+			// otherwise the draft response is stored in the shared cache and served
+			// on cache hits without token verification until TTL/purge. Opt out for
+			// any request carrying a `_preview` param (valid or not): those URLs are
+			// per-token, so cached copies are useless at best and drafts at worst.
+			if (hasPreviewToken) {
+				optOutOfRouteCache(routeCache);
+			}
 			if (preview) {
 				response = new Response(response.body, response);
 				response.headers.set("Cache-Control", "private, no-store");
@@ -133,7 +176,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					editMode,
 					isPreview: !!preview,
 				});
-				return injectToolbar(response, toolbarHtml);
+				return injectToolbar(response, toolbarHtml, routeCache);
 			}
 
 			return response;
@@ -147,7 +190,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			editMode: false,
 			isPreview: false,
 		});
-		return injectToolbar(response, toolbarHtml);
+		return injectToolbar(response, toolbarHtml, routeCache);
 	}
 
 	return next();

--- a/packages/core/src/astro/middleware/request-context.ts
+++ b/packages/core/src/astro/middleware/request-context.ts
@@ -10,6 +10,7 @@
  * - Toolbar injection: floating pill for authenticated editors
  */
 
+import type { APIContext } from "astro";
 import { defineMiddleware } from "astro:middleware";
 
 import { resolveSecretsCached } from "#config/secrets.js";
@@ -18,15 +19,8 @@ import { verifyPreviewToken, parseContentId } from "../../preview/tokens.js";
 import { getRequestContext, runWithContext } from "../../request-context.js";
 import { renderToolbar } from "../../visual-editing/toolbar.js";
 
-/**
- * The subset of Astro's route-cache API the middleware needs. `context.cache`
- * ships with Astro's route caching; typed structurally (and called
- * optionally) so the middleware stays compatible with Astro versions that
- * predate it.
- */
-interface RouteCacheLike {
-	set(input: false): void;
-}
+/** Astro's route-cache handle. EmDash requires Astro 6+, so it's always present. */
+type RouteCache = APIContext["cache"];
 
 /**
  * Opt the current request out of Astro's route cache (e.g. Workers Cache on
@@ -34,10 +28,11 @@ interface RouteCacheLike {
  * the shared-cache TTL from the route-cache options (on Cloudflare via
  * `Cloudflare-CDN-Cache-Control`), so session-specific responses must
  * explicitly disable it or they get stored in the shared cache and served to
- * anonymous visitors without ever invoking the middleware again.
+ * anonymous visitors without ever invoking the middleware again. With no cache
+ * provider configured this is a no-op (`NoopAstroCache`/`DisabledAstroCache`).
  */
-function optOutOfRouteCache(cache: RouteCacheLike | undefined): void {
-	cache?.set(false);
+function optOutOfRouteCache(cache: RouteCache): void {
+	cache.set(false);
 }
 
 /**
@@ -47,7 +42,7 @@ function optOutOfRouteCache(cache: RouteCacheLike | undefined): void {
 async function injectToolbar(
 	response: Response,
 	toolbarHtml: string,
-	routeCache: RouteCacheLike | undefined,
+	routeCache: RouteCache,
 ): Promise<Response> {
 	const contentType = response.headers.get("content-type");
 	if (!contentType?.includes("text/html")) return response;
@@ -115,10 +110,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Astro context includes currentLocale when i18n is configured
 	const locale = (context as { currentLocale?: string }).currentLocale;
 
-	// Astro's route-cache handle. Read defensively — absent on Astro
-	// versions that predate route caching.
-	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- structural read, see RouteCacheLike
-	const routeCache = (context as { cache?: RouteCacheLike }).cache;
+	const routeCache = context.cache;
 
 	// Verify preview token if present.
 	// The preview secret is resolved via `resolveSecretsCached`: env wins,

--- a/packages/core/tests/unit/astro/request-context-route-cache.test.ts
+++ b/packages/core/tests/unit/astro/request-context-route-cache.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression tests: preview and toolbar responses must opt out of Astro's
+ * route cache, not just set `Cache-Control`.
+ *
+ * `Cache-Control: private, no-store` governs browsers and downstream
+ * proxies, but the shared edge cache (e.g. Workers Cache on Cloudflare)
+ * follows the route-cache options — on Cloudflare the adapter emits
+ * `Cloudflare-CDN-Cache-Control` from them. Verified on a stock deploy:
+ * a valid preview URL was a MISS on request 1 and a shared-cache HIT on
+ * requests 2+, i.e. draft content was served without any token
+ * verification until TTL/purge, even after token expiry.
+ *
+ * The fix calls `context.cache.set(false)` for requests carrying a
+ * `_preview` param and for toolbar-injected editor responses.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+
+import onRequest from "../../../src/astro/middleware/request-context.js";
+
+function buildContext(opts: {
+	pathname?: string;
+	search?: string;
+	user?: { id: string; role: number } | null;
+	editCookie?: boolean;
+	cache?: { set: (input: unknown) => void };
+}) {
+	const url = new URL(`https://example.com${opts.pathname ?? "/blog"}${opts.search ?? ""}`);
+	return {
+		request: new Request(url),
+		url,
+		cookies: {
+			get: vi.fn((name: string) =>
+				name === "emdash-edit-mode" && opts.editCookie ? { value: "true" } : undefined,
+			),
+			set: vi.fn(),
+		},
+		locals: { user: opts.user ?? null },
+		cache: opts.cache,
+	} as unknown as Parameters<typeof onRequest>[0];
+}
+
+const htmlResponse = () =>
+	new Response("<html><body>hello</body></html>", {
+		headers: { "content-type": "text/html" },
+	});
+
+describe("route-cache opt-out for preview and toolbar responses", () => {
+	it("opts out of the route cache when a _preview param is present", async () => {
+		const cache = { set: vi.fn() };
+		// No emdash.db on locals — token can't be verified, but the response
+		// still must not be stored under the per-token URL.
+		const context = buildContext({ search: "?_preview=some-token", cache });
+
+		await onRequest(context, async () => htmlResponse());
+
+		expect(cache.set).toHaveBeenCalledWith(false);
+	});
+
+	it("opts out of the route cache when the toolbar is injected", async () => {
+		const cache = { set: vi.fn() };
+		const context = buildContext({ user: { id: "u1", role: 30 }, cache });
+
+		const response = await onRequest(context, async () => htmlResponse());
+
+		// Confirm we're on the actual-injection path.
+		expect(await response.text()).toContain('id="emdash-toolbar"');
+		expect(cache.set).toHaveBeenCalledWith(false);
+	});
+
+	it("leaves the route cache alone for editor requests without injection (non-HTML)", async () => {
+		const cache = { set: vi.fn() };
+		const context = buildContext({
+			pathname: "/api/data.json",
+			user: { id: "u1", role: 30 },
+			cache,
+		});
+
+		await onRequest(
+			context,
+			async () => new Response('{"ok":true}', { headers: { "content-type": "application/json" } }),
+		);
+
+		expect(cache.set).not.toHaveBeenCalled();
+	});
+
+	it("leaves the route cache alone for anonymous requests without CMS signals", async () => {
+		const cache = { set: vi.fn() };
+		const context = buildContext({ cache });
+
+		await onRequest(context, async () => htmlResponse());
+
+		expect(cache.set).not.toHaveBeenCalled();
+	});
+
+	it("does not throw when context.cache is absent (older Astro)", async () => {
+		const context = buildContext({ search: "?_preview=some-token" });
+
+		const response = await onRequest(context, async () => htmlResponse());
+
+		expect(response.status).toBe(200);
+	});
+});

--- a/packages/core/tests/unit/astro/request-context-route-cache.test.ts
+++ b/packages/core/tests/unit/astro/request-context-route-cache.test.ts
@@ -26,7 +26,7 @@ function buildContext(opts: {
 	search?: string;
 	user?: { id: string; role: number } | null;
 	editCookie?: boolean;
-	cache?: { set: (input: unknown) => void };
+	cache: { set: (input: unknown) => void };
 }) {
 	const url = new URL(`https://example.com${opts.pathname ?? "/blog"}${opts.search ?? ""}`);
 	return {
@@ -94,13 +94,5 @@ describe("route-cache opt-out for preview and toolbar responses", () => {
 		await onRequest(context, async () => htmlResponse());
 
 		expect(cache.set).not.toHaveBeenCalled();
-	});
-
-	it("does not throw when context.cache is absent (older Astro)", async () => {
-		const context = buildContext({ search: "?_preview=some-token" });
-
-		const response = await onRequest(context, async () => htmlResponse());
-
-		expect(response.status).toBe(200);
 	});
 });

--- a/packages/core/tests/unit/astro/request-context-toolbar-cache.test.ts
+++ b/packages/core/tests/unit/astro/request-context-toolbar-cache.test.ts
@@ -24,6 +24,7 @@ function editorRequestContext(pathname = "/blog") {
 		url: new URL(`https://example.com${pathname}`),
 		cookies: { get: vi.fn(() => undefined), set: vi.fn() },
 		locals: { user: { id: "u1", role: 30 } },
+		cache: { set: vi.fn() },
 	} as unknown as Parameters<typeof onRequest>[0];
 }
 


### PR DESCRIPTION
## What does this PR do?

With route caching enabled (Workers Cache on Cloudflare), preview responses and editor-toolbar HTML end up in the **shared edge cache** and get served to subsequent requests without any token verification or worker invocation.

Verified empirically on a stock Cloudflare deploy (0.27.0, the documented `routeRules` setup): a valid preview URL (`?_preview=<token>`) returned `cf-cache-status: MISS` with `Cache-Control: private, no-store` on request 1 — and shared-cache `HIT`s on requests 2 and 3. The draft content stays reachable until TTL/purge, **including after the token expires**. (First reported in the #1820 review thread.)

Root cause: the request-context middleware sets only the `Cache-Control` header on preview/toolbar responses. That governs browsers and downstream proxies — but the edge cache follows Astro's **route-cache options** (on Cloudflare the adapter emits `Cloudflare-CDN-Cache-Control` from them), which the middleware never touched.

The fix:

- Any request carrying a `_preview` param now calls `context.cache.set(false)` (opt out of route caching). This is deliberately keyed on the param's presence rather than token validity: preview URLs are per-token, so cached copies are useless at best and drafts at worst.
- Toolbar-injected editor responses opt out the same way (their `Cache-Control: private, no-store` guard from #1398 had the same blind spot). Non-HTML editor responses are unaffected and stay cacheable.
- The middleware uses Astro's typed `context.cache` API directly (EmDash requires Astro 6+, which always provides it — thanks @ascorbic). Dev mode and deployments without a cache provider are unaffected: `NoopAstroCache`/`DisabledAstroCache` accept `set(false)` as a no-op.

New unit tests cover: preview param present → opt-out; toolbar injected → opt-out; editor non-HTML response → cache untouched; anonymous fast path → cache untouched.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation *(n/a — no admin UI changes)*
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: *(n/a — bug fix)*

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

Measurements from the stock demo deploy (before the fix):

```
request 1: cf-cache-status: MISS   cache-control: private, no-store
request 2: cf-cache-status: HIT
request 3: cf-cache-status: HIT
```

```
✓ tests/unit/astro/request-context-route-cache.test.ts (5 tests)
✓ tests/unit/astro/ (133 tests total)
```
