### PR TITLE
fix(docs): publish the seed file JSON Schema

### DIFF
--- a/docs/public/seed.schema.json
+++ b/docs/public/seed.schema.json
@@ -1,0 +1,285 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://emdashcms.com/seed.schema.json",
+	"title": "EmDash seed file",
+	"description": "Schema for EmDash version 1 seed files.",
+	"type": "object",
+	"required": ["version"],
+	"properties": {
+		"$schema": { "type": "string", "format": "uri-reference" },
+		"version": { "const": "1" },
+		"defaultLocale": { "type": "string", "minLength": 1, "pattern": "^\\S(?:.*\\S)?$" },
+		"meta": { "$ref": "#/$defs/meta" },
+		"settings": { "$ref": "#/$defs/settings" },
+		"collections": { "type": "array", "items": { "$ref": "#/$defs/collection" } },
+		"taxonomies": { "type": "array", "items": { "$ref": "#/$defs/taxonomy" } },
+		"bylines": { "type": "array", "items": { "$ref": "#/$defs/byline" } },
+		"menus": { "type": "array", "items": { "$ref": "#/$defs/menu" } },
+		"redirects": { "type": "array", "items": { "$ref": "#/$defs/redirect" } },
+		"widgetAreas": { "type": "array", "items": { "$ref": "#/$defs/widgetArea" } },
+		"sections": { "type": "array", "items": { "$ref": "#/$defs/section" } },
+		"content": {
+			"type": "object",
+			"additionalProperties": { "type": "array", "items": { "$ref": "#/$defs/contentEntry" } }
+		}
+	},
+	"additionalProperties": true,
+	"$defs": {
+		"meta": {
+			"type": "object",
+			"properties": {
+				"name": { "type": "string" },
+				"description": { "type": "string" },
+				"author": { "type": "string" }
+			},
+			"additionalProperties": true
+		},
+		"settings": {
+			"type": "object",
+			"properties": {
+				"title": { "type": "string" },
+				"tagline": { "type": "string" },
+				"logo": { "$ref": "#/$defs/mediaReference" },
+				"favicon": { "$ref": "#/$defs/mediaReference" },
+				"url": { "type": "string" },
+				"postsPerPage": { "type": "number" },
+				"dateFormat": { "type": "string" },
+				"timezone": { "type": "string" },
+				"social": { "type": "object", "additionalProperties": { "type": "string" } },
+				"seo": { "type": "object", "additionalProperties": true }
+			},
+			"additionalProperties": true
+		},
+		"mediaReference": {
+			"type": "object",
+			"required": ["mediaId"],
+			"properties": {
+				"mediaId": { "type": "string" },
+				"alt": { "type": "string" }
+			},
+			"additionalProperties": true
+		},
+		"collection": {
+			"type": "object",
+			"required": ["slug", "label", "fields"],
+			"properties": {
+				"slug": { "$ref": "#/$defs/identifier" },
+				"label": { "type": "string", "minLength": 1 },
+				"labelSingular": { "type": "string" },
+				"description": { "type": "string" },
+				"icon": { "type": "string" },
+				"supports": {
+					"type": "array",
+					"items": { "enum": ["drafts", "revisions", "preview", "scheduling", "search", "seo"] },
+					"uniqueItems": true
+				},
+				"urlPattern": { "type": "string" },
+				"commentsEnabled": { "type": "boolean" },
+				"fields": { "type": "array", "items": { "$ref": "#/$defs/field" } }
+			},
+			"additionalProperties": true
+		},
+		"field": {
+			"type": "object",
+			"required": ["slug", "label", "type"],
+			"properties": {
+				"slug": { "$ref": "#/$defs/identifier" },
+				"label": { "type": "string", "minLength": 1 },
+				"type": {
+					"enum": [
+						"string",
+						"text",
+						"url",
+						"number",
+						"integer",
+						"boolean",
+						"datetime",
+						"select",
+						"multiSelect",
+						"portableText",
+						"image",
+						"file",
+						"reference",
+						"json",
+						"slug",
+						"repeater"
+					]
+				},
+				"required": { "type": "boolean" },
+				"unique": { "type": "boolean" },
+				"searchable": { "type": "boolean" },
+				"defaultValue": true,
+				"validation": { "type": "object" },
+				"widget": { "type": "string" },
+				"options": { "type": "object" }
+			},
+			"additionalProperties": true
+		},
+		"taxonomy": {
+			"type": "object",
+			"required": ["name", "label", "hierarchical", "collections"],
+			"properties": {
+				"id": { "type": "string" },
+				"name": { "$ref": "#/$defs/identifier" },
+				"label": { "type": "string", "minLength": 1 },
+				"labelSingular": { "type": "string" },
+				"hierarchical": { "type": "boolean" },
+				"collections": { "type": "array", "items": { "$ref": "#/$defs/identifier" } },
+				"locale": { "type": "string" },
+				"translationOf": { "type": "string" },
+				"terms": { "type": "array", "items": { "$ref": "#/$defs/taxonomyTerm" } }
+			},
+			"additionalProperties": true
+		},
+		"taxonomyTerm": {
+			"type": "object",
+			"required": ["slug", "label"],
+			"properties": {
+				"id": { "type": "string" },
+				"slug": { "type": "string", "minLength": 1 },
+				"label": { "type": "string", "minLength": 1 },
+				"description": { "type": "string" },
+				"parent": { "type": "string" },
+				"locale": { "type": "string" },
+				"translationOf": { "type": "string" }
+			},
+			"additionalProperties": true
+		},
+		"byline": {
+			"type": "object",
+			"required": ["id", "slug", "displayName"],
+			"properties": {
+				"id": { "type": "string", "minLength": 1 },
+				"slug": { "type": "string", "minLength": 1 },
+				"displayName": { "type": "string", "minLength": 1 },
+				"bio": { "type": "string" },
+				"websiteUrl": { "type": "string" },
+				"isGuest": { "type": "boolean" },
+				"avatar": { "$ref": "#/$defs/bylineAvatar" }
+			},
+			"additionalProperties": true
+		},
+		"bylineAvatar": {
+			"type": "object",
+			"required": ["storageKey"],
+			"properties": {
+				"storageKey": { "type": "string", "minLength": 1 },
+				"alt": { "type": "string" },
+				"filename": { "type": "string" },
+				"mimeType": { "type": "string" },
+				"width": { "type": "number" },
+				"height": { "type": "number" }
+			},
+			"additionalProperties": true
+		},
+		"menu": {
+			"type": "object",
+			"required": ["name", "label", "items"],
+			"properties": {
+				"id": { "type": "string" },
+				"name": { "$ref": "#/$defs/identifier" },
+				"label": { "type": "string", "minLength": 1 },
+				"locale": { "type": "string" },
+				"translationOf": { "type": "string" },
+				"items": { "type": "array", "items": { "$ref": "#/$defs/menuItem" } }
+			},
+			"additionalProperties": true
+		},
+		"menuItem": {
+			"type": "object",
+			"required": ["type"],
+			"properties": {
+				"id": { "type": "string" },
+				"type": { "type": "string", "minLength": 1 },
+				"label": { "type": "string" },
+				"url": { "type": "string" },
+				"ref": { "type": "string" },
+				"collection": { "type": "string" },
+				"target": { "enum": ["_blank", "_self"] },
+				"titleAttr": { "type": "string" },
+				"cssClasses": { "type": "string" },
+				"locale": { "type": "string" },
+				"translationOf": { "type": "string" },
+				"children": { "type": "array", "items": { "$ref": "#/$defs/menuItem" } }
+			},
+			"additionalProperties": true
+		},
+		"redirect": {
+			"type": "object",
+			"required": ["source", "destination"],
+			"properties": {
+				"source": { "type": "string", "pattern": "^/(?!/)" },
+				"destination": { "type": "string", "pattern": "^/(?!/)" },
+				"type": { "enum": [301, 302, 307, 308] },
+				"enabled": { "type": "boolean" },
+				"groupName": { "type": ["string", "null"] }
+			},
+			"additionalProperties": true
+		},
+		"widgetArea": {
+			"type": "object",
+			"required": ["name", "label", "widgets"],
+			"properties": {
+				"name": { "$ref": "#/$defs/identifier" },
+				"label": { "type": "string", "minLength": 1 },
+				"description": { "type": "string" },
+				"widgets": { "type": "array", "items": { "$ref": "#/$defs/widget" } }
+			},
+			"additionalProperties": true
+		},
+		"widget": {
+			"type": "object",
+			"required": ["type"],
+			"properties": {
+				"type": { "enum": ["content", "menu", "component"] },
+				"title": { "type": "string" },
+				"content": { "type": "array", "items": { "type": "object", "required": ["_type"] } },
+				"menuName": { "type": "string" },
+				"componentId": { "type": "string" },
+				"props": { "type": "object" }
+			},
+			"additionalProperties": true
+		},
+		"section": {
+			"type": "object",
+			"required": ["slug", "title", "content"],
+			"properties": {
+				"slug": { "type": "string", "minLength": 1 },
+				"title": { "type": "string", "minLength": 1 },
+				"description": { "type": "string" },
+				"keywords": { "type": "array", "items": { "type": "string" } },
+				"content": { "type": "array", "items": { "type": "object", "required": ["_type"] } },
+				"source": { "enum": ["theme", "import"] }
+			},
+			"additionalProperties": true
+		},
+		"contentEntry": {
+			"type": "object",
+			"required": ["id", "slug", "data"],
+			"properties": {
+				"id": { "type": "string", "minLength": 1 },
+				"slug": { "type": "string", "minLength": 1 },
+				"status": { "enum": ["published", "draft"] },
+				"data": { "type": "object" },
+				"taxonomies": {
+					"type": "object",
+					"additionalProperties": { "type": "array", "items": { "type": "string" } }
+				},
+				"bylines": { "type": "array", "items": { "$ref": "#/$defs/bylineCredit" } },
+				"locale": { "type": "string" },
+				"translationOf": { "type": "string" }
+			},
+			"additionalProperties": true
+		},
+		"bylineCredit": {
+			"type": "object",
+			"required": ["byline"],
+			"properties": {
+				"byline": { "type": "string", "minLength": 1 },
+				"roleLabel": { "type": "string" }
+			},
+			"additionalProperties": true
+		},
+		"identifier": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+	}
+}

