### PR TITLE
docs: document rendering SEO panel data via getSeoMeta (#1518)

### DIFF
--- a/docs/src/content/docs/guides/querying-content.mdx
+++ b/docs/src/content/docs/guides/querying-content.mdx
@@ -196,6 +196,40 @@ interface ContentEntry<T> {
 
 The `data` object within `entry` contains all fields defined for the content type. The `edit` proxy provides visual editing annotations (see below).
 
+## Rendering SEO Panel Data
+
+For collections with `supports: ["seo"]`, editors can set an SEO title, meta description, OG image, canonical URL, and a "hide from search engines" (noindex) toggle in the admin's SEO panel. That data is delivered on the entry as `entry.data.seo` — but it only reaches the rendered page if your template emits it. Use `getSeoMeta` to resolve the panel fields (with sensible fallbacks to `data.title` / `data.excerpt`) into ready-to-render meta tags:
+
+```astro title="src/pages/posts/[...slug].astro"
+---
+import { getEmDashEntry, getSeoMeta } from "emdash";
+
+const { entry } = await getEmDashEntry("posts", Astro.params.slug);
+if (!entry) return Astro.redirect("/404");
+
+const seo = getSeoMeta(entry, {
+  siteTitle: "My Site",
+  siteUrl: "https://example.com",
+  path: Astro.url.pathname,
+});
+---
+
+<head>
+  <title>{seo.title}</title>
+  {seo.description && <meta name="description" content={seo.description} />}
+  {seo.ogImage && <meta property="og:image" content={seo.ogImage} />}
+  {seo.canonical && <link rel="canonical" href={seo.canonical} />}
+  {seo.robots && <meta name="robots" content={seo.robots} />}
+</head>
+```
+
+<Aside type="caution">
+	Templates that hand-roll meta tags from `data.title` / `data.excerpt` silently bypass the
+	entire SEO panel — including the noindex toggle, which is an indexing risk, not just
+	cosmetic. Every detail-page template for an SEO-enabled collection should render through
+	`getSeoMeta` (or read the raw fields via `getContentSeo`).
+</Aside>
+
 ## Preview Mode
 
 EmDash handles preview automatically via middleware. When a URL contains a valid `_preview` token, the middleware verifies it and sets up the request context. Your query functions then serve draft content without any special parameters:

--- a/docs/src/content/docs/guides/querying-content.mdx
+++ b/docs/src/content/docs/guides/querying-content.mdx
@@ -204,7 +204,10 @@ For collections with `supports: ["seo"]`, editors can set an SEO title, meta des
 ---
 import { getEmDashEntry, getSeoMeta } from "emdash";
 
-const { entry } = await getEmDashEntry("posts", Astro.params.slug);
+const { entry, error } = await getEmDashEntry("posts", Astro.params.slug);
+if (error) {
+  return new Response("Server error", { status: 500 });
+}
 if (!entry) return Astro.redirect("/404");
 
 const seo = getSeoMeta(entry, {


### PR DESCRIPTION
## What does this PR do?

Addresses the documentation half of #1518. The SEO panel's data has been reachable on the render path since #1285 (`entry.data.seo`), but `getSeoMeta` / `getContentSeo` were documented nowhere in the public docs — only in the in-repo agent skill references. So the footgun in #1518 stands: a template that hand-rolls `<title>`/`<meta>` from `data.title` silently bypasses the entire panel, including the noindex toggle.

This adds a "Rendering SEO Panel Data" section to the Querying Content guide with a complete `getSeoMeta` example (title/description/OG image/canonical/robots) and a caution box calling out that every detail-page template for an SEO-enabled collection must render through it.

It deliberately does *not* attempt the "warn the editor in the admin when the template doesn't consume SEO" idea from the issue — detecting template wiring from the server is a design discussion, not a docs fix.

## Type of change

- [x] Documentation update

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — docs only
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, docs
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a
- [ ] I have added a changeset (if this PR changes a published package) — n/a, docs
- [ ] New features link to an approved Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude (Fable 5)

## Screenshots / test output

n/a — docs. Example verified against the actual `SeoMetaOptions` / `SeoMeta` shapes in `packages/core/src/seo/index.ts`.