### PR TITLE
feat(plugin-types): add declared access escalation

### DIFF
--- a/.changeset/calm-access-rules.md
+++ b/.changeset/calm-access-rules.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-types": minor
+---
+
+Adds canonical declared-access comparison, structured escalation diffs, and stable digest input generation.

--- a/packages/plugin-types/src/declared-access.ts
+++ b/packages/plugin-types/src/declared-access.ts
@@ -1,0 +1,398 @@
+import type { DeclaredAccess } from "./index.js";
+
+export type CanonicalJsonValue =
+	| null
+	| boolean
+	| number
+	| string
+	| readonly CanonicalJsonValue[]
+	| { readonly [key: string]: CanonicalJsonValue };
+
+export type CanonicalAccessConstraints = Readonly<Record<string, CanonicalJsonValue>>;
+
+export interface CanonicalDeclaredAccess {
+	readonly content?: Readonly<{
+		read?: CanonicalAccessConstraints;
+		write?: CanonicalAccessConstraints;
+	}>;
+	readonly email?: Readonly<{
+		events?: CanonicalAccessConstraints;
+		send?: CanonicalAccessConstraints;
+		transport?: CanonicalAccessConstraints;
+	}>;
+	readonly media?: Readonly<{
+		read?: CanonicalAccessConstraints;
+		write?: CanonicalAccessConstraints;
+	}>;
+	readonly network?: Readonly<{
+		request?: CanonicalAccessConstraints & { readonly allowedHosts?: readonly string[] };
+	}>;
+	readonly page?: Readonly<{ fragments?: CanonicalAccessConstraints }>;
+	readonly users?: Readonly<{ read?: CanonicalAccessConstraints }>;
+}
+
+export type AccessChangeKind =
+	| "category-added"
+	| "category-removed"
+	| "operation-added"
+	| "operation-removed"
+	| "constraint-added"
+	| "constraint-removed"
+	| "constraint-changed";
+
+export interface AccessChange {
+	readonly kind: AccessChangeKind;
+	readonly category: string;
+	readonly operation?: string;
+	readonly path: readonly string[];
+	readonly previous?: CanonicalJsonValue;
+	readonly next?: CanonicalJsonValue;
+	readonly escalation: boolean;
+}
+
+export interface AccessDiff {
+	readonly changes: readonly AccessChange[];
+	readonly escalation: boolean;
+}
+
+type CanonicalObject = Readonly<Record<string, CanonicalJsonValue>>;
+
+const DIGEST_DOMAIN = "@emdash-cms/plugin-types/declared-access";
+const DIGEST_VERSION = 1;
+
+function isObject(value: CanonicalJsonValue | undefined): value is CanonicalObject {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function compareStrings(left: string, right: string): number {
+	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function defineDataProperty(
+	target: Record<string, CanonicalJsonValue>,
+	key: string,
+	value: CanonicalJsonValue,
+): void {
+	Object.defineProperty(target, key, {
+		value,
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	});
+}
+
+function canonicalizeJson(
+	value: unknown,
+	ancestors: Set<object>,
+	path: readonly string[],
+): CanonicalJsonValue {
+	if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+	if (typeof value === "number") {
+		if (!Number.isFinite(value))
+			throw new TypeError(`Non-finite number at ${path.join(".") || "root"}`);
+		return Object.is(value, -0) ? 0 : value;
+	}
+	if (typeof value !== "object") {
+		throw new TypeError(`Non-JSON value at ${path.join(".") || "root"}`);
+	}
+	if (Object.getOwnPropertySymbols(value).length > 0) {
+		throw new TypeError(`Symbol-keyed property at ${path.join(".") || "root"}`);
+	}
+	if (ancestors.has(value)) throw new TypeError(`Circular value at ${path.join(".") || "root"}`);
+	ancestors.add(value);
+
+	let result: CanonicalJsonValue;
+	if (Array.isArray(value)) {
+		const output: CanonicalJsonValue[] = [];
+		for (let index = 0; index < value.length; index++) {
+			if (!Object.hasOwn(value, index)) {
+				throw new TypeError(`Sparse array at ${[...path, String(index)].join(".")}`);
+			}
+			output.push(canonicalizeJson(value[index], ancestors, [...path, String(index)]));
+		}
+		result = Object.freeze(output);
+	} else {
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) {
+			throw new TypeError(`Non-JSON object at ${path.join(".") || "root"}`);
+		}
+		const output: Record<string, CanonicalJsonValue> = {};
+		for (const key of Object.keys(value).toSorted(compareStrings)) {
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (!descriptor || !("value" in descriptor)) {
+				throw new TypeError(`Non-JSON property at ${[...path, key].join(".")}`);
+			}
+			defineDataProperty(
+				output,
+				key,
+				canonicalizeJson(descriptor.value, ancestors, [...path, key]),
+			);
+		}
+		result = Object.freeze(output);
+	}
+
+	ancestors.delete(value);
+	return result;
+}
+
+function requireObject(
+	value: CanonicalJsonValue | undefined,
+	path: readonly string[],
+): CanonicalObject {
+	if (!isObject(value)) throw new TypeError(`Expected object at ${path.join(".") || "root"}`);
+	return value;
+}
+
+function normalizeDeclaredAccess(value: DeclaredAccess): CanonicalObject {
+	const canonical = requireObject(canonicalizeJson(value, new Set(), []), []);
+	const output: Record<string, CanonicalJsonValue> = {};
+
+	for (const category of Object.keys(canonical)) {
+		const operations = requireObject(canonical[category], [category]);
+		const normalizedOperations: Record<string, CanonicalJsonValue> = {};
+		for (const operation of Object.keys(operations)) {
+			const constraints = requireObject(operations[operation], [category, operation]);
+			const normalizedConstraints: Record<string, CanonicalJsonValue> = { ...constraints };
+			if (
+				category === "network" &&
+				operation === "request" &&
+				Object.hasOwn(constraints, "allowedHosts")
+			) {
+				const hosts = constraints.allowedHosts;
+				if (!isStringArray(hosts)) {
+					throw new TypeError("Expected network.request.allowedHosts to be an array of strings");
+				}
+				normalizedConstraints.allowedHosts = Object.freeze(
+					[...new Set(hosts)].toSorted(compareStrings),
+				);
+			}
+			defineDataProperty(normalizedOperations, operation, Object.freeze(normalizedConstraints));
+		}
+		if (
+			(category === "content" || category === "media") &&
+			Object.hasOwn(normalizedOperations, "write")
+		) {
+			normalizedOperations.read ??= Object.freeze({});
+		}
+		defineDataProperty(
+			output,
+			category,
+			Object.freeze(
+				Object.fromEntries(
+					Object.entries(normalizedOperations).toSorted(([left], [right]) =>
+						compareStrings(left, right),
+					),
+				),
+			),
+		);
+	}
+
+	return Object.freeze(output);
+}
+
+/**
+ * Returns an immutable, implication-closed declared-access value with recursively
+ * sorted keys and canonical host sets. Non-JSON runtime values throw TypeError.
+ */
+export function canonicalizeDeclaredAccess(value: DeclaredAccess): CanonicalDeclaredAccess {
+	return normalizeDeclaredAccess(value) as CanonicalDeclaredAccess;
+}
+
+function canonicalString(value: DeclaredAccess): string {
+	return JSON.stringify(canonicalizeDeclaredAccess(value));
+}
+
+export function declaredAccessEqual(previous: DeclaredAccess, next: DeclaredAccess): boolean {
+	return canonicalString(previous) === canonicalString(next);
+}
+
+function change(
+	kind: AccessChangeKind,
+	category: string,
+	operation: string | undefined,
+	path: readonly string[],
+	previous: CanonicalJsonValue | undefined,
+	next: CanonicalJsonValue | undefined,
+	escalation: boolean,
+): AccessChange {
+	return Object.freeze({
+		kind,
+		category,
+		operation,
+		path: Object.freeze([...path]),
+		previous,
+		next,
+		escalation,
+	});
+}
+
+function patternCovers(oldPattern: string, newPattern: string): boolean {
+	if (oldPattern === "*") return true;
+	if (oldPattern === newPattern) return true;
+	if (!oldPattern.startsWith("*.")) return oldPattern === newPattern;
+	const oldSuffix = oldPattern.slice(1);
+	if (newPattern.startsWith("*.")) {
+		const newSuffix = newPattern.slice(1);
+		return newSuffix !== oldSuffix && newSuffix.endsWith(oldSuffix);
+	}
+	return newPattern.endsWith(oldSuffix) && newPattern.length > oldSuffix.length;
+}
+
+function hostsEscalate(previous: readonly string[], next: readonly string[]): boolean {
+	return next.some(
+		(nextPattern) => !previous.some((oldPattern) => patternCovers(oldPattern, nextPattern)),
+	);
+}
+
+function valuesEqual(previous: CanonicalJsonValue, next: CanonicalJsonValue): boolean {
+	return JSON.stringify(previous) === JSON.stringify(next);
+}
+
+function diffConstraints(
+	previous: CanonicalObject,
+	next: CanonicalObject,
+	category: string,
+	operation: string,
+): AccessChange[] {
+	const changes: AccessChange[] = [];
+	const keys = [...new Set([...Object.keys(previous), ...Object.keys(next)])].toSorted(
+		compareStrings,
+	);
+	for (const key of keys) {
+		const hadOldValue = Object.hasOwn(previous, key);
+		const hasNewValue = Object.hasOwn(next, key);
+		const oldValue = previous[key];
+		const newValue = next[key];
+		const path = [category, operation, key];
+		const knownHosts = category === "network" && operation === "request" && key === "allowedHosts";
+		if (!hadOldValue) {
+			changes.push(
+				change("constraint-added", category, operation, path, undefined, newValue, !knownHosts),
+			);
+		} else if (!hasNewValue) {
+			changes.push(
+				change("constraint-removed", category, operation, path, oldValue, undefined, true),
+			);
+		} else {
+			if (oldValue === undefined || newValue === undefined) {
+				throw new TypeError(`Non-JSON constraint at ${path.join(".")}`);
+			}
+			if (valuesEqual(oldValue, newValue)) continue;
+			let escalation = true;
+			if (knownHosts) {
+				if (!isStringArray(oldValue) || !isStringArray(newValue)) {
+					throw new TypeError("Expected network.request.allowedHosts to be arrays of strings");
+				}
+				escalation = hostsEscalate(oldValue, newValue);
+			}
+			changes.push(
+				change("constraint-changed", category, operation, path, oldValue, newValue, escalation),
+			);
+		}
+	}
+	return changes;
+}
+
+export function diffDeclaredAccess(previous: DeclaredAccess, next: DeclaredAccess): AccessDiff {
+	const oldAccess = normalizeDeclaredAccess(previous);
+	const newAccess = normalizeDeclaredAccess(next);
+	const changes: AccessChange[] = [];
+	const categories = [...new Set([...Object.keys(oldAccess), ...Object.keys(newAccess)])].toSorted(
+		compareStrings,
+	);
+
+	for (const category of categories) {
+		const hadOldCategory = Object.hasOwn(oldAccess, category);
+		const hasNewCategory = Object.hasOwn(newAccess, category);
+		const oldCategory = oldAccess[category];
+		const newCategory = newAccess[category];
+		if (!hadOldCategory) {
+			changes.push(
+				change("category-added", category, undefined, [category], undefined, newCategory, true),
+			);
+			continue;
+		}
+		if (!hasNewCategory) {
+			changes.push(
+				change("category-removed", category, undefined, [category], oldCategory, undefined, false),
+			);
+			continue;
+		}
+		if (oldCategory === undefined || newCategory === undefined) {
+			throw new TypeError(`Non-JSON category at ${category}`);
+		}
+
+		const oldOperations = requireObject(oldCategory, [category]);
+		const newOperations = requireObject(newCategory, [category]);
+		const operations = [
+			...new Set([...Object.keys(oldOperations), ...Object.keys(newOperations)]),
+		].toSorted(compareStrings);
+		for (const operation of operations) {
+			const hadOldOperation = Object.hasOwn(oldOperations, operation);
+			const hasNewOperation = Object.hasOwn(newOperations, operation);
+			const oldOperation = oldOperations[operation];
+			const newOperation = newOperations[operation];
+			if (!hadOldOperation) {
+				changes.push(
+					change(
+						"operation-added",
+						category,
+						operation,
+						[category, operation],
+						undefined,
+						newOperation,
+						true,
+					),
+				);
+			} else if (!hasNewOperation) {
+				changes.push(
+					change(
+						"operation-removed",
+						category,
+						operation,
+						[category, operation],
+						oldOperation,
+						undefined,
+						false,
+					),
+				);
+			} else {
+				if (oldOperation === undefined || newOperation === undefined) {
+					throw new TypeError(`Non-JSON operation at ${category}.${operation}`);
+				}
+				changes.push(
+					...diffConstraints(
+						requireObject(oldOperation, [category, operation]),
+						requireObject(newOperation, [category, operation]),
+						category,
+						operation,
+					),
+				);
+			}
+		}
+	}
+
+	return Object.freeze({
+		changes: Object.freeze(changes),
+		escalation: changes.some((item) => item.escalation),
+	});
+}
+
+export function isDeclaredAccessEscalation(
+	previous: DeclaredAccess,
+	next: DeclaredAccess,
+): boolean {
+	return diffDeclaredAccess(previous, next).escalation;
+}
+
+/**
+ * Returns the canonical JSON preimage for a declared-access digest. The format
+ * is domain-separated and versioned; callers choose and apply the hash.
+ */
+export function declaredAccessDigestInput(value: DeclaredAccess): string {
+	return `{"declaredAccess":${canonicalString(value)},"domain":${JSON.stringify(DIGEST_DOMAIN)},"version":${DIGEST_VERSION}}`;
+}

--- a/packages/plugin-types/src/index.ts
+++ b/packages/plugin-types/src/index.ts
@@ -471,3 +471,18 @@ export {
 	reconcileManifestAccess,
 } from "./manifest-schema.js";
 export type { ValidatedPluginManifest } from "./manifest-schema.js";
+export {
+	canonicalizeDeclaredAccess,
+	declaredAccessDigestInput,
+	declaredAccessEqual,
+	diffDeclaredAccess,
+	isDeclaredAccessEscalation,
+} from "./declared-access.js";
+export type {
+	AccessChange,
+	AccessChangeKind,
+	AccessDiff,
+	CanonicalAccessConstraints,
+	CanonicalDeclaredAccess,
+	CanonicalJsonValue,
+} from "./declared-access.js";

--- a/packages/plugin-types/tests/declared-access.test.ts
+++ b/packages/plugin-types/tests/declared-access.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	canonicalizeDeclaredAccess,
+	declaredAccessDigestInput,
+	declaredAccessEqual,
+	diffDeclaredAccess,
+	isDeclaredAccessEscalation,
+} from "../src/index.js";
+import type { DeclaredAccess } from "../src/index.js";
+
+const access = (allowedHosts?: string[]): DeclaredAccess => ({
+	network: { request: allowedHosts === undefined ? {} : { allowedHosts } },
+});
+const sparseArray: unknown[] = [];
+sparseArray.length = 1;
+
+describe("declared access escalation decision table", () => {
+	const cases: Array<{
+		name: string;
+		previous: DeclaredAccess;
+		next: DeclaredAccess;
+		escalation: boolean;
+	}> = [
+		{ name: "equal empty access", previous: {}, next: {}, escalation: false },
+		{
+			name: "first release with access",
+			previous: {},
+			next: { users: { read: {} } },
+			escalation: true,
+		},
+		{
+			name: "category removal",
+			previous: { users: { read: {} } },
+			next: {},
+			escalation: false,
+		},
+		{
+			name: "operation addition",
+			previous: { email: { send: {} } },
+			next: { email: { send: {}, events: {} } },
+			escalation: true,
+		},
+		{
+			name: "operation removal",
+			previous: { email: { send: {}, events: {} } },
+			next: { email: { send: {} } },
+			escalation: false,
+		},
+		{
+			name: "restricted to unrestricted",
+			previous: access(["api.example.com"]),
+			next: access(),
+			escalation: true,
+		},
+		{
+			name: "unrestricted to restricted",
+			previous: access(),
+			next: access(["api.example.com"]),
+			escalation: false,
+		},
+		{
+			name: "deny-all to restricted",
+			previous: access([]),
+			next: access(["api.example.com"]),
+			escalation: true,
+		},
+		{
+			name: "restricted to deny-all",
+			previous: access(["api.example.com"]),
+			next: access([]),
+			escalation: false,
+		},
+		{
+			name: "wildcard covers exact subdomain",
+			previous: access(["*.example.com"]),
+			next: access(["api.example.com"]),
+			escalation: false,
+		},
+		{
+			name: "wildcard excludes bare domain",
+			previous: access(["*.example.com"]),
+			next: access(["example.com"]),
+			escalation: true,
+		},
+		{
+			name: "wildcard covers narrower wildcard",
+			previous: access(["*.example.com"]),
+			next: access(["*.api.example.com"]),
+			escalation: false,
+		},
+		{
+			name: "exact does not cover wildcard",
+			previous: access(["api.example.com"]),
+			next: access(["*.api.example.com"]),
+			escalation: true,
+		},
+		{
+			name: "exact covers itself",
+			previous: access(["api.example.com"]),
+			next: access(["api.example.com"]),
+			escalation: false,
+		},
+		{
+			name: "exact excludes another host",
+			previous: access(["api.example.com"]),
+			next: access(["cdn.example.com"]),
+			escalation: true,
+		},
+		{
+			name: "star covers every host",
+			previous: access(["*"]),
+			next: access(["example.com", "*.api.example.com"]),
+			escalation: false,
+		},
+	];
+
+	it.each(cases)("$name", ({ previous, next, escalation }) => {
+		const diff = diffDeclaredAccess(previous, next);
+		expect(diff.escalation).toBe(escalation);
+		expect(isDeclaredAccessEscalation(previous, next)).toBe(diff.escalation);
+	});
+});
+
+describe("canonicalizeDeclaredAccess", () => {
+	it("materializes write implications without mutating input and is idempotent", () => {
+		const input: DeclaredAccess = { media: { write: {} }, content: { write: {} } };
+		const canonical = canonicalizeDeclaredAccess(input);
+		expect(canonical).toEqual({ content: { read: {}, write: {} }, media: { read: {}, write: {} } });
+		expect(input).toEqual({ media: { write: {} }, content: { write: {} } });
+		expect(canonicalizeDeclaredAccess(canonical)).toEqual(canonical);
+		expect(Object.isFrozen(canonical)).toBe(true);
+		expect(
+			declaredAccessEqual({ content: { write: {} } }, { content: { read: {}, write: {} } }),
+		).toBe(true);
+	});
+
+	it("sorts keys recursively and host sets while preserving other array order", () => {
+		const first = {
+			network: {
+				request: { z: { b: 2, a: 1 }, list: [2, 1], allowedHosts: ["b.test", "a.test", "b.test"] },
+			},
+		} as DeclaredAccess;
+		const second = {
+			network: { request: { allowedHosts: ["a.test", "b.test"], list: [2, 1], z: { a: 1, b: 2 } } },
+		} as DeclaredAccess;
+		expect(declaredAccessEqual(first, second)).toBe(true);
+		expect(canonicalizeDeclaredAccess(first).network?.request?.allowedHosts).toEqual([
+			"a.test",
+			"b.test",
+		]);
+		expect(
+			declaredAccessEqual(first, {
+				network: { request: { ...second.network?.request, list: [1, 2] } },
+			} as DeclaredAccess),
+		).toBe(false);
+	});
+
+	it.each([
+		["undefined", { users: { read: { value: undefined } } }],
+		["function", { users: { read: { value: () => undefined } } }],
+		["NaN", { users: { read: { value: Number.NaN } } }],
+		["sparse array", { users: { read: { value: sparseArray } } }],
+	])("rejects malformed %s runtime values", (_, value) => {
+		expect(() => declaredAccessDigestInput(value as DeclaredAccess)).toThrow(TypeError);
+	});
+});
+
+describe("unknown constraints", () => {
+	const unknown = (constraints: Record<string, unknown>): DeclaredAccess => ({
+		users: { read: constraints },
+	});
+	const fromJson = (constraints: string): DeclaredAccess =>
+		JSON.parse(`{"users":{"read":${constraints}}}`) as DeclaredAccess;
+
+	it.each([
+		["equal", unknown({ policy: { b: 2, a: 1 } }), unknown({ policy: { a: 1, b: 2 } }), false],
+		["added", unknown({}), unknown({ policy: true }), true],
+		["removed", unknown({ policy: true }), unknown({}), true],
+		["changed", unknown({ policy: 1 }), unknown({ policy: 2 }), true],
+		[
+			"nested array equal",
+			unknown({ policy: { values: [1, 2] } }),
+			unknown({ policy: { values: [1, 2] } }),
+			false,
+		],
+		[
+			"nested array reordered",
+			unknown({ policy: { values: [1, 2] } }),
+			unknown({ policy: { values: [2, 1] } }),
+			true,
+		],
+	] as const)("handles %s unknown constraints conservatively", (_, previous, next, escalation) => {
+		expect(diffDeclaredAccess(previous, next).escalation).toBe(escalation);
+	});
+
+	it("preserves JSON-derived __proto__ constraints without equality or digest collisions", () => {
+		const constrained = fromJson('{"__proto__":{"scope":"all"}}');
+		const empty = unknown({});
+
+		expect(declaredAccessEqual(constrained, empty)).toBe(false);
+		expect(declaredAccessDigestInput(constrained)).not.toBe(declaredAccessDigestInput(empty));
+	});
+
+	it("reports changed and removed __proto__ constraints as deterministic escalations", () => {
+		const previous = fromJson('{"__proto__":{"level":1}}');
+		const next = fromJson('{"__proto__":{"level":2}}');
+
+		expect(diffDeclaredAccess(previous, next)).toEqual({
+			changes: [
+				{
+					kind: "constraint-changed",
+					category: "users",
+					operation: "read",
+					path: ["users", "read", "__proto__"],
+					previous: { level: 1 },
+					next: { level: 2 },
+					escalation: true,
+				},
+			],
+			escalation: true,
+		});
+		expect(diffDeclaredAccess(previous, unknown({}))).toEqual({
+			changes: [
+				{
+					kind: "constraint-removed",
+					category: "users",
+					operation: "read",
+					path: ["users", "read", "__proto__"],
+					previous: { level: 1 },
+					next: undefined,
+					escalation: true,
+				},
+			],
+			escalation: true,
+		});
+	});
+
+	it("keeps canonical __proto__ values idempotent with safe object prototypes", () => {
+		const canonical = canonicalizeDeclaredAccess(fromJson('{"__proto__":{"enabled":true}}'));
+		const constraints = canonical.users?.read;
+
+		expect(Object.hasOwn(constraints ?? {}, "__proto__")).toBe(true);
+		expect(Object.getPrototypeOf(constraints)).toBe(Object.prototype);
+		expect(canonicalizeDeclaredAccess(canonical)).toEqual(canonical);
+	});
+
+	it("preserves and compares constructor and prototype constraints", () => {
+		const previous = fromJson('{"constructor":{"mode":"old"},"prototype":{"enabled":true}}');
+		const next = fromJson('{"constructor":{"mode":"new"},"prototype":{"enabled":true}}');
+
+		expect(canonicalizeDeclaredAccess(previous).users?.read).toEqual({
+			constructor: { mode: "old" },
+			prototype: { enabled: true },
+		});
+		expect(declaredAccessEqual(previous, next)).toBe(false);
+		expect(diffDeclaredAccess(previous, next).changes).toEqual([
+			{
+				kind: "constraint-changed",
+				category: "users",
+				operation: "read",
+				path: ["users", "read", "constructor"],
+				previous: { mode: "old" },
+				next: { mode: "new" },
+				escalation: true,
+			},
+		]);
+	});
+
+	it("rejects symbol-keyed own properties", () => {
+		const constraints = {};
+		Object.defineProperty(constraints, Symbol("constraint"), {
+			value: true,
+			enumerable: true,
+		});
+
+		expect(() => canonicalizeDeclaredAccess(unknown(constraints))).toThrow(TypeError);
+	});
+});
+
+describe("structured diff", () => {
+	it("has deterministic ordering, machine-readable paths, and no display strings", () => {
+		const diff = diffDeclaredAccess(
+			{ users: { read: { z: 1 } }, email: { send: {} } },
+			{ users: { read: { a: 1 } }, content: { read: {} }, email: { events: {} } },
+		);
+		expect(diff.changes.map(({ kind, path, escalation }) => ({ kind, path, escalation }))).toEqual([
+			{ kind: "category-added", path: ["content"], escalation: true },
+			{ kind: "operation-added", path: ["email", "events"], escalation: true },
+			{ kind: "operation-removed", path: ["email", "send"], escalation: false },
+			{ kind: "constraint-added", path: ["users", "read", "a"], escalation: true },
+			{ kind: "constraint-removed", path: ["users", "read", "z"], escalation: true },
+		]);
+		for (const item of diff.changes) {
+			expect(Object.keys(item).toSorted()).toEqual(
+				["category", "escalation", "kind", "next", "operation", "path", "previous"].toSorted(),
+			);
+		}
+	});
+});
+
+describe("declaredAccessDigestInput", () => {
+	it("is domain/version separated and stable for semantic equality", () => {
+		const implied = declaredAccessDigestInput({ content: { write: {} } });
+		expect(implied).toBe(declaredAccessDigestInput({ content: { read: {}, write: {} } }));
+		expect(implied).toContain('"domain":"@emdash-cms/plugin-types/declared-access"');
+		expect(implied).toContain('"version":1');
+		expect(implied).not.toBe(declaredAccessDigestInput({ content: { read: {} } }));
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds canonical declared-access comparison primitives for delegated release policy checks. The new API closes write-implies-read access, normalizes host sets, produces deterministic structured escalation diffs, and generates a domain-separated digest preimage.

Unknown constraints are compared conservatively, wildcard host containment follows RFC #1870, and malformed or prototype-sensitive non-JSON input is safely represented or rejected.

Related to #1908 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No admin UI strings changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: OpenCode with GPT-5.6-sol; independent review with Claude Opus 4.8

## Screenshots / test output

- Full monorepo build and package typecheck pass
- Quick and type-aware lint: zero diagnostics
- Plugin types: 67 tests pass, including 35 declared-access tests
- Formatting, changeset status, generated-archive check, and `git diff --check` pass
- Independent post-fix review found no high or medium findings

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-delegated-release-service-08-access-escalation-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/delegated-release-service-08-access-escalation`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
