### PR TITLE
feat: render hreflang alternates in page head for translated content

### DIFF
--- a/.changeset/hreflang-alternates.md
+++ b/.changeset/hreflang-alternates.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds hreflang alternate links to the page head for translated content. `<EmDashHead>` now emits a `<link rel="alternate" hreflang="...">` per published translation (plus `x-default`) automatically, and a new `getHreflangAlternates()` helper resolves the same set for hand-rolled heads.

--- a/docs/src/content/docs/guides/internationalization.mdx
+++ b/docs/src/content/docs/guides/internationalization.mdx
@@ -378,6 +378,43 @@ Translation siblings are cross-linked with `xhtml:link` alternates so search eng
 
 Siblings are grouped by `translation_group`, so a row added later (a new locale variant of an existing post) automatically appears as an alternate on every other variant. Sites with a single locale produce a plain sitemap with no `xhtml` namespace.
 
+## hreflang Alternates in the Page Head
+
+The same alternates belong in the `<head>` of every content page. If your layout uses [`<EmDashHead>`](/plugins/creating-plugins/hooks/#pagemetadata), this is automatic: when i18n is enabled and the page context includes `content`, it emits one `<link rel="alternate">` per published translation sibling — including a self-referencing link, as Google recommends — plus `x-default`:
+
+```html
+<link rel="alternate" hreflang="en" href="https://example.com/blog/hello" />
+<link rel="alternate" hreflang="fr" href="https://example.com/fr/blog/bonjour" />
+<link rel="alternate" hreflang="x-default" href="https://example.com/blog/hello" />
+```
+
+For hand-rolled heads, resolve the alternates with `getHreflangAlternates`:
+
+```astro title="src/pages/blog/[slug].astro"
+---
+import { getEmDashEntry, getHreflangAlternates } from "emdash";
+
+const { entry } = await getEmDashEntry("posts", Astro.params.slug);
+const alternates = await getHreflangAlternates("posts", entry.data.id, {
+	siteUrl: Astro.url.origin,
+});
+---
+
+<head>
+	{alternates.map((a) => <link rel="alternate" hreflang={a.hreflang} href={a.href} />)}
+</head>
+```
+
+Behaviour matches the sitemap exactly:
+
+- **`x-default`** points at the default-locale variant. When the default locale has no published translation, it falls back to the first routable variant, so the set never lacks an `x-default`.
+- **Unpublished siblings are excluded** — draft translations never leak into alternates.
+- **Unroutable locales are dropped.** A row whose locale isn't in your configured `i18n.locales` can't be served, and linking search engines to a 404 is worse than no link.
+- **Untranslated entries** still get a self-referencing alternate and `x-default` when i18n is enabled, mirroring the sitemap.
+- With **i18n disabled**, the result is empty and no queries run.
+
+URLs are built from the collection's `urlPattern` and localized through your Astro i18n routing config (`prefixDefaultLocale`, custom locale `path` mappings), so head and sitemap always agree.
+
 ## Importing Multilingual Content
 
 Import WordPress content through the admin migration tool — see [Content Import](/migration/content-import/) and [Migrate from WordPress](/migration/from-wordpress/). A WXR export does not carry the locale and translation-group structure that WPML or Polylang add, so imported content lands in your default locale.

--- a/packages/core/src/components/EmDashHead.astro
+++ b/packages/core/src/components/EmDashHead.astro
@@ -33,6 +33,8 @@ import { renderSiteIdentity } from "../page/site-identity.js";
 import { getPageRuntime } from "../page/index.js";
 import { getSiteSettings } from "../settings/index.js";
 import { absolutizeMediaUrl } from "../page/absolute-url.js";
+import { getHreflangAlternates } from "../seo/hreflang.js";
+import { isI18nEnabled } from "../i18n/config.js";
 
 interface Props {
 	page: PublicPageContext;
@@ -83,8 +85,32 @@ if (runtime) {
 		defaultOgImage,
 	);
 
+	// hreflang alternates for translated content entries (#1690). Only
+	// queried when i18n is enabled and this page renders a content entry;
+	// non-i18n sites skip this entirely. Contributions sit with the base
+	// layer, so plugins can override individual hreflang entries (dedup
+	// key is the hreflang value).
+	let hreflangContributions: PageMetadataContribution[] = [];
+	if (page.content && isI18nEnabled()) {
+		const siteUrl = page.siteUrl || siteSettings.url || new URL(page.url).origin;
+		const alternates = await getHreflangAlternates(page.content.collection, page.content.id, {
+			siteUrl,
+		});
+		hreflangContributions = alternates.map((a) => ({
+			kind: "link",
+			rel: "alternate",
+			href: a.href,
+			hreflang: a.hreflang,
+		}));
+	}
+
 	const siteContributions = generateSiteSeoContributions(siteSettings.seo);
-	const allContributions = [...pluginContributions, ...siteContributions, ...baseContributions];
+	const allContributions = [
+		...pluginContributions,
+		...siteContributions,
+		...baseContributions,
+		...hreflangContributions,
+	];
 	const resolved = resolvePageMetadata(allContributions);
 	jsonLdScripts = resolved.jsonld;
 	metadataHtml = renderPageMetadata(resolved, { includeJsonLd: false });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -404,8 +404,8 @@ export type {
 } from "./settings/types.js";
 
 // SEO
-export { getSeoMeta, getContentSeo } from "./seo/index.js";
-export type { SeoMeta, SeoMetaOptions } from "./seo/index.js";
+export { getSeoMeta, getContentSeo, getHreflangAlternates } from "./seo/index.js";
+export type { SeoMeta, SeoMetaOptions, HreflangAlternate, HreflangOptions } from "./seo/index.js";
 
 // Public page contribution types
 export type {

--- a/packages/core/src/seo/hreflang.ts
+++ b/packages/core/src/seo/hreflang.ts
@@ -13,6 +13,11 @@
  * - Variants whose locale isn't in the configured `i18n.locales` list
  *   are dropped: linking to a route the site can't serve is worse than
  *   no link at all.
+ * - Variants flagged `noindex` in the SEO panel are excluded — the
+ *   sitemap doesn't list them, and pointing search engines at a page
+ *   that asks not to be indexed is a contradictory signal. When the
+ *   entry itself is noindex the result is empty: a page opting out of
+ *   indexing shouldn't announce an hreflang set at all.
  * - When i18n is disabled (or no absolute site URL can be resolved,
  *   which hreflang requires) the result is empty and no queries run.
  */
@@ -28,6 +33,29 @@ import { getCollectionInfoWithDb } from "../schema/query.js";
 import { getSiteSettingsWithDb } from "../settings/index.js";
 
 const TRAILING_SLASH_RE = /\/$/;
+const ABSOLUTE_URL_RE = /^https?:\/\//i;
+
+/**
+ * IDs of variants flagged `noindex` in the SEO panel. Entries without
+ * an `_emdash_seo` row are indexable by default (same as the sitemap).
+ * The id list is bounded by the number of configured locales, so no
+ * chunking is needed.
+ */
+async function findNoindexIds(
+	db: Kysely<Database>,
+	collection: string,
+	ids: string[],
+): Promise<Set<string>> {
+	if (ids.length === 0) return new Set();
+	const rows = await db
+		.selectFrom("_emdash_seo")
+		.select("content_id")
+		.where("collection", "=", collection)
+		.where("content_id", "in", ids)
+		.where("seo_no_index", "=", 1)
+		.execute();
+	return new Set(rows.map((r) => r.content_id));
+}
 
 /** A single alternate link, ready to render as `<link rel="alternate">`. */
 export interface HreflangAlternate {
@@ -97,7 +125,9 @@ export async function getHreflangAlternatesWithDb(
 		const settings = await getSiteSettingsWithDb(db);
 		siteUrl = settings.url;
 	}
-	if (!siteUrl) return [];
+	// hreflang requires fully-qualified URLs; a relative site URL would
+	// produce invalid output (and EmDashHead's isSafeHref would drop it).
+	if (!siteUrl || !ABSOLUTE_URL_RE.test(siteUrl)) return [];
 	siteUrl = siteUrl.replace(TRAILING_SLASH_RE, "");
 
 	const repo = new ContentRepository(db);
@@ -110,8 +140,21 @@ export async function getHreflangAlternatesWithDb(
 	let variants = await repo.findTranslations(collection, group);
 	if (variants.length === 0) variants = [item];
 
-	const published = variants.filter((v) => v.status === "published");
+	let published = variants.filter((v) => v.status === "published");
 	if (published.length === 0) return [];
+
+	// Exclude noindex variants, matching the sitemap's `_emdash_seo`
+	// filter so head and sitemap agree on which variants are
+	// discoverable. When the requested entry itself is noindex, emit
+	// nothing: a page opting out of indexing shouldn't announce an
+	// hreflang set.
+	const noindexIds = await findNoindexIds(
+		db,
+		collection,
+		published.map((v) => v.id),
+	);
+	if (noindexIds.has(item.id)) return [];
+	published = published.filter((v) => !noindexIds.has(v.id));
 
 	const info = await getCollectionInfoWithDb(db, collection);
 	const urlPattern = info?.urlPattern ?? null;

--- a/packages/core/src/seo/hreflang.ts
+++ b/packages/core/src/seo/hreflang.ts
@@ -1,0 +1,149 @@
+/**
+ * hreflang alternate resolution for translated content (#1690).
+ *
+ * Mirrors the sitemap route's semantics so the render path and the
+ * sitemap always agree:
+ *
+ * - Alternates are emitted per published locale variant of a
+ *   translation group, including a self-referencing entry (Google
+ *   recommends the page annotate itself).
+ * - `x-default` points at the default-locale variant, falling back to
+ *   the first routable variant when the default locale has no
+ *   translation.
+ * - Variants whose locale isn't in the configured `i18n.locales` list
+ *   are dropped: linking to a route the site can't serve is worse than
+ *   no link at all.
+ * - When i18n is disabled (or no absolute site URL can be resolved,
+ *   which hreflang requires) the result is empty and no queries run.
+ */
+
+import type { Kysely } from "kysely";
+
+import { ContentRepository } from "../database/repositories/content.js";
+import type { Database } from "../database/types.js";
+import { getI18nConfig, isI18nEnabled } from "../i18n/config.js";
+import { interpolateUrlPattern, localizePath } from "../i18n/resolve.js";
+import { requestCached } from "../request-cache.js";
+import { getCollectionInfoWithDb } from "../schema/query.js";
+import { getSiteSettingsWithDb } from "../settings/index.js";
+
+const TRAILING_SLASH_RE = /\/$/;
+
+/** A single alternate link, ready to render as `<link rel="alternate">`. */
+export interface HreflangAlternate {
+	/** Locale code, or `"x-default"` for the default variant */
+	hreflang: string;
+	/** Absolute URL of the variant */
+	href: string;
+}
+
+export interface HreflangOptions {
+	/**
+	 * Absolute site origin (e.g. `https://example.com`) used to build
+	 * the alternate URLs. Falls back to the site settings URL; when
+	 * neither is available the result is empty, since hreflang
+	 * requires fully-qualified URLs.
+	 */
+	siteUrl?: string;
+}
+
+/**
+ * Resolve hreflang alternates for a content entry.
+ *
+ * @example
+ * ```astro
+ * ---
+ * import { getHreflangAlternates } from "emdash";
+ *
+ * const alternates = await getHreflangAlternates("posts", entry.data.id, {
+ *   siteUrl: Astro.url.origin,
+ * });
+ * ---
+ * <head>
+ *   {alternates.map((a) => <link rel="alternate" hreflang={a.hreflang} href={a.href} />)}
+ * </head>
+ * ```
+ */
+export async function getHreflangAlternates(
+	collection: string,
+	entryId: string,
+	options: HreflangOptions = {},
+): Promise<HreflangAlternate[]> {
+	if (!isI18nEnabled()) return [];
+	const key = `hreflang:${collection}:${entryId}:${options.siteUrl ?? ""}`;
+	return requestCached(key, async () => {
+		const { getDb } = await import("../loader.js");
+		const db = await getDb();
+		return getHreflangAlternatesWithDb(db, collection, entryId, options);
+	});
+}
+
+/**
+ * Resolve hreflang alternates with an explicit db handle.
+ *
+ * @internal Use `getHreflangAlternates()` in templates. This variant is
+ * for routes/components that already have a database handle.
+ */
+export async function getHreflangAlternatesWithDb(
+	db: Kysely<Database>,
+	collection: string,
+	entryId: string,
+	options: HreflangOptions = {},
+): Promise<HreflangAlternate[]> {
+	if (!isI18nEnabled()) return [];
+
+	let siteUrl = options.siteUrl;
+	if (!siteUrl) {
+		const settings = await getSiteSettingsWithDb(db);
+		siteUrl = settings.url;
+	}
+	if (!siteUrl) return [];
+	siteUrl = siteUrl.replace(TRAILING_SLASH_RE, "");
+
+	const repo = new ContentRepository(db);
+	const item = await repo.findByIdOrSlug(collection, entryId);
+	if (!item) return [];
+
+	// Legacy rows imported before i18n may have no translation_group;
+	// treat them as a single-variant group.
+	const group = item.translationGroup || item.id;
+	let variants = await repo.findTranslations(collection, group);
+	if (variants.length === 0) variants = [item];
+
+	const published = variants.filter((v) => v.status === "published");
+	if (published.length === 0) return [];
+
+	const info = await getCollectionInfoWithDb(db, collection);
+	const urlPattern = info?.urlPattern ?? null;
+
+	const resolved: Array<{ locale: string; href: string }> = [];
+	for (const variant of published) {
+		const locale = variant.locale || "en";
+		const path = interpolateUrlPattern({
+			pattern: urlPattern,
+			collection,
+			slug: variant.slug || variant.id,
+			id: variant.id,
+		});
+		const localized = await localizePath(path, locale);
+		if (localized === null) continue;
+		resolved.push({ locale, href: `${siteUrl}${localized}` });
+	}
+	if (resolved.length === 0) return [];
+
+	resolved.sort((a, b) => a.locale.localeCompare(b.locale));
+	const alternates: HreflangAlternate[] = resolved.map((r) => ({
+		hreflang: r.locale,
+		href: r.href,
+	}));
+
+	// x-default: default-locale variant, else the first routable one.
+	// Same fallback the sitemap route uses.
+	const defaultLocale = getI18nConfig()?.defaultLocale;
+	const xDefault = resolved.find((r) => r.locale === defaultLocale) ?? resolved[0];
+	if (xDefault) {
+		alternates.push({ hreflang: "x-default", href: xDefault.href });
+	}
+
+	return alternates;
+}

--- a/packages/core/src/seo/index.ts
+++ b/packages/core/src/seo/index.ts
@@ -32,6 +32,9 @@
 import type { ContentSeo } from "../database/repositories/types.js";
 import { buildSeoImageUrl } from "./media-url.js";
 
+export { getHreflangAlternates, getHreflangAlternatesWithDb } from "./hreflang.js";
+export type { HreflangAlternate, HreflangOptions } from "./hreflang.js";
+
 const TRAILING_SLASH_RE = /\/$/;
 const ABSOLUTE_URL_RE = /^https?:\/\//i;
 

--- a/packages/core/tests/integration/seo/hreflang.test.ts
+++ b/packages/core/tests/integration/seo/hreflang.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for render-path hreflang alternates (#1690).
+ *
+ * Mirrors the sitemap route's semantics: alternates per published
+ * translation sibling (including self), `x-default` on the
+ * default-locale variant, unroutable locales dropped, and empty output
+ * when i18n is disabled. `astro:i18n` isn't available under vitest, so
+ * `localizePath` uses its manual-prefix fallback — the same behaviour
+ * default-routing sites get.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createDatabase } from "../../../src/database/connection.js";
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
+import { _resetAstroI18nCacheForTests } from "../../../src/i18n/resolve.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { getHreflangAlternatesWithDb } from "../../../src/seo/hreflang.js";
+
+const SITE = "https://example.com";
+
+describe("getHreflangAlternates (#1690)", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+
+	beforeEach(async () => {
+		db = createDatabase({ url: ":memory:" });
+		await runMigrations(db);
+		repo = new ContentRepository(db);
+
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "post", label: "Posts", labelSingular: "Post" });
+		await registry.createField("post", { slug: "title", label: "Title", type: "string" });
+		await db
+			.updateTable("_emdash_collections")
+			.set({ url_pattern: "/blog/{slug}" })
+			.where("slug", "=", "post")
+			.execute();
+
+		setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"], prefixDefaultLocale: false });
+		_resetAstroI18nCacheForTests();
+	});
+
+	afterEach(async () => {
+		setI18nConfig(null);
+		_resetAstroI18nCacheForTests();
+		await db.destroy();
+	});
+
+	async function createPair() {
+		const en = await repo.create({
+			type: "post",
+			slug: "hello",
+			data: { title: "Hello" },
+			status: "published",
+			locale: "en",
+		});
+		const fr = await repo.create({
+			type: "post",
+			slug: "bonjour",
+			data: { title: "Bonjour" },
+			status: "published",
+			locale: "fr",
+			translationOf: en.id,
+		});
+		return { en, fr };
+	}
+
+	it("returns alternates for every published sibling plus x-default", async () => {
+		const { en } = await createPair();
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		expect(alternates).toEqual([
+			{ hreflang: "en", href: `${SITE}/blog/hello` },
+			{ hreflang: "fr", href: `${SITE}/fr/blog/bonjour` },
+			{ hreflang: "x-default", href: `${SITE}/blog/hello` },
+		]);
+	});
+
+	it("returns the same set when resolved from a non-default sibling", async () => {
+		const { fr } = await createPair();
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", fr.id, { siteUrl: SITE });
+
+		expect(alternates.map((a) => a.hreflang)).toEqual(["en", "fr", "x-default"]);
+		expect(alternates.at(-1)?.href).toBe(`${SITE}/blog/hello`);
+	});
+
+	it("annotates untranslated entries with self + x-default", async () => {
+		const en = await repo.create({
+			type: "post",
+			slug: "solo",
+			data: { title: "Solo" },
+			status: "published",
+			locale: "en",
+		});
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		expect(alternates).toEqual([
+			{ hreflang: "en", href: `${SITE}/blog/solo` },
+			{ hreflang: "x-default", href: `${SITE}/blog/solo` },
+		]);
+	});
+
+	it("excludes unpublished siblings", async () => {
+		const en = await repo.create({
+			type: "post",
+			slug: "hello",
+			data: { title: "Hello" },
+			status: "published",
+			locale: "en",
+		});
+		await repo.create({
+			type: "post",
+			slug: "bonjour",
+			data: { title: "Bonjour" },
+			status: "draft",
+			locale: "fr",
+			translationOf: en.id,
+		});
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		expect(alternates.map((a) => a.hreflang)).toEqual(["en", "x-default"]);
+	});
+
+	it("drops siblings whose locale is not in the configured list", async () => {
+		const en = await repo.create({
+			type: "post",
+			slug: "hello",
+			data: { title: "Hello" },
+			status: "published",
+			locale: "en",
+		});
+		await repo.create({
+			type: "post",
+			slug: "hallo",
+			data: { title: "Hallo" },
+			status: "published",
+			locale: "de", // not in ["en", "fr"]
+			translationOf: en.id,
+		});
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		expect(alternates.map((a) => a.hreflang)).toEqual(["en", "x-default"]);
+	});
+
+	it("falls back to the first routable variant for x-default when the default locale is missing", async () => {
+		setI18nConfig({ defaultLocale: "de", locales: ["de", "en", "fr"], prefixDefaultLocale: false });
+		_resetAstroI18nCacheForTests();
+		const { en } = await createPair();
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		const xDefault = alternates.find((a) => a.hreflang === "x-default");
+		expect(xDefault?.href).toBe(`${SITE}/en/blog/hello`);
+	});
+
+	it("returns empty when i18n is disabled", async () => {
+		setI18nConfig(null);
+		_resetAstroI18nCacheForTests();
+		const en = await repo.create({
+			type: "post",
+			slug: "hello",
+			data: { title: "Hello" },
+			status: "published",
+			locale: "en",
+		});
+
+		expect(await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE })).toEqual([]);
+	});
+
+	it("returns empty when no absolute site URL is available", async () => {
+		const { en } = await createPair();
+
+		expect(await getHreflangAlternatesWithDb(db, "post", en.id)).toEqual([]);
+	});
+
+	it("returns empty for a missing entry", async () => {
+		expect(await getHreflangAlternatesWithDb(db, "post", "nope", { siteUrl: SITE })).toEqual([]);
+	});
+
+	it("uses the default /{collection}/{slug} pattern when none is configured", async () => {
+		await db
+			.updateTable("_emdash_collections")
+			.set({ url_pattern: null })
+			.where("slug", "=", "post")
+			.execute();
+		const { en } = await createPair();
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		expect(alternates[0]?.href).toBe(`${SITE}/post/hello`);
+	});
+});

