### PR TITLE
fix(core): dev-mode lingui macro plugin never fires on Windows — admin stuck on loading screen

### DIFF
--- a/.changeset/windows-dev-lingui.md
+++ b/.changeset/windows-dev-lingui.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes admin dev-mode loading screen on Windows by normalizing path separators and converting Windows absolute paths to `file://` URLs for the Lingui macro plugin.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import type { AstroConfig } from "astro";
 import type { Plugin } from "vite";
@@ -64,6 +64,11 @@ import {
 } from "./virtual-modules.js";
 
 const LOCALE_MESSAGES_RE = /[/\\]([a-z]{2}(?:-[A-Z]{2})?)[/\\]messages\.mjs$/;
+
+/** Windows paths in forward-slash (Vite id) form; a no-op on POSIX. */
+function toPosixPath(p: string): string {
+	return p.replace(/\\/g, "/");
+}
 /**
  * Vite plugin that compiles Lingui macros in admin source files.
  * Only active in dev mode when the admin package is aliased to source for HMR.
@@ -74,6 +79,12 @@ function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plug
 	// Resolve @babel/core from admin's devDependencies, not core's.
 	const adminRequire = createRequire(resolve(adminDistPath, "index.js"));
 	const babelCorePath = adminRequire.resolve("@babel/core");
+	// Vite module ids use forward slashes on every platform, while path.resolve()
+	// produces backslashes on Windows — a plain startsWith against the raw path
+	// never matches there, so the macro transform silently skips every admin file
+	// and raw `@lingui/*/macro` imports reach the browser. Compare in
+	// forward-slash space (a no-op on POSIX).
+	const adminSourcePrefix = toPosixPath(adminSourcePath);
 
 	return {
 		name: "emdash-lingui-macro",
@@ -82,15 +93,23 @@ function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plug
 			// Redirect relative locale catalog imports (e.g. ./de/messages.mjs) from
 			// within admin source to the compiled dist/locales/ directory, since
 			// lingui compile only runs during build — not in dev watch mode.
-			if (!importer?.startsWith(adminSourcePath)) return;
+			if (!importer || !toPosixPath(importer).startsWith(adminSourcePrefix)) return;
 			const match = id.match(LOCALE_MESSAGES_RE);
 			if (match?.[1]) {
-				return resolve(adminDistPath, "locales", match[1], "messages.mjs");
+				const redirected = resolve(adminDistPath, "locales", match[1], "messages.mjs");
+				// Node's ESM loader accepts bare absolute paths on POSIX but rejects
+				// Windows drive paths (import("C:/…") parses "c:" as a URL protocol),
+				// so hand it a file:// URL there. POSIX ids stay exactly as before.
+				return process.platform === "win32" ? pathToFileURL(redirected).href : redirected;
 			}
 		},
 		async transform(code, id) {
-			if (!id.startsWith(adminSourcePath) || !code.includes("@lingui")) return;
-			const { transformAsync } = (await import(babelCorePath)) as typeof import("@babel/core");
+			if (!toPosixPath(id).startsWith(adminSourcePrefix) || !code.includes("@lingui")) return;
+			// import() needs a file:// URL for Windows absolute paths; require.resolve
+			// gave us a plain platform path. pathToFileURL is correct on POSIX too.
+			const { transformAsync } = (await import(
+				pathToFileURL(babelCorePath).href
+			)) as typeof import("@babel/core");
 			const result = await transformAsync(code, {
 				filename: id,
 				plugins: ["@lingui/babel-plugin-lingui-macro"],

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -69,6 +69,7 @@ const LOCALE_MESSAGES_RE = /[/\\]([a-z]{2}(?:-[A-Z]{2})?)[/\\]messages\.mjs$/;
 function toPosixPath(p: string): string {
 	return p.replace(/\\/g, "/");
 }
+
 /**
  * Vite plugin that compiles Lingui macros in admin source files.
  * Only active in dev mode when the admin package is aliased to source for HMR.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import type { AstroConfig } from "astro";
 import type { Plugin } from "vite";
@@ -70,6 +70,11 @@ import {
 } from "./virtual-modules.js";
 
 const LOCALE_MESSAGES_RE = /[/\\]([a-z]{2}(?:-[A-Z]{2})?)[/\\]messages\.mjs$/;
+
+/** Windows paths in forward-slash (Vite id) form; a no-op on POSIX. */
+function toPosixPath(p: string): string {
+	return p.replace(/\\/g, "/");
+}
 /**
  * Vite plugin that compiles Lingui macros in admin source files.
  * Only active in dev mode when the admin package is aliased to source for HMR.
@@ -80,6 +85,12 @@ function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plug
 	// Resolve @babel/core from admin's devDependencies, not core's.
 	const adminRequire = createRequire(resolve(adminDistPath, "index.js"));
 	const babelCorePath = adminRequire.resolve("@babel/core");
+	// Vite module ids use forward slashes on every platform, while path.resolve()
+	// produces backslashes on Windows — a plain startsWith against the raw path
+	// never matches there, so the macro transform silently skips every admin file
+	// and raw `@lingui/*/macro` imports reach the browser. Compare in
+	// forward-slash space (a no-op on POSIX).
+	const adminSourcePrefix = toPosixPath(adminSourcePath);
 
 	return {
 		name: "emdash-lingui-macro",
@@ -88,15 +99,23 @@ function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plug
 			// Redirect relative locale catalog imports (e.g. ./de/messages.mjs) from
 			// within admin source to the compiled dist/locales/ directory, since
 			// lingui compile only runs during build — not in dev watch mode.
-			if (!importer?.startsWith(adminSourcePath)) return;
+			if (!importer || !toPosixPath(importer).startsWith(adminSourcePrefix)) return;
 			const match = id.match(LOCALE_MESSAGES_RE);
 			if (match?.[1]) {
-				return resolve(adminDistPath, "locales", match[1], "messages.mjs");
+				const redirected = resolve(adminDistPath, "locales", match[1], "messages.mjs");
+				// Node's ESM loader accepts bare absolute paths on POSIX but rejects
+				// Windows drive paths (import("C:/…") parses "c:" as a URL protocol),
+				// so hand it a file:// URL there. POSIX ids stay exactly as before.
+				return process.platform === "win32" ? pathToFileURL(redirected).href : redirected;
 			}
 		},
 		async transform(code, id) {
-			if (!id.startsWith(adminSourcePath) || !code.includes("@lingui")) return;
-			const { transformAsync } = (await import(babelCorePath)) as typeof import("@babel/core");
+			if (!toPosixPath(id).startsWith(adminSourcePrefix) || !code.includes("@lingui")) return;
+			// import() needs a file:// URL for Windows absolute paths; require.resolve
+			// gave us a plain platform path. pathToFileURL is correct on POSIX too.
+			const { transformAsync } = (await import(
+				pathToFileURL(babelCorePath).href
+			)) as typeof import("@babel/core");
 			const result = await transformAsync(code, {
 				filename: id,
 				plugins: ["@lingui/babel-plugin-lingui-macro"],

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -75,6 +75,7 @@ const LOCALE_MESSAGES_RE = /[/\\]([a-z]{2}(?:-[A-Z]{2})?)[/\\]messages\.mjs$/;
 function toPosixPath(p: string): string {
 	return p.replace(/\\/g, "/");
 }
+
 /**
  * Vite plugin that compiles Lingui macros in admin source files.
  * Only active in dev mode when the admin package is aliased to source for HMR.


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only dev-mode failure where the admin never gets past "Loading EmDash…". Every admin astro-island fails hydration — first `Could not resolve "babel-plugin-macros"`, then `ReferenceError: process is not defined` — because the Lingui macro transform is being skipped and raw `@lingui/*/macro` imports reach the browser.

`linguiMacroPlugin` in `packages/core/src/astro/integration/vite-config.ts` gates its `transform` and locale-catalog `resolveId` on `id.startsWith(adminSourcePath)`. Vite ids use forward slashes on every platform, but `path.resolve()` returns backslashes on Windows — so the prefix check never matches and the transform silently skips every admin file. Two follow-on Windows landmines sit behind it: `await import()` of a bare `C:\…` babel path (Node's ESM loader parses `c:` as a URL protocol), and the locale redirect returning a bare Windows path that reaches the ESM loader from `useLocale.ts`.

Three fixes, all no-ops on POSIX:
1. Compare ids against a forward-slash-normalized `adminSourcePath`.
2. `import(pathToFileURL(babelCorePath).href)`.
3. Return the locale redirect as a `file://` URL only on win32 — POSIX returns the identical bare path as before.

No issue filed — discovered while working on #1934.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code (Anthropic Claude model family). The diagnosis, the three fixes and this description were written with it; the Windows repro and the verification below were run by hand.

## Screenshots / test output

Verified on Windows 11 (Node 24, pnpm 11): before — admin permanently on the loading screen with the hydration errors above; after — the setup wizard renders and hydrates cleanly (`document.querySelectorAll('astro-island[ssr]').length === 0`), walkable through the Site and Account steps. `tsgo --noEmit` and `oxlint --type-aware` on `packages/core` both pass; `prettier --check` is clean. There is no dev-only Vite-plugin test harness in the repo to add a unit test against, so verification is the live Windows repro above.

