### PR TITLE
feat(registry): ingest signed labels in the aggregator

### DIFF
--- a/apps/aggregator/migrations/0003_label_history_identity.sql
+++ b/apps/aggregator/migrations/0003_label_history_identity.sql
@@ -8,6 +8,15 @@
 -- different label landing at coordinates the ingestor already used. `cts`/`exp`
 -- gain epoch-millisecond columns because RFC 3339 strings compare incorrectly
 -- across timezone offsets in SQL.
+-- Guard: refuse to run against a deployment that has label rows. The
+-- reference deployment was preflight-confirmed empty, but a self-hosted
+-- aggregator may not be. The CHECK is unsatisfiable, so the INSERTs only
+-- succeed when their SELECTs return no rows.
+CREATE TABLE _label_migration_guard (never INTEGER CHECK (never IS NULL AND never IS NOT NULL));
+INSERT INTO _label_migration_guard SELECT 1 FROM labels LIMIT 1;
+INSERT INTO _label_migration_guard SELECT 1 FROM label_state LIMIT 1;
+DROP TABLE _label_migration_guard;
+
 DROP TABLE labels;
 DROP TABLE label_state;
 

--- a/apps/aggregator/migrations/0003_label_history_identity.sql
+++ b/apps/aggregator/migrations/0003_label_history_identity.sql
@@ -1,0 +1,70 @@
+-- Collision-safe label history identity + integer-comparable timestamps.
+--
+-- `labels`/`label_state` are empty in every deployment (no writer exists yet;
+-- production preflight confirmed zero rows), so this drops and recreates both
+-- rather than migrating data. Primary key becomes the SHA-256 digest of the
+-- canonical signed-label bytes (`encodeSignedLabel`), so exact redelivery is a
+-- silent no-op; `UNIQUE (src, source_sequence, frame_index)` catches a
+-- different label landing at coordinates the ingestor already used. `cts`/`exp`
+-- gain epoch-millisecond columns because RFC 3339 strings compare incorrectly
+-- across timezone offsets in SQL.
+DROP TABLE labels;
+DROP TABLE label_state;
+
+-- Append-only label history. Every label received is written here, including
+-- negations. Current state is derived from latest cts per (src, uri, val) and
+-- projected into label_state below for hot-path lookups.
+CREATE TABLE labels (
+	digest TEXT PRIMARY KEY,                    -- SHA-256 hex of encodeSignedLabel(label)
+	src TEXT NOT NULL,                          -- labeler DID
+	uri TEXT NOT NULL,                          -- AT URI of subject
+	cid TEXT,                                   -- optional version-specific CID
+	val TEXT NOT NULL,                          -- e.g. 'security-yanked', '!takedown'
+	neg INTEGER NOT NULL DEFAULT 0,
+	cts TEXT NOT NULL,
+	cts_epoch_ms INTEGER NOT NULL,
+	exp TEXT,                                   -- optional expiry (RFC 3339)
+	exp_epoch_ms INTEGER,
+	sig BLOB NOT NULL,                          -- raw signature for client re-verification
+	ver INTEGER NOT NULL DEFAULT 1,
+	source_sequence INTEGER NOT NULL,           -- subscribeLabels frame seq
+	frame_index INTEGER NOT NULL,               -- index of this label within the frame's labels array
+	trusted INTEGER NOT NULL DEFAULT 0,
+	received_at TEXT NOT NULL,
+	UNIQUE (src, source_sequence, frame_index)
+);
+
+CREATE INDEX idx_labels_subject ON labels(uri);
+CREATE INDEX idx_labels_latest ON labels(src, uri, val, cts_epoch_ms DESC);
+
+-- Latest-state projection: one row per (src, uri, val) holding the most recent
+-- cts seen, including the neg flag and exp timestamp. Updated in the same
+-- batch as the labels insert above. Query-time filters apply
+-- `neg = 0 AND (exp_epoch_ms IS NULL OR exp_epoch_ms > now())` to determine
+-- whether a label is currently in force.
+--
+-- Why retain rows for negated/expired labels rather than deleting them: an
+-- out-of-order delivery (a positive label arriving after its negation) could
+-- otherwise reinsert a row we'd already retracted. Keeping the row with its
+-- `cts_epoch_ms` lets the upsert reject the older positive.
+CREATE TABLE label_state (
+	src TEXT NOT NULL,
+	uri TEXT NOT NULL,
+	val TEXT NOT NULL,
+	cid TEXT,
+	neg INTEGER NOT NULL DEFAULT 0,
+	cts TEXT NOT NULL,
+	cts_epoch_ms INTEGER NOT NULL,
+	exp TEXT,
+	exp_epoch_ms INTEGER,
+	digest TEXT NOT NULL,
+	source_sequence INTEGER NOT NULL,
+	frame_index INTEGER NOT NULL,
+	trusted INTEGER NOT NULL DEFAULT 0,
+	PRIMARY KEY (src, uri, val)
+);
+
+-- Hot path for hard filters (yanked, takedown, etc.) from trusted issuers.
+-- Partial index keeps the index small by storing only currently-active rows.
+CREATE INDEX idx_label_state_enforce ON label_state(uri, val, trusted)
+	WHERE neg = 0 AND trusted = 1;

--- a/apps/aggregator/package.json
+++ b/apps/aggregator/package.json
@@ -31,7 +31,8 @@
 		"@atcute/repo": "catalog:",
 		"@atcute/xrpc-server": "catalog:",
 		"@atcute/xrpc-server-cloudflare": "catalog:",
-		"@emdash-cms/registry-lexicons": "workspace:*"
+		"@emdash-cms/registry-lexicons": "workspace:*",
+		"@emdash-cms/registry-moderation": "workspace:*"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "catalog:",

--- a/apps/aggregator/src/index.ts
+++ b/apps/aggregator/src/index.ts
@@ -20,6 +20,8 @@ import { isDid } from "@atcute/lexicons/syntax";
 import { drainBackfillDeadLetterBatch, processBackfillBatch } from "./backfill-consumer.js";
 import { discoverDids, enqueueBackfillJobs } from "./backfill.js";
 import type { BackfillJob, RecordsJob } from "./env.js";
+import type { LabelIngestJob } from "./label-ingest-types.js";
+import { drainLabelsDeadLetterBatch, processLabelsBatch } from "./labels-consumer.js";
 import { drainDeadLetterBatch, processBatch } from "./records-consumer.js";
 import { RECORDS_DO_NAME } from "./records-do.js";
 import { handleXrpc } from "./routes/xrpc/router.js";
@@ -29,7 +31,10 @@ const RECORDS_QUEUE_NAME = "emdash-aggregator-records";
 const RECORDS_DLQ_NAME = "emdash-aggregator-records-dlq";
 const BACKFILL_QUEUE_NAME = "emdash-aggregator-backfill";
 const BACKFILL_DLQ_NAME = "emdash-aggregator-backfill-dlq";
+const LABELS_QUEUE_NAME = "emdash-aggregator-labels";
+const LABELS_DLQ_NAME = "emdash-aggregator-labels-dlq";
 
