### PR TITLE
fix(plugin-audit-log): declare capabilities required by registered hooks (#1263)

### DIFF
--- a/.changeset/audit-log-declare-hook-capabilities.md
+++ b/.changeset/audit-log-declare-hook-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-audit-log": patch
+---
+
+Fixes create/update and media-upload events missing from the audit log. The plugin now declares the `content:write` and `media:read` capabilities its `content:beforeSave` and `media:afterUpload` hooks require — previously the hook pipeline silently skipped both hooks, so only deletes were recorded.

--- a/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
+++ b/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
@@ -36,7 +36,8 @@ function loadManifest(): { capabilities: string[] } {
 		const c = raw[i]!;
 		if (inString) {
 			out += c;
-			if (c === "\\") out += raw[++i] ?? ""; // keep the escaped char verbatim
+			if (c === "\\")
+				out += raw[++i] ?? ""; // keep the escaped char verbatim
 			else if (c === '"') inString = false;
 			i++;
 			continue;

--- a/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
+++ b/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
@@ -12,6 +12,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { HookPipeline } from "../../../src/plugins/hooks.js";
@@ -78,9 +79,7 @@ describe("audit-log manifest capabilities (#1263)", () => {
 			for (const name of hookNames) {
 				expect(registered, `hook "${name}" was skipped`).toContain(name);
 			}
-			const skips = warn.mock.calls.filter(([msg]) =>
-				String(msg).includes("without"),
-			);
+			const skips = warn.mock.calls.filter(([msg]) => String(msg).includes("without"));
 			expect(skips).toEqual([]);
 		} finally {
 			warn.mockRestore();

--- a/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
+++ b/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for #1263: the audit-log plugin's manifest must keep
+ * declaring every capability its registered hooks require. The hook
+ * pipeline silently skips hooks whose capability is missing, so an
+ * under-declaring manifest doesn't fail loudly — audit entries just
+ * stop being written.
+ *
+ * Instead of hardcoding the hook → capability map, this test feeds the
+ * real manifest capabilities and the real hook names from the plugin
+ * source into HookPipeline and asserts nothing gets skipped.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { HookPipeline } from "../../../src/plugins/hooks.js";
+import type { ResolvedPlugin } from "../../../src/plugins/types.js";
+
+const PLUGIN_DIR = join(__dirname, "../../../../plugins/audit-log");
+
+/**
+ * Parse the JSONC manifest. Good enough for this manifest's shape
+ * (comments and trailing commas, no `//` inside string values other
+ * than after `:` as in URLs); the real loader in plugin-cli uses
+ * jsonc-parser, which isn't a core dependency.
+ */
+function loadManifest(): { capabilities: string[] } {
+	const raw = readFileSync(join(PLUGIN_DIR, "emdash-plugin.jsonc"), "utf8");
+	const withoutComments = raw
+		.replace(/\/\*[\s\S]*?\*\//g, "")
+		.replace(/^\s*\/\/.*$/gm, "")
+		.replace(/([^:"])\/\/.*$/gm, "$1")
+		.replace(/,(\s*[}\]])/g, "$1");
+	return JSON.parse(withoutComments) as { capabilities: string[] };
+}
+
+/** Hook names the plugin actually registers, from its default export. */
+async function loadHookNames(): Promise<string[]> {
+	const mod = (await import(join(PLUGIN_DIR, "src/plugin.ts"))) as {
+		default: { hooks: Record<string, unknown> };
+	};
+	return Object.keys(mod.default.hooks);
+}
+
+describe("audit-log manifest capabilities (#1263)", () => {
+	it("declares every capability its registered hooks require", async () => {
+		const manifest = loadManifest();
+		const hookNames = await loadHookNames();
+
+		// Sanity: the hooks this regression is about are actually registered.
+		expect(hookNames).toContain("content:beforeSave");
+		expect(hookNames).toContain("media:afterUpload");
+
+		const plugin: ResolvedPlugin = {
+			id: "audit-log",
+			version: "0.0.0-test",
+			capabilities: manifest.capabilities as ResolvedPlugin["capabilities"],
+			allowedHosts: [],
+			storage: {},
+			admin: { pages: [], widgets: [] },
+			hooks: Object.fromEntries(
+				hookNames.map((name) => [
+					name,
+					{ pluginId: "audit-log", handler: vi.fn(), priority: 10, dependencies: [] },
+				]),
+			) as ResolvedPlugin["hooks"],
+			routes: {},
+		};
+
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const pipeline = new HookPipeline([plugin]);
+			const registered = pipeline.getRegisteredHooks();
+
+			// Every hook the plugin declares must survive registration —
+			// a skipped hook means the manifest under-declares capabilities.
+			for (const name of hookNames) {
+				expect(registered, `hook "${name}" was skipped`).toContain(name);
+			}
+			const skips = warn.mock.calls.filter(([msg]) =>
+				String(msg).includes("without"),
+			);
+			expect(skips).toEqual([]);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});

--- a/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
+++ b/packages/core/tests/unit/plugins/audit-log-manifest.test.ts
@@ -11,34 +11,63 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { describe, expect, it, vi } from "vitest";
 
 import { HookPipeline } from "../../../src/plugins/hooks.js";
 import type { ResolvedPlugin } from "../../../src/plugins/types.js";
 
-const PLUGIN_DIR = join(__dirname, "../../../../plugins/audit-log");
+const PLUGIN_DIR = join(dirname(fileURLToPath(import.meta.url)), "../../../../plugins/audit-log");
 
 /**
- * Parse the JSONC manifest. Good enough for this manifest's shape
- * (comments and trailing commas, no `//` inside string values other
- * than after `:` as in URLs); the real loader in plugin-cli uses
+ * Strip JSONC comments and trailing commas with a char scanner that
+ * tracks string state, so a `//` or `/*` inside a string value (e.g. a
+ * URL) is never treated as a comment. The real loader in plugin-cli uses
  * jsonc-parser, which isn't a core dependency.
  */
 function loadManifest(): { capabilities: string[] } {
 	const raw = readFileSync(join(PLUGIN_DIR, "emdash-plugin.jsonc"), "utf8");
-	const withoutComments = raw
-		.replace(/\/\*[\s\S]*?\*\//g, "")
-		.replace(/^\s*\/\/.*$/gm, "")
-		.replace(/([^:"])\/\/.*$/gm, "$1")
-		.replace(/,(\s*[}\]])/g, "$1");
-	return JSON.parse(withoutComments) as { capabilities: string[] };
+	let out = "";
+	let i = 0;
+	let inString = false;
+	while (i < raw.length) {
+		const c = raw[i]!;
+		if (inString) {
+			out += c;
+			if (c === "\\") out += raw[++i] ?? ""; // keep the escaped char verbatim
+			else if (c === '"') inString = false;
+			i++;
+			continue;
+		}
+		if (c === '"') {
+			inString = true;
+			out += c;
+			i++;
+			continue;
+		}
+		if (c === "/" && raw[i + 1] === "/") {
+			while (i < raw.length && raw[i] !== "\n") i++;
+			continue;
+		}
+		if (c === "/" && raw[i + 1] === "*") {
+			i += 2;
+			while (i < raw.length && !(raw[i] === "*" && raw[i + 1] === "/")) i++;
+			i += 2;
+			continue;
+		}
+		out += c;
+		i++;
+	}
+	// Trailing commas are safe to drop now that no string content remains.
+	out = out.replace(/,(\s*[}\]])/g, "$1");
+	return JSON.parse(out) as { capabilities: string[] };
 }
 
 /** Hook names the plugin actually registers, from its default export. */
 async function loadHookNames(): Promise<string[]> {
-	const mod = (await import(join(PLUGIN_DIR, "src/plugin.ts"))) as {
+	const mod = (await import(pathToFileURL(join(PLUGIN_DIR, "src/plugin.ts")).href)) as {
 		default: { hooks: Record<string, unknown> };
 	};
 	return Object.keys(mod.default.hooks);
@@ -84,5 +113,12 @@ describe("audit-log manifest capabilities (#1263)", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+
+	it("loadManifest leaves string contents with comment markers intact", () => {
+		// A URL inside a string must survive comment stripping — regression
+		// guard for the scanner misreading `//` in "https://…" as a comment.
+		const parsed = loadManifest();
+		expect(Array.isArray(parsed.capabilities)).toBe(true);
 	});
 });

--- a/packages/plugins/audit-log/emdash-plugin.jsonc
+++ b/packages/plugins/audit-log/emdash-plugin.jsonc
@@ -9,10 +9,14 @@
 	"security": { "url": "https://github.com/emdash-cms/emdash/security/advisories/new" },
 	"description": "Tracks content and media changes (create / update / delete) for compliance and debugging.",
 
-	// Trust contract. Reads content to capture before-state in
-	// update audit entries; declares the `entries` storage collection
-	// where audit log lives. No outbound network.
-	"capabilities": ["content:read"],
+	// Trust contract. Reads content to capture before-state in update
+	// audit entries. `content:write` is required by the content:beforeSave
+	// hook (it can mutate content — this plugin only observes and returns
+	// the event unchanged) and `media:read` by media:afterUpload; without
+	// them the hook pipeline silently skips those hooks. Declares the
+	// `entries` storage collection where the audit log lives. No outbound
+	// network.
+	"capabilities": ["content:read", "content:write", "media:read"],
 	"allowedHosts": [],
 	"storage": {
 		"entries": { "indexes": ["timestamp", "action", "resourceType", "collection"] },


### PR DESCRIPTION
## What does this PR do?

Fixes #1263: `@emdash-cms/plugin-audit-log` declares only `content:read` in its manifest, but registers hooks gated on more:

- `content:beforeSave` requires `content:write` (the hook *can* mutate content — this plugin only observes and returns the event unchanged, but the gate is on the hook, not the handler's behavior)
- `media:afterUpload` requires `media:read`

The hook pipeline enforces this via its capability map (`packages/core/src/plugins/hooks.ts`) and **silently skips** under-declared hooks, exactly as the boot warnings in the issue show. Net effect: only deletes were audited — creates, updates, and media uploads never reached the log. A commenter confirmed this still reproduces on emdash 0.27.0 with the latest published plugin (0.2.0).

The fix adds the two missing capabilities to `emdash-plugin.jsonc` (the single source of truth — the plugin-cli build propagates it into `dist/index.mjs` and `dist/manifest.json`, verified locally) and documents in the trust-contract comment why `content:write` is needed for a read-only observer. Also captures the design question from the issue for the maintainers: if a read-only "observe saves" tier is ever wanted, that would be a core hook-map change, not a plugin change — this PR takes the minimal path of declaring what the current contract requires.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (config-only change; plugin package builds clean)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) (no test change needed — manifest config; plugin-cli build validates the manifest and was run locally)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, declarative manifest fix; the enforcement logic in core is already tested
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a
- [x] I have added a changeset (if this PR changes a published package) — patch for `@emdash-cms/plugin-audit-log`
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude (Fable 5)

## Screenshots / test output

Built artifacts after the fix:

```
dist/manifest.json:
  "capabilities": [
    "content:read",
    "content:write",
    "media:read"
  ],
```