### PR TITLE
feat(core): add withEmDashRuntime() so queue/scheduled handlers can invoke plugin routes

### DIFF
--- a/.changeset/with-emdash-runtime.md
+++ b/.changeset/with-emdash-runtime.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds `withEmDashRuntime()` to `emdash/middleware` so request-free handlers (Cloudflare Queue consumers, custom `scheduled()` handlers) can access the EmDash runtime and invoke plugin routes directly — previously the runtime was only reachable through `locals.emdash` on an HTTP request.

--- a/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
@@ -325,6 +325,44 @@ function SettingsPage() {
 }
 ```
 
+## Calling routes from queue and scheduled handlers
+
+Platform-event handlers (a Cloudflare Queue consumer, a custom `scheduled()` handler) have no HTTP request and therefore no `locals.emdash`. Use `withEmDashRuntime()` from `emdash/middleware` to get the runtime directly and invoke a plugin route without a request:
+
+```typescript title="src/worker.ts"
+import { withEmDashRuntime } from "emdash/middleware";
+
+export default {
+	// ... fetch/scheduled from @emdash-cms/cloudflare/worker
+
+	async queue(batch: MessageBatch) {
+		await withEmDashRuntime(async (runtime) => {
+			for (const message of batch.messages) {
+				const result = await runtime.handlePluginApiRoute(
+					"my-plugin",
+					"POST",
+					"/finishJob",
+					new Request("https://internal/", {
+						method: "POST",
+						body: JSON.stringify(message.body),
+					}),
+				);
+				if (result.success) message.ack();
+				else message.retry();
+			}
+		});
+	},
+};
+```
+
+This resolves the same cached runtime that request handlers use, so plugin storage, hooks, and media access all behave exactly as they do during a request. On connection-backed database adapters (e.g. Postgres over Hyperdrive) the callback runs under an event-scoped connection that is committed and closed when it returns.
+
+<Aside type="caution">
+	`withEmDashRuntime()` is server-only and fully trusted — the callback gets the raw runtime with
+	no auth or CSRF checks, the same trust level as plugin cron. Validate any external input (queue
+	message bodies included) before passing it to a plugin route.
+</Aside>
+
 ## Calling routes externally
 
 Public routes are callable directly:

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -67,6 +67,9 @@ import { createPublicPluginApiRouteHandler } from "./public-plugin-api-routes.js
 import { resolveSessionUser } from "./session-user.js";
 import type { EmDashHandlers } from "./types.js";
 
+// Public type for withEmDashRuntime() consumers (queue/scheduled handlers).
+export type { EmDashRuntime } from "../emdash-runtime.js";
+
 /**
  * Runtime init lock reclaim deadline. Must be strictly larger than the db
  * init deadline: this lock wraps EmDashRuntime.create() → getDatabase() →
@@ -285,22 +288,81 @@ export async function runScheduledTasks(
 ): Promise<{ published: PublishedRef[] }> {
 	const config = getConfig();
 	if (!config) return { published: [] };
+	return runOutsideRequest(config, (runtime) => runtime.runScheduledTasks(options));
+}
+
+/**
+ * Run a callback against the EmDash runtime outside any HTTP request — from a
+ * Cloudflare Queue consumer, a `scheduled()` handler, or any other
+ * platform-event handler that has no request and therefore no `locals.emdash`.
+ *
+ * Resolves the same cached runtime singleton request handlers use, so hooks,
+ * plugin state, and storage all behave exactly as they do during a request.
+ * A typical queue consumer finishes a job by calling back into a plugin route:
+ *
+ * ```ts
+ * import { withEmDashRuntime } from "emdash/middleware";
+ *
+ * async function queue(batch: MessageBatch) {
+ * 	await withEmDashRuntime(async (runtime) => {
+ * 		for (const message of batch.messages) {
+ * 			await runtime.handlePluginApiRoute(
+ * 				"my-plugin",
+ * 				"POST",
+ * 				"/finishJob",
+ * 				new Request("https://internal/", {
+ * 					method: "POST",
+ * 					body: JSON.stringify(message.body),
+ * 				}),
+ * 			);
+ * 		}
+ * 	});
+ * }
+ * ```
+ *
+ * Server-only and fully trusted: the callback gets the raw runtime with no
+ * auth or CSRF checks, same trust level as plugin cron. Never expose it to
+ * user input without validating that input yourself.
+ *
+ * Throws when EmDash is not configured (no `emdash()` Astro integration).
+ */
+export async function withEmDashRuntime<T>(
+	run: (runtime: EmDashRuntime) => T | Promise<T>,
+): Promise<T> {
+	const config = getConfig();
+	if (!config) {
+		throw new Error(
+			"EmDash is not configured — withEmDashRuntime() requires the emdash() Astro integration.",
+		);
+	}
+	return runOutsideRequest(config, async (runtime) => run(runtime));
+}
+
+/**
+ * Shared plumbing for request-free entry points (`runScheduledTasks`,
+ * `withEmDashRuntime`): resolve the runtime singleton, then run the callback
+ * under an event-scoped db connection when the adapter needs one.
+ *
+ * Connection-backed adapters (e.g. Postgres over Hyperdrive) cannot reuse
+ * the per-isolate singleton from a platform event: its socket belongs to the
+ * request that opened it, and workerd rejects cross-event I/O. Open an
+ * event-scoped connection and run the callback under it in ALS — the
+ * runtime's db getter, the cron executor, and plugin contexts all resolve
+ * the connection from ALS — then close it. Gated on the adapter being
+ * connection-backed (it exposes `close()`); stateless adapters (D1, Node
+ * SQLite) return null or a close-less scope and keep using the singleton.
+ */
+async function runOutsideRequest<T>(
+	config: EmDashConfig,
+	fn: (runtime: EmDashRuntime) => Promise<T>,
+): Promise<T> {
 	const runtime = await getRuntime(config);
 
-	// Connection-backed adapters (e.g. Postgres over Hyperdrive) cannot reuse
-	// the per-isolate singleton from a Cron Trigger: its socket belongs to the
-	// request that opened it, and workerd rejects cross-event I/O. Open an
-	// event-scoped connection for the sweep and run the batch under it in ALS —
-	// the runtime's db getter, the cron executor, and plugin cron contexts all
-	// resolve the connection from ALS — then close it. Gated on the adapter
-	// being connection-backed (it exposes `close()`); stateless adapters (D1,
-	// Node SQLite) return null or a close-less scope and keep using the
-	// singleton, so their cron path is unchanged.
 	const scoped = createRequestScopedDb({
 		config: config.database?.config,
 		isAuthenticated: false,
-		// The sweep publishes and cleans up — a write workload — so a
-		// connection-backed adapter routes it to the primary.
+		// Event handlers publish, clean up, or run jobs — a write workload —
+		// so a connection-backed adapter routes them to the primary.
 		isWrite: true,
 		cookies: NOOP_COOKIE_JAR,
 		url: CRON_EVENT_URL,
@@ -308,7 +370,7 @@ export async function runScheduledTasks(
 	if (!scoped?.close) {
 		// Stateless adapter (or no per-request scoping): the singleton is safe
 		// outside a request. Any close-less scope created above is discarded.
-		return runtime.runScheduledTasks(options);
+		return fn(runtime);
 	}
 
 	const parent = getRequestContext();
@@ -316,19 +378,19 @@ export async function runScheduledTasks(
 		? { ...parent, db: scoped.db }
 		: { editMode: false, db: scoped.db, metrics: createRequestMetrics(performance.now()) };
 	try {
-		return await runWithContext(ctx, () => runtime.runScheduledTasks(options));
+		return await runWithContext(ctx, () => fn(runtime));
 	} finally {
-		// Guard both so a throw in teardown can't mask the sweep result or skip
-		// close() and leak the connection. Mirrors closeSafely() in scoped-db.ts.
+		// Guard both so a throw in teardown can't mask the callback result or
+		// skip close() and leak the connection. Mirrors closeSafely() in scoped-db.ts.
 		try {
 			scoped.commit();
 		} catch (error) {
-			console.error("[scheduled] request-scoped db commit failed:", error);
+			console.error("[emdash] event-scoped db commit failed:", error);
 		}
 		try {
 			scoped.close();
 		} catch (error) {
-			console.error("[scheduled] request-scoped db close failed:", error);
+			console.error("[emdash] event-scoped db close failed:", error);
 		}
 	}
 }

--- a/packages/core/tests/unit/astro/with-emdash-runtime-unconfigured.test.ts
+++ b/packages/core/tests/unit/astro/with-emdash-runtime-unconfigured.test.ts
@@ -1,0 +1,54 @@
+/**
+ * withEmDashRuntime() error contract (#1887): throws when EmDash is not
+ * configured (no `emdash()` Astro integration), unlike `runScheduledTasks`
+ * which silently no-ops.
+ *
+ * Separate file from with-emdash-runtime.test.ts because the
+ * `virtual:emdash/config` mock is module-level: this file mocks the
+ * unconfigured state (`default: null`), the other one a valid config.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+
+vi.mock("virtual:emdash/config", () => ({ default: null }), { virtual: true });
+
+vi.mock(
+	"virtual:emdash/dialect",
+	() => ({
+		createDialect: vi.fn(),
+		createRequestScopedDb: vi.fn().mockReturnValue(null),
+		createCoalescingDialect: undefined,
+	}),
+	{ virtual: true },
+);
+
+vi.mock("virtual:emdash/media-providers", () => ({ mediaProviders: [] }), { virtual: true });
+vi.mock("virtual:emdash/plugins", () => ({ plugins: [] }), { virtual: true });
+vi.mock(
+	"virtual:emdash/sandbox-runner",
+	() => ({ createSandboxRunner: null, sandboxBypassed: false, sandboxEnabled: false }),
+	{ virtual: true },
+);
+vi.mock("virtual:emdash/sandboxed-plugins", () => ({ sandboxedPlugins: [] }), { virtual: true });
+vi.mock("virtual:emdash/storage", () => ({ createStorage: null }), { virtual: true });
+vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual: true });
+vi.mock("virtual:emdash/scheduler", () => ({ createScheduler: null }), { virtual: true });
+
+import { runScheduledTasks, withEmDashRuntime } from "../../../src/astro/middleware.js";
+
+describe("withEmDashRuntime without EmDash config (#1887)", () => {
+	it("throws the documented error and never runs the callback", async () => {
+		const callback = vi.fn(async () => "should-not-run");
+
+		await expect(withEmDashRuntime(callback)).rejects.toThrow("EmDash is not configured");
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it("runScheduledTasks keeps its silent no-op contract by contrast", async () => {
+		await expect(runScheduledTasks()).resolves.toEqual({ published: [] });
+	});
+});

--- a/packages/core/tests/unit/astro/with-emdash-runtime.test.ts
+++ b/packages/core/tests/unit/astro/with-emdash-runtime.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for withEmDashRuntime() (#1887): the request-free runtime accessor
+ * for queue consumers and scheduled() handlers.
+ *
+ * Covers the stateless-adapter fast path, the connection-backed adapter path
+ * (event-scoped db in ALS + guaranteed commit/close), and error propagation.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+
+const { MOCK_RUNTIME } = vi.hoisted(() => ({
+	MOCK_RUNTIME: {
+		_marker: "runtime",
+		handlePluginApiRoute: vi.fn(async () => ({ success: true, data: { done: true } })),
+		runScheduledTasks: vi.fn(async () => ({ published: [] })),
+	},
+}));
+
+vi.mock(
+	"virtual:emdash/config",
+	() => ({
+		default: {
+			database: { config: { binding: "DB" } },
+			auth: { mode: "none" },
+		},
+	}),
+	{ virtual: true },
+);
+
+vi.mock(
+	"virtual:emdash/dialect",
+	() => ({
+		createDialect: vi.fn(),
+		createRequestScopedDb: vi.fn().mockReturnValue(null),
+		createCoalescingDialect: undefined,
+	}),
+	{ virtual: true },
+);
+
+vi.mock("virtual:emdash/media-providers", () => ({ mediaProviders: [] }), { virtual: true });
+vi.mock("virtual:emdash/plugins", () => ({ plugins: [] }), { virtual: true });
+vi.mock(
+	"virtual:emdash/sandbox-runner",
+	() => ({ createSandboxRunner: null, sandboxBypassed: false, sandboxEnabled: false }),
+	{ virtual: true },
+);
+vi.mock("virtual:emdash/sandboxed-plugins", () => ({ sandboxedPlugins: [] }), { virtual: true });
+vi.mock("virtual:emdash/storage", () => ({ createStorage: null }), { virtual: true });
+vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual: true });
+vi.mock("virtual:emdash/scheduler", () => ({ createScheduler: null }), { virtual: true });
+
+vi.mock("../../../src/emdash-runtime.js", () => ({
+	DB_INIT_DEADLINE_MS: 30_000,
+	EmDashRuntime: {
+		create: async () => MOCK_RUNTIME,
+	},
+}));
+
+import { createRequestScopedDb } from "virtual:emdash/dialect";
+
+import { withEmDashRuntime } from "../../../src/astro/middleware.js";
+import { getRequestContext } from "../../../src/request-context.js";
+
+const RUNTIME_HOLDER_KEY = Symbol.for("emdash:runtime-holder");
+
+describe("withEmDashRuntime (#1887)", () => {
+	beforeEach(() => {
+		// Reset the globalThis runtime singleton so each test builds fresh
+		delete (globalThis as Record<symbol, unknown>)[RUNTIME_HOLDER_KEY];
+		vi.mocked(createRequestScopedDb).mockReset().mockReturnValue(null);
+	});
+
+	it("passes the runtime to the callback and returns its result (stateless adapter)", async () => {
+		const result = await withEmDashRuntime(async (runtime) => {
+			expect(runtime).toBe(MOCK_RUNTIME);
+			return "job-done";
+		});
+		expect(result).toBe("job-done");
+	});
+
+	it("supports a synchronous callback", async () => {
+		await expect(withEmDashRuntime(() => 42)).resolves.toBe(42);
+	});
+
+	it("runs the callback under the event-scoped db and commits/closes it", async () => {
+		const commit = vi.fn();
+		const close = vi.fn();
+		const scopedDb = { _marker: "scoped" };
+		vi.mocked(createRequestScopedDb).mockReturnValue({
+			db: scopedDb as never,
+			commit,
+			close,
+		});
+
+		let dbSeenByCallback: unknown;
+		const result = await withEmDashRuntime(async () => {
+			dbSeenByCallback = getRequestContext()?.db;
+			return "ok";
+		});
+
+		expect(result).toBe("ok");
+		expect(dbSeenByCallback).toBe(scopedDb);
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(close).toHaveBeenCalledTimes(1);
+		// The event context must not leak past the call
+		expect(getRequestContext()).toBeUndefined();
+
+		// The scope must be flagged as a write workload so connection-backed
+		// adapters route queue jobs to the primary.
+		const opts = vi.mocked(createRequestScopedDb).mock.calls[0]?.[0];
+		expect(opts).toMatchObject({ isAuthenticated: false, isWrite: true });
+	});
+
+	it("still commits and closes the scoped db when the callback throws", async () => {
+		const commit = vi.fn();
+		const close = vi.fn();
+		vi.mocked(createRequestScopedDb).mockReturnValue({
+			db: { _marker: "scoped" } as never,
+			commit,
+			close,
+		});
+
+		await expect(
+			withEmDashRuntime(async () => {
+				throw new Error("job failed");
+			}),
+		).rejects.toThrow("job failed");
+
+		expect(commit).toHaveBeenCalledTimes(1);
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the singleton path for a close-less scope", async () => {
+		const commit = vi.fn();
+		vi.mocked(createRequestScopedDb).mockReturnValue({
+			db: { _marker: "scoped" } as never,
+			commit,
+		});
+
+		await expect(withEmDashRuntime(() => "ok")).resolves.toBe("ok");
+		// Close-less scope is discarded — nothing to commit outside a request
+		expect(commit).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Closes #1887
Discussion: https://github.com/emdash-cms/emdash/discussions/1960

Request-free handlers (a Cloudflare Queue consumer, a custom `scheduled()` handler) had no supported way to reach the EmDash runtime or invoke a plugin route: `handlePluginApiRoute` is only attached to `locals.emdash` on a real HTTP request, and the `SELF.fetch()` workaround fails because a cookieless self-request gets the *limited* `locals.emdash` without it — the queue message just retries and dead-letters.

This adds the accessor the issue proposes, exported from `emdash/middleware` next to `runScheduledTasks`:

```ts
import { withEmDashRuntime } from "emdash/middleware";

