### PR TITLE
fix(registry): remove ambiguous label regexes

### DIFF
--- a/apps/labeler/src/config.ts
+++ b/apps/labeler/src/config.ts
@@ -1,6 +1,6 @@
 import { P256PublicKey, parsePublicMultikey } from "@atcute/crypto";
 
-const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+(?:[:][A-Za-z0-9._:%-]+)*$/;
+const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const KEY_VERSION = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/;
 const DID_WEB_HOST = /^did:web:([^:]+)$/;
 

--- a/apps/labeler/src/query-labels.ts
+++ b/apps/labeler/src/query-labels.ts
@@ -8,7 +8,7 @@ import {
 } from "./signing-rotation.js";
 import { xrpcError } from "./xrpc.js";
 
-const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+(?:[:][A-Za-z0-9._:%-]+)*$/;
+const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const DIGITS = /^\d+$/;
 const POSITIVE_INTEGER = /^[1-9]\d*$/;
 const DEFAULT_LIMIT = 50;

--- a/apps/labeler/src/service.ts
+++ b/apps/labeler/src/service.ts
@@ -9,9 +9,9 @@ import {
 } from "./signing-rotation.js";
 import type { LabelPublisher } from "./subscribe-labels.js";
 
-const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+(?:[:][A-Za-z0-9._:%-]+)*$/;
+const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const REGISTRY_RECORD =
-	/^at:\/\/(did:[a-z0-9]+:[A-Za-z0-9._:%-]+(?:[:][A-Za-z0-9._:%-]+)*)\/(com\.emdashcms\.experimental\.package\.(?:profile|release))\/([A-Za-z0-9._~:%-]+)$/;
+	/^at:\/\/(did:[a-z0-9]+:[A-Za-z0-9._:%-]+)\/(com\.emdashcms\.experimental\.package\.(?:profile|release))\/([A-Za-z0-9._~:%-]+)$/;
 
 export type ManualLabelValue =
 	| "!takedown"

--- a/apps/labeler/src/signing-rotation.ts
+++ b/apps/labeler/src/signing-rotation.ts
@@ -3,7 +3,7 @@ import { verifyLabel, type LabelSigner, type SignedLabel } from "@emdash-cms/reg
 
 const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/;
 const P256_MULTIKEY = /^zDna[1-9A-HJ-NP-Za-km-z]+$/;
-const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+(?:[:][A-Za-z0-9._:%-]+)*$/;
+const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 
 interface SigningStateRow {
 	issuer_did: string;

--- a/apps/labeler/test/service.test.ts
+++ b/apps/labeler/test/service.test.ts
@@ -489,6 +489,46 @@ describe("manual label issuance", () => {
 		).rejects.toThrow("release record");
 	});
 
