### PR TITLE
fix: render and edit consecutive blockquote blocks as one quote

### DIFF
--- a/.changeset/blockquote-grouping.md
+++ b/.changeset/blockquote-grouping.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes multi-paragraph blockquotes splitting into separate quotes: consecutive quote paragraphs now render as a single blockquote on the site and load as one quote block in the editor, so merging them no longer reverts on reload.

--- a/packages/core/src/components/BlockquoteGroup.astro
+++ b/packages/core/src/components/BlockquoteGroup.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Renders a run of consecutive `style: "blockquote"` Portable Text blocks
+ * as ONE `<blockquote>` with a paragraph per block.
+ *
+ * Portable Text is flat, so a multi-paragraph quote is stored as
+ * consecutive blockquote-styled blocks; rendering each as its own
+ * `<blockquote>` split single quotes into disconnected fragments (#1884).
+ * The grouping itself happens in `portable-text-blockquote-group.ts`,
+ * applied by the `PortableText` wrapper.
+ */
+import { PortableText } from "astro-portabletext";
+
+import type { BlockquoteGroupNode } from "./portable-text-blockquote-group.js";
+import Block from "./Block.astro";
+import { emdashMarkComponents } from "./marks.js";
+
+export interface Props {
+	node: BlockquoteGroupNode;
+}
+
+const { node } = Astro.props;
+
+// Restyle the quoted blocks as "normal" so each renders as a <p> inside
+// the shared <blockquote> (and doesn't re-trigger blockquote handling).
+const paragraphs = (node?.blocks ?? []).map((block) => ({ ...block, style: "normal" }));
+---
+
+<blockquote>
+	<PortableText
+		value={paragraphs}
+		components={{ block: Block, mark: emdashMarkComponents }}
+	/>
+</blockquote>

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -365,6 +365,40 @@ function portableTextToPM(blocks: PTBlock[]): JSONContent {
 				} else break;
 			}
 			content.push(convertPTList(listBlocks, listType));
