### PR TITLE
docs: add email setup guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -74,6 +74,7 @@ export default defineConfig({
 						{ label: "Sections", slug: "guides/sections" },
 						{ label: "Site Settings", slug: "guides/site-settings" },
 						{ label: "Authentication", slug: "guides/authentication" },
+						{ label: "Email Setup", slug: "guides/email" },
 						{ label: "Atmosphere Login", slug: "guides/atmosphere-auth" },
 						{ label: "AI Tools", slug: "guides/ai-tools" },
 						{ label: "x402 Payments", slug: "guides/x402-payments" },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -76,6 +76,7 @@ export default defineConfig({
 						{ label: "Sections", slug: "guides/sections" },
 						{ label: "Site Settings", slug: "guides/site-settings" },
 						{ label: "Authentication", slug: "guides/authentication" },
+						{ label: "Email Setup", slug: "guides/email" },
 						{ label: "Atmosphere Login", slug: "guides/atmosphere-auth" },
 						{ label: "AI Tools", slug: "guides/ai-tools" },
 						{ label: "x402 Payments", slug: "guides/x402-payments" },

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -71,7 +71,7 @@ After setup, returning to the admin panel triggers passkey authentication:
 
 ## Magic Link Fallback
 
-If you can't use your passkey (e.g., lost device), magic links provide an alternative. This requires email to be configured.
+If you can't use your passkey (e.g., lost device), magic links provide an alternative. This requires email to be configured — see [Email Setup](/guides/email/).
 
 <Steps>
 

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -72,7 +72,7 @@ After setup, returning to the admin panel triggers passkey authentication:
 
 ## Log in with a magic link
 
-If you cannot use your passkey, a magic link provides an alternative. The site must have an email provider configured before EmDash can send the link.
+If you cannot use your passkey, a magic link provides an alternative. The site must have an email provider configured before EmDash can send the link — see [Email Setup](/guides/email/).
 
 <Steps>
 

--- a/docs/src/content/docs/guides/email.mdx
+++ b/docs/src/content/docs/guides/email.mdx
@@ -1,0 +1,133 @@
+---
+title: Email Setup
+description: Configure email delivery for magic links, invites, and password recovery — in development and production.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+EmDash uses email for **magic link login**, **user invites**, and **account recovery**. Email delivery is handled by plugins, not by config-file settings — there is no SMTP block in `astro.config.mjs` or `wrangler.jsonc`.
+
+This guide covers how the email pipeline works, what you get out of the box in development, and how to wire up a real provider for production.
+
+## How Email Delivery Works
+
+Every outgoing email flows through a three-stage pipeline:
+
+1. `email:beforeSend` — middleware hooks that can transform or cancel a message
+2. `email:deliver` — **exactly one** provider plugin delivers the message
+3. `email:afterSend` — fire-and-forget hooks for logging or analytics
+
+The delivery step is an [exclusive hook](/reference/hooks/#emaildeliver): a provider plugin registers `email:deliver`, and EmDash routes all mail through it. If no provider is active, features that need email are unavailable — invite links must then be copied and shared manually from the Users page.
+
+You can see the current pipeline state under **Settings → Email** in the admin: whether a provider is active, which plugin it is, any registered middleware, and a **send test email** button that exercises the full pipeline.
+
+## Development: Built-in Console Provider
+
+In development (`astro dev`), EmDash auto-activates a built-in console provider when no other provider is selected. It does not send anything — it logs each email to the terminal and keeps the last 100 messages in memory.
+
+That means magic links and invites work out of the box in dev: request a magic link, then copy the URL from your terminal output. You can also list captured emails at the dev-only endpoint `GET /_emdash/api/dev/emails` (and clear them with `DELETE`).
+
+The console provider is dev-only and never runs in production builds.
+
+## Production: Install a Provider Plugin
+
+For production you need a plugin that registers `email:deliver`. Two routes:
+
+### Option 1: The community `emdash-smtp` plugin
+
+The community-maintained [`emdash-smtp`](https://github.com/masonjames/emdash-smtp) plugin family covers generic SMTP plus hosted providers, including Amazon SES, Brevo, Mailgun, Postmark, Resend, SendGrid, Zoho, and more.
+
+```bash
+pnpm add emdash-smtp
+```
+
+```js title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+import { emdashSmtp } from "emdash-smtp";
+
+export default defineConfig({
+	integrations: [
+		emdash({
+			// ...your database/storage config
+			plugins: [emdashSmtp()],
+		}),
+	],
+});
+```
+
+Provider credentials are configured through the plugin's own settings — see its README for the provider matrix and setup details.
+
+<Aside type="note" title="Cloudflare Workers: prefer HTTP APIs over raw SMTP">
+	Workers cannot open raw SMTP connections on port 25, so on Cloudflare deployments choose an
+	HTTP-based provider (Resend, SendGrid, Mailgun, Postmark, SES via API, …) rather than generic
+	SMTP. HTTP providers are plain `fetch` calls and work on every Workers plan, including the free
+	tier.
+</Aside>
+
+### Option 2: Write your own provider
+
+A provider is a small plugin whose `email:deliver` hook forwards the message to your email service's HTTP API. The message shape is `{ to, subject, text, html? }`; your provider supplies the `from` address:
+
+```ts
+hooks: {
+	"email:deliver": {
+		exclusive: true,
+		handler: async (event) => {
+			const response = await fetch("https://api.resend.com/emails", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${import.meta.env.RESEND_API_KEY}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					from: "My Site <noreply@example.com>",
+					to: event.message.to,
+					subject: event.message.subject,
+					text: event.message.text,
+					html: event.message.html,
+				}),
+			});
+			if (!response.ok) {
+				throw new Error(`Email delivery failed: ${response.status}`);
+			}
+		},
+	},
+},
+```
+
+The hook goes into a regular plugin — see [Your First Native Plugin](/plugins/creating-native-plugins/your-first-native-plugin/) for the packaging (plugins must be a file/package entrypoint; an inline `definePlugin()` in `astro.config.mjs` is not supported). Native providers registering `email:deliver` need the `hooks.email-transport:register` capability.
+
+## Secrets on Cloudflare
+
+Store API keys as Worker secrets, never in `wrangler.jsonc` vars:
+
+```bash
+wrangler secret put RESEND_API_KEY
+```
+
+For local development put the same key in `.env` (note: if a `.dev.vars` file exists, Wrangler ignores `.env` entirely). Read it in code via `import.meta.env.RESEND_API_KEY`.
+
+## Selecting a Provider and Testing
+
+<Steps>
+
+1. Install and activate the provider plugin, then open **Settings → Email** in the admin.
+
+2. If more than one plugin registers `email:deliver`, pick the active provider there — only one delivers at a time.
+
+3. Use **Send test email** to verify the full pipeline end to end. The result surfaces delivery errors directly, which is the fastest way to debug credentials.
+
+</Steps>
+
+## Troubleshooting
+
+- **"No email provider is configured"** — no active plugin registers `email:deliver`. Install and activate a provider, then select it in Settings → Email.
+- **Magic links / invites silently unavailable** — same cause. Without a provider, the Users page still creates invites, but you must copy the invite link manually.
+- **Works in dev, fails in production** — dev uses the built-in console provider, which masks a missing production provider. Check Settings → Email on the deployed site.
+- **Emails land in spam** — configure SPF/DKIM/DMARC for your sending domain at your email provider; this is provider-side, not an EmDash setting.
+
+## Related
+
+- [Authentication](/guides/authentication/) — magic links, invites, and recovery flows that rely on email
+- [Email hooks reference](/reference/hooks/#email-hooks) — `email:beforeSend`, `email:deliver`, `email:afterSend`

--- a/docs/src/content/docs/guides/email.mdx
+++ b/docs/src/content/docs/guides/email.mdx
@@ -11,15 +11,9 @@ This guide covers how the email pipeline works, what you get out of the box in d
 
 ## How Email Delivery Works
 
-Every outgoing email flows through a three-stage pipeline:
+A single active provider plugin delivers all outgoing mail. If no provider is active, features that need email are unavailable — invite links must then be copied and shared manually from the Users page.
 
-1. `email:beforeSend` — middleware hooks that can transform or cancel a message
-2. `email:deliver` — **exactly one** provider plugin delivers the message
-3. `email:afterSend` — fire-and-forget hooks for logging or analytics
-
-The delivery step is an [exclusive hook](/reference/hooks/#emaildeliver): a provider plugin registers `email:deliver`, and EmDash routes all mail through it. If no provider is active, features that need email are unavailable — invite links must then be copied and shared manually from the Users page.
-
-You can see the current pipeline state under **Settings → Email** in the admin: whether a provider is active, which plugin it is, any registered middleware, and a **send test email** button that exercises the full pipeline.
+You can see the current state under **Settings → Email** in the admin: whether a provider is active, which plugin it is, and a **send test email** button that exercises the full pipeline.
 
 ## Development: Built-in Console Provider
 
@@ -30,10 +24,6 @@ That means magic links and invites work out of the box in dev: request a magic l
 The console provider is dev-only and never runs in production builds.
 
 ## Production: Install a Provider Plugin
-
-For production you need a plugin that registers `email:deliver`. Two routes:
-
-### Option 1: The community `emdash-smtp` plugin
 
 The community-maintained [`emdash-smtp`](https://github.com/masonjames/emdash-smtp) plugin family covers generic SMTP plus hosted providers, including Amazon SES, Brevo, Mailgun, Postmark, Resend, SendGrid, Zoho, and more.
 
@@ -65,38 +55,7 @@ Provider credentials are configured through the plugin's own settings — see it
 	tier.
 </Aside>
 
-### Option 2: Write your own provider
-
-A provider is a small plugin whose `email:deliver` hook forwards the message to your email service's HTTP API. The message shape is `{ to, subject, text, html? }`; your provider supplies the `from` address:
-
-```ts
-hooks: {
-	"email:deliver": {
-		exclusive: true,
-		handler: async (event) => {
-			const response = await fetch("https://api.resend.com/emails", {
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${import.meta.env.RESEND_API_KEY}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					from: "My Site <noreply@example.com>",
-					to: event.message.to,
-					subject: event.message.subject,
-					text: event.message.text,
-					html: event.message.html,
-				}),
-			});
-			if (!response.ok) {
-				throw new Error(`Email delivery failed: ${response.status}`);
-			}
-		},
-	},
-},
-```
-
-The hook goes into a regular plugin — see [Your First Native Plugin](/plugins/creating-native-plugins/your-first-native-plugin/) for the packaging (plugins must be a file/package entrypoint; an inline `definePlugin()` in `astro.config.mjs` is not supported). Native providers registering `email:deliver` need the `hooks.email-transport:register` capability.
+If you are a plugin author and want to build a provider for a service that isn't covered, see the [`email:deliver` hook reference](/reference/hooks/#emaildeliver).
 
 ## Secrets on Cloudflare
 
@@ -114,7 +73,7 @@ For local development put the same key in `.env` (note: if a `.dev.vars` file ex
 
 1. Install and activate the provider plugin, then open **Settings → Email** in the admin.
 
-2. If more than one plugin registers `email:deliver`, pick the active provider there — only one delivers at a time.
+2. If more than one provider plugin is installed, pick the active one there — only one delivers at a time.
 
 3. Use **Send test email** to verify the full pipeline end to end. The result surfaces delivery errors directly, which is the fastest way to debug credentials.
 
@@ -122,7 +81,7 @@ For local development put the same key in `.env` (note: if a `.dev.vars` file ex
 
 ## Troubleshooting
 
-- **"No email provider is configured"** — no active plugin registers `email:deliver`. Install and activate a provider, then select it in Settings → Email.
+- **"No email provider is configured"** — no provider plugin is active. Install and activate one, then select it in Settings → Email.
 - **Magic links / invites silently unavailable** — same cause. Without a provider, the Users page still creates invites, but you must copy the invite link manually.
 - **Works in dev, fails in production** — dev uses the built-in console provider, which masks a missing production provider. Check Settings → Email on the deployed site.
 - **Emails land in spam** — configure SPF/DKIM/DMARC for your sending domain at your email provider; this is provider-side, not an EmDash setting.

--- a/docs/src/content/docs/guides/email.mdx
+++ b/docs/src/content/docs/guides/email.mdx
@@ -55,8 +55,6 @@ Provider credentials are configured through the plugin's own settings — see it
 	tier.
 </Aside>
 
-If you are a plugin author and want to build a provider for a service that isn't covered, see the [`email:deliver` hook reference](/reference/hooks/#emaildeliver).
-
 ## Secrets on Cloudflare
 
 Store API keys as Worker secrets, never in `wrangler.jsonc` vars:

--- a/docs/src/content/docs/guides/email.mdx
+++ b/docs/src/content/docs/guides/email.mdx
@@ -1,11 +1,11 @@
 ---
 title: Email Setup
-description: Configure email delivery for magic links, invites, and password recovery — in development and production.
+description: Configure email delivery for magic links, invites, and account recovery — in development and production.
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Steps } from "@astrojs/starlight/components";
 
-EmDash uses email for **magic link login**, **user invites**, and **account recovery**. Email delivery is handled by plugins, not by config-file settings — there is no SMTP block in `astro.config.mjs` or `wrangler.jsonc`.
+EmDash uses email for **magic link login**, **user invites**, and **account recovery**. A provider plugin delivers the mail; you choose and configure the provider by installing its plugin.
 
 This guide covers how the email pipeline works, what you get out of the box in development, and how to wire up a real provider for production.
 
@@ -25,11 +25,19 @@ The console provider is dev-only and never runs in production builds.
 
 ## Production: Install a Provider Plugin
 
+### Cloudflare Workers
+
+On Cloudflare, use the `cloudflareEmail()` plugin from `@emdash-cms/cloudflare/plugins`. It sends through Cloudflare Email Sending over a `send_email` Worker binding, so it needs no external account or API key. The [Cloudflare deployment guide](/deployment/cloudflare/#email) walks through onboarding the sender domain, adding the binding, and registering the plugin.
+
+### Node and other platforms
+
 The community-maintained [`emdash-smtp`](https://github.com/masonjames/emdash-smtp) plugin family covers generic SMTP plus hosted providers, including Amazon SES, Brevo, Mailgun, Postmark, Resend, SendGrid, Zoho, and more.
 
 ```bash
 pnpm add emdash-smtp
 ```
+
+The following configuration registers the plugin with EmDash:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from "astro/config";
@@ -48,22 +56,11 @@ export default defineConfig({
 
 Provider credentials are configured through the plugin's own settings — see its README for the provider matrix and setup details.
 
-<Aside type="note" title="Cloudflare Workers: prefer HTTP APIs over raw SMTP">
-	Workers cannot open raw SMTP connections on port 25, so on Cloudflare deployments choose an
-	HTTP-based provider (Resend, SendGrid, Mailgun, Postmark, SES via API, …) rather than generic
-	SMTP. HTTP providers are plain `fetch` calls and work on every Workers plan, including the free
-	tier.
-</Aside>
+## Where provider credentials live
 
-## Secrets on Cloudflare
+Provider plugins declare their API keys and passwords as plugin settings. Enter them on the plugin's settings page in the admin; EmDash stores them in the database alongside other plugin settings, and rotating a key means pasting the new value there. [Secrets & Key Management](/deployment/secrets/#plugin-secrets) describes the storage and its caveats.
 
-Store API keys as Worker secrets, never in `wrangler.jsonc` vars:
-
-```bash
-wrangler secret put RESEND_API_KEY
-```
-
-For local development put the same key in `.env` (note: if a `.dev.vars` file exists, Wrangler ignores `.env` entirely). Read it in code via `process.env.RESEND_API_KEY` — never `import.meta.env`, which is inlined at build time and would bake the build machine's value into the bundle.
+Whether a plugin can read a deployment secret (`wrangler secret put`, `.env`) instead depends on its format, so follow its README. Sandboxed plugins cannot access `process.env` or platform bindings. A native plugin can read `process.env`; it must not use `import.meta.env`, which is inlined at build time and bakes the build machine's value into the bundle.
 
 ## Selecting a Provider and Testing
 

--- a/docs/src/content/docs/guides/email.mdx
+++ b/docs/src/content/docs/guides/email.mdx
@@ -1,0 +1,90 @@
+---
+title: Email Setup
+description: Configure email delivery for magic links, invites, and password recovery — in development and production.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+EmDash uses email for **magic link login**, **user invites**, and **account recovery**. Email delivery is handled by plugins, not by config-file settings — there is no SMTP block in `astro.config.mjs` or `wrangler.jsonc`.
+
+This guide covers how the email pipeline works, what you get out of the box in development, and how to wire up a real provider for production.
+
+## How Email Delivery Works
+
+A single active provider plugin delivers all outgoing mail. If no provider is active, features that need email are unavailable — invite links must then be copied and shared manually from the Users page.
+
+You can see the current state under **Settings → Email** in the admin: whether a provider is active, which plugin it is, and a **send test email** button that exercises the full pipeline.
+
+## Development: Built-in Console Provider
+
+In development (`astro dev`), EmDash auto-activates a built-in console provider when no other provider is selected. It does not send anything — it logs each email to the terminal and keeps the last 100 messages in memory.
+
+That means magic links and invites work out of the box in dev: request a magic link, then copy the URL from your terminal output. You can also list captured emails at the dev-only endpoint `GET /_emdash/api/dev/emails` (and clear them with `DELETE`).
+
+The console provider is dev-only and never runs in production builds.
+
+## Production: Install a Provider Plugin
+
+The community-maintained [`emdash-smtp`](https://github.com/masonjames/emdash-smtp) plugin family covers generic SMTP plus hosted providers, including Amazon SES, Brevo, Mailgun, Postmark, Resend, SendGrid, Zoho, and more.
+
+```bash
+pnpm add emdash-smtp
+```
+
+```js title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+import { emdashSmtp } from "emdash-smtp";
+
+export default defineConfig({
+	integrations: [
+		emdash({
+			// ...your database/storage config
+			plugins: [emdashSmtp()],
+		}),
+	],
+});
+```
+
+Provider credentials are configured through the plugin's own settings — see its README for the provider matrix and setup details.
+
+<Aside type="note" title="Cloudflare Workers: prefer HTTP APIs over raw SMTP">
+	Workers cannot open raw SMTP connections on port 25, so on Cloudflare deployments choose an
+	HTTP-based provider (Resend, SendGrid, Mailgun, Postmark, SES via API, …) rather than generic
+	SMTP. HTTP providers are plain `fetch` calls and work on every Workers plan, including the free
+	tier.
+</Aside>
+
+## Secrets on Cloudflare
+
+Store API keys as Worker secrets, never in `wrangler.jsonc` vars:
+
+```bash
+wrangler secret put RESEND_API_KEY
+```
+
+For local development put the same key in `.env` (note: if a `.dev.vars` file exists, Wrangler ignores `.env` entirely). Read it in code via `process.env.RESEND_API_KEY` — never `import.meta.env`, which is inlined at build time and would bake the build machine's value into the bundle.
+
+## Selecting a Provider and Testing
+
+<Steps>
+
+1. Install and activate the provider plugin, then open **Settings → Email** in the admin.
+
+2. If more than one provider plugin is installed, pick the active one there — only one delivers at a time.
+
+3. Use **Send test email** to verify the full pipeline end to end. The result surfaces delivery errors directly, which is the fastest way to debug credentials.
+
+</Steps>
+
+## Troubleshooting
+
+- **"No email provider is configured"** — no provider plugin is active. Install and activate one, then select it in Settings → Email.
+- **Magic links / invites silently unavailable** — same cause. Without a provider, the Users page still creates invites, but you must copy the invite link manually.
+- **Works in dev, fails in production** — dev uses the built-in console provider, which masks a missing production provider. Check Settings → Email on the deployed site.
+- **Emails land in spam** — configure SPF/DKIM/DMARC for your sending domain at your email provider; this is provider-side, not an EmDash setting.
+
+## Related
+
+- [Authentication](/guides/authentication/) — magic links, invites, and recovery flows that rely on email
+- [Email hooks reference](/reference/hooks/#email-hooks) — `email:beforeSend`, `email:deliver`, `email:afterSend`


### PR DESCRIPTION
## What does this PR do?

Adds a site-owner-facing **Email Setup** guide (`/guides/email/`), closing the docs gap from #802. The reporter there couldn't figure out where SMTP credentials go — `astro.config.mjs`? `wrangler.jsonc`? a plugin? — because the answer ("email is delivered by provider plugins registering the exclusive `email:deliver` hook, not by config-file settings") was only documented from the plugin-author perspective in the hooks reference.

The new guide covers:

- How the three-stage email pipeline works and what email powers (magic links, invites, recovery)
- **Development**: the built-in console provider (auto-active in dev, logs to terminal, dev-only `/_emdash/api/dev/emails` endpoint) — magic links work out of the box locally
- **Production**: the community [`emdash-smtp`](https://github.com/masonjames/emdash-smtp) plugin family, or writing a minimal custom provider against an HTTP email API
- **Cloudflare specifics**: prefer HTTP-based providers over raw SMTP on Workers; store API keys with `wrangler secret put`; the `.dev.vars`-wins-over-`.env` gotcha
- Selecting the active provider and using the test-email button in Settings → Email
- Troubleshooting (no provider configured, works-in-dev-only, spam/SPF)

Also adds the guide to the docs sidebar (after Authentication) and cross-links it from the Authentication guide's magic-link section.

Content was verified against the actual implementation (`packages/core/src/plugins/email.ts`, `email-console.ts`, `astro/routes/api/settings/email.ts`, `astro/routes/api/dev/emails.ts`).

Closes #802 (the second, actionable half of it — the Firefox passkey report there is vague/stale; a fresh issue with repro steps would be the way to pursue that separately).

## Type of change

- [x] Documentation

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (n/a — docs-only change)
- [x] `pnpm lint` passes (n/a — docs-only change)
- [x] `pnpm test` passes (or targeted tests for my change) (docs build passes: `pnpm --filter docs build`)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, docs
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, docs
- [ ] I have added a changeset (if this PR changes a published package) — n/a, docs only
- [ ] New features link to an approved Discussion — n/a, docs

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude (Fable 5)