+	it("preserves registry-record DID captures", async () => {
+		await expect(
+			issue(
+				"at://did:example::leading-empty/com.emdashcms.experimental.package.profile/empty-leading-segment",
+				"package-disputed",
+			),
+		).resolves.toBeDefined();
+		await expect(
+			issue(
+				"at://did:example:doubled::segment/com.emdashcms.experimental.package.release/demo:1.0.0",
+				"security-yanked",
+			),
+		).resolves.toBeDefined();
+		await expect(
+			issueManualLabel(
+				testEnv.DB,
+				config,
+				await signer(),
+				action("collection captured as DID suffix"),
+				proposal(
+					"at://did:example:publisher:com.emdashcms.experimental.package.release/demo:1.0.0",
+				),
+			),
+		).rejects.toThrow("release record");
+	});
+
+	it("rejects long invalid registry-record authorities without ambiguous matching", async () => {
+		await expect(
+			issueManualLabel(
+				testEnv.DB,
+				config,
+				await signer(),
+				action("invalid long registry authority"),
+				proposal(
+					`at://did:example:${"%:".repeat(100_000)}!/com.emdashcms.experimental.package.release/demo`,
+				),
+			),
+		).rejects.toThrow("release record");
+	});
+
 	it("rejects a signer that is not bound to the configured labeler DID", async () => {
 		await expect(
 			issueManualLabel(

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -185,14 +185,14 @@ interface LabelReduction {
 }
 
 const RFC3339 = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
-const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+(?:[:][A-Za-z0-9._:%-]+)*$/;
+const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const P256_ORDER = BigInt("0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 const LABEL_FIELDS = new Set(["ver", "src", "uri", "cid", "val", "neg", "cts", "exp"]);
 const SIGNED_LABEL_FIELDS = new Set([...LABEL_FIELDS, "sig"]);
 const PRINTABLE_LABEL_VALUE = /^[^\p{Cc}]{1,128}$/u;
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
 const ATPROTO_URI =
-	/^at:\/\/(?:did:[a-z0-9]+:[A-Za-z0-9._:%-]+(?:[:][A-Za-z0-9._:%-]+)*|[A-Za-z0-9.-]+)\/[A-Za-z0-9.-]+(?:\/[A-Za-z0-9._~:%-]+)?$/;
+	/^at:\/\/(?:did:[a-z0-9]+:[A-Za-z0-9._:%-]+|[A-Za-z0-9.-]+)\/[A-Za-z0-9.-]+(?:\/[A-Za-z0-9._~:%-]+)?$/;
 
 function daysFromCivil(year: bigint, month: bigint, day: bigint): bigint {
 	const adjustedYear = year - (month <= 2n ? 1n : 0n);

--- a/packages/registry-moderation/tests/label-crypto.test.ts
+++ b/packages/registry-moderation/tests/label-crypto.test.ts
@@ -117,6 +117,39 @@ describe("ATProto label v1 crypto", () => {
 		);
 	});
 
+	it("preserves DID and ATProto URI grammar without ambiguous colon matching", async () => {
+		const boundSigner = await signer();
+		for (const uri of [
+			"did:plc:abc123",
+			"did:web:example.com",
+			"did:example::leading-empty",
+			"did:example:doubled::segment",
+			"did:example:trailing:",
+			"at://did:example::leading-empty/com.example.collection/record",
+			"at://did:example:doubled::segment/com.example.collection/record:1",
+			"at://example.com/com.example.collection/record:1",
+			"at://example.com/com.example.collection",
+		]) {
+			await expect(boundSigner.sign({ ...signingLabel(), uri })).resolves.toMatchObject({ uri });
+		}
+
+		for (const uri of [
+			"did:example:",
+			"did:Example:value",
+			"did:example-method:value",
+			"did:example:value/path",
+			"did:example:value?query",
+			"at://did:example:/com.example.collection/record",
+			"at://example.com//record",
+			"at://example.com/com.example.collection/",
+			`at://did:example:${"%:".repeat(100_000)}!/com.example.collection/record`,
+		]) {
+			await expect(boundSigner.sign({ ...signingLabel(), uri })).rejects.toThrow(
+				"label.uri must be an at:// URI or DID",
+			);
+		}
+	});
+
 	it("rejects non-canonical, zero, and out-of-range private scalar forms", async () => {
 		for (const privateKey of [
 			fixture.privateKey + "=",


### PR DESCRIPTION
## What does this PR do?

Removes language-redundant nested DID suffixes that caused CodeQL to report ten high-severity polynomial and inefficient regular-expression alerts on the plugin registry labelling-service branch.

The simplified patterns preserve the exact accepted language and registry-record capture behavior while making colon-heavy invalid input linear-time. Regression tests cover valid and invalid DID/AT URI forms, capture boundaries, and 100,000-repeat adversarial inputs.

Related to #1909.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs; a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Admin i18n and a Discussion are not applicable. The unreleased `@emdash-cms/registry-moderation` package already has its introduction changeset on the integration branch, so this blocker fix does not add duplicate release notes.

## AI-generated code disclosure

- [x] This PR includes AI-generated code; model/tool: OpenCode with GPT-5.6-sol, independently reviewed with Claude Opus 4.8

## Screenshots / test output

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`: 0 warnings and 0 errors across 2,078 files
- `pnpm --filter @emdash-cms/labeler test`: 29 tests passed
- `pnpm --filter @emdash-cms/registry-moderation test`: 61 tests passed
- Targeted formatting and `git diff --check` passed
- Independent review found no high or medium issues
- 800,000-input equivalence fuzzing found zero match or capture divergences
- Old adversarial regexes exceeded 20 seconds; simplified forms completed in approximately 0.25 ms