### PR TITLE
fix(core): plugin storage where-filters fail on Postgres with boolean = integer (#920)

### DIFF
--- a/.changeset/fix-plugin-storage-postgres-filters.md
+++ b/.changeset/fix-plugin-storage-postgres-filters.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes plugin storage `query()` and `count()` failing on PostgreSQL with "operator does not exist: boolean = integer" whenever a `where` filter was supplied.

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -215,17 +215,23 @@ export function binaryType(db: Kysely<any>): ColumnDataType {
 }
 
 /**
- * SQL expression for extracting a field from a JSON/JSONB column.
+ * SQL expression for extracting a field from a JSON column stored as text.
  *
  * sqlite:   json_extract(column, '$.path')
- * postgres: column->>'path'
+ * postgres: (column)::jsonb->>'path'
+ *
+ * The Postgres cast is required because JSON columns (e.g.
+ * `_plugin_storage.data`) are `text`, and `text ->> unknown` is not an
+ * operator. The cast is immutable, so the same expression works in
+ * expression indexes — queries and indexes must build it through this
+ * helper so the planner can match them.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function jsonExtractExpr(db: Kysely<any>, column: string, path: string): string {
 	validateIdentifier(column, "JSON column name");
 	validateJsonFieldName(path, "JSON path");
 	if (isPostgres(db)) {
-		return `${column}->>'${path}'`;
+		return `(${column})::jsonb->>'${path}'`;
 	}
 	return `json_extract(${column}, '$.${path}')`;
 }

--- a/packages/core/src/database/repositories/plugin-storage.ts
+++ b/packages/core/src/database/repositories/plugin-storage.ts
@@ -302,7 +302,8 @@ export class PluginStorageRepository<T = unknown> implements StorageCollection<T
 		}
 
 		const result = await query.executeTakeFirst();
-		return result?.count ?? 0;
+		// Number() because the pg driver returns COUNT(*) (bigint) as a string.
+		return Number(result?.count ?? 0);
 	}
 }
 

--- a/packages/core/src/database/repositories/plugin-storage.ts
+++ b/packages/core/src/database/repositories/plugin-storage.ts
@@ -7,7 +7,7 @@
  * @see PLUGIN-SYSTEM.md § Plugin Storage > Full API Reference
  */
 
-import type { Kysely } from "kysely";
+import type { Kysely, RawBuilder } from "kysely";
 import { sql } from "kysely";
 
 import {
@@ -26,6 +26,26 @@ import type {
 import { withTransaction } from "../transaction.js";
 import type { Database } from "../types.js";
 import { encodeCursor, decodeCursor } from "./types.js";
+
+/**
+ * Interleave a `?`-placeholder SQL string with its params into a single
+ * boolean raw expression. Used as a WHERE predicate directly — wrapping it
+ * in `(...) = 1` breaks on Postgres, which has a strict boolean type (#920).
+ */
+function rawWhereExpr(sqlText: string, params: unknown[]): RawBuilder<boolean> {
+	const parts: ReturnType<typeof sql>[] = [];
+	let paramIndex = 0;
+	const sqlParts = sqlText.split("?");
+	for (let i = 0; i < sqlParts.length; i++) {
+		if (i > 0) {
+			parts.push(sql`${params[paramIndex++]}`);
+		}
+		if (sqlParts[i]) {
+			parts.push(sql.raw(sqlParts[i]));
+		}
+	}
+	return sql<boolean>`(${sql.join(parts, sql.raw(""))})`;
+}
 
 /**
  * Plugin Storage Repository
@@ -211,19 +231,7 @@ export class PluginStorageRepository<T = unknown> implements StorageCollection<T
 		// Add JSON extraction WHERE conditions
 		const whereResult = buildWhereClause(this.db, where);
 		if (whereResult.sql) {
-			// Use sql template to add the raw WHERE conditions with params
-			const whereSqlParts: ReturnType<typeof sql>[] = [];
-			let paramIndex = 0;
-			const sqlParts = whereResult.sql.split("?");
-			for (let i = 0; i < sqlParts.length; i++) {
-				if (i > 0) {
-					whereSqlParts.push(sql`${whereResult.params[paramIndex++]}`);
-				}
-				if (sqlParts[i]) {
-					whereSqlParts.push(sql.raw(sqlParts[i]));
-				}
-			}
-			query = query.where(({ eb }) => eb(sql.join(whereSqlParts, sql.raw("")), "=", sql.raw("1")));
+			query = query.where(rawWhereExpr(whereResult.sql, whereResult.params));
 		}
 
 		// Handle cursor-based pagination — throws on invalid cursor.
@@ -289,21 +297,7 @@ export class PluginStorageRepository<T = unknown> implements StorageCollection<T
 		if (where && Object.keys(where).length > 0) {
 			const whereResult = buildWhereClause(this.db, where);
 			if (whereResult.sql) {
-				// Use sql template to add the raw WHERE conditions with params
-				const whereSqlParts: ReturnType<typeof sql>[] = [];
-				let paramIndex = 0;
-				const sqlParts = whereResult.sql.split("?");
-				for (let i = 0; i < sqlParts.length; i++) {
-					if (i > 0) {
-						whereSqlParts.push(sql`${whereResult.params[paramIndex++]}`);
-					}
-					if (sqlParts[i]) {
-						whereSqlParts.push(sql.raw(sqlParts[i]));
-					}
-				}
-				query = query.where(({ eb }) =>
-					eb(sql.join(whereSqlParts, sql.raw("")), "=", sql.raw("1")),
-				);
+				query = query.where(rawWhereExpr(whereResult.sql, whereResult.params));
 			}
 		}
 

--- a/packages/core/tests/integration/plugins/storage-dialect.test.ts
+++ b/packages/core/tests/integration/plugins/storage-dialect.test.ts
@@ -56,7 +56,7 @@ describeEachDialect("plugin storage filtered query/count (#920)", (dialect) => {
 		await seed(repo);
 
 		const result = await repo.query({ where: { provider: "resend" } });
-		expect(result.items.map((i) => i.id).sort()).toEqual(["p1", "p3"]);
+		expect(result.items.map((i) => i.id).toSorted()).toEqual(["p1", "p3"]);
 	});
 
 	it("query() combines where with orderBy", async () => {
@@ -75,7 +75,7 @@ describeEachDialect("plugin storage filtered query/count (#920)", (dialect) => {
 		await seed(repo);
 
 		const result = await repo.query({ where: { priority: { gt: 1 } } });
-		expect(result.items.map((i) => i.id).sort()).toEqual(["p2", "p3"]);
+		expect(result.items.map((i) => i.id).toSorted()).toEqual(["p2", "p3"]);
 	});
 
 	it("count() with a where filter counts matching documents", async () => {

--- a/packages/core/tests/integration/plugins/storage-dialect.test.ts
+++ b/packages/core/tests/integration/plugins/storage-dialect.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Plugin storage query/count with `where` filters, on both dialects (#920).
+ *
+ * The filtered paths wrapped the JSON-extraction predicate in `(...) = 1`.
+ * SQLite coerces booleans to integers so that worked, but Postgres has a
+ * strict boolean type and rejected every filtered list()/count() with
+ * "operator does not exist: boolean = integer". This runs the filtered
+ * paths end-to-end on both dialects to guard the predicate shape.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { PluginStorageRepository } from "../../../src/database/repositories/plugin-storage.js";
+import type { Database } from "../../../src/database/types.js";
+import {
+	type DialectTestContext,
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+} from "../../utils/test-db.js";
+
+interface ProviderDoc {
+	provider: string;
+	active: boolean;
+	priority: number;
+}
+
+describeEachDialect("plugin storage filtered query/count (#920)", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+	});
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	function makeRepo() {
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- dialect context db vs Database type
+		const db = ctx.db as unknown as Kysely<Database>;
+		return new PluginStorageRepository<ProviderDoc>(db, "emdash-smtp", "providers", [
+			"provider",
+			"priority",
+		]);
+	}
+
+	async function seed(repo: PluginStorageRepository<ProviderDoc>) {
+		await repo.put("p1", { provider: "resend", active: true, priority: 1 });
+		await repo.put("p2", { provider: "sendgrid", active: false, priority: 2 });
+		await repo.put("p3", { provider: "resend", active: false, priority: 3 });
+	}
+
+	it("query() with a where filter returns matching documents", async () => {
+		const repo = makeRepo();
+		await seed(repo);
+
+		const result = await repo.query({ where: { provider: "resend" } });
+		expect(result.items.map((i) => i.id).sort()).toEqual(["p1", "p3"]);
+	});
+
+	it("query() combines where with orderBy", async () => {
+		const repo = makeRepo();
+		await seed(repo);
+
+		const result = await repo.query({
+			where: { provider: "resend" },
+			orderBy: { priority: "desc" },
+		});
+		expect(result.items.map((i) => i.id)).toEqual(["p3", "p1"]);
+	});
+
+	it("query() supports operator objects in where", async () => {
+		const repo = makeRepo();
+		await seed(repo);
+
+		const result = await repo.query({ where: { priority: { gt: 1 } } });
+		expect(result.items.map((i) => i.id).sort()).toEqual(["p2", "p3"]);
+	});
+
+	it("count() with a where filter counts matching documents", async () => {
+		const repo = makeRepo();
+		await seed(repo);
+
+		expect(await repo.count({ provider: "resend" })).toBe(2);
+		expect(await repo.count({ provider: "sendgrid" })).toBe(1);
+		expect(await repo.count({ provider: "nope" })).toBe(0);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #920: on PostgreSQL, every plugin storage `query()` / `count()` call with a `where` filter failed with `operator does not exist: boolean = integer` (reported via `emdash-smtp`, whose provider lookups filter storage).

Root cause: `PluginStorageRepository` fit the raw JSON-extraction predicate into Kysely's binary `eb(lhs, "=", rhs)` by wrapping it as `(json_extract(...) = ?) = 1`. SQLite coerces booleans to integers so the extra `= 1` was harmless there; Postgres has a strict boolean type and rejects the comparison outright — so filtered reads never worked on PG.

Fix: pass the predicate directly to `.where()` as a boolean raw expression (`rawWhereExpr` helper, shared by `query()` and `count()`), keeping the existing `?`-placeholder parameterization intact. No SQL semantics change on SQLite.

Tests: new `storage-dialect.test.ts` runs the filtered query/count paths end-to-end via `describeEachDialect`, so the regression is exercised against real Postgres in CI's PG job (equality filters, `where` + `orderBy`, range filters, filtered counts). Verified green on SQLite locally; I don't have a local Postgres, so relying on the CI PG matrix for the dialect that actually regressed — the failure mode is deterministic (the old SQL is a hard type error on PG).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — plugin storage unit + integration suites
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a
- [x] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude (Fable 5)

## Screenshots / test output

```
 Test Files  6 passed (6)
      Tests  116 passed (116)   (integration/plugins, SQLite)
 Test Files  1 passed (1)
      Tests  30 passed (30)     (unit plugin-storage)
```