async function queue(batch: MessageBatch) {
	await withEmDashRuntime(async (runtime) => {
		for (const message of batch.messages) {
			await runtime.handlePluginApiRoute("my-plugin", "POST", "/finishJob", request);
		}
	});
}
```

**Not a new mechanism.** The internal request-free path plugin cron already relies on (`getConfig() → getRuntime() → createRequestScopedDb() → runWithContext()`) is refactored into a shared `runOutsideRequest()` helper; `runScheduledTasks` now goes through the same helper, so both entry points share one implementation:

- Resolves the **same cached runtime singleton** request handlers use.
- **Connection-backed adapters** (e.g. Postgres over Hyperdrive) get an event-scoped connection installed in ALS, committed and closed after the callback (guarded so teardown errors can't mask the result or leak the connection) — workerd rejects cross-event I/O on the cold-start singleton's socket.
- **Stateless adapters** (D1, Node SQLite) keep using the singleton, unchanged.
- The event scope is flagged `isWrite: true` so queue jobs route to the primary.
- Throws a clear error when EmDash is not configured (unlike `runScheduledTasks`, which no-ops — user code should hear about a misconfiguration).

The `EmDashRuntime` type is re-exported from `emdash/middleware` so the callback can be typed. Docs: new "Calling routes from queue and scheduled handlers" section in the plugin API-routes guide, including a caution that the helper is server-only and fully trusted (same trust level as plugin cron — validate queue message bodies yourself).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a, no admin UI changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1960

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

```
✓ tests/unit/astro/with-emdash-runtime.test.ts (5 tests)
  ✓ passes the runtime to the callback and returns its result (stateless adapter)
  ✓ supports a synchronous callback
  ✓ runs the callback under the event-scoped db and commits/closes it
  ✓ still commits and closes the scoped db when the callback throws
  ✓ uses the singleton path for a close-less scope

# full astro middleware + scheduled-publish suites after the refactor:
Test Files  23 passed (23)
     Tests  174 passed (174)
```

Verified the built `emdash/middleware` dts exports `withEmDashRuntime` and the `EmDashRuntime` type; docs build passes.