### PR TITLE
feat(registry): add label verification primitives

### DIFF
--- a/.changeset/bright-labels-verify.md
+++ b/.changeset/bright-labels-verify.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-moderation": patch
+---
+
+Adds signed-label parsing, encoding, and public-key verification APIs with distinguishable invalid-signature errors that remain `TypeError`-compatible.

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -1,4 +1,4 @@
-import { encode } from "@atcute/cbor";
+import { encode, toBytes } from "@atcute/cbor";
 import { fromString as cidFromString, toString as cidToString } from "@atcute/cid";
 import { P256PrivateKey, P256PublicKey, parsePublicMultikey } from "@atcute/crypto";
 import { fromBase64Url, toBase64Url } from "@atcute/multibase";
@@ -94,6 +94,14 @@ export type LabelDidResolver = (did: string) => Promise<LabelDidDocument>;
 export interface LabelVerificationInput {
 	label: SignedLabel;
 	resolveDid: LabelDidResolver;
+}
+
+/** Indicates that a valid, correctly sourced label failed cryptographic verification. */
+export class InvalidLabelSignatureError extends TypeError {
+	constructor(message: string) {
+		super(message);
+		this.name = "InvalidLabelSignatureError";
+	}
 }
 
 export interface AcceptedLabelerPolicy {
@@ -383,11 +391,26 @@ function validateLabelObject(value: unknown, signed: boolean): SignedLabel | Uns
 	if (!signed) return canonical;
 	if (!(sig instanceof Uint8Array) || sig.length !== 64)
 		throw new TypeError("label.sig must be a 64-byte compact P-256 signature");
-	return { ...canonical, sig };
+	return { ...canonical, sig: Uint8Array.from(sig) };
 }
 
 function canonicalLabelBytes(label: UnsignedLabel): Uint8Array {
 	return encode(validateLabelObject(label, false));
+}
+
+/** Parses and canonically reconstructs an unknown signed ATProto label v1 value. */
+export function parseSignedLabel(value: unknown): SignedLabel {
+	return validateLabelObject(value, true);
+}
+
+/**
+ * Encodes a complete signed label as deterministic canonical CBOR for digest
+ * or identity use after successful verification. Encoding alone does not
+ * authenticate a label.
+ */
+export function encodeSignedLabel(label: SignedLabel): Uint8Array {
+	const { sig, ...unsigned } = parseSignedLabel(label);
+	return encode({ ...unsigned, sig: toBytes(sig) });
 }
 
 function importPrivateScalar(value: string): Promise<P256PrivateKey> {
@@ -472,16 +495,29 @@ export async function createLabelSigner(input: CreateLabelSignerInput): Promise<
 	};
 }
 
