### PR TITLE
perf(admin): serve the content-list search filter from the FTS5 index

### DIFF
--- a/.changeset/admin-search-fts.md
+++ b/.changeset/admin-search-fts.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Speeds up the admin content-list search on collections with full-text search enabled: the filter is now served from the FTS5 index (token-prefix matching plus slug-prefix lookup) instead of scanning every row. Collections without search enabled, and PostgreSQL databases, keep the previous substring matching.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -5,6 +5,7 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
+import { isSqlite } from "../../database/dialect-helpers.js";
 import { BylineRepository } from "../../database/repositories/byline.js";
 import type { ContentBylineInput } from "../../database/repositories/byline.js";
 import { CommentRepository } from "../../database/repositories/comment.js";
@@ -31,6 +32,7 @@ import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
 import { getI18nConfig, isI18nEnabled } from "../../i18n/config.js";
 import { invalidateRedirectCache } from "../../redirects/cache.js";
+import { FTSManager } from "../../search/fts-manager.js";
 import { invalidateTermCache } from "../../taxonomies/index.js";
 import { isMissingTableError } from "../../utils/db-errors.js";
 import { encodeRev, validateRev } from "../rev.js";
@@ -330,6 +332,30 @@ async function resolveSearchColumns(db: Kysely<Database>, collection: string): P
 }
 
 /**
+ * Decide whether the content-list `q` filter can be served from the
+ * collection's FTS5 index instead of a full-scan substring LIKE (#1517).
+ *
+ * Requires SQLite (FTS5 is SQLite-only), search enabled on the collection,
+ * every non-slug display column present in the searchable-field set (or the
+ * index would miss matches the LIKE finds), and the index table actually
+ * existing.
+ */
+async function canUseFtsForListFilter(
+	db: Kysely<Database>,
+	collection: string,
+	searchColumns: string[],
+): Promise<boolean> {
+	if (!isSqlite(db)) return false;
+	const ftsManager = new FTSManager(db);
+	const config = await ftsManager.getSearchConfig(collection);
+	if (!config?.enabled) return false;
+	const searchable = new Set(await ftsManager.getSearchableFields(collection));
+	const covered = searchColumns.every((col) => col === "slug" || searchable.has(col));
+	if (!covered) return false;
+	return ftsManager.ftsTableExists(collection);
+}
+
+/**
  * Create a 301 auto-redirect from an entry's old URL to its new one after a
  * slug change, using the collection's URL pattern. Shared by
  * handleContentUpdate (direct slug edits) and handleContentPublish (slug edits
@@ -418,6 +444,7 @@ export async function handleContentList(
 		if (q) {
 			where.q = q;
 			where.searchColumns = await resolveSearchColumns(db, collection);
+			where.useFts = await canUseFtsForListFilter(db, collection, where.searchColumns);
 		}
 
 		const result = await repo.findMany(collection, {

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -2,6 +2,7 @@ import { sql, type Kysely } from "kysely";
 import { ulid } from "ulidx";
 
 import { invalidateCollectionCache } from "../../object-cache/index.js";
+import { buildFtsPrefixMatch, buildSlugGlobPrefix } from "../../search/match.js";
 import { chunks, SQL_BATCH_SIZE } from "../../utils/chunks.js";
 import { isMissingTableError } from "../../utils/db-errors.js";
 import { slugify } from "../../utils/slugify.js";
@@ -525,7 +526,7 @@ export class ContentRepository {
 			query = query.where("locale" as any, "=", options.where.locale);
 		}
 
-		query = this.applySearchFilter(query, options.where);
+		query = this.applySearchFilter(query, options.where, type);
 		query = this.applyDateFilter(query, options.where);
 
 		// Handle cursor pagination — decodeCursor throws InvalidCursorError
@@ -804,18 +805,45 @@ export class ContentRepository {
 	}
 
 	/**
-	 * Apply the optional case-insensitive `q` substring filter across the
-	 * handler-resolved `searchColumns` (OR'd). User input is treated literally
-	 * (LIKE wildcards escaped) and `lower()` is applied on both sides for
-	 * SQLite/Postgres case-insensitive parity.
+	 * Apply the optional `q` filter.
+	 *
+	 * When the handler sets `useFts` (collection has a healthy FTS5 index
+	 * covering the display columns; SQLite only), the filter is served from
+	 * the index: a token-prefix MATCH against `_emdash_fts_<slug>` OR'd with
+	 * an index-served `slug GLOB 'term*'` prefix (the slug is not in the FTS
+	 * index). Both sides are index-backed, so SQLite's OR optimization avoids
+	 * the full-table scan the LIKE fallback needs (#1517). The trade-off is
+	 * search semantics: token-prefix matching instead of arbitrary substring.
+	 *
+	 * Fallback (Postgres, search disabled, or no usable terms): case-
+	 * insensitive substring LIKE across the handler-resolved `searchColumns`
+	 * (OR'd). User input is treated literally (LIKE wildcards escaped) and
+	 * `lower()` is applied on both sides for SQLite/Postgres parity.
 	 */
 	private applySearchFilter<QB extends { where: (cb: (eb: any) => unknown) => QB }>(
 		query: QB,
-		where?: { q?: string; searchColumns?: string[] },
+		where: { q?: string; searchColumns?: string[]; useFts?: boolean } | undefined,
+		type: string,
 	): QB {
 		const term = where?.q?.trim();
 		const columns = where?.searchColumns;
 		if (!term || !columns || columns.length === 0) return query;
+
+		if (where.useFts) {
+			const match = buildFtsPrefixMatch(term);
+			if (match) {
+				validateIdentifier(type, "collection slug");
+				const ftsTable = `_emdash_fts_${type}`;
+				const slugPrefix = buildSlugGlobPrefix(term);
+				return query.where((eb) =>
+					eb.or([
+						sql<boolean>`id IN (SELECT id FROM ${sql.ref(ftsTable)} WHERE ${sql.ref(ftsTable)} MATCH ${match})`,
+						sql<boolean>`slug GLOB ${slugPrefix}`,
+					]),
+				);
+			}
+			// No usable terms (e.g. quotes only) — fall through to LIKE.
+		}
 
 		const escaped = term.replace(LIKE_WILDCARD_RE, (c) => `\\${c}`);
 		const pattern = `%${escaped}%`;
@@ -878,7 +906,7 @@ export class ContentRepository {
 			query = query.where("locale" as any, "=", where.locale);
 		}
 
-		query = this.applySearchFilter(query, where);
+		query = this.applySearchFilter(query, where, type);
 		query = this.applyDateFilter(query, where);
 
 		const result = await query.executeTakeFirst();

--- a/packages/core/src/database/repositories/types.ts
+++ b/packages/core/src/database/repositories/types.ts
@@ -158,6 +158,14 @@ export interface FindManyOptions {
 		 * repository stays generic. Each name is validated as a SQL identifier.
 		 */
 		searchColumns?: string[];
+		/**
+		 * Serve `q` from the collection's FTS5 index (`_emdash_fts_<slug>`)
+		 * instead of an unindexable substring LIKE. Set by the handler only
+		 * when the collection has search enabled and the index exists
+		 * (SQLite only). The repository combines a token-prefix MATCH with
+		 * an index-served slug prefix so slug lookups keep working.
+		 */
+		useFts?: boolean;
 		/** Inclusive date range over a whitelisted timestamp column. */
 		dateFilter?: ContentDateFilter;
 	};

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -1,0 +1,50 @@
+/**
+ * FTS5 match-expression builder for structured (non-user-syntax) queries.
+ *
+ * Unlike `escapeQuery` in `query.ts` (which powers the public search API and
+ * deliberately passes through FTS5 operators like AND/OR/NOT), this builder
+ * treats the input as plain words: every term is double-quoted with interior
+ * quotes escaped, so the result can never produce an FTS5 syntax error. Used
+ * by the admin content-list filter, where the input is a filter box, not a
+ * search-syntax field.
+ */
+
+const WHITESPACE_RE = /\s+/;
+const DOUBLE_QUOTE_RE = /"/g;
+const GLOB_SPECIAL_RE = /[[\]*?]/g;
+
+/**
+ * Build a prefix-matching FTS5 MATCH expression from free-form input.
+ *
+ * `hello wor` becomes `"hello"* "wor"*` — implicit AND with per-term prefix
+ * matching. Returns `""` when the input contains no usable terms; callers
+ * must fall back to their non-FTS path in that case.
+ */
+export function buildFtsPrefixMatch(input: string): string {
+	const terms = input
+		.trim()
+		.split(WHITESPACE_RE)
+		.map((term) => term.replace(DOUBLE_QUOTE_RE, '""'))
+		.filter((term) => term.length > 0);
+
+	if (terms.length === 0) return "";
+	return terms.map((term) => `"${term}"*`).join(" ");
+}
+
+/**
+ * Build a GLOB prefix pattern from free-form input, treating GLOB
+ * metacharacters (`* ? [ ]`) literally by wrapping each in a character
+ * class (GLOB has no ESCAPE clause).
+ *
+ * GLOB (unlike default LIKE) is case-sensitive, so with a lowercased
+ * pattern it matches slugs (lowercase by construction) while staying
+ * servable by the ordinary BINARY-collated slug index — SQLite's GLOB
+ * optimization turns a `prefix*` pattern into an index range scan.
+ */
+export function buildSlugGlobPrefix(input: string): string {
+	const escaped = input
+		.trim()
+		.toLowerCase()
+		.replace(GLOB_SPECIAL_RE, (c) => `[${c}]`);
+	return `${escaped}*`;
+}

--- a/packages/core/tests/integration/content/content-list-search-fts.test.ts
+++ b/packages/core/tests/integration/content/content-list-search-fts.test.ts
@@ -1,0 +1,161 @@
+/**
+ * FTS-backed admin content-list search (#1517).
+ *
+ * When a collection has search enabled, the list filter's `q` is served from
+ * the FTS5 index (token-prefix MATCH plus an index-served slug GLOB prefix)
+ * instead of the full-scan `lower(col) LIKE '%term%'`. These tests pin the
+ * user-visible behavior of that path — matching, count parity, literal
+ * treatment of FTS metacharacters — and the fallback when the display
+ * columns aren't covered by the index.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleContentCreate, handleContentList } from "../../../src/api/handlers/content.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { FTSManager } from "../../../src/search/fts-manager.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+type Db = Awaited<ReturnType<typeof setupTestDatabase>>;
+
+async function seedPosts(db: Db) {
+	for (let i = 0; i < 30; i++) {
+		const created = await handleContentCreate(db, "posts", {
+			slug: `post-${String(i).padStart(3, "0")}`,
+			data: { title: `Ordinary Post ${i}` },
+		});
+		if (!created.success) throw new Error("seed failed");
+	}
+	const needle = await handleContentCreate(db, "posts", {
+		slug: "the-needle-post",
+		data: { title: "zzz Needle Headline" },
+	});
+	if (!needle.success) throw new Error("needle seed failed");
+
+	const quoted = await handleContentCreate(db, "posts", {
+		slug: "quoted-post",
+		data: { title: 'He said "quoted" loudly' },
+	});
+	if (!quoted.success) throw new Error("quoted seed failed");
+}
+
+function titlesOf(result: {
+	success: boolean;
+	data?: { items: { data: Record<string, unknown> }[] };
+}) {
+	if (!result.success || !result.data) throw new Error("list failed");
+	return result.data.items.map((i) => i.data.title as string);
+}
+
+describe("content list search served by FTS (#1517)", () => {
+	let db: Db;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "posts", label: "Posts", labelSingular: "Post" });
+		await registry.createField("posts", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+			searchable: true,
+		});
+		await seedPosts(db);
+		await new FTSManager(db).enableSearch("posts");
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("finds an entry by title token prefix", async () => {
+		const result = await handleContentList(db, "posts", { q: "Needle", limit: 20 });
+		expect(titlesOf(result)).toEqual(["zzz Needle Headline"]);
+	});
+
+	it("matches case-insensitively", async () => {
+		const lower = await handleContentList(db, "posts", { q: "needle", limit: 20 });
+		expect(titlesOf(lower)).toContain("zzz Needle Headline");
+
+		const upper = await handleContentList(db, "posts", { q: "NEEDLE", limit: 20 });
+		expect(titlesOf(upper)).toContain("zzz Needle Headline");
+	});
+
+	it("matches multi-word prefixes across the title", async () => {
+		const result = await handleContentList(db, "posts", { q: "need head", limit: 20 });
+		expect(titlesOf(result)).toContain("zzz Needle Headline");
+	});
+
+	it("finds an entry by slug prefix (slug is not in the FTS index)", async () => {
+		const result = await handleContentList(db, "posts", { q: "the-needle", limit: 20 });
+		expect(titlesOf(result)).toContain("zzz Needle Headline");
+	});
+
+	it("returns a total that matches the filtered set, not the whole table", async () => {
+		const result = await handleContentList(db, "posts", { q: "Needle", limit: 20 });
+		if (!result.success) throw new Error("list failed");
+		expect(result.data.total).toBe(1);
+	});
+
+	it("treats double quotes in the query literally instead of erroring", async () => {
+		const result = await handleContentList(db, "posts", { q: '"quoted"', limit: 20 });
+		if (!result.success) throw new Error(`list failed: ${JSON.stringify(result)}`);
+		expect(titlesOf(result)).toContain('He said "quoted" loudly');
+	});
+
+	it("treats FTS operators as plain words", async () => {
+		// Must not throw and must not match everything.
+		const result = await handleContentList(db, "posts", { q: "needle AND", limit: 100 });
+		if (!result.success) throw new Error("list failed");
+		expect(titlesOf(result)).not.toContain("Ordinary Post 0");
+	});
+
+	it("excludes soft-deleted rows (FTS triggers keep the index in sync)", async () => {
+		const before = await handleContentList(db, "posts", { q: "Needle", limit: 20 });
+		if (!before.success) throw new Error("list failed");
+		const needleId = before.data.items[0]?.id;
+		if (!needleId) throw new Error("needle not found");
+
+		await db
+			.updateTable("ec_posts" as never)
+			.set({ deleted_at: new Date().toISOString() } as never)
+			.where("id" as never, "=", needleId as never)
+			.execute();
+
+		const after = await handleContentList(db, "posts", { q: "Needle", limit: 20 });
+		if (!after.success) throw new Error("list failed");
+		expect(after.data.items).toHaveLength(0);
+		expect(after.data.total).toBe(0);
+	});
+});
+
+describe("content list search falls back to LIKE when FTS cannot serve it", () => {
+	let db: Db;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "posts", label: "Posts", labelSingular: "Post" });
+		// `title` exists but is NOT searchable — the FTS index (over `body`)
+		// would miss title matches, so the filter must stay on LIKE.
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		await registry.createField("posts", {
+			slug: "body",
+			label: "Body",
+			type: "text",
+			searchable: true,
+		});
+		await seedPosts(db);
+		await new FTSManager(db).enableSearch("posts");
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("still finds title matches via the LIKE fallback", async () => {
+		// Mid-word substring — only LIKE can match this; proves the handler
+		// did not route to FTS despite search being enabled.
+		const result = await handleContentList(db, "posts", { q: "eedle", limit: 20 });
+		expect(titlesOf(result)).toContain("zzz Needle Headline");
+	});
+});

--- a/packages/core/tests/unit/search/match.test.ts
+++ b/packages/core/tests/unit/search/match.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFtsPrefixMatch, buildSlugGlobPrefix } from "../../../src/search/match.js";
+
+describe("buildFtsPrefixMatch", () => {
+	it("quotes each term with prefix matching, implicit AND", () => {
+		expect(buildFtsPrefixMatch("hello wor")).toBe('"hello"* "wor"*');
+	});
+
+	it("escapes interior double quotes so no input can produce FTS5 syntax errors", () => {
+		expect(buildFtsPrefixMatch('say "hi"')).toBe('"say"* """hi"""*');
+	});
+
+	it("neutralizes FTS5 operators by quoting them", () => {
+		expect(buildFtsPrefixMatch("cats AND dogs")).toBe('"cats"* "AND"* "dogs"*');
+	});
+
+	it("returns empty string for whitespace-only input", () => {
+		expect(buildFtsPrefixMatch("   ")).toBe("");
+	});
+});
+
+describe("buildSlugGlobPrefix", () => {
+	it("lowercases and appends the prefix wildcard", () => {
+		expect(buildSlugGlobPrefix("My-Post")).toBe("my-post*");
+	});
+
+	it("treats GLOB metacharacters literally via character classes", () => {
+		expect(buildSlugGlobPrefix("a*b?c[d]")).toBe("a[*]b[?]c[[]d[]]*");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #1517 (milestone 1.0): the admin content-list search box generated

```sql
lower("slug") like lower(?) escape '\' or lower("title") like lower(?) escape '\'
```

with a `%term%` pattern — doubly unindexable (leading wildcard + `lower()` wrapping the column) — so **every keystroke scanned all non-deleted rows in the locale, twice** (page fetch + the count for the pagination denominator). On D1 these are primary reads with a terrible rows-read/rows-returned ratio.

As the issue suggests, the filter now uses the FTS layer EmDash already ships. When the collection has search enabled and the index covers the display columns, the `q` filter becomes:

```sql
id IN (SELECT id FROM _emdash_fts_<slug> WHERE _emdash_fts_<slug> MATCH '"term"*')
OR slug GLOB 'term*'
```

Both sides are index-backed. `EXPLAIN QUERY PLAN` before/after on a seeded table:

```
OLD:  SCAN ec_posts
NEW:  MULTI-INDEX OR
        SCAN _emdash_fts_posts VIRTUAL TABLE INDEX 0:M3   (inverted index)
        SEARCH ec_posts USING INDEX idx_ec_posts_slug (slug>? AND slug<?)
```

Design notes:

- **Routing is conservative.** `useFts` is set by the handler only when: SQLite (FTS5 is SQLite-only), `search_config.enabled`, every non-slug display column (`title`/`name`) is in the searchable-field set (otherwise FTS would miss matches LIKE finds), and the FTS table exists. Everything else — Postgres, search disabled, uncovered columns — keeps the existing LIKE fallback, unchanged.
- **The MATCH expression cannot syntax-error.** A new `buildFtsPrefixMatch` helper quotes every term (interior quotes doubled) and treats FTS operators as plain words — unlike the public search API's `escapeQuery`, which intentionally passes operators through. A list filter box is not a search-syntax field.
- **Slug lookups keep working.** The slug is not in the FTS index, so the filter OR's an index-served `slug GLOB 'term*'` prefix (GLOB metacharacters escaped via character classes; GLOB's case-sensitive BINARY comparison is what lets SQLite use the ordinary slug index, and slugs are lowercase by construction).
- **Semantics change on FTS-enabled collections** from arbitrary substring to token-prefix matching (`need head` finds "Needle Headline"; mid-word `eedle` no longer matches). That's standard search behavior and what the FTS index can serve; the count and the page use the same filter, so the pagination denominator stays consistent.
- Index integrity is already handled elsewhere: boot-time `verifyAndRepairAll` plus migration 039.

Tests: unit tests for the two expression builders; integration tests for the FTS path (title token prefix, case-insensitivity, multi-word, slug prefix, filtered `total`, literal quotes, operators as plain words, soft-delete sync) and for the LIKE fallback when a display column isn't covered by the index. The existing `content-list-search.test.ts` (both dialects) passes unchanged.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation *(n/a — no admin UI changes)*
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: *(n/a — fixes the triaged milestone-1.0 issue #1517, which already outlines this approach)*

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

```
✓ tests/unit/search/match.test.ts (6 tests)
✓ tests/integration/content/content-list-search-fts.test.ts (10 tests)
✓ tests/integration/content + tests/integration/search + content-handlers (90 tests total)
```