### PR TITLE
feat: `toolbar` config option with client-side bootstrap mode for shared caches

### DIFF
--- a/.changeset/toolbar-client-mode.md
+++ b/.changeset/toolbar-client-mode.md
@@ -1,0 +1,6 @@
+---
+"emdash": minor
+"@emdash-cms/admin": patch
+---
+
+Adds a `toolbar` config option for reliable editor-toolbar delivery behind shared caches. `toolbar: "client"` keeps public HTML identical for every visitor and shows a client-side "Edit" pill for logged-in editors that opens a fresh, uncached editor render via an `_edit` query param; `toolbar: false` disables the toolbar entirely. The toolbar can now also be dismissed in the browser via its × button. The default (`"server"`) is unchanged.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -367,6 +367,33 @@ emdash({
 
 Uploads that exceed the configured limit are rejected with a `413 Payload Too Large` response on the direct upload path, or a `400 Validation Error` on the signed-URL path.
 
+### `toolbar`
+
+**Optional.** Controls how the editor toolbar (the floating pill on public pages) is delivered. Defaults to `"server"`.
+
+| Value | Behavior |
+| ----- | -------- |
+| `"server"` (default) | The toolbar is injected server-side into every HTML response rendered for an authenticated editor. |
+| `"client"` | Public HTML is identical for every visitor. A tiny bootstrap script shows an "Edit" pill in browsers that have logged into the admin; clicking it verifies the session and reloads the page with an `_edit` query param, which is always rendered fresh (never cached) with the full toolbar. |
+| `false` | Never render the toolbar or the bootstrap script. |
+
+```js
+emdash({
+	toolbar: "client",
+})
+```
+
+Use `"client"` when your public HTML is served through a shared cache (Cloudflare Cache Everything / [Workers Cache](https://developers.cloudflare.com/workers/cache/), Fastly, Varnish, …). With server-side injection, an editor browsing the public site receives the cached anonymous variant — without the toolbar — whenever an anonymous visitor primed the cache first, so the toolbar appears and disappears with cache state. In client mode nothing session-specific is injected into shareable HTML, so the cache stays fully effective and the toolbar is reliable.
+
+Notes on `"client"` mode:
+
+- Logged-out visitors who open a shared `?_edit` URL are redirected to the canonical URL, so the param can't leak drafts or prime extra cache entries with page content.
+- The "logged in" signal is a non-secret `localStorage` flag set by the admin; the pill verifies the real session before entering the edit view.
+- The bootstrap is a small inline `<script>`. If your site sends a strict `Content-Security-Policy` without `'unsafe-inline'`, add a hash for it — the same applies to the server-injected toolbar.
+- EmDash injects nothing session-specific — but if your own templates branch on `Astro.locals.user` (e.g. an "Admin" nav link for logged-in users), that variance is still in your HTML and still fragments the cache.
+
+In every mode, the toolbar can be dismissed in the browser via its × button (per-browser, until the next time an editor opens the admin). Preview and edit-mode responses always render server-side with `Cache-Control: private, no-store`.
+
 ### `experimental`
 
 **Optional.** Opt-in features whose behaviour or wire format may change, or be removed, in a minor release. Each field is independently enabled.

--- a/packages/admin/src/components/Header.tsx
+++ b/packages/admin/src/components/Header.tsx
@@ -12,6 +12,12 @@ import { ThemeToggle } from "./ThemeToggle";
 export type { CurrentUser } from "../lib/api/current-user";
 
 async function handleLogout() {
+	// Clear the public-site toolbar-bootstrap flag (see Shell.tsx).
+	try {
+		localStorage.removeItem("emdash-editor");
+	} catch {
+		// ignore — flag is best-effort
+	}
 	const res = await apiFetch("/_emdash/api/auth/logout?redirect=/_emdash/admin/login", {
 		method: "POST",
 		credentials: "same-origin",

--- a/packages/admin/src/components/Shell.tsx
+++ b/packages/admin/src/components/Shell.tsx
@@ -47,6 +47,26 @@ export function Shell({ children, manifest }: ShellProps) {
 		}
 	}, [user?.isFirstLogin]);
 
+	// Maintain the non-secret "an editor session may exist in this browser"
+	// localStorage flag consumed by the public-site toolbar bootstrap
+	// (`toolbar: "client"`, Discussion #1742). Set here — not in the login
+	// flows — so every auth method (passkey, OAuth, magic link, dev bypass)
+	// is covered. Opening the admin also un-dismisses the toolbar.
+	// Key literals are duplicated in emdash core, which the admin can't import.
+	React.useEffect(() => {
+		if (!user) return;
+		try {
+			if (user.role >= 30) {
+				localStorage.setItem("emdash-editor", "1");
+				localStorage.removeItem("emdash-toolbar-dismissed");
+			} else {
+				localStorage.removeItem("emdash-editor");
+			}
+		} catch {
+			// localStorage unavailable — the toolbar pill just won't appear
+		}
+	}, [user]);
+
 	return (
 		<Sidebar.Provider
 			defaultOpen

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -350,6 +350,7 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 		trustedProxyHeaders: resolvedConfig.trustedProxyHeaders,
 		maxUploadSize: resolvedConfig.maxUploadSize,
 		admin: resolvedConfig.admin,
+		toolbar: resolvedConfig.toolbar,
 	};
 
 	// Determine auth mode for route injection

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -590,6 +590,30 @@ export interface EmDashConfig {
 	};
 
 	/**
+	 * Editor toolbar delivery on public pages.
+	 *
+	 * - `"server"` (default): the toolbar is injected server-side into every
+	 *   HTML response rendered for an authenticated editor. Simple and
+	 *   zero-config, but behind a shared cache (Cloudflare Cache Everything /
+	 *   Workers Cache, Fastly, Varnish, …) editors often receive the cached
+	 *   anonymous variant — without the toolbar — whenever an anonymous visitor
+	 *   primed the cache first, so the toolbar appears and disappears with
+	 *   cache state.
+	 * - `"client"`: public HTML is identical for everyone (nothing
+	 *   session-specific is injected server-side, so shared caches stay fully
+	 *   effective). A tiny bootstrap script shows an "Edit" pill for browsers
+	 *   that have logged into the admin (non-secret localStorage flag). Clicking
+	 *   it verifies the session and reloads the page with an `_edit` query
+	 *   param, which is always rendered fresh (never cached) with the full
+	 *   toolbar. Logged-out visitors opening an `_edit` URL are redirected to
+	 *   the canonical URL.
+	 * - `false`: never render the toolbar or bootstrap script.
+	 *
+	 * See the visual-editing docs for the cache-behavior details.
+	 */
+	toolbar?: "server" | "client" | false;
+
+	/**
 	 * Version of Astro the host project is building with. Populated by the
 	 * integration's `astro:config:setup` hook (not authored by the user) and
 	 * surfaced to the admin and the registry install gate so a plugin's

--- a/packages/core/src/astro/middleware/request-context.ts
+++ b/packages/core/src/astro/middleware/request-context.ts
@@ -8,16 +8,27 @@
  * - Preview tokens: _preview query param with signed HMAC token
  * - Edit mode: emdash-edit-mode cookie (for visual editing)
  * - Toolbar injection: floating pill for authenticated editors
+ * - Client toolbar mode (`toolbar: "client"`): cache-identical HTML with a
+ *   client-side bootstrap pill and an `_edit` query param for fresh editor
+ *   renders (Discussion #1742)
  */
 
 import type { APIContext } from "astro";
 import { defineMiddleware } from "astro:middleware";
 
+// @ts-ignore - virtual module
+import virtualConfig from "virtual:emdash/config";
+
 import { resolveSecretsCached } from "#config/secrets.js";
 
 import { verifyPreviewToken, parseContentId } from "../../preview/tokens.js";
 import { getRequestContext, runWithContext } from "../../request-context.js";
+import { EDIT_PARAM, renderToolbarBootstrap } from "../../visual-editing/toolbar-bootstrap.js";
 import { renderToolbar } from "../../visual-editing/toolbar.js";
+
+type ToolbarMode = "server" | "client" | false;
+
+const toolbarMode: ToolbarMode = virtualConfig?.toolbar ?? "server";
 
 /** Astro's route-cache handle. EmDash requires Astro 6+, so it's always present. */
 type RouteCache = APIContext["cache"];
@@ -36,6 +47,34 @@ function optOutOfRouteCache(cache: RouteCache): void {
 }
 
 /**
+ * Inject HTML before `</body>` if the response is an HTML page with a body
+ * end tag. Does not touch cache headers — callers decide whether the result
+ * is still shareable. `injected` tells the caller whether anything changed.
+ */
+async function injectBeforeBodyEnd(
+	response: Response,
+	htmlToInject: string,
+): Promise<{ response: Response; injected: boolean }> {
+	const contentType = response.headers.get("content-type");
+	if (!contentType?.includes("text/html")) return { response, injected: false };
+
+	const html = await response.text();
+	if (!html.includes("</body>")) {
+		// Body already consumed — rebuild the response unchanged.
+		return { response: new Response(html, response), injected: false };
+	}
+
+	const injected = html.replace("</body>", `${htmlToInject}</body>`);
+	return {
+		response: new Response(injected, {
+			status: response.status,
+			headers: response.headers,
+		}),
+		injected: true,
+	};
+}
+
+/**
  * Inject toolbar HTML into a response if it's an HTML page.
  * Returns the original response if not HTML.
  */
@@ -44,25 +83,42 @@ async function injectToolbar(
 	toolbarHtml: string,
 	routeCache: RouteCache,
 ): Promise<Response> {
-	const contentType = response.headers.get("content-type");
-	if (!contentType?.includes("text/html")) return response;
+	const result = await injectBeforeBodyEnd(response, toolbarHtml);
+	if (result.injected) {
+		// Toolbar-injected HTML is session-specific (its presence reveals an
+		// active editor session); it must never be stored in a shared CDN cache
+		// and served to anonymous visitors. Mirrors the preview branch's guard
+		// (#1398). `Cache-Control` covers browsers/downstream proxies; the
+		// route-cache opt-out covers the shared edge cache, which ignores
+		// `Cache-Control`.
+		result.response.headers.set("Cache-Control", "private, no-store");
+		optOutOfRouteCache(routeCache);
+	}
+	return result.response;
+}
 
-	const html = await response.text();
-	if (!html.includes("</body>")) return new Response(html, response);
+/**
+ * Inject the client-toolbar bootstrap script. Identical for every visitor, so
+ * cache headers and route-cache options are left untouched and the response
+ * stays fully shareable.
+ */
+async function injectBootstrap(response: Response): Promise<Response> {
+	const result = await injectBeforeBodyEnd(response, renderToolbarBootstrap());
+	return result.response;
+}
 
-	const injected = html.replace("</body>", `${toolbarHtml}</body>`);
-	const result = new Response(injected, {
-		status: response.status,
-		headers: response.headers,
+/**
+ * Redirect an `_edit` URL to its canonical form (same URL without the param).
+ * Applied when the requester is not an authenticated editor, so a shared
+ * `?_edit` link degrades gracefully for everyone else (Discussion #1742).
+ */
+function redirectToCanonical(url: URL): Response {
+	const canonical = new URL(url);
+	canonical.searchParams.delete(EDIT_PARAM);
+	return new Response(null, {
+		status: 302,
+		headers: { Location: canonical.pathname + canonical.search + canonical.hash },
 	});
-	// Toolbar-injected HTML is session-specific (its presence reveals an active
-	// editor session); it must never be stored in a shared CDN cache and served
-	// to anonymous visitors. Mirrors the preview branch's guard (#1398).
-	// `Cache-Control` covers browsers/downstream proxies; the route-cache
-	// opt-out covers the shared edge cache, which ignores `Cache-Control`.
-	result.headers.set("Cache-Control", "private, no-store");
-	optOutOfRouteCache(routeCache);
-	return result;
 }
 
 export const onRequest = defineMiddleware(async (context, next) => {
@@ -97,9 +153,30 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// Fast path: check for CMS signals before doing any work
 	const hasEditCookie = cookies.get("emdash-edit-mode")?.value === "true";
 	const hasPreviewToken = url.searchParams.has("_preview");
+	// `_edit` requests a fresh (never cached) editor render; only meaningful in
+	// client toolbar mode where public HTML is otherwise identical for everyone.
+	const hasEditParam = toolbarMode === "client" && url.searchParams.has(EDIT_PARAM);
 
-	// No CMS signals and not an editor → skip everything (zero overhead)
+	if (hasEditParam) {
+		// `_edit` URLs are their own cache key. Never store them in the route
+		// cache — a cached anonymous redirect would bounce editors back to the
+		// canonical URL, and a cached editor render must never be shared.
+		optOutOfRouteCache(context.cache);
+
+		// A non-editor (anonymous, logged-out, or insufficient role) opening an
+		// `_edit` URL is sent to the canonical URL — shared `?_edit` links
+		// degrade gracefully and never prime a cache entry with page content.
+		if (!isEditor) {
+			return redirectToCanonical(url);
+		}
+	}
+
+	// No CMS signals and not an editor → skip everything (zero overhead in
+	// server mode; client mode injects the identical-for-everyone bootstrap)
 	if (!hasEditCookie && !hasPreviewToken && !isEditor) {
+		if (toolbarMode === "client") {
+			return injectBootstrap(await next());
+		}
 		return next();
 	}
 
@@ -162,8 +239,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				response.headers.set("Cache-Control", "private, no-store");
 			}
 
-			// Inject toolbar for authenticated editors
-			if (isEditor) {
+			// Inject toolbar for authenticated editors. Preview and edit-mode
+			// responses are session-specific (`private, no-store` + route-cache
+			// opt-out) in every toolbar mode, so the server toolbar is safe to
+			// inject here even in client mode.
+			if (isEditor && toolbarMode !== false) {
 				const toolbarHtml = renderToolbar({
 					editMode,
 					isPreview: !!preview,
@@ -171,12 +251,33 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				return injectToolbar(response, toolbarHtml, routeCache);
 			}
 
+			// Stale edit cookie without a session (client mode): still serve the
+			// shareable bootstrap variant.
+			if (toolbarMode === "client" && !isEditor && !preview) {
+				return injectBootstrap(response);
+			}
+
 			return response;
 		});
 	}
 
-	// Editor without CMS signals — no ALS needed, but inject toolbar
+	// Editor without preview/edit-mode signals.
 	if (isEditor) {
+		if (toolbarMode === false) {
+			return next();
+		}
+
+		// Client mode: without the `_edit` param the response must stay
+		// byte-identical to the anonymous variant (plus the same bootstrap
+		// script), so shared caches serve one entry for everyone. The bootstrap
+		// pill is the editor's entry point into the fresh `_edit` render.
+		if (toolbarMode === "client" && !hasEditParam) {
+			return injectBootstrap(await next());
+		}
+
+		// Server mode, or an `_edit` request in client mode: inject the full
+		// toolbar (response becomes `private, no-store` and route-cache
+		// opted out).
 		const response = await next();
 		const toolbarHtml = renderToolbar({
 			editMode: false,

--- a/packages/core/src/astro/middleware/request-context.ts
+++ b/packages/core/src/astro/middleware/request-context.ts
@@ -15,7 +15,6 @@
 
 import type { APIContext } from "astro";
 import { defineMiddleware } from "astro:middleware";
-
 // @ts-ignore - virtual module
 import virtualConfig from "virtual:emdash/config";
 
@@ -117,7 +116,14 @@ function redirectToCanonical(url: URL): Response {
 	canonical.searchParams.delete(EDIT_PARAM);
 	return new Response(null, {
 		status: 302,
-		headers: { Location: canonical.pathname + canonical.search + canonical.hash },
+		headers: {
+			Location: canonical.pathname + canonical.search + canonical.hash,
+			// Header-following caches (Fastly, Varnish, browsers) must not store
+			// the redirect — a cached 302 would bounce editors back to the
+			// canonical URL. The route-cache opt-out at the call site covers the
+			// Workers Cache, which ignores Cache-Control.
+			"Cache-Control": "private, no-store",
+		},
 	});
 }
 

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -20,6 +20,7 @@ declare module "virtual:emdash/config" {
 		auth?: AuthDescriptor;
 		authProviders?: AuthProviderDescriptor[];
 		i18n?: I18nConfig | null;
+		toolbar?: "server" | "client" | false;
 	}
 
 	const config: VirtualConfig;

--- a/packages/core/src/visual-editing/toolbar-bootstrap.ts
+++ b/packages/core/src/visual-editing/toolbar-bootstrap.ts
@@ -1,0 +1,120 @@
+/**
+ * EmDash Toolbar Bootstrap (toolbar: "client")
+ *
+ * A tiny script injected into every public HTML response when the client
+ * toolbar mode is enabled. It is identical for every visitor, so the HTML
+ * stays fully cacheable by shared caches (Workers Cache, Cache Everything,
+ * Fastly, Varnish, …).
+ *
+ * Behavior: if this browser has logged into the admin (non-secret
+ * localStorage flag set by the admin SPA), render a small "Edit" pill.
+ * Clicking it verifies the session server-side and reloads the page with the
+ * `_edit` query param — that URL is always rendered fresh with the full
+ * server-side toolbar. Logged-out browsers pay one localStorage read and
+ * nothing else. See Discussion #1742.
+ */
+
+/**
+ * Non-secret localStorage flag set by the admin SPA when an editor session
+ * exists in this browser. It only means "a session may exist" — the click
+ * handler verifies the real session before entering edit mode. The literal
+ * is duplicated in `@emdash-cms/admin` (Shell/Header), which cannot import
+ * from core.
+ */
+export const EDITOR_FLAG_KEY = "emdash-editor";
+
+/**
+ * localStorage flag set when the user dismisses the toolbar in this browser.
+ * Cleared the next time an editor opens the admin. Also duplicated in
+ * `@emdash-cms/admin`.
+ */
+export const TOOLBAR_DISMISSED_KEY = "emdash-toolbar-dismissed";
+
+/**
+ * Query param that requests a fresh (never cached) editor render. Presence is
+ * verified server-side: non-editors are redirected to the canonical URL.
+ */
+export const EDIT_PARAM = "_edit";
+
+export function renderToolbarBootstrap(): string {
+	return `
+<!-- EmDash Toolbar Bootstrap -->
+<script>
+(function() {
+  var flag, dismissed;
+  try {
+    flag = localStorage.getItem("${EDITOR_FLAG_KEY}");
+    dismissed = localStorage.getItem("${TOOLBAR_DISMISSED_KEY}");
+  } catch (e) {
+    return;
+  }
+  if (!flag || dismissed) return;
+  // The server toolbar is present on _edit / edit-mode / preview renders.
+  if (document.getElementById("emdash-toolbar")) return;
+
+  var root = document.createElement("div");
+  root.id = "emdash-toolbar-bootstrap";
+  root.style.cssText = "position:fixed;bottom:16px;left:50%;transform:translateX(-50%);z-index:999999;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:13px;line-height:1;-webkit-font-smoothing:antialiased;";
+
+  var inner = document.createElement("div");
+  inner.style.cssText = "display:flex;align-items:center;gap:10px;padding:8px 16px;background:#1a1a1a;color:#e0e0e0;border-radius:999px;box-shadow:0 4px 24px rgba(0,0,0,0.3),0 0 0 1px rgba(255,255,255,0.08);white-space:nowrap;user-select:none;";
+
+  var logo = document.createElement("span");
+  logo.textContent = "EmDash";
+  logo.style.cssText = "font-weight:600;font-size:12px;letter-spacing:0.02em;color:#fff;opacity:0.7;";
+
+  var divider = document.createElement("span");
+  divider.style.cssText = "width:1px;height:16px;background:rgba(255,255,255,0.15);";
+
+  var editBtn = document.createElement("button");
+  editBtn.textContent = "Edit";
+  editBtn.style.cssText = "padding:4px 12px;background:#3b82f6;color:#fff;border:none;border-radius:999px;font-size:12px;font-weight:600;cursor:pointer;font-family:inherit;";
+
+  var closeBtn = document.createElement("button");
+  closeBtn.textContent = "\\u00d7";
+  closeBtn.title = "Hide toolbar";
+  closeBtn.setAttribute("aria-label", "Hide toolbar");
+  closeBtn.style.cssText = "background:none;border:none;color:#666;cursor:pointer;font-size:16px;padding:0 2px;line-height:1;font-family:inherit;";
+
+  editBtn.addEventListener("click", function() {
+    editBtn.disabled = true;
+    fetch("/_emdash/api/auth/me", {
+      credentials: "same-origin",
+      headers: { "X-EmDash-Request": "1" }
+    })
+    .then(function(r) { return r.ok ? r.json() : null; })
+    .then(function(body) {
+      var user = body && body.data;
+      if (user && user.role >= 30) {
+        var u = new URL(location.href);
+        u.searchParams.set("${EDIT_PARAM}", "1");
+        location.href = u.toString();
+      } else if (user) {
+        // Logged in but not an editor — the flag is stale for this browser.
+        try { localStorage.removeItem("${EDITOR_FLAG_KEY}"); } catch (e) {}
+        root.remove();
+      } else {
+        // No session — go to the admin login page.
+        location.href = "/_emdash/admin/login";
+      }
+    })
+    .catch(function() {
+      editBtn.disabled = false;
+    });
+  });
+
+  closeBtn.addEventListener("click", function() {
+    try { localStorage.setItem("${TOOLBAR_DISMISSED_KEY}", "1"); } catch (e) {}
+    root.remove();
+  });
+
+  inner.appendChild(logo);
+  inner.appendChild(divider);
+  inner.appendChild(editBtn);
+  inner.appendChild(closeBtn);
+  root.appendChild(inner);
+  document.body.appendChild(root);
+})();
+</script>
+`;
+}

--- a/packages/core/src/visual-editing/toolbar.ts
+++ b/packages/core/src/visual-editing/toolbar.ts
@@ -39,6 +39,8 @@ export function renderToolbar(config: ToolbarConfig): string {
     </a>
 
     <button class="emdash-tb-publish" id="emdash-tb-publish" style="display:none">Publish</button>
+
+    <button class="emdash-tb-dismiss" id="emdash-tb-dismiss" title="Hide toolbar" aria-label="Hide toolbar">&times;</button>
   </div>
 </div>
 
@@ -231,6 +233,23 @@ export function renderToolbar(config: ToolbarConfig): string {
   .emdash-tb-publish:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  /* Dismiss button */
+  .emdash-tb-dismiss {
+    background: none;
+    border: none;
+    color: #666;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 2px;
+    font-family: inherit;
+    transition: color 0.15s;
+  }
+
+  .emdash-tb-dismiss:hover {
+    color: #fff;
   }
 
   /* Edit mode: editable hover styles — uses :has() to check toolbar state */
@@ -518,7 +537,34 @@ export function renderToolbar(config: ToolbarConfig): string {
   var publishBtn = document.getElementById("emdash-tb-publish");
   if (!toolbar || !toggle || !statusEl || !publishBtn || !saveStatusEl) return;
 
+  // Dismissed in this browser (localStorage flag, cleared on the next admin
+  // visit). Remove the toolbar entirely instead of rendering it.
+  try {
+    if (localStorage.getItem("emdash-toolbar-dismissed")) {
+      toolbar.remove();
+      return;
+    }
+  } catch (e) {
+    // localStorage unavailable — render normally
+  }
+
   var isEditMode = toolbar.getAttribute("data-edit-mode") === "true";
+
+  var dismissBtn = document.getElementById("emdash-tb-dismiss");
+  if (dismissBtn) {
+    dismissBtn.addEventListener("click", function() {
+      try { localStorage.setItem("emdash-toolbar-dismissed", "1"); } catch (e) {}
+      // Dismissing while edit mode is on would strand the user in edit mode
+      // with no UI to leave it — clear the cookie too.
+      if (isEditMode) {
+        document.cookie = "emdash-edit-mode=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT";
+        toolbar.remove();
+        location.replace(location.href);
+        return;
+      }
+      toolbar.remove();
+    });
+  }
 
   // CSRF-protected fetch — adds X-EmDash-Request header to all API calls
   function ecFetch(url, init) {

--- a/packages/core/tests/unit/astro/request-context-toolbar-mode.test.ts
+++ b/packages/core/tests/unit/astro/request-context-toolbar-mode.test.ts
@@ -153,11 +153,17 @@ describe("toolbar bootstrap script", () => {
 		const { renderToolbarBootstrap } =
 			await import("../../../src/visual-editing/toolbar-bootstrap.js");
 		const html = renderToolbarBootstrap();
-		const match = /<script>([\s\S]*)<\/script>/.exec(html);
-		expect(match?.[1]).toBeTruthy();
+		// Index-based extraction (not regex): this parses our own generated
+		// string with known fixed tags, not untrusted HTML.
+		const open = html.indexOf("<script>");
+		const close = html.lastIndexOf("</script>");
+		expect(open).toBeGreaterThanOrEqual(0);
+		expect(close).toBeGreaterThan(open);
+		const script = html.slice(open + "<script>".length, close);
+		expect(script.trim()).toBeTruthy();
 		// Throws SyntaxError if the template literal produced broken JS.
 		// eslint-disable-next-line typescript/no-implied-eval -- deliberate parse-only syntax check of generated script, never invoked
-		expect(() => new Function(match![1]!)).not.toThrow();
+		expect(() => new Function(script)).not.toThrow();
 	});
 });
 

--- a/packages/core/tests/unit/astro/request-context-toolbar-mode.test.ts
+++ b/packages/core/tests/unit/astro/request-context-toolbar-mode.test.ts
@@ -37,6 +37,7 @@ function buildContext(opts: {
 	return {
 		request: new Request(url),
 		url,
+		cache: { set: vi.fn() },
 		cookies: {
 			get: vi.fn((name: string) =>
 				name === "emdash-edit-mode" && opts.editCookie ? { value: "true" } : undefined,
@@ -78,11 +79,14 @@ describe("toolbar: server (default)", () => {
 describe("toolbar: client", () => {
 	it("injects the identical bootstrap into anonymous HTML without touching cache headers", async () => {
 		const onRequest = await loadMiddleware("client");
-		const res = await onRequest(buildContext({}), async () => htmlResponse());
+		const context = buildContext({});
+		const res = await onRequest(context, async () => htmlResponse());
 		const html = await res.text();
 		expect(html).toContain("emdash-toolbar-bootstrap");
 		expect(html).not.toContain('id="emdash-toolbar"');
 		expect(res.headers.get("Cache-Control")).toBeNull();
+		// The response stays shareable — no route-cache opt-out.
+		expect(context.cache.set).not.toHaveBeenCalled();
 	});
 
 	it("serves editors the same bootstrap variant when no _edit param is present", async () => {
@@ -99,12 +103,13 @@ describe("toolbar: client", () => {
 
 	it("renders the full server toolbar for editors on _edit requests, uncacheable", async () => {
 		const onRequest = await loadMiddleware("client");
-		const res = await onRequest(buildContext({ user: EDITOR, search: "?_edit=1" }), async () =>
-			htmlResponse(),
-		);
+		const context = buildContext({ user: EDITOR, search: "?_edit=1" });
+		const res = await onRequest(context, async () => htmlResponse());
 		const html = await res.text();
 		expect(html).toContain('id="emdash-toolbar"');
 		expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+		// _edit responses must never enter the shared route cache.
+		expect(context.cache.set).toHaveBeenCalledWith(false);
 	});
 
 	it("redirects non-editors on _edit URLs to the canonical URL without rendering", async () => {
@@ -112,12 +117,15 @@ describe("toolbar: client", () => {
 		const next = vi.fn(async () => htmlResponse());
 
 		for (const user of [null, { id: "u2", role: 20 }]) {
-			const res = await onRequest(
-				buildContext({ user, search: "?_edit=1&page=2", pathname: "/blog" }),
-				next,
-			);
+			const context = buildContext({ user, search: "?_edit=1&page=2", pathname: "/blog" });
+			const res = await onRequest(context, next);
 			expect(res.status).toBe(302);
 			expect(res.headers.get("Location")).toBe("/blog?page=2");
+			// The redirect must not be stored either — a cached 302 would bounce
+			// editors back to the canonical URL. Route-cache opt-out covers the
+			// Workers Cache; the header covers header-following caches.
+			expect(context.cache.set).toHaveBeenCalledWith(false);
+			expect(res.headers.get("Cache-Control")).toBe("private, no-store");
 		}
 		expect(next).not.toHaveBeenCalled();
 	});

--- a/packages/core/tests/unit/astro/request-context-toolbar-mode.test.ts
+++ b/packages/core/tests/unit/astro/request-context-toolbar-mode.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the `toolbar` config modes (Discussion #1742).
+ *
+ * - `"server"` (default): current behavior — the toolbar is injected
+ *   server-side for authenticated editors.
+ * - `"client"`: public HTML is identical for everyone (bootstrap script,
+ *   cache headers untouched). The full toolbar is only server-rendered for
+ *   requests carrying the `_edit` param (editors only — everyone else is
+ *   redirected to the canonical URL) or an active edit-mode/preview signal.
+ * - `false`: no toolbar, no bootstrap.
+ *
+ * The middleware reads the mode from `virtual:emdash/config` at module scope,
+ * so each case loads a fresh module instance via `vi.resetModules()`.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+type Middleware = (context: unknown, next: () => Promise<Response>) => Promise<Response> | Response;
+
+async function loadMiddleware(toolbar: unknown): Promise<Middleware> {
+	vi.resetModules();
+	vi.doMock("astro:middleware", () => ({
+		defineMiddleware: (handler: unknown) => handler,
+	}));
+	vi.doMock("virtual:emdash/config", () => ({ default: { toolbar } }));
+	const mod = await import("../../../src/astro/middleware/request-context.js");
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- test harness casts the middleware to a plain function
+	return mod.default as unknown as Middleware;
+}
+
+function buildContext(opts: {
+	pathname?: string;
+	search?: string;
+	user?: { id: string; role: number } | null;
+	editCookie?: boolean;
+}) {
+	const url = new URL(`https://example.com${opts.pathname ?? "/blog"}${opts.search ?? ""}`);
+	return {
+		request: new Request(url),
+		url,
+		cookies: {
+			get: vi.fn((name: string) =>
+				name === "emdash-edit-mode" && opts.editCookie ? { value: "true" } : undefined,
+			),
+			set: vi.fn(),
+		},
+		locals: { user: opts.user ?? null },
+	};
+}
+
+const htmlResponse = () =>
+	new Response("<html><body>hello</body></html>", {
+		headers: { "content-type": "text/html" },
+	});
+
+const EDITOR = { id: "u1", role: 30 };
+
+describe("toolbar: server (default)", () => {
+	it("injects the toolbar for editors and leaves anonymous HTML untouched", async () => {
+		const onRequest = await loadMiddleware(undefined);
+
+		const editorRes = await onRequest(buildContext({ user: EDITOR }), async () => htmlResponse());
+		expect(await editorRes.text()).toContain('id="emdash-toolbar"');
+		expect(editorRes.headers.get("Cache-Control")).toBe("private, no-store");
+
+		const anonRes = await onRequest(buildContext({}), async () => htmlResponse());
+		const anonHtml = await anonRes.text();
+		expect(anonHtml).not.toContain("emdash-toolbar");
+		expect(anonRes.headers.get("Cache-Control")).toBeNull();
+	});
+
+	it("ignores the _edit param entirely", async () => {
+		const onRequest = await loadMiddleware(undefined);
+		const res = await onRequest(buildContext({ search: "?_edit=1" }), async () => htmlResponse());
+		expect(res.status).toBe(200);
+	});
+});
+
+describe("toolbar: client", () => {
+	it("injects the identical bootstrap into anonymous HTML without touching cache headers", async () => {
+		const onRequest = await loadMiddleware("client");
+		const res = await onRequest(buildContext({}), async () => htmlResponse());
+		const html = await res.text();
+		expect(html).toContain("emdash-toolbar-bootstrap");
+		expect(html).not.toContain('id="emdash-toolbar"');
+		expect(res.headers.get("Cache-Control")).toBeNull();
+	});
+
+	it("serves editors the same bootstrap variant when no _edit param is present", async () => {
+		const onRequest = await loadMiddleware("client");
+
+		const editorRes = await onRequest(buildContext({ user: EDITOR }), async () => htmlResponse());
+		const anonRes = await onRequest(buildContext({}), async () => htmlResponse());
+
+		// Byte-identical to the anonymous variant — this is what keeps shared
+		// caches serving one entry for everyone.
+		expect(await editorRes.text()).toBe(await anonRes.text());
+		expect(editorRes.headers.get("Cache-Control")).toBeNull();
+	});
+
+	it("renders the full server toolbar for editors on _edit requests, uncacheable", async () => {
+		const onRequest = await loadMiddleware("client");
+		const res = await onRequest(buildContext({ user: EDITOR, search: "?_edit=1" }), async () =>
+			htmlResponse(),
+		);
+		const html = await res.text();
+		expect(html).toContain('id="emdash-toolbar"');
+		expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+	});
+
+	it("redirects non-editors on _edit URLs to the canonical URL without rendering", async () => {
+		const onRequest = await loadMiddleware("client");
+		const next = vi.fn(async () => htmlResponse());
+
+		for (const user of [null, { id: "u2", role: 20 }]) {
+			const res = await onRequest(
+				buildContext({ user, search: "?_edit=1&page=2", pathname: "/blog" }),
+				next,
+			);
+			expect(res.status).toBe(302);
+			expect(res.headers.get("Location")).toBe("/blog?page=2");
+		}
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("still injects the server toolbar for editors in active edit mode (cookie)", async () => {
+		const onRequest = await loadMiddleware("client");
+		const res = await onRequest(buildContext({ user: EDITOR, editCookie: true }), async () =>
+			htmlResponse(),
+		);
+		expect(await res.text()).toContain('id="emdash-toolbar"');
+		expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+	});
+
+	it("serves the bootstrap variant for a stale edit cookie without a session", async () => {
+		const onRequest = await loadMiddleware("client");
+		const res = await onRequest(buildContext({ editCookie: true }), async () => htmlResponse());
+		const html = await res.text();
+		expect(html).toContain("emdash-toolbar-bootstrap");
+		expect(html).not.toContain('id="emdash-toolbar"');
+	});
+});
+
+describe("toolbar bootstrap script", () => {
+	it("generates syntactically valid JavaScript", async () => {
+		const { renderToolbarBootstrap } =
+			await import("../../../src/visual-editing/toolbar-bootstrap.js");
+		const html = renderToolbarBootstrap();
+		const match = /<script>([\s\S]*)<\/script>/.exec(html);
+		expect(match?.[1]).toBeTruthy();
+		// Throws SyntaxError if the template literal produced broken JS.
+		// eslint-disable-next-line typescript/no-implied-eval -- deliberate parse-only syntax check of generated script, never invoked
+		expect(() => new Function(match![1]!)).not.toThrow();
+	});
+});
+
+describe("toolbar: false", () => {
+	it("renders neither the toolbar nor the bootstrap for anyone", async () => {
+		const onRequest = await loadMiddleware(false);
+
+		for (const user of [null, EDITOR]) {
+			const res = await onRequest(buildContext({ user }), async () => htmlResponse());
+			const html = await res.text();
+			expect(html).not.toContain("emdash-toolbar");
+			expect(res.headers.get("Cache-Control")).toBeNull();
+		}
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Implements the design agreed in Discussion #1742 (labeled *Approved for PR*): a reliable editor toolbar for sites whose public HTML is served through a shared cache (Cloudflare Cache Everything / Workers Cache, Fastly, Varnish, …), where the server-injected toolbar today appears and disappears with cache state.

New `toolbar` config option on `emdash()`:

- **`"server"` (default)** — current behavior, unchanged.
- **`"client"`** — public HTML is byte-identical for every visitor (nothing session-specific is injected, cache headers untouched, so shared caches serve one entry for everyone). A tiny bootstrap script renders an "Edit" pill for browsers that have logged into the admin, based on a **non-secret localStorage flag** set by the admin SPA on login (covers passkey, OAuth, magic link, dev bypass) and cleared on logout. Clicking the pill verifies the real session (`GET /_emdash/api/auth/me`) — logged out goes to the login page — and reloads the page with an **`_edit` query param**, which is always rendered fresh with the full server toolbar and `Cache-Control: private, no-store`. Non-editors opening a shared `?_edit` URL get an early **302 redirect to the canonical URL**, so the param can't leak drafts or prime extra cache entries with page content. The param deliberately does not persist across navigation.
- **`false`** — never render the toolbar or bootstrap.

Additionally (all modes): the toolbar now has a **× dismiss button** (per-browser localStorage flag, cleared the next time an editor opens the admin). Dismissing while edit mode is active also clears the `emdash-edit-mode` cookie so the user isn't stranded in edit mode with no UI.

Preview and edit-mode responses keep rendering server-side with `private, no-store` in every mode, exactly as today.

### Verification

- 10 new unit tests covering all three modes: anonymous/editor variants byte-identical in client mode, `_edit` render is `no-store`, canonical redirect for anonymous and low-role users, stale edit cookie handling, `false` mode, and a syntax check of the generated bootstrap script.
- Verified end to end on the simple demo (Node adapter, dev): anonymous HTML carries only the bootstrap and no cache-header changes; editor HTML without the param is byte-identical to anonymous; the pill appears after admin login, clicking it lands on `?_edit=1` with the full toolbar (`private, no-store`); edit-mode toggle works from there; dismiss hides the pill/toolbar, clears the edit cookie, and un-dismisses on the next admin visit; `?_edit` as anonymous 302s to the canonical URL preserving other params.

### Notes

- The bootstrap is inline `<script>` like the existing toolbar; the docs note the CSP hash requirement for strict policies.
- The localStorage key literals are duplicated between core and the admin package (admin can't import core); both sides carry a pointer comment.
- Docs: new `toolbar` section in the configuration reference, including the caveat that user templates branching on `Astro.locals.user` still fragment the cache on their own.
- The toolbar itself is public-site UI (plain HTML string, not the Lingui'd admin SPA), so the two new strings ("Edit", "Hide toolbar") are English like all existing toolbar strings.

Closes the implementation side of Discussion #1742.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1742

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

`toolbar: "client"`, editor after clicking the Edit pill (page reloaded with `?_edit=1`, full toolbar with the new × dismiss button):

_(see Verification above — 10/10 unit tests pass, live-tested on the simple demo)_