### PR TITLE
fix(cli): import plugin artifacts through file URLs

### DIFF
--- a/.changeset/calm-validator-paths.md
+++ b/.changeset/calm-validator-paths.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash plugin bundle` and `emdash plugin validate` on Windows by importing generated plugin artifacts through portable file URLs.

--- a/packages/core/src/cli/commands/bundle-utils.ts
+++ b/packages/core/src/cli/commands/bundle-utils.ts
@@ -9,6 +9,7 @@ import { createWriteStream } from "node:fs";
 import { readdir, stat, access } from "node:fs/promises";
 import { resolve, join } from "node:path";
 import { pipeline } from "node:stream/promises";
+import { pathToFileURL } from "node:url";
 
 import { imageSize } from "image-size";
 import { packTar } from "modern-tar/fs";
@@ -103,6 +104,11 @@ export async function fileExists(path: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+/** Convert an absolute build artifact path into a portable ESM import specifier. */
+export function toFileImportSpecifier(path: string): string {
+	return pathToFileURL(path).href;
 }
 
 // ── Image dimension readers ──────────────────────────────────────────────────

--- a/packages/core/src/cli/commands/bundle.ts
+++ b/packages/core/src/cli/commands/bundle.ts
@@ -37,6 +37,7 @@ import {
 	MAX_SCREENSHOT_HEIGHT,
 	readImageDimensions,
 	resolveSourceEntry,
+	toFileImportSpecifier,
 	totalBundleBytes,
 	validateBundleSize,
 } from "./bundle-utils.js";
@@ -202,7 +203,10 @@ export const bundleCommand = defineCommand({
 			}
 
 			// Dynamic import of the built plugin
-			const pluginModule = (await import(mainOutputPath)) as Record<string, unknown>;
+			const pluginModule = (await import(toFileImportSpecifier(mainOutputPath))) as Record<
+				string,
+				unknown
+			>;
 
 			// Extract manifest from the imported module.
 			// Supports three patterns:
@@ -269,7 +273,9 @@ export const bundleCommand = defineCommand({
 								const backendBaseName = basename(backendEntry).replace(TS_EXT_RE, "");
 								const backendProbePath = await findBuildOutput(backendProbeDir, backendBaseName);
 								if (backendProbePath) {
-									const backendModule = (await import(backendProbePath)) as Record<string, unknown>;
+									const backendModule = (await import(
+										toFileImportSpecifier(backendProbePath)
+									)) as Record<string, unknown>;
 									const standardDef = (backendModule.default ?? {}) as Record<string, unknown>;
 									const hooks = standardDef.hooks as Record<string, unknown> | undefined;
 									const routes = standardDef.routes as Record<string, unknown> | undefined;

--- a/packages/core/tests/unit/cli/bundle-utils.test.ts
+++ b/packages/core/tests/unit/cli/bundle-utils.test.ts
@@ -22,6 +22,7 @@ import {
 	findNodeBuiltinImports,
 	findBuildOutput,
 	findSourceExports,
+	toFileImportSpecifier,
 } from "../../../src/cli/commands/bundle-utils.js";
 import type { ResolvedPlugin } from "../../../src/plugins/types.js";
 
@@ -274,6 +275,16 @@ describe("findBuildOutput", () => {
 
 	it("returns undefined when no match", async () => {
 		expect(await findBuildOutput(tempDir, "index")).toBeUndefined();
+	});
+});
+
+describe("toFileImportSpecifier", () => {
+	it("returns a file URL for an absolute build artifact path", () => {
+		const artifactPath = join(tmpdir(), "emdash-plugin", "index.mjs");
+		const specifier = toFileImportSpecifier(artifactPath);
+
+		expect(new URL(specifier).protocol).toBe("file:");
+		expect(specifier).not.toBe(artifactPath);
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes the current `emdash plugin bundle` / `emdash plugin validate` pipeline on Windows. The CLI was passing raw absolute artifact paths such as `C:\\...` to native `import()`, so Node interpreted the drive letter as an unsupported URL scheme.

Both generated-module imports now go through a small `pathToFileURL(...).href` helper. The helper has a cross-platform unit test that asserts an absolute artifact path becomes a `file:` specifier.

Related to #1236, which fixed the same class of bug in the earlier plugin CLI pipeline.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No user-visible strings are added.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable (bug fix)

Targeted type-aware lint passed for all three changed TypeScript files; the full repository lint was not run.

## Screenshots / test output

- `pnpm --filter emdash exec vitest run tests/unit/cli/bundle-utils.test.ts`: 32 tests passed.
- `pnpm --filter "emdash..." build && pnpm --filter emdash typecheck`: passed.
- Targeted `oxlint --type-aware --deny-warnings`: 0 warnings, 0 errors.