+export { LabelIngestDO } from "./label-ingest-do.js";
 export { RecordsJetstreamDO } from "./records-do.js";
 
 /**
@@ -286,6 +291,14 @@ export default {
 				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by queue name
 				drainBackfillDeadLetterBatch(batch as MessageBatch<BackfillJob>, env);
 				return;
+			case LABELS_QUEUE_NAME:
+				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by queue name
+				await processLabelsBatch(batch as MessageBatch<LabelIngestJob>, env);
+				return;
+			case LABELS_DLQ_NAME:
+				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by queue name
+				await drainLabelsDeadLetterBatch(batch as MessageBatch<LabelIngestJob>, env);
+				return;
 			default:
 				console.error("[aggregator] unknown queue, acking batch", { queue: batch.queue });
 				for (const m of batch.messages) m.ack();
@@ -302,8 +315,37 @@ export default {
 		const id = env.RECORDS_DO.idFromName(RECORDS_DO_NAME);
 		const stub = env.RECORDS_DO.get(id);
 		ctx.waitUntil(stub.fetch("https://do.internal/liveness"));
+
+		// Same liveness pump for every configured labeler's ingest DO. One
+		// instance per DID (`getByName`); `trusted` gates enforcement
+		// elsewhere, so every configured labeler gets a subscription
+		// regardless of that flag.
+		ctx.waitUntil(wakeLabelIngestDOs(env));
 	},
 };
+
+async function wakeLabelIngestDOs(env: Env): Promise<void> {
+	try {
+		const rows = await env.DB.prepare(`SELECT did FROM labelers`).all<{ did: string }>();
+		for (const row of rows.results ?? []) {
+			const stub = env.LABEL_INGEST_DO.getByName(row.did);
+			// Fire-and-forget per labeler — one slow/unreachable DO shouldn't
+			// block waking the others.
+			void stub
+				.fetch(`https://do.internal/wake?did=${encodeURIComponent(row.did)}`)
+				.catch((err: unknown) => {
+					console.error("[aggregator] label ingest DO wake failed", {
+						did: row.did,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				});
+		}
+	} catch (err) {
+		console.error("[aggregator] label ingest DO wake pump failed", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
 
 type BackfillRequestParsed = { mode: "explicit"; dids: string[] } | { mode: "discover" };
 

--- a/apps/aggregator/src/index.ts
+++ b/apps/aggregator/src/index.ts
@@ -327,19 +327,22 @@ export default {
 async function wakeLabelIngestDOs(env: Env): Promise<void> {
 	try {
 		const rows = await env.DB.prepare(`SELECT did FROM labelers`).all<{ did: string }>();
-		for (const row of rows.results ?? []) {
-			const stub = env.LABEL_INGEST_DO.getByName(row.did);
-			// Fire-and-forget per labeler — one slow/unreachable DO shouldn't
-			// block waking the others.
-			void stub
-				.fetch(`https://do.internal/wake?did=${encodeURIComponent(row.did)}`)
-				.catch((err: unknown) => {
-					console.error("[aggregator] label ingest DO wake failed", {
-						did: row.did,
-						error: err instanceof Error ? err.message : String(err),
-					});
-				});
-		}
+		// Awaited collectively so waitUntil keeps the invocation alive until
+		// every wake lands; the per-fetch catch keeps one unreachable DO from
+		// failing the rest.
+		await Promise.all(
+			(rows.results ?? []).map((row) =>
+				env.LABEL_INGEST_DO.getByName(row.did)
+					.fetch(`https://do.internal/wake?did=${encodeURIComponent(row.did)}`)
+					.then(() => undefined)
+					.catch((err: unknown) => {
+						console.error("[aggregator] label ingest DO wake failed", {
+							did: row.did,
+							error: err instanceof Error ? err.message : String(err),
+						});
+					}),
+			),
+		);
 	} catch (err) {
 		console.error("[aggregator] label ingest DO wake pump failed", {
 			error: err instanceof Error ? err.message : String(err),

--- a/apps/aggregator/src/label-ingest-do.ts
+++ b/apps/aggregator/src/label-ingest-do.ts
@@ -1,0 +1,154 @@
+/**
+ * Label ingest DO: holds a long-lived outbound WebSocket to one labeler's
+ * `subscribeLabels` stream. One instance per labeler, named by DID
+ * (`env.LABEL_INGEST_DO.getByName(did)`) — see `index.ts`'s `scheduled()`.
+ *
+ * Unlike the records DO (a fixed singleton), this DO doesn't know its DID
+ * until something tells it. The `did` isn't part of the binding name lookup
+ * key material available inside the DO itself, so the first `fetch()` (the
+ * cron wake, `?did=...`) supplies it; the DO persists it in its own storage
+ * so later wakes/restarts don't need the query param. A DO instance that has
+ * never been woken with a `did` refuses to run.
+ *
+ * The DO is thin by design — all the loop / verification / cursor / backoff
+ * logic lives in `LabelIngestor`. The DO just wires real bindings in and
+ * exposes a health check.
+ */
+
+import {
+	AtprotoWebDidDocumentResolver,
+	CompositeDidDocumentResolver,
+	PlcDidDocumentResolver,
+} from "@atcute/identity-resolver";
+import { DurableObject } from "cloudflare:workers";
+
+import { LabelIngestor, type LabelCursorStore } from "./label-ingestor.js";
+import { RealLabelStreamClient } from "./label-stream-client.js";
+import { createD1LabelerIdentityCache, LabelerResolver } from "./labeler-resolver.js";
+import { boundFetch } from "./utils.js";
+
+const DID_STORAGE_KEY = "labelIngest:did";
+
+/** D1-backed cursor store for one labeler, keyed `labeler:<did>` in the
+ * shared `ingest_state` table (also used by the Jetstream cursor). Cursor is
+ * stored as TEXT — `ingest_state.cursor` holds both Jetstream's microsecond
+ * `time_us` and this frame `seq`, so the column stays a string for either
+ * shape. */
+function createD1LabelCursorStore(db: D1Database, did: string): LabelCursorStore {
+	const source = `labeler:${did}`;
+	return {
+		async get(): Promise<number | undefined> {
+			const row = await db
+				.prepare(`SELECT cursor FROM ingest_state WHERE source = ?`)
+				.bind(source)
+				.first<{ cursor: string }>();
+			if (!row) return undefined;
+			const cursor = Number(row.cursor);
+			return Number.isSafeInteger(cursor) ? cursor : undefined;
+		},
+		async put(cursor: number): Promise<void> {
+			await db
+				.prepare(
+					`INSERT INTO ingest_state (source, cursor, updated_at)
+					 VALUES (?, ?, datetime('now'))
+					 ON CONFLICT(source) DO UPDATE SET
+					   cursor = excluded.cursor,
+					   updated_at = excluded.updated_at`,
+				)
+				.bind(source, String(cursor))
+				.run();
+		},
+	};
+}
+
+export class LabelIngestDO extends DurableObject {
+	private did: string | null = null;
+	private ingestor: LabelIngestor | null = null;
+	/** Held so the run loop isn't garbage-collected. */
+	private runPromise: Promise<void> | null = null;
+
+	constructor(state: DurableObjectState, env: Env) {
+		super(state, env);
+		// Blocks fetch() until the persisted DID (if any) is loaded, so a
+		// restarted DO resumes its labeler without needing the wake request
+		// to repeat `?did=`.
+		state
+			.blockConcurrencyWhile(async () => {
+				const stored = await state.storage.get<string>(DID_STORAGE_KEY);
+				if (stored) this.start(stored);
+			})
+			.catch((err: unknown) => {
+				console.error("[aggregator] label ingest DO storage bootstrap failed", {
+					error: err instanceof Error ? err.message : String(err),
+				});
+			});
+	}
+
+	/**
+	 * Health surface for the cron wake pump. `consecutiveFailures: 0` means
+	 * the most recent connection attempt fully processed at least one frame;
+	 * non-zero means the labeler is unreachable, its signing key can't be
+	 * resolved, or every label in the current frame is failing verification.
+	 */
+	override async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		const requestedDid = url.searchParams.get("did");
+		if (!this.did) {
+			if (!requestedDid) {
+				return Response.json({ error: "missing did" }, { status: 400 });
+			}
+			await this.ctx.storage.put(DID_STORAGE_KEY, requestedDid);
+			this.start(requestedDid);
+		} else if (requestedDid && requestedDid !== this.did) {
+			// The DO's name is derived from `did` (`getByName(did)`), so this
+			// should be unreachable in production. Log rather than crash — an
+			// operational script hitting the wrong DO by hand shouldn't panic
+			// an otherwise-healthy ingestor.
+			console.error("[aggregator] label ingest DO wake did mismatch", {
+				did: this.did,
+				requestedDid,
+			});
+		}
+		return Response.json({
+			did: this.did,
+			cursor: this.ingestor?.currentCursor ?? null,
+			consecutiveFailures: this.ingestor?.consecutiveFailures ?? 0,
+		});
+	}
+
+	private start(did: string): void {
+		if (this.ingestor) return;
+		this.did = did;
+		const resolver = new LabelerResolver({
+			cache: createD1LabelerIdentityCache(this.env.DB),
+			resolver: new CompositeDidDocumentResolver({
+				methods: {
+					plc: new PlcDidDocumentResolver({ fetch: boundFetch }),
+					web: new AtprotoWebDidDocumentResolver({ fetch: boundFetch }),
+				},
+			}),
+		});
+		this.ingestor = new LabelIngestor({
+			did,
+			client: new RealLabelStreamClient(),
+			queue: this.env.LABELS_QUEUE,
+			cursorStore: createD1LabelCursorStore(this.env.DB, did),
+			resolver,
+			logger: {
+				warn: (msg, ctx) => console.warn(`[aggregator] ${msg}`, { did, ...ctx }),
+				error: (msg, ctx) => console.error(`[aggregator] ${msg}`, { did, ...ctx }),
+			},
+		});
+		// Fire-and-forget. The run loop absorbs every recoverable error path
+		// internally (transient queue failures, connection drops, verification
+		// failures all retry with backoff). The catch is here defensively — if
+		// a future change introduces a non-recoverable rejection, we want it in
+		// the logs rather than as an unhandled promise.
+		this.runPromise = this.ingestor.run().catch((err) => {
+			console.error("[aggregator] label ingestor crashed", {
+				did,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		});
+	}
+}

--- a/apps/aggregator/src/label-ingest-types.ts
+++ b/apps/aggregator/src/label-ingest-types.ts
@@ -1,0 +1,30 @@
+import { fromBase64Url, toBase64Url } from "@atcute/multibase";
+import type { SignedLabel } from "@emdash-cms/registry-moderation";
+
+/** A `SignedLabel` with `sig` as an unpadded base64url string for queue serialization. */
+export interface SignedLabelWire extends Omit<SignedLabel, "sig"> {
+	sig: string;
+}
+
+/**
+ * One label queued for durable history + projection writes. Enqueued only
+ * after `label-ingestor.ts` verifies the signature; `sourceSequence` and
+ * `frameIndex` pin the label's coordinates in the source labeler's stream for
+ * the `(src, source_sequence, frame_index)` collision check.
+ */
+export interface LabelIngestJob {
+	src: string;
+	sourceSequence: number;
+	frameIndex: number;
+	label: SignedLabelWire;
+}
+
+export function toWire(label: SignedLabel): SignedLabelWire {
+	const { sig, ...rest } = label;
+	return { ...rest, sig: toBase64Url(sig) };
+}
+
+export function fromWire(wire: SignedLabelWire): SignedLabel {
+	const { sig, ...rest } = wire;
+	return { ...rest, sig: fromBase64Url(sig) };
+}

--- a/apps/aggregator/src/label-ingestor.ts
+++ b/apps/aggregator/src/label-ingestor.ts
@@ -243,8 +243,11 @@ export class LabelIngestor {
 				if (verificationClosed) {
 					// Fail closed: nothing from this frame is enqueued, the
 					// cursor doesn't move, and the connection ends here (the
-					// `finally` below closes `sub`). The run loop's backoff
-					// counter picks this up as a failed attempt.
+					// `finally` below closes `sub`). Earlier frames in this
+					// connection don't count as progress — otherwise a stream
+					// alternating good and unverifiable frames would reset the
+					// backoff counter every connection and never escalate.
+					this.madeProgress = false;
 					break;
 				}
 

--- a/apps/aggregator/src/label-ingestor.ts
+++ b/apps/aggregator/src/label-ingestor.ts
@@ -1,0 +1,305 @@
+/**
+ * Signed-label ingestor. Subscribes to one labeler's `subscribeLabels`
+ * stream, verifies every label against the labeler's resolved `#atproto_label`
+ * key, enqueues verified labels, and persists the cursor so reconnects resume
+ * cleanly.
+ *
+ * Owns:
+ *   - Connection lifecycle (connect → consume → disconnect → backoff →
+ *     reconnect, indefinitely until `stop()` is called). Same shape as
+ *     `JetstreamIngestor`.
+ *   - Fail-closed verification: a label is enqueued only after its signature
+ *     verifies against the configured labeler's key. One resolver-refresh
+ *     retry per connection absorbs a key rotation landing mid-stream; a
+ *     second failure closes the connection rather than skip the label —
+ *     the labeler is untrusted from that point until it reconnects.
+ *   - Cursor persistence after every label in a frame has been enqueued.
+ *     Persisting only after all sends resolve means a crash mid-frame
+ *     replays the whole frame on reconnect; the consumer's digest-keyed
+ *     `ON CONFLICT DO NOTHING` absorbs the duplicate.
+ *   - Exponential backoff with jitter, capped, reset on each connection
+ *     attempt that made progress.
+ *
+ * Pure constructor injection — no DO/D1/Queue/cloudflare:workers imports —
+ * so unit tests instantiate it directly with a fake `LabelStreamClient` + an
+ * in-memory queue + a `Map`-backed cursor store + a fake resolver.
+ */
+
+import {
+	parseSignedLabel,
+	verifyLabelWithPublicKey,
+	type SignedLabel,
+} from "@emdash-cms/registry-moderation";
+
+import { toWire } from "./label-ingest-types.js";
+import type { LabelIngestJob } from "./label-ingest-types.js";
+import type { LabelStreamClient, LabelStreamHandle } from "./label-stream-client.js";
+import type { ResolvedLabelerIdentity } from "./labeler-resolver.js";
+
+/** Subset of `Queue.send` we use; loose return type because workerd's
+ * `Queue.send` resolves to `QueueSendResponse` while a hand-rolled in-memory
+ * test queue resolves to `void` — neither matters to the ingestor. */
+export interface LabelJobQueue {
+	send(job: LabelIngestJob): Promise<unknown>;
+}
+
+/** Persisted cursor is the last fully processed frame `seq`. `get()` returns
+ * `undefined` when nothing has been persisted yet (fresh labeler, DO
+ * restart with empty D1 row) — the ingestor subscribes with `cursor: 0`. */
+export interface LabelCursorStore {
+	get(): Promise<number | undefined>;
+	put(cursor: number): Promise<void>;
+}
+
+/** Narrow slice of `LabelerResolver` the ingestor needs. */
+export interface LabelResolver {
+	resolve(did: string): Promise<ResolvedLabelerIdentity>;
+	/** Bypasses the cache for the single per-connection retry after a
+	 * verification failure. */
+	resolveFresh(did: string): Promise<ResolvedLabelerIdentity>;
+}
+
+export interface LabelIngestorBackoffConfig {
+	/** Initial delay after the first disconnect (ms). Default 1s. */
+	initialDelayMs?: number;
+	/** Cap (ms). Default 60s. */
+	maxDelayMs?: number;
+	/** Multiplier per retry. Default 2. */
+	multiplier?: number;
+	/** ±jitter as a fraction of the delay. Default 0.2 (±20%). 0 disables. */
+	jitter?: number;
+}
+
+export interface LabelIngestorLogger {
+	info?(msg: string, ctx?: Record<string, unknown>): void;
+	warn?(msg: string, ctx?: Record<string, unknown>): void;
+	error?(msg: string, ctx?: Record<string, unknown>): void;
+}
+
+export interface LabelIngestorOptions {
+	/** The labeler DID this ingestor serves. Every label's `src` must equal
+	 * this exactly; a mismatch is treated as a verification failure. */
+	did: string;
+	client: LabelStreamClient;
+	queue: LabelJobQueue;
+	cursorStore: LabelCursorStore;
+	resolver: LabelResolver;
+	backoff?: LabelIngestorBackoffConfig;
+	logger?: LabelIngestorLogger;
+	/** Sleep impl, swap in tests to skip real backoff waits. */
+	sleep?: (ms: number) => Promise<void>;
+	/** Random source for jitter, swap in tests for determinism. */
+	random?: () => number;
+}
+
+const DEFAULT_BACKOFF: Required<LabelIngestorBackoffConfig> = {
+	initialDelayMs: 1_000,
+	maxDelayMs: 60_000,
+	multiplier: 2,
+	jitter: 0.2,
+};
+
+export class LabelIngestor {
+	private readonly did: string;
+	private readonly client: LabelStreamClient;
+	private readonly queue: LabelJobQueue;
+	private readonly cursorStore: LabelCursorStore;
+	private readonly resolver: LabelResolver;
+	private readonly backoff: Required<LabelIngestorBackoffConfig>;
+	private readonly logger: LabelIngestorLogger;
+	private readonly sleep: (ms: number) => Promise<void>;
+	private readonly random: () => number;
+
+	private stopped = false;
+	private currentSub: LabelStreamHandle | null = null;
+	private cursor = 0;
+	/** Set once a frame's labels are fully enqueued and its cursor persisted.
+	 * Read by the run loop to decide whether to reset the backoff counter. */
+	private madeProgress = false;
+
+	private _consecutiveFailures = 0;
+
+	constructor(opts: LabelIngestorOptions) {
+		this.did = opts.did;
+		this.client = opts.client;
+		this.queue = opts.queue;
+		this.cursorStore = opts.cursorStore;
+		this.resolver = opts.resolver;
+		this.backoff = { ...DEFAULT_BACKOFF, ...opts.backoff };
+		this.logger = opts.logger ?? {};
+		this.sleep = opts.sleep ?? defaultSleep;
+		this.random = opts.random ?? Math.random;
+	}
+
+	/** The frame `seq` most recently enqueued + persisted. `0` until the
+	 * first frame or if nothing was ever persisted. */
+	get currentCursor(): number {
+		return this.cursor;
+	}
+
+	/** Number of consecutive failed/empty connection attempts. `0` means the
+	 * most recent attempt produced at least one fully processed frame. */
+	get consecutiveFailures(): number {
+		return this._consecutiveFailures;
+	}
+
+	/**
+	 * Run the connect-consume-reconnect loop until `stop()` is called.
+	 *
+	 * Resolves when `stop()` is called and the current subscription drains.
+	 * Does NOT reject for transient failures — connection drops, decode
+	 * errors, verification failures, and queue.send rejections all increment
+	 * the backoff counter and retry. The DO observes liveness via
+	 * `currentCursor` and `consecutiveFailures`.
+	 */
+	async run(): Promise<void> {
+		// Loaded inside the retry loop: a transient D1 failure at DO cold start
+		// must count as a failed attempt and retry, not kill the loop for the
+		// lifetime of the DO instance.
+		let cursorLoaded = false;
+
+		while (!this.stopped) {
+			try {
+				if (!cursorLoaded) {
+					this.cursor = (await this.cursorStore.get()) ?? 0;
+					cursorLoaded = true;
+				}
+				await this.connectAndConsume();
+				if (this.madeProgress) this._consecutiveFailures = 0;
+				else this._consecutiveFailures += 1;
+			} catch (err) {
+				if (this.madeProgress) this._consecutiveFailures = 0;
+				else this._consecutiveFailures += 1;
+				this.logger.warn?.("label stream subscription failed", {
+					did: this.did,
+					error: err instanceof Error ? err.message : String(err),
+					consecutiveFailures: this._consecutiveFailures,
+				});
+			}
+			if (this.stopped) break;
+			await this.sleep(this.computeBackoff(this._consecutiveFailures));
+		}
+	}
+
+	stop(): void {
+		this.stopped = true;
+		this.currentSub?.close();
+	}
+
+	private async connectAndConsume(): Promise<void> {
+		this.madeProgress = false;
+
+		const identity = await this.resolver.resolve(this.did);
+		let publicKey = identity.publicKey;
+		// One resolver-refresh retry per connection, spent on the first label
+		// that fails verification. A second failure — either the retry itself,
+		// or any later label once the retry is spent — closes the connection.
+		let retryUsed = false;
+
+		const sub = this.client.subscribe({ endpoint: identity.endpoint, cursor: this.cursor });
+		this.currentSub = sub;
+		try {
+			for await (const event of sub) {
+				if (this.stopped) break;
+
+				const verified: SignedLabel[] = [];
+				let verificationClosed = false;
+
+				for (let frameIndex = 0; frameIndex < event.labels.length; frameIndex++) {
+					const raw = event.labels[frameIndex];
+					try {
+						verified.push(await this.verifyOne(raw, publicKey));
+						continue;
+					} catch (err) {
+						if (retryUsed) {
+							this.logger.error?.("label verification failed", {
+								did: this.did,
+								seq: event.seq,
+								frameIndex,
+								error: err instanceof Error ? err.message : String(err),
+							});
+							verificationClosed = true;
+							break;
+						}
+						retryUsed = true;
+						try {
+							const fresh = await this.resolver.resolveFresh(this.did);
+							publicKey = fresh.publicKey;
+							verified.push(await this.verifyOne(raw, publicKey));
+							continue;
+						} catch (retryErr) {
+							this.logger.error?.("label verification failed after key refresh", {
+								did: this.did,
+								seq: event.seq,
+								frameIndex,
+								error: retryErr instanceof Error ? retryErr.message : String(retryErr),
+							});
+							verificationClosed = true;
+							break;
+						}
+					}
+				}
+
+				if (verificationClosed) {
+					// Fail closed: nothing from this frame is enqueued, the
+					// cursor doesn't move, and the connection ends here (the
+					// `finally` below closes `sub`). The run loop's backoff
+					// counter picks this up as a failed attempt.
+					break;
+				}
+
+				for (let frameIndex = 0; frameIndex < verified.length; frameIndex++) {
+					await this.queue.send({
+						src: this.did,
+						sourceSequence: event.seq,
+						frameIndex,
+						label: toWire(verified[frameIndex]!),
+					});
+				}
+				// Persist only after every send in the frame has resolved.
+				this.cursor = event.seq;
+				await this.cursorStore.put(event.seq);
+				this.madeProgress = true;
+			}
+		} finally {
+			sub.close();
+			if (this.currentSub === sub) this.currentSub = null;
+		}
+	}
+
+	private async verifyOne(
+		raw: unknown,
+		publicKey: ResolvedLabelerIdentity["publicKey"],
+	): Promise<SignedLabel> {
+		const label = parseSignedLabel(raw);
+		if (label.src !== this.did) {
+			throw new TypeError(
+				`label.src '${label.src}' does not match configured labeler '${this.did}'`,
+			);
+		}
+		await verifyLabelWithPublicKey({ label, expectedSource: this.did, publicKey });
+		return label;
+	}
+
+	private computeBackoff(failures: number): number {
+		// Defensive: `failures` is always >= 1 when called from the run loop
+		// (the increment happens before computeBackoff), but a future caller
+		// passing 0 would give `initialDelayMs / multiplier`, which is below
+		// the floor. Clamp explicitly.
+		const exp = Math.min(
+			Math.max(
+				this.backoff.initialDelayMs,
+				this.backoff.initialDelayMs * this.backoff.multiplier ** (failures - 1),
+			),
+			this.backoff.maxDelayMs,
+		);
+		if (this.backoff.jitter <= 0) return exp;
+		const range = exp * this.backoff.jitter;
+		const offset = (this.random() * 2 - 1) * range;
+		return Math.max(0, Math.round(exp + offset));
+	}
+}
+
+function defaultSleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/aggregator/src/label-stream-client.ts
+++ b/apps/aggregator/src/label-stream-client.ts
@@ -1,0 +1,262 @@
+/**
+ * Signed-label subscription transport (`com.atproto.label.subscribeLabels`).
+ *
+ * Mirrors the `JetstreamClient`/`RealJetstreamClient` split in
+ * `jetstream-client.ts`: a narrow interface the ingestor depends on, plus a
+ * production implementation. Unlike Jetstream (wrapped from `@atcute/jetstream`),
+ * there's no library for this XRPC subscription — we hand-roll the WebSocket
+ * over a `fetch` upgrade and the two-CBOR-value frame format the labeler
+ * writes in `apps/labeler/src/subscribe-labels.ts` (`encodeEvent`).
+ *
+ * Frame shape: a CBOR-encoded header object concatenated with a CBOR-encoded
+ * payload object in one binary WebSocket message — `decodeFirst` twice, no
+ * length prefix. Two message kinds:
+ *   - `{ op: 1, t: "#labels" }` header, `{ seq, labels }` payload — one
+ *     labeler event. Structurally validated here; label contents stay
+ *     `unknown[]` because parsing/verification is the ingestor's job.
+ *   - `{ op: -1 }` header, `{ error, message }` payload — the labeler is
+ *     refusing the subscription (e.g. `FutureCursor`). Thrown as
+ *     `LabelStreamError`; the ingestor logs and backs off rather than
+ *     resetting its cursor.
+ *
+ * An unknown `t` under `op: 1` is ignored for forward compatibility. Anything
+ * else — bad CBOR, wrong shape, unrecognised `op` — throws, because a label
+ * stream we can't parse is a stream we must not silently skip past.
+ */
+
+import { decodeFirst } from "@atcute/cbor";
+
+import { isPlainObject } from "./utils.js";
+
+const MAX_LABELS_PER_FRAME = 200;
+
+export interface LabelStreamEvent {
+	seq: number;
+	labels: unknown[];
+}
+
+export interface LabelStreamSubscribeOptions {
+	endpoint: string;
+	/** Always sent explicitly — the labeler's default cursor is "now", which
+	 * would silently skip history. */
+	cursor: number;
+}
+
+export interface LabelStreamHandle extends AsyncIterable<LabelStreamEvent> {
+	close(): void;
+}
+
+export interface LabelStreamClient {
+	subscribe(opts: LabelStreamSubscribeOptions): LabelStreamHandle;
+}
+
+/** Carries the labeler's `{ error, message }` payload from an `op: -1` frame. */
+export class LabelStreamError extends Error {
+	override readonly name = "LabelStreamError";
+	constructor(
+		readonly error: string,
+		message: string,
+	) {
+		super(message);
+	}
+}
+
+/**
+ * Decodes and structurally validates one binary subscribeLabels message.
+ * Exported as the test seam for `label-stream-client.test.ts` — same role as
+ * `wrapAtcuteSubscription` in `jetstream-client.ts`: exercise the decode path
+ * directly instead of standing up a real socket.
+ *
+ * Returns `null` for a forward-compatible `op: 1` frame with an unrecognised
+ * `t` (ignore and keep reading). Throws `LabelStreamError` for `op: -1`.
+ * Throws a plain `TypeError` for anything malformed or structurally invalid.
+ */
+export function decodeLabelStreamFrame(bytes: Uint8Array): LabelStreamEvent | null {
+	let header: unknown;
+	let remainder: Uint8Array;
+	try {
+		[header, remainder] = decodeFirst(bytes);
+	} catch {
+		throw new TypeError("subscribeLabels frame header failed to decode as CBOR");
+	}
+	if (!isPlainObject(header) || typeof header["op"] !== "number") {
+		throw new TypeError("subscribeLabels frame header must be an object with a numeric op");
+	}
+
+	let payload: unknown;
+	try {
+		[payload] = decodeFirst(remainder);
+	} catch {
+		throw new TypeError("subscribeLabels frame payload failed to decode as CBOR");
+	}
+
+	const op = header["op"];
+	if (op === -1) {
+		if (
+			!isPlainObject(payload) ||
+			typeof payload["error"] !== "string" ||
+			typeof payload["message"] !== "string"
+		) {
+			throw new TypeError("subscribeLabels error frame must carry string error and message fields");
+		}
+		throw new LabelStreamError(payload["error"], payload["message"]);
+	}
+	if (op !== 1) {
+		throw new TypeError(`subscribeLabels frame has unsupported op: ${op}`);
+	}
+	if (header["t"] !== "#labels") return null;
+	return validateLabelsPayload(payload);
+}
+
+function validateLabelsPayload(payload: unknown): LabelStreamEvent {
+	if (!isPlainObject(payload)) {
+		throw new TypeError("#labels frame payload must be an object");
+	}
+	const seq = payload["seq"];
+	if (typeof seq !== "number" || !Number.isSafeInteger(seq) || seq <= 0) {
+		throw new TypeError("#labels frame seq must be a positive safe integer");
+	}
+	const labels = payload["labels"];
+	if (!Array.isArray(labels) || labels.length === 0) {
+		throw new TypeError("#labels frame labels must be a non-empty array");
+	}
+	if (labels.length > MAX_LABELS_PER_FRAME) {
+		throw new TypeError(
+			`#labels frame labels must contain at most ${MAX_LABELS_PER_FRAME} entries`,
+		);
+	}
+	return { seq, labels };
+}
+
+type QueueEntry = { kind: "value"; value: LabelStreamEvent } | { kind: "error"; error: unknown };
+
+interface PendingNext {
+	resolve(result: IteratorResult<LabelStreamEvent>): void;
+	reject(error: unknown): void;
+}
+
+/**
+ * Production client: opens the WebSocket via a `fetch` upgrade (workerd's
+ * outbound WebSocket idiom — there's no browser `new WebSocket()` here) and
+ * adapts the event-driven socket into a pull-based async iterator.
+ *
+ * Buffering scheme: decoded frames (or decode errors) land in a small FIFO
+ * queue as they arrive; a pending `next()` call is handed the head of the
+ * queue directly instead of buffering it, so a fast consumer never pays for
+ * the queue at all. `close()` unblocks a pending `next()` immediately
+ * (`done: true`) rather than waiting on the socket's own close event, which
+ * may never come if the remote end is unresponsive.
+ */
+export class RealLabelStreamClient implements LabelStreamClient {
+	subscribe(opts: LabelStreamSubscribeOptions): LabelStreamHandle {
+		return createHandle(opts);
+	}
+}
+
+function createHandle(opts: LabelStreamSubscribeOptions): LabelStreamHandle {
+	const queue: QueueEntry[] = [];
+	let pending: PendingNext | null = null;
+	let ended = false;
+	let socket: WebSocket | null = null;
+
+	const deliver = (entry: QueueEntry): void => {
+		if (ended) return;
+		if (pending) {
+			const waiter = pending;
+			pending = null;
+			if (entry.kind === "error") waiter.reject(entry.error);
+			else waiter.resolve({ value: entry.value, done: false });
+			return;
+		}
+		queue.push(entry);
+	};
+
+	const finish = (): void => {
+		if (ended) return;
+		ended = true;
+		if (pending) {
+			const waiter = pending;
+			pending = null;
+			waiter.resolve({ value: undefined, done: true });
+		}
+	};
+
+	const handleMessage = (data: ArrayBuffer): void => {
+		let decoded: LabelStreamEvent | null;
+		try {
+			decoded = decodeLabelStreamFrame(new Uint8Array(data));
+		} catch (err) {
+			deliver({ kind: "error", error: err });
+			// Fail closed: don't keep reading a stream we can't parse.
+			socket?.close();
+			return;
+		}
+		if (decoded !== null) deliver({ kind: "value", value: decoded });
+	};
+
+	void (async () => {
+		try {
+			const url = `${opts.endpoint}/xrpc/com.atproto.label.subscribeLabels?cursor=${opts.cursor}`;
+			const response = await fetch(url, { headers: { upgrade: "websocket" } });
+			if (response.status !== 101 || !response.webSocket) {
+				throw new Error(`subscribeLabels upgrade failed with status ${response.status}`);
+			}
+			socket = response.webSocket;
+			socket.accept();
+			if (ended) {
+				// close() won the race against the upgrade: without this the
+				// accepted socket would stay open with nobody reading it.
+				socket.close();
+				return;
+			}
+			socket.addEventListener("message", (event: MessageEvent) => {
+				if (!(event.data instanceof ArrayBuffer)) {
+					deliver({
+						kind: "error",
+						error: new TypeError("subscribeLabels message was not binary"),
+					});
+					socket?.close();
+					return;
+				}
+				handleMessage(event.data);
+			});
+			// Code 1013 is the labeler's backpressure signal (see
+			// `apps/labeler/src/subscribe-labels.ts`'s `send`): the subscriber
+			// must reconnect with a cursor. Every other close code also just
+			// ends the iterator — the run loop's reconnect-with-backoff handles
+			// both cases identically.
+			socket.addEventListener("close", () => {
+				finish();
+			});
+		} catch (err) {
+			deliver({ kind: "error", error: err });
+			finish();
+		}
+	})();
+
+	return {
+		close(): void {
+			socket?.close();
+			finish();
+		},
+		[Symbol.asyncIterator](): AsyncIterator<LabelStreamEvent> {
+			return {
+				next(): Promise<IteratorResult<LabelStreamEvent>> {
+					const entry = queue.shift();
+					if (entry) {
+						if (entry.kind === "error") return Promise.reject(entry.error);
+						return Promise.resolve({ value: entry.value, done: false });
+					}
+					if (ended) return Promise.resolve({ value: undefined, done: true });
+					return new Promise((resolve, reject) => {
+						pending = { resolve, reject };
+					});
+				},
+				return(): Promise<IteratorResult<LabelStreamEvent>> {
+					finish();
+					return Promise.resolve({ value: undefined, done: true });
+				},
+			};
+		},
+	};
+}

--- a/apps/aggregator/src/label-stream-client.ts
+++ b/apps/aggregator/src/label-stream-client.ts
@@ -218,13 +218,8 @@ function createHandle(opts: LabelStreamSubscribeOptions): LabelStreamHandle {
 				throw new Error(`subscribeLabels upgrade failed with status ${response.status}`);
 			}
 			socket = response.webSocket;
-			socket.accept();
-			if (ended) {
-				// close() won the race against the upgrade: without this the
-				// accepted socket would stay open with nobody reading it.
-				socket.close();
-				return;
-			}
+			// Listeners attach before accept() so a frame or close arriving
+			// immediately after the upgrade can't slip past unhandled.
 			socket.addEventListener("message", (event: MessageEvent) => {
 				if (!(event.data instanceof ArrayBuffer)) {
 					deliver({
@@ -244,6 +239,13 @@ function createHandle(opts: LabelStreamSubscribeOptions): LabelStreamHandle {
 			socket.addEventListener("close", () => {
 				finish();
 			});
+			socket.accept();
+			if (ended) {
+				// close() won the race against the upgrade: without this the
+				// accepted socket would stay open with nobody reading it.
+				socket.close();
+				return;
+			}
 		} catch (err) {
 			deliver({ kind: "error", error: err });
 			finish();

--- a/apps/aggregator/src/label-stream-client.ts
+++ b/apps/aggregator/src/label-stream-client.ts
@@ -29,6 +29,11 @@ import { decodeFirst } from "@atcute/cbor";
 import { isPlainObject } from "./utils.js";
 
 const MAX_LABELS_PER_FRAME = 200;
+/** Cap on decoded frames buffered ahead of the consumer. The labeler bounds
+ * its own outbound buffer, but that says nothing about our inbound side: a
+ * fast replay against a consumer stalled on verification or queue sends
+ * would otherwise grow the buffer without limit. */
+const MAX_BUFFERED_FRAMES = 256;
 
 export interface LabelStreamEvent {
 	seq: number;
@@ -169,6 +174,17 @@ function createHandle(opts: LabelStreamSubscribeOptions): LabelStreamHandle {
 			return;
 		}
 		queue.push(entry);
+		if (queue.length > MAX_BUFFERED_FRAMES) {
+			// Fail closed like every other unrecoverable stream condition. The
+			// dropped frames were never cursor-persisted, so the reconnect
+			// replays them from the labeler's retained history.
+			queue.length = 0;
+			queue.push({
+				kind: "error",
+				error: new Error("subscribeLabels inbound buffer overflow: consumer too slow"),
+			});
+			socket?.close();
+		}
 	};
 
 	const finish = (): void => {

--- a/apps/aggregator/src/labels-consumer.ts
+++ b/apps/aggregator/src/labels-consumer.ts
@@ -1,0 +1,373 @@
+/**
+ * Labels queue consumer. Writes append-only history (`labels`) plus a
+ * current-state projection (`label_state`) for every verified signed label
+ * enqueued by `LabelIngestor` (`label-ingestor.ts`).
+ *
+ * For each `LabelIngestJob`:
+ *
+ *   1. `fromWire` + `parseSignedLabel` revalidate the payload (defense in
+ *      depth — the queue payload is internal, but the parse is cheap).
+ *   2. Compute the SHA-256 digest of `encodeSignedLabel(label)`. This is the
+ *      `labels` primary key, so exact redelivery (same signed bytes) is a
+ *      silent no-op via `ON CONFLICT(digest) DO NOTHING`.
+ *   3. Look up `labelers.trusted` for `job.src` (cached per batch) and snapshot
+ *      it onto the written rows as receipt-time provenance.
+ *   4. One `db.batch()` writes the history row and conditionally upserts
+ *      `label_state`, keyed by `(src, uri, val)`, keeping only the winner by
+ *      `(cts_epoch_ms, source_sequence, frame_index)`.
+ *
+ * Error policy:
+ *   - Structurally invalid wire payload: `dead_letters` row (`LABEL_INVALID`),
+ *     ack. Never retry — the bytes won't parse differently next time.
+ *   - `src` absent from `labelers`: `dead_letters` row
+ *     (`LABEL_UNKNOWN_SOURCE`), ack. The ingestor only subscribes to
+ *     configured labelers, so this indicates the row was removed between
+ *     subscribe and delivery.
+ *   - A different signed label landing at coordinates
+ *     `(src, source_sequence, frame_index)` already occupied by another
+ *     label: `dead_letters` row (`LABEL_COORDINATE_CONFLICT`), ack. This is a
+ *     permanent conflict — the labeler is replaying its stream inconsistently.
+ *   - Any other D1 failure: `retry()`.
+ */
+
+import {
+	encodeSignedLabel,
+	parseSignedLabel,
+	type SignedLabel,
+} from "@emdash-cms/registry-moderation";
+
+import { fromWire, type LabelIngestJob } from "./label-ingest-types.js";
+
+/** Deps the consumer needs at runtime. Tests inject their own `db` (and
+ * optionally `now`) to run against a real D1 instance without a live queue. */
+export interface ConsumerDeps {
+	db: D1Database;
+	now?: () => Date;
+}
+
+/** Subset of `cloudflare:workers` `Message` we use; defining inline so tests
+ * don't need to import workerd types. */
+export interface MessageController {
+	ack(): void;
+	retry(): void;
+}
+
+/** Subset of a `MessageBatch`. Workers' real batch object satisfies this. */
+export interface MessageBatchLike<T> {
+	readonly messages: ReadonlyArray<MessageController & { body: T }>;
+}
+
+/** Reason codes written to `dead_letters.reason` for labels jobs. */
+export type LabelDeadLetterReason =
+	| "LABEL_INVALID"
+	| "LABEL_UNKNOWN_SOURCE"
+	| "LABEL_COORDINATE_CONFLICT"
+	| "LABEL_UNEXPECTED_ERROR";
+
+/** `dead_letters.collection` value for labels jobs — the table is shared with
+ * the records consumer, which stores an actual NSID there; labels jobs have
+ * no NSID, so this is a fixed tag identifying the ingest pipeline. */
+const LABEL_DEAD_LETTER_COLLECTION = "com.atproto.label.subscribeLabels";
+
+export async function processLabelsBatch(
+	batch: MessageBatchLike<LabelIngestJob>,
+	env: Env,
+	depsOverride?: ConsumerDeps,
+): Promise<void> {
+	const deps = depsOverride ?? { db: env.DB };
+	// Cached across the whole batch: labelers rarely change mid-batch, and a
+	// lookup per message would otherwise cost one D1 round trip per label.
+	const trustedCache = new Map<string, boolean | null>();
+	// Process jobs independently — see records-consumer.ts's processBatch for
+	// why the try/catch has to wrap each message rather than the loop.
+	for (const message of batch.messages) {
+		try {
+			await processLabelMessage(message.body, message, deps, trustedCache);
+		} catch (err) {
+			console.error("[aggregator] processLabelMessage threw unexpectedly", {
+				src: message.body.src,
+				sourceSequence: message.body.sourceSequence,
+				frameIndex: message.body.frameIndex,
+				error: err instanceof Error ? err.message : String(err),
+			});
+			message.retry();
+		}
+	}
+}
+
+/**
+ * Drain the labels DLQ. Same "log + ack" policy as `drainDeadLetterBatch` in
+ * records-consumer.ts: record the job to Workers logs and `dead_letters`, ack
+ * so the DLQ doesn't grow unbounded.
+ */
+export async function drainLabelsDeadLetterBatch(
+	batch: MessageBatchLike<LabelIngestJob>,
+	env: Env,
+): Promise<void> {
+	const now = new Date();
+	for (const message of batch.messages) {
+		const job = message.body;
+		console.warn("[aggregator] labels DLQ drain: acking job", {
+			src: job.src,
+			sourceSequence: job.sourceSequence,
+			frameIndex: job.frameIndex,
+		});
+		try {
+			await writeDeadLetter(env.DB, job, "LABEL_UNEXPECTED_ERROR", "drained from DLQ", now);
+			message.ack();
+		} catch (err) {
+			console.error("[aggregator] labels DLQ drain: failed to write forensics row, retrying", {
+				src: job.src,
+				error: err instanceof Error ? err.message : String(err),
+			});
+			message.retry();
+		}
+	}
+}
+
+async function processLabelMessage(
+	job: LabelIngestJob,
+	controller: MessageController,
+	deps: ConsumerDeps,
+	trustedCache: Map<string, boolean | null>,
+): Promise<void> {
+	const now = deps.now ?? (() => new Date());
+
+	let label: SignedLabel;
+	try {
+		label = parseSignedLabel(fromWire(job.label));
+	} catch (err) {
+		await writeDeadLetter(
+			deps.db,
+			job,
+			"LABEL_INVALID",
+			err instanceof Error ? err.message : String(err),
+			now(),
+		);
+		controller.ack();
+		return;
+	}
+
+	if (label.src !== job.src) {
+		// The ingestor enqueues job.src = verified label.src, so a mismatch means
+		// the job did not come from our producer. The digest and the (src, ...)
+		// row keys would disagree about which labeler signed these bytes.
+		await writeDeadLetter(
+			deps.db,
+			job,
+			"LABEL_INVALID",
+			`label src '${label.src}' does not match job src '${job.src}'`,
+			now(),
+		);
+		controller.ack();
+		return;
+	}
+
+	const trusted = await lookupTrusted(deps.db, job.src, trustedCache);
+	if (trusted === null) {
+		await writeDeadLetter(
+			deps.db,
+			job,
+			"LABEL_UNKNOWN_SOURCE",
+			`no labelers row for src '${job.src}'`,
+			now(),
+		);
+		controller.ack();
+		return;
+	}
+
+	const digest = await digestSignedLabel(label);
+	const ctsEpochMs = Date.parse(label.cts);
+	const expEpochMs = label.exp === undefined ? null : Date.parse(label.exp);
+
+	try {
+		await deps.db.batch([
+			insertLabelStmt(deps.db, job, label, digest, ctsEpochMs, expEpochMs, trusted, now()),
+			upsertLabelStateStmt(deps.db, job, label, digest, ctsEpochMs, expEpochMs, trusted),
+		]);
+	} catch (err) {
+		if (isCoordinateConflict(err)) {
+			await writeDeadLetter(
+				deps.db,
+				job,
+				"LABEL_COORDINATE_CONFLICT",
+				`a different label already occupies (src=${job.src}, source_sequence=${job.sourceSequence}, frame_index=${job.frameIndex})`,
+				now(),
+			);
+			controller.ack();
+			return;
+		}
+		console.error("[aggregator] labels batch write failed", {
+			src: job.src,
+			sourceSequence: job.sourceSequence,
+			frameIndex: job.frameIndex,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		controller.retry();
+		return;
+	}
+
+	controller.ack();
+}
+
+async function lookupTrusted(
+	db: D1Database,
+	src: string,
+	cache: Map<string, boolean | null>,
+): Promise<boolean | null> {
+	const cached = cache.get(src);
+	if (cached !== undefined) return cached;
+	const row = await db
+		.prepare(`SELECT trusted FROM labelers WHERE did = ?`)
+		.bind(src)
+		.first<{ trusted: number }>();
+	const trusted = row ? row.trusted === 1 : null;
+	cache.set(src, trusted);
+	return trusted;
+}
+
+async function digestSignedLabel(label: SignedLabel): Promise<string> {
+	const bytes = encodeSignedLabel(label);
+	const hash = await crypto.subtle.digest("SHA-256", bytes);
+	return toHex(new Uint8Array(hash));
+}
+
+const HEX_ALPHABET = "0123456789abcdef";
+function toHex(bytes: Uint8Array): string {
+	let out = "";
+	for (const byte of bytes) {
+		out += HEX_ALPHABET[byte >> 4];
+		out += HEX_ALPHABET[byte & 0x0f];
+	}
+	return out;
+}
+
+function insertLabelStmt(
+	db: D1Database,
+	job: LabelIngestJob,
+	label: SignedLabel,
+	digest: string,
+	ctsEpochMs: number,
+	expEpochMs: number | null,
+	trusted: boolean,
+	receivedAt: Date,
+): D1PreparedStatement {
+	return db
+		.prepare(
+			`INSERT INTO labels
+			   (digest, src, uri, cid, val, neg, cts, cts_epoch_ms, exp, exp_epoch_ms,
+			    sig, ver, source_sequence, frame_index, trusted, received_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(digest) DO NOTHING`,
+		)
+		.bind(
+			digest,
+			job.src,
+			label.uri,
+			label.cid ?? null,
+			label.val,
+			label.neg === true ? 1 : 0,
+			label.cts,
+			ctsEpochMs,
+			label.exp ?? null,
+			expEpochMs,
+			label.sig,
+			label.ver,
+			job.sourceSequence,
+			job.frameIndex,
+			trusted ? 1 : 0,
+			receivedAt.toISOString(),
+		);
+}
+
+function upsertLabelStateStmt(
+	db: D1Database,
+	job: LabelIngestJob,
+	label: SignedLabel,
+	digest: string,
+	ctsEpochMs: number,
+	expEpochMs: number | null,
+	trusted: boolean,
+): D1PreparedStatement {
+	return db
+		.prepare(
+			`INSERT INTO label_state
+			   (src, uri, val, cid, neg, cts, cts_epoch_ms, exp, exp_epoch_ms,
+			    digest, source_sequence, frame_index, trusted)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(src, uri, val) DO UPDATE SET
+			   cid = excluded.cid,
+			   neg = excluded.neg,
+			   cts = excluded.cts,
+			   cts_epoch_ms = excluded.cts_epoch_ms,
+			   exp = excluded.exp,
+			   exp_epoch_ms = excluded.exp_epoch_ms,
+			   digest = excluded.digest,
+			   source_sequence = excluded.source_sequence,
+			   frame_index = excluded.frame_index,
+			   trusted = excluded.trusted
+			 WHERE excluded.cts_epoch_ms > label_state.cts_epoch_ms
+			    OR (excluded.cts_epoch_ms = label_state.cts_epoch_ms
+			        AND (excluded.source_sequence > label_state.source_sequence
+			             OR (excluded.source_sequence = label_state.source_sequence
+			                 AND excluded.frame_index > label_state.frame_index)))`,
+		)
+		.bind(
+			job.src,
+			label.uri,
+			label.val,
+			label.cid ?? null,
+			label.neg === true ? 1 : 0,
+			label.cts,
+			ctsEpochMs,
+			label.exp ?? null,
+			expEpochMs,
+			digest,
+			job.sourceSequence,
+			job.frameIndex,
+			trusted ? 1 : 0,
+		);
+}
+
+/**
+ * Distinguishes the `UNIQUE (src, source_sequence, frame_index)` conflict
+ * from any other D1 failure. The `labels` INSERT already resolves a digest
+ * (primary key) conflict via `ON CONFLICT(digest) DO NOTHING`, so the only
+ * constraint violation that can still reach here is the coordinate index —
+ * D1 doesn't surface a structured error code, so the column names in
+ * SQLite's message text are the only reliable signal.
+ */
+function isCoordinateConflict(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	return (
+		err.message.includes("UNIQUE constraint failed") &&
+		err.message.includes("labels.source_sequence") &&
+		err.message.includes("labels.frame_index")
+	);
+}
+
+async function writeDeadLetter(
+	db: D1Database,
+	job: LabelIngestJob,
+	reason: LabelDeadLetterReason,
+	detail: string | null,
+	now: Date,
+): Promise<void> {
+	const payloadBytes = new TextEncoder().encode(JSON.stringify(job.label));
+	await db
+		.prepare(
+			`INSERT INTO dead_letters
+			   (did, collection, rkey, reason, detail, payload, received_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			job.src,
+			LABEL_DEAD_LETTER_COLLECTION,
+			`${job.sourceSequence}:${job.frameIndex}`,
+			reason,
+			detail,
+			payloadBytes,
+			now.toISOString(),
+		)
+		.run();
+}

--- a/apps/aggregator/src/labels-consumer.ts
+++ b/apps/aggregator/src/labels-consumer.ts
@@ -179,6 +179,20 @@ async function processLabelMessage(
 	const digest = await digestSignedLabel(label);
 	const ctsEpochMs = Date.parse(label.cts);
 	const expEpochMs = label.exp === undefined ? null : Date.parse(label.exp);
+	if (Number.isNaN(ctsEpochMs) || (expEpochMs !== null && Number.isNaN(expEpochMs))) {
+		// parseSignedLabel validates both datetimes, so this shouldn't fire —
+		// but a NaN committed into the epoch columns would silently invert
+		// every projection and enforcement comparison. Fail closed instead.
+		await writeDeadLetter(
+			deps.db,
+			job,
+			"LABEL_INVALID",
+			`cts/exp did not parse to an instant (cts=${label.cts}, exp=${label.exp ?? "absent"})`,
+			now(),
+		);
+		controller.ack();
+		return;
+	}
 
 	try {
 		await deps.db.batch([

--- a/apps/aggregator/src/routes/xrpc/searchPackages.ts
+++ b/apps/aggregator/src/routes/xrpc/searchPackages.ts
@@ -154,10 +154,10 @@ const ENFORCEMENT_FILTER_SQL = `
 	AND NOT EXISTS (
 		SELECT 1 FROM label_state ls
 		WHERE ls.uri = 'at://' || p.did || '/${NSID.packageProfile}/' || p.slug
-		  AND ls.val IN ('!takedown', 'security:yanked')
+		  AND ls.val IN ('!takedown', 'security-yanked')
 		  AND ls.trusted = 1
 		  AND ls.neg = 0
-		  AND (ls.exp IS NULL OR ls.exp > strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+		  AND (ls.exp_epoch_ms IS NULL OR ls.exp_epoch_ms > CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 	)
 `;
 

--- a/apps/aggregator/test/label-ingestor.test.ts
+++ b/apps/aggregator/test/label-ingestor.test.ts
@@ -1,0 +1,706 @@
+/**
+ * LabelIngestor unit tests.
+ *
+ * Drives the ingestor against a fake `LabelStreamClient`, an in-memory queue,
+ * a `Map`-backed cursor store, and a fake resolver — no DO/D1/Queue runtime
+ * needed, mirroring `jetstream-ingestor.test.ts`'s injection style.
+ *
+ * The happy-path and verification-retry tests sign labels with a real P-256
+ * keypair via `createLabelSigner` (`@emdash-cms/registry-moderation`), so
+ * `verifyLabelWithPublicKey` runs for real rather than through a stub —
+ * exactly the pipeline the labeler and the ingestor both use in production.
+ */
+
+import { P256PrivateKeyExportable } from "@atcute/crypto";
+import { toBase64Url } from "@atcute/multibase";
+import {
+	createLabelSigner,
+	type LabelSigner,
+	type UnsignedLabel,
+} from "@emdash-cms/registry-moderation";
+import { describe, expect, it } from "vitest";
+
+import { toWire, type LabelIngestJob } from "../src/label-ingest-types.js";
+import {
+	LabelIngestor,
+	type LabelCursorStore,
+	type LabelIngestorLogger,
+	type LabelJobQueue,
+	type LabelResolver,
+} from "../src/label-ingestor.js";
+import type {
+	LabelStreamClient,
+	LabelStreamEvent,
+	LabelStreamSubscribeOptions,
+} from "../src/label-stream-client.js";
+import type { ResolvedLabelerIdentity } from "../src/labeler-resolver.js";
+
+const LABELER_DID = "did:web:labeler.example";
+const ENDPOINT = "https://labeler.example";
+
+interface TestKey {
+	signer: LabelSigner;
+	identity: ResolvedLabelerIdentity;
+}
+
+/** Generates a real P-256 keypair, wraps it in a `createLabelSigner` whose
+ * `resolveDid` is a closure returning a self-consistent DID document (no
+ * network, no fixtures) and an `ResolvedLabelerIdentity` pointing at the same
+ * key — everything the ingestor and `verifyLabelWithPublicKey` need. */
+async function makeKey(issuerDid: string = LABELER_DID): Promise<TestKey> {
+	const keypair = await P256PrivateKeyExportable.createKeypair();
+	const privateKey = toBase64Url(await keypair.exportPrivateKey("raw"));
+	const multikey = await keypair.exportPublicKey("multikey");
+	const document = {
+		id: issuerDid,
+		verificationMethod: [
+			{
+				id: "#atproto_label",
+				type: "Multikey",
+				controller: issuerDid,
+				publicKeyMultibase: multikey,
+			},
+		],
+	};
+	const signer = await createLabelSigner({
+		issuerDid,
+		privateKey,
+		resolveDid: async () => document,
+	});
+	return {
+		signer,
+		identity: {
+			endpoint: ENDPOINT,
+			publicKey: keypair,
+			signingKeyId: `${issuerDid}#atproto_label`,
+		},
+	};
+}
+
+function labelInput(uri: string): Omit<UnsignedLabel, "src"> {
+	return { ver: 1, uri, val: "test-value", cts: "2026-07-10T12:00:00.000Z" };
+}
+
+class FakeHandle {
+	closed = false;
+	private queue: LabelStreamEvent[] = [];
+	private pending: ((result: IteratorResult<LabelStreamEvent>) => void) | null = null;
+	private ended = false;
+
+	push(event: LabelStreamEvent): void {
+		if (this.pending) {
+			const resolve = this.pending;
+			this.pending = null;
+			resolve({ value: event, done: false });
+			return;
+		}
+		this.queue.push(event);
+	}
+
+	endNormally(): void {
+		if (this.ended) return;
+		this.ended = true;
+		if (this.pending) {
+			const resolve = this.pending;
+			this.pending = null;
+			resolve({ value: undefined, done: true });
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		this.endNormally();
+	}
+
+	[Symbol.asyncIterator](): AsyncIterator<LabelStreamEvent> {
+		return {
+			next: (): Promise<IteratorResult<LabelStreamEvent>> => {
+				const item = this.queue.shift();
+				if (item) return Promise.resolve({ value: item, done: false });
+				if (this.ended) return Promise.resolve({ value: undefined, done: true });
+				return new Promise((resolve) => {
+					this.pending = resolve;
+				});
+			},
+		};
+	}
+}
+
+/** Fake transport. `emit`/`disconnect` act on the most recently subscribed
+ * handle, mirroring `MockJetstream`'s driveable style. */
+class FakeLabelStreamClient implements LabelStreamClient {
+	readonly subscribeCalls: LabelStreamSubscribeOptions[] = [];
+	private readonly handles: FakeHandle[] = [];
+
+	subscribe(opts: LabelStreamSubscribeOptions): FakeHandle {
+		this.subscribeCalls.push(opts);
+		const handle = new FakeHandle();
+		this.handles.push(handle);
+		return handle;
+	}
+
+	private current(): FakeHandle {
+		const handle = this.handles.at(-1);
+		if (!handle) throw new Error("subscribe() has not been called yet");
+		return handle;
+	}
+
+	emit(event: LabelStreamEvent): void {
+		this.current().push(event);
+	}
+
+	/** Simulates a clean server-side disconnect uninvolved with verification
+	 * — the ingestor should reconnect with backoff. */
+	disconnect(): void {
+		this.current().endNormally();
+	}
+
+	get closedHandleCount(): number {
+		return this.handles.filter((h) => h.closed).length;
+	}
+}
+
+class FakeLabelResolver implements LabelResolver {
+	resolveCalls = 0;
+	resolveFreshCalls = 0;
+	current: ResolvedLabelerIdentity;
+	/** What `resolveFresh` returns. Defaults to `current`; tests override to
+	 * simulate a key rotation (or a still-wrong key, for the persistent-failure
+	 * path). */
+	fresh: ResolvedLabelerIdentity;
+
+	constructor(identity: ResolvedLabelerIdentity) {
+		this.current = identity;
+		this.fresh = identity;
+	}
+
+	resolve(): Promise<ResolvedLabelerIdentity> {
+		this.resolveCalls += 1;
+		return Promise.resolve(this.current);
+	}
+
+	resolveFresh(): Promise<ResolvedLabelerIdentity> {
+		this.resolveFreshCalls += 1;
+		return Promise.resolve(this.fresh);
+	}
+}
+
+class InMemoryQueue implements LabelJobQueue {
+	readonly jobs: LabelIngestJob[] = [];
+	send(job: LabelIngestJob): Promise<void> {
+		this.jobs.push(job);
+		return Promise.resolve();
+	}
+}
+
+class MapCursorStore implements LabelCursorStore {
+	private cursor: number | undefined;
+	readonly puts: number[] = [];
+	constructor(initial?: number) {
+		this.cursor = initial;
+	}
+	get(): Promise<number | undefined> {
+		return Promise.resolve(this.cursor);
+	}
+	put(cursor: number): Promise<void> {
+		this.cursor = cursor;
+		this.puts.push(cursor);
+		return Promise.resolve();
+	}
+}
+
+/** Records send-resolution and cursor-put order into one shared log so
+ * ordering assertions don't depend on wall-clock timing. */
+class DeferredQueue implements LabelJobQueue {
+	readonly jobs: LabelIngestJob[] = [];
+	private readonly resolvers: Array<() => void> = [];
+	constructor(private readonly log: string[]) {}
+
+	send(job: LabelIngestJob): Promise<void> {
+		this.jobs.push(job);
+		return new Promise<void>((resolve) => {
+			this.resolvers.push(() => {
+				this.log.push(`send-resolved:${job.frameIndex}`);
+				resolve();
+			});
+		});
+	}
+
+	resolveNext(): void {
+		const next = this.resolvers.shift();
+		if (!next) throw new Error("no pending send to resolve");
+		next();
+	}
+}
+
+class LoggingCursorStore implements LabelCursorStore {
+	private cursor: number | undefined;
+	constructor(private readonly log: string[]) {}
+	get(): Promise<number | undefined> {
+		return Promise.resolve(this.cursor);
+	}
+	put(cursor: number): Promise<void> {
+		this.log.push(`cursor-put:${cursor}`);
+		this.cursor = cursor;
+		return Promise.resolve();
+	}
+}
+
+const TIGHT_BACKOFF = { initialDelayMs: 1, maxDelayMs: 5, multiplier: 2, jitter: 0 };
+
+/** Wait until the predicate returns true or the test times out. Polls the
+ * microtask + macrotask queue rather than wall-clock. */
+async function waitFor(predicate: () => boolean, label: string, attempts = 200): Promise<void> {
+	for (let i = 0; i < attempts; i++) {
+		if (predicate()) return;
+		await Promise.resolve();
+		await new Promise<void>((r) => setTimeout(r, 0));
+	}
+	throw new Error(`waitFor timed out: ${label}`);
+}
+
+describe("LabelIngestor", () => {
+	it("verifies a real signed label and enqueues it, advancing the cursor", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const cursorStore = new MapCursorStore();
+		const resolver = new FakeLabelResolver(key.identity);
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore,
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		const signed = await key.signer.sign(labelInput("at://did:example:pub/x/1"));
+		client.emit({ seq: 1, labels: [signed] });
+
+		await waitFor(() => queue.jobs.length === 1, "label enqueued");
+		expect(queue.jobs[0]).toEqual({
+			src: LABELER_DID,
+			sourceSequence: 1,
+			frameIndex: 0,
+			label: toWire(signed),
+		});
+		expect(ingestor.currentCursor).toBe(1);
+		await waitFor(() => cursorStore.puts.includes(1), "cursor persisted");
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("enqueues every label in a multi-label frame with the correct frameIndex", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const resolver = new FakeLabelResolver(key.identity);
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore: new MapCursorStore(),
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		const a = await key.signer.sign(labelInput("at://did:example:pub/a/1"));
+		const b = await key.signer.sign(labelInput("at://did:example:pub/b/1"));
+		client.emit({ seq: 7, labels: [a, b] });
+
+		await waitFor(() => queue.jobs.length === 2, "both labels enqueued");
+		expect(queue.jobs[0]?.frameIndex).toBe(0);
+		expect(queue.jobs[1]?.frameIndex).toBe(1);
+		expect(queue.jobs[0]?.sourceSequence).toBe(7);
+		expect(queue.jobs[1]?.sourceSequence).toBe(7);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("subscribes with cursor 0 when no cursor is persisted", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue: new InMemoryQueue(),
+			cursorStore: new MapCursorStore(),
+			resolver: new FakeLabelResolver(key.identity),
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		await waitFor(() => client.subscribeCalls.length === 1, "subscribed");
+		expect(client.subscribeCalls[0]).toEqual({ endpoint: ENDPOINT, cursor: 0 });
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("subscribes with the persisted cursor when one exists", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue: new InMemoryQueue(),
+			cursorStore: new MapCursorStore(42),
+			resolver: new FakeLabelResolver(key.identity),
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		await waitFor(() => client.subscribeCalls.length === 1, "subscribed");
+		expect(client.subscribeCalls[0]).toEqual({ endpoint: ENDPOINT, cursor: 42 });
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("retries a failed initial cursor load instead of dying at cold start", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const store = new MapCursorStore(42);
+		let getCalls = 0;
+		const flakyStore: LabelCursorStore = {
+			get(): Promise<number | undefined> {
+				getCalls += 1;
+				if (getCalls === 1) return Promise.reject(new Error("transient D1 failure"));
+				return store.get();
+			},
+			put: (cursor) => store.put(cursor),
+		};
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue: new InMemoryQueue(),
+			cursorStore: flakyStore,
+			resolver: new FakeLabelResolver(key.identity),
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		await waitFor(() => client.subscribeCalls.length === 1, "subscribed after cursor retry");
+		expect(getCalls).toBe(2);
+		expect(client.subscribeCalls[0]).toEqual({ endpoint: ENDPOINT, cursor: 42 });
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("retries once via resolveFresh after a verification failure, then enqueues", async () => {
+		const staleKey = await makeKey();
+		const rotatedKey = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const cursorStore = new MapCursorStore();
+		const resolver = new FakeLabelResolver(staleKey.identity);
+		resolver.fresh = rotatedKey.identity;
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore,
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		// Signed with the rotated key, but the resolver's cache still points
+		// at the stale one — first verification attempt must fail.
+		const signed = await rotatedKey.signer.sign(labelInput("at://did:example:pub/x/1"));
+		client.emit({ seq: 5, labels: [signed] });
+
+		await waitFor(() => queue.jobs.length === 1, "label enqueued after retry");
+		expect(resolver.resolveFreshCalls).toBe(1);
+		expect(ingestor.currentCursor).toBe(5);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("closes the connection on a second verification failure, enqueueing nothing and leaving the cursor unchanged", async () => {
+		const configuredKey = await makeKey();
+		const unknownKey = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const cursorStore = new MapCursorStore();
+		const resolver = new FakeLabelResolver(configuredKey.identity);
+		// The refresh doesn't help — still the wrong key.
+		resolver.fresh = configuredKey.identity;
+		const logger: LabelIngestorLogger = { error: () => {}, warn: () => {} };
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore,
+			resolver,
+			logger,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		const signed = await unknownKey.signer.sign(labelInput("at://did:example:pub/x/1"));
+		client.emit({ seq: 9, labels: [signed] });
+
+		await waitFor(() => ingestor.consecutiveFailures >= 1, "failure counted");
+		expect(queue.jobs).toHaveLength(0);
+		expect(ingestor.currentCursor).toBe(0);
+		expect(resolver.resolveFreshCalls).toBe(1);
+		expect(client.closedHandleCount).toBeGreaterThanOrEqual(1);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("treats a src mismatch as a verification failure", async () => {
+		const configuredKey = await makeKey(LABELER_DID);
+		const otherIssuer = await makeKey("did:web:other.example");
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const resolver = new FakeLabelResolver(configuredKey.identity);
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore: new MapCursorStore(),
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		// Validly signed by its own issuer, but that issuer isn't the DID this
+		// ingestor is configured for.
+		const signed = await otherIssuer.signer.sign(labelInput("at://did:example:pub/x/1"));
+		client.emit({ seq: 3, labels: [signed] });
+
+		await waitFor(() => ingestor.consecutiveFailures >= 1, "failure counted");
+		expect(queue.jobs).toHaveLength(0);
+		expect(ingestor.currentCursor).toBe(0);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("fails closed on a malformed label (parseSignedLabel throws)", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const resolver = new FakeLabelResolver(key.identity);
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore: new MapCursorStore(),
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		await waitFor(() => client.subscribeCalls.length === 1, "subscribed");
+		client.emit({ seq: 4, labels: [{ not: "a valid label" }] });
+
+		await waitFor(() => ingestor.consecutiveFailures >= 1, "failure counted");
+		expect(queue.jobs).toHaveLength(0);
+		expect(ingestor.currentCursor).toBe(0);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("fails closed on a tampered signature", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const resolver = new FakeLabelResolver(key.identity);
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore: new MapCursorStore(),
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		const signed = await key.signer.sign(labelInput("at://did:example:pub/x/1"));
+		const tampered = { ...signed, sig: signed.sig.map((b, i) => (i === 0 ? b ^ 0xff : b)) };
+		client.emit({ seq: 6, labels: [tampered] });
+
+		await waitFor(() => ingestor.consecutiveFailures >= 1, "failure counted");
+		expect(queue.jobs).toHaveLength(0);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("persists the cursor only after every send in the frame resolves", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const log: string[] = [];
+		const queue = new DeferredQueue(log);
+		const cursorStore = new LoggingCursorStore(log);
+		const resolver = new FakeLabelResolver(key.identity);
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore,
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		const a = await key.signer.sign(labelInput("at://did:example:pub/a/1"));
+		const b = await key.signer.sign(labelInput("at://did:example:pub/b/1"));
+		client.emit({ seq: 3, labels: [a, b] });
+
+		await waitFor(() => queue.jobs.length === 1, "first send started");
+		expect(log).toEqual([]);
+
+		queue.resolveNext();
+		await waitFor(() => queue.jobs.length === 2, "second send started");
+		expect(log).toEqual(["send-resolved:0"]);
+
+		queue.resolveNext();
+		await waitFor(() => log.includes("cursor-put:3"), "cursor persisted");
+		expect(log).toEqual(["send-resolved:0", "send-resolved:1", "cursor-put:3"]);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("does not persist the cursor when a queue.send call rejects", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const cursorStore = new MapCursorStore();
+		const queue: LabelJobQueue = {
+			send: () => Promise.reject(new Error("queue unavailable")),
+		};
+		const resolver = new FakeLabelResolver(key.identity);
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore,
+			resolver,
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		const signed = await key.signer.sign(labelInput("at://did:example:pub/x/1"));
+		client.emit({ seq: 1, labels: [signed] });
+
+		await waitFor(() => ingestor.consecutiveFailures >= 1, "failure counted after send rejection");
+		expect(cursorStore.puts).toHaveLength(0);
+		expect(ingestor.currentCursor).toBe(0);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("resets backoff after a frame is fully processed, even across reconnects", async () => {
+		const key = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const resolver = new FakeLabelResolver(key.identity);
+		const sleeps: number[] = [];
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore: new MapCursorStore(),
+			resolver,
+			backoff: { initialDelayMs: 10, maxDelayMs: 1000, multiplier: 10, jitter: 0 },
+			sleep: (ms) => {
+				sleeps.push(ms);
+				return Promise.resolve();
+			},
+		});
+		const runPromise = ingestor.run();
+
+		const a = await key.signer.sign(labelInput("at://did:example:pub/a/1"));
+		client.emit({ seq: 1, labels: [a] });
+		await waitFor(() => queue.jobs.length === 1, "first job");
+		client.disconnect();
+		await waitFor(() => sleeps.length >= 1, "first backoff");
+		await waitFor(() => client.subscribeCalls.length === 2, "reconnected");
+
+		const b = await key.signer.sign(labelInput("at://did:example:pub/b/1"));
+		client.emit({ seq: 2, labels: [b] });
+		await waitFor(() => queue.jobs.length === 2, "second job", 500);
+		client.disconnect();
+		await waitFor(() => sleeps.length >= 2, "second backoff", 500);
+
+		// Both backoffs are the initial delay (10ms), not 100ms (10×10) —
+		// progress in between resets the counter each time.
+		expect(sleeps[0]).toBe(10);
+		expect(sleeps[1]).toBe(10);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("escalates backoff across repeated verification failures and resets once one succeeds", async () => {
+		const configuredKey = await makeKey();
+		const unknownKey = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		// The refresh never helps — every attempt is signed by a key the
+		// resolver never returns, so every connection attempt fails.
+		const resolver = new FakeLabelResolver(configuredKey.identity);
+		const sleeps: number[] = [];
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore: new MapCursorStore(),
+			resolver,
+			backoff: { initialDelayMs: 10, maxDelayMs: 80, multiplier: 2, jitter: 0 },
+			sleep: (ms) => {
+				sleeps.push(ms);
+				return Promise.resolve();
+			},
+		});
+		const runPromise = ingestor.run();
+
+		for (let i = 0; i < 2; i++) {
+			await waitFor(() => client.subscribeCalls.length === i + 1, `attempt ${i} connected`);
+			const signed = await unknownKey.signer.sign(labelInput(`at://did:example:pub/x/${i}`));
+			client.emit({ seq: i + 1, labels: [signed] });
+			await waitFor(() => sleeps.length === i + 1, `backoff ${i}`);
+		}
+		expect(sleeps[0]).toBe(10);
+		expect(sleeps[1]).toBe(20);
+
+		// Now let the same connection succeed with the correctly configured key.
+		await waitFor(() => client.subscribeCalls.length === 3, "third attempt connected");
+		const good = await configuredKey.signer.sign(labelInput("at://did:example:pub/good/1"));
+		client.emit({ seq: 100, labels: [good] });
+		await waitFor(() => queue.jobs.length === 1, "succeeded after escalation");
+		// consecutiveFailures resets only once connectAndConsume() returns, which
+		// requires the subscription to end — disconnect to observe the reset.
+		client.disconnect();
+		await waitFor(() => ingestor.consecutiveFailures === 0, "backoff reset after progress");
+
+		ingestor.stop();
+		await runPromise;
+	});
+});

--- a/apps/aggregator/test/label-ingestor.test.ts
+++ b/apps/aggregator/test/label-ingestor.test.ts
@@ -549,6 +549,41 @@ describe("LabelIngestor", () => {
 		await runPromise;
 	});
 
+	it("counts a failure when a connection ends on a verification failure after earlier progress", async () => {
+		const key = await makeKey();
+		const wrongKey = await makeKey();
+		const client = new FakeLabelStreamClient();
+		const queue = new InMemoryQueue();
+		const ingestor = new LabelIngestor({
+			did: LABELER_DID,
+			client,
+			queue,
+			cursorStore: new MapCursorStore(),
+			resolver: new FakeLabelResolver(key.identity),
+			backoff: TIGHT_BACKOFF,
+			sleep: () => Promise.resolve(),
+		});
+		const runPromise = ingestor.run();
+
+		const good = await key.signer.sign(labelInput("at://did:example:pub/x/1"));
+		client.emit({ seq: 1, labels: [good] });
+		await waitFor(() => queue.jobs.length === 1, "good frame enqueued");
+
+		// Same connection: a frame that cannot verify. The good frame must not
+		// count as progress that resets the backoff counter.
+		const bad = await wrongKey.signer.sign(labelInput("at://did:example:pub/x/2"));
+		client.emit({ seq: 2, labels: [bad] });
+		await waitFor(
+			() => ingestor.consecutiveFailures >= 1,
+			"failure counted despite earlier progress",
+		);
+		expect(queue.jobs).toHaveLength(1);
+		expect(ingestor.currentCursor).toBe(1);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
 	it("persists the cursor only after every send in the frame resolves", async () => {
 		const key = await makeKey();
 		const client = new FakeLabelStreamClient();

--- a/apps/aggregator/test/label-stream-client.test.ts
+++ b/apps/aggregator/test/label-stream-client.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `decodeLabelStreamFrame` unit tests.
+ *
+ * Frames are built the same way `apps/labeler/src/subscribe-labels.ts`'s
+ * `encodeEvent` builds them: two CBOR-encoded values (header, payload)
+ * concatenated with no length prefix. Testing the decode function directly
+ * (rather than driving a real WebSocket) mirrors `jetstream-client.ts`'s
+ * `wrapAtcuteSubscription` test seam — the transport plumbing around it is
+ * exercised by the ingestor/DO integration paths, not here.
+ */
+
+import { encode, toBytes } from "@atcute/cbor";
+import { describe, expect, it } from "vitest";
+
+import { decodeLabelStreamFrame, LabelStreamError } from "../src/label-stream-client.js";
+
+function frame(header: Record<string, unknown>, payload: Record<string, unknown>): Uint8Array {
+	const encodedHeader = encode(header);
+	const encodedPayload = encode(payload);
+	const bytes = new Uint8Array(encodedHeader.length + encodedPayload.length);
+	bytes.set(encodedHeader);
+	bytes.set(encodedPayload, encodedHeader.length);
+	return bytes;
+}
+
+function sampleLabel(uri: string): Record<string, unknown> {
+	return {
+		ver: 1,
+		src: "did:web:labeler.example",
+		uri,
+		val: "test-value",
+		cts: "2026-07-10T12:00:00.000Z",
+		sig: toBytes(new Uint8Array(64).fill(7)),
+	};
+}
+
+describe("decodeLabelStreamFrame", () => {
+	it("decodes a valid #labels frame", () => {
+		const bytes = frame(
+			{ op: 1, t: "#labels" },
+			{ seq: 1, labels: [sampleLabel("at://did:example:pub/x/1")] },
+		);
+		const event = decodeLabelStreamFrame(bytes);
+		expect(event).not.toBeNull();
+		expect(event?.seq).toBe(1);
+		expect(event?.labels).toHaveLength(1);
+	});
+
+	it("decodes a multi-label frame", () => {
+		const bytes = frame(
+			{ op: 1, t: "#labels" },
+			{
+				seq: 42,
+				labels: [sampleLabel("at://did:example:pub/a/1"), sampleLabel("at://did:example:pub/b/1")],
+			},
+		);
+		const event = decodeLabelStreamFrame(bytes);
+		expect(event?.seq).toBe(42);
+		expect(event?.labels).toHaveLength(2);
+	});
+
+	it("ignores an op:1 frame with an unrecognised t (forward compatibility)", () => {
+		const bytes = frame({ op: 1, t: "#futureEventKind" }, { anything: true });
+		expect(decodeLabelStreamFrame(bytes)).toBeNull();
+	});
+
+	it("throws LabelStreamError carrying error and message for an op:-1 frame", () => {
+		const bytes = frame(
+			{ op: -1 },
+			{ error: "FutureCursor", message: "cursor is ahead of the stream" },
+		);
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(LabelStreamError);
+		try {
+			decodeLabelStreamFrame(bytes);
+			expect.unreachable();
+		} catch (err) {
+			expect(err).toBeInstanceOf(LabelStreamError);
+			const streamErr = err as LabelStreamError;
+			expect(streamErr.error).toBe("FutureCursor");
+			expect(streamErr.message).toBe("cursor is ahead of the stream");
+		}
+	});
+
+	it("throws on an op:-1 frame missing error/message fields", () => {
+		const bytes = frame({ op: -1 }, { unrelated: true });
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(TypeError);
+	});
+
+	it("throws on an unsupported op", () => {
+		const bytes = frame({ op: 2 }, { seq: 1, labels: [sampleLabel("at://did:example:pub/x/1")] });
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(TypeError);
+	});
+
+	it("throws on malformed CBOR", () => {
+		const garbage = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff]);
+		expect(() => decodeLabelStreamFrame(garbage)).toThrow(TypeError);
+	});
+
+	it("throws when the header isn't a CBOR object", () => {
+		const encodedHeader = encode("not-an-object");
+		const encodedPayload = encode({ seq: 1, labels: [sampleLabel("at://did:example:pub/x/1")] });
+		const bytes = new Uint8Array(encodedHeader.length + encodedPayload.length);
+		bytes.set(encodedHeader);
+		bytes.set(encodedPayload, encodedHeader.length);
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(TypeError);
+	});
+
+	it("rejects a non-positive seq", () => {
+		const bytes = frame(
+			{ op: 1, t: "#labels" },
+			{ seq: 0, labels: [sampleLabel("at://did:example:pub/x/1")] },
+		);
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(TypeError);
+	});
+
+	it("rejects a non-integer seq", () => {
+		const bytes = frame(
+			{ op: 1, t: "#labels" },
+			{ seq: 1.5, labels: [sampleLabel("at://did:example:pub/x/1")] },
+		);
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(TypeError);
+	});
+
+	it("rejects an empty labels array", () => {
+		const bytes = frame({ op: 1, t: "#labels" }, { seq: 1, labels: [] });
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(TypeError);
+	});
+
+	it("rejects a labels array over the 200-entry cap", () => {
+		const labels = Array.from({ length: 201 }, (_, i) =>
+			sampleLabel(`at://did:example:pub/x/${i}`),
+		);
+		const bytes = frame({ op: 1, t: "#labels" }, { seq: 1, labels });
+		expect(() => decodeLabelStreamFrame(bytes)).toThrow(TypeError);
+	});
+
+	it("accepts exactly 200 labels", () => {
+		const labels = Array.from({ length: 200 }, (_, i) =>
+			sampleLabel(`at://did:example:pub/x/${i}`),
+		);
+		const bytes = frame({ op: 1, t: "#labels" }, { seq: 1, labels });
+		const event = decodeLabelStreamFrame(bytes);
+		expect(event?.labels).toHaveLength(200);
+	});
+});

--- a/apps/aggregator/test/labels-consumer.test.ts
+++ b/apps/aggregator/test/labels-consumer.test.ts
@@ -1,0 +1,598 @@
+/**
+ * Labels consumer tests.
+ *
+ * Runs against real D1 (workerd test pool) with real signed labels: a P-256
+ * keypair via `P256PrivateKeyExportable.createKeypair()` and
+ * `createLabelSigner` from `@emdash-cms/registry-moderation`, with a closure
+ * `resolveDid` returning a self-consistent DID document — the same helper
+ * shape as `label-ingestor.test.ts`. This exercises `parseSignedLabel` +
+ * `encodeSignedLabel` for real rather than through a stub, since digest
+ * identity (the whole point of this consumer) depends on canonical encoding.
+ */
+
+import { create as createCid, toString as cidToString, CODEC_RAW } from "@atcute/cid";
+import { P256PrivateKeyExportable } from "@atcute/crypto";
+import { toBase64Url } from "@atcute/multibase";
+import {
+	createLabelSigner,
+	encodeSignedLabel,
+	type LabelSigner,
+	type SignedLabel,
+	type UnsignedLabel,
+} from "@emdash-cms/registry-moderation";
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { toWire, type LabelIngestJob } from "../src/label-ingest-types.js";
+import {
+	type ConsumerDeps,
+	drainLabelsDeadLetterBatch,
+	type MessageController,
+	processLabelsBatch,
+} from "../src/labels-consumer.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+
+const LABELER_DID = "did:web:labeler.example";
+const UNTRUSTED_LABELER_DID = "did:web:untrusted-labeler.example";
+const UNKNOWN_LABELER_DID = "did:web:unknown-labeler.example";
+const SUBJECT_URI = "at://did:plc:subject00000000000000000/com.example.thing/x";
+const NOW = new Date("2026-07-11T12:00:00.000Z");
+
+let signer: LabelSigner;
+let untrustedSigner: LabelSigner;
+
+async function makeSigner(issuerDid: string): Promise<LabelSigner> {
+	const keypair = await P256PrivateKeyExportable.createKeypair();
+	const privateKey = toBase64Url(await keypair.exportPrivateKey("raw"));
+	const multikey = await keypair.exportPublicKey("multikey");
+	const document = {
+		id: issuerDid,
+		verificationMethod: [
+			{
+				id: "#atproto_label",
+				type: "Multikey",
+				controller: issuerDid,
+				publicKeyMultibase: multikey,
+			},
+		],
+	};
+	return createLabelSigner({ issuerDid, privateKey, resolveDid: async () => document });
+}
+
+async function makeCid(seed: string): Promise<string> {
+	const encoded = new TextEncoder().encode(seed);
+	const bytes = new Uint8Array(new ArrayBuffer(encoded.length));
+	bytes.set(encoded);
+	const cid = await createCid(CODEC_RAW, bytes);
+	return cidToString(cid);
+}
+
+async function digestOf(label: SignedLabel): Promise<string> {
+	const bytes = encodeSignedLabel(label);
+	const hash = await crypto.subtle.digest("SHA-256", bytes);
+	return Array.from(new Uint8Array(hash), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function labelInput(
+	overrides: Partial<Omit<UnsignedLabel, "src">> = {},
+): Omit<UnsignedLabel, "src"> {
+	return {
+		ver: 1,
+		uri: SUBJECT_URI,
+		val: "test-value",
+		cts: "2026-07-10T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+function jobFor(
+	src: string,
+	sourceSequence: number,
+	frameIndex: number,
+	label: SignedLabel,
+): LabelIngestJob {
+	return { src, sourceSequence, frameIndex, label: toWire(label) };
+}
+
+class FakeMessage implements MessageController {
+	acked = 0;
+	retried = 0;
+	constructor(readonly body: LabelIngestJob) {}
+	ack(): void {
+		this.acked += 1;
+	}
+	retry(): void {
+		this.retried += 1;
+	}
+}
+
+async function runBatch(jobs: LabelIngestJob[], deps?: ConsumerDeps): Promise<FakeMessage[]> {
+	const messages = jobs.map((job) => new FakeMessage(job));
+	await processLabelsBatch({ messages }, { DB: testEnv.DB } as unknown as Env, deps);
+	return messages;
+}
+
+async function seedLabeler(did: string, trusted: boolean): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO labelers (did, endpoint, signing_key, signing_key_id, trusted, added_at, last_resolved_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			did,
+			"https://labeler.example",
+			"unused-in-tests",
+			`${did}#atproto_label`,
+			trusted ? 1 : 0,
+			NOW.toISOString(),
+			NOW.toISOString(),
+		)
+		.run();
+}
+
+async function countRows(table: string): Promise<number> {
+	const row = await testEnv.DB.prepare(`SELECT COUNT(*) as n FROM ${table}`).first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+interface LabelRow {
+	digest: string;
+	src: string;
+	uri: string;
+	cid: string | null;
+	val: string;
+	neg: number;
+	cts: string;
+	cts_epoch_ms: number;
+	exp: string | null;
+	exp_epoch_ms: number | null;
+	sig: ArrayBuffer;
+	ver: number;
+	source_sequence: number;
+	frame_index: number;
+	trusted: number;
+	received_at: string;
+}
+
+interface LabelStateRow {
+	src: string;
+	uri: string;
+	val: string;
+	cid: string | null;
+	neg: number;
+	cts: string;
+	cts_epoch_ms: number;
+	exp: string | null;
+	exp_epoch_ms: number | null;
+	digest: string;
+	source_sequence: number;
+	frame_index: number;
+	trusted: number;
+}
+
+async function getLabelState(src: string, uri: string, val: string): Promise<LabelStateRow | null> {
+	return (
+		(await testEnv.DB.prepare(`SELECT * FROM label_state WHERE src = ? AND uri = ? AND val = ?`)
+			.bind(src, uri, val)
+			.first<LabelStateRow>()) ?? null
+	);
+}
+
+const DEPS: ConsumerDeps = { db: testEnv.DB, now: () => NOW };
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+	signer = await makeSigner(LABELER_DID);
+	untrustedSigner = await makeSigner(UNTRUSTED_LABELER_DID);
+});
+
+beforeEach(async () => {
+	for (const table of ["labels", "label_state", "dead_letters", "labelers"]) {
+		await testEnv.DB.prepare(`DELETE FROM ${table}`).run();
+	}
+	await seedLabeler(LABELER_DID, true);
+});
+
+describe("processLabelsBatch: happy path", () => {
+	it("writes one labels row and one label_state row for a single verified label", async () => {
+		const label = await signer.sign(labelInput());
+		const job = jobFor(LABELER_DID, 1, 0, label);
+
+		const [msg] = await runBatch([job], DEPS);
+		expect(msg?.acked).toBe(1);
+		expect(msg?.retried).toBe(0);
+
+		const digest = await digestOf(label);
+		const row = await testEnv.DB.prepare(`SELECT * FROM labels WHERE digest = ?`)
+			.bind(digest)
+			.first<LabelRow>();
+		expect(row).toMatchObject({
+			digest,
+			src: LABELER_DID,
+			uri: SUBJECT_URI,
+			cid: null,
+			val: "test-value",
+			neg: 0,
+			cts: "2026-07-10T12:00:00.000Z",
+			cts_epoch_ms: Date.parse("2026-07-10T12:00:00.000Z"),
+			exp: null,
+			exp_epoch_ms: null,
+			ver: 1,
+			source_sequence: 1,
+			frame_index: 0,
+			trusted: 1,
+			received_at: NOW.toISOString(),
+		});
+		expect(new Uint8Array(row!.sig)).toEqual(label.sig);
+
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state).toMatchObject({
+			digest,
+			neg: 0,
+			cts_epoch_ms: Date.parse("2026-07-10T12:00:00.000Z"),
+			source_sequence: 1,
+			frame_index: 0,
+			trusted: 1,
+		});
+	});
+});
+
+describe("processLabelsBatch: exact redelivery", () => {
+	it("is a silent no-op — acked both times, one history row, state unchanged", async () => {
+		const label = await signer.sign(labelInput());
+		const job = jobFor(LABELER_DID, 1, 0, label);
+
+		const [first] = await runBatch([job], DEPS);
+		expect(first?.acked).toBe(1);
+		const [second] = await runBatch([job], DEPS);
+		expect(second?.acked).toBe(1);
+		expect(second?.retried).toBe(0);
+
+		expect(await countRows("labels")).toBe(1);
+		expect(await countRows("dead_letters")).toBe(0);
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state).toMatchObject({ source_sequence: 1, frame_index: 0 });
+	});
+});
+
+describe("processLabelsBatch: same-cts survival", () => {
+	it("keeps both history rows when two different labels share (src, uri, val, cts)", async () => {
+		const cts = "2026-07-10T12:00:00.000Z";
+		const cidA = await makeCid("label-a");
+		const cidB = await makeCid("label-b");
+		const labelA = await signer.sign(labelInput({ cts, cid: cidA }));
+		const labelB = await signer.sign(labelInput({ cts, cid: cidB }));
+		const jobA = jobFor(LABELER_DID, 1, 0, labelA);
+		const jobB = jobFor(LABELER_DID, 2, 0, labelB);
+
+		const [msgA] = await runBatch([jobA], DEPS);
+		const [msgB] = await runBatch([jobB], DEPS);
+		expect(msgA?.acked).toBe(1);
+		expect(msgB?.acked).toBe(1);
+
+		expect(await countRows("labels")).toBe(2);
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state?.digest).toBe(await digestOf(labelB));
+		expect(state).toMatchObject({ source_sequence: 2, frame_index: 0, cid: cidB });
+	});
+});
+
+describe("processLabelsBatch: projection ordering", () => {
+	it("a newer cts replaces state", async () => {
+		const older = await signer.sign(labelInput({ cts: "2026-07-10T12:00:00.000Z" }));
+		const newer = await signer.sign(labelInput({ cts: "2026-07-10T13:00:00.000Z" }));
+		await runBatch([jobFor(LABELER_DID, 1, 0, older)], DEPS);
+		await runBatch([jobFor(LABELER_DID, 2, 0, newer)], DEPS);
+
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state?.digest).toBe(await digestOf(newer));
+	});
+
+	it("an older-cts job arriving after (out-of-order delivery) leaves state at the newer event", async () => {
+		const older = await signer.sign(labelInput({ cts: "2026-07-10T12:00:00.000Z" }));
+		const newer = await signer.sign(labelInput({ cts: "2026-07-10T13:00:00.000Z" }));
+		await runBatch([jobFor(LABELER_DID, 2, 0, newer)], DEPS);
+		await runBatch([jobFor(LABELER_DID, 1, 0, older)], DEPS);
+
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state?.digest).toBe(await digestOf(newer));
+		expect(await countRows("labels")).toBe(2);
+	});
+
+	it("equal cts with lower coordinates does not replace state", async () => {
+		const cts = "2026-07-10T12:00:00.000Z";
+		const cidA = await makeCid("equal-cts-a");
+		const cidB = await makeCid("equal-cts-b");
+		const winner = await signer.sign(labelInput({ cts, cid: cidA }));
+		const loser = await signer.sign(labelInput({ cts, cid: cidB }));
+		await runBatch([jobFor(LABELER_DID, 5, 2, winner)], DEPS);
+		await runBatch([jobFor(LABELER_DID, 5, 1, loser)], DEPS);
+
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state?.digest).toBe(await digestOf(winner));
+	});
+});
+
+describe("processLabelsBatch: negation", () => {
+	it("a later neg=1 event wins state; history keeps both", async () => {
+		const positive = await signer.sign(labelInput({ cts: "2026-07-10T12:00:00.000Z" }));
+		const negation = await signer.sign(labelInput({ cts: "2026-07-10T13:00:00.000Z", neg: true }));
+		await runBatch([jobFor(LABELER_DID, 1, 0, positive)], DEPS);
+		await runBatch([jobFor(LABELER_DID, 2, 0, negation)], DEPS);
+
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state).toMatchObject({ neg: 1, digest: await digestOf(negation) });
+		expect(await countRows("labels")).toBe(2);
+	});
+});
+
+describe("processLabelsBatch: expiry metadata", () => {
+	it("stores exp/exp_epoch_ms on both tables when present", async () => {
+		const label = await signer.sign(labelInput({ exp: "2027-01-01T00:00:00.000Z" }));
+		await runBatch([jobFor(LABELER_DID, 1, 0, label)], DEPS);
+
+		const digest = await digestOf(label);
+		const row = await testEnv.DB.prepare(`SELECT exp, exp_epoch_ms FROM labels WHERE digest = ?`)
+			.bind(digest)
+			.first<{ exp: string; exp_epoch_ms: number }>();
+		expect(row).toMatchObject({
+			exp: "2027-01-01T00:00:00.000Z",
+			exp_epoch_ms: Date.parse("2027-01-01T00:00:00.000Z"),
+		});
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state).toMatchObject({
+			exp: "2027-01-01T00:00:00.000Z",
+			exp_epoch_ms: Date.parse("2027-01-01T00:00:00.000Z"),
+		});
+	});
+
+	it("leaves exp/exp_epoch_ms NULL when absent", async () => {
+		const label = await signer.sign(labelInput());
+		await runBatch([jobFor(LABELER_DID, 1, 0, label)], DEPS);
+
+		const digest = await digestOf(label);
+		const row = await testEnv.DB.prepare(`SELECT exp, exp_epoch_ms FROM labels WHERE digest = ?`)
+			.bind(digest)
+			.first<{ exp: string | null; exp_epoch_ms: number | null }>();
+		expect(row).toMatchObject({ exp: null, exp_epoch_ms: null });
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "test-value");
+		expect(state).toMatchObject({ exp: null, exp_epoch_ms: null });
+	});
+});
+
+describe("processLabelsBatch: trusted snapshot", () => {
+	it("a job from an untrusted source writes trusted=0, unaffected by later flips", async () => {
+		await seedLabeler(UNTRUSTED_LABELER_DID, false);
+		const label = await untrustedSigner.sign(labelInput());
+		await runBatch([jobFor(UNTRUSTED_LABELER_DID, 1, 0, label)], DEPS);
+
+		const digest = await digestOf(label);
+		const before = await testEnv.DB.prepare(`SELECT trusted FROM labels WHERE digest = ?`)
+			.bind(digest)
+			.first<{ trusted: number }>();
+		expect(before?.trusted).toBe(0);
+		const stateBefore = await getLabelState(UNTRUSTED_LABELER_DID, SUBJECT_URI, "test-value");
+		expect(stateBefore?.trusted).toBe(0);
+
+		await testEnv.DB.prepare(`UPDATE labelers SET trusted = 1 WHERE did = ?`)
+			.bind(UNTRUSTED_LABELER_DID)
+			.run();
+
+		const after = await testEnv.DB.prepare(`SELECT trusted FROM labels WHERE digest = ?`)
+			.bind(digest)
+			.first<{ trusted: number }>();
+		expect(after?.trusted).toBe(0);
+		const stateAfter = await getLabelState(UNTRUSTED_LABELER_DID, SUBJECT_URI, "test-value");
+		expect(stateAfter?.trusted).toBe(0);
+	});
+});
+
+describe("processLabelsBatch: LABEL_UNKNOWN_SOURCE", () => {
+	it("dead-letters a job whose src has no labelers row, acks, writes nothing else", async () => {
+		const orphanSigner = await makeSigner(UNKNOWN_LABELER_DID);
+		const label = await orphanSigner.sign(labelInput());
+		const [msg] = await runBatch([jobFor(UNKNOWN_LABELER_DID, 1, 0, label)], DEPS);
+
+		expect(msg?.acked).toBe(1);
+		expect(msg?.retried).toBe(0);
+		expect(await countRows("labels")).toBe(0);
+		expect(await countRows("label_state")).toBe(0);
+		const dl = await testEnv.DB.prepare(`SELECT reason, did FROM dead_letters`).first<{
+			reason: string;
+			did: string;
+		}>();
+		expect(dl).toMatchObject({ reason: "LABEL_UNKNOWN_SOURCE", did: UNKNOWN_LABELER_DID });
+	});
+});
+
+describe("processLabelsBatch: LABEL_INVALID", () => {
+	it("dead-letters a structurally broken wire label, acks, writes nothing else", async () => {
+		const label = await signer.sign(labelInput());
+		const wire = toWire(label);
+		const job: LabelIngestJob = {
+			src: LABELER_DID,
+			sourceSequence: 1,
+			frameIndex: 0,
+			label: { ...wire, val: "" }, // empty val fails validateLabelValue
+		};
+
+		const [msg] = await runBatch([job], DEPS);
+		expect(msg?.acked).toBe(1);
+		expect(msg?.retried).toBe(0);
+		expect(await countRows("labels")).toBe(0);
+		expect(await countRows("label_state")).toBe(0);
+		const dl = await testEnv.DB.prepare(`SELECT reason FROM dead_letters`).first<{
+			reason: string;
+		}>();
+		expect(dl?.reason).toBe("LABEL_INVALID");
+	});
+});
+
+describe("processLabelsBatch: src mismatch", () => {
+	it("dead-letters a job whose src differs from the signed label's src", async () => {
+		await seedLabeler(UNTRUSTED_LABELER_DID, false);
+		const label = await untrustedSigner.sign(labelInput());
+		const [msg] = await runBatch([jobFor(LABELER_DID, 1, 0, label)], DEPS);
+
+		expect(msg?.acked).toBe(1);
+		expect(msg?.retried).toBe(0);
+		expect(await countRows("labels")).toBe(0);
+		expect(await countRows("label_state")).toBe(0);
+		const dl = await testEnv.DB.prepare(`SELECT reason FROM dead_letters`).first<{
+			reason: string;
+		}>();
+		expect(dl?.reason).toBe("LABEL_INVALID");
+	});
+});
+
+describe("processLabelsBatch: LABEL_COORDINATE_CONFLICT", () => {
+	it("a second, different label at the same coordinates dead-letters; first survives unaffected", async () => {
+		const first = await signer.sign(labelInput({ val: "value-a" }));
+		const second = await signer.sign(labelInput({ val: "value-b" }));
+		const jobFirst = jobFor(LABELER_DID, 9, 3, first);
+		const jobSecond = jobFor(LABELER_DID, 9, 3, second);
+
+		const [msg1] = await runBatch([jobFirst], DEPS);
+		expect(msg1?.acked).toBe(1);
+		const [msg2] = await runBatch([jobSecond], DEPS);
+		expect(msg2?.acked).toBe(1);
+		expect(msg2?.retried).toBe(0);
+
+		expect(await countRows("labels")).toBe(1);
+		const digestFirst = await digestOf(first);
+		const row = await testEnv.DB.prepare(`SELECT digest FROM labels`).first<{ digest: string }>();
+		expect(row?.digest).toBe(digestFirst);
+
+		const dl = await testEnv.DB.prepare(`SELECT reason FROM dead_letters`).first<{
+			reason: string;
+		}>();
+		expect(dl?.reason).toBe("LABEL_COORDINATE_CONFLICT");
+
+		// No state row for the second label's val — its batch rolled back entirely.
+		const stateSecond = await getLabelState(LABELER_DID, SUBJECT_URI, "value-b");
+		expect(stateSecond).toBeNull();
+		const stateFirst = await getLabelState(LABELER_DID, SUBJECT_URI, "value-a");
+		expect(stateFirst?.digest).toBe(digestFirst);
+	});
+});
+
+describe("processLabelsBatch: cursor-0 replay idempotency", () => {
+	it("replaying an identical mixed batch leaves history count and state identical", async () => {
+		const cidC = await makeCid("replay-c");
+		const labels = await Promise.all([
+			signer.sign(labelInput({ val: "v1", cts: "2026-07-10T12:00:00.000Z" })),
+			signer.sign(labelInput({ val: "v2", cts: "2026-07-10T12:05:00.000Z" })),
+			signer.sign(labelInput({ val: "v3", cts: "2026-07-10T12:10:00.000Z", neg: true })),
+			signer.sign(
+				labelInput({ val: "v4", cts: "2026-07-10T12:15:00.000Z", exp: "2027-01-01T00:00:00.000Z" }),
+			),
+			signer.sign(labelInput({ val: "v5", cts: "2026-07-10T12:20:00.000Z", cid: cidC })),
+		]);
+		const jobs = labels.map((label, i) => jobFor(LABELER_DID, 100 + i, 0, label));
+
+		await runBatch(jobs, DEPS);
+		const historyBefore = await countRows("labels");
+		const statesBefore = await testEnv.DB.prepare(
+			`SELECT src, uri, val, digest, cts_epoch_ms, source_sequence, frame_index, trusted
+			 FROM label_state ORDER BY val`,
+		).all();
+
+		// Replay the identical set in a fresh batch (simulates cursor-0 rebuild).
+		await runBatch(jobs, DEPS);
+		const historyAfter = await countRows("labels");
+		const statesAfter = await testEnv.DB.prepare(
+			`SELECT src, uri, val, digest, cts_epoch_ms, source_sequence, frame_index, trusted
+			 FROM label_state ORDER BY val`,
+		).all();
+
+		expect(historyAfter).toBe(historyBefore);
+		expect(historyBefore).toBe(5);
+		expect(statesAfter.results).toEqual(statesBefore.results);
+	});
+});
+
+describe("processLabelsBatch: per-message isolation", () => {
+	it("a valid job lands while an invalid job in the same batch dead-letters; both ack", async () => {
+		const valid = await signer.sign(labelInput({ val: "valid-value" }));
+		const validJob = jobFor(LABELER_DID, 1, 0, valid);
+		const invalidWire = toWire(await signer.sign(labelInput({ val: "invalid-value" })));
+		const invalidJob: LabelIngestJob = {
+			src: LABELER_DID,
+			sourceSequence: 1,
+			frameIndex: 1,
+			label: { ...invalidWire, val: "" },
+		};
+
+		const [msgValid, msgInvalid] = await runBatch([validJob, invalidJob], DEPS);
+		expect(msgValid?.acked).toBe(1);
+		expect(msgInvalid?.acked).toBe(1);
+
+		expect(await countRows("labels")).toBe(1);
+		const state = await getLabelState(LABELER_DID, SUBJECT_URI, "valid-value");
+		expect(state).not.toBeNull();
+		const dl = await testEnv.DB.prepare(`SELECT reason FROM dead_letters`).first<{
+			reason: string;
+		}>();
+		expect(dl?.reason).toBe("LABEL_INVALID");
+	});
+});
+
+describe("processLabelsBatch: transient D1 failure", () => {
+	it("retries when db.batch() throws a non-constraint error", async () => {
+		const label = await signer.sign(labelInput());
+		const job = jobFor(LABELER_DID, 1, 0, label);
+
+		const failingDb = {
+			prepare: () => ({
+				bind: () => ({
+					first: () => Promise.resolve({ trusted: 1 }),
+					run: () => Promise.resolve({ meta: { changes: 1 } }),
+				}),
+			}),
+			batch: () => Promise.reject(new Error("D1 unavailable")),
+		} as unknown as D1Database;
+
+		const [msg] = await runBatch([job], { db: failingDb, now: () => NOW });
+		expect(msg?.retried).toBe(1);
+		expect(msg?.acked).toBe(0);
+	});
+});
+
+describe("drainLabelsDeadLetterBatch", () => {
+	it("acks each message and writes a forensics row", async () => {
+		const label = await signer.sign(labelInput());
+		const job = jobFor(LABELER_DID, 1, 0, label);
+		const message = new FakeMessage(job);
+
+		await drainLabelsDeadLetterBatch({ messages: [message] }, { DB: testEnv.DB } as unknown as Env);
+
+		expect(message.acked).toBe(1);
+		expect(await countRows("dead_letters")).toBe(1);
+		const dl = await testEnv.DB.prepare(`SELECT reason FROM dead_letters`).first<{
+			reason: string;
+		}>();
+		expect(dl?.reason).toBe("LABEL_UNEXPECTED_ERROR");
+	});
+
+	it("retries the message when writeDeadLetter throws", async () => {
+		const label = await signer.sign(labelInput());
+		const job = jobFor(LABELER_DID, 1, 0, label);
+		const message = new FakeMessage(job);
+		const failingDb = {
+			prepare: () => ({
+				bind: () => ({
+					run: () => Promise.reject(new Error("D1 unavailable")),
+				}),
+			}),
+		} as unknown as D1Database;
+
+		await drainLabelsDeadLetterBatch({ messages: [message] }, { DB: failingDb } as unknown as Env);
+
+		expect(message.retried).toBe(1);
+		expect(message.acked).toBe(0);
+	});
+});

--- a/apps/aggregator/test/migrations.test.ts
+++ b/apps/aggregator/test/migrations.test.ts
@@ -1,0 +1,35 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+
+describe("0003_label_history_identity", () => {
+	it("refuses to run when label rows already exist", async () => {
+		const migrations = testEnv.TEST_MIGRATIONS;
+		const guarded = migrations.findIndex((m) => m.name.includes("0003_label_history_identity"));
+		expect(guarded).toBeGreaterThan(0);
+
+		await applyD1Migrations(testEnv.DB, migrations.slice(0, guarded));
+		await testEnv.DB.prepare(
+			`INSERT INTO labels (src, uri, val, cts, sig, received_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+			.bind(
+				"did:web:labels.example",
+				"at://did:plc:x/com.emdashcms.experimental.package.release/pkg:1.0.0",
+				"security-yanked",
+				"2026-01-01T00:00:00.000Z",
+				new Uint8Array([1, 2, 3]),
+				"2026-01-01T00:00:00.000Z",
+			)
+			.run();
+
+		await expect(
+			applyD1Migrations(testEnv.DB, migrations.slice(guarded, guarded + 1)),
+		).rejects.toThrow();
+	});
+});

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -37,6 +37,7 @@ beforeEach(async () => {
 	await testEnv.DB.prepare("DELETE FROM packages").run();
 	await testEnv.DB.prepare("DELETE FROM publishers").run();
 	await testEnv.DB.prepare("DELETE FROM publisher_verifications").run();
+	await testEnv.DB.prepare("DELETE FROM label_state").run();
 });
 
 interface SeedPackageOpts {
@@ -136,6 +137,49 @@ function defaultVersionSort(version: string): string {
 	const [major = "0", minor = "0", patch = "0"] = version.split(".");
 	const pad = (s: string) => s.padStart(10, "0");
 	return `${pad(major)}.${pad(minor)}.${pad(patch)}.~`;
+}
+
+function packageUri(slug: string, did: string = DID_A): string {
+	return `at://${did}/${NSID.packageProfile}/${slug}`;
+}
+
+async function seedLabelState(opts: {
+	uri: string;
+	val: string;
+	trusted?: boolean;
+	neg?: boolean;
+	exp?: string;
+}): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO label_state
+		   (src, uri, val, cid, neg, cts, cts_epoch_ms, exp, exp_epoch_ms,
+		    digest, source_sequence, frame_index, trusted)
+		 VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			"did:web:labels.example",
+			opts.uri,
+			opts.val,
+			opts.neg ? 1 : 0,
+			NOW.toISOString(),
+			NOW.getTime(),
+			opts.exp ?? null,
+			opts.exp === undefined ? null : Date.parse(opts.exp),
+			`digest-${opts.uri}-${opts.val}`,
+			1,
+			0,
+			opts.trusted === false ? 0 : 1,
+		)
+		.run();
+}
+
+/** An expiry that is an hour in the past as an instant, rendered with a
+ * +14:00 offset so its raw string compares lexically AFTER the current UTC
+ * timestamp — the case that text comparison gets wrong. */
+function offsetExpiredExp(): string {
+	const instant = Date.now() - 60 * 60 * 1000;
+	const local = new Date(instant + 14 * 60 * 60 * 1000);
+	return local.toISOString().replace(/\.\d{3}Z$/, "+14:00");
 }
 
 describe("getPackage", () => {
@@ -358,6 +402,38 @@ describe("searchPackages", () => {
 			.map((p) => p.slug)
 			.filter((s) => secondBody.packages.some((p) => p.slug === s));
 		expect(overlap).toEqual([]);
+	});
+
+	it("hides a package with an active trusted security-yanked label", async () => {
+		await seedPackage({ slug: "risky" });
+		await seedPackage({ slug: "safe" });
+		await seedLabelState({ uri: packageUri("risky"), val: "security-yanked" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toEqual(["safe"]);
+	});
+
+	it("does not hide a package whose takedown expired, even when the raw exp string compares lexically after now", async () => {
+		await seedPackage({ slug: "recovered" });
+		await seedLabelState({
+			uri: packageUri("recovered"),
+			val: "!takedown",
+			exp: offsetExpiredExp(),
+		});
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toEqual(["recovered"]);
+	});
+
+	it("ignores blocking labels from untrusted sources", async () => {
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown", trusted: false });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toEqual(["demo"]);
 	});
 
 	it("doesn't blow up on FTS-unsafe query chars (defensive quoting)", async () => {

--- a/apps/aggregator/worker-configuration.d.ts
+++ b/apps/aggregator/worker-configuration.d.ts
@@ -4,16 +4,18 @@
 declare namespace Cloudflare {
 	interface GlobalProps {
 		mainModule: typeof import("./src/index");
-		durableNamespaces: "RecordsJetstreamDO";
+		durableNamespaces: "RecordsJetstreamDO" | "LabelIngestDO";
 	}
 	interface Env {
 		DB: D1Database;
 		RECORDS_QUEUE: Queue;
 		BACKFILL_QUEUE: Queue;
+		LABELS_QUEUE: Queue;
 		JETSTREAM_URL: "wss://jetstream2.us-east.bsky.network/subscribe";
 		RELAY_URL: "https://bsky.network";
 		ADMIN_TOKEN: string;
 		RECORDS_DO: DurableObjectNamespace<import("./src/index").RecordsJetstreamDO>;
+		LABEL_INGEST_DO: DurableObjectNamespace<import("./src/index").LabelIngestDO>;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/apps/aggregator/wrangler.jsonc
+++ b/apps/aggregator/wrangler.jsonc
@@ -35,6 +35,13 @@
 				"binding": "BACKFILL_QUEUE",
 				"queue": "emdash-aggregator-backfill",
 			},
+			{
+				// Verified signed labels, one per labeler-stream frame
+				// element. Producer is LabelIngestDO; consumed by
+				// labels-consumer.ts into the labels/label_state tables.
+				"binding": "LABELS_QUEUE",
+				"queue": "emdash-aggregator-labels",
+			},
 		],
 		"consumers": [
 			{
@@ -86,6 +93,26 @@
 				"max_batch_timeout": 30,
 				"max_retries": 3,
 			},
+			{
+				// The digest primary key and cts-ordered projection upsert
+				// make same-batch message order irrelevant, so this mirrors
+				// the records queue's steady-state tuning.
+				"queue": "emdash-aggregator-labels",
+				"max_batch_size": 25,
+				"max_batch_timeout": 5,
+				"max_retries": 5,
+				"dead_letter_queue": "emdash-aggregator-labels-dlq",
+			},
+			{
+				// Drains the labels DLQ. Same posture as the records DLQ:
+				// log + write a `dead_letters` row, then ack. No DLQ-of-DLQ;
+				// workerd drops the message if the D1 write also fails after
+				// max_retries.
+				"queue": "emdash-aggregator-labels-dlq",
+				"max_batch_size": 25,
+				"max_batch_timeout": 30,
+				"max_retries": 3,
+			},
 		],
 	},
 	"durable_objects": {
@@ -94,12 +121,20 @@
 				"name": "RECORDS_DO",
 				"class_name": "RecordsJetstreamDO",
 			},
+			{
+				"name": "LABEL_INGEST_DO",
+				"class_name": "LabelIngestDO",
+			},
 		],
 	},
 	"migrations": [
 		{
 			"tag": "v1",
 			"new_sqlite_classes": ["RecordsJetstreamDO"],
+		},
+		{
+			"tag": "v2",
+			"new_sqlite_classes": ["LabelIngestDO"],
 		},
 	],
 	"triggers": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       '@emdash-cms/registry-lexicons':
         specifier: workspace:*
         version: link:../../packages/registry-lexicons
+      '@emdash-cms/registry-moderation':
+        specifier: workspace:*
+        version: link:../../packages/registry-moderation
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'


### PR DESCRIPTION
## What does this PR do?

Implements aggregator signed-label ingest — W4.2, W4.3, and the collision-safe history migration from the labelling-service plan (#1909).

- **`LabelIngestDO`** (one per configured labeler, named by DID, woken from the existing cron): maintains the outbound `com.atproto.label.subscribeLabels` WebSocket, verifies every label against the labeler's resolved `#atproto_label` key **before** queue acceptance, and persists its cursor to `ingest_state` (`labeler:<did>`) only after every label in a frame is durably enqueued. A fresh labeler subscribes from `cursor=0` for full history (the labeler's default is "start from now"). Any unverifiable label fails closed: nothing enqueued, cursor unmoved, connection closed with backoff — after one `resolveFresh` retry per connection to absorb key rotation.
- **Labels queue consumer**: writes append-only history (`labels`) and the `label_state` projection in one atomic `db.batch`. History identity is the SHA-256 digest of the canonical signed bytes (exact redelivery is a silent no-op) plus `UNIQUE (src, source_sequence, frame_index)` (a different label at taken coordinates dead-letters as a permanent conflict). Projection winner per `(src, uri, val)` is decided by validated epoch-ms instants, tie-broken by stream coordinates, in a conditional upsert that stays correct under concurrent batches and out-of-order delivery.
- **Migration 0003** drops and recreates `labels`/`label_state` with the collision-safe identity and `cts_epoch_ms`/`exp_epoch_ms` columns. The tables are empty in every deployment: no writer existed anywhere in code, and the production zero-row preflight was confirmed on #1909.
- **Enforcement filter fixes** (adversarial-review findings that would have gone live with this writer): `searchPackages`' hard filter matched the legacy `security:yanked` value instead of canonical `security-yanked`, and compared RFC 3339 expiry strings as text — which misorders across timezone offsets. It now matches the canonical value and compares `exp_epoch_ms`. Both regressions are covered by tests that were verified to fail against the old SQL.

Review notes:

- `isCoordinateConflict` classifies the coordinate-unique violation by SQLite error text (both column names must appear). This is exercised against workerd/miniflare D1 in tests; if production D1 ever words it differently, the failure degrades to retry → labels DLQ → forensics `dead_letters` row rather than silent loss.
- A labeler row removed after its DO persisted the DID keeps a fail-closed retry loop (resolution fails; nothing is ingested). Deprovisioning/reconciliation is W4.7.
- The subscription covers all configured `labelers` rows; `trusted` gates enforcement, not subscription, so untrusted-but-known labelers build history without policy effect.

Implementation PRs target `feat/plugin-registry-labelling-service` per the umbrella PR. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n is n/a — no UI changes. Changeset is n/a — `@emdash-cms/aggregator` is a private package; the only published-package change is adding `@emdash-cms/registry-moderation` as its dependency, which doesn't alter any published package.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (design, review, fixes) and Sonnet/Opus subagents (implementation, adversarial review)

## Screenshots / test output

- `pnpm --filter @emdash-cms/aggregator test`: 13 files, 265 tests pass (44 ingestor/stream-client unit tests with real P-256 signing, 19 workerd/D1 consumer tests, 3 enforcement-filter regression tests)
- `pnpm --filter @emdash-cms/aggregator typecheck` clean
- `pnpm lint:quick` 0 diagnostics; type-aware `pnpm lint:json` has no findings in any touched file
- Enforcement regression tests confirmed to fail against the pre-fix SQL (stash-verified) before passing with the fix

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-aggregator-ingest-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-aggregator-ingest`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
