### PR TITLE
feat(seo): getSeoMeta accepts defaultTitle/defaultDescription (#1518)

### DIFF
--- a/.changeset/seo-meta-defaults.md
+++ b/.changeset/seo-meta-defaults.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds `defaultTitle` and `defaultDescription` options to `getSeoMeta` so pages with computed titles or descriptions can pass their own fallbacks while values set in the admin SEO panel still take precedence. Previously such pages had to drop down to `getContentSeo` and merge panel values by hand.

--- a/packages/core/src/seo/index.ts
+++ b/packages/core/src/seo/index.ts
@@ -83,6 +83,17 @@ export interface SeoMetaOptions {
 	path?: string;
 	/** Default OG image URL if content has none */
 	defaultOgImage?: string;
+	/**
+	 * Default page title used when the SEO panel has none. Ranks above the
+	 * `data.title` fallback, so computed titles (e.g. `` `${title} (cover of
+	 * ${artist})` ``) apply while an editor-set SEO title still wins.
+	 */
+	defaultTitle?: string;
+	/**
+	 * Default description used when the SEO panel has none. Ranks above the
+	 * `data.excerpt` fallback; an editor-set SEO description still wins.
+	 */
+	defaultDescription?: string;
 }
 
 /**
@@ -96,7 +107,7 @@ export interface SeoMetaOptions {
  * @returns Resolved meta tags ready for template use
  */
 export function getSeoMeta<T>(content: SeoContentInput<T>, options: SeoMetaOptions = {}): SeoMeta {
-	const { siteTitle, siteUrl, path, defaultOgImage } = options;
+	const { siteTitle, siteUrl, path, defaultOgImage, defaultTitle, defaultDescription } = options;
 	const separator = options.titleSeparator || " | ";
 	// SEO can be in content.seo (ContentItem) or content.data.seo (ContentEntry)
 	const seo = content.seo ??
@@ -108,15 +119,19 @@ export function getSeoMeta<T>(content: SeoContentInput<T>, options: SeoMetaOptio
 			noIndex: false,
 		};
 
-	// Title: SEO title > content title > fallback
+	// Title: SEO panel title > caller default > content title
 	const pageTitle =
-		seo.title || (typeof content.data.title === "string" ? content.data.title : null) || "";
+		seo.title ||
+		defaultTitle ||
+		(typeof content.data.title === "string" ? content.data.title : null) ||
+		"";
 
 	const fullTitle = siteTitle && pageTitle ? `${pageTitle}${separator}${siteTitle}` : pageTitle;
 
-	// Description: SEO description > excerpt
+	// Description: SEO panel description > caller default > excerpt
 	const description =
 		seo.description ||
+		defaultDescription ||
 		(typeof content.data.excerpt === "string" ? content.data.excerpt : null) ||
 		null;
 

--- a/packages/core/tests/unit/seo/get-seo-meta.test.ts
+++ b/packages/core/tests/unit/seo/get-seo-meta.test.ts
@@ -47,3 +47,46 @@ describe("getSeoMeta ogImage URL building", () => {
 		expect(meta.ogImage).toBe("https://example.com/_emdash/api/media/file/01KS.svg");
 	});
 });
+
+describe("getSeoMeta defaultTitle / defaultDescription (#1518)", () => {
+	const entry = {
+		data: { title: "Raw Title", excerpt: "Raw excerpt" },
+	};
+
+	it("uses computed defaults over data.title / data.excerpt", () => {
+		const meta = getSeoMeta(entry, {
+			defaultTitle: "Raw Title (cover of Artist)",
+			defaultDescription: "A computed description",
+		});
+		expect(meta.title).toBe("Raw Title (cover of Artist)");
+		expect(meta.description).toBe("A computed description");
+	});
+
+	it("lets an editor-set SEO panel value win over the caller default", () => {
+		const meta = getSeoMeta(
+			{
+				data: {
+					...entry.data,
+					seo: { title: "Panel Title", description: "Panel description" },
+				},
+			},
+			{
+				defaultTitle: "Computed default",
+				defaultDescription: "Computed description",
+			},
+		);
+		expect(meta.title).toBe("Panel Title");
+		expect(meta.description).toBe("Panel description");
+	});
+
+	it("still falls back to data.title / data.excerpt without defaults", () => {
+		const meta = getSeoMeta(entry, {});
+		expect(meta.title).toBe("Raw Title");
+		expect(meta.description).toBe("Raw excerpt");
+	});
+
+	it("applies the siteTitle suffix to the default title", () => {
+		const meta = getSeoMeta(entry, { defaultTitle: "Computed", siteTitle: "My Site" });
+		expect(meta.title).toBe("Computed | My Site");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Implements suggestion 2 from #1518 (milestone 1.0): `getSeoMeta` now accepts `defaultTitle` and `defaultDescription` options.

Design discussion: https://github.com/emdash-cms/emdash/discussions/1956

Today the helper's only fallbacks are `data.title` / `data.excerpt`. A page with a computed title (the issue's example: `"Maeta — {title} (cover of {artist})"`) can't use `getSeoMeta` at all — the author has to drop down to `getContentSeo` and merge panel-vs-default by hand, or (worse, and this is the footgun) hand-roll `<title>` and silently bypass the whole SEO panel including the `noindex` toggle.

The new options slot in between the panel value and the data fallback:

- title: SEO panel title > `defaultTitle` > `data.title`
- description: SEO panel description > `defaultDescription` > `data.excerpt`

Editor-set panel values always win, so the panel stays authoritative. Purely additive; existing callers are unaffected. The `siteTitle` suffix applies to a default title like any other page title.

Complements the docs fixes for suggestion 1 (#1519 by the reporter, #1900) by removing the main remaining reason to hand-roll `<title>` in the first place. Suggestion 3 (dev-mode warning) is intentionally out of scope — it needs render-path tracking and is better evaluated once docs + this helper have landed.

Refs #1518

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Translation
- [ ] Documentation
- [ ] Performance
- [ ] Tests
- [ ] Chore

## How was this change tested?

- New unit tests in `tests/unit/seo/get-seo-meta.test.ts`: defaults beat `data.title`/`data.excerpt`, panel values beat defaults, behavior without defaults is unchanged, `siteTitle` suffix applies to the default title
- Existing `tests/integration/seo/seo.test.ts` still passes (67 tests total across both files)
- `pnpm typecheck`, `pnpm lint`, `pnpm format` all clean

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have added a changeset (`pnpm changeset`) if this change affects published packages
- [x] For features: I have opened a Discussion and linked it here

## AI-generated code disclosure

- [x] Portions of this PR were generated with an AI tool

**Which tool?** Cursor (Fable 5)