### PR TITLE
feat(plugins): expose authenticated caller to route handlers as `ctx.user`

### DIFF
--- a/.changeset/plugin-route-caller.md
+++ b/.changeset/plugin-route-caller.md
@@ -1,0 +1,7 @@
+---
+"emdash": minor
+"@emdash-cms/cloudflare": minor
+"@emdash-cms/sandbox-workerd": minor
+---
+
+Adds the authenticated caller to plugin route handlers. Private plugin API routes now receive the requesting user as `ctx.user` (native format) / `routeCtx.user` (standard format) — `{ id, email, name, role, createdAt }` — so plugins can implement per-user logic without trusting a user id from the request body. Public routes and machine tokens with no bound user receive `undefined`.

--- a/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
@@ -149,7 +149,7 @@ Key details of this configuration:
 - **`entrypoint` is the package's main export.** EmDash imports it at runtime and calls the default export to construct the resolved plugin.
 - **`options` flow descriptor → `createPlugin`.** Anything the user passes when registering the plugin (`analyticsPlugin({ enabled: false })`) is preserved on the descriptor and forwarded to `createPlugin`. Sandboxed plugins don't have this surface — they read settings from KV instead.
 - **`id`, `version`, and `capabilities` appear twice.** Once on the descriptor, once on `definePlugin()`. They should match. The descriptor's copy is what `astro.config.mjs` sees at build time; the `definePlugin()` copy is what runs at request time.
-- **Native route handlers take a single argument** — `(ctx: RouteContext)` where `ctx.input`, `ctx.request`, and `ctx.requestMeta` are merged with the regular `PluginContext` properties. This is the opposite of standard format's two-argument shape. See [API routes](/plugins/creating-plugins/api-routes/) for the full surface (everything else is identical).
+- **Native route handlers take a single argument** — `(ctx: RouteContext)` where `ctx.input`, `ctx.request`, `ctx.requestMeta`, and `ctx.user` (the authenticated caller on private routes) are merged with the regular `PluginContext` properties. This is the opposite of standard format's two-argument shape. See [API routes](/plugins/creating-plugins/api-routes/) for the full surface (everything else is identical).
 
 ## Plugin id rules
 

