### PR TITLE
ci: opt in to checkout v7 fork guard in workflow_run apply jobs

### DIFF
--- a/.github/workflows/auto-format-apply.yml
+++ b/.github/workflows/auto-format-apply.yml
@@ -149,6 +149,13 @@ jobs:
           repository: ${{ steps.pr.outputs.full_name }}
           ref: ${{ steps.pr.outputs.sha }}
           persist-credentials: false
+          # Reviewed opt-in to checkout v7's fork guard: no code from the
+          # fork tree is ever executed here. The steps below only `git apply`
+          # the patch from the trusted format artifact and run git
+          # add/commit/push — no scripts, hooks, or tooling from the
+          # checked-out tree. Credentials are not persisted; the push uses
+          # a scoped app token via GIT_ASKPASS.
+          allow-unsafe-pr-checkout: true
 
       - name: Apply patch
         if: steps.download.outputs.found == 'true'

--- a/.github/workflows/query-counts-apply.yml
+++ b/.github/workflows/query-counts-apply.yml
@@ -154,6 +154,13 @@ jobs:
           repository: ${{ steps.pr.outputs.full_name }}
           ref: ${{ steps.pr.outputs.sha }}
           persist-credentials: false
+          # Reviewed opt-in to checkout v7's fork guard: no code from the
+          # fork tree is ever executed here. The steps below only copy the
+          # inert snapshot JSONs from the trusted measure artifact and run
+          # git add/commit/push — no scripts, hooks, or tooling from the
+          # checked-out tree. Credentials are not persisted; the push uses
+          # a scoped app token via GIT_ASKPASS.
+          allow-unsafe-pr-checkout: true
 
       - name: Apply snapshots
         if: steps.download.outputs.found == 'true'


### PR DESCRIPTION
## What does this PR do?

Repairs the `Query Counts — Apply` and `Auto Format — Apply` workflows for fork PRs. Since the `actions/checkout` v7 bump (#1611), checkout refuses to fetch fork PR code from a `workflow_run` workflow unless the step explicitly opts in with `allow-unsafe-pr-checkout: true`. Every apply run that actually reaches the `Checkout (fork)` step now fails with:

> Refusing to check out fork pull request code from a 'workflow_run' workflow. … To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

Example failing runs: [29079049235](https://github.com/emdash-cms/emdash/actions/runs/29079049235) (PR #1905), [29074697406](https://github.com/emdash-cms/emdash/actions/runs/29074697406). The recent "successful" runs only succeeded because they skipped both checkout steps (no artifact to apply) — so fork PRs currently never get snapshot updates or auto-formatting pushed back.

The opt-in matches the trust design these workflows already document (from the #1638 hardening): after the fork checkout, **no code from the fork tree is executed** — the jobs only copy the inert snapshot JSONs / `git apply` the patch from the trusted measure/format artifact, then `git add`/`commit`/`push` with a scoped app token supplied via `GIT_ASKPASS`, with `persist-credentials: false` on the checkout. This PR adds `allow-unsafe-pr-checkout: true` to the two fork checkout steps plus a comment explaining why the checkout is safe, so the reviewed rationale lives next to the opt-in.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- n/a: workflow-only change -->
- [ ] `pnpm lint` passes <!-- n/a: workflow-only change -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: workflow-only change -->
- [ ] `pnpm format` has been run <!-- n/a: workflow-only change -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a -->
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. <!-- n/a -->
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- n/a: CI only -->
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... <!-- n/a -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5, reviewed by me

## Screenshots / test output

Failure signature from the linked runs:

```
##[error]Refusing to check out fork pull request code from a 'workflow_run' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities.
```