### PR TITLE
feat(registry): add labeller Lexicons

### DIFF
--- a/.changeset/lucky-labellers-contract.md
+++ b/.changeset/lucky-labellers-contract.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-lexicons": patch
+---
+
+Adds experimental labeller assessment and policy query contracts.

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/defs.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/defs.json
@@ -1,0 +1,330 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeller.defs",
+	"description": "Shared public views for the experimental EmDash registry labeller. These views explain standard ATProto labels; label distribution remains com.atproto.label.*. EXPERIMENTAL.",
+	"defs": {
+		"assessmentSubject": {
+			"type": "object",
+			"required": ["uri", "cid"],
+			"properties": {
+				"uri": { "type": "string", "format": "at-uri" },
+				"cid": { "type": "string", "format": "cid" }
+			}
+		},
+		"manualActionSubject": {
+			"type": "object",
+			"required": ["uri"],
+			"properties": {
+				"uri": { "type": "string", "format": "uri" },
+				"cid": { "type": "string", "format": "cid" }
+			}
+		},
+		"labelSummary": {
+			"type": "object",
+			"required": ["val", "active", "issuedAt"],
+			"properties": {
+				"val": { "type": "string", "minLength": 1, "maxLength": 128 },
+				"active": { "type": "boolean" },
+				"issuedAt": { "type": "string", "format": "datetime" },
+				"expiresAt": { "type": "string", "format": "datetime" }
+			}
+		},
+		"coverage": {
+			"type": "object",
+			"required": ["code", "metadata", "images", "dependencies"],
+			"properties": {
+				"code": { "type": "string", "knownValues": ["complete", "partial", "unavailable"] },
+				"metadata": { "type": "string", "knownValues": ["complete", "partial", "unavailable"] },
+				"images": {
+					"type": "string",
+					"knownValues": ["complete", "not-present", "partial", "unavailable"]
+				},
+				"dependencies": { "type": "string", "knownValues": ["complete", "partial", "unavailable"] }
+			}
+		},
+		"artifact": {
+			"type": "object",
+			"required": ["checksum"],
+			"properties": {
+				"id": { "type": "string", "maxLength": 256 },
+				"checksum": { "type": "string", "minLength": 1, "maxLength": 256 }
+			}
+		},
+		"model": {
+			"type": "object",
+			"required": ["provider", "modelId", "promptVersion"],
+			"properties": {
+				"provider": { "type": "string", "knownValues": ["workers-ai"] },
+				"modelId": { "type": "string", "minLength": 1, "maxLength": 256 },
+				"promptVersion": { "type": "string", "minLength": 1, "maxLength": 128 }
+			}
+		},
+		"scannerVersion": {
+			"type": "object",
+			"required": ["scanner", "version"],
+			"properties": {
+				"scanner": { "type": "string", "minLength": 1, "maxLength": 128 },
+				"version": { "type": "string", "minLength": 1, "maxLength": 128 }
+			}
+		},
+		"publicAssessment": {
+			"type": "object",
+			"required": [
+				"id",
+				"src",
+				"subject",
+				"state",
+				"summary",
+				"coverage",
+				"labels",
+				"policyVersion",
+				"assessmentSchemaVersion",
+				"scannerVersions",
+				"createdAt",
+				"reconsiderationUrl"
+			],
+			"properties": {
+				"id": { "type": "string", "minLength": 1, "maxLength": 64 },
+				"src": { "type": "string", "format": "did" },
+				"subject": { "type": "ref", "ref": "#assessmentSubject" },
+				"artifact": { "type": "ref", "ref": "#artifact" },
+				"state": {
+					"type": "string",
+					"knownValues": ["pending", "passed", "warned", "blocked", "error", "superseded"]
+				},
+				"summary": { "type": "string", "minLength": 1, "maxLength": 4096 },
+				"coverage": { "type": "ref", "ref": "#coverage" },
+				"labels": {
+					"type": "array",
+					"maxLength": 64,
+					"items": { "type": "ref", "ref": "#labelSummary" }
+				},
+				"policyVersion": { "type": "string", "minLength": 1, "maxLength": 128 },
+				"assessmentSchemaVersion": { "type": "integer", "minimum": 1 },
+				"model": { "type": "ref", "ref": "#model" },
+				"scannerVersions": {
+					"type": "array",
+					"maxLength": 64,
+					"items": { "type": "ref", "ref": "#scannerVersion" }
+				},
+				"createdAt": { "type": "string", "format": "datetime" },
+				"completedAt": { "type": "string", "format": "datetime" },
+				"supersedesAssessmentId": { "type": "string", "minLength": 1, "maxLength": 64 },
+				"reconsiderationUrl": { "type": "string", "format": "uri", "maxLength": 2048 }
+			}
+		},
+		"publicManualAction": {
+			"type": "object",
+			"required": ["id", "src", "subject", "type", "summary", "labels", "createdAt"],
+			"properties": {
+				"id": { "type": "string", "minLength": 1, "maxLength": 64 },
+				"src": { "type": "string", "format": "did" },
+				"subject": { "type": "ref", "ref": "#manualActionSubject" },
+				"type": {
+					"type": "string",
+					"knownValues": ["override", "label-issue", "label-retraction", "emergency-takedown"]
+				},
+				"summary": { "type": "string", "minLength": 1, "maxLength": 4096 },
+				"labels": {
+					"type": "array",
+					"maxLength": 64,
+					"items": { "type": "ref", "ref": "#labelSummary" }
+				},
+				"createdAt": { "type": "string", "format": "datetime" }
+			}
+		},
+		"publisherSubject": {
+			"type": "object",
+			"required": ["kind"],
+			"properties": { "kind": { "type": "string", "knownValues": ["did"] } }
+		},
+		"supportedSubjects": {
+			"type": "object",
+			"required": ["publisher", "packageCollections", "releaseCollections"],
+			"properties": {
+				"publisher": { "type": "ref", "ref": "#publisherSubject" },
+				"packageCollections": {
+					"type": "array",
+					"maxLength": 32,
+					"items": { "type": "string", "format": "nsid" }
+				},
+				"releaseCollections": {
+					"type": "array",
+					"maxLength": 32,
+					"items": { "type": "string", "format": "nsid" }
+				}
+			}
+		},
+		"policyLabel": {
+			"type": "object",
+			"required": ["value", "category", "officialEffect", "subjectRules", "locales"],
+			"properties": {
+				"value": { "type": "string", "minLength": 1, "maxLength": 128 },
+				"category": {
+					"type": "string",
+					"knownValues": ["eligibility", "automated-block", "warning", "manual-system"]
+				},
+				"officialEffect": {
+					"type": "string",
+					"knownValues": ["pass", "pending", "error", "block", "warn", "redact"]
+				},
+				"subjectRules": {
+					"type": "array",
+					"maxLength": 8,
+					"items": { "type": "ref", "ref": "#subjectRule" }
+				},
+				"locales": {
+					"type": "array",
+					"maxLength": 64,
+					"items": { "type": "ref", "ref": "#policyLocale" }
+				}
+			}
+		},
+		"subjectRule": {
+			"type": "object",
+			"required": ["subject", "cidRule", "issuanceModes"],
+			"properties": {
+				"subject": { "type": "string", "knownValues": ["release", "package", "publisher"] },
+				"cidRule": { "type": "string", "knownValues": ["required", "optional", "forbidden"] },
+				"issuanceModes": {
+					"type": "array",
+					"minLength": 1,
+					"maxLength": 3,
+					"items": { "type": "string", "knownValues": ["automated", "reviewer", "admin"] }
+				}
+			}
+		},
+		"policyLocale": {
+			"type": "object",
+			"required": ["lang", "name", "description"],
+			"properties": {
+				"lang": { "type": "string", "format": "language" },
+				"name": { "type": "string", "minLength": 1, "maxLength": 1024 },
+				"description": { "type": "string", "minLength": 1, "maxLength": 4096 }
+			}
+		},
+		"labelerPolicy": {
+			"type": "object",
+			"required": [
+				"schemaVersion",
+				"policyVersion",
+				"effectiveAt",
+				"labellerDid",
+				"assessmentSchemaVersion",
+				"supportedSubjects",
+				"reasonCodes",
+				"labels",
+				"overrideRule",
+				"precedence",
+				"publicApi",
+				"contact",
+				"transparency"
+			],
+			"properties": {
+				"schemaVersion": { "type": "integer", "minimum": 1, "maximum": 1 },
+				"policyVersion": { "type": "string", "minLength": 1, "maxLength": 128 },
+				"effectiveAt": { "type": "string", "format": "datetime" },
+				"labellerDid": { "type": "string", "format": "did" },
+				"assessmentSchemaVersion": { "type": "integer", "minimum": 1 },
+				"supportedSubjects": { "type": "ref", "ref": "#supportedSubjects" },
+				"reasonCodes": {
+					"type": "array",
+					"maxLength": 256,
+					"items": { "type": "ref", "ref": "#reasonCode" }
+				},
+				"labels": {
+					"type": "array",
+					"maxLength": 256,
+					"items": { "type": "ref", "ref": "#policyLabel" }
+				},
+				"overrideRule": { "type": "ref", "ref": "#overrideRule" },
+				"precedence": {
+					"type": "array",
+					"maxLength": 32,
+					"items": { "type": "string", "minLength": 1, "maxLength": 128 }
+				},
+				"publicApi": { "type": "ref", "ref": "#publicApi" },
+				"contact": { "type": "ref", "ref": "#contact" },
+				"transparency": { "type": "ref", "ref": "#transparency" }
+			}
+		},
+		"reasonCode": {
+			"type": "object",
+			"required": ["code", "description"],
+			"properties": {
+				"code": { "type": "string", "minLength": 1, "maxLength": 128 },
+				"description": { "type": "string", "minLength": 1, "maxLength": 4096 }
+			}
+		},
+		"overrideRule": {
+			"type": "object",
+			"required": [
+				"subject",
+				"cidRule",
+				"reviewerLabels",
+				"requireSameSource",
+				"requireAtomicIssuance"
+			],
+			"properties": {
+				"subject": { "type": "string", "knownValues": ["release"] },
+				"cidRule": { "type": "string", "knownValues": ["required"] },
+				"reviewerLabels": {
+					"type": "array",
+					"minLength": 1,
+					"maxLength": 8,
+					"items": { "type": "string", "minLength": 1, "maxLength": 128 }
+				},
+				"requireSameSource": { "type": "boolean" },
+				"requireAtomicIssuance": { "type": "boolean" }
+			}
+		},
+		"publicApi": {
+			"type": "object",
+			"required": [
+				"baseUrl",
+				"policyUrl",
+				"getAssessmentNsid",
+				"getCurrentAssessmentNsid",
+				"listAssessmentsNsid",
+				"getPolicyNsid"
+			],
+			"properties": {
+				"baseUrl": { "type": "string", "format": "uri", "maxLength": 2048 },
+				"policyUrl": { "type": "string", "format": "uri", "maxLength": 2048 },
+				"getAssessmentNsid": { "type": "string", "format": "nsid" },
+				"getCurrentAssessmentNsid": { "type": "string", "format": "nsid" },
+				"listAssessmentsNsid": { "type": "string", "format": "nsid" },
+				"getPolicyNsid": { "type": "string", "format": "nsid" }
+			}
+		},
+		"contact": {
+			"type": "object",
+			"required": ["reconsiderationUrl", "reconsiderationEmail"],
+			"properties": {
+				"reconsiderationUrl": { "type": "string", "format": "uri", "maxLength": 2048 },
+				"reconsiderationEmail": { "type": "string", "minLength": 1, "maxLength": 256 }
+			}
+		},
+		"transparency": {
+			"type": "object",
+			"required": ["modelOutputIsAdvisoryEvidence"],
+			"properties": { "modelOutputIsAdvisoryEvidence": { "type": "boolean" } }
+		},
+		"currentAssessmentView": {
+			"type": "object",
+			"required": ["src", "subject", "activeLabels"],
+			"properties": {
+				"src": { "type": "string", "format": "did" },
+				"subject": { "type": "ref", "ref": "#assessmentSubject" },
+				"current": { "type": "ref", "ref": "#publicAssessment" },
+				"pending": { "type": "ref", "ref": "#publicAssessment" },
+				"activeLabels": {
+					"type": "array",
+					"maxLength": 64,
+					"items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
+				},
+				"override": { "type": "ref", "ref": "#publicManualAction" }
+			}
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/getAssessment.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/getAssessment.json
@@ -1,0 +1,27 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeller.getAssessment",
+	"description": "Fetch one immutable public assessment by ID. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"parameters": {
+				"type": "params",
+				"required": ["id"],
+				"properties": { "id": { "type": "string", "minLength": 1, "maxLength": 64 } }
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "ref",
+					"ref": "com.emdashcms.experimental.labeller.defs#publicAssessment"
+				}
+			},
+			"errors": [
+				{ "name": "InvalidRequest" },
+				{ "name": "NotFound" },
+				{ "name": "RateLimitExceeded" }
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/getCurrentAssessment.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/getCurrentAssessment.json
@@ -1,0 +1,32 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeller.getCurrentAssessment",
+	"description": "Fetch effective assessment state for an exact release URI and CID. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"parameters": {
+				"type": "params",
+				"required": ["uri", "cid"],
+				"properties": {
+					"uri": { "type": "string", "format": "at-uri" },
+					"cid": { "type": "string", "format": "cid" },
+					"src": { "type": "string", "format": "did" }
+				}
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "ref",
+					"ref": "com.emdashcms.experimental.labeller.defs#currentAssessmentView"
+				}
+			},
+			"errors": [
+				{ "name": "InvalidRequest" },
+				{ "name": "NotFound" },
+				{ "name": "UnsupportedSource" },
+				{ "name": "RateLimitExceeded" }
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/getPolicy.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/getPolicy.json
@@ -1,0 +1,15 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeller.getPolicy",
+	"description": "Fetch the current machine-readable labeller policy document. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"output": {
+				"encoding": "application/json",
+				"schema": { "type": "ref", "ref": "com.emdashcms.experimental.labeller.defs#labelerPolicy" }
+			},
+			"errors": [{ "name": "RateLimitExceeded" }]
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/listAssessments.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeller/listAssessments.json
@@ -1,0 +1,48 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeller.listAssessments",
+	"description": "Page through public assessments using bounded exact-subject and state filters. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"parameters": {
+				"type": "params",
+				"properties": {
+					"src": { "type": "string", "format": "did" },
+					"uri": { "type": "string", "format": "at-uri" },
+					"cid": { "type": "string", "format": "cid" },
+					"state": {
+						"type": "string",
+						"knownValues": ["pending", "passed", "warned", "blocked", "error", "superseded"]
+					},
+					"limit": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 },
+					"cursor": { "type": "string", "maxLength": 1024 }
+				}
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "object",
+					"required": ["assessments"],
+					"properties": {
+						"assessments": {
+							"type": "array",
+							"maxLength": 100,
+							"items": {
+								"type": "ref",
+								"ref": "com.emdashcms.experimental.labeller.defs#publicAssessment"
+							}
+						},
+						"cursor": { "type": "string", "maxLength": 1024 }
+					}
+				}
+			},
+			"errors": [
+				{ "name": "InvalidRequest" },
+				{ "name": "InvalidCursor" },
+				{ "name": "UnsupportedSource" },
+				{ "name": "RateLimitExceeded" }
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/src/generated/index.ts
+++ b/packages/registry-lexicons/src/generated/index.ts
@@ -4,6 +4,11 @@ export * as ComEmdashcmsExperimentalAggregatorGetPackage from "./types/com/emdas
 export * as ComEmdashcmsExperimentalAggregatorListReleases from "./types/com/emdashcms/experimental/aggregator/listReleases.js";
 export * as ComEmdashcmsExperimentalAggregatorResolvePackage from "./types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as ComEmdashcmsExperimentalAggregatorSearchPackages from "./types/com/emdashcms/experimental/aggregator/searchPackages.js";
+export * as ComEmdashcmsExperimentalLabellerDefs from "./types/com/emdashcms/experimental/labeller/defs.js";
+export * as ComEmdashcmsExperimentalLabellerGetAssessment from "./types/com/emdashcms/experimental/labeller/getAssessment.js";
+export * as ComEmdashcmsExperimentalLabellerGetCurrentAssessment from "./types/com/emdashcms/experimental/labeller/getCurrentAssessment.js";
+export * as ComEmdashcmsExperimentalLabellerGetPolicy from "./types/com/emdashcms/experimental/labeller/getPolicy.js";
+export * as ComEmdashcmsExperimentalLabellerListAssessments from "./types/com/emdashcms/experimental/labeller/listAssessments.js";
 export * as ComEmdashcmsExperimentalPackageProfile from "./types/com/emdashcms/experimental/package/profile.js";
 export * as ComEmdashcmsExperimentalPackageRelease from "./types/com/emdashcms/experimental/package/release.js";
 export * as ComEmdashcmsExperimentalPackageReleaseExtension from "./types/com/emdashcms/experimental/package/releaseExtension.js";

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/defs.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/defs.ts
@@ -1,0 +1,685 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import * as ComAtprotoLabelDefs from "@atcute/atproto/types/label/defs";
+
+const _artifactSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#artifact",
+		),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 256
+	 */
+	checksum: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 256),
+	]),
+	/**
+	 * @maxLength 256
+	 */
+	id: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 256),
+		]),
+	),
+});
+const _assessmentSubjectSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#assessmentSubject",
+		),
+	),
+	cid: /*#__PURE__*/ v.cidString(),
+	uri: /*#__PURE__*/ v.resourceUriString(),
+});
+const _contactSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal("com.emdashcms.experimental.labeller.defs#contact"),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 256
+	 */
+	reconsiderationEmail: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 256),
+	]),
+	/**
+	 * @maxLength 2048
+	 */
+	reconsiderationUrl: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.genericUriString(),
+		[/*#__PURE__*/ v.stringLength(0, 2048)],
+	),
+});
+const _coverageSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#coverage",
+		),
+	),
+	code: /*#__PURE__*/ v.string<
+		"complete" | "partial" | "unavailable" | (string & {})
+	>(),
+	dependencies: /*#__PURE__*/ v.string<
+		"complete" | "partial" | "unavailable" | (string & {})
+	>(),
+	images: /*#__PURE__*/ v.string<
+		"complete" | "not-present" | "partial" | "unavailable" | (string & {})
+	>(),
+	metadata: /*#__PURE__*/ v.string<
+		"complete" | "partial" | "unavailable" | (string & {})
+	>(),
+});
+const _currentAssessmentViewSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#currentAssessmentView",
+		),
+	),
+	/**
+	 * @maxLength 64
+	 */
+	get activeLabels() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 64)],
+		);
+	},
+	get current() {
+		return /*#__PURE__*/ v.optional(publicAssessmentSchema);
+	},
+	get override() {
+		return /*#__PURE__*/ v.optional(publicManualActionSchema);
+	},
+	get pending() {
+		return /*#__PURE__*/ v.optional(publicAssessmentSchema);
+	},
+	src: /*#__PURE__*/ v.didString(),
+	get subject() {
+		return assessmentSubjectSchema;
+	},
+});
+const _labelSummarySchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#labelSummary",
+		),
+	),
+	active: /*#__PURE__*/ v.boolean(),
+	expiresAt: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.datetimeString()),
+	issuedAt: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	val: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+});
+const _labelerPolicySchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#labelerPolicy",
+		),
+	),
+	/**
+	 * @minimum 1
+	 */
+	assessmentSchemaVersion: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.integer(),
+		[/*#__PURE__*/ v.integerRange(1)],
+	),
+	get contact() {
+		return contactSchema;
+	},
+	effectiveAt: /*#__PURE__*/ v.datetimeString(),
+	labellerDid: /*#__PURE__*/ v.didString(),
+	/**
+	 * @maxLength 256
+	 */
+	get labels() {
+		return /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(policyLabelSchema), [
+			/*#__PURE__*/ v.arrayLength(0, 256),
+		]);
+	},
+	get overrideRule() {
+		return overrideRuleSchema;
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	policyVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * @maxLength 32
+	 */
+	precedence: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(
+			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 128),
+			]),
+		),
+		[/*#__PURE__*/ v.arrayLength(0, 32)],
+	),
+	get publicApi() {
+		return publicApiSchema;
+	},
+	/**
+	 * @maxLength 256
+	 */
+	get reasonCodes() {
+		return /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(reasonCodeSchema), [
+			/*#__PURE__*/ v.arrayLength(0, 256),
+		]);
+	},
+	/**
+	 * @minimum 1
+	 * @maximum 1
+	 */
+	schemaVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+		/*#__PURE__*/ v.integerRange(1, 1),
+	]),
+	get supportedSubjects() {
+		return supportedSubjectsSchema;
+	},
+	get transparency() {
+		return transparencySchema;
+	},
+});
+const _manualActionSubjectSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#manualActionSubject",
+		),
+	),
+	cid: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.cidString()),
+	uri: /*#__PURE__*/ v.genericUriString(),
+});
+const _modelSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal("com.emdashcms.experimental.labeller.defs#model"),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 256
+	 */
+	modelId: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 256),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	promptVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	provider: /*#__PURE__*/ v.string<"workers-ai" | (string & {})>(),
+});
+const _overrideRuleSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#overrideRule",
+		),
+	),
+	cidRule: /*#__PURE__*/ v.string<"required" | (string & {})>(),
+	requireAtomicIssuance: /*#__PURE__*/ v.boolean(),
+	requireSameSource: /*#__PURE__*/ v.boolean(),
+	/**
+	 * @minLength 1
+	 * @maxLength 8
+	 */
+	reviewerLabels: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(
+			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 128),
+			]),
+		),
+		[/*#__PURE__*/ v.arrayLength(1, 8)],
+	),
+	subject: /*#__PURE__*/ v.string<"release" | (string & {})>(),
+});
+const _policyLabelSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#policyLabel",
+		),
+	),
+	category: /*#__PURE__*/ v.string<
+		| "automated-block"
+		| "eligibility"
+		| "manual-system"
+		| "warning"
+		| (string & {})
+	>(),
+	/**
+	 * @maxLength 64
+	 */
+	get locales() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(policyLocaleSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 64)],
+		);
+	},
+	officialEffect: /*#__PURE__*/ v.string<
+		"block" | "error" | "pass" | "pending" | "redact" | "warn" | (string & {})
+	>(),
+	/**
+	 * @maxLength 8
+	 */
+	get subjectRules() {
+		return /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(subjectRuleSchema), [
+			/*#__PURE__*/ v.arrayLength(0, 8),
+		]);
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	value: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+});
+const _policyLocaleSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#policyLocale",
+		),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 4096
+	 */
+	description: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 4096),
+	]),
+	lang: /*#__PURE__*/ v.languageCodeString(),
+	/**
+	 * @minLength 1
+	 * @maxLength 1024
+	 */
+	name: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 1024),
+	]),
+});
+const _publicApiSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#publicApi",
+		),
+	),
+	/**
+	 * @maxLength 2048
+	 */
+	baseUrl: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.genericUriString(), [
+		/*#__PURE__*/ v.stringLength(0, 2048),
+	]),
+	getAssessmentNsid: /*#__PURE__*/ v.nsidString(),
+	getCurrentAssessmentNsid: /*#__PURE__*/ v.nsidString(),
+	getPolicyNsid: /*#__PURE__*/ v.nsidString(),
+	listAssessmentsNsid: /*#__PURE__*/ v.nsidString(),
+	/**
+	 * @maxLength 2048
+	 */
+	policyUrl: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.genericUriString(), [
+		/*#__PURE__*/ v.stringLength(0, 2048),
+	]),
+});
+const _publicAssessmentSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#publicAssessment",
+		),
+	),
+	get artifact() {
+		return /*#__PURE__*/ v.optional(artifactSchema);
+	},
+	/**
+	 * @minimum 1
+	 */
+	assessmentSchemaVersion: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.integer(),
+		[/*#__PURE__*/ v.integerRange(1)],
+	),
+	completedAt: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.datetimeString()),
+	get coverage() {
+		return coverageSchema;
+	},
+	createdAt: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * @minLength 1
+	 * @maxLength 64
+	 */
+	id: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 64),
+	]),
+	/**
+	 * @maxLength 64
+	 */
+	get labels() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(labelSummarySchema),
+			[/*#__PURE__*/ v.arrayLength(0, 64)],
+		);
+	},
+	get model() {
+		return /*#__PURE__*/ v.optional(modelSchema);
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	policyVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * @maxLength 2048
+	 */
+	reconsiderationUrl: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.genericUriString(),
+		[/*#__PURE__*/ v.stringLength(0, 2048)],
+	),
+	/**
+	 * @maxLength 64
+	 */
+	get scannerVersions() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(scannerVersionSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 64)],
+		);
+	},
+	src: /*#__PURE__*/ v.didString(),
+	state: /*#__PURE__*/ v.string<
+		| "blocked"
+		| "error"
+		| "passed"
+		| "pending"
+		| "superseded"
+		| "warned"
+		| (string & {})
+	>(),
+	get subject() {
+		return assessmentSubjectSchema;
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 4096
+	 */
+	summary: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 4096),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 64
+	 */
+	supersedesAssessmentId: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(1, 64),
+		]),
+	),
+});
+const _publicManualActionSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#publicManualAction",
+		),
+	),
+	createdAt: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * @minLength 1
+	 * @maxLength 64
+	 */
+	id: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 64),
+	]),
+	/**
+	 * @maxLength 64
+	 */
+	get labels() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(labelSummarySchema),
+			[/*#__PURE__*/ v.arrayLength(0, 64)],
+		);
+	},
+	src: /*#__PURE__*/ v.didString(),
+	get subject() {
+		return manualActionSubjectSchema;
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 4096
+	 */
+	summary: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 4096),
+	]),
+	type: /*#__PURE__*/ v.string<
+		| "emergency-takedown"
+		| "label-issue"
+		| "label-retraction"
+		| "override"
+		| (string & {})
+	>(),
+});
+const _publisherSubjectSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#publisherSubject",
+		),
+	),
+	kind: /*#__PURE__*/ v.string<"did" | (string & {})>(),
+});
+const _reasonCodeSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#reasonCode",
+		),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	code: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 4096
+	 */
+	description: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 4096),
+	]),
+});
+const _scannerVersionSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#scannerVersion",
+		),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	scanner: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	version: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+});
+const _subjectRuleSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#subjectRule",
+		),
+	),
+	cidRule: /*#__PURE__*/ v.string<
+		"forbidden" | "optional" | "required" | (string & {})
+	>(),
+	/**
+	 * @minLength 1
+	 * @maxLength 3
+	 */
+	issuanceModes: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(
+			/*#__PURE__*/ v.string<
+				"admin" | "automated" | "reviewer" | (string & {})
+			>(),
+		),
+		[/*#__PURE__*/ v.arrayLength(1, 3)],
+	),
+	subject: /*#__PURE__*/ v.string<
+		"package" | "publisher" | "release" | (string & {})
+	>(),
+});
+const _supportedSubjectsSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#supportedSubjects",
+		),
+	),
+	/**
+	 * @maxLength 32
+	 */
+	packageCollections: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(/*#__PURE__*/ v.nsidString()),
+		[/*#__PURE__*/ v.arrayLength(0, 32)],
+	),
+	get publisher() {
+		return publisherSubjectSchema;
+	},
+	/**
+	 * @maxLength 32
+	 */
+	releaseCollections: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(/*#__PURE__*/ v.nsidString()),
+		[/*#__PURE__*/ v.arrayLength(0, 32)],
+	),
+});
+const _transparencySchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeller.defs#transparency",
+		),
+	),
+	modelOutputIsAdvisoryEvidence: /*#__PURE__*/ v.boolean(),
+});
+
+type artifact$schematype = typeof _artifactSchema;
+type assessmentSubject$schematype = typeof _assessmentSubjectSchema;
+type contact$schematype = typeof _contactSchema;
+type coverage$schematype = typeof _coverageSchema;
+type currentAssessmentView$schematype = typeof _currentAssessmentViewSchema;
+type labelSummary$schematype = typeof _labelSummarySchema;
+type labelerPolicy$schematype = typeof _labelerPolicySchema;
+type manualActionSubject$schematype = typeof _manualActionSubjectSchema;
+type model$schematype = typeof _modelSchema;
+type overrideRule$schematype = typeof _overrideRuleSchema;
+type policyLabel$schematype = typeof _policyLabelSchema;
+type policyLocale$schematype = typeof _policyLocaleSchema;
+type publicApi$schematype = typeof _publicApiSchema;
+type publicAssessment$schematype = typeof _publicAssessmentSchema;
+type publicManualAction$schematype = typeof _publicManualActionSchema;
+type publisherSubject$schematype = typeof _publisherSubjectSchema;
+type reasonCode$schematype = typeof _reasonCodeSchema;
+type scannerVersion$schematype = typeof _scannerVersionSchema;
+type subjectRule$schematype = typeof _subjectRuleSchema;
+type supportedSubjects$schematype = typeof _supportedSubjectsSchema;
+type transparency$schematype = typeof _transparencySchema;
+
+export interface artifactSchema extends artifact$schematype {}
+export interface assessmentSubjectSchema extends assessmentSubject$schematype {}
+export interface contactSchema extends contact$schematype {}
+export interface coverageSchema extends coverage$schematype {}
+export interface currentAssessmentViewSchema extends currentAssessmentView$schematype {}
+export interface labelSummarySchema extends labelSummary$schematype {}
+export interface labelerPolicySchema extends labelerPolicy$schematype {}
+export interface manualActionSubjectSchema extends manualActionSubject$schematype {}
+export interface modelSchema extends model$schematype {}
+export interface overrideRuleSchema extends overrideRule$schematype {}
+export interface policyLabelSchema extends policyLabel$schematype {}
+export interface policyLocaleSchema extends policyLocale$schematype {}
+export interface publicApiSchema extends publicApi$schematype {}
+export interface publicAssessmentSchema extends publicAssessment$schematype {}
+export interface publicManualActionSchema extends publicManualAction$schematype {}
+export interface publisherSubjectSchema extends publisherSubject$schematype {}
+export interface reasonCodeSchema extends reasonCode$schematype {}
+export interface scannerVersionSchema extends scannerVersion$schematype {}
+export interface subjectRuleSchema extends subjectRule$schematype {}
+export interface supportedSubjectsSchema extends supportedSubjects$schematype {}
+export interface transparencySchema extends transparency$schematype {}
+
+export const artifactSchema = _artifactSchema as artifactSchema;
+export const assessmentSubjectSchema =
+	_assessmentSubjectSchema as assessmentSubjectSchema;
+export const contactSchema = _contactSchema as contactSchema;
+export const coverageSchema = _coverageSchema as coverageSchema;
+export const currentAssessmentViewSchema =
+	_currentAssessmentViewSchema as currentAssessmentViewSchema;
+export const labelSummarySchema = _labelSummarySchema as labelSummarySchema;
+export const labelerPolicySchema = _labelerPolicySchema as labelerPolicySchema;
+export const manualActionSubjectSchema =
+	_manualActionSubjectSchema as manualActionSubjectSchema;
+export const modelSchema = _modelSchema as modelSchema;
+export const overrideRuleSchema = _overrideRuleSchema as overrideRuleSchema;
+export const policyLabelSchema = _policyLabelSchema as policyLabelSchema;
+export const policyLocaleSchema = _policyLocaleSchema as policyLocaleSchema;
+export const publicApiSchema = _publicApiSchema as publicApiSchema;
+export const publicAssessmentSchema =
+	_publicAssessmentSchema as publicAssessmentSchema;
+export const publicManualActionSchema =
+	_publicManualActionSchema as publicManualActionSchema;
+export const publisherSubjectSchema =
+	_publisherSubjectSchema as publisherSubjectSchema;
+export const reasonCodeSchema = _reasonCodeSchema as reasonCodeSchema;
+export const scannerVersionSchema =
+	_scannerVersionSchema as scannerVersionSchema;
+export const subjectRuleSchema = _subjectRuleSchema as subjectRuleSchema;
+export const supportedSubjectsSchema =
+	_supportedSubjectsSchema as supportedSubjectsSchema;
+export const transparencySchema = _transparencySchema as transparencySchema;
+
+export interface Artifact extends v.InferInput<typeof artifactSchema> {}
+export interface AssessmentSubject extends v.InferInput<
+	typeof assessmentSubjectSchema
+> {}
+export interface Contact extends v.InferInput<typeof contactSchema> {}
+export interface Coverage extends v.InferInput<typeof coverageSchema> {}
+export interface CurrentAssessmentView extends v.InferInput<
+	typeof currentAssessmentViewSchema
+> {}
+export interface LabelSummary extends v.InferInput<typeof labelSummarySchema> {}
+export interface LabelerPolicy extends v.InferInput<
+	typeof labelerPolicySchema
+> {}
+export interface ManualActionSubject extends v.InferInput<
+	typeof manualActionSubjectSchema
+> {}
+export interface Model extends v.InferInput<typeof modelSchema> {}
+export interface OverrideRule extends v.InferInput<typeof overrideRuleSchema> {}
+export interface PolicyLabel extends v.InferInput<typeof policyLabelSchema> {}
+export interface PolicyLocale extends v.InferInput<typeof policyLocaleSchema> {}
+export interface PublicApi extends v.InferInput<typeof publicApiSchema> {}
+export interface PublicAssessment extends v.InferInput<
+	typeof publicAssessmentSchema
+> {}
+export interface PublicManualAction extends v.InferInput<
+	typeof publicManualActionSchema
+> {}
+export interface PublisherSubject extends v.InferInput<
+	typeof publisherSubjectSchema
+> {}
+export interface ReasonCode extends v.InferInput<typeof reasonCodeSchema> {}
+export interface ScannerVersion extends v.InferInput<
+	typeof scannerVersionSchema
+> {}
+export interface SubjectRule extends v.InferInput<typeof subjectRuleSchema> {}
+export interface SupportedSubjects extends v.InferInput<
+	typeof supportedSubjectsSchema
+> {}
+export interface Transparency extends v.InferInput<typeof transparencySchema> {}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/getAssessment.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/getAssessment.ts
@@ -1,0 +1,40 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabellerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeller.getAssessment",
+	{
+		params: /*#__PURE__*/ v.object({
+			/**
+			 * @minLength 1
+			 * @maxLength 64
+			 */
+			id: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 64),
+			]),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalLabellerDefs.publicAssessmentSchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeller.getAssessment": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/getCurrentAssessment.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/getCurrentAssessment.ts
@@ -1,0 +1,36 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabellerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeller.getCurrentAssessment",
+	{
+		params: /*#__PURE__*/ v.object({
+			cid: /*#__PURE__*/ v.cidString(),
+			src: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.didString()),
+			uri: /*#__PURE__*/ v.resourceUriString(),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalLabellerDefs.currentAssessmentViewSchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeller.getCurrentAssessment": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/getPolicy.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/getPolicy.ts
@@ -1,0 +1,32 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabellerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeller.getPolicy",
+	{
+		params: null,
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalLabellerDefs.labelerPolicySchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeller.getPolicy": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/listAssessments.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeller/listAssessments.ts
@@ -1,0 +1,84 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabellerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeller.listAssessments",
+	{
+		params: /*#__PURE__*/ v.object({
+			cid: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.cidString()),
+			/**
+			 * @maxLength 1024
+			 */
+			cursor: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+					/*#__PURE__*/ v.stringLength(0, 1024),
+				]),
+			),
+			/**
+			 * @minimum 1
+			 * @maximum 100
+			 * @default 50
+			 */
+			limit: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+					/*#__PURE__*/ v.integerRange(1, 100),
+				]),
+				50,
+			),
+			src: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.didString()),
+			state: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.string<
+					| "blocked"
+					| "error"
+					| "passed"
+					| "pending"
+					| "superseded"
+					| "warned"
+					| (string & {})
+				>(),
+			),
+			uri: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.resourceUriString()),
+		}),
+		output: {
+			type: "lex",
+			schema: /*#__PURE__*/ v.object({
+				/**
+				 * @maxLength 100
+				 */
+				get assessments() {
+					return /*#__PURE__*/ v.constrain(
+						/*#__PURE__*/ v.array(
+							ComEmdashcmsExperimentalLabellerDefs.publicAssessmentSchema,
+						),
+						[/*#__PURE__*/ v.arrayLength(0, 100)],
+					);
+				},
+				/**
+				 * @maxLength 1024
+				 */
+				cursor: /*#__PURE__*/ v.optional(
+					/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+						/*#__PURE__*/ v.stringLength(0, 1024),
+					]),
+				),
+			}),
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export interface $output extends v.InferXRPCBodyInput<mainSchema["output"]> {}
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeller.listAssessments": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/index.ts
+++ b/packages/registry-lexicons/src/index.ts
@@ -28,6 +28,12 @@ export * as AggregatorListReleases from "./generated/types/com/emdashcms/experim
 export * as AggregatorResolvePackage from "./generated/types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as AggregatorSearchPackages from "./generated/types/com/emdashcms/experimental/aggregator/searchPackages.js";
 
