### PR TITLE
fix(admin): surface validation issue details in error messages (#255)

### DIFF
--- a/.changeset/surface-validation-issue-details.md
+++ b/.changeset/surface-validation-issue-details.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes validation errors in the admin showing only a generic "Invalid request data" message. The per-field details (e.g. "name: Too big: expected string to have <=63 characters") are now included, so users can see what to correct.

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -19,18 +19,48 @@ export function apiFetch(input: string | URL | Request, init?: RequestInit): Pro
 }
 
 /**
+ * Extract per-field validation messages from `error.details.issues`
+ * (the shape `parseBody` returns for VALIDATION_ERROR). Returns e.g.
+ * `"name: Too big: expected string to have <=63 characters"`, or
+ * `undefined` when the details don't match that shape.
+ */
+function formatIssueDetails(error: object): string | undefined {
+	if (!("details" in error)) return undefined;
+	const { details } = error;
+	if (typeof details !== "object" || details === null || !("issues" in details)) return undefined;
+	const { issues } = details;
+	if (!Array.isArray(issues)) return undefined;
+	const parts: string[] = [];
+	for (const issue of issues) {
+		if (typeof issue !== "object" || issue === null) continue;
+		const message = "message" in issue && typeof issue.message === "string" ? issue.message : "";
+		if (!message) continue;
+		const path = "path" in issue && typeof issue.path === "string" ? issue.path : "";
+		parts.push(path ? `${path}: ${message}` : message);
+	}
+	return parts.length > 0 ? parts.join("; ") : undefined;
+}
+
+/**
  * Throw an error with the message from the API response body if available,
  * falling back to a generic message. All API error responses use the shape
- * `{ error: { code, message } }`.
+ * `{ error: { code, message, details? } }`. For validation errors the
+ * per-field messages in `details.issues` are appended so the user sees
+ * what to fix instead of a generic "Invalid request data" (#255).
  */
 export async function throwResponseError(res: Response, fallback: string): Promise<never> {
 	const body: unknown = await res.json().catch(() => ({}));
 	let message: string | undefined;
 	if (typeof body === "object" && body !== null && "error" in body) {
 		const { error } = body;
-		if (typeof error === "object" && error !== null && "message" in error) {
-			const { message: errorMessage } = error;
-			if (typeof errorMessage === "string") message = errorMessage;
+		if (typeof error === "object" && error !== null) {
+			if ("message" in error && typeof error.message === "string") {
+				message = error.message;
+			}
+			const issueDetails = formatIssueDetails(error);
+			if (issueDetails) {
+				message = message ? `${message}: ${issueDetails}` : issueDetails;
+			}
 		}
 	}
 	throw new Error(message || `${fallback}: ${res.statusText}`);

--- a/packages/admin/tests/lib/api-client.test.ts
+++ b/packages/admin/tests/lib/api-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { apiFetch, fetchManifest } from "../../src/lib/api/client";
+import { apiFetch, fetchManifest, throwResponseError } from "../../src/lib/api/client";
 
 describe("apiFetch", () => {
 	let fetchSpy: ReturnType<typeof vi.fn>;
@@ -67,5 +67,63 @@ describe("fetchManifest", () => {
 			.fn()
 			.mockResolvedValue(new Response("", { status: 500, statusText: "Internal Server Error" }));
 		await expect(fetchManifest()).rejects.toThrow("Failed to fetch manifest");
+	});
+});
+
+/**
+ * Regression tests for #255: VALIDATION_ERROR responses carry the actual
+ * field problem in `error.details.issues`, but only the generic
+ * `error.message` ("Invalid request data") ever reached the user.
+ */
+describe("throwResponseError", () => {
+	const errorResponse = (error: unknown, status = 400) =>
+		new Response(JSON.stringify({ error }), { status });
+
+	it("uses the server error message when present", async () => {
+		await expect(
+			throwResponseError(errorResponse({ code: "NOT_FOUND", message: "Post not found" }), "Failed"),
+		).rejects.toThrow("Post not found");
+	});
+
+	it("appends validation issue details to the message", async () => {
+		const response = errorResponse({
+			code: "VALIDATION_ERROR",
+			message: "Invalid request data",
+			details: {
+				issues: [{ path: "name", message: "Too big: expected string to have <=63 characters" }],
+			},
+		});
+		await expect(throwResponseError(response, "Failed")).rejects.toThrow(
+			"Invalid request data: name: Too big: expected string to have <=63 characters",
+		);
+	});
+
+	it("joins multiple issues and tolerates missing paths", async () => {
+		const response = errorResponse({
+			code: "VALIDATION_ERROR",
+			message: "Invalid request data",
+			details: {
+				issues: [{ path: "slug", message: "Required" }, { message: "Unrecognized key" }],
+			},
+		});
+		await expect(throwResponseError(response, "Failed")).rejects.toThrow(
+			"Invalid request data: slug: Required; Unrecognized key",
+		);
+	});
+
+	it("ignores malformed details", async () => {
+		const response = errorResponse({
+			code: "VALIDATION_ERROR",
+			message: "Invalid request data",
+			details: { issues: "not-an-array" },
+		});
+		await expect(throwResponseError(response, "Failed")).rejects.toThrow("Invalid request data");
+	});
+
+	it("falls back to statusText when the body is not JSON", async () => {
+		const response = new Response("boom", { status: 500, statusText: "Internal Server Error" });
+		await expect(throwResponseError(response, "Failed")).rejects.toThrow(
+			"Failed: Internal Server Error",
+		);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

When a request fails validation, the server responds with the actual field problem in `error.details.issues` — but the admin's `throwResponseError` only ever surfaced the generic `error.message`, so users saw "Invalid request data" with no hint what to fix (#255's repro: a taxonomy name over 63 characters).

This appends the per-field messages to the thrown error, so every toast/dialog that already displays mutation errors now shows e.g.:

> Invalid request data: name: Too big: expected string to have <=63 characters

One change in the shared helper fixes it for all admin API calls (taxonomies, content, settings, …) — no per-form changes needed. Malformed or missing `details` fall back to the previous behavior.

Closes #255

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a — the surfaced text is the server's message, which is English-only by design for now)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a — bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude (Fable 5)

## Screenshots / test output

5 new regression tests in `api-client.test.ts` (`throwResponseError`: issue details appended, multiple issues joined, missing paths tolerated, malformed details ignored, non-JSON body fallback). The two detail-surfacing tests fail without the fix. Full admin suite: 1062 passed.