--- a/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
@@ -95,6 +95,29 @@ routes: {
 	Public routes skip authentication, scope, and CSRF entirely. Anyone on the internet can call them. Use `public: true` only for endpoints that need to accept external traffic — webhooks, public-facing search endpoints — and validate the input carefully.
 </Aside>
 
+### The authenticated caller
+
+On private routes, `routeCtx.user` is the authenticated user making the request — resolved and authorized by EmDash before your handler runs, so you can trust it for per-user logic (per-user API keys, OAuth connections, plugin-managed preferences):
+
+```typescript
+routes: {
+	"connect/start": {
+		handler: async (routeCtx, ctx) => {
+			// Never read the acting user from the request body — any authenticated
+			// session could impersonate another user that way. Use routeCtx.user.
+			const caller = routeCtx.user;
+			if (!caller) throw new Error("No caller bound");
+			await ctx.kv.set(`user:${caller.id}:connection`, { startedAt: Date.now() });
+			return { userId: caller.id };
+		},
+	},
+},
+```
+
+`routeCtx.user` is `undefined` on public routes (they skip auth, so no caller is bound — even when the visitor happens to have an admin session) and for token-authed requests where the token isn't bound to a user (machine tokens). The shape matches the `UserInfo` returned by `ctx.users`: `{ id, email, name, role, createdAt }` — no sensitive fields.
+
+Note that caller identity is separate from the `users:read` capability: `routeCtx.user` tells you **who is calling** and is always available on private routes, while `ctx.users` is a user-directory **lookup** that requires the capability.
+
 ## Input validation
 
 `input` accepts a Zod schema. The dispatcher parses the request body (POST/PUT/PATCH) or query string (GET/DELETE), validates it, and passes the typed result to your handler as `routeCtx.input`. Invalid input returns a 400 before your handler runs.
@@ -359,6 +382,15 @@ interface SandboxedRouteContext {
 	input: unknown; // narrow with the `input` Zod schema at the route level
 	request: SandboxedRequest;
 	requestMeta?: unknown;
+	user?: UserInfo; // authenticated caller on private routes; undefined on public routes
+}
+
+interface UserInfo {
+	id: string;
+	email: string;
+	name: string | null;
+	role: number;
+	createdAt: string;
 }
 
 interface PluginContext {

--- a/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
@@ -105,6 +105,29 @@ routes: {
 	Public routes skip authentication, scope, and CSRF entirely. Anyone on the internet can call them. Use `public: true` only for endpoints that need to accept external traffic — webhooks, public-facing search endpoints — and validate the input carefully.
 </Aside>
 
+### The authenticated caller
+
+On private routes, `routeCtx.user` is the authenticated user making the request — resolved and authorized by EmDash before your handler runs, so you can trust it for per-user logic (per-user API keys, OAuth connections, plugin-managed preferences):
+
+```typescript
+routes: {
+	"connect/start": {
+		handler: async (routeCtx, ctx) => {
+			// Never read the acting user from the request body — any authenticated
+			// session could impersonate another user that way. Use routeCtx.user.
+			const caller = routeCtx.user;
+			if (!caller) throw new Error("No caller bound");
+			await ctx.kv.set(`user:${caller.id}:connection`, { startedAt: Date.now() });
+			return { userId: caller.id };
+		},
+	},
+},
+```
+
+`routeCtx.user` is `undefined` on public routes (they skip auth, so no caller is bound — even when the visitor happens to have an admin session) and for token-authed requests where the token isn't bound to a user (machine tokens). The shape matches the `UserInfo` returned by `ctx.users`: `{ id, email, name, role, createdAt }` — no sensitive fields.
+
+Note that caller identity is separate from the `users:read` capability: `routeCtx.user` tells you **who is calling** and is always available on private routes, while `ctx.users` is a user-directory **lookup** that requires the capability.
+
 ### Caching public responses
 
 API responses default to `Cache-Control: private, no-store`. For public routes that serve the same data to everyone — a product catalog, a public search index — that means every page view pays a full round-trip to the origin. Public routes can opt in to CDN/browser caching with `cacheControl`:
@@ -490,6 +513,15 @@ interface SandboxedRouteContext {
 	input: unknown; // narrow with the `input` Zod schema at the route level
 	request: SandboxedRequest;
 	requestMeta?: unknown;
+	user?: UserInfo; // authenticated caller on private routes; undefined on public routes
+}
+
+interface UserInfo {
+	id: string;
+	email: string;
+	name: string | null;
+	role: number;
+	createdAt: string;
 }
 
 interface PluginContext {

--- a/packages/cloudflare/src/sandbox/wrapper.ts
+++ b/packages/cloudflare/src/sandbox/wrapper.ts
@@ -232,8 +232,9 @@ export default class PluginEntrypoint extends WorkerEntrypoint {
 			throw new Error(\`Route \${routeName} handler is not a function\`);
 		}
 		
-		// Execute the route handler with input, request metadata, and context
-		return handler({ input, request: serializedRequest, requestMeta: serializedRequest.meta }, ctx);
+		// Execute the route handler with input, request metadata, the
+		// authenticated caller (private routes only, #812), and context
+		return handler({ input, request: serializedRequest, requestMeta: serializedRequest.meta, user: serializedRequest.user }, ctx);
 	}
 }
 `;

--- a/packages/cloudflare/src/sandbox/wrapper.ts
+++ b/packages/cloudflare/src/sandbox/wrapper.ts
@@ -258,10 +258,16 @@ export default class PluginEntrypoint extends WorkerEntrypoint {
 			throw new Error(\`Route \${routeName} handler is not a function\`);
 		}
 		
-		// Execute the route handler with input, request metadata, and context
+		// Execute the route handler with input, request metadata, the
+		// authenticated caller (private routes only, #812), and context
 		try {
 			return await handler(
-				{ input, request: serializedRequest, requestMeta: serializedRequest.meta },
+				{
+					input,
+					request: serializedRequest,
+					requestMeta: serializedRequest.meta,
+					user: serializedRequest.user,
+				},
 				ctx,
 			);
 		} catch (error) {

--- a/packages/cloudflare/src/sandbox/wrapper.ts
+++ b/packages/cloudflare/src/sandbox/wrapper.ts
@@ -259,7 +259,7 @@ export default class PluginEntrypoint extends WorkerEntrypoint {
 		}
 		
 		// Execute the route handler with input, request metadata, the
-		// authenticated caller (private routes only, #812), and context
+		// authenticated caller (private routes only), and context
 		try {
 			return await handler(
 				{

--- a/packages/core/src/astro/routes/api/mcp.ts
+++ b/packages/core/src/astro/routes/api/mcp.ts
@@ -48,6 +48,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 				scopes: [],
 				extra: {
 					emdash,
+					user,
 					userId: user.id,
 					userRole: user.role,
 					tokenScopes: locals.tokenScopes,

--- a/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
+++ b/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
@@ -67,7 +67,13 @@ const handleRequest: APIRoute = async ({ params, request, locals }) => {
 		}
 	}
 
-	const result = await emdash.handlePluginApiRoute(pluginId, method, `/${path}`, request);
+	// Forward the caller only for private routes: it was validated by the
+	// requirePerm/requireScope checks above, so plugins can trust ctx.user.
+	// Public routes intentionally skip auth, so no caller is bound even when
+	// an ambient session happens to exist (#812).
+	const caller = routeMeta.public ? undefined : user;
+
+	const result = await emdash.handlePluginApiRoute(pluginId, method, `/${path}`, request, caller);
 
 	if (!result.success) {
 		const code = result.error?.code ?? "PLUGIN_ERROR";

--- a/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
+++ b/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
@@ -73,7 +73,13 @@ const handleRequest: APIRoute = async ({ params, request, locals }) => {
 		}
 	}
 
-	const result = await emdash.handlePluginApiRoute(pluginId, method, `/${path}`, request);
+	// Forward the caller only for private routes: it was validated by the
+	// requirePerm/requireScope checks above, so plugins can trust ctx.user.
+	// Public routes intentionally skip auth, so no caller is bound even when
+	// an ambient session happens to exist (#812).
+	const caller = routeMeta.public ? undefined : user;
+
+	const result = await emdash.handlePluginApiRoute(pluginId, method, `/${path}`, request, caller);
 
 	if (!result.success) {
 		const code = result.error?.code ?? "PLUGIN_ERROR";

--- a/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
+++ b/packages/core/src/astro/routes/api/plugins/[pluginId]/[...path].ts
@@ -75,8 +75,8 @@ const handleRequest: APIRoute = async ({ params, request, locals }) => {
 
 	// Forward the caller only for private routes: it was validated by the
 	// requirePerm/requireScope checks above, so plugins can trust ctx.user.
-	// Public routes intentionally skip auth, so no caller is bound even when
-	// an ambient session happens to exist (#812).
+	// Public routes skip auth, so no caller is bound even when an ambient
+	// session happens to exist.
 	const caller = routeMeta.public ? undefined : user;
 
 	const result = await emdash.handlePluginApiRoute(pluginId, method, `/${path}`, request, caller);

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -8,6 +8,8 @@
 import type { Element } from "@emdash-cms/blocks";
 import type { Kysely } from "kysely";
 
+import type { RouteCallerInput } from "../plugins/routes.js";
+
 // Re-export core types
 export type {
 	ContentItem,
@@ -394,12 +396,14 @@ export interface EmDashHandlers {
 
 	handleRevisionRestore: (revisionId: string, callerUserId: string) => Promise<HandlerResponse>;
 
-	// Plugin API route handler
+	// Plugin API route handler. `user` is the authenticated caller for
+	// private routes, exposed to plugin handlers as `ctx.user` (#812).
 	handlePluginApiRoute: (
 		pluginId: string,
 		method: string,
 		path: string,
 		request: Request,
+		user?: RouteCallerInput | null,
 	) => Promise<HandlerResponse>;
 
 	// Public-only plugin API route handler for SSR page components.

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -8,7 +8,7 @@
 import type { Element } from "@emdash-cms/blocks";
 import type { Kysely } from "kysely";
 
-import type { RouteMeta } from "../plugins/routes.js";
+import type { RouteCallerInput, RouteMeta } from "../plugins/routes.js";
 
 // Re-export core types
 export type {
@@ -410,12 +410,14 @@ export interface EmDashHandlers {
 
 	handleRevisionRestore: (revisionId: string, callerUserId: string) => Promise<HandlerResponse>;
 
-	// Plugin API route handler
+	// Plugin API route handler. `user` is the authenticated caller for
+	// private routes, exposed to plugin handlers as `ctx.user` (#812).
 	handlePluginApiRoute: (
 		pluginId: string,
 		method: string,
 		path: string,
 		request: Request,
+		user?: RouteCallerInput | null,
 	) => Promise<HandlerResponse>;
 
 	// Public-only plugin API route handler for SSR page components.

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -411,7 +411,7 @@ export interface EmDashHandlers {
 	handleRevisionRestore: (revisionId: string, callerUserId: string) => Promise<HandlerResponse>;
 
 	// Plugin API route handler. `user` is the authenticated caller for
-	// private routes, exposed to plugin handlers as `ctx.user` (#812).
+	// private routes, exposed to plugin handlers as `ctx.user`.
 	handlePluginApiRoute: (
 		pluginId: string,
 		method: string,
@@ -465,6 +465,7 @@ export interface EmDashHandlers {
 		input: unknown,
 		actorId: string,
 		request: Request,
+		caller?: RouteCallerInput | null,
 	) => Promise<HandlerResponse>;
 	handlePluginMcpDenied: (
 		pluginId: string,

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -53,6 +53,7 @@ import type {
 	PageFragmentContribution,
 	PortableTextBlockConfig,
 	FieldWidgetConfig,
+	UserInfo,
 } from "./plugins/types.js";
 import type { FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
@@ -174,7 +175,12 @@ import {
 } from "./plugins/hooks.js";
 import { normalizeManifestRoute } from "./plugins/manifest-schema.js";
 import { extractRequestMeta, sanitizeHeadersForSandbox } from "./plugins/request-meta.js";
-import { PluginRouteRegistry, type RouteMeta } from "./plugins/routes.js";
+import {
+	PluginRouteRegistry,
+	toRouteCallerInfo,
+	type RouteCallerInput,
+	type RouteMeta,
+} from "./plugins/routes.js";
 import type { CronScheduler } from "./plugins/scheduler/types.js";
 import { PluginStateRepository } from "./plugins/state.js";
 import { normalizeRegistryConfig } from "./registry/config.js";
@@ -3314,13 +3320,24 @@ export class EmDashRuntime {
 		return null;
 	}
 
-	async handlePluginApiRoute(pluginId: string, _method: string, path: string, request: Request) {
+	async handlePluginApiRoute(
+		pluginId: string,
+		_method: string,
+		path: string,
+		request: Request,
+		user?: RouteCallerInput | null,
+	) {
 		if (!this.isPluginEnabled(pluginId)) {
 			return {
 				success: false,
 				error: { code: "NOT_FOUND", message: `Plugin not enabled: ${pluginId}` },
 			};
 		}
+
+		// Authenticated caller for `ctx.user`. Undefined for public routes
+		// (the catch-all only forwards the caller after private-route auth)
+		// and for machine tokens with no bound user (#812).
+		const caller = user ? toRouteCallerInfo(user) : undefined;
 
 		// Check trusted (configured) plugins first — this must match the
 		// resolution order in getPluginRouteMeta to avoid auth/execution mismatches.
@@ -3343,13 +3360,13 @@ export class EmDashRuntime {
 				// No body or not JSON
 			}
 
-			return routeRegistry.invoke(pluginId, routeKey, { request, body });
+			return routeRegistry.invoke(pluginId, routeKey, { request, body, user: caller });
 		}
 
 		// Check sandboxed (marketplace) plugins second
 		const sandboxedPlugin = this.findSandboxedPlugin(pluginId);
 		if (sandboxedPlugin) {
-			return this.handleSandboxedRoute(sandboxedPlugin, path, request);
+			return this.handleSandboxedRoute(sandboxedPlugin, path, request, caller);
 		}
 
 		return {
@@ -3604,6 +3621,7 @@ export class EmDashRuntime {
 		plugin: SandboxedPluginInstance,
 		path: string,
 		request: Request,
+		user?: UserInfo,
 	): Promise<{
 		success: boolean;
 		data?: unknown;
@@ -3626,6 +3644,7 @@ export class EmDashRuntime {
 				method: request.method,
 				headers,
 				meta,
+				user,
 			});
 			return { success: true, data: result };
 		} catch (error) {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -3745,7 +3745,7 @@ export class EmDashRuntime {
 
 		// Authenticated caller for `ctx.user`. Undefined for public routes
 		// (the catch-all only forwards the caller after private-route auth)
-		// and for machine tokens with no bound user (#812).
+		// and for machine tokens with no bound user.
 		const caller = user ? toRouteCallerInfo(user) : undefined;
 
 		// Check trusted (configured) plugins first — this must match the
@@ -3898,6 +3898,7 @@ export class EmDashRuntime {
 		input: unknown,
 		actorId: string,
 		request: Request,
+		caller?: RouteCallerInput | null,
 	) {
 		const requestMeta = extractRequestMeta(request, getTrustedProxyHeaders(this.config));
 		const audit = new AuditRepository(this.db);
@@ -3909,7 +3910,13 @@ export class EmDashRuntime {
 			headers,
 			body: JSON.stringify(input),
 		});
-		const result = await this.handlePluginApiRoute(pluginId, "POST", route, internalRequest);
+		const result = await this.handlePluginApiRoute(
+			pluginId,
+			"POST",
+			route,
+			internalRequest,
+			caller,
+		);
 		await audit.log({
 			actorId,
 			actorIp: requestMeta.ip ?? undefined,

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -81,6 +81,7 @@ import type {
 	PortableTextBlockConfig,
 	FieldWidgetConfig,
 	SettingField,
+	UserInfo,
 } from "./plugins/types.js";
 import { MAX_COLLECTION_LIST_COLUMNS, type FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
@@ -214,6 +215,8 @@ import {
 	buildRouteMeta,
 	parseRouteInput,
 	PluginRouteRegistry,
+	toRouteCallerInfo,
+	type RouteCallerInput,
 	type RouteMeta,
 } from "./plugins/routes.js";
 import type { CronScheduler } from "./plugins/scheduler/types.js";
@@ -3726,13 +3729,24 @@ export class EmDashRuntime {
 		return meta.admin?.settingsSchema ?? {};
 	}
 
-	async handlePluginApiRoute(pluginId: string, _method: string, path: string, request: Request) {
+	async handlePluginApiRoute(
+		pluginId: string,
+		_method: string,
+		path: string,
+		request: Request,
+		user?: RouteCallerInput | null,
+	) {
 		if (!this.isPluginEnabled(pluginId)) {
 			return {
 				success: false,
 				error: { code: "NOT_FOUND", message: `Plugin not enabled: ${pluginId}` },
 			};
 		}
+
+		// Authenticated caller for `ctx.user`. Undefined for public routes
+		// (the catch-all only forwards the caller after private-route auth)
+		// and for machine tokens with no bound user (#812).
+		const caller = user ? toRouteCallerInfo(user) : undefined;
 
 		// Check trusted (configured) plugins first — this must match the
 		// resolution order in getPluginRouteMeta to avoid auth/execution mismatches.
@@ -3751,13 +3765,13 @@ export class EmDashRuntime {
 			// Body methods parse JSON; GET/HEAD/DELETE parse the query string (#2146).
 			const body = await parseRouteInput(request);
 
-			return routeRegistry.invoke(pluginId, routeKey, { request, body });
+			return routeRegistry.invoke(pluginId, routeKey, { request, body, user: caller });
 		}
 
 		// Check sandboxed (marketplace) plugins second
 		const sandboxedPlugin = this.findSandboxedPlugin(pluginId);
 		if (sandboxedPlugin) {
-			return this.handleSandboxedRoute(sandboxedPlugin, path, request);
+			return this.handleSandboxedRoute(sandboxedPlugin, path, request, caller);
 		}
 
 		return {
@@ -4221,6 +4235,7 @@ export class EmDashRuntime {
 		plugin: SandboxedPluginInstance,
 		path: string,
 		request: Request,
+		user?: UserInfo,
 	): Promise<{
 		success: boolean;
 		data?: unknown;
@@ -4240,6 +4255,7 @@ export class EmDashRuntime {
 				method: request.method,
 				headers,
 				meta,
+				user,
 			});
 			return { success: true, data: result };
 		} catch (error) {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -31,6 +31,7 @@ import { hasScope } from "../auth/api-tokens.js";
 import { convertDataForRead, convertDataForWrite } from "../client/portable-text.js";
 import type { FieldSchema } from "../client/portable-text.js";
 import { decodeCursor, InvalidCursorError } from "../database/repositories/types.js";
+import type { RouteCallerInput } from "../plugins/routes.js";
 import { decodeBase64, encodeBase64 } from "../utils/base64.js";
 
 const COLLECTION_SLUG_PATTERN = /^[a-z][a-z0-9_]*$/;
@@ -408,11 +409,12 @@ function jsonResult(data: unknown): SuccessEnvelope {
 // ---------------------------------------------------------------------------
 // Context extraction
 //
-// The route handler passes emdash + userId in authInfo.extra.
+// The route handler passes the runtime and authenticated user in authInfo.extra.
 // ---------------------------------------------------------------------------
 
 interface EmDashExtra {
 	emdash: EmDashHandlers;
+	user: RouteCallerInput;
 	userId: string;
 	/** The authenticated user's RBAC role level. */
 	userRole: RoleLevel;
@@ -717,6 +719,7 @@ export function createMcpServer(
 					input,
 					payload.userId,
 					request,
+					payload.user,
 				);
 				if (!result.success) return unwrap(result);
 				if (tool.outputSchema) {

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -83,6 +83,7 @@ import type {
 	PluginContext,
 	UninstallEvent,
 	UninstallHandler,
+	UserInfo,
 } from "./plugins/types.js";
 
 /**
@@ -175,6 +176,13 @@ export interface SandboxedRouteContext {
 	input: unknown;
 	request: SandboxedRequest;
 	requestMeta?: unknown;
+	/**
+	 * Authenticated caller, if the route is private. Resolved and
+	 * authorized by the host before dispatch — trust it over any user id
+	 * in the request body. `undefined` for public routes and for machine
+	 * tokens with no bound user.
+	 */
+	user?: UserInfo;
 }
 
 /**

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -86,6 +86,7 @@ import type {
 	PluginContext,
 	UninstallEvent,
 	UninstallHandler,
+	UserInfo,
 } from "./plugins/types.js";
 
 /**
@@ -178,6 +179,13 @@ export interface SandboxedRouteContext {
 	input: unknown;
 	request: SandboxedRequest;
 	requestMeta?: unknown;
+	/**
+	 * Authenticated caller, if the route is private. Resolved and
+	 * authorized by the host before dispatch — trust it over any user id
+	 * in the request body. `undefined` for public routes and for machine
+	 * tokens with no bound user.
+	 */
+	user?: UserInfo;
 }
 
 /**

--- a/packages/core/src/plugins/adapt-sandbox-entry.ts
+++ b/packages/core/src/plugins/adapt-sandbox-entry.ts
@@ -220,8 +220,9 @@ export function adaptSandboxEntry(
 						input: ctx.input,
 						request: requestShape,
 						requestMeta: ctx.requestMeta,
+						user: ctx.user,
 					};
-					const { input: _, request: __, requestMeta: ___, ...pluginCtx } = ctx;
+					const { input: _, request: __, requestMeta: ___, user: ____, ...pluginCtx } = ctx;
 					return handler(routeCtx, pluginCtx);
 				},
 			};

--- a/packages/core/src/plugins/adapt-sandbox-entry.ts
+++ b/packages/core/src/plugins/adapt-sandbox-entry.ts
@@ -250,8 +250,9 @@ export function adaptSandboxEntry(
 						input: ctx.input,
 						request: requestShape,
 						requestMeta: ctx.requestMeta,
+						user: ctx.user,
 					};
-					const { input: _, request: __, requestMeta: ___, ...pluginCtx } = ctx;
+					const { input: _, request: __, requestMeta: ___, user: ____, ...pluginCtx } = ctx;
 					return handler(routeCtx, pluginCtx);
 				},
 			};

--- a/packages/core/src/plugins/routes.ts
+++ b/packages/core/src/plugins/routes.ts
@@ -10,7 +10,7 @@
 
 import { PluginContextFactory, type PluginContextFactoryOptions } from "./context.js";
 import { extractRequestMeta } from "./request-meta.js";
-import type { ResolvedPlugin, RouteContext, PluginRoute } from "./types.js";
+import type { ResolvedPlugin, RouteContext, PluginRoute, UserInfo } from "./types.js";
 
 /**
  * Body-reading methods on `Request`. EmDash parses the request body once before
@@ -71,6 +71,34 @@ export interface RouteResult<T = unknown> {
 }
 
 /**
+ * Host-side user shape accepted when dispatching a plugin route. Structurally
+ * matches `User` from `@emdash-cms/auth` so hosts can pass `locals.user`
+ * directly without the plugin layer depending on the auth package.
+ */
+export interface RouteCallerInput {
+	id: string;
+	email: string;
+	name: string | null;
+	role: number;
+	createdAt: Date | string;
+}
+
+/**
+ * Convert the host's authenticated user into the read-only `UserInfo` shape
+ * exposed to plugins as `ctx.user`. Strips sensitive/irrelevant fields and
+ * keeps the value structured-clone-safe for sandboxed plugins.
+ */
+export function toRouteCallerInfo(user: RouteCallerInput): UserInfo {
+	return {
+		id: user.id,
+		email: user.email,
+		name: user.name,
+		role: user.role,
+		createdAt: typeof user.createdAt === "string" ? user.createdAt : user.createdAt.toISOString(),
+	};
+}
+
+/**
  * Route invocation options
  */
 export interface InvokeRouteOptions {
@@ -78,6 +106,11 @@ export interface InvokeRouteOptions {
 	request: Request;
 	/** Request body (already parsed) */
 	body?: unknown;
+	/**
+	 * Authenticated caller resolved by the host, exposed to the handler as
+	 * `ctx.user`. Undefined for public routes and unbound machine tokens.
+	 */
+	user?: UserInfo;
 }
 
 /**
@@ -141,6 +174,7 @@ export class PluginRouteHandler {
 			// (#1293). Metadata extraction uses the original request (headers only).
 			request: guardConsumedRequestBody(options.request),
 			requestMeta: extractRequestMeta(options.request, this.trustedProxyHeaders),
+			user: options.user,
 		};
 
 		// Execute handler

--- a/packages/core/src/plugins/routes.ts
+++ b/packages/core/src/plugins/routes.ts
@@ -11,7 +11,7 @@
 import { MediaUsageActivationWriteBlockedError } from "../api/media-usage-write-fence.js";
 import { PluginContextFactory, type PluginContextFactoryOptions } from "./context.js";
 import { extractRequestMeta } from "./request-meta.js";
-import type { ResolvedPlugin, RouteContext, PluginRoute } from "./types.js";
+import type { ResolvedPlugin, RouteContext, PluginRoute, UserInfo } from "./types.js";
 
 /**
  * Body-reading methods on `Request`. EmDash parses the request body once before
@@ -132,6 +132,34 @@ export interface RouteResult<T = unknown> {
 }
 
 /**
+ * Host-side user shape accepted when dispatching a plugin route. Structurally
+ * matches `User` from `@emdash-cms/auth` so hosts can pass `locals.user`
+ * directly without the plugin layer depending on the auth package.
+ */
+export interface RouteCallerInput {
+	id: string;
+	email: string;
+	name: string | null;
+	role: number;
+	createdAt: Date | string;
+}
+
+/**
+ * Convert the host's authenticated user into the read-only `UserInfo` shape
+ * exposed to plugins as `ctx.user`. Strips sensitive/irrelevant fields and
+ * keeps the value structured-clone-safe for sandboxed plugins.
+ */
+export function toRouteCallerInfo(user: RouteCallerInput): UserInfo {
+	return {
+		id: user.id,
+		email: user.email,
+		name: user.name,
+		role: user.role,
+		createdAt: typeof user.createdAt === "string" ? user.createdAt : user.createdAt.toISOString(),
+	};
+}
+
+/**
  * Route invocation options
  */
 export interface InvokeRouteOptions {
@@ -139,6 +167,11 @@ export interface InvokeRouteOptions {
 	request: Request;
 	/** Request body (already parsed) */
 	body?: unknown;
+	/**
+	 * Authenticated caller resolved by the host, exposed to the handler as
+	 * `ctx.user`. Undefined for public routes and unbound machine tokens.
+	 */
+	user?: UserInfo;
 }
 
 /**
@@ -202,6 +235,7 @@ export class PluginRouteHandler {
 			// (#1293). Metadata extraction uses the original request (headers only).
 			request: guardConsumedRequestBody(options.request),
 			requestMeta: extractRequestMeta(options.request, this.trustedProxyHeaders),
+			user: options.user,
 		};
 
 		// Execute handler

--- a/packages/core/src/plugins/sandbox/types.ts
+++ b/packages/core/src/plugins/sandbox/types.ts
@@ -10,7 +10,7 @@
 import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
-import type { PluginManifest, RequestMeta } from "../types.js";
+import type { PluginManifest, RequestMeta, UserInfo } from "../types.js";
 
 /**
  * Resource limits for sandboxed plugins.
@@ -133,6 +133,11 @@ export interface SerializedRequest {
 	headers: Record<string, string>;
 	/** Normalized request metadata extracted before RPC serialization */
 	meta: RequestMeta;
+	/**
+	 * Authenticated caller for private routes, resolved by the host before
+	 * dispatch. Undefined for public routes and unbound machine tokens (#812).
+	 */
+	user?: UserInfo;
 }
 
 /**

--- a/packages/core/src/plugins/sandbox/types.ts
+++ b/packages/core/src/plugins/sandbox/types.ts
@@ -142,7 +142,7 @@ export interface SerializedRequest {
 	meta: RequestMeta;
 	/**
 	 * Authenticated caller for private routes, resolved by the host before
-	 * dispatch. Undefined for public routes and unbound machine tokens (#812).
+	 * dispatch. Undefined for public routes and unbound machine tokens.
 	 */
 	user?: UserInfo;
 }

--- a/packages/core/src/plugins/sandbox/types.ts
+++ b/packages/core/src/plugins/sandbox/types.ts
@@ -10,7 +10,7 @@
 import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
-import type { PluginManifest, RequestMeta } from "../types.js";
+import type { PluginManifest, RequestMeta, UserInfo } from "../types.js";
 
 /**
  * Resource limits for sandboxed plugins.
@@ -140,6 +140,11 @@ export interface SerializedRequest {
 	headers: Record<string, string>;
 	/** Normalized request metadata extracted before RPC serialization */
 	meta: RequestMeta;
+	/**
+	 * Authenticated caller for private routes, resolved by the host before
+	 * dispatch. Undefined for public routes and unbound machine tokens (#812).
+	 */
+	user?: UserInfo;
 }
 
 const SANDBOX_ROUTE_ERROR_DEFINITIONS = {

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1160,6 +1160,18 @@ export interface RouteContext<TInput = unknown> extends PluginContext {
 	request: Request;
 	/** Normalized request metadata (IP, user agent, geo) */
 	requestMeta: RequestMeta;
+	/**
+	 * Authenticated caller, if the route is private. The host has already
+	 * authenticated and authorized this user before dispatch, so the value
+	 * is trustworthy — unlike a user id read from the request body.
+	 *
+	 * `undefined` for public routes (which skip auth entirely) and for
+	 * token-authed requests where no user is bound to the token.
+	 *
+	 * Not gated by the `read:users` capability: this is the caller's own
+	 * identity for the current request, not a user directory lookup.
+	 */
+	user?: UserInfo;
 }
 
 /**

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1175,6 +1175,18 @@ export interface RouteContext<TInput = unknown> extends PluginContext {
 	request: Request;
 	/** Normalized request metadata (IP, user agent, geo) */
 	requestMeta: RequestMeta;
+	/**
+	 * Authenticated caller, if the route is private. The host has already
+	 * authenticated and authorized this user before dispatch, so the value
+	 * is trustworthy — unlike a user id read from the request body.
+	 *
+	 * `undefined` for public routes (which skip auth entirely) and for
+	 * token-authed requests where no user is bound to the token.
+	 *
+	 * Not gated by the `read:users` capability: this is the caller's own
+	 * identity for the current request, not a user directory lookup.
+	 */
+	user?: UserInfo;
 }
 
 /**

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1183,7 +1183,7 @@ export interface RouteContext<TInput = unknown> extends PluginContext {
 	 * `undefined` for public routes (which skip auth entirely) and for
 	 * token-authed requests where no user is bound to the token.
 	 *
-	 * Not gated by the `read:users` capability: this is the caller's own
+	 * Not gated by the `users:read` capability: this is the caller's own
 	 * identity for the current request, not a user directory lookup.
 	 */
 	user?: UserInfo;

--- a/packages/core/tests/integration/runtime/plugin-media-route.test.ts
+++ b/packages/core/tests/integration/runtime/plugin-media-route.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it, vi } from "vitest";
 import { EmDashRuntime } from "../../../src/emdash-runtime.js";
 import type { RuntimeDependencies } from "../../../src/emdash-runtime.js";
 import { definePlugin } from "../../../src/plugins/define-plugin.js";
+import type { RouteCallerInput } from "../../../src/plugins/routes.js";
 import type { Storage } from "../../../src/storage/types.js";
 
 /** Minimal in-memory Storage backend that records uploaded keys. */
@@ -119,15 +120,24 @@ describe("EmDashRuntime.handlePluginMcpTool", () => {
 		const { storage } = createFakeStorage();
 		const runtime = await EmDashRuntime.create(createDeps(storage));
 		let capturedRequest: Request | undefined;
+		let capturedCaller: RouteCallerInput | null | undefined;
 		vi.spyOn(runtime, "handlePluginApiRoute").mockImplementation(
-			async (_pluginId, _method, _route, request) => {
+			async (_pluginId, _method, _route, request, caller) => {
 				capturedRequest = request;
+				capturedCaller = caller;
 				return { success: true, data: { ok: true } };
 			},
 		);
 
 		try {
 			const input = { message: "short" };
+			const caller: RouteCallerInput = {
+				id: "test-actor",
+				email: "actor@example.com",
+				name: "Test Actor",
+				role: 1,
+				createdAt: "2026-01-01T00:00:00.000Z",
+			};
 			await runtime.handlePluginMcpTool(
 				"media-uploader",
 				"echo",
@@ -143,12 +153,14 @@ describe("EmDashRuntime.handlePluginMcpTool", () => {
 					},
 					body: JSON.stringify({ jsonrpc: "2.0", method: "tools/call", params: input }),
 				}),
+				caller,
 			);
 
 			expect(capturedRequest).toBeDefined();
 			expect(capturedRequest!.headers.get("content-length")).toBeNull();
 			expect(capturedRequest!.headers.get("content-encoding")).toBeNull();
 			expect(await capturedRequest!.json()).toEqual(input);
+			expect(capturedCaller).toBe(caller);
 		} finally {
 			await runtime.stopCron();
 		}

--- a/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
+++ b/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
@@ -100,3 +100,33 @@ describe("plugin API catch-all auth (#1853)", () => {
 		expect(handlePluginApiRoute).toHaveBeenCalledOnce();
 	});
 });
+
+describe("plugin API catch-all caller forwarding (#812)", () => {
+	it("forwards the authenticated caller for private routes", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, false);
+		const res = await invoke(POST, "POST", locals);
+		expect(res.status).toBe(200);
+		expect(handlePluginApiRoute).toHaveBeenCalledWith(
+			"demo",
+			"POST",
+			"/updateHomeConfig",
+			expect.any(Request),
+			expect.objectContaining({ id: "u1", role: Role.ADMIN }),
+		);
+	});
+
+	it("does not forward a caller on public routes, even with an ambient session", async () => {
+		// Public routes skip auth entirely — a logged-in user browsing the site
+		// must not be bound as the caller of a public plugin route.
+		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, true);
+		const res = await invoke(GET, "GET", locals, { csrf: false });
+		expect(res.status).toBe(200);
+		expect(handlePluginApiRoute).toHaveBeenCalledWith(
+			"demo",
+			"GET",
+			"/updateHomeConfig",
+			expect.any(Request),
+			undefined,
+		);
+	});
+});

--- a/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
+++ b/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
@@ -108,7 +108,7 @@ describe("plugin API catch-all auth (#1853)", () => {
 	});
 });
 
-describe("plugin API catch-all caller forwarding (#812)", () => {
+describe("plugin API catch-all caller forwarding", () => {
 	it("forwards the authenticated caller for private routes", async () => {
 		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, false);
 		const res = await invoke(POST, "POST", locals);

--- a/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
+++ b/packages/core/tests/unit/astro/plugin-api-route-auth.test.ts
@@ -107,3 +107,33 @@ describe("plugin API catch-all auth (#1853)", () => {
 		expect(handlePluginApiRoute).toHaveBeenCalledOnce();
 	});
 });
+
+describe("plugin API catch-all caller forwarding (#812)", () => {
+	it("forwards the authenticated caller for private routes", async () => {
+		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, false);
+		const res = await invoke(POST, "POST", locals);
+		expect(res.status).toBe(200);
+		expect(handlePluginApiRoute).toHaveBeenCalledWith(
+			"demo",
+			"POST",
+			"/updateHomeConfig",
+			expect.any(Request),
+			expect.objectContaining({ id: "u1", role: Role.ADMIN }),
+		);
+	});
+
+	it("does not forward a caller on public routes, even with an ambient session", async () => {
+		// Public routes skip auth entirely — a logged-in user browsing the site
+		// must not be bound as the caller of a public plugin route.
+		const { locals, handlePluginApiRoute } = createLocals(Role.ADMIN, true);
+		const res = await invoke(GET, "GET", locals, { csrf: false });
+		expect(res.status).toBe(200);
+		expect(handlePluginApiRoute).toHaveBeenCalledWith(
+			"demo",
+			"GET",
+			"/updateHomeConfig",
+			expect.any(Request),
+			undefined,
+		);
+	});
+});

--- a/packages/core/tests/unit/mcp/authorization.test.ts
+++ b/packages/core/tests/unit/mcp/authorization.test.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 import type { EmDashHandlers } from "../../../src/astro/types.js";
 import { createMcpServer, type PluginMcpRegistration } from "../../../src/mcp/server.js";
+import type { RouteCallerInput } from "../../../src/plugins/routes.js";
 
 // ---------------------------------------------------------------------------
 // Test constants
@@ -207,6 +208,7 @@ function createAuthenticatedPair(authInfo: {
 	emdash: EmDashHandlers;
 	userId: string;
 	userRole: RoleLevel;
+	user: RouteCallerInput;
 	tokenScopes?: string[];
 }): [AuthInjectingTransport, InMemoryTransport] {
 	const clientTransport = new AuthInjectingTransport(authInfo);
@@ -227,6 +229,7 @@ async function setupMcpPair(opts: {
 	handlers?: EmDashHandlers;
 	tokenScopes?: string[];
 	pluginTools?: PluginMcpRegistration[];
+	user?: RouteCallerInput;
 }): Promise<{ client: Client; cleanup: () => Promise<void> }> {
 	const handlers = opts.handlers ?? createMockHandlers();
 	const server = createMcpServer(
@@ -237,6 +240,13 @@ async function setupMcpPair(opts: {
 		emdash: handlers,
 		userId: opts.userId,
 		userRole: opts.userRole,
+		user: opts.user ?? {
+			id: opts.userId,
+			email: `${opts.userId}@example.com`,
+			name: null,
+			role: opts.userRole,
+			createdAt: "2026-01-01T00:00:00.000Z",
+		},
 		tokenScopes: opts.tokenScopes,
 	});
 
@@ -309,6 +319,13 @@ describe("MCP Authorization", () => {
 
 		it("dispatches with a plugin-specific scope and returns structured output", async () => {
 			const handlers = createMockHandlers();
+			const caller: RouteCallerInput = {
+				id: AUTHOR_USER_ID,
+				email: "author@example.com",
+				name: "Author",
+				role: Role.CONTRIBUTOR,
+				createdAt: "2026-01-01T00:00:00.000Z",
+			};
 			handlers.handlePluginMcpTool = vi.fn().mockResolvedValue({
 				success: true,
 				data: { id: "event-1" },
@@ -317,6 +334,7 @@ describe("MCP Authorization", () => {
 				userId: AUTHOR_USER_ID,
 				userRole: Role.CONTRIBUTOR,
 				tokenScopes: ["mcp:tools:calendar"],
+				user: caller,
 				handlers,
 				pluginTools: [pluginTool],
 			}));
@@ -337,6 +355,7 @@ describe("MCP Authorization", () => {
 				{ title: "Launch" },
 				AUTHOR_USER_ID,
 				expect.any(Request),
+				caller,
 			);
 		});
 

--- a/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
+++ b/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
@@ -366,6 +366,43 @@ describe("adaptSandboxEntry", () => {
 			expect(pluginCtx).not.toHaveProperty("requestMeta");
 		});
 
+		it("passes the authenticated caller into routeCtx.user, not pluginCtx (#812)", async () => {
+			const standardHandler = vi.fn().mockResolvedValue({ ok: true });
+
+			const def: SandboxedPlugin = {
+				routes: {
+					whoami: { handler: standardHandler },
+				},
+			};
+			const result = adaptSandboxEntry(def, createDescriptor());
+
+			const caller = {
+				id: "u1",
+				email: "a@b.c",
+				name: "A",
+				role: 2,
+				createdAt: "2026-01-01T00:00:00.000Z",
+			};
+			const mockCtx = {
+				input: {},
+				request: new Request("http://localhost/test"),
+				requestMeta: { ip: null, userAgent: null, referer: null, geo: null },
+				user: caller,
+				plugin: { id: "test-plugin", version: "1.0.0" },
+				kv: {} as any,
+				storage: {} as any,
+				log: {} as any,
+				site: { name: "", url: "", locale: "en" },
+				url: (p: string) => p,
+			};
+
+			await result.routes.whoami.handler(mockCtx as any);
+
+			const [routeCtx, pluginCtx] = standardHandler.mock.calls[0];
+			expect(routeCtx.user).toEqual(caller);
+			expect(pluginCtx).not.toHaveProperty("user");
+		});
+
 		it("preserves public flag on routes", () => {
 			const def: SandboxedPlugin = {
 				routes: {

--- a/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
+++ b/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
@@ -442,6 +442,43 @@ describe("adaptSandboxEntry", () => {
 			expect(pluginCtx.storage).toBeDefined();
 		});
 
+		it("passes the authenticated caller into routeCtx.user, not pluginCtx (#812)", async () => {
+			const standardHandler = vi.fn().mockResolvedValue({ ok: true });
+
+			const def: SandboxedPlugin = {
+				routes: {
+					whoami: { handler: standardHandler },
+				},
+			};
+			const result = adaptSandboxEntry(def, createDescriptor());
+
+			const caller = {
+				id: "u1",
+				email: "a@b.c",
+				name: "A",
+				role: 2,
+				createdAt: "2026-01-01T00:00:00.000Z",
+			};
+			const mockCtx = {
+				input: {},
+				request: new Request("http://localhost/test"),
+				requestMeta: { ip: null, userAgent: null, referer: null, geo: null },
+				user: caller,
+				plugin: { id: "test-plugin", version: "1.0.0" },
+				kv: {} as any,
+				storage: {} as any,
+				log: {} as any,
+				site: { name: "", url: "", locale: "en" },
+				url: (p: string) => p,
+			};
+
+			await result.routes.whoami.handler(mockCtx as any);
+
+			const [routeCtx, pluginCtx] = standardHandler.mock.calls[0];
+			expect(routeCtx.user).toEqual(caller);
+			expect(pluginCtx).not.toHaveProperty("user");
+		});
+
 		it("preserves public flag on routes", () => {
 			const def: SandboxedPlugin = {
 				routes: {

--- a/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
+++ b/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
@@ -442,7 +442,7 @@ describe("adaptSandboxEntry", () => {
 			expect(pluginCtx.storage).toBeDefined();
 		});
 
-		it("passes the authenticated caller into routeCtx.user, not pluginCtx (#812)", async () => {
+		it("passes the authenticated caller into routeCtx.user, not pluginCtx", async () => {
 			const standardHandler = vi.fn().mockResolvedValue({ ok: true });
 
 			const def: SandboxedPlugin = {

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -19,6 +19,7 @@ import {
 	PluginRouteRegistry,
 	PluginRouteError,
 	createRouteRegistry,
+	toRouteCallerInfo,
 } from "../../../src/plugins/routes.js";
 import type { ResolvedPlugin } from "../../../src/plugins/types.js";
 
@@ -125,6 +126,48 @@ describe("PluginRouteError", () => {
 			expect(error.code).toBe("INTERNAL_ERROR");
 			expect(error.status).toBe(500);
 			expect(error.message).toBe("Something broke");
+		});
+	});
+});
+
+describe("toRouteCallerInfo (#812)", () => {
+	it("maps the host user to the plugin-facing UserInfo shape", () => {
+		const info = toRouteCallerInfo({
+			id: "u1",
+			email: "a@b.c",
+			name: null,
+			role: 4,
+			createdAt: new Date("2026-01-02T03:04:05.000Z"),
+		});
+
+		expect(info).toEqual({
+			id: "u1",
+			email: "a@b.c",
+			name: null,
+			role: 4,
+			createdAt: "2026-01-02T03:04:05.000Z",
+		});
+	});
+
+	it("passes string createdAt through and strips extra fields", () => {
+		// Extra host-side fields (avatarUrl, data, …) must not leak to plugins.
+		const hostUser = {
+			id: "u1",
+			email: "a@b.c",
+			name: "A",
+			role: 2,
+			createdAt: "2026-01-01T00:00:00.000Z",
+			avatarUrl: "https://x/y.png",
+			data: { secret: true },
+		};
+		const info = toRouteCallerInfo(hostUser);
+
+		expect(info).toEqual({
+			id: "u1",
+			email: "a@b.c",
+			name: "A",
+			role: 2,
+			createdAt: "2026-01-01T00:00:00.000Z",
 		});
 	});
 });
@@ -332,6 +375,50 @@ describe("PluginRouteHandler", () => {
 
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual({ hasEmail: true, hasSend: true });
+		});
+
+		it("exposes the authenticated caller as ctx.user (#812)", async () => {
+			const plugin = createTestPlugin({
+				routes: {
+					whoami: {
+						handler: async (ctx) => ({ user: ctx.user ?? null }),
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const caller = {
+				id: "user-1",
+				email: "author@example.com",
+				name: "Author",
+				role: 2,
+				createdAt: "2026-01-01T00:00:00.000Z",
+			};
+			const result = await handler.invoke("whoami", {
+				request: new Request("http://test.com/whoami"),
+				user: caller,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ user: caller });
+		});
+
+		it("leaves ctx.user undefined when no caller is provided (#812)", async () => {
+			const plugin = createTestPlugin({
+				routes: {
+					whoami: {
+						handler: async (ctx) => ({ user: ctx.user ?? null }),
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("whoami", {
+				request: new Request("http://test.com/whoami"),
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ user: null });
 		});
 
 		it("surfaces an actionable error when a handler reads the consumed request body (#1293)", async () => {

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -131,7 +131,7 @@ describe("PluginRouteError", () => {
 	});
 });
 
-describe("toRouteCallerInfo (#812)", () => {
+describe("toRouteCallerInfo", () => {
 	it("maps the host user to the plugin-facing UserInfo shape", () => {
 		const info = toRouteCallerInfo({
 			id: "u1",
@@ -405,7 +405,7 @@ describe("PluginRouteHandler", () => {
 			expect(result.data).toEqual({ hasEmail: true, hasSend: true });
 		});
 
-		it("exposes the authenticated caller as ctx.user (#812)", async () => {
+		it("exposes the authenticated caller as ctx.user", async () => {
 			const plugin = createTestPlugin({
 				routes: {
 					whoami: {
@@ -431,7 +431,7 @@ describe("PluginRouteHandler", () => {
 			expect(result.data).toEqual({ user: caller });
 		});
 
-		it("leaves ctx.user undefined when no caller is provided (#812)", async () => {
+		it("leaves ctx.user undefined when no caller is provided", async () => {
 			const plugin = createTestPlugin({
 				routes: {
 					whoami: {

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -20,6 +20,7 @@ import {
 	PluginRouteRegistry,
 	PluginRouteError,
 	createRouteRegistry,
+	toRouteCallerInfo,
 } from "../../../src/plugins/routes.js";
 import type { ResolvedPlugin } from "../../../src/plugins/types.js";
 
@@ -126,6 +127,48 @@ describe("PluginRouteError", () => {
 			expect(error.code).toBe("INTERNAL_ERROR");
 			expect(error.status).toBe(500);
 			expect(error.message).toBe("Something broke");
+		});
+	});
+});
+
+describe("toRouteCallerInfo (#812)", () => {
+	it("maps the host user to the plugin-facing UserInfo shape", () => {
+		const info = toRouteCallerInfo({
+			id: "u1",
+			email: "a@b.c",
+			name: null,
+			role: 4,
+			createdAt: new Date("2026-01-02T03:04:05.000Z"),
+		});
+
+		expect(info).toEqual({
+			id: "u1",
+			email: "a@b.c",
+			name: null,
+			role: 4,
+			createdAt: "2026-01-02T03:04:05.000Z",
+		});
+	});
+
+	it("passes string createdAt through and strips extra fields", () => {
+		// Extra host-side fields (avatarUrl, data, …) must not leak to plugins.
+		const hostUser = {
+			id: "u1",
+			email: "a@b.c",
+			name: "A",
+			role: 2,
+			createdAt: "2026-01-01T00:00:00.000Z",
+			avatarUrl: "https://x/y.png",
+			data: { secret: true },
+		};
+		const info = toRouteCallerInfo(hostUser);
+
+		expect(info).toEqual({
+			id: "u1",
+			email: "a@b.c",
+			name: "A",
+			role: 2,
+			createdAt: "2026-01-01T00:00:00.000Z",
 		});
 	});
 });
@@ -360,6 +403,50 @@ describe("PluginRouteHandler", () => {
 
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual({ hasEmail: true, hasSend: true });
+		});
+
+		it("exposes the authenticated caller as ctx.user (#812)", async () => {
+			const plugin = createTestPlugin({
+				routes: {
+					whoami: {
+						handler: async (ctx) => ({ user: ctx.user ?? null }),
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const caller = {
+				id: "user-1",
+				email: "author@example.com",
+				name: "Author",
+				role: 2,
+				createdAt: "2026-01-01T00:00:00.000Z",
+			};
+			const result = await handler.invoke("whoami", {
+				request: new Request("http://test.com/whoami"),
+				user: caller,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ user: caller });
+		});
+
+		it("leaves ctx.user undefined when no caller is provided (#812)", async () => {
+			const plugin = createTestPlugin({
+				routes: {
+					whoami: {
+						handler: async (ctx) => ({ user: ctx.user ?? null }),
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("whoami", {
+				request: new Request("http://test.com/whoami"),
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ user: null });
 		});
 
 		it("surfaces an actionable error when a handler reads the consumed request body (#1293)", async () => {

--- a/packages/workerd/src/sandbox/wrapper.ts
+++ b/packages/workerd/src/sandbox/wrapper.ts
@@ -413,8 +413,15 @@ export default {
 			}
 
 			try {
+				// user: authenticated caller for private routes, resolved by
+				// the host before dispatch (#812).
 				const result = await handler(
-					{ input, request: serializedRequest, requestMeta: serializedRequest?.meta },
+					{
+						input,
+						request: serializedRequest,
+						requestMeta: serializedRequest?.meta,
+						user: serializedRequest?.user,
+					},
 					ctx,
 				);
 				return Response.json(result);

--- a/packages/workerd/src/sandbox/wrapper.ts
+++ b/packages/workerd/src/sandbox/wrapper.ts
@@ -461,8 +461,15 @@ export default {
 			}
 
 			try {
+				// user: authenticated caller for private routes, resolved by
+				// the host before dispatch (#812).
 				const result = await handler(
-					{ input, request: serializedRequest, requestMeta: serializedRequest?.meta },
+					{
+						input,
+						request: serializedRequest,
+						requestMeta: serializedRequest?.meta,
+						user: serializedRequest?.user,
+					},
 					ctx,
 				);
 				return Response.json(result);

--- a/packages/workerd/src/sandbox/wrapper.ts
+++ b/packages/workerd/src/sandbox/wrapper.ts
@@ -462,7 +462,7 @@ export default {
 
 			try {
 				// user: authenticated caller for private routes, resolved by
-				// the host before dispatch (#812).
+				// the host before dispatch.
 				const result = await handler(
 					{
 						input,


### PR DESCRIPTION
## What does this PR do?

The plugin API catch-all resolves the authenticated user, uses it to enforce `plugins:manage` + scope + CSRF — and then drops it before invoking the plugin's handler. Plugins had no first-class way to know **who is calling** a private route, forcing bad workarounds (reading a user id from the request body is trivially spoofable).

This threads the validated caller through `handlePluginApiRoute` into the route context, exactly as proposed in #812:

- **Native format:** `ctx.user` on `RouteContext`.
- **Standard (sandboxed) format:** `routeCtx.user` — wired through the in-process adapter, the Cloudflare Worker Loader wrapper, and both workerd runners (`SerializedRequest.user` is structured-clone/JSON-safe).
- The exposed shape is the existing read-only `UserInfo` (`{ id, email, name, role, createdAt }`) — the same shape `ctx.users` returns, with sensitive host-side fields (`avatarUrl`, `data`, …) stripped by `toRouteCallerInfo()`.

Semantics (per the issue):

- **Private routes:** `ctx.user` is the authenticated caller, validated by the existing `requirePerm`/`requireScope` checks one frame up.
- **Public routes:** `ctx.user` is `undefined` — the catch-all only forwards the caller after private-route auth, so an ambient admin session browsing the site is never bound to a public route.
- **Machine tokens with no bound user:** `undefined`.

Purely additive — no change for plugins that don't read `ctx.user`, no migration, no flag. Caller identity is intentionally **not** gated by the `users:read` capability (it's the caller's own identity, not a directory lookup).

Tests: route handler exposes/omits `ctx.user` (unit), catch-all forwards the caller only for private routes (unit, including the ambient-session case), sandbox adapter puts `user` on `routeCtx` and strips it from `pluginCtx`, `toRouteCallerInfo` mapping (Date→ISO, field stripping). Docs updated in the API-routes guide (new "The authenticated caller" section + route context reference) and the native-plugin guide.

Closes #812
Discussion: https://github.com/emdash-cms/emdash/discussions/1757

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a, no admin UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1757

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

```
tests/unit/plugins + tests/unit/astro/plugin-api-route-auth.test.ts
 Test Files  30 passed (30)
      Tests  629 passed (629)

tests/integration/plugins + tests/unit/astro
 Test Files  26 passed (26)
      Tests  276 passed (276)

@emdash-cms/sandbox-workerd: 76 passed · @emdash-cms/cloudflare: 222 passed
```