### PR TITLE
fix(plugins): require manage + CSRF on private plugin routes regardless of HTTP method

### DIFF
--- a/.changeset/plugin-route-method-auth.md
+++ b/.changeset/plugin-route-method-auth.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes a privilege escalation on private plugin API routes: an editor (or a cross-origin page) could invoke admin-only, state-changing plugin routes by sending them as `GET` or `HEAD` instead of `POST`, which bypassed the permission tier and CSRF check. Every private plugin route now requires `plugins:manage` and the CSRF header regardless of HTTP method.

--- a/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
+++ b/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
@@ -39,11 +39,16 @@ const handleRequest: APIRoute = async ({ params, request, locals }) => {
 
 	// Public routes skip auth, CSRF, and scope checks entirely
 	if (!routeMeta.public) {
-		// Private routes require authentication and permission checks
-		const permission = ["GET", "HEAD", "OPTIONS"].includes(method)
-			? "plugins:read"
-			: "plugins:manage";
-		const denied = requirePerm(user, permission);
+		// Plugin routes are dispatched by name only — the HTTP method never
+		// selects a different handler, so a route reached via GET or HEAD runs
+		// exactly the same code (and side effects) as one reached via POST.
+		// Method-based tiering is therefore unsafe: gating GET/HEAD/OPTIONS on
+		// `plugins:read` with no CSRF let an editor (or a cross-origin page,
+		// since HEAD is CORS-safe) invoke a mutating admin route by choosing the
+		// method (#1853). Astro also dispatches HEAD to the GET export, so no
+		// explicit HEAD handler is needed to reach a "GET" route. Gate every
+		// private invocation on `plugins:manage` + CSRF regardless of method.
+		const denied = requirePerm(user, "plugins:manage");
 		if (denied) return denied;
 
 		// Token scope enforcement — plugin routes require "admin" scope.
@@ -51,16 +56,13 @@ const handleRequest: APIRoute = async ({ params, request, locals }) => {
 		const scopeError = requireScope(locals, "admin");
 		if (scopeError) return scopeError;
 
-		// CSRF protection for state-changing requests on private routes.
-		// Plugin routes use soft auth in the middleware (user resolved but not required),
-		// so the middleware's CSRF check doesn't run. We enforce it here for private routes.
-		// Token-authed requests (which set tokenScopes) are exempt — tokens aren't
-		// ambient credentials like cookies.
-		if (
-			!["GET", "HEAD", "OPTIONS"].includes(method) &&
-			!locals.tokenScopes &&
-			request.headers.get("X-EmDash-Request") !== "1"
-		) {
+		// CSRF protection on private routes. Plugin routes use soft auth in the
+		// middleware (user resolved but not required), so the middleware's CSRF
+		// check doesn't run — enforce it here. Applied to every method because
+		// any method can trigger a state change (see above). Token-authed
+		// requests (which set tokenScopes) are exempt — tokens aren't ambient
+		// credentials like cookies.
+		if (!locals.tokenScopes && request.headers.get("X-EmDash-Request") !== "1") {
 			return apiError("CSRF_REJECTED", "Missing required header", 403);
 		}
 	}

--- a/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
+++ b/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Auth for the plugin API catch-all (`/_emdash/api/plugins/{id}/*`).
+ *
+ * Regression coverage for #1853: because plugin routes dispatch by name only
+ * (the HTTP method never selects a different handler), a route reached via GET
+ * or HEAD runs the same code as one reached via POST. The route must not tier
+ * permission or CSRF by method — every private invocation needs
+ * `plugins:manage` and the CSRF header, so an editor or a cross-origin HEAD
+ * can't invoke a mutating admin route by choosing the method.
+ */
+
+import type { RoleLevel } from "@emdash-cms/auth";
+import { Role } from "@emdash-cms/auth";
+import type { APIRoute } from "astro";
+import { describe, expect, it, vi } from "vitest";
+
+import { GET, POST } from "../../../src/astro/routes/api/plugins/[pluginId]/[...path].js";
+
+function createLocals(role: RoleLevel | null, routePublic: boolean) {
+	const handlePluginApiRoute = vi.fn(async () => ({ success: true, data: { ok: true } }));
+	return {
+		locals: {
+			user: role == null ? null : { id: "u1", role },
+			emdash: {
+				handlePluginApiRoute,
+				getPluginRouteMeta: () => ({ public: routePublic }),
+			},
+		},
+		handlePluginApiRoute,
+	};
+}
+
+function invoke(
+	handler: APIRoute,
+	method: string,
+	locals: unknown,
+	{ csrf = true }: { csrf?: boolean } = {},
+) {
+	const headers = new Headers();
+	if (csrf) headers.set("X-EmDash-Request", "1");
+	const request = new Request("https://example.com/_emdash/api/plugins/demo/updateHomeConfig", {
+		method,
+		headers,
+	});
+	// The catch-all reads params.pluginId / params.path and locals.
+	return handler({
+		params: { pluginId: "demo", path: "updateHomeConfig" },
+		request,
+		locals,
+	} as never);
+}
+
+describe("plugin API catch-all auth (#1853)", () => {
+	it("does not run a private route for an editor via GET", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.EDITOR, false);
+		const res = await invoke(GET, "GET", locals);
+		expect(res.status).toBe(403);
+		expect(handlePluginApiRoute).not.toHaveBeenCalled();
+	});
+
+	it("does not run a private route for an editor via HEAD (dispatched to GET export)", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.EDITOR, false);
+		const res = await invoke(GET, "HEAD", locals);
+		expect(res.status).toBe(403);
+		expect(handlePluginApiRoute).not.toHaveBeenCalled();
+	});
+
+	it("still blocks an editor via POST", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.EDITOR, false);
+		const res = await invoke(POST, "POST", locals);
+		expect(res.status).toBe(403);
+		expect(handlePluginApiRoute).not.toHaveBeenCalled();
+	});
+
+	it("rejects a private GET without the CSRF header even for an admin", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, false);
+		const res = await invoke(GET, "GET", locals, { csrf: false });
+		expect(res.status).toBe(403);
+		expect(handlePluginApiRoute).not.toHaveBeenCalled();
+	});
+
+	it("allows an admin with the CSRF header (GET)", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, false);
+		const res = await invoke(GET, "GET", locals);
+		expect(res.status).toBe(200);
+		expect(handlePluginApiRoute).toHaveBeenCalledOnce();
+	});
+
+	it("allows an admin with the CSRF header (POST)", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, false);
+		const res = await invoke(POST, "POST", locals);
+		expect(res.status).toBe(200);
+		expect(handlePluginApiRoute).toHaveBeenCalledOnce();
+	});
+
+	it("leaves public routes reachable without auth or CSRF", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(null, true);
+		const res = await invoke(GET, "GET", locals, { csrf: false });
+		expect(res.status).toBe(200);
+		expect(handlePluginApiRoute).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #1853 — a privilege escalation / CSRF hole on the plugin API catch-all (`/_emdash/api/plugins/{id}/*`).

Plugin routes dispatch **by name only** — the HTTP method never selects a different handler, so a route reached via `GET` or `HEAD` runs exactly the same code (and side effects) as one reached via `POST`. But the catch-all tiered permission by method:

- `GET`/`HEAD`/`OPTIONS` → `plugins:read` (editor) + **CSRF skipped**
- everything else → `plugins:manage` (admin) + CSRF required

So an **editor** could invoke an admin-only, state-changing plugin route by sending it as `GET`, and a **cross-origin page** could reach it via `HEAD` (a CORS-safe method that Astro dispatches to the `GET` export, then strips the body — the handler still runs). The reporter verified this end-to-end on 0.25.1: `HEAD /_emdash/api/plugins/<id>/updateHomeConfig` returned 200 and overwrote stored plugin state.

The fix stops trusting the method as a read/write signal: every **private** plugin invocation now requires `plugins:manage` and the `X-EmDash-Request` CSRF header, regardless of method. Public routes (`public: true`) are unchanged — they still skip auth and CSRF as before.

**Behavior note:** the `plugins:read`/`GET` tier is removed. In practice every first-party admin caller (plugin admin pages, field `optionsRoute`) already uses `POST`, which already required `plugins:manage`, so this doesn't regress existing flows — it only closes the method-chosen bypass. A per-route method/permission declaration (issue suggestion 2/3) would be a larger, additive change; happy to go that way instead if maintainers prefer to keep a read tier.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation *(n/a — no UI strings)*
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion *(n/a — bug fix)*

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

New regression test `tests/unit/astro/plugin-api-route-auth.test.ts` (7 cases). The GET- and HEAD-as-editor cases fail on `main` and pass with the fix (verified by reverting the source change):

```
Tests  7 passed (7)   # with fix
Tests  3 failed | 4 passed (7)   # source reverted, test kept
```