### PR TITLE
fix(visual-editing): flush unsaved inline edits on pagehide

### DIFF
--- a/.changeset/inline-editor-pagehide-flush.md
+++ b/.changeset/inline-editor-pagehide-flush.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes unsaved inline (visual) editor changes being silently lost when navigating away, e.g. via the browser back button. Edits are now flushed with a keepalive request when the page unloads.

--- a/e2e/tests/visual-editing.spec.ts
+++ b/e2e/tests/visual-editing.spec.ts
@@ -297,6 +297,36 @@ test.describe("Inline Editor", () => {
 		await expect(picker).toBeHidden({ timeout: 3000 });
 	});
 
+	test("flushes unsaved edits when navigating away (#1582)", async ({ page }) => {
+		await gotoWithRetry(page, POST_WITH_IMAGE_PATH);
+
+		const editor = page.locator(".emdash-inline-editor");
+		await expect(editor).toBeVisible({ timeout: 15000 });
+
+		// Type into the editor and do NOT blur — the only save trigger
+		// used to be the blur handler, so browser-back lost the edit.
+		await editor.locator("p").last().click();
+		await page.keyboard.press("End");
+		await page.keyboard.type(" Repro1582");
+
+		const savePromise = page.waitForRequest(
+			(req) => req.url().includes("/api/content/posts/") && req.method() === "PUT",
+			{ timeout: 10000 },
+		);
+
+		// Browser back: no React blur fires, only pagehide.
+		await page.goBack();
+
+		// The pagehide flush must fire a keepalive PUT…
+		await savePromise;
+
+		// …and the edit must survive a fresh load of the post.
+		await gotoWithRetry(page, POST_WITH_IMAGE_PATH);
+		const reloadedEditor = page.locator(".emdash-inline-editor");
+		await expect(reloadedEditor).toBeVisible({ timeout: 15000 });
+		await expect(reloadedEditor.locator("text=Repro1582")).toBeVisible();
+	});
+
 	test("media picker can be closed with X button", async ({ page }) => {
 		await gotoWithRetry(page, POST_WITH_IMAGE_PATH);
 

--- a/e2e/tests/visual-editing.spec.ts
+++ b/e2e/tests/visual-editing.spec.ts
@@ -309,6 +309,10 @@ test.describe("Inline Editor", () => {
 		await page.keyboard.press("End");
 		await page.keyboard.type(" Repro1582");
 
+		// waitForRequest, not waitForResponse: the keepalive PUT outlives the
+		// page, and Playwright never delivers response events for a page that
+		// has navigated away — waiting for the response times out even when
+		// the save succeeds.
 		const savePromise = page.waitForRequest(
 			(req) => req.url().includes("/api/content/posts/") && req.method() === "PUT",
 			{ timeout: 10000 },
@@ -320,7 +324,16 @@ test.describe("Inline Editor", () => {
 		// The pagehide flush must fire a keepalive PUT…
 		await savePromise;
 
-		// …and the edit must survive a fresh load of the post.
+		// …and the server must persist it. Poll the rendered page instead of
+		// reloading immediately: on slow runners the PUT may still be in
+		// flight when the request event fires.
+		await expect
+			.poll(async () => (await page.request.get(POST_WITH_IMAGE_PATH)).text(), {
+				timeout: 10000,
+			})
+			.toContain("Repro1582");
+
+		// The edit must survive a fresh load of the post.
 		await gotoWithRetry(page, POST_WITH_IMAGE_PATH);
 		const reloadedEditor = page.locator(".emdash-inline-editor");
 		await expect(reloadedEditor).toBeVisible({ timeout: 15000 });

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -1915,7 +1915,7 @@ export function InlinePortableTextEditor({
 	// doesn't reliably fire React blur, and a plain fetch started during
 	// unload is cancelled by the navigation — edits were silently lost
 	// (#1582). `keepalive` lets the PUT outlive the page.
-	// ponytail: keepalive caps the body at 64KB — a very long document
+	// Caveat: keepalive caps the body at 64KB — a very long document
 	// can still be lost on unload. Upgrade path: debounced autosave
 	// while typing (like the admin editor) so unload flushes are rare.
 	React.useEffect(() => {

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -1864,44 +1864,65 @@ export function InlinePortableTextEditor({
 		return pmToPortableText(json);
 	}, []);
 
-	const save = React.useCallback(async () => {
-		if (savingRef.current) return;
+	const save = React.useCallback(
+		async (options?: { keepalive?: boolean }) => {
+			// A pagehide flush must not be skipped: an in-flight blur save is
+			// cancelled by the navigation, so the keepalive request is the only
+			// one that can still land (#1582).
+			if (savingRef.current && !options?.keepalive) return;
 
-		const current = JSON.stringify(getBlocks());
-		const initial = JSON.stringify(initialRef.current);
-		if (current === initial) return;
+			const current = JSON.stringify(getBlocks());
+			const initial = JSON.stringify(initialRef.current);
+			if (current === initial) return;
 
-		savingRef.current = true;
-		try {
-			const res = await fetch(
-				`/_emdash/api/content/${encodeURIComponent(collection)}/${encodeURIComponent(entryId)}`,
-				{
-					method: "PUT",
-					credentials: "same-origin",
-					headers: { "Content-Type": "application/json", "X-EmDash-Request": "1" },
-					body: JSON.stringify({ data: { [field]: getBlocks() } }),
-				},
-			);
-
-			if (res.ok) {
-				initialRef.current = getBlocks();
-				document.dispatchEvent(new CustomEvent("emdash:save", { detail: { state: "saved" } }));
-				document.dispatchEvent(
-					new CustomEvent("emdash:content-changed", {
-						detail: { collection, id: entryId },
-					}),
+			savingRef.current = true;
+			try {
+				const res = await fetch(
+					`/_emdash/api/content/${encodeURIComponent(collection)}/${encodeURIComponent(entryId)}`,
+					{
+						method: "PUT",
+						credentials: "same-origin",
+						headers: { "Content-Type": "application/json", "X-EmDash-Request": "1" },
+						body: JSON.stringify({ data: { [field]: getBlocks() } }),
+						keepalive: options?.keepalive ?? false,
+					},
 				);
-			} else {
+
+				if (res.ok) {
+					initialRef.current = getBlocks();
+					document.dispatchEvent(new CustomEvent("emdash:save", { detail: { state: "saved" } }));
+					document.dispatchEvent(
+						new CustomEvent("emdash:content-changed", {
+							detail: { collection, id: entryId },
+						}),
+					);
+				} else {
+					document.dispatchEvent(new CustomEvent("emdash:save", { detail: { state: "error" } }));
+					console.error("Save failed:", res.status);
+				}
+			} catch (err) {
 				document.dispatchEvent(new CustomEvent("emdash:save", { detail: { state: "error" } }));
-				console.error("Save failed:", res.status);
+				console.error("Save failed:", err);
+			} finally {
+				savingRef.current = false;
 			}
-		} catch (err) {
-			document.dispatchEvent(new CustomEvent("emdash:save", { detail: { state: "error" } }));
-			console.error("Save failed:", err);
-		} finally {
-			savingRef.current = false;
-		}
-	}, [collection, entryId, field, getBlocks]);
+		},
+		[collection, entryId, field, getBlocks],
+	);
+
+	// Flush unsaved edits when the page goes away (browser back/forward,
+	// link click, tab close). The blur handler doesn't cover this: unload
+	// doesn't reliably fire React blur, and a plain fetch started during
+	// unload is cancelled by the navigation — edits were silently lost
+	// (#1582). `keepalive` lets the PUT outlive the page.
+	// ponytail: keepalive caps the body at 64KB — a very long document
+	// can still be lost on unload. Upgrade path: debounced autosave
+	// while typing (like the admin editor) so unload flushes are rare.
+	React.useEffect(() => {
+		const flush = () => void save({ keepalive: true });
+		window.addEventListener("pagehide", flush);
+		return () => window.removeEventListener("pagehide", flush);
+	}, [save]);
 
 	// Create slash commands extension once — uses refs to avoid re-render loop
 	const slashCommandsExtension = React.useMemo(


### PR DESCRIPTION
## What does this PR do?

The inline (visual) editor only saved on its React `blur` handler. Browser back/forward (or closing the tab) never fires that blur — and even when a blur save had just started, the plain `fetch` was cancelled by the navigation. Result: inline edits were silently lost, with no request ever reaching the server.

**Reproduction** (before this fix): enable edit mode on a post, type into the body, hit the browser back button, navigate forward again — the edit is gone and the server log shows no PUT.

Note for triage: the admin content editor is *not* affected (it autosaves, which is likely why earlier reproduction attempts against the admin failed). The bug is specific to the inline editor in edit mode on the public site, which matches the video in the issue.

The fix:

- A `pagehide` listener flushes unsaved changes with a `keepalive` PUT, which is allowed to outlive the page.
- The flush bypasses the in-flight-save guard, because a blur save racing the navigation gets cancelled — the keepalive request is the only one that can still land.
- Known ceiling (commented in code): `keepalive` caps the body at 64KB, so extremely long documents can still be lost on unload. The upgrade path is a debounced autosave like the admin editor uses.

New e2e test in `visual-editing.spec.ts`: types into the inline editor without blurring, presses browser back, asserts the PUT fires and the edit survives a fresh page load. Verified red without the fix, green with it.

Closes #1582

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

```
[1/1] [chromium] › e2e/tests/visual-editing.spec.ts:300:2 › Inline Editor › flushes unsaved edits when navigating away (#1582)
  1 passed (9.2s)
```

Without the fix, the same test fails (no PUT is ever sent and the reloaded page shows the original text).