--- a/packages/core/tests/integration/smoke/template-smoke.test.ts
+++ b/packages/core/tests/integration/smoke/template-smoke.test.ts
@@ -32,6 +32,7 @@ const exec = promisify(execFile);
 const WORKSPACE_ROOT = resolve(import.meta.dirname, "../../../../..");
 const CLI_BIN = resolve(import.meta.dirname, "../../../dist/cli/index.mjs");
 const VALIDATION_FAILED_RE = /validation failed/i;
+const SEED_SCHEMA_URL = "https://emdashcms.com/seed.schema.json";
 
 // ---------------------------------------------------------------------------
 // Discover all templates and demos with seed files
@@ -95,6 +96,22 @@ function discoverFixtures(): SiteFixture[] {
 }
 
 const fixtures = discoverFixtures();
+
+describe("published seed schema", () => {
+	it("is available at the canonical docs site path", () => {
+		const schemaPath = resolve(WORKSPACE_ROOT, "docs/public/seed.schema.json");
+		const schema = JSON.parse(readFileSync(schemaPath, "utf-8")) as {
+			$id?: string;
+			properties?: { version?: { const?: string } };
+		};
+
+		expect(schema.$id).toBe(SEED_SCHEMA_URL);
+		expect(schema.properties?.version?.const).toBe("1");
+		for (const fixture of fixtures) {
+			expect(fixture.seed.$schema).toBe(SEED_SCHEMA_URL);
+		}
+	});
+});
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
## What does this PR do?

Publishes the JSON Schema already referenced by EmDash seed files at `https://emdashcms.com/seed.schema.json`.

The documentation, templates, demos, and `export-seed` output all point JSON editors to this URL for validation and autocomplete, but the docs site currently returns its HTML 404 page. The schema is now a static docs asset and covers the documented version 1 seed structures. A smoke test protects the canonical path and verifies that shipped seed fixtures use the same URL.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable; no admin UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (not applicable; docs-site-only change)
- [x] New features link to an approved Discussion: not applicable; this restores an already documented URL

`pnpm typecheck` currently fails on unchanged upstream code at `packages/core/src/auth/oauth-state-store.ts:83` (`OAuthState.inviteToken`) and `packages/core/src/plugins/context.ts:1098` (`taxonomies:read`).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 Codex

## Screenshots / test output

- `pnpm --filter emdash test:smoke`
- `pnpm --filter docs build`
- `pnpm lint`
- `pnpm lint:json` reports 0 diagnostics
- Verified `docs/dist/client/seed.schema.json` is byte-identical to the source asset