--- a/packages/core/tests/integration/seo/hreflang.test.ts
+++ b/packages/core/tests/integration/seo/hreflang.test.ts
@@ -183,6 +183,34 @@ describe("getHreflangAlternates (#1690)", () => {
 		expect(await getHreflangAlternatesWithDb(db, "post", en.id)).toEqual([]);
 	});
 
+	it("returns empty for a relative site URL", async () => {
+		const { en } = await createPair();
+
+		expect(await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: "/base" })).toEqual([]);
+	});
+
+	it("excludes noindex siblings, matching the sitemap filter", async () => {
+		const { en, fr } = await createPair();
+		await db
+			.insertInto("_emdash_seo")
+			.values({ collection: "post", content_id: fr.id, seo_no_index: 1 })
+			.execute();
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		expect(alternates.map((a) => a.hreflang)).toEqual(["en", "x-default"]);
+	});
+
+	it("returns empty when the entry itself is noindex", async () => {
+		const { en } = await createPair();
+		await db
+			.insertInto("_emdash_seo")
+			.values({ collection: "post", content_id: en.id, seo_no_index: 1 })
+			.execute();
+
+		expect(await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE })).toEqual([]);
+	});
+
 	it("returns empty for a missing entry", async () => {
 		expect(await getHreflangAlternatesWithDb(db, "post", "nope", { siteUrl: SITE })).toEqual([]);
 	});


