### PR TITLE
fix(plugin-cli): preserve profile extensions on publish

### DIFF
--- a/.changeset/preserve-profile-extensions.md
+++ b/.changeset/preserve-profile-extensions.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-cli": patch
+---
+
+Fixes subsequent `emdash-plugin publish` commands removing existing package-profile extensions.

--- a/packages/plugin-cli/src/publish/api.ts
+++ b/packages/plugin-cli/src/publish/api.ts
@@ -277,6 +277,7 @@ interface PackageProfileRecordShape {
 	description?: string;
 	keywords?: string[];
 	sections?: Record<string, string>;
+	extensions?: Record<string, unknown>;
 }
 
 /** An image artifact embedded in a release (`release.json#artifact`). */
@@ -709,11 +710,9 @@ async function getRecordOrNull(
  * update rather than overwriting an invalid record with a slightly-different
  * invalid record).
  *
- * Unknown / extra fields on the existing record are intentionally preserved
- * verbatim via the spread. If they violate the lexicon, the local
- * `validateLocally` pass before `applyWrites` will reject the candidate
- * with a `LEXICON_VALIDATION_FAILED` error rather than letting an invalid
- * record propagate to the registry.
+ * The canonical profile fields are re-emitted explicitly. A valid keyed
+ * `extensions` map is preserved verbatim; other unknown top-level fields
+ * remain excluded from the canonical update path.
  */
 function stampLastUpdated(existingValue: unknown): PackageProfileRecordShape | null {
 	if (!existingValue || typeof existingValue !== "object") return null;
@@ -745,6 +744,9 @@ function stampLastUpdated(existingValue: unknown): PackageProfileRecordShape | n
 	if (typeof v.description === "string") candidate.description = v.description;
 	if (Array.isArray(v.keywords)) candidate.keywords = v.keywords;
 	if (v.sections && typeof v.sections === "object") candidate.sections = v.sections;
+	if (v.extensions && typeof v.extensions === "object" && !Array.isArray(v.extensions)) {
+		candidate.extensions = v.extensions;
+	}
 	return candidate as unknown as PackageProfileRecordShape;
 }
 

--- a/packages/plugin-cli/tests/publish.test.ts
+++ b/packages/plugin-cli/tests/publish.test.ts
@@ -254,6 +254,39 @@ describe("publishRelease", () => {
 			expect(profileOp?.$type).toBe("com.atproto.repo.applyWrites#update");
 		});
 
+		it("preserves profile extensions when publishing a later release", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			const extensions = {
+				[NSID.packageProfileExtension]: {
+					$type: NSID.packageProfileExtension,
+					repository: "https://github.com/example/test-plugin",
+					releasePolicy: {
+						requireProvenance: true,
+						confirmation: "always",
+						approvers: ["did:plc:approver"],
+					},
+				},
+				"com.example.unknown.extension": {
+					$type: "com.example.unknown.extension",
+					value: { preserve: ["this", "exactly"] },
+				},
+			};
+			pds.seedRecord(NSID.packageProfile, "test-plugin", {
+				...wellShapedProfile,
+				extensions,
+			});
+
+			await publishRelease(
+				buildOptions(pds, {
+					manifest: buildManifest({ version: "1.1.0" }),
+					url: "https://example.com/test-plugin-1.1.0.tar.gz",
+				}),
+			);
+
+			const profile = pds.records.get(`at://${TEST_DID}/${NSID.packageProfile}/test-plugin`);
+			expect((profile!.value as { extensions?: unknown }).extensions).toEqual(extensions);
+		});
+
 		it("does not touch a malformed existing profile (just writes the release)", async () => {
 			const pds = new MockPds({ did: TEST_DID });
 			// Existing profile is missing required fields. We refuse to update

--- a/packages/plugin-cli/tests/update-package.test.ts
+++ b/packages/plugin-cli/tests/update-package.test.ts
@@ -224,10 +224,22 @@ describe("updatePackage", () => {
 			expect(pds.callsTo("com.atproto.repo.putRecord")).toHaveLength(0);
 		});
 
-		it("preserves unknown forward-compatible fields on the existing record", async () => {
+		it("preserves extensions and unknown forward-compatible fields on the existing record", async () => {
 			const pds = new MockPds({ did: TEST_DID });
+			const extensions = {
+				[NSID.packageProfileExtension]: {
+					$type: NSID.packageProfileExtension,
+					repository: "https://github.com/example/test-plugin",
+					releasePolicy: { requireProvenance: true },
+				},
+				"com.example.unknown.extension": {
+					$type: "com.example.unknown.extension",
+					value: { preserve: ["this", "exactly"] },
+				},
+			};
 			seedProfile(pds, {
 				sections: { description: "long-form text" },
+				extensions,
 				someFutureField: { nested: true },
 			});
 
@@ -242,6 +254,7 @@ describe("updatePackage", () => {
 			const stored = pds.records.get(`at://${TEST_DID}/${NSID.packageProfile}/${SLUG}`);
 			const value = stored!.value as Record<string, unknown>;
 			expect(value.sections).toEqual({ description: "long-form text" });
+			expect(value.extensions).toEqual(extensions);
 			expect(value.someFutureField).toEqual({ nested: true });
 		});
 	});


### PR DESCRIPTION
## What does this PR do?

Fixes subsequent `emdash-plugin publish` calls dropping existing package-profile extensions while bumping `lastUpdated`.

The publish path now retains the valid keyed extensions map, including the delegated-release policy extension and unknown forward-compatible extension entries. `update-package` already preserved this data; its regression coverage now makes that guarantee explicit.

Related to #1908 and #1918.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/changesets/changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

i18n and a new Discussion are not applicable: no admin UI is changed, and this fixes data loss introduced by the newly merged record extension contract.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6-terra

## Screenshots / test output

- `pnpm build` passes with existing virtual-import and deliberate test-plugin `eval` warnings
- Focused publish/update tests pass: 61 tests
- `pnpm --filter @emdash-cms/plugin-cli typecheck` passes
- `pnpm lint` passes with 0 warnings/errors
- Targeted formatting and `git diff --check` pass