+		} else if (
+			isPTTextBlock(block) &&
+			block.style === "blockquote" &&
+			block.listItem === undefined
+		) {
+			// Group consecutive blockquote blocks into ONE blockquote node —
+			// PT is flat, so a multi-paragraph quote is stored as a run of
+			// blockquote-styled blocks. Mirrors the grouping in
+			// content/converters/portable-text-to-prosemirror.ts; without it
+			// merges revert on reload in the inline editor too (#1884).
+			const quoteBlocks: PTTextBlock[] = [];
+			while (i < blocks.length) {
+				const cur = blocks[i];
+				if (
+					!cur ||
+					!isPTTextBlock(cur) ||
+					cur.style !== "blockquote" ||
+					cur.listItem !== undefined
+				) {
+					break;
+				}
+				quoteBlocks.push(cur);
+				i++;
+			}
+			content.push({
+				type: "blockquote",
+				content: quoteBlocks.map((quoteBlock) => {
+					const pmContent = convertPTSpans(quoteBlock.children, quoteBlock.markDefs || []);
+					return {
+						type: "paragraph",
+						content: pmContent.length > 0 ? pmContent : undefined,
+					};
+				}),
+			});
 		} else {
 			const c = convertPTBlock(block);
 			if (c) content.push(c);

--- a/packages/core/src/components/PortableText.astro
+++ b/packages/core/src/components/PortableText.astro
@@ -22,6 +22,7 @@ import { getEditMeta } from "../query.js";
 import { pluginBlockComponents } from "virtual:emdash/block-components";
 import { emdashComponents } from "./index.js";
 import InlineEditor from "./InlineEditor.astro";
+import { groupBlockquoteRuns } from "./portable-text-blockquote-group.js";
 
 export interface Props extends Omit<PortableTextProps, "value"> {
 	value: PortableTextProps["value"];
@@ -37,6 +38,11 @@ const withPlugins = mergeComponents(emdashComponents, { type: pluginBlockCompone
 const mergedComponents = userComponents
 	? mergeComponents(withPlugins, userComponents)
 	: withPlugins;
+
+// A multi-paragraph quote is stored as consecutive blockquote-styled blocks
+// (Portable Text is flat); merge each run into one blockquoteGroup node so
+// it renders as a single <blockquote> instead of several (#1884).
+const renderValue = Array.isArray(value) ? groupBlockquoteRuns(value) : value;
 ---
 
 {editMeta ? (
@@ -47,5 +53,5 @@ const mergedComponents = userComponents
 		field={editMeta.field}
 	/>
 ) : (
-	<BasePortableText value={value} components={mergedComponents} {...rest} />
+	<BasePortableText value={renderValue} components={mergedComponents} {...rest} />
 )}

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -59,6 +59,7 @@ export { default as StrikeThrough } from "./marks/StrikeThrough.astro";
 export { default as Link } from "./marks/Link.astro";
 
 import BlockComponent from "./Block.astro";
+import BlockquoteGroupComponent from "./BlockquoteGroup.astro";
 import BreakComponent from "./Break.astro";
 import ButtonComponent from "./Button.astro";
 import ButtonsComponent from "./Buttons.astro";
@@ -88,6 +89,7 @@ import TableComponent from "./Table.astro";
 export const emdashComponents = {
 	block: BlockComponent,
 	type: {
+		blockquoteGroup: BlockquoteGroupComponent,
 		image: ImageComponent,
 		code: CodeComponent,
 		embed: EmbedComponent,

--- a/packages/core/src/components/portable-text-blockquote-group.ts
+++ b/packages/core/src/components/portable-text-blockquote-group.ts
@@ -1,0 +1,68 @@
+/**
+ * Groups consecutive Portable Text blocks with style "blockquote" into a
+ * single synthetic `blockquoteGroup` node so they render as ONE
+ * `<blockquote>` with a paragraph per block.
+ *
+ * Portable Text is flat: a multi-paragraph quote (e.g. from a WordPress
+ * `core/quote` import) is stored as consecutive blocks with
+ * `style: "blockquote"`. Rendering each of those as its own `<blockquote>`
+ * visually splits the quote (#1884).
+ *
+ * Runs of a single block are left untouched, so existing single-paragraph
+ * quotes render byte-for-byte as before.
+ */
+
+interface TextBlockLike {
+	_type: string;
+	_key?: string;
+	style?: string;
+	listItem?: string;
+}
+
+export interface BlockquoteGroupNode {
+	_type: "blockquoteGroup";
+	_key: string;
+	blocks: TextBlockLike[];
+}
+
+function isBlockquoteBlock(block: unknown): block is TextBlockLike {
+	if (typeof block !== "object" || block === null) return false;
+	const b: Partial<TextBlockLike> = block;
+	// Quote-styled list items belong to their list, not to a quote run.
+	return b._type === "block" && b.style === "blockquote" && b.listItem === undefined;
+}
+
+export function groupBlockquoteRuns(blocks: unknown[]): unknown[] {
+	const result: unknown[] = [];
+	let i = 0;
+
+	while (i < blocks.length) {
+		const current = blocks[i];
+		if (!isBlockquoteBlock(current)) {
+			result.push(current);
+			i++;
+			continue;
+		}
+
+		const run: TextBlockLike[] = [];
+		let next: unknown = current;
+		while (i < blocks.length && isBlockquoteBlock(next)) {
+			run.push(next);
+			i++;
+			next = blocks[i];
+		}
+
+		if (run.length === 1) {
+			result.push(run[0]);
+		} else {
+			const group: BlockquoteGroupNode = {
+				_type: "blockquoteGroup",
+				_key: `${run[0]?._key ?? "quote"}-group`,
+				blocks: run,
+			};
+			result.push(group);
+		}
+	}
+
+	return result;
+}

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -60,6 +60,37 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 			}
 
 			content.push(convertList(listBlocks, listType));
+		} else if (isTextBlock(block) && block.style === "blockquote") {
+			// Collect a blockquote "run": Portable Text is flat, so a
+			// multi-paragraph quote is stored as consecutive blocks with
+			// style "blockquote" (that's what the Gutenberg importer emits
+			// and what prosemirrorToPortableText serializes back to).
+			// Without this grouping each paragraph became its own quote
+			// node, and editor merges reverted on reload (#1884).
+			const quoteBlocks: PortableTextTextBlock[] = [];
+			while (i < blocks.length) {
+				const current = blocks[i];
+				if (
+					!isTextBlock(current) ||
+					current.style !== "blockquote" ||
+					current.listItem !== undefined
+				) {
+					break;
+				}
+				quoteBlocks.push(current);
+				i++;
+			}
+
+			content.push({
+				type: "blockquote",
+				content: quoteBlocks.map((quoteBlock) => {
+					const paragraph = convertSpans(quoteBlock.children, quoteBlock.markDefs || []);
+					return {
+						type: "paragraph",
+						content: paragraph.length > 0 ? paragraph : undefined,
+					};
+				}),
+			});
 		} else {
 			const converted = convertBlock(block);
 			if (converted) {

--- a/packages/core/tests/unit/components/blockquote-group.test.ts
+++ b/packages/core/tests/unit/components/blockquote-group.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for #1884 (render side): consecutive blockquote-styled
+ * Portable Text blocks are one quote and must render as a single
+ * <blockquote>. `groupBlockquoteRuns` merges each run into a synthetic
+ * `blockquoteGroup` node consumed by BlockquoteGroup.astro.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+	groupBlockquoteRuns,
+	type BlockquoteGroupNode,
+} from "../../../src/components/portable-text-blockquote-group.js";
+
+function block(key: string, style: string, extra: Record<string, unknown> = {}) {
+	return { _type: "block", _key: key, style, children: [], ...extra };
+}
+
+describe("groupBlockquoteRuns (#1884)", () => {
+	it("merges consecutive blockquote blocks into one group node", () => {
+		const input = [
+			block("p1", "normal"),
+			block("q1", "blockquote"),
+			block("q2", "blockquote"),
+			block("p2", "normal"),
+		];
+
+		const result = groupBlockquoteRuns(input);
+
+		expect(result).toHaveLength(3);
+		expect(result[0]).toBe(input[0]);
+		expect(result[2]).toBe(input[3]);
+		const group = result[1] as BlockquoteGroupNode;
+		expect(group._type).toBe("blockquoteGroup");
+		expect(group._key).toBe("q1-group");
+		expect(group.blocks.map((b) => b._key)).toEqual(["q1", "q2"]);
+	});
+
+	it("leaves a single blockquote block untouched", () => {
+		const input = [block("q1", "blockquote")];
+		expect(groupBlockquoteRuns(input)).toEqual(input);
+	});
+
+	it("does not merge runs separated by other blocks", () => {
+		const input = [
+			block("q1", "blockquote"),
+			block("p1", "normal"),
+			block("q2", "blockquote"),
+			block("q3", "blockquote"),
+		];
+
+		const result = groupBlockquoteRuns(input);
+
+		expect(result).toHaveLength(3);
+		expect(result[0]).toBe(input[0]);
+		expect((result[2] as BlockquoteGroupNode)._type).toBe("blockquoteGroup");
+	});
+
+	it("excludes quote-styled list items and non-block types from runs", () => {
+		const input = [
+			block("q1", "blockquote"),
+			block("li", "blockquote", { listItem: "bullet", level: 1 }),
+			{ _type: "image", _key: "img" },
+			block("q2", "blockquote"),
+		];
+
+		const result = groupBlockquoteRuns(input);
+
+		expect(result).toEqual(input);
+	});
+});

--- a/packages/core/tests/unit/components/inline-portable-text-blockquote.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-blockquote.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Inline editor blockquote grouping tests (#1884).
+ *
+ * Mirrors tests/unit/converters/blockquote-grouping.test.ts against the
+ * inline (visual-editing) editor's own PT ⇄ PM converters: consecutive
+ * blockquote-styled Portable Text blocks must load as ONE blockquote
+ * node, and the PT → PM → PT round-trip must be stable so a merged
+ * quote doesn't split again on reload.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+	_pmToPortableText as pmToPortableText,
+	_portableTextToPM as portableTextToPM,
+} from "../../../src/components/InlinePortableTextEditor.js";
+
+function quoteBlock(key: string, text: string) {
+	return {
+		_type: "block",
+		_key: key,
+		style: "blockquote",
+		children: [{ _type: "span", _key: `${key}-s`, text }],
+	};
+}
+
+function normalBlock(key: string, text: string) {
+	return {
+		_type: "block",
+		_key: key,
+		style: "normal",
+		children: [{ _type: "span", _key: `${key}-s`, text }],
+	};
+}
+
+describe("blockquote grouping (inline editor seam)", () => {
+	it("merges consecutive blockquote blocks into one blockquote node", () => {
+		const pm = portableTextToPM([quoteBlock("q1", "First"), quoteBlock("q2", "Second")]);
+
+		expect(pm.content).toHaveLength(1);
+		const quote = pm.content?.[0] as { type: string; content?: Array<{ type: string }> };
+		expect(quote.type).toBe("blockquote");
+		expect(quote.content).toHaveLength(2);
+		expect(quote.content?.every((p) => p.type === "paragraph")).toBe(true);
+	});
+
+	it("does not merge blockquotes separated by other blocks", () => {
+		const pm = portableTextToPM([
+			quoteBlock("q1", "First"),
+			normalBlock("n1", "Between"),
+			quoteBlock("q2", "Second"),
+		]);
+
+		const types = (pm.content ?? []).map((n) => (n as { type: string }).type);
+		expect(types).toEqual(["blockquote", "paragraph", "blockquote"]);
+	});
+
+	it("is stable through PT → PM → PT (no split on reload)", () => {
+		const original = [quoteBlock("q1", "First"), quoteBlock("q2", "Second")];
+
+		const once = pmToPortableText(portableTextToPM(original)) as Array<{
+			style?: string;
+			children?: Array<{ text?: string }>;
+		}>;
+		expect(once).toHaveLength(2);
+		expect(once.every((b) => b.style === "blockquote")).toBe(true);
+		expect(once.map((b) => b.children?.[0]?.text)).toEqual(["First", "Second"]);
+
+		// Second round-trip must not change the shape further.
+		const twice = pmToPortableText(portableTextToPM(once as never));
+		expect(twice).toHaveLength(2);
+	});
+
+	it("keeps a single blockquote block as one quote with one paragraph", () => {
+		const pm = portableTextToPM([quoteBlock("q1", "Only")]);
+
+		expect(pm.content).toHaveLength(1);
+		const quote = pm.content?.[0] as { type: string; content?: unknown[] };
+		expect(quote.type).toBe("blockquote");
+		expect(quote.content).toHaveLength(1);
+	});
+});

--- a/packages/core/tests/unit/converters/blockquote-grouping.test.ts
+++ b/packages/core/tests/unit/converters/blockquote-grouping.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression tests for #1884: consecutive Portable Text blocks with
+ * style "blockquote" are one quote (that's what the Gutenberg importer
+ * emits for a multi-paragraph <blockquote>), but the editor converter
+ * turned each block into its own blockquote node. The visible symptoms:
+ * a single quote renders/edits as several disconnected quotes, and
+ * merging them in the editor never survives a reload because the
+ * PM → PT serializer flattens a multi-paragraph quote back into
+ * consecutive blocks.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
+import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
+import type {
+	PortableTextBlock,
+	PortableTextTextBlock,
+} from "../../../src/content/converters/types.js";
+
+function quoteBlock(key: string, text: string): PortableTextBlock {
+	return {
+		_type: "block",
+		_key: key,
+		style: "blockquote",
+		children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+	};
+}
+
+describe("blockquote grouping (#1884)", () => {
+	it("merges consecutive blockquote blocks into one blockquote node", () => {
+		const doc = portableTextToProsemirror([
+			quoteBlock("q1", "If recursive service is requested…"),
+			quoteBlock("q2", "- The answer to the query…"),
+		]);
+
+		expect(doc.content).toHaveLength(1);
+		const quote = doc.content[0];
+		expect(quote?.type).toBe("blockquote");
+		expect(quote?.content?.map((p) => p.type)).toEqual(["paragraph", "paragraph"]);
+		expect(quote?.content?.[0]?.content?.[0]?.text).toBe("If recursive service is requested…");
+		expect(quote?.content?.[1]?.content?.[0]?.text).toBe("- The answer to the query…");
+	});
+
+	it("does not merge blockquote blocks separated by another block", () => {
+		const doc = portableTextToProsemirror([
+			quoteBlock("q1", "First quote"),
+			{
+				_type: "block",
+				_key: "p1",
+				style: "normal",
+				children: [{ _type: "span", _key: "p1-s", text: "Between", marks: [] }],
+			},
+			quoteBlock("q2", "Second quote"),
+		]);
+
+		expect(doc.content?.map((n) => n.type)).toEqual(["blockquote", "paragraph", "blockquote"]);
+	});
+
+	it("keeps a multi-paragraph quote stable through PT → PM → PT", () => {
+		const original = [quoteBlock("q1", "Paragraph one"), quoteBlock("q2", "Paragraph two")];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(original));
+
+		expect(roundTripped).toHaveLength(2);
+		const [first, second] = roundTripped as PortableTextTextBlock[];
+		expect(first?.style).toBe("blockquote");
+		expect(second?.style).toBe("blockquote");
+		expect(first?.children[0]?.text).toBe("Paragraph one");
+		expect(second?.children[0]?.text).toBe("Paragraph two");
+
+		// …and importantly, loading that output again yields ONE quote node,
+		// so an editor merge doesn't revert on reload.
+		const reloaded = portableTextToProsemirror(roundTripped);
+		expect(reloaded.content).toHaveLength(1);
+		expect(reloaded.content[0]?.type).toBe("blockquote");
+	});
+
+	it("does not group quote-styled list items into the quote run", () => {
+		const listQuote: PortableTextBlock = {
+			_type: "block",
+			_key: "lq",
+			style: "blockquote",
+			listItem: "bullet",
+			level: 1,
+			children: [{ _type: "span", _key: "lq-s", text: "quoted bullet", marks: [] }],
+		};
+		const doc = portableTextToProsemirror([quoteBlock("q1", "Quote"), listQuote]);
+
+		expect(doc.content?.map((n) => n.type)).toEqual(["blockquote", "bulletList"]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a multi-paragraph blockquote splitting into multiple disconnected quotes — both on the rendered site and in the editor, where merging the blocks reverted on reload.

Closes #1884

**Root cause:** Portable Text is flat, so a multi-paragraph `<blockquote>` (which is exactly what the Gutenberg importer's `core/quote` transformer emits) is stored as *consecutive blocks with `style: "blockquote"`*. Both consumers treated each block as its own quote:

- `portableTextToProsemirror` created one blockquote node per block → the editor shows a single quote as several quotes. Merging them can never stick, because `prosemirrorToPortableText` (correctly) serializes a multi-paragraph quote node back into consecutive flat blocks — the next editor load split them again. This is the "merge reverts on reload" behaviour from the issue.
- The `PortableText` Astro component rendered one `<blockquote>` element per block → the split HTML shown in the issue report.

**Fix:** treat a run of consecutive blockquote-styled blocks as one quote in both places:

- Editor load (`portableTextToProsemirror`): a run merges into a single blockquote node with one paragraph per block. The PT → PM → PT round-trip is now stable, so editor merges survive reloads.
- Rendering (`PortableText.astro`): a run is pre-grouped into a synthetic `blockquoteGroup` node rendered by a new `BlockquoteGroup.astro` as one `<blockquote>` with a `<p>` per paragraph (following the nested-render pattern of `Columns.astro`).

Behaviour is deliberately conservative: single-block quotes are left untouched and render byte-for-byte as before, quote-styled list items keep belonging to their list, and runs separated by any other block stay separate quotes. No stored content changes — this only fixes how the existing canonical representation is loaded and rendered.

Tested with new regression tests in `tests/unit/converters/blockquote-grouping.test.ts` (run merging, non-adjacent runs staying separate, PT → PM → PT round-trip stability — the "merge reverts on reload" repro — and list-item exclusion) and `tests/unit/components/blockquote-group.test.ts` (render-side grouping helper). Full core unit suite passes (232 files, 3108 tests).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. <!-- n/a: no admin UI strings in this PR -->
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... <!-- n/a: bug fix -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5, reviewed and tested by me

## Screenshots / test output

New regression tests plus full core unit suite: 232 files, 3108 tests passing locally.