### PR TITLE
docs(database): warn that D1 sessions hang with global_fetch_strictly_public

### DIFF
--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -127,6 +127,18 @@ export default defineConfig({
 	definition.
 </Aside>
 
+<Aside type="caution" title="Incompatible with global_fetch_strictly_public">
+	Do not enable `session: "auto"` (or `"primary-first"`) together with the
+	[`global_fetch_strictly_public`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public)
+	compatibility flag. The Sessions API establishes the session through an internal Cloudflare
+	request, which that flag blocks — every SSR request then hangs until the Worker hits its wall-clock
+	limit (~10s) and is canceled, with no error in the logs (`wrangler tail` shows `outcome: "canceled"`
+	and near-zero CPU time).
+
+	If you need `global_fetch_strictly_public`, set `session: "disabled"` (the default). All queries go
+	to the primary database — you lose replica read latency, but requests resolve normally.
+</Aside>
+
 ## libSQL
 
 libSQL is a fork of SQLite that supports remote connections. Use it when you need a remote database without Cloudflare D1.

--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -111,13 +111,17 @@ export default defineConfig({
 	REST API. The `session` option only controls EmDash's client-side session management.
 </Aside>
 
-<Aside type="caution">
-	Sessions are incompatible with the
+<Aside type="caution" title="Incompatible with global_fetch_strictly_public">
+	Do not enable `session: "auto"` (or `"primary-first"`) together with the
 	[`global_fetch_strictly_public`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public)
-	compatibility flag: the internal request the D1 Sessions API makes to route queries to replicas
-	is silently blocked, and every SSR request hangs with nothing in the logs. The hang may only
-	begin once replicas finish provisioning, so it can pass an initial post-deploy check. If your
-	Worker needs that flag, keep `session` disabled. See
+	compatibility flag. The Sessions API establishes the session through an internal Cloudflare
+	request, which that flag blocks — every SSR request then hangs until the Worker hits its wall-clock
+	limit (~10s) and is canceled, with no error in the logs (`wrangler tail` shows `outcome: "canceled"`
+	and near-zero CPU time). The hang may only begin once replicas finish provisioning, so it can pass
+	an initial post-deploy check.
+
+	If you need `global_fetch_strictly_public`, set `session: "disabled"` (the default). All queries go
+	to the primary database — you lose replica read latency, but requests resolve normally. See
 	[#1273](https://github.com/emdash-cms/emdash/issues/1273).
 </Aside>
 
@@ -125,18 +129,6 @@ export default defineConfig({
 	Anonymous visitors may see data that is a few seconds stale. For a CMS this is expected — content
 	changes are not real-time, and if you have route caching enabled the response is already stale by
 	definition.
-</Aside>
-
-<Aside type="caution" title="Incompatible with global_fetch_strictly_public">
-	Do not enable `session: "auto"` (or `"primary-first"`) together with the
-	[`global_fetch_strictly_public`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public)
-	compatibility flag. The Sessions API establishes the session through an internal Cloudflare
-	request, which that flag blocks — every SSR request then hangs until the Worker hits its wall-clock
-	limit (~10s) and is canceled, with no error in the logs (`wrangler tail` shows `outcome: "canceled"`
-	and near-zero CPU time).
-
-	If you need `global_fetch_strictly_public`, set `session: "disabled"` (the default). All queries go
-	to the primary database — you lose replica read latency, but requests resolve normally.
 </Aside>
 
 ## libSQL


### PR DESCRIPTION
## What does this PR do?

Documents the incompatibility reported in #1273: `d1({ session: "auto" })` (or `"primary-first"`) combined with the `global_fetch_strictly_public` compatibility flag makes **every SSR request hang** until the Worker hits its wall-clock limit (~10s) and is canceled — with no error in the logs, which makes it very hard to diagnose.

The Sessions API establishes its session through an internal Cloudflare request; `global_fetch_strictly_public` blocks connections to Cloudflare-internal addresses, so that request hangs silently. The workaround is `session: "disabled"` (the default).

This adds a caution box to the read-replication section of the database deployment guide with the symptom, the cause, and the workaround. It implements suggestion 1 from the issue (document the incompatibility).

The issue also floats a runtime timeout (2) and auto-detecting the flag to fall back to `disabled` (3). Both are trickier than they look and I left them out on purpose: the hang is inside D1's internal control-plane request during the first query, not a `fetch()` we own, so there's no clean seam to time out without racing every request; and there's no supported way to read a Worker's compatibility flags at runtime, so the fallback can't be triggered reliably. If maintainers want to pursue either, it's worth a short design discussion — happy to follow up.

Verified by @swissky in production (0.26.0, Astro 7 + Cloudflare Workers) — see the confirmation comment on the issue; the hang can even pass an initial smoke test and only start once a replica is provisioned.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes *(n/a — docs-only)*
- [ ] `pnpm lint` passes *(n/a — docs-only)*
- [ ] `pnpm test` passes *(n/a — docs-only)*
- [ ] `pnpm format` has been run *(prose-only MDX change)*
- [ ] I have added/updated tests for my changes *(n/a — docs-only)*
- [ ] User-visible strings in the admin UI are wrapped for translation *(n/a — docs)*
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) *(n/a — docs-only, no published-package change)*
- [ ] New features link to an approved Discussion *(n/a — docs)*

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5