### PR DESCRIPTION
## What does this PR do?

Implements render-path hreflang alternates for translated content, per the acceptance criteria in #1690. Multilingual SEO previously stopped at the sitemap — translation siblings were cross-linked there, but rendered pages carried no `hreflang` annotations in their `<head>`.

Closes #1690

**What's added:**

- **`getHreflangAlternates(collection, entryId, { siteUrl })`** — a public helper (exported from `emdash` and `emdash/seo`, with a `*WithDb` variant for callers that already hold a database handle) that resolves the alternate set for a content entry. Result resolution is request-cached.
- **Automatic emission in `<EmDashHead>`** — when i18n is enabled and the page context carries a `content` reference, it emits one `<link rel="alternate" hreflang="...">` per variant plus `x-default`. The links join the contribution pipeline at the base layer, so plugins can override individual hreflang entries (the existing dedup key is the hreflang value). Non-i18n sites skip this entirely — zero extra queries.

**Semantics deliberately mirror the sitemap route so head and sitemap always agree:**

- One alternate per **published** translation sibling, including a self-referencing entry (per Google's recommendation); drafts are excluded.
- `x-default` points at the default-locale variant, falling back to the first routable variant when the default locale has no translation.
- Variants whose locale isn't in the configured `i18n.locales` are dropped — linking search engines to an unservable route is worse than no link.
- Untranslated entries still get self + `x-default` when i18n is enabled (matching sitemap behaviour).
- URLs are built from the collection's `urlPattern` and localized through the resolved Astro i18n routing config (`prefixDefaultLocale`, custom locale `path` mappings), via the same `interpolateUrlPattern`/`localizePath` helpers the sitemap uses.

**Acceptance criteria mapping:** content pages emit `rel=alternate` per translation (EmDashHead + helper) ✓ · `x-default` documented and implemented consistently with the sitemap ✓ · locale routing honours Astro and EmDash i18n config (`localizePath`) ✓ · missing/unroutable translations handled safely (dropped; empty result for missing entries) ✓ · tests cover translated and untranslated entries ✓.

Documentation: new "hreflang Alternates in the Page Head" section in the internationalization guide, covering the automatic EmDashHead path, the manual helper, and the `x-default` fallback rules.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. <!-- n/a: no admin UI strings -->
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1807 (Roadmap discussion for this issue; scope per maintainer-authored #1690, milestone 1.0)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5, reviewed and tested by me

## Screenshots / test output

New test suite `tests/integration/seo/hreflang.test.ts` (10 tests): translated pair, resolution from a non-default sibling, untranslated entry (self + x-default), unpublished siblings excluded, unroutable locales dropped, x-default fallback when the default locale is missing, i18n disabled, missing site URL, missing entry, and the default `/{collection}/{slug}` pattern. Full seo + page test set passes (7 files, 130 tests); lint and typecheck clean.
