### PR TITLE
fix: prevent Postgres migration stampede when a pending migration fails

### DIFF
--- a/.changeset/pg-migration-lock-stampede.md
+++ b/.changeset/pg-migration-lock-stampede.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes a database stampede on Postgres when a pending migration fails at runtime: requests no longer pile up waiting on the migration lock, failed migrations are retried with a backoff instead of on every request, and failed attempts no longer leak idle database connections.

--- a/packages/cloudflare/src/db/hyperdrive.ts
+++ b/packages/cloudflare/src/db/hyperdrive.ts
@@ -62,6 +62,7 @@
 
 import { env, waitUntil } from "cloudflare:workers";
 import { kyselyLogOption } from "emdash/database/instrumentation";
+import { withFailFastPgMigrationLock } from "emdash/database/pg-migration-lock";
 import { type Dialect, Kysely, PostgresDialect } from "kysely";
 // `pg` is provided by the consuming site (an optional peer of `emdash`); it is
 // kept external from this package's bundle.
@@ -125,8 +126,12 @@ export function createDialect(config: HyperdriveConfig): Dialect {
 	const binding = requireBinding(config);
 	// Cold-start migrations are sequential, so a single connection is enough,
 	// and keeping it to 1 leaves the bulk of Hyperdrive's connection budget for
-	// the per-request pools.
-	return new PostgresDialect({ pool: createPool(binding.connectionString, 1) });
+	// the per-request pools. Fail-fast migration locking: when another isolate
+	// is already migrating, throw instead of parking this connection on
+	// Kysely's blocking `pg_advisory_xact_lock` (#1744).
+	return withFailFastPgMigrationLock(
+		new PostgresDialect({ pool: createPool(binding.connectionString, 1) }),
+	);
 }
 
 /**

--- a/packages/cloudflare/src/db/hyperdrive.ts
+++ b/packages/cloudflare/src/db/hyperdrive.ts
@@ -62,7 +62,7 @@
 
 import { env, waitUntil } from "cloudflare:workers";
 import { kyselyLogOption } from "emdash/database/instrumentation";
-import { withFailFastPgMigrationLock } from "emdash/database/pg-migration-lock";
+import { FailFastPostgresDialect } from "emdash/database/pg-migration-lock";
 import { type Dialect, Kysely, PostgresDialect } from "kysely";
 // `pg` is provided by the consuming site (an optional peer of `emdash`); it is
 // kept external from this package's bundle.
@@ -129,9 +129,7 @@ export function createDialect(config: HyperdriveConfig): Dialect {
 	// the per-request pools. Fail-fast migration locking: when another isolate
 	// is already migrating, throw instead of parking this connection on
 	// Kysely's blocking `pg_advisory_xact_lock` (#1744).
-	return withFailFastPgMigrationLock(
-		new PostgresDialect({ pool: createPool(binding.connectionString, 1) }),
-	);
+	return new FailFastPostgresDialect({ pool: createPool(binding.connectionString, 1) });
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,6 +90,10 @@
       "types": "./dist/database/instrumentation.d.mts",
       "default": "./dist/database/instrumentation.mjs"
     },
+    "./database/pg-migration-lock": {
+      "types": "./dist/database/pg-migration-lock.d.mts",
+      "default": "./dist/database/pg-migration-lock.mjs"
+    },
     "./storage/local": {
       "types": "./dist/storage/local.d.mts",
       "default": "./dist/storage/local.mjs"

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -571,8 +571,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
 							// requests carry no session.
 							storage: runtime.storage,
 						} as EmDashHandlers;
-					} catch {
-						// Non-fatal — EmDashHead will fall back to base SEO contributions
+					} catch (error) {
+						// Non-fatal — EmDashHead falls back to base SEO contributions —
+						// but log it: a persistently failing init (e.g. a failing
+						// migration, #1744) is otherwise invisible on the anonymous
+						// path, silently degrading every public page.
+						console.error("[emdash] runtime init failed (page renders without CMS data):", error);
 					}
 					timings.push({ name: "rt", dur: performance.now() - t0, desc: "Runtime init" });
 					// Append cold-only sub-phase timings so the breakdown is visible

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -77,6 +77,17 @@ import type { EmDashHandlers } from "./types.js";
 const RUNTIME_INIT_DEADLINE_MS = DB_INIT_DEADLINE_MS + 15_000;
 
 /**
+ * Throttle for the anonymous-path runtime-init failure log. While a site is
+ * stuck (e.g. a failing migration in its backoff window, #1744) every
+ * anonymous request lands in that catch; one line per interval per isolate
+ * keeps the failure visible without flooding logs on a busy site. Plain
+ * module state (not globalThis): a duplicated SSR chunk just means an extra
+ * log line, which is harmless.
+ */
+const RUNTIME_INIT_ERROR_LOG_INTERVAL_MS = 30_000;
+let lastRuntimeInitErrorLogAt = 0;
+
+/**
  * Whether we've verified the database has been set up.
  * On a fresh deployment the first request may hit a public page, bypassing
  * runtime init. Without this check, template helpers like getSiteSettings()
@@ -573,10 +584,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
 						} as EmDashHandlers;
 					} catch (error) {
 						// Non-fatal — EmDashHead falls back to base SEO contributions —
-						// but log it: a persistently failing init (e.g. a failing
-						// migration, #1744) is otherwise invisible on the anonymous
-						// path, silently degrading every public page.
-						console.error("[emdash] runtime init failed (page renders without CMS data):", error);
+						// but log it (throttled): a persistently failing init (e.g. a
+						// failing migration, #1744) is otherwise invisible on the
+						// anonymous path, silently degrading every public page.
+						if (Date.now() - lastRuntimeInitErrorLogAt >= RUNTIME_INIT_ERROR_LOG_INTERVAL_MS) {
+							lastRuntimeInitErrorLogAt = Date.now();
+							console.error("[emdash] runtime init failed (page renders without CMS data):", error);
+						}
 					}
 					timings.push({ name: "rt", dur: performance.now() - t0, desc: "Runtime init" });
 					// Append cold-only sub-phase timings so the breakdown is visible

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -1,6 +1,7 @@
 import { type Kysely, sql } from "kysely";
 import { type Migration, type MigrationProvider, Migrator } from "kysely/migration";
 
+import { MIGRATION_LOCK_BUSY_MESSAGE } from "../pg-migration-lock.js";
 import type { Database } from "../types.js";
 // Import migrations statically for bundling
 import * as m001 from "./001_initial.js";
@@ -129,6 +130,12 @@ const MIGRATION_LOCK_TABLE = "_emdash_migrations_lock";
 
 export interface MigrationOptions {
 	migrationTableSchema?: string;
+	/**
+	 * Override how long to wait for a concurrent migrator to finish before
+	 * giving up. Defaults to MIGRATION_RACE_WAIT_MS; tests shorten it so the
+	 * give-up path doesn't take 10 seconds per case.
+	 */
+	raceWaitMs?: number;
 }
 
 function createMigrator(db: Kysely<Database>, options?: MigrationOptions): Migrator {
@@ -260,8 +267,11 @@ async function getAppliedMigrationCount(db: Kysely<Database>): Promise<number | 
  * been migrated by a newer build still treats the wait as settled instead
  * of timing out.
  */
-async function waitForConcurrentMigrator(db: Kysely<Database>): Promise<boolean> {
-	const deadline = Date.now() + MIGRATION_RACE_WAIT_MS;
+async function waitForConcurrentMigrator(
+	db: Kysely<Database>,
+	waitMs: number = MIGRATION_RACE_WAIT_MS,
+): Promise<boolean> {
+	const deadline = Date.now() + waitMs;
 	while (Date.now() < deadline) {
 		const count = await getAppliedMigrationCount(db);
 		if (count !== null && count >= MIGRATION_COUNT) {
@@ -341,12 +351,25 @@ export async function runMigrations(
 		const failedMigration = results?.find((r) => r.status === "Error");
 
 		// Concurrent-migration race: another caller is applying (or just
-		// applied) the same migration. Wait for it to finish, then verify
-		// the schema is fully migrated and treat as success.
-		if (MIGRATION_RACE_PATTERN.test(msg)) {
-			const settled = await waitForConcurrentMigrator(db);
+		// applied) the same migration. SQLite/D1 surface it as the
+		// bookkeeping UNIQUE violation (their migration lock is a no-op);
+		// Postgres surfaces it as the fail-fast advisory try-lock reporting
+		// busy (see pg-migration-lock.ts). Either way: wait for the
+		// concurrent migrator to finish, then verify the schema is fully
+		// migrated and treat as success.
+		const lockBusy = msg.includes(MIGRATION_LOCK_BUSY_MESSAGE);
+		if (MIGRATION_RACE_PATTERN.test(msg) || lockBusy) {
+			const settled = await waitForConcurrentMigrator(db, options?.raceWaitMs);
 			if (settled) {
 				return { applied };
+			}
+			if (lockBusy) {
+				// The lock holder never finished (its migration is likely
+				// failing too). Surface a clear error instead of the raw
+				// sentinel message.
+				throw new Error(
+					"Migration failed: another instance holds the migration lock and pending migrations were not applied within the wait window",
+				);
 			}
 		}
 

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -124,6 +124,24 @@ export interface MigrationStatus {
 	pending: string[];
 }
 
+/**
+ * Thrown when another instance held the migration lock for the whole wait
+ * window. This is NOT a migration failure — the holder may simply be slow
+ * (e.g. many pending migrations over a remote Postgres connection) — so
+ * callers with failure-backoff logic (`getDatabase` in emdash-runtime.ts)
+ * exempt it: the next request waits again instead of backing off, and init
+ * recovers as soon as the holder finishes.
+ */
+export class ConcurrentMigrationTimeoutError extends Error {
+	constructor(waitMs: number) {
+		super(
+			`Timed out waiting for another instance's migrations: the migration lock was still held after ${waitMs}ms. ` +
+				"It may still be applying migrations, or its migration may be failing repeatedly.",
+		);
+		this.name = "ConcurrentMigrationTimeoutError";
+	}
+}
+
 /** Custom migration table name */
 const MIGRATION_TABLE = "_emdash_migrations";
 const MIGRATION_LOCK_TABLE = "_emdash_migrations_lock";
@@ -364,12 +382,11 @@ export async function runMigrations(
 				return { applied };
 			}
 			if (lockBusy) {
-				// The lock holder never finished (its migration is likely
-				// failing too). Surface a clear error instead of the raw
-				// sentinel message.
-				throw new Error(
-					"Migration failed: another instance holds the migration lock and pending migrations were not applied within the wait window",
-				);
+				// The lock holder didn't finish within the wait window —
+				// either it's slow or its migration is failing. Surface a
+				// distinct error type instead of the raw sentinel message so
+				// callers can tell "still in progress" from "failed".
+				throw new ConcurrentMigrationTimeoutError(options?.raceWaitMs ?? MIGRATION_RACE_WAIT_MS);
 			}
 		}
 

--- a/packages/core/src/database/pg-migration-lock.ts
+++ b/packages/core/src/database/pg-migration-lock.ts
@@ -1,0 +1,73 @@
+/**
+ * Fail-fast Postgres migration locking.
+ *
+ * Kysely's stock `PostgresAdapter.acquireMigrationLock` runs
+ * `select pg_advisory_xact_lock(...)` — an unbounded blocking wait on a
+ * database-wide advisory lock, held for the whole migration transaction.
+ * On Cloudflare Workers that is a stampede amplifier (#1744): every isolate
+ * that cold-starts while migrations are pending parks a connection inside
+ * Postgres waiting for the lock, and when the holder's migration fails and
+ * rolls back, the next waiter acquires the lock and re-runs the same
+ * failing migration.
+ *
+ * `withFailFastPgMigrationLock` swaps the blocking wait for
+ * `pg_try_advisory_xact_lock`: when another migrator holds the lock, the
+ * adapter throws `MIGRATION_LOCK_BUSY_MESSAGE` immediately instead of
+ * queueing inside the database. `runMigrations` treats that error like the
+ * SQLite/D1 concurrent-migration race — it polls the migration table with
+ * cheap bounded SELECTs until the concurrent migrator finishes (or the
+ * wait deadline passes), without holding a transaction open.
+ */
+
+import type { Dialect, Kysely, MigrationLockOptions } from "kysely";
+import { PostgresAdapter as KyselyPostgresAdapter, sql } from "kysely";
+
+/**
+ * Sentinel message thrown when another migrator holds the advisory lock.
+ * `runMigrations` matches on it to route into the concurrent-migrator wait.
+ */
+export const MIGRATION_LOCK_BUSY_MESSAGE = "EMDASH_MIGRATION_LOCK_BUSY";
+
+/**
+ * Kysely's advisory lock id (LOCK_ID in kysely's postgres-adapter). Reused
+ * deliberately: during a rolling deploy, old isolates still run the stock
+ * blocking adapter, and using the same id keeps old and new builds mutually
+ * exclusive on the same lock.
+ */
+const KYSELY_PG_MIGRATION_LOCK_ID = BigInt("3853314791062309107");
+
+/**
+ * Extends the stock adapter so every capability flag and `instanceof` check
+ * is inherited, and keeps the class NAME `PostgresAdapter` because
+ * `detectDialect()` (dialect-helpers.ts) identifies the dialect via
+ * `adapter.constructor.name` — a differently-named adapter would make every
+ * dialect helper fall back to SQLite SQL against a Postgres database.
+ */
+class PostgresAdapter extends KyselyPostgresAdapter {
+	// eslint-disable-next-line typescript/no-explicit-any -- matches the DialectAdapter signature
+	override async acquireMigrationLock(db: Kysely<any>, _opt: MigrationLockOptions): Promise<void> {
+		// Transaction-level lock, like the stock adapter: Postgres supports
+		// transactional DDL, so `db` here is the migration transaction and
+		// the lock is released automatically on commit/rollback.
+		const result = await sql<{ acquired: boolean }>`
+			select pg_try_advisory_xact_lock(${sql.lit(KYSELY_PG_MIGRATION_LOCK_ID)}) as acquired
+		`.execute(db);
+		if (!result.rows[0]?.acquired) {
+			throw new Error(MIGRATION_LOCK_BUSY_MESSAGE);
+		}
+	}
+}
+
+/**
+ * Wrap a Postgres dialect so migration locking fails fast instead of
+ * blocking inside the database. Everything except `acquireMigrationLock`
+ * delegates to the wrapped dialect unchanged.
+ */
+export function withFailFastPgMigrationLock(dialect: Dialect): Dialect {
+	return {
+		createAdapter: () => new PostgresAdapter(),
+		createDriver: () => dialect.createDriver(),
+		createIntrospector: (db) => dialect.createIntrospector(db),
+		createQueryCompiler: () => dialect.createQueryCompiler(),
+	};
+}

--- a/packages/core/src/database/pg-migration-lock.ts
+++ b/packages/core/src/database/pg-migration-lock.ts
@@ -64,6 +64,13 @@ class PostgresAdapter extends KyselyPostgresAdapter {
  * delegates to the wrapped dialect unchanged.
  */
 export function withFailFastPgMigrationLock(dialect: Dialect): Dialect {
+	// Guard misuse up front: the replacement adapter is Postgres-specific
+	// (advisory-lock SQL, capability flags), so wrapping a non-Postgres
+	// dialect must fail here with a clear error, not at query time with a
+	// wrong-dialect one.
+	if (!(dialect.createAdapter() instanceof KyselyPostgresAdapter)) {
+		throw new Error("withFailFastPgMigrationLock requires a Postgres dialect");
+	}
 	return {
 		createAdapter: () => new PostgresAdapter(),
 		createDriver: () => dialect.createDriver(),

--- a/packages/core/src/database/pg-migration-lock.ts
+++ b/packages/core/src/database/pg-migration-lock.ts
@@ -10,7 +10,7 @@
  * rolls back, the next waiter acquires the lock and re-runs the same
  * failing migration.
  *
- * `withFailFastPgMigrationLock` swaps the blocking wait for
+ * `FailFastPostgresDialect` swaps the blocking wait for
  * `pg_try_advisory_xact_lock`: when another migrator holds the lock, the
  * adapter throws `MIGRATION_LOCK_BUSY_MESSAGE` immediately instead of
  * queueing inside the database. `runMigrations` treats that error like the
@@ -19,8 +19,8 @@
  * wait deadline passes), without holding a transaction open.
  */
 
-import type { Dialect, Kysely, MigrationLockOptions } from "kysely";
-import { PostgresAdapter as KyselyPostgresAdapter, sql } from "kysely";
+import type { DialectAdapter, Kysely, MigrationLockOptions } from "kysely";
+import { PostgresAdapter as KyselyPostgresAdapter, PostgresDialect, sql } from "kysely";
 
 /**
  * Sentinel message thrown when another migrator holds the advisory lock.
@@ -59,22 +59,14 @@ class PostgresAdapter extends KyselyPostgresAdapter {
 }
 
 /**
- * Wrap a Postgres dialect so migration locking fails fast instead of
- * blocking inside the database. Everything except `acquireMigrationLock`
- * delegates to the wrapped dialect unchanged.
+ * Drop-in replacement for Kysely's `PostgresDialect` whose migration lock
+ * fails fast instead of blocking inside the database. Everything except
+ * `createAdapter` is inherited unchanged, and because it subclasses
+ * `PostgresDialect`, the public dialect type of `emdash/db/postgres` stays
+ * `PostgresDialect` and `instanceof` checks keep working.
  */
-export function withFailFastPgMigrationLock(dialect: Dialect): Dialect {
-	// Guard misuse up front: the replacement adapter is Postgres-specific
-	// (advisory-lock SQL, capability flags), so wrapping a non-Postgres
-	// dialect must fail here with a clear error, not at query time with a
-	// wrong-dialect one.
-	if (!(dialect.createAdapter() instanceof KyselyPostgresAdapter)) {
-		throw new Error("withFailFastPgMigrationLock requires a Postgres dialect");
+export class FailFastPostgresDialect extends PostgresDialect {
+	override createAdapter(): DialectAdapter {
+		return new PostgresAdapter();
 	}
-	return {
-		createAdapter: () => new PostgresAdapter(),
-		createDriver: () => dialect.createDriver(),
-		createIntrospector: (db) => dialect.createIntrospector(db),
-		createQueryCompiler: () => dialect.createQueryCompiler(),
-	};
 }

--- a/packages/core/src/db/postgres.ts
+++ b/packages/core/src/db/postgres.ts
@@ -5,16 +5,16 @@
  * Loaded at runtime via virtual module.
  */
 
-import { type Dialect, PostgresDialect } from "kysely";
+import type { PostgresDialect } from "kysely";
 import { Pool } from "pg";
 
-import { withFailFastPgMigrationLock } from "../database/pg-migration-lock.js";
+import { FailFastPostgresDialect } from "../database/pg-migration-lock.js";
 import type { PostgresConfig } from "./adapters.js";
 
 /**
  * Create a PostgreSQL dialect from config
  */
-export function createDialect(config: PostgresConfig): Dialect {
+export function createDialect(config: PostgresConfig): PostgresDialect {
 	const pool = new Pool({
 		connectionString: config.connectionString,
 		host: config.host,
@@ -29,5 +29,5 @@ export function createDialect(config: PostgresConfig): Dialect {
 
 	// Fail-fast migration locking instead of Kysely's blocking advisory
 	// lock — see pg-migration-lock.ts (#1744).
-	return withFailFastPgMigrationLock(new PostgresDialect({ pool }));
+	return new FailFastPostgresDialect({ pool });
 }

--- a/packages/core/src/db/postgres.ts
+++ b/packages/core/src/db/postgres.ts
@@ -5,15 +5,16 @@
  * Loaded at runtime via virtual module.
  */
 
-import { PostgresDialect } from "kysely";
+import { type Dialect, PostgresDialect } from "kysely";
 import { Pool } from "pg";
 
+import { withFailFastPgMigrationLock } from "../database/pg-migration-lock.js";
 import type { PostgresConfig } from "./adapters.js";
 
 /**
  * Create a PostgreSQL dialect from config
  */
-export function createDialect(config: PostgresConfig): PostgresDialect {
+export function createDialect(config: PostgresConfig): Dialect {
 	const pool = new Pool({
 		connectionString: config.connectionString,
 		host: config.host,
@@ -26,5 +27,7 @@ export function createDialect(config: PostgresConfig): PostgresDialect {
 		max: config.pool?.max ?? 10,
 	});
 
-	return new PostgresDialect({ pool });
+	// Fail-fast migration locking instead of Kysely's blocking advisory
+	// lock — see pg-migration-lock.ts (#1744).
+	return withFailFastPgMigrationLock(new PostgresDialect({ pool }));
 }

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -22,7 +22,11 @@ import { getAuthMode } from "./auth/mode.js";
 import { getTrustedProxyHeaders } from "./auth/trusted-proxy.js";
 import { isSqlite } from "./database/dialect-helpers.js";
 import { kyselyLogOption } from "./database/instrumentation.js";
-import { MIGRATION_RACE_WAIT_MS, runMigrations } from "./database/migrations/runner.js";
+import {
+	ConcurrentMigrationTimeoutError,
+	MIGRATION_RACE_WAIT_MS,
+	runMigrations,
+} from "./database/migrations/runner.js";
 import { RevisionRepository } from "./database/repositories/revision.js";
 import type {
 	ContentItem as ContentItemInternal,
@@ -1650,11 +1654,14 @@ export class EmDashRuntime {
 
 		const throwIfBackingOff = () => {
 			const failure = holder.failures.get(cacheKey);
-			if (failure && Date.now() - failure.at < DB_INIT_FAILURE_BACKOFF_MS) {
+			if (!failure) return;
+			if (Date.now() - failure.at < DB_INIT_FAILURE_BACKOFF_MS) {
 				throw new Error(
 					`Database initialization is backing off after a recent migration failure: ${failure.message}`,
 				);
 			}
+			// Expired — drop it so the map only ever holds active backoffs.
+			holder.failures.delete(cacheKey);
 		};
 		throwIfBackingOff();
 
@@ -1673,10 +1680,16 @@ export class EmDashRuntime {
 				try {
 					await runMigrations(db);
 				} catch (error) {
-					holder.failures.set(cacheKey, {
-						at: Date.now(),
-						message: error instanceof Error ? error.message : String(error),
-					});
+					// Timing out behind another instance's in-flight migrations
+					// is not a failure of OUR migration — the holder may just be
+					// slow. Don't back off for it: the next request waits again
+					// and init recovers the moment the holder finishes.
+					if (!(error instanceof ConcurrentMigrationTimeoutError)) {
+						holder.failures.set(cacheKey, {
+							at: Date.now(),
+							message: error instanceof Error ? error.message : String(error),
+						});
+					}
 					// Every attempt builds a fresh dialect/pool; close it or each
 					// failed init leaks its connection(s) (#1744 observed these
 					// piling up as idle Postgres connections).

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -385,17 +385,41 @@ const DB_HOLDER_KEY = Symbol.for("emdash:db-cache");
 interface DbHolder {
 	cache: Map<string, Kysely<Database>>;
 	lock: InitLock;
+	/**
+	 * Recent migration failures, keyed like `cache`. A failed migration is
+	 * near-certain to fail again immediately (schema conflict, broken
+	 * migration), and without this every request in a warm isolate would
+	 * re-attempt it — on Workers with Postgres that stampedes the database
+	 * through the migration advisory lock (#1744). Entries expire after
+	 * DB_INIT_FAILURE_BACKOFF_MS; a successful init clears them.
+	 */
+	failures: Map<string, { at: number; message: string }>;
 }
 const globalSymbolStore = globalThis as Record<symbol, unknown>;
 function getDbHolder(): DbHolder {
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis symbol slot, written only below
 	let holder = globalSymbolStore[DB_HOLDER_KEY] as DbHolder | undefined;
 	if (!holder) {
-		holder = { cache: new Map<string, Kysely<Database>>(), lock: createInitLock() };
+		holder = {
+			cache: new Map<string, Kysely<Database>>(),
+			lock: createInitLock(),
+			failures: new Map(),
+		};
 		globalSymbolStore[DB_HOLDER_KEY] = holder;
 	}
+	// A holder created by an older copy of this module (dev-server HMR keeps
+	// globalThis across reloads) may predate the failures map.
+	holder.failures ??= new Map();
 	return holder;
 }
+
+/**
+ * After a database init fails (migrations threw), skip re-attempting for
+ * this long. Cold isolates still get one attempt each, so a transient
+ * failure heals on its own; a persistently failing migration is retried at
+ * most once per backoff window per isolate instead of on every request.
+ */
+const DB_INIT_FAILURE_BACKOFF_MS = 30_000;
 
 /**
  * Auto-seed runs at most once per isolate per database. Its lock + "done" set
@@ -1623,14 +1647,43 @@ export class EmDashRuntime {
 		// owner's init still completes and populates the cache. Net: a stale
 		// lock is reclaimed after a deadline.
 		const holder = getDbHolder();
+
+		const throwIfBackingOff = () => {
+			const failure = holder.failures.get(cacheKey);
+			if (failure && Date.now() - failure.at < DB_INIT_FAILURE_BACKOFF_MS) {
+				throw new Error(
+					`Database initialization is backing off after a recent migration failure: ${failure.message}`,
+				);
+			}
+		};
+		throwIfBackingOff();
+
 		return initWithLock(
 			holder.lock,
 			() => holder.cache.get(cacheKey),
 			async (isCurrentClaim) => {
+				// Re-check under the lock: a request that entered the wait loop
+				// before the failure was recorded must not immediately re-run
+				// the failing migration when the lock frees up.
+				throwIfBackingOff();
+
 				const dialect = deps.createDialect(dbConfig.config);
 				const db = new Kysely<Database>({ dialect, log: kyselyLogOption() });
 
-				await runMigrations(db);
+				try {
+					await runMigrations(db);
+				} catch (error) {
+					holder.failures.set(cacheKey, {
+						at: Date.now(),
+						message: error instanceof Error ? error.message : String(error),
+					});
+					// Every attempt builds a fresh dialect/pool; close it or each
+					// failed init leaks its connection(s) (#1744 observed these
+					// piling up as idle Postgres connections).
+					await db.destroy().catch(() => {});
+					throw error;
+				}
+				holder.failures.delete(cacheKey);
 
 				// Note: legacy installs may carry a stray `emdash:manifest_cache`
 				// row in the options table from versions that persisted a JSON

--- a/packages/core/tests/integration/database/migration-lock-pg.test.ts
+++ b/packages/core/tests/integration/database/migration-lock-pg.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Fail-fast Postgres migration locking (#1744).
+ *
+ * On Cloudflare Workers, EmDash's per-isolate init lock cannot coordinate
+ * across isolates, so multiple isolates can run `runMigrations` against the
+ * same Postgres database concurrently. Kysely's stock adapter serializes
+ * them with a *blocking* `pg_advisory_xact_lock` — when a pending migration
+ * keeps failing, every cold start parks a connection inside Postgres
+ * waiting for the lock and then retries the same failing migration.
+ *
+ * These tests run only when EMDASH_TEST_PG is set. They simulate the
+ * concurrent isolate by holding the advisory lock from a second connection
+ * of the same pool (a distinct Postgres session, like another isolate's
+ * connection).
+ */
+
+import { sql } from "kysely";
+import { describe, expect, it } from "vitest";
+
+import { MIGRATION_COUNT, runMigrations } from "../../../src/database/migrations/runner.js";
+import {
+	createTestPostgresDatabase,
+	hasPgTestDatabase,
+	type PgTestContext,
+	setupTestPostgresDatabase,
+	teardownTestPostgresDatabase,
+} from "../../utils/test-db.js";
+
+/** Kysely's migration advisory lock id (mirrored in pg-migration-lock.ts). */
+const LOCK_ID = BigInt("3853314791062309107");
+
+/**
+ * Acquire the migration advisory lock on a dedicated session (a separate
+ * connection from the context's pool) and hold it until `release()` is
+ * called — simulating another isolate's in-flight migrator.
+ */
+async function holdMigrationLock(
+	ctx: PgTestContext,
+): Promise<{ release: () => void; done: Promise<void> }> {
+	let release!: () => void;
+	const held = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	let acquired!: () => void;
+	let failed!: (error: unknown) => void;
+	const acquiredPromise = new Promise<void>((resolve, reject) => {
+		acquired = resolve;
+		failed = reject;
+	});
+	const done = ctx.db
+		.transaction()
+		.execute(async (trx) => {
+			await sql`select pg_advisory_xact_lock(${sql.lit(LOCK_ID)})`.execute(trx);
+			acquired();
+			// Keep the transaction (and therefore the lock) open until released.
+			await held;
+		})
+		.catch((error: unknown) => {
+			failed(error);
+			throw error;
+		});
+	await acquiredPromise;
+	return { release, done };
+}
+
+describe.runIf(hasPgTestDatabase)("Fail-fast Postgres migration lock (#1744)", () => {
+	it("fails fast instead of blocking when another migrator holds the lock", async () => {
+		// Fresh schema, no migrations applied — the state of a database whose
+		// pending migrations another isolate is (unsuccessfully) applying.
+		const ctx = await createTestPostgresDatabase();
+		try {
+			const lock = await holdMigrationLock(ctx);
+			try {
+				const start = Date.now();
+				await expect(
+					runMigrations(ctx.db, { migrationTableSchema: ctx.schemaName, raceWaitMs: 300 }),
+				).rejects.toThrow(/holds the migration lock/i);
+				// The old behavior blocked inside pg_advisory_xact_lock until the
+				// holder finished — i.e. forever in this test. The fail-fast path
+				// must return promptly: try-lock + a bounded ~300ms poll.
+				expect(Date.now() - start).toBeLessThan(5000);
+			} finally {
+				lock.release();
+				await lock.done;
+			}
+		} finally {
+			await teardownTestPostgresDatabase(ctx);
+		}
+	});
+
+	it("treats the busy lock as success once the concurrent migrator finishes", async () => {
+		// Fully migrated schema with the last migration row removed — the
+		// bookkeeping state a waiter observes while another isolate applies
+		// the final pending migration.
+		const ctx = await setupTestPostgresDatabase();
+		try {
+			const lastRow = await sql<{ name: string; timestamp: string }>`
+				SELECT name, timestamp FROM _emdash_migrations ORDER BY name DESC LIMIT 1
+			`.execute(ctx.db);
+			const last = lastRow.rows[0]!;
+			await sql`DELETE FROM _emdash_migrations WHERE name = ${last.name}`.execute(ctx.db);
+
+			const lock = await holdMigrationLock(ctx);
+			try {
+				const migration = runMigrations(ctx.db, {
+					migrationTableSchema: ctx.schemaName,
+					raceWaitMs: 10_000,
+				});
+				// While the migrator polls for the "concurrent migrator", restore
+				// the row (as if the lock holder just applied the migration)...
+				await sql`
+					INSERT INTO _emdash_migrations (name, timestamp)
+					VALUES (${last.name}, ${last.timestamp})
+				`.execute(ctx.db);
+				// ...and it must settle as success without applying anything itself.
+				await expect(migration).resolves.toEqual({ applied: [] });
+			} finally {
+				lock.release();
+				await lock.done;
+			}
+		} finally {
+			await teardownTestPostgresDatabase(ctx);
+		}
+	});
+
+	it("surfaces a genuinely failing migration without queueing concurrent callers", async () => {
+		// The incident shape: a pending migration that fails every attempt
+		// (here: re-running 001_initial against an already-built schema).
+		// Concurrent callers must all fail in bounded time — none may hang on
+		// the advisory lock.
+		const ctx = await setupTestPostgresDatabase();
+		try {
+			await sql`DELETE FROM _emdash_migrations WHERE name = '001_initial'`.execute(ctx.db);
+
+			const start = Date.now();
+			const results = await Promise.allSettled([
+				runMigrations(ctx.db, { migrationTableSchema: ctx.schemaName, raceWaitMs: 500 }),
+				runMigrations(ctx.db, { migrationTableSchema: ctx.schemaName, raceWaitMs: 500 }),
+			]);
+			expect(Date.now() - start).toBeLessThan(15_000);
+
+			// Both reject: the migration genuinely fails, and the concurrent
+			// caller either observes the busy lock (and the holder never
+			// completes) or re-runs the same failing migration itself.
+			expect(results.map((r) => r.status)).toEqual(["rejected", "rejected"]);
+			// The real migration error must not be swallowed as a race.
+			const messages = results.map((r) =>
+				r.status === "rejected" ? String((r.reason as Error).message) : "",
+			);
+			expect(messages.some((m) => /Migration failed/i.test(m))).toBe(true);
+
+			// And the bookkeeping still reflects the failure: the deleted row
+			// was not silently restored.
+			const count = await sql<{ count: number }>`
+				SELECT COUNT(*) as count FROM _emdash_migrations
+			`.execute(ctx.db);
+			expect(Number(count.rows[0]?.count)).toBe(MIGRATION_COUNT - 1);
+		} finally {
+			await teardownTestPostgresDatabase(ctx);
+		}
+	});
+});

--- a/packages/core/tests/integration/database/migration-lock-pg.test.ts
+++ b/packages/core/tests/integration/database/migration-lock-pg.test.ts
@@ -17,7 +17,11 @@
 import { sql } from "kysely";
 import { describe, expect, it } from "vitest";
 
-import { MIGRATION_COUNT, runMigrations } from "../../../src/database/migrations/runner.js";
+import {
+	ConcurrentMigrationTimeoutError,
+	MIGRATION_COUNT,
+	runMigrations,
+} from "../../../src/database/migrations/runner.js";
 import {
 	createTestPostgresDatabase,
 	hasPgTestDatabase,
@@ -72,9 +76,12 @@ describe.runIf(hasPgTestDatabase)("Fail-fast Postgres migration lock (#1744)", (
 			const lock = await holdMigrationLock(ctx);
 			try {
 				const start = Date.now();
+				// The distinct error type matters: getDatabase() exempts it from
+				// the failure backoff, since the lock holder may simply be slow
+				// rather than failing.
 				await expect(
 					runMigrations(ctx.db, { migrationTableSchema: ctx.schemaName, raceWaitMs: 300 }),
-				).rejects.toThrow(/holds the migration lock/i);
+				).rejects.toThrow(ConcurrentMigrationTimeoutError);
 				// The old behavior blocked inside pg_advisory_xact_lock until the
 				// holder finished — i.e. forever in this test. The fail-fast path
 				// must return promptly: try-lock + a bounded ~300ms poll.

--- a/packages/core/tests/integration/runtime/create.test.ts
+++ b/packages/core/tests/integration/runtime/create.test.ts
@@ -11,7 +11,7 @@
 import { randomUUID } from "node:crypto";
 
 import Database from "better-sqlite3";
-import { Kysely, SqliteDialect } from "kysely";
+import { Kysely, sql, SqliteDialect } from "kysely";
 import { describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_COMMENT_MODERATOR_PLUGIN_ID } from "../../../src/comments/moderator.js";
@@ -215,6 +215,40 @@ describe("EmDashRuntime.create — cold boot", () => {
 				// already closed
 			}
 		}
+	});
+
+	// A failed migration must not be retried on every create() call: on
+	// Workers each request in a warm isolate re-enters create(), and without
+	// a backoff every request re-runs the failing migration against the
+	// database (#1744). The failure is remembered per database entrypoint
+	// and re-attempts are skipped for a backoff window.
+	it("backs off after a migration failure instead of retrying immediately", async () => {
+		// A database whose next migration deterministically fails: fully
+		// migrated, then the 001_initial bookkeeping row is removed so the
+		// migrator re-runs it against existing tables.
+		const sqlite = new Database(":memory:");
+		const setupDb = new Kysely<EmDashDatabase>({
+			dialect: new SqliteDialect({ database: sqlite }),
+		});
+		await runMigrations(setupDb);
+		await sql`DELETE FROM _emdash_migrations WHERE name = '001_initial'`.execute(setupDb);
+
+		let dialectCalls = 0;
+		const deps: RuntimeDependencies = {
+			...createDeps(),
+			createDialect: () => {
+				dialectCalls += 1;
+				return new SqliteDialect({ database: sqlite });
+			},
+		};
+
+		await expect(EmDashRuntime.create(deps)).rejects.toThrow(/Migration failed/i);
+		expect(dialectCalls).toBe(1);
+
+		// An immediate retry (same entrypoint → same failure record) must
+		// fail fast without building a new connection or touching the db.
+		await expect(EmDashRuntime.create(deps)).rejects.toThrow(/backing off/i);
+		expect(dialectCalls).toBe(1);
 	});
 
 	// A per-request isolated db (playground / DO preview) must never be

--- a/packages/core/tests/unit/database/pg-migration-lock.test.ts
+++ b/packages/core/tests/unit/database/pg-migration-lock.test.ts
@@ -1,0 +1,43 @@
+import { PostgresDialect } from "kysely";
+import { describe, expect, it } from "vitest";
+
+import { withFailFastPgMigrationLock } from "../../../src/database/pg-migration-lock.js";
+
+/**
+ * The wrapper must change only `acquireMigrationLock`. If it dropped the
+ * adapter's capability flags, the Kysely Migrator would stop running
+ * migrations inside a transaction (supportsTransactionalDdl) — silently
+ * breaking rollback-on-failure. The lock behavior itself is covered by the
+ * Postgres integration tests (migration-lock-pg.test.ts).
+ */
+describe("withFailFastPgMigrationLock", () => {
+	it("preserves the wrapped adapter's capability flags", () => {
+		const dialect = new PostgresDialect({ pool: {} as never });
+		const inner = dialect.createAdapter();
+		const wrapped = withFailFastPgMigrationLock(dialect).createAdapter();
+
+		expect(wrapped.supportsTransactionalDdl).toBe(true);
+		expect(wrapped.supportsTransactionalDdl).toBe(inner.supportsTransactionalDdl);
+		expect(wrapped.supportsReturning).toBe(inner.supportsReturning);
+		expect(wrapped.supportsCreateIfNotExists).toBe(inner.supportsCreateIfNotExists ?? false);
+		expect(wrapped.supportsMultipleConnections).toBe(inner.supportsMultipleConnections ?? true);
+	});
+
+	it("still identifies as PostgresAdapter for dialect detection", () => {
+		// detectDialect() (dialect-helpers.ts) matches on the adapter's
+		// constructor name; a differently-named adapter class would make
+		// every dialect helper emit SQLite SQL against Postgres.
+		const wrapped = withFailFastPgMigrationLock(new PostgresDialect({ pool: {} as never }));
+		expect(wrapped.createAdapter().constructor.name).toBe("PostgresAdapter");
+	});
+
+	it("delegates the non-adapter dialect factories unchanged", () => {
+		const dialect = new PostgresDialect({ pool: {} as never });
+		const wrapped = withFailFastPgMigrationLock(dialect);
+
+		expect(wrapped.createQueryCompiler().constructor).toBe(
+			dialect.createQueryCompiler().constructor,
+		);
+		expect(wrapped.createDriver().constructor).toBe(dialect.createDriver().constructor);
+	});
+});

--- a/packages/core/tests/unit/database/pg-migration-lock.test.ts
+++ b/packages/core/tests/unit/database/pg-migration-lock.test.ts
@@ -1,4 +1,5 @@
-import { PostgresDialect } from "kysely";
+import Database from "better-sqlite3";
+import { PostgresDialect, SqliteDialect } from "kysely";
 import { describe, expect, it } from "vitest";
 
 import { withFailFastPgMigrationLock } from "../../../src/database/pg-migration-lock.js";
@@ -29,6 +30,14 @@ describe("withFailFastPgMigrationLock", () => {
 		// every dialect helper emit SQLite SQL against Postgres.
 		const wrapped = withFailFastPgMigrationLock(new PostgresDialect({ pool: {} as never }));
 		expect(wrapped.createAdapter().constructor.name).toBe("PostgresAdapter");
+	});
+
+	it("rejects a non-Postgres dialect at wrap time", () => {
+		// The replacement adapter runs Postgres advisory-lock SQL; wrapping
+		// another dialect must fail immediately, not at query time.
+		expect(() =>
+			withFailFastPgMigrationLock(new SqliteDialect({ database: new Database(":memory:") })),
+		).toThrow(/requires a Postgres dialect/i);
 	});
 
 	it("delegates the non-adapter dialect factories unchanged", () => {

--- a/packages/core/tests/unit/database/pg-migration-lock.test.ts
+++ b/packages/core/tests/unit/database/pg-migration-lock.test.ts
@@ -1,52 +1,38 @@
-import Database from "better-sqlite3";
-import { PostgresDialect, SqliteDialect } from "kysely";
+import { PostgresDialect } from "kysely";
 import { describe, expect, it } from "vitest";
 
-import { withFailFastPgMigrationLock } from "../../../src/database/pg-migration-lock.js";
+import { FailFastPostgresDialect } from "../../../src/database/pg-migration-lock.js";
 
 /**
- * The wrapper must change only `acquireMigrationLock`. If it dropped the
+ * The dialect must change only `acquireMigrationLock`. If it dropped the
  * adapter's capability flags, the Kysely Migrator would stop running
  * migrations inside a transaction (supportsTransactionalDdl) — silently
  * breaking rollback-on-failure. The lock behavior itself is covered by the
  * Postgres integration tests (migration-lock-pg.test.ts).
  */
-describe("withFailFastPgMigrationLock", () => {
-	it("preserves the wrapped adapter's capability flags", () => {
-		const dialect = new PostgresDialect({ pool: {} as never });
-		const inner = dialect.createAdapter();
-		const wrapped = withFailFastPgMigrationLock(dialect).createAdapter();
+describe("FailFastPostgresDialect", () => {
+	it("preserves the stock adapter's capability flags", () => {
+		const stock = new PostgresDialect({ pool: {} as never }).createAdapter();
+		const adapter = new FailFastPostgresDialect({ pool: {} as never }).createAdapter();
 
-		expect(wrapped.supportsTransactionalDdl).toBe(true);
-		expect(wrapped.supportsTransactionalDdl).toBe(inner.supportsTransactionalDdl);
-		expect(wrapped.supportsReturning).toBe(inner.supportsReturning);
-		expect(wrapped.supportsCreateIfNotExists).toBe(inner.supportsCreateIfNotExists ?? false);
-		expect(wrapped.supportsMultipleConnections).toBe(inner.supportsMultipleConnections ?? true);
+		expect(adapter.supportsTransactionalDdl).toBe(true);
+		expect(adapter.supportsTransactionalDdl).toBe(stock.supportsTransactionalDdl);
+		expect(adapter.supportsReturning).toBe(stock.supportsReturning);
+		expect(adapter.supportsCreateIfNotExists).toBe(stock.supportsCreateIfNotExists ?? false);
+		expect(adapter.supportsMultipleConnections).toBe(stock.supportsMultipleConnections ?? true);
 	});
 
 	it("still identifies as PostgresAdapter for dialect detection", () => {
 		// detectDialect() (dialect-helpers.ts) matches on the adapter's
 		// constructor name; a differently-named adapter class would make
 		// every dialect helper emit SQLite SQL against Postgres.
-		const wrapped = withFailFastPgMigrationLock(new PostgresDialect({ pool: {} as never }));
-		expect(wrapped.createAdapter().constructor.name).toBe("PostgresAdapter");
+		const adapter = new FailFastPostgresDialect({ pool: {} as never }).createAdapter();
+		expect(adapter.constructor.name).toBe("PostgresAdapter");
 	});
 
-	it("rejects a non-Postgres dialect at wrap time", () => {
-		// The replacement adapter runs Postgres advisory-lock SQL; wrapping
-		// another dialect must fail immediately, not at query time.
-		expect(() =>
-			withFailFastPgMigrationLock(new SqliteDialect({ database: new Database(":memory:") })),
-		).toThrow(/requires a Postgres dialect/i);
-	});
-
-	it("delegates the non-adapter dialect factories unchanged", () => {
-		const dialect = new PostgresDialect({ pool: {} as never });
-		const wrapped = withFailFastPgMigrationLock(dialect);
-
-		expect(wrapped.createQueryCompiler().constructor).toBe(
-			dialect.createQueryCompiler().constructor,
-		);
-		expect(wrapped.createDriver().constructor).toBe(dialect.createDriver().constructor);
+	it("remains a PostgresDialect for the public dialect type", () => {
+		// `emdash/db/postgres` publicly returns PostgresDialect; the fail-fast
+		// dialect must not narrow or break that type contract.
+		expect(new FailFastPostgresDialect({ pool: {} as never })).toBeInstanceOf(PostgresDialect);
 	});
 });

--- a/packages/core/tests/utils/test-db.ts
+++ b/packages/core/tests/utils/test-db.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "node:crypto";
 
 import Database from "better-sqlite3";
-import { Kysely, PostgresDialect, SqliteDialect } from "kysely";
+import { Kysely, SqliteDialect } from "kysely";
 import { Pool } from "pg";
 import { describe } from "vitest";
 
 import { getMigrationStatus, runMigrations } from "../../src/database/migrations/runner.js";
 import type { MigrationStatus } from "../../src/database/migrations/runner.js";
-import { withFailFastPgMigrationLock } from "../../src/database/pg-migration-lock.js";
+import { FailFastPostgresDialect } from "../../src/database/pg-migration-lock.js";
 import type { Database as DatabaseSchema } from "../../src/database/types.js";
 import { SchemaRegistry } from "../../src/schema/registry.js";
 import { resetTaxonomyDefsCacheForTests } from "../../src/taxonomies/index.js";
@@ -287,9 +287,9 @@ export async function createTestPostgresDatabase(): Promise<PgTestContext> {
 	});
 
 	const db = new Kysely<DatabaseSchema>({
-		// Wrapped like the production Postgres dialects so every PG test
+		// Same dialect as the production Postgres adapters so every PG test
 		// exercises the fail-fast migration lock.
-		dialect: withFailFastPgMigrationLock(new PostgresDialect({ pool: testPool })),
+		dialect: new FailFastPostgresDialect({ pool: testPool }),
 	});
 
 	return { db, schemaName };

--- a/packages/core/tests/utils/test-db.ts
+++ b/packages/core/tests/utils/test-db.ts
@@ -7,6 +7,7 @@ import { describe } from "vitest";
 
 import { getMigrationStatus, runMigrations } from "../../src/database/migrations/runner.js";
 import type { MigrationStatus } from "../../src/database/migrations/runner.js";
+import { withFailFastPgMigrationLock } from "../../src/database/pg-migration-lock.js";
 import type { Database as DatabaseSchema } from "../../src/database/types.js";
 import { SchemaRegistry } from "../../src/schema/registry.js";
 import { resetTaxonomyDefsCacheForTests } from "../../src/taxonomies/index.js";
@@ -286,7 +287,9 @@ export async function createTestPostgresDatabase(): Promise<PgTestContext> {
 	});
 
 	const db = new Kysely<DatabaseSchema>({
-		dialect: new PostgresDialect({ pool: testPool }),
+		// Wrapped like the production Postgres dialects so every PG test
+		// exercises the fail-fast migration lock.
+		dialect: withFailFastPgMigrationLock(new PostgresDialect({ pool: testPool })),
 	});
 
 	return { db, schemaName };

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -88,6 +88,8 @@ export default defineConfig({
 		"src/db/postgres.ts",
 		// Query instrumentation (used by first-party adapters like @emdash-cms/cloudflare)
 		"src/database/instrumentation.ts",
+		// Fail-fast Postgres migration lock (used by @emdash-cms/cloudflare's Hyperdrive adapter)
+		"src/database/pg-migration-lock.ts",
 		// Storage adapters (runtime - loaded via virtual:emdash/storage)
 		"src/storage/local.ts",
 		"src/storage/s3.ts",


### PR DESCRIPTION
## What does this PR do?

Fixes the runtime-migration stampede reported in #1744: on Cloudflare Workers with Postgres (e.g. via Hyperdrive), a pending migration that keeps failing caused every cold isolate — and every request in warm isolates — to re-attempt it. Each attempt queued on Kysely's *blocking* `pg_advisory_xact_lock` inside Postgres (98.58% of the reporter's query runtime, p50 ~3s per lock wait) and leaked an idle connection.

Three changes:

1. **Fail-fast migration lock** (`pg-migration-lock.ts`, applied to the node `pg` and Hyperdrive dialects): `acquireMigrationLock` now uses `pg_try_advisory_xact_lock`. A busy lock routes into the existing bounded `waitForConcurrentMigrator` poll (the same recovery path SQLite/D1 races use) instead of parking a connection inside the database. The lock id matches Kysely's stock adapter so old and new builds still serialize during rolling deploys.
2. **Failure backoff** (`emdash-runtime.ts`): a migration failure is remembered per database entrypoint and re-attempts are skipped for 30s (checked before *and* under the init lock). Cold isolates still get one attempt each, so transient failures self-heal. Failed attempts now `destroy()` their Kysely/pool — previously each one leaked a connection, matching the idle-connection buildup in the issue.
3. **Visibility** (`middleware.ts`): runtime init failures on the anonymous path were silently swallowed; they now log, so a site stuck in this state is no longer invisible.

Implementation note: the lock wrapper subclasses Kysely's `PostgresAdapter` and keeps the class *name*, because `detectDialect()` identifies the dialect via `adapter.constructor.name` — a delegating wrapper with its own class name made every dialect helper emit SQLite SQL against Postgres (caught by the new PG integration tests; there's now a unit test pinning that contract). The shared PG test utilities also route through the wrapper so all Postgres tests exercise the production lock behavior.

Closes #1744

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (core + cloudflare; the pre-existing `plugin-cli` failure on `main` is a stale `plugin-types` dist, unrelated)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes — full core suite (4771 tests) run with `EMDASH_TEST_PG` set against a local Postgres, plus the cloudflare suite (214 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code + Claude Fable 5

## Screenshots / test output

New tests (TDD repro of the incident shape):

- `tests/integration/database/migration-lock-pg.test.ts` (runs when `EMDASH_TEST_PG` is set):
  - fails fast in bounded time while another session holds the advisory lock (previously blocked indefinitely)
  - settles as success when the concurrent migrator finishes during the wait
  - concurrent callers against a genuinely failing migration all fail in bounded time with the real error surfaced, and bookkeeping is not silently advanced
- `tests/integration/runtime/create.test.ts`: a failed migration is not re-attempted by the next `create()` call — it fails fast without building a new connection
- `tests/unit/database/pg-migration-lock.test.ts`: wrapper preserves adapter capability flags and the `PostgresAdapter` constructor name that dialect detection relies on

```
 Test Files  334 passed (334)
      Tests  4771 passed (4771)   # core, EMDASH_TEST_PG enabled
 Test Files  15 passed (15)
      Tests  214 passed (214)     # @emdash-cms/cloudflare
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-pg-migration-lock-stampede-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/pg-migration-lock-stampede`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