-/** Verifies a signed label against the source DID's exact `#atproto_label` P-256 key. */
-export async function verifyLabel(input: LabelVerificationInput): Promise<VerifiedModerationLabel> {
-	const label = validateLabelObject(input.label, true);
-	const key = await resolveLabelPublicKey(label.src, input.resolveDid);
+/** Verifies a signed label against an expected source and resolved P-256 public key. */
+export async function verifyLabelWithPublicKey(input: {
+	label: SignedLabel;
+	expectedSource: string;
+	publicKey: P256PublicKey;
+}): Promise<VerifiedModerationLabel> {
+	validateDid(input.expectedSource, "expectedSource");
+	const label = parseSignedLabel(input.label);
+	if (label.src !== input.expectedSource)
+		throw new TypeError("label.src does not match expectedSource");
 	const { sig, ...verified } = label;
-	if (!(await key.verify(sig, canonicalLabelBytes(verified))))
-		throw new TypeError("label signature is invalid");
+	if (!(await input.publicKey.verify(sig, canonicalLabelBytes(verified))))
+		throw new InvalidLabelSignatureError("label signature is invalid");
 	const verifiedLabel: VerifiedModerationLabel = { ...verified, [verifiedModerationLabel]: true };
 	Object.defineProperty(verifiedLabel, verifiedModerationLabel, { enumerable: false });
 	return verifiedLabel;
+}
+
+/** Verifies a signed label against the source DID's exact `#atproto_label` P-256 key. */
+export async function verifyLabel(input: LabelVerificationInput): Promise<VerifiedModerationLabel> {
+	const label = parseSignedLabel(input.label);
+	const publicKey = await resolveLabelPublicKey(label.src, input.resolveDid);
+	return verifyLabelWithPublicKey({ label, expectedSource: label.src, publicKey });
 }
 
 function streamKey(label: ModerationLabel): string {

--- a/packages/registry-moderation/tests/label-crypto.test.ts
+++ b/packages/registry-moderation/tests/label-crypto.test.ts
@@ -1,13 +1,19 @@
 import { readFileSync } from "node:fs";
 
-import { encode } from "@atcute/cbor";
+import { encode, toBytes } from "@atcute/cbor";
+import { P256PrivateKey, P256PublicKey, parsePublicMultikey } from "@atcute/crypto";
+import { fromBase64Url } from "@atcute/multibase";
 import { verifySignature } from "@atproto/crypto";
 import { describe, expect, it } from "vitest";
 
 import {
 	createLabelSigner,
+	encodeSignedLabel,
+	InvalidLabelSignatureError,
+	parseSignedLabel,
 	verifyAndEvaluateReleaseModeration,
 	verifyLabel,
+	verifyLabelWithPublicKey,
 	type LabelDidDocument,
 	type SignedLabel,
 	type UnsignedLabel,
@@ -57,6 +63,12 @@ async function signedLabel(): Promise<SignedLabel> {
 	return (await signer()).sign(signingLabel());
 }
 
+async function publicKey(): Promise<P256PublicKey> {
+	const parsed = parsePublicMultikey(fixture.multikey);
+	if (parsed.type !== "p256") throw new TypeError("fixture must contain a P-256 key");
+	return P256PublicKey.importRaw(parsed.publicKeyBytes);
+}
+
 async function verify(label: SignedLabel, didDocument = document()) {
 	return verifyLabel({ label, resolveDid: async () => didDocument });
 }
@@ -79,6 +91,105 @@ function asHighS(signature: Uint8Array): Uint8Array {
 }
 
 describe("ATProto label v1 crypto", () => {
+	it("parses unknown signed labels through strict canonical reconstruction", async () => {
+		const signed = await signedLabel();
+		const inherited = Object.create({ val: signed.val }) as Record<string, unknown>;
+		Object.assign(inherited, signed);
+		delete inherited.val;
+		expect(() => parseSignedLabel(inherited)).toThrow("label.val");
+
+		let accessed = false;
+		const accessor = { ...signed };
+		Object.defineProperty(accessor, "val", {
+			enumerable: true,
+			get() {
+				accessed = true;
+				return signed.val;
+			},
+		});
+		expect(() => parseSignedLabel(accessor)).toThrow("label.val");
+		expect(accessed).toBe(false);
+
+		const parsed = parseSignedLabel({ ...signed, neg: false });
+		expect(parsed).toEqual(signed);
+		expect(parsed.sig).not.toBe(signed.sig);
+		expect("neg" in parsed).toBe(false);
+	});
+
+	it("isolates parsed and encoded labels from caller signature mutation", () => {
+		const originalSignature = Uint8Array.from({ length: 64 }, (_, index) => index);
+		const signed = { ...fixture.label, sig: Buffer.from(originalSignature) };
+		const parsed = parseSignedLabel(signed);
+		const encoded = encodeSignedLabel(parsed);
+
+		signed.sig.fill(0xff);
+
+		expect(parsed.sig).not.toBe(signed.sig);
+		expect(parsed.sig.constructor).toBe(Uint8Array);
+		expect(Buffer.isBuffer(parsed.sig)).toBe(false);
+		expect(parsed.sig).toEqual(originalSignature);
+		expect(encodeSignedLabel(parsed)).toEqual(encoded);
+	});
+
+	it("encodes stable canonical CBOR for the complete signed label", () => {
+		const signed = {
+			...fixture.label,
+			sig: Uint8Array.from({ length: 64 }, (_, index) => index),
+		};
+		const canonical = encodeSignedLabel(signed);
+
+		expect(encodeSignedLabel({ ...signed, neg: false })).toEqual(canonical);
+		expect(encodeSignedLabel(parseSignedLabel(signed))).toEqual(canonical);
+		const { sig, ...unsigned } = parseSignedLabel(signed);
+		expect(canonical).toEqual(encode({ ...unsigned, sig: toBytes(sig) }));
+		expect(canonical).not.toEqual(unsignedBytes(unsigned));
+		expect(Buffer.from(canonical).toString("hex")).toBe(
+			"a763636964783b6261666b72656966346f61796d756d3534693571656662776f626c7274357a6173666a68707968797661637073657174656869337175656577356d636374737818323032362d30372d31305431323a30303a30302e3030305a637369675840000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f63737263736469643a6578616d706c653a6c6162656c657263757269783061743a2f2f6469643a6578616d706c653a7075626c69736865722f636f6d2e6578616d706c652e72656c656173652f316376616c716173736573736d656e742d7061737365646376657201",
+		);
+	});
+
+	it("distinguishes only cryptographic mismatches from other verification failures", async () => {
+		const signed = await signedLabel();
+		const key = await publicKey();
+		const error = new InvalidLabelSignatureError("label signature is invalid");
+		expect(error).toBeInstanceOf(TypeError);
+		expect(error.name).toBe("InvalidLabelSignatureError");
+		expect(error.message).toBe("label signature is invalid");
+
+		await expect(
+			verifyLabelWithPublicKey({
+				label: signed,
+				expectedSource: "did:example:other",
+				publicKey: key,
+			}),
+		).rejects.not.toBeInstanceOf(InvalidLabelSignatureError);
+		await expect(
+			verifyLabelWithPublicKey({
+				label: { ...signed, sig: new Uint8Array(63) },
+				expectedSource: signed.src,
+				publicKey: key,
+			}),
+		).rejects.not.toBeInstanceOf(InvalidLabelSignatureError);
+		await expect(
+			verifyLabelWithPublicKey({
+				label: { ...signed, sig: new Uint8Array(64) },
+				expectedSource: signed.src,
+				publicKey: key,
+			}),
+		).rejects.toBeInstanceOf(InvalidLabelSignatureError);
+	});
+
+	it("verifies with a resolved public key identically to DID-based verification", async () => {
+		const signed = await signedLabel();
+		const direct = await verifyLabelWithPublicKey({
+			label: signed,
+			expectedSource: fixture.label.src,
+			publicKey: await publicKey(),
+		});
+
+		expect(direct).toEqual(await verify(signed));
+	});
+
 	it("binds a signer to #atproto_label and signs canonical label CBOR", async () => {
 		const signed = await signedLabel();
 		const verified = await verify(signed);
@@ -99,9 +210,18 @@ describe("ATProto label v1 crypto", () => {
 		const signed = await signedLabel();
 		const bytes = unsignedBytes(fixture.label);
 		const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+		const privateKey = await P256PrivateKey.importRaw(fromBase64Url(fixture.privateKey));
+		const digestSignature = await privateKey.sign(digest);
 
 		expect(await verifySignature(`did:key:${fixture.multikey}`, bytes, signed.sig)).toBe(true);
 		expect(await verifySignature(`did:key:${fixture.multikey}`, digest, signed.sig)).toBe(false);
+		await expect(
+			verifyLabelWithPublicKey({
+				label: { ...signed, sig: digestSignature },
+				expectedSource: signed.src,
+				publicKey: await publicKey(),
+			}),
+		).rejects.toBeInstanceOf(InvalidLabelSignatureError);
 	});
 
 	it("rejects unsupported fields, invalid dates, and values exceeding 128 UTF-8 bytes", async () => {
@@ -204,13 +324,22 @@ describe("ATProto label v1 crypto", () => {
 
 	it("rejects malleable, DER, and altered signatures or labels", async () => {
 		const signed = await signedLabel();
-		await expect(verify({ ...signed, sig: asHighS(signed.sig) })).rejects.toThrow(
-			"signature is invalid",
-		);
-		await expect(verify({ ...signed, sig: new Uint8Array(70) })).rejects.toThrow("64-byte compact");
-		await expect(verify({ ...signed, val: "assessment-pending" })).rejects.toThrow(
-			"signature is invalid",
-		);
+		const key = await publicKey();
+		for (const label of [
+			{ ...signed, sig: asHighS(signed.sig) },
+			{ ...signed, val: "assessment-pending" },
+		]) {
+			await expect(
+				verifyLabelWithPublicKey({ label, expectedSource: signed.src, publicKey: key }),
+			).rejects.toBeInstanceOf(InvalidLabelSignatureError);
+		}
+		await expect(
+			verifyLabelWithPublicKey({
+				label: { ...signed, sig: new Uint8Array(70) },
+				expectedSource: signed.src,
+				publicKey: key,
+			}),
+		).rejects.not.toBeInstanceOf(InvalidLabelSignatureError);
 	});
 
 	it("verifies labels before evaluating their moderation effect", async () => {


### PR DESCRIPTION
## What does this PR do?

Adds the shared signed-label parsing, canonical encoding, and resolved-key verification primitives required before the aggregator can consume label subscriptions. Invalid cryptographic signatures now have a distinguishable `InvalidLabelSignatureError` while remaining compatible with existing `TypeError` handling.

This is the shared-contract precursor for W4.2 in the plugin registry labelling service plan. The outbound subscription Durable Object remains paused until this contract lands.

Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs; a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

RFC #694 and the umbrella implementation PR #1909 are the approved design sources. There are no admin UI strings or translation changes.

## AI-generated code disclosure

- [x] This PR includes AI-generated code; model/tool: OpenCode with GPT-5.6-sol

## Screenshots / test output

- `pnpm build` passes
- `pnpm typecheck` passes
- `pnpm lint` passes with 0 warnings and 0 errors
- Registry moderation: 66 tests pass
- Labeler workerd integration: 29 tests pass
- Formatting and `git diff --check` pass
- `publint` passes; `attw` reaches its known internal `filename` crash while checking the packed package
- Two independent review rounds report no remaining high or medium findings

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-17-label-verification-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-17-label-verification`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