+export * as LabellerDefs from "./generated/types/com/emdashcms/experimental/labeller/defs.js";
+export * as LabellerGetAssessment from "./generated/types/com/emdashcms/experimental/labeller/getAssessment.js";
+export * as LabellerGetCurrentAssessment from "./generated/types/com/emdashcms/experimental/labeller/getCurrentAssessment.js";
+export * as LabellerGetPolicy from "./generated/types/com/emdashcms/experimental/labeller/getPolicy.js";
+export * as LabellerListAssessments from "./generated/types/com/emdashcms/experimental/labeller/listAssessments.js";
+
 export * as PackageProfile from "./generated/types/com/emdashcms/experimental/package/profile.js";
 export * as PackageRelease from "./generated/types/com/emdashcms/experimental/package/release.js";
 export * as PackageReleaseExtension from "./generated/types/com/emdashcms/experimental/package/releaseExtension.js";
@@ -52,6 +58,11 @@ export const NSID = {
 	aggregatorListReleases: "com.emdashcms.experimental.aggregator.listReleases",
 	aggregatorResolvePackage: "com.emdashcms.experimental.aggregator.resolvePackage",
 	aggregatorSearchPackages: "com.emdashcms.experimental.aggregator.searchPackages",
+	labellerDefs: "com.emdashcms.experimental.labeller.defs",
+	labellerGetAssessment: "com.emdashcms.experimental.labeller.getAssessment",
+	labellerGetCurrentAssessment: "com.emdashcms.experimental.labeller.getCurrentAssessment",
+	labellerGetPolicy: "com.emdashcms.experimental.labeller.getPolicy",
+	labellerListAssessments: "com.emdashcms.experimental.labeller.listAssessments",
 } as const;
 
 export type NSIDValue = (typeof NSID)[keyof typeof NSID];
@@ -84,6 +95,10 @@ export const QUERY_NSIDS = [
 	NSID.aggregatorListReleases,
 	NSID.aggregatorResolvePackage,
 	NSID.aggregatorSearchPackages,
+	NSID.labellerGetAssessment,
+	NSID.labellerGetCurrentAssessment,
+	NSID.labellerGetPolicy,
+	NSID.labellerListAssessments,
 ] as const;
 
 import type * as PackageProfileNs from "./generated/types/com/emdashcms/experimental/package/profile.js";

--- a/packages/registry-lexicons/tests/labeller.test.ts
+++ b/packages/registry-lexicons/tests/labeller.test.ts
@@ -1,0 +1,154 @@
+import { is } from "@atcute/lexicons/validations";
+import { describe, expect, it } from "vitest";
+
+import {
+	LabellerDefs,
+	LabellerGetAssessment,
+	LabellerGetCurrentAssessment,
+	LabellerGetPolicy,
+	LabellerListAssessments,
+	NSID,
+} from "../src/index.js";
+
+const assessment: LabellerDefs.PublicAssessment = {
+	id: "asmt_01J2Q5Y7V8N9M0K1H2G3F4E5D6",
+	src: "did:web:labels.emdashcms.com",
+	subject: {
+		uri: "at://did:plc:publisher/com.emdashcms.experimental.package.release/gallery:1.0.0",
+		cid: "bafyreiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	},
+	state: "passed",
+	summary: "No blocking condition found.",
+	coverage: {
+		code: "complete",
+		metadata: "complete",
+		images: "not-present",
+		dependencies: "complete",
+	},
+	labels: [{ val: "assessment-passed", active: true, issuedAt: "2026-07-10T12:00:00Z" }],
+	policyVersion: "2026-07-10",
+	assessmentSchemaVersion: 1,
+	scannerVersions: [{ scanner: "dependency", version: "1.0.0" }],
+	createdAt: "2026-07-10T12:00:00Z",
+	completedAt: "2026-07-10T12:01:00Z",
+	reconsiderationUrl: "https://emdashcms.com/plugin-moderation/reconsideration",
+};
+
+describe("labeller Lexicons", () => {
+	it("validates the public assessment and current-assessment output", () => {
+		const output: LabellerGetCurrentAssessment.$output = {
+			src: assessment.src,
+			subject: assessment.subject,
+			current: assessment,
+			activeLabels: [
+				{
+					ver: 1,
+					src: assessment.src,
+					uri: assessment.subject.uri,
+					cid: assessment.subject.cid,
+					val: "assessment-passed",
+					cts: assessment.completedAt,
+				},
+			],
+		};
+
+		expect(is(LabellerDefs.publicAssessmentSchema, assessment)).toBe(true);
+		expect(
+			is(LabellerDefs.publicAssessmentSchema, {
+				...assessment,
+				subject: { ...assessment.subject, uri: "did:web:publisher.example.com" },
+			}),
+		).toBe(false);
+		expect(is(LabellerGetCurrentAssessment.mainSchema.output.schema, output)).toBe(true);
+	});
+
+	it("validates a publisher-level manual action with a DID subject", () => {
+		const action: LabellerDefs.PublicManualAction = {
+			id: "action_01J2Q5Y7V8N9M0K1H2G3F4E5D6",
+			src: assessment.src,
+			subject: { uri: "did:web:publisher.example.com" },
+			type: "emergency-takedown",
+			summary: "The publisher identity is believed to be compromised.",
+			labels: [
+				{
+					val: "publisher-compromised",
+					active: true,
+					issuedAt: "2026-07-10T12:00:00Z",
+				},
+			],
+			createdAt: "2026-07-10T12:00:00Z",
+		};
+
+		expect(is(LabellerDefs.publicManualActionSchema, action)).toBe(true);
+	});
+
+	it("validates query parameters and rejects schema-invalid inputs", () => {
+		const current: LabellerGetCurrentAssessment.$params = {
+			uri: assessment.subject.uri,
+			cid: assessment.subject.cid,
+			src: assessment.src,
+		};
+		const list: LabellerListAssessments.$params = { state: "passed", limit: 50 };
+
+		expect(is(LabellerGetCurrentAssessment.mainSchema.params, current)).toBe(true);
+		expect(is(LabellerListAssessments.mainSchema.params, list)).toBe(true);
+		expect(
+			is(LabellerGetCurrentAssessment.mainSchema.params, { ...current, src: "not-a-did" }),
+		).toBe(false);
+		expect(
+			is(LabellerGetCurrentAssessment.mainSchema.params, {
+				...current,
+				uri: "https://example.com/release",
+			}),
+		).toBe(false);
+		expect(is(LabellerListAssessments.mainSchema.params, { cursor: "a".repeat(1025) })).toBe(false);
+		expect(is(LabellerListAssessments.mainSchema.params, { limit: 101 })).toBe(false);
+	});
+
+	it("validates endpoint output shapes and the fixed-field policy document", () => {
+		const list: LabellerListAssessments.$output = { assessments: [assessment] };
+		const policy: LabellerGetPolicy.$output = {
+			schemaVersion: 1,
+			policyVersion: "2026-07-10",
+			effectiveAt: "2026-07-10T00:00:00Z",
+			labellerDid: assessment.src,
+			assessmentSchemaVersion: 1,
+			supportedSubjects: {
+				publisher: { kind: "did" },
+				packageCollections: [NSID.packageProfile],
+				releaseCollections: [NSID.packageRelease],
+			},
+			reasonCodes: [{ code: "missing-assessment-pass", description: "No active pass label." }],
+			labels: [],
+			overrideRule: {
+				subject: "release",
+				cidRule: "required",
+				reviewerLabels: ["assessment-passed", "assessment-overridden"],
+				requireSameSource: true,
+				requireAtomicIssuance: true,
+			},
+			precedence: ["manual-block", "eligible"],
+			publicApi: {
+				baseUrl: "https://labels.emdashcms.com/xrpc/",
+				policyUrl: "https://labels.emdashcms.com/.well-known/emdash-labeler-policy.json",
+				getAssessmentNsid: NSID.labellerGetAssessment,
+				getCurrentAssessmentNsid: NSID.labellerGetCurrentAssessment,
+				listAssessmentsNsid: NSID.labellerListAssessments,
+				getPolicyNsid: NSID.labellerGetPolicy,
+			},
+			contact: {
+				reconsiderationUrl: assessment.reconsiderationUrl,
+				reconsiderationEmail: "plugin-moderation@emdashcms.com",
+			},
+			transparency: { modelOutputIsAdvisoryEvidence: true },
+		};
+
+		expect(is(LabellerGetAssessment.mainSchema.params, { id: assessment.id })).toBe(true);
+		expect(is(LabellerGetAssessment.mainSchema.params, { id: "" })).toBe(false);
+		expect(is(LabellerListAssessments.mainSchema.output.schema, list)).toBe(true);
+		expect(is(LabellerGetPolicy.mainSchema.output.schema, policy)).toBe(true);
+		expect(is(LabellerGetPolicy.mainSchema.output.schema, { ...policy, schemaVersion: 2 })).toBe(
+			false,
+		);
+	});
+});

--- a/packages/registry-lexicons/tests/types.test.ts
+++ b/packages/registry-lexicons/tests/types.test.ts
@@ -167,6 +167,11 @@ describe("NSID map", () => {
 			"com.emdashcms.experimental.aggregator.listReleases",
 			"com.emdashcms.experimental.aggregator.resolvePackage",
 			"com.emdashcms.experimental.aggregator.searchPackages",
+			"com.emdashcms.experimental.labeller.defs",
+			"com.emdashcms.experimental.labeller.getAssessment",
+			"com.emdashcms.experimental.labeller.getCurrentAssessment",
+			"com.emdashcms.experimental.labeller.getPolicy",
+			"com.emdashcms.experimental.labeller.listAssessments",
 		].toSorted();
 
 		const actual = Object.values(NSID).toSorted();


### PR DESCRIPTION
## What does this PR do?

Adds experimental public Lexicons for the EmDash registry labeller.

- Defines public assessment, current assessment, manual-action, and fixed-field policy views.
- Adds `getAssessment`, `getCurrentAssessment`, `listAssessments`, and `getPolicy` query contracts.
- Generates TypeScript contracts and exports their NSIDs.
- Adds schema tests, including publisher-DID manual actions.

Implements W1.2/W1.3 from #1909. It adds contracts only; no labeler service routes are implemented yet.

Related to #1909 and #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n is not applicable because this package has no user interface.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6-sol and independent review subagents

## Screenshots / test output

- `pnpm run codegen` passes
- `pnpm build` passes
- `pnpm --filter @emdash-cms/registry-lexicons test`: 14 passed
- `pnpm --filter @emdash-cms/registry-lexicons typecheck` passes
- `pnpm lint` passes
- `pnpm changeset status` passes
- `git diff --check` passes

`attw --pack` retains its existing internal `filename` crash after `publint` succeeds.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeller-10-labeller-lexicons-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeller-10-labeller-lexicons`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
