### PR TITLE
feat(registry): label-aware aggregator reads

### DIFF
--- a/.changeset/labeler-headers-negotiation.md
+++ b/.changeset/labeler-headers-negotiation.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-moderation": patch
+---
+
+Adds `parseAcceptLabelersHeader` and `serializeContentLabelersHeader` for the `atproto-accept-labelers` / `atproto-content-labelers` negotiation headers, with DID deduplication and redact-flag merging.

--- a/.changeset/lucky-labelers-hard-blocks.md
+++ b/.changeset/lucky-labelers-hard-blocks.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-moderation": patch
+---
+
+Exports the package-scope and release-scope hard-block label value sets so consumers share one vocabulary.

--- a/.changeset/lucky-labelers-search-description.md
+++ b/.changeset/lucky-labelers-search-description.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-lexicons": patch
+---
+
+Updates the `searchPackages` description to the canonical moderation vocabulary.

--- a/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
+++ b/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
@@ -25,6 +25,7 @@ import { type ReleaseRow, releaseColumns, releaseView } from "./views.js";
 export async function getLatestRelease(
 	env: Env,
 	params: AggregatorGetLatestRelease.$params,
+	_request: Request,
 ): Promise<Response> {
 	const session = env.DB.withSession("first-primary");
 

--- a/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
+++ b/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
@@ -15,54 +15,113 @@
  * make this endpoint return `NotFound` even though the package
  * demonstrably has other live releases (visible via `listReleases`). The
  * denormalisation is an optimisation, not a correctness gate.
+ *
+ * Label-aware selection: when the request's accepted-labeler policy (W4.4)
+ * is non-empty, `packages.latest_version` can't be trusted (it doesn't
+ * know about label state), so the fast path is skipped entirely in favour
+ * of the authoritative ORDER BY query with `buildReleaseEnforcementSql`
+ * appended — official-policy exclusion, independent of `redact`.
  */
 
 import { json, XRPCError } from "@atcute/xrpc-server";
 import { type AggregatorGetLatestRelease } from "@emdash-cms/registry-lexicons";
 
-import { type ReleaseRow, releaseColumns, releaseView } from "./views.js";
+import { parseSignatureMetadataCid } from "../../utils.js";
+import { buildReleaseEnforcementSql, hydrateLabels } from "./label-enforcement.js";
+import { getRequestLabelerPolicy } from "./request-policy.js";
+import { type ReleaseRow, packageUri, releaseColumns, releaseUri, releaseView } from "./views.js";
 
 export async function getLatestRelease(
 	env: Env,
 	params: AggregatorGetLatestRelease.$params,
-	_request: Request,
+	request: Request,
 ): Promise<Response> {
 	const session = env.DB.withSession("first-primary");
+	const { accepted } = getRequestLabelerPolicy(request);
 
-	// Fast path: pull the latest_version pointer + matching release in one
-	// query. The tombstoned_at filter is the integrity gate — if the
-	// pointer is stale (release tombstoned, refresh pending), this misses
-	// and we fall through.
-	const fast = await session
-		.prepare(
-			`SELECT ${releaseColumns("r.")}
-			 FROM packages p
-			 JOIN releases r ON r.did = p.did AND r.package = p.slug AND r.version = p.latest_version
-			 WHERE p.did = ? AND p.slug = ? AND r.tombstoned_at IS NULL`,
-		)
-		.bind(params.did, params.package)
-		.first<ReleaseRow>();
-	if (fast) return json(releaseView(fast));
+	if (accepted.length === 0) {
+		// Fast path: pull the latest_version pointer + matching release in one
+		// query. The tombstoned_at filter is the integrity gate — if the
+		// pointer is stale (release tombstoned, refresh pending), this misses
+		// and we fall through.
+		const fast = await session
+			.prepare(
+				`SELECT ${releaseColumns("r.")}
+				 FROM packages p
+				 JOIN releases r ON r.did = p.did AND r.package = p.slug AND r.version = p.latest_version
+				 WHERE p.did = ? AND p.slug = ? AND r.tombstoned_at IS NULL`,
+			)
+			.bind(params.did, params.package)
+			.first<ReleaseRow>();
+		if (fast) return json(releaseView(fast));
 
-	// Slow-path fallback: the authoritative ORDER BY. Costs an extra D1
-	// round-trip on the rare miss but guarantees we don't 404 on a package
-	// that has live releases. Tiebreakers (version, rkey) keep the result
-	// deterministic if version_sort ties, matching listReleases' ordering.
-	const slow = await session
+		// Slow-path fallback: the authoritative ORDER BY. Costs an extra D1
+		// round-trip on the rare miss but guarantees we don't 404 on a package
+		// that has live releases. Tiebreakers (version, rkey) keep the result
+		// deterministic if version_sort ties, matching listReleases' ordering.
+		const slow = await session
+			.prepare(
+				`SELECT ${releaseColumns()}
+				 FROM releases
+				 WHERE did = ? AND package = ? AND tombstoned_at IS NULL
+				 ORDER BY version_sort DESC, version DESC, rkey DESC
+				 LIMIT 1`,
+			)
+			.bind(params.did, params.package)
+			.first<ReleaseRow>();
+		if (slow) return json(releaseView(slow));
+
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No eligible release for (${params.did}, ${params.package}).`,
+		});
+	}
+
+	const nowMs = Date.now();
+	const enforcement = buildReleaseEnforcementSql(accepted, nowMs);
+	const winner = await session
 		.prepare(
-			`SELECT ${releaseColumns()}
-			 FROM releases
-			 WHERE did = ? AND package = ? AND tombstoned_at IS NULL
-			 ORDER BY version_sort DESC, version DESC, rkey DESC
+			`SELECT ${releaseColumns("r.")}, p.signature_metadata AS package_signature_metadata
+			 FROM releases r
+			 JOIN packages p ON p.did = r.did AND p.slug = r.package
+			 WHERE r.did = ? AND r.package = ? AND r.tombstoned_at IS NULL
+			 ${enforcement.sql}
+			 ORDER BY r.version_sort DESC, r.version DESC, r.rkey DESC
 			 LIMIT 1`,
 		)
-		.bind(params.did, params.package)
-		.first<ReleaseRow>();
-	if (slow) return json(releaseView(slow));
+		.bind(params.did, params.package, ...enforcement.bindings)
+		.first<ReleaseRow & { package_signature_metadata: string | null }>();
+	if (!winner) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No eligible release for (${params.did}, ${params.package}).`,
+		});
+	}
 
-	throw new XRPCError({
-		status: 404,
-		error: "NotFound",
-		message: `No eligible release for (${params.did}, ${params.package}).`,
-	});
+	const releaseSubjectUri = releaseUri(winner);
+	const packageSubjectUri = packageUri({ did: winner.did, slug: winner.package });
+	const labelsByUri = await hydrateLabels(
+		session,
+		accepted,
+		[
+			{
+				uri: releaseSubjectUri,
+				currentCid: parseSignatureMetadataCid(winner.signature_metadata) ?? undefined,
+			},
+			{
+				uri: packageSubjectUri,
+				currentCid: parseSignatureMetadataCid(winner.package_signature_metadata) ?? undefined,
+			},
+			{ uri: winner.did },
+		],
+		nowMs,
+	);
+	const labels = [
+		...(labelsByUri.get(releaseSubjectUri) ?? []),
+		...(labelsByUri.get(packageSubjectUri) ?? []),
+		...(labelsByUri.get(winner.did) ?? []),
+	];
+	return json(releaseView(winner, labels));
 }

--- a/apps/aggregator/src/routes/xrpc/getPackage.ts
+++ b/apps/aggregator/src/routes/xrpc/getPackage.ts
@@ -17,6 +17,7 @@ import { type PackageRow, packageColumns, packageView } from "./views.js";
 export async function getPackage(
 	env: Env,
 	params: AggregatorGetPackage.$params,
+	_request: Request,
 ): Promise<Response> {
 	// `first-primary` because the same row could become subject to a takedown
 	// label between two reads; once the labeler (Slice 2) writes, the next

--- a/apps/aggregator/src/routes/xrpc/getPackage.ts
+++ b/apps/aggregator/src/routes/xrpc/getPackage.ts
@@ -12,12 +12,15 @@
 import { json, XRPCError } from "@atcute/xrpc-server";
 import { type AggregatorDefs, type AggregatorGetPackage } from "@emdash-cms/registry-lexicons";
 
-import { type PackageRow, packageColumns, packageView } from "./views.js";
+import { parseSignatureMetadataCid } from "../../utils.js";
+import { hydrateLabels, isRedacted } from "./label-enforcement.js";
+import { getRequestLabelerPolicy } from "./request-policy.js";
+import { type PackageRow, packageColumns, packageUri, packageView } from "./views.js";
 
 export async function getPackage(
 	env: Env,
 	params: AggregatorGetPackage.$params,
-	_request: Request,
+	request: Request,
 ): Promise<Response> {
 	// `first-primary` because the same row could become subject to a takedown
 	// label between two reads; once the labeler (Slice 2) writes, the next
@@ -34,6 +37,28 @@ export async function getPackage(
 			message: `No package indexed under (${params.did}, ${params.slug}).`,
 		});
 	}
-	const view: AggregatorDefs.PackageView = packageView(row);
+
+	const { accepted } = getRequestLabelerPolicy(request);
+	const uri = packageUri(row);
+	const labelsByUri = await hydrateLabels(
+		session,
+		accepted,
+		[
+			{ uri, currentCid: parseSignatureMetadataCid(row.signature_metadata) ?? undefined },
+			{ uri: row.did },
+		],
+		Date.now(),
+	);
+	const labels = [...(labelsByUri.get(uri) ?? []), ...(labelsByUri.get(row.did) ?? [])];
+	if (isRedacted(labels, accepted)) {
+		// Indistinguishable from absence — that is what redaction means.
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No package indexed under (${params.did}, ${params.slug}).`,
+		});
+	}
+
+	const view: AggregatorDefs.PackageView = packageView(row, labels);
 	return json(view);
 }

--- a/apps/aggregator/src/routes/xrpc/label-enforcement.ts
+++ b/apps/aggregator/src/routes/xrpc/label-enforcement.ts
@@ -1,0 +1,229 @@
+/**
+ * Shared label enforcement (SQL exclusion) and hydration (view `labels`)
+ * for the Read API, keyed off the request's accepted-labeler policy
+ * (W4.4, `request-policy.ts`).
+ *
+ * Two separate concerns live here:
+ *   - `build*EnforcementSql` appends a `NOT EXISTS` clause that excludes
+ *     subjects carrying a hard-block label from an accepted source. Used
+ *     for search (page-level filtering) and latest-release selection.
+ *   - `hydrateLabels` fetches the actual label rows for a set of subjects
+ *     so views can carry them on the wire; `isRedacted` then decides
+ *     whether a `redact: true` source's `!takedown` should turn a 200
+ *     into a 404 (`getPackage`/`resolvePackage`/`listReleases`).
+ *
+ * Both builders take `nowMs` explicitly (rather than calling `Date.now()`
+ * internally) so a single request's SQL-side exclusion and hydration pass
+ * agree on the same instant.
+ */
+
+import { NSID } from "@emdash-cms/registry-lexicons";
+import {
+	PACKAGE_SCOPE_BLOCK_VALUES,
+	RELEASE_BLOCK_VALUES,
+	type AcceptedLabelerPolicy,
+} from "@emdash-cms/registry-moderation";
+
+/** Keeps a hydration query's `uri IN (...)` clause within D1's
+ * bound-parameter limit when a page carries many subjects. */
+const HYDRATION_CHUNK_SIZE = 50;
+/** Matches the lexicon's `labels` maxLength on both `packageView` and
+ * `releaseView`. Applied only at the view boundary (`capLabels`), never to
+ * hydration results — redaction decisions must see the full label set. */
+export const LABELS_MAX_LENGTH = 64;
+
+export interface EnforcementSql {
+	sql: string;
+	bindings: unknown[];
+}
+
+/** Matches `com.atproto.label.defs#label`'s optional fields; hydrated
+ * views never carry `sig` or `ver` (nor `neg` — only active labels are
+ * hydrated in the first place). */
+export interface LabelView {
+	src: string;
+	uri: string;
+	cid?: string;
+	val: string;
+	cts: string;
+	exp?: string;
+}
+
+export interface HydrationSubject {
+	uri: string;
+	/** Omit for a subject with no single current version (publisher DIDs).
+	 * A CID-bound label never applies to such a subject. */
+	currentCid?: string;
+}
+
+function inClause(values: readonly string[]): string {
+	return values.map(() => "?").join(", ");
+}
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+	const out: T[][] = [];
+	for (let index = 0; index < items.length; index += size)
+		out.push(items.slice(index, index + size));
+	return out;
+}
+
+/**
+ * `NOT EXISTS` clause excluding a package whose profile URI or publisher
+ * DID carries an active, unexpired `PACKAGE_SCOPE_BLOCK_VALUES` label from
+ * an accepted source. Empty `accepted` is a no-op (no enforcement without
+ * an accepted policy to enforce). All values — source DIDs, label values,
+ * `nowMs` — are bound parameters; only the compile-time NSID constant is
+ * interpolated into the SQL text.
+ *
+ * Deliberately BROADER than `evaluateReleaseModeration`'s subject rules,
+ * always in the fail-closed (over-hide) direction: the shared CID predicate
+ * lets a CID-bound label match at DID scope, and value/subject pairings the
+ * evaluator would reject (e.g. `publisher-compromised` on a package URI)
+ * still exclude here. Read enforcement hides; the evaluator remains the
+ * only eligibility engine.
+ */
+export function buildPackageEnforcementSql(
+	accepted: AcceptedLabelerPolicy[],
+	nowMs: number,
+	alias = "p.",
+): EnforcementSql {
+	if (accepted.length === 0) return { sql: "", bindings: [] };
+	const srcs = accepted.map((policy) => policy.did);
+	const sql = `
+		AND NOT EXISTS (
+			SELECT 1 FROM label_state ls
+			WHERE ls.src IN (${inClause(srcs)})
+			  AND ls.val IN (${inClause(PACKAGE_SCOPE_BLOCK_VALUES)})
+			  AND (ls.uri = 'at://' || ${alias}did || '/${NSID.packageProfile}/' || ${alias}slug OR ls.uri = ${alias}did)
+			  AND ls.neg = 0
+			  AND (ls.exp_epoch_ms IS NULL OR ls.exp_epoch_ms > ?)
+			  AND (ls.cid IS NULL OR ls.cid = json_extract(${alias}signature_metadata, '$.cid'))
+		)
+	`;
+	return { sql, bindings: [...srcs, ...PACKAGE_SCOPE_BLOCK_VALUES, nowMs] };
+}
+
+export interface ReleaseEnforcementAliases {
+	/** Alias (with trailing dot) of the `releases` row. Default `"r."`. */
+	release?: string;
+	/** Alias (with trailing dot) of the joined `packages` row, needed for
+	 * the package-scope cascade's CID comparison. Default `"p."`. */
+	package?: string;
+}
+
+/**
+ * `NOT EXISTS` clause excluding a release whose own URI carries a
+ * `RELEASE_BLOCK_VALUES` label, or whose parent package URI / publisher DID
+ * carries a `PACKAGE_SCOPE_BLOCK_VALUES` label (cascade), from an accepted
+ * source. Requires the `packages` row joined under `aliases.package` — the
+ * package-scope branch's CID comparison reads its `signature_metadata`.
+ */
+export function buildReleaseEnforcementSql(
+	accepted: AcceptedLabelerPolicy[],
+	nowMs: number,
+	aliases: ReleaseEnforcementAliases = {},
+): EnforcementSql {
+	if (accepted.length === 0) return { sql: "", bindings: [] };
+	const releaseAlias = aliases.release ?? "r.";
+	const packageAlias = aliases.package ?? "p.";
+	const srcs = accepted.map((policy) => policy.did);
+	const sql = `
+		AND NOT EXISTS (
+			SELECT 1 FROM label_state ls
+			WHERE ls.src IN (${inClause(srcs)})
+			  AND ls.neg = 0
+			  AND (ls.exp_epoch_ms IS NULL OR ls.exp_epoch_ms > ?)
+			  AND (
+					(
+						ls.uri = 'at://' || ${releaseAlias}did || '/${NSID.packageRelease}/' || ${releaseAlias}rkey
+						AND ls.val IN (${inClause(RELEASE_BLOCK_VALUES)})
+						AND (ls.cid IS NULL OR ls.cid = json_extract(${releaseAlias}signature_metadata, '$.cid'))
+					)
+					OR
+					(
+						(ls.uri = 'at://' || ${packageAlias}did || '/${NSID.packageProfile}/' || ${packageAlias}slug OR ls.uri = ${releaseAlias}did)
+						AND ls.val IN (${inClause(PACKAGE_SCOPE_BLOCK_VALUES)})
+						AND (ls.cid IS NULL OR ls.cid = json_extract(${packageAlias}signature_metadata, '$.cid'))
+					)
+			  )
+		)
+	`;
+	return {
+		sql,
+		bindings: [...srcs, nowMs, ...RELEASE_BLOCK_VALUES, ...PACKAGE_SCOPE_BLOCK_VALUES],
+	};
+}
+
+interface LabelStateRow {
+	src: string;
+	uri: string;
+	cid: string | null;
+	val: string;
+	cts: string;
+	exp: string | null;
+}
+
+/**
+ * Fetches active, unexpired label rows from accepted sources for a set of
+ * subjects, applying CID applicability app-side (a CID-bound label applies
+ * only when it matches the subject's current CID; `cid IS NULL` is
+ * URI-wide). Returns a `Map` keyed by subject URI — callers combine the
+ * entries relevant to one view (e.g. release + package + publisher URIs).
+ *
+ * Returns UNTRUNCATED label sets: `isRedacted` must see every applicable
+ * label, or a `!takedown` past a truncation boundary silently un-redacts
+ * the subject. The lexicon's 64-label wire cap is applied by the views
+ * (`capLabels`), after redaction has been decided.
+ */
+export async function hydrateLabels(
+	db: D1DatabaseSession,
+	accepted: AcceptedLabelerPolicy[],
+	subjects: HydrationSubject[],
+	nowMs: number,
+): Promise<Map<string, LabelView[]>> {
+	const out = new Map<string, LabelView[]>();
+	if (accepted.length === 0 || subjects.length === 0) return out;
+
+	const currentCidByUri = new Map<string, string | undefined>();
+	const uris: string[] = [];
+	for (const subject of subjects) {
+		if (!currentCidByUri.has(subject.uri)) uris.push(subject.uri);
+		currentCidByUri.set(subject.uri, subject.currentCid);
+	}
+	const srcs = accepted.map((policy) => policy.did);
+
+	for (const batch of chunk(uris, HYDRATION_CHUNK_SIZE)) {
+		const result = await db
+			.prepare(
+				`SELECT src, uri, cid, val, cts, exp
+				 FROM label_state
+				 WHERE uri IN (${inClause(batch)})
+				   AND src IN (${inClause(srcs)})
+				   AND neg = 0
+				   AND (exp_epoch_ms IS NULL OR exp_epoch_ms > ?)`,
+			)
+			.bind(...batch, ...srcs, nowMs)
+			.all<LabelStateRow>();
+
+		for (const row of result.results ?? []) {
+			const currentCid = currentCidByUri.get(row.uri);
+			if (row.cid !== null && row.cid !== currentCid) continue;
+			const label: LabelView = { src: row.src, uri: row.uri, val: row.val, cts: row.cts };
+			if (row.cid !== null) label.cid = row.cid;
+			if (row.exp !== null) label.exp = row.exp;
+			const existing = out.get(row.uri);
+			if (existing) existing.push(label);
+			else out.set(row.uri, [label]);
+		}
+	}
+
+	return out;
+}
+
+/** True iff any hydrated label is an active `!takedown` from a source
+ * whose accepted policy has `redact: true`. Applicability (CID scoping,
+ * expiry, negation) was already established by `hydrateLabels`. */
+export function isRedacted(labels: LabelView[], accepted: AcceptedLabelerPolicy[]): boolean {
+	const redactBySrc = new Map(accepted.map((policy) => [policy.did, policy.redact]));
+	return labels.some((label) => label.val === "!takedown" && redactBySrc.get(label.src) === true);
+}

--- a/apps/aggregator/src/routes/xrpc/listReleases.ts
+++ b/apps/aggregator/src/routes/xrpc/listReleases.ts
@@ -13,8 +13,11 @@
 import { InvalidRequestError, json, XRPCError } from "@atcute/xrpc-server";
 import { type AggregatorDefs, type AggregatorListReleases } from "@emdash-cms/registry-lexicons";
 
+import { parseSignatureMetadataCid } from "../../utils.js";
 import { decodeListCursor, encodeListCursor, InvalidCursorError } from "./cursor.js";
-import { type ReleaseRow, releaseColumns, releaseView } from "./views.js";
+import { type HydrationSubject, hydrateLabels, isRedacted } from "./label-enforcement.js";
+import { getRequestLabelerPolicy } from "./request-policy.js";
+import { type ReleaseRow, packageUri, releaseColumns, releaseUri, releaseView } from "./views.js";
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
@@ -22,21 +25,24 @@ const MAX_LIMIT = 100;
 export async function listReleases(
 	env: Env,
 	params: AggregatorListReleases.$params,
-	_request: Request,
+	request: Request,
 ): Promise<Response> {
 	const limit = clampLimit(params.limit);
 	const session = env.DB.withSession("first-primary");
+	const { accepted } = getRequestLabelerPolicy(request);
+	const nowMs = Date.now();
 
-	// Confirm parent package exists. One extra D1 read per request — could be
-	// folded into a JOIN, but the explicit existence check keeps the NotFound
-	// signal cheap and unambiguous (the empty-list response shape would
-	// otherwise mean "package exists, no releases" or "package doesn't exist"
-	// indistinguishably).
-	const parentExists = await session
-		.prepare(`SELECT 1 AS hit FROM packages WHERE did = ? AND slug = ?`)
+	// Confirm parent package exists, fetching its `signature_metadata` too —
+	// package-scope hydration below needs the current CID. One extra D1 read
+	// per request — could be folded into a JOIN, but the explicit existence
+	// check keeps the NotFound signal cheap and unambiguous (the empty-list
+	// response shape would otherwise mean "package exists, no releases" or
+	// "package doesn't exist" indistinguishably).
+	const parent = await session
+		.prepare(`SELECT signature_metadata FROM packages WHERE did = ? AND slug = ?`)
 		.bind(params.did, params.package)
-		.first<{ hit: number }>();
-	if (!parentExists) {
+		.first<{ signature_metadata: string | null }>();
+	if (!parent) {
 		throw new XRPCError({
 			status: 404,
 			error: "NotFound",
@@ -85,14 +91,57 @@ export async function listReleases(
 	// Read limit+1 to detect a next page without a trailing COUNT query.
 	const hasMore = items.length > limit;
 	const page = hasMore ? items.slice(0, limit) : items;
+	// Cursor derives from the last FETCHED row, before label-redaction
+	// filtering below — a page shortened by redacted omissions must still
+	// advance the cursor past every row the caller saw, not just the ones
+	// it returned.
 	const last = page.at(-1);
+
+	const parentPackageUri = packageUri({ did: params.did, slug: params.package });
+	const parentPackageCid = parseSignatureMetadataCid(parent.signature_metadata) ?? undefined;
+	const subjects: HydrationSubject[] = [
+		{ uri: parentPackageUri, currentCid: parentPackageCid },
+		{ uri: params.did },
+	];
+	for (const row of page) {
+		subjects.push({
+			uri: releaseUri(row),
+			currentCid: parseSignatureMetadataCid(row.signature_metadata) ?? undefined,
+		});
+	}
+	const labelsByUri = await hydrateLabels(session, accepted, subjects, nowMs);
+
+	// A redacted parent package must be indistinguishable from an absent one,
+	// matching getPackage — a 200 with an empty list would leak that the
+	// package exists but was taken down.
+	const parentLabels = [
+		...(labelsByUri.get(parentPackageUri) ?? []),
+		...(labelsByUri.get(params.did) ?? []),
+	];
+	if (isRedacted(parentLabels, accepted)) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No package indexed under (${params.did}, ${params.package}).`,
+		});
+	}
+
+	const releases: AggregatorDefs.ReleaseView[] = [];
+	for (const row of page) {
+		const uri = releaseUri(row);
+		const labels = [
+			...(labelsByUri.get(uri) ?? []),
+			...(labelsByUri.get(parentPackageUri) ?? []),
+			...(labelsByUri.get(params.did) ?? []),
+		];
+		if (isRedacted(labels, accepted)) continue;
+		releases.push(releaseView(row, labels));
+	}
 
 	const response: {
 		releases: AggregatorDefs.ReleaseView[];
 		cursor?: string;
-	} = {
-		releases: page.map(releaseView),
-	};
+	} = { releases };
 	if (hasMore && last) {
 		// Cursor encodes the internal `version_sort` format. If the
 		// `computeVersionSort` encoding ever changes, in-flight cursors

--- a/apps/aggregator/src/routes/xrpc/listReleases.ts
+++ b/apps/aggregator/src/routes/xrpc/listReleases.ts
@@ -149,6 +149,12 @@ export async function listReleases(
 		// 400 (per the strict-cursor policy) and fall back to fetching
 		// page 1. Acceptable for the experimental NSID; revisit if/when
 		// we stabilise.
+		//
+		// An all-redacted page returns an empty list WITH a cursor, which
+		// lets a caller infer hidden rows exist. Accepted trade-off: the
+		// alternatives either stop pagination early (cursor only when a row
+		// survived) or re-page server-side until the page fills. Package-
+		// level redaction — the sensitive case — 404s above instead.
 		response.cursor = encodeListCursor({ versionSort: last.version_sort, version: last.version });
 	}
 	return json(response);

--- a/apps/aggregator/src/routes/xrpc/listReleases.ts
+++ b/apps/aggregator/src/routes/xrpc/listReleases.ts
@@ -22,6 +22,7 @@ const MAX_LIMIT = 100;
 export async function listReleases(
 	env: Env,
 	params: AggregatorListReleases.$params,
+	_request: Request,
 ): Promise<Response> {
 	const limit = clampLimit(params.limit);
 	const session = env.DB.withSession("first-primary");

--- a/apps/aggregator/src/routes/xrpc/request-policy.ts
+++ b/apps/aggregator/src/routes/xrpc/request-policy.ts
@@ -1,0 +1,109 @@
+/**
+ * Resolves the accepted-labelers policy for one aggregator request from the
+ * `atproto-accept-labelers` request header (W4.4). `handleXrpc` resolves this
+ * once per request before dispatch; handlers read the result back via
+ * `getRequestLabelerPolicy`.
+ */
+
+import { InvalidRequestError } from "@atcute/xrpc-server";
+import {
+	InvalidAcceptLabelersHeaderError,
+	parseAcceptLabelersHeader,
+	serializeContentLabelersHeader,
+	type AcceptedLabelerPolicy,
+} from "@emdash-cms/registry-moderation";
+
+const ACCEPT_LABELERS_HEADER = "atproto-accept-labelers";
+// Keeps `IN (...)` clauses within D1's bound-parameter limit.
+const AVAILABILITY_CHUNK_SIZE = 50;
+
+export interface RequestLabelerPolicy {
+	/** Effective, deduped, availability-filtered accepted labelers. */
+	accepted: AcceptedLabelerPolicy[];
+	/** `atproto-content-labelers` header value; "" means the header is omitted. */
+	contentLabelersHeader: string;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+	const out: T[][] = [];
+	for (let index = 0; index < items.length; index += size)
+		out.push(items.slice(index, index + size));
+	return out;
+}
+
+async function defaultAcceptedPolicy(env: Env): Promise<AcceptedLabelerPolicy[]> {
+	const session = env.DB.withSession("first-primary");
+	const result = await session
+		.prepare(`SELECT did FROM labelers WHERE trusted = 1 ORDER BY did ASC`)
+		.all<{ did: string }>();
+	return (result.results ?? []).map((row) => ({ did: row.did, redact: true }));
+}
+
+/** Drops requested DIDs the deployment doesn't ingest, preserving request order. */
+async function filterAvailable(
+	env: Env,
+	requested: AcceptedLabelerPolicy[],
+): Promise<AcceptedLabelerPolicy[]> {
+	if (requested.length === 0) return [];
+	const session = env.DB.withSession("first-primary");
+	const available = new Set<string>();
+	for (const batch of chunk(
+		requested.map((policy) => policy.did),
+		AVAILABILITY_CHUNK_SIZE,
+	)) {
+		const placeholders = batch.map(() => "?").join(", ");
+		const result = await session
+			.prepare(`SELECT did FROM labelers WHERE did IN (${placeholders})`)
+			.bind(...batch)
+			.all<{ did: string }>();
+		for (const row of result.results ?? []) available.add(row.did);
+	}
+	return requested.filter((policy) => available.has(policy.did));
+}
+
+const requestPolicies = new WeakMap<Request, RequestLabelerPolicy>();
+
+/**
+ * Resolves and stashes the request's labeler policy. Call exactly once per
+ * request, before dispatching to a handler. Throws `InvalidRequestError` for
+ * malformed header syntax; any other rejection (e.g. a D1 error) propagates
+ * as-is so the caller 500s rather than failing open to an empty policy.
+ */
+export async function resolveRequestLabelerPolicy(
+	env: Env,
+	request: Request,
+): Promise<RequestLabelerPolicy> {
+	const header = request.headers.get(ACCEPT_LABELERS_HEADER);
+	let accepted: AcceptedLabelerPolicy[];
+	if (header === null) {
+		accepted = await defaultAcceptedPolicy(env);
+	} else {
+		let requested: AcceptedLabelerPolicy[];
+		try {
+			requested = parseAcceptLabelersHeader(header);
+		} catch (err) {
+			if (err instanceof InvalidAcceptLabelersHeaderError) {
+				throw new InvalidRequestError({
+					message: `invalid ${ACCEPT_LABELERS_HEADER} header: ${err.message}`,
+				});
+			}
+			throw err;
+		}
+		accepted = await filterAvailable(env, requested);
+	}
+	const policy: RequestLabelerPolicy = {
+		accepted,
+		contentLabelersHeader: serializeContentLabelersHeader(accepted),
+	};
+	requestPolicies.set(request, policy);
+	return policy;
+}
+
+/** Reads back the policy `resolveRequestLabelerPolicy` stashed for this request. */
+export function getRequestLabelerPolicy(request: Request): RequestLabelerPolicy {
+	const policy = requestPolicies.get(request);
+	if (!policy) {
+		throw new Error("request labeler policy was not resolved before handler dispatch");
+	}
+	return policy;
+}

--- a/apps/aggregator/src/routes/xrpc/resolvePackage.ts
+++ b/apps/aggregator/src/routes/xrpc/resolvePackage.ts
@@ -50,6 +50,7 @@ function getHandleResolver(): CompositeHandleResolver {
 export async function resolvePackage(
 	env: Env,
 	params: AggregatorResolvePackage.$params,
+	_request: Request,
 ): Promise<Response> {
 	let did: string;
 	try {

--- a/apps/aggregator/src/routes/xrpc/resolvePackage.ts
+++ b/apps/aggregator/src/routes/xrpc/resolvePackage.ts
@@ -25,8 +25,10 @@ import {
 import { json, XRPCError } from "@atcute/xrpc-server";
 import { type AggregatorResolvePackage } from "@emdash-cms/registry-lexicons";
 
-import { boundFetch } from "../../utils.js";
-import { type PackageRow, packageColumns, packageView } from "./views.js";
+import { boundFetch, parseSignatureMetadataCid } from "../../utils.js";
+import { hydrateLabels, isRedacted } from "./label-enforcement.js";
+import { getRequestLabelerPolicy } from "./request-policy.js";
+import { type PackageRow, packageColumns, packageUri, packageView } from "./views.js";
 
 /** Cache the resolver per worker isolate. Construction is allocation-only
  * (no I/O), but reusing a single instance avoids per-request setup. */
@@ -50,7 +52,7 @@ function getHandleResolver(): CompositeHandleResolver {
 export async function resolvePackage(
 	env: Env,
 	params: AggregatorResolvePackage.$params,
-	_request: Request,
+	request: Request,
 ): Promise<Response> {
 	let did: string;
 	try {
@@ -78,7 +80,28 @@ export async function resolvePackage(
 			message: `No package indexed under resolved (${did}, ${params.slug}).`,
 		});
 	}
-	const view = packageView(row);
+
+	const { accepted } = getRequestLabelerPolicy(request);
+	const uri = packageUri(row);
+	const labelsByUri = await hydrateLabels(
+		session,
+		accepted,
+		[
+			{ uri, currentCid: parseSignatureMetadataCid(row.signature_metadata) ?? undefined },
+			{ uri: row.did },
+		],
+		Date.now(),
+	);
+	const labels = [...(labelsByUri.get(uri) ?? []), ...(labelsByUri.get(row.did) ?? [])];
+	if (isRedacted(labels, accepted)) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No package indexed under resolved (${did}, ${params.slug}).`,
+		});
+	}
+
+	const view = packageView(row, labels);
 	// Surface the handle we resolved — the lexicon's view has an optional
 	// `handle` field for exactly this case (best-effort current handle).
 	view.handle = params.handle;

--- a/apps/aggregator/src/routes/xrpc/router.ts
+++ b/apps/aggregator/src/routes/xrpc/router.ts
@@ -21,7 +21,7 @@
  *     (immutable bytes).
  */
 
-import { XRPCRouter } from "@atcute/xrpc-server";
+import { XRPCError, XRPCRouter } from "@atcute/xrpc-server";
 import {
 	AggregatorGetLatestRelease,
 	AggregatorGetPackage,
@@ -33,6 +33,7 @@ import {
 import { getLatestRelease } from "./getLatestRelease.js";
 import { getPackage } from "./getPackage.js";
 import { listReleases } from "./listReleases.js";
+import { resolveRequestLabelerPolicy } from "./request-policy.js";
 import { resolvePackage } from "./resolvePackage.js";
 import { searchPackages } from "./searchPackages.js";
 import { syncGetRecord } from "./sync-get-record.js";
@@ -51,15 +52,16 @@ const SYNC_GET_RECORD_PATH = "/xrpc/com.atproto.sync.getRecord";
  * `*` is correct here because nothing in our responses depends on the
  * caller's origin or credentials -- there are no cookies, no auth, no
  * per-origin policy. We allow `atproto-accept-labelers` and
- * `content-type` as request headers (the only two clients send), echo
- * back the labelers header for symmetry with atproto's labeler-aware
- * clients, and cap preflight cache at 24h.
+ * `content-type` as request headers (the only two clients send), expose
+ * the response headers a labeler-aware client needs to read
+ * (`atproto-content-labelers`, `content-language`), and cap preflight
+ * cache at 24h.
  */
 const CORS_HEADERS: Record<string, string> = {
 	"access-control-allow-origin": "*",
 	"access-control-allow-methods": "GET, POST, OPTIONS",
 	"access-control-allow-headers": "content-type, atproto-accept-labelers",
-	"access-control-expose-headers": "atproto-accept-labelers, content-language",
+	"access-control-expose-headers": "atproto-content-labelers, content-language",
 	"access-control-max-age": "86400",
 };
 
@@ -97,6 +99,24 @@ export async function handleXrpc(env: Env, request: Request): Promise<Response |
 		});
 	}
 
+	// Resolve the accepted-labelers policy once, before dispatch, so every
+	// handler sees the same policy the response's `atproto-content-labelers`
+	// header reports below. A malformed header 400s in the same envelope
+	// shape the router itself produces for InvalidRequest; any other failure
+	// (e.g. a D1 error) propagates so the caller 500s instead of the request
+	// silently falling open to an empty policy.
+	let policy: Awaited<ReturnType<typeof resolveRequestLabelerPolicy>>;
+	try {
+		policy = await resolveRequestLabelerPolicy(env, request);
+	} catch (err) {
+		if (!(err instanceof XRPCError)) throw err;
+		const errorResponse = err.toResponse();
+		const headers = new Headers(errorResponse.headers);
+		headers.set("cache-control", NO_STORE);
+		applyCorsHeaders(headers);
+		return new Response(errorResponse.body, { status: errorResponse.status, headers });
+	}
+
 	const router = getRouter(env);
 	const response = await router.fetch(request);
 	// Override Cache-Control unconditionally on aggregator endpoints — the
@@ -109,6 +129,9 @@ export async function handleXrpc(env: Env, request: Request): Promise<Response |
 	const headers = new Headers(response.headers);
 	headers.set("cache-control", NO_STORE);
 	applyCorsHeaders(headers);
+	if (policy.contentLabelersHeader !== "") {
+		headers.set("atproto-content-labelers", policy.contentLabelersHeader);
+	}
 	return new Response(response.body, {
 		status: response.status,
 		statusText: response.statusText,
@@ -134,19 +157,19 @@ function getRouter(env: Env): XRPCRouter {
 function createRouter(env: Env): XRPCRouter {
 	const router = new XRPCRouter();
 	router.addQuery(AggregatorGetPackage.mainSchema, {
-		handler: ({ params }) => getPackage(env, params),
+		handler: ({ params, request }) => getPackage(env, params, request),
 	});
 	router.addQuery(AggregatorListReleases.mainSchema, {
-		handler: ({ params }) => listReleases(env, params),
+		handler: ({ params, request }) => listReleases(env, params, request),
 	});
 	router.addQuery(AggregatorGetLatestRelease.mainSchema, {
-		handler: ({ params }) => getLatestRelease(env, params),
+		handler: ({ params, request }) => getLatestRelease(env, params, request),
 	});
 	router.addQuery(AggregatorSearchPackages.mainSchema, {
-		handler: ({ params }) => searchPackages(env, params),
+		handler: ({ params, request }) => searchPackages(env, params, request),
 	});
 	router.addQuery(AggregatorResolvePackage.mainSchema, {
-		handler: ({ params }) => resolvePackage(env, params),
+		handler: ({ params, request }) => resolvePackage(env, params, request),
 	});
 	return router;
 }

--- a/apps/aggregator/src/routes/xrpc/searchPackages.ts
+++ b/apps/aggregator/src/routes/xrpc/searchPackages.ts
@@ -9,10 +9,10 @@
  * pagination scans more rows. At Slice 1 scale (hundreds of packages) it's
  * a non-issue.
  *
- * Takedown filter joins `label_state` even though that table is empty in
- * Slice 1 — keeps the contract honest for Slice 2 (when the labeler starts
- * writing), and the optimiser short-circuits the NOT EXISTS subquery
- * cheaply when no rows match. See plan §Search.
+ * Enforcement excludes packages carrying an active `PACKAGE_SCOPE_BLOCK_VALUES`
+ * label from a source the request's accepted-labeler policy (W4.4) covers —
+ * see `buildPackageEnforcementSql`. Other label state is hydrated on each
+ * page result so clients can make their own eligibility call.
  *
  * `q` is passed directly to FTS5 MATCH. Special characters in user input
  * are escaped via `quoteFtsQuery` so a stray `"`/`*`/`(` doesn't blow up
@@ -21,14 +21,18 @@
  */
 
 import { InvalidRequestError, json } from "@atcute/xrpc-server";
-import {
-	type AggregatorDefs,
-	NSID,
-	type AggregatorSearchPackages,
-} from "@emdash-cms/registry-lexicons";
+import { type AggregatorDefs, type AggregatorSearchPackages } from "@emdash-cms/registry-lexicons";
 
+import { parseSignatureMetadataCid } from "../../utils.js";
 import { decodeOffsetCursor, encodeOffsetCursor, InvalidCursorError } from "./cursor.js";
-import { type PackageRow, packageColumns, packageView } from "./views.js";
+import {
+	buildPackageEnforcementSql,
+	type EnforcementSql,
+	type HydrationSubject,
+	hydrateLabels,
+} from "./label-enforcement.js";
+import { getRequestLabelerPolicy } from "./request-policy.js";
+import { type PackageRow, packageColumns, packageUri, packageView } from "./views.js";
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
@@ -36,7 +40,7 @@ const MAX_LIMIT = 100;
 export async function searchPackages(
 	env: Env,
 	params: AggregatorSearchPackages.$params,
-	_request: Request,
+	request: Request,
 ): Promise<Response> {
 	const limit = clampLimit(params.limit);
 	let offset: number;
@@ -49,6 +53,9 @@ export async function searchPackages(
 		throw err;
 	}
 	const session = env.DB.withSession("first-primary");
+	const { accepted } = getRequestLabelerPolicy(request);
+	const nowMs = Date.now();
+	const enforcement = buildPackageEnforcementSql(accepted, nowMs);
 
 	const hasQuery = typeof params.q === "string" && params.q.trim().length > 0;
 	const hasCapability = typeof params.capability === "string" && params.capability.length > 0;
@@ -57,10 +64,11 @@ export async function searchPackages(
 	if (hasQuery) {
 		const ftsQuery = quoteFtsQuery(params.q!);
 		const result = await session
-			.prepare(buildFtsSearchSql(hasCapability))
+			.prepare(buildFtsSearchSql(hasCapability, enforcement.sql))
 			.bind(
 				...buildFtsBindings(
 					ftsQuery,
+					enforcement.bindings,
 					hasCapability ? params.capability : undefined,
 					limit + 1,
 					offset,
@@ -72,9 +80,14 @@ export async function searchPackages(
 		// No query → ordered list of all packages, label-filtered. last_updated
 		// DESC keeps the "what's new" view sensible for an empty search box.
 		const result = await session
-			.prepare(buildBrowseSql(hasCapability))
+			.prepare(buildBrowseSql(hasCapability, enforcement.sql))
 			.bind(
-				...buildBrowseBindings(hasCapability ? params.capability : undefined, limit + 1, offset),
+				...buildBrowseBindings(
+					enforcement.bindings,
+					hasCapability ? params.capability : undefined,
+					limit + 1,
+					offset,
+				),
 			)
 			.all<PackageRow>();
 		rows = result.results ?? [];
@@ -83,23 +96,41 @@ export async function searchPackages(
 	const hasMore = rows.length > limit;
 	const page = hasMore ? rows.slice(0, limit) : rows;
 
+	const subjects: HydrationSubject[] = [];
+	const seenDids = new Set<string>();
+	for (const row of page) {
+		subjects.push({
+			uri: packageUri(row),
+			currentCid: parseSignatureMetadataCid(row.signature_metadata) ?? undefined,
+		});
+		if (!seenDids.has(row.did)) {
+			seenDids.add(row.did);
+			subjects.push({ uri: row.did });
+		}
+	}
+	const labelsByUri = await hydrateLabels(session, accepted, subjects, nowMs);
+
 	const response: {
 		packages: AggregatorDefs.PackageView[];
 		cursor?: string;
 	} = {
-		packages: page.map(packageView),
+		packages: page.map((row) => {
+			const uri = packageUri(row);
+			const labels = [...(labelsByUri.get(uri) ?? []), ...(labelsByUri.get(row.did) ?? [])];
+			return packageView(row, labels);
+		}),
 	};
 	if (hasMore) response.cursor = encodeOffsetCursor({ offset: offset + limit });
 	return json(response);
 }
 
-function buildFtsSearchSql(hasCapability: boolean): string {
+function buildFtsSearchSql(hasCapability: boolean, enforcementSql: string): string {
 	return `
 		SELECT ${packageColumns("p.")}
 		FROM packages_fts
 		JOIN packages p ON p.rowid = packages_fts.rowid
 		WHERE packages_fts MATCH ?
-		${ENFORCEMENT_FILTER_SQL}
+		${enforcementSql}
 		${hasCapability ? CAPABILITY_FILTER_SQL : ""}
 		ORDER BY bm25(packages_fts), p.last_updated DESC, p.did ASC, p.slug ASC
 		LIMIT ? OFFSET ?
@@ -108,17 +139,18 @@ function buildFtsSearchSql(hasCapability: boolean): string {
 
 function buildFtsBindings(
 	ftsQuery: string,
+	enforcementBindings: EnforcementSql["bindings"],
 	capability: string | undefined,
 	limit: number,
 	offset: number,
 ): unknown[] {
-	const out: unknown[] = [ftsQuery];
+	const out: unknown[] = [ftsQuery, ...enforcementBindings];
 	if (capability !== undefined) out.push(capability);
 	out.push(limit, offset);
 	return out;
 }
 
-function buildBrowseSql(hasCapability: boolean): string {
+function buildBrowseSql(hasCapability: boolean, enforcementSql: string): string {
 	// Stable tiebreakers (did, slug) so offset pagination doesn't shuffle
 	// rows across pages when many packages share `last_updated` (or it's
 	// NULL — `last_updated` comes from the optional record.lastUpdated
@@ -128,7 +160,7 @@ function buildBrowseSql(hasCapability: boolean): string {
 		SELECT ${packageColumns("p.")}
 		FROM packages p
 		WHERE 1=1
-		${ENFORCEMENT_FILTER_SQL}
+		${enforcementSql}
 		${hasCapability ? CAPABILITY_FILTER_SQL : ""}
 		ORDER BY p.last_updated IS NULL, p.last_updated DESC, p.did ASC, p.slug ASC
 		LIMIT ? OFFSET ?
@@ -136,31 +168,16 @@ function buildBrowseSql(hasCapability: boolean): string {
 }
 
 function buildBrowseBindings(
+	enforcementBindings: EnforcementSql["bindings"],
 	capability: string | undefined,
 	limit: number,
 	offset: number,
 ): unknown[] {
-	const out: unknown[] = [];
+	const out: unknown[] = [...enforcementBindings];
 	if (capability !== undefined) out.push(capability);
 	out.push(limit, offset);
 	return out;
 }
-
-/** Hard-enforcement label filter. The Slice 2 labeler writes to
- * `label_state`; until then the table is empty so this clause is a no-op
- * (the NOT EXISTS short-circuits). The plan calls for shipping the filter
- * now to lock the contract — adding it later would be a behaviour change
- * for cached clients. */
-const ENFORCEMENT_FILTER_SQL = `
-	AND NOT EXISTS (
-		SELECT 1 FROM label_state ls
-		WHERE ls.uri = 'at://' || p.did || '/${NSID.packageProfile}/' || p.slug
-		  AND ls.val IN ('!takedown', 'security-yanked')
-		  AND ls.trusted = 1
-		  AND ls.neg = 0
-		  AND (ls.exp_epoch_ms IS NULL OR ls.exp_epoch_ms > CAST(strftime('%s', 'now') AS INTEGER) * 1000)
-	)
-`;
 
 const CAPABILITY_FILTER_SQL = `
 	AND p.capabilities IS NOT NULL

--- a/apps/aggregator/src/routes/xrpc/searchPackages.ts
+++ b/apps/aggregator/src/routes/xrpc/searchPackages.ts
@@ -36,6 +36,7 @@ const MAX_LIMIT = 100;
 export async function searchPackages(
 	env: Env,
 	params: AggregatorSearchPackages.$params,
+	_request: Request,
 ): Promise<Response> {
 	const limit = clampLimit(params.limit);
 	let offset: number;

--- a/apps/aggregator/src/routes/xrpc/views.ts
+++ b/apps/aggregator/src/routes/xrpc/views.ts
@@ -21,6 +21,7 @@
 import { type AggregatorDefs, NSID } from "@emdash-cms/registry-lexicons";
 
 import { isPlainObject, parseSignatureMetadataCid } from "../../utils.js";
+import { LABELS_MAX_LENGTH, type LabelView } from "./label-enforcement.js";
 
 /** Subset of columns from `packages` we read for `packageView`. Selecting
  * exactly these columns keeps the SQL query auditable and cheap. */
@@ -107,6 +108,45 @@ export function releaseColumns(prefix = ""): string {
 	return RELEASE_VIEW_COLUMN_NAMES.map((c) => `${prefix}${c}`).join(", ");
 }
 
+/** AT URI of a package's profile record — the `packageView.uri` and the
+ * hydration subject handlers hydrate labels for before calling
+ * `packageView`. Single source of truth so the two never drift. No return
+ * type annotation, and `as const` on the template literal: together these
+ * keep the inferred type as a template-literal pattern rather than
+ * widening to plain `string`, which `packageView.uri`'s `ResourceUri`
+ * type needs. */
+export function packageUri(row: Pick<PackageRow, "did" | "slug">) {
+	return `at://${row.did}/${NSID.packageProfile}/${row.slug}` as const;
+}
+
+/** AT URI of a release record — the `releaseView.uri` and the hydration
+ * subject handlers hydrate labels for before calling `releaseView`. */
+export function releaseUri(row: Pick<ReleaseRow, "did" | "rkey">) {
+	return `at://${row.did}/${NSID.packageRelease}/${row.rkey}` as const;
+}
+
+/** Caps a combined labels array at the lexicon's maxLength. A view's
+ * labels are the union of multiple hydrated subjects (e.g. a release's own
+ * URI plus its parent package and publisher DID), each individually
+ * capped by `hydrateLabels` — the concatenation can still exceed it. */
+function capLabels(labels: LabelView[], uri: string): LabelView[] {
+	if (labels.length <= LABELS_MAX_LENGTH) return labels;
+	console.warn("[aggregator] view labels truncated to maxLength", {
+		uri,
+		count: labels.length,
+		cap: LABELS_MAX_LENGTH,
+	});
+	return labels.slice(0, LABELS_MAX_LENGTH);
+}
+
+/** `LabelView.src` is `string`; the lexicon's `Label.src` is a branded DID
+ * template type. Safe to assert — `src` is a labeler DID validated at
+ * ingest time, same trust boundary as the `did` cast below. */
+function toLexiconLabels(labels: LabelView[]): AggregatorDefs.PackageView["labels"] {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion
+	return labels as AggregatorDefs.PackageView["labels"];
+}
+
 /**
  * Map a `packages` row to the lexicon's `packageView`. The synthesized
  * `profile` field reconstructs the package.profile record JSON from the
@@ -116,9 +156,13 @@ export function releaseColumns(prefix = ""): string {
  * `indexedAt` falls back to `verified_at` for any historical row that
  * predates migration 0002 (`indexed_at` is nullable at the schema level —
  * see migration comment).
+ *
+ * `labels` are hydrated by the caller (package URI + publisher DID
+ * subjects) and passed in; defaulting to `[]` covers the accepted-policy-
+ * empty case where there's nothing to hydrate.
  */
-export function packageView(row: PackageRow): AggregatorDefs.PackageView {
-	const uri = `at://${row.did}/${NSID.packageProfile}/${row.slug}` as const;
+export function packageView(row: PackageRow, labels: LabelView[] = []): AggregatorDefs.PackageView {
+	const uri = packageUri(row);
 	const cid = parseSignatureMetadataCid(row.signature_metadata) ?? "";
 	// `mirrors` is on releaseView, not packageView — packages aren't
 	// mirrored, releases are. Don't add it here even though they share the
@@ -131,7 +175,7 @@ export function packageView(row: PackageRow): AggregatorDefs.PackageView {
 		slug: row.slug,
 		profile: synthesizePackageProfile(row, uri),
 		indexedAt: row.indexed_at ?? row.verified_at,
-		labels: [],
+		labels: toLexiconLabels(capLabels(labels, uri)),
 	};
 	if (row.latest_version !== null) {
 		view.latestVersion = row.latest_version;
@@ -145,9 +189,12 @@ export function packageView(row: PackageRow): AggregatorDefs.PackageView {
  * normalised columns. `mirrors: []` is intentional — the artifact mirror
  * worker (Slice 3) is what populates real mirror URLs; until then the
  * field is the empty contract.
+ *
+ * `labels` are hydrated by the caller (release URI + package URI +
+ * publisher DID subjects, carrying cascade context) and passed in.
  */
-export function releaseView(row: ReleaseRow): AggregatorDefs.ReleaseView {
-	const uri = `at://${row.did}/${NSID.packageRelease}/${row.rkey}` as const;
+export function releaseView(row: ReleaseRow, labels: LabelView[] = []): AggregatorDefs.ReleaseView {
+	const uri = releaseUri(row);
 	const cid = parseSignatureMetadataCid(row.signature_metadata) ?? "";
 	return {
 		uri,
@@ -159,7 +206,7 @@ export function releaseView(row: ReleaseRow): AggregatorDefs.ReleaseView {
 		release: synthesizePackageRelease(row),
 		mirrors: [],
 		indexedAt: row.indexed_at ?? row.verified_at,
-		labels: [],
+		labels: toLexiconLabels(capLabels(labels, uri)),
 	};
 }
 

--- a/apps/aggregator/src/routes/xrpc/views.ts
+++ b/apps/aggregator/src/routes/xrpc/views.ts
@@ -127,8 +127,9 @@ export function releaseUri(row: Pick<ReleaseRow, "did" | "rkey">) {
 
 /** Caps a combined labels array at the lexicon's maxLength. A view's
  * labels are the union of multiple hydrated subjects (e.g. a release's own
- * URI plus its parent package and publisher DID), each individually
- * capped by `hydrateLabels` — the concatenation can still exceed it. */
+ * URI plus its parent package and publisher DID). Hydration returns
+ * untruncated per-subject sets so redaction decisions see every label;
+ * this boundary cap trims only the final view array. */
 function capLabels(labels: LabelView[], uri: string): LabelView[] {
 	if (labels.length <= LABELS_MAX_LENGTH) return labels;
 	console.warn("[aggregator] view labels truncated to maxLength", {

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -26,6 +26,13 @@ const DID_A = "did:plc:read000000000000000000aa";
 const DID_B = "did:plc:read000000000000000000bb";
 const NOW = new Date("2026-05-10T12:00:00.000Z");
 
+/** Default-policy labeler: seeded `trusted = 1` so the missing-header
+ * default (`SELECT did FROM labelers WHERE trusted = 1`) picks it up. */
+const LABELER_DID = "did:web:labels.example";
+/** Configured but untrusted — absent from the default policy, but
+ * available (and echoed) when a request explicitly names it. */
+const UNTRUSTED_LABELER_DID = "did:web:untrusted-labels.example";
+
 beforeAll(async () => {
 	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
 });
@@ -38,6 +45,7 @@ beforeEach(async () => {
 	await testEnv.DB.prepare("DELETE FROM publishers").run();
 	await testEnv.DB.prepare("DELETE FROM publisher_verifications").run();
 	await testEnv.DB.prepare("DELETE FROM label_state").run();
+	await testEnv.DB.prepare("DELETE FROM labelers").run();
 });
 
 interface SeedPackageOpts {
@@ -143,32 +151,59 @@ function packageUri(slug: string, did: string = DID_A): string {
 	return `at://${did}/${NSID.packageProfile}/${slug}`;
 }
 
+function releaseUri(pkg: string, version: string, did: string = DID_A): string {
+	return `at://${did}/${NSID.packageRelease}/${pkg}:${version}`;
+}
+
+/** Seeds a `labelers` row so a DID is "available" per W4.4's resolution:
+ * `trusted = 1` rows feed the missing-header default set; any row (trusted
+ * or not) makes a DID acceptable when explicitly requested. */
+async function seedLabeler(did: string, trusted: boolean): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO labelers (did, endpoint, signing_key, signing_key_id, trusted, added_at, last_resolved_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			did,
+			"https://labeler.example",
+			"unused-in-tests",
+			`${did}#atproto_label`,
+			trusted ? 1 : 0,
+			NOW.toISOString(),
+			NOW.toISOString(),
+		)
+		.run();
+}
+
 async function seedLabelState(opts: {
 	uri: string;
 	val: string;
-	trusted?: boolean;
+	src?: string;
+	cid?: string | null;
 	neg?: boolean;
 	exp?: string;
 }): Promise<void> {
+	const src = opts.src ?? LABELER_DID;
 	await testEnv.DB.prepare(
 		`INSERT INTO label_state
 		   (src, uri, val, cid, neg, cts, cts_epoch_ms, exp, exp_epoch_ms,
 		    digest, source_sequence, frame_index, trusted)
-		 VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	)
 		.bind(
-			"did:web:labels.example",
+			src,
 			opts.uri,
 			opts.val,
+			opts.cid ?? null,
 			opts.neg ? 1 : 0,
 			NOW.toISOString(),
 			NOW.getTime(),
 			opts.exp ?? null,
 			opts.exp === undefined ? null : Date.parse(opts.exp),
-			`digest-${opts.uri}-${opts.val}`,
+			`digest-${src}-${opts.uri}-${opts.val}`,
 			1,
 			0,
-			opts.trusted === false ? 0 : 1,
+			1,
 		)
 		.run();
 }
@@ -238,6 +273,128 @@ describe("getPackage", () => {
 		);
 		const body = (await res.json()) as Record<string, unknown>;
 		expect(body).not.toHaveProperty("latestVersion");
+	});
+
+	it("404s (redacted) when a default-accepted source's !takedown is active", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("NotFound");
+	});
+
+	it("redacts even when the takedown sits beyond the 64-label wire cap", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		for (let i = 0; i < 64; i++) {
+			await seedLabelState({ uri: packageUri("demo"), val: `note-${i}` });
+		}
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("caps wire labels at 64 without affecting the response status", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		for (let i = 0; i < 70; i++) {
+			await seedLabelState({ uri: packageUri("demo"), val: `note-${i}` });
+		}
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { labels: unknown[] };
+		expect(body.labels).toHaveLength(64);
+	});
+
+	it("returns 200 with the label present when the same takedown comes from a non-redact accepted source", async () => {
+		await seedLabeler(UNTRUSTED_LABELER_DID, false);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown", src: UNTRUSTED_LABELER_DID });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+			{ headers: { "atproto-accept-labelers": UNTRUSTED_LABELER_DID } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { labels: Array<{ src: string; val: string }> };
+		expect(body.labels).toContainEqual(
+			expect.objectContaining({ src: UNTRUSTED_LABELER_DID, val: "!takedown" }),
+		);
+	});
+
+	it("hydrates publisher-DID labels alongside package-URI labels", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: DID_A, val: "low-quality" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { labels: Array<{ src: string; uri: string; val: string }> };
+		expect(body.labels).toContainEqual(
+			expect.objectContaining({ src: LABELER_DID, uri: DID_A, val: "low-quality" }),
+		);
+	});
+
+	it("only hydrates unexpired, non-negated labels", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: packageUri("demo"), val: "low-quality" });
+		await seedLabelState({
+			uri: packageUri("demo"),
+			val: "broken-release",
+			exp: new Date(NOW.getTime() - 60_000).toISOString(),
+		});
+		await seedLabelState({ uri: packageUri("demo"), val: "obfuscated-code", neg: true });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { labels: Array<{ val: string }> };
+		expect(body.labels.map((l) => l.val)).toEqual(["low-quality"]);
+	});
+
+	it("sets atproto-content-labelers when the request used the default policy", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.headers.get("atproto-content-labelers")).toBe(`${LABELER_DID};redact`);
+	});
+
+	it("hydrated labels carry only the label spec's optional fields (no sig, no neg)", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: packageUri("demo"), val: "low-quality", cid: null });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		const body = (await res.json()) as { labels: Array<Record<string, unknown>> };
+		expect(body.labels).toHaveLength(1);
+		const label = body.labels[0]!;
+		expect(label).toMatchObject({ src: LABELER_DID, uri: packageUri("demo"), val: "low-quality" });
+		expect(label).toHaveProperty("cts");
+		expect(label).not.toHaveProperty("cid");
+		expect(label).not.toHaveProperty("exp");
+		expect(label).not.toHaveProperty("sig");
+		expect(label).not.toHaveProperty("neg");
+		expect(label).not.toHaveProperty("ver");
 	});
 });
 
@@ -309,6 +466,88 @@ describe("listReleases", () => {
 		);
 		expect(res.status).toBe(400);
 	});
+
+	it("omits a release redacted by a default-accepted source's !takedown", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "2.0.0" });
+		await seedLabelState({ uri: releaseUri("demo", "2.0.0"), val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo`,
+		);
+		const body = (await res.json()) as { releases: Array<{ version: string }> };
+		expect(body.releases.map((r) => r.version)).toEqual(["1.0.0"]);
+	});
+
+	it("returns a blocked-but-not-redacted release with its labels intact", async () => {
+		await seedLabeler(UNTRUSTED_LABELER_DID, false);
+		await seedPackage({ slug: "demo" });
+		await seedRelease({ version: "1.0.0" });
+		await seedLabelState({
+			uri: releaseUri("demo", "1.0.0"),
+			val: "malware",
+			src: UNTRUSTED_LABELER_DID,
+		});
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo`,
+			{ headers: { "atproto-accept-labelers": UNTRUSTED_LABELER_DID } },
+		);
+		const body = (await res.json()) as {
+			releases: Array<{ version: string; labels: Array<{ val: string }> }>;
+		};
+		expect(body.releases.map((r) => r.version)).toEqual(["1.0.0"]);
+		expect(body.releases[0]!.labels).toContainEqual(
+			expect.objectContaining({ src: UNTRUSTED_LABELER_DID, val: "malware" }),
+		);
+	});
+
+	it("404s when the parent package carries a redacted takedown, matching getPackage", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "2.0.0" });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("NotFound");
+	});
+
+	it("pages correctly when a page has redacted omissions", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedRelease({ version: "1.1.0" });
+		await seedRelease({ version: "1.2.0" });
+		await seedRelease({ version: "1.3.0" });
+		await seedRelease({ version: "1.4.0" });
+		// Redact the last item of what would otherwise be the first raw page
+		// ([1.4.0, 1.3.0] at limit=2) — the cursor must still derive from
+		// 1.3.0 (the last row actually fetched), not 1.4.0 (the last row
+		// that survived the redaction filter).
+		await seedLabelState({ uri: releaseUri("demo", "1.3.0"), val: "!takedown" });
+
+		const first = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo&limit=2`,
+		);
+		const firstBody = (await first.json()) as {
+			releases: Array<{ version: string }>;
+			cursor: string;
+		};
+		expect(firstBody.releases.map((r) => r.version)).toEqual(["1.4.0"]);
+		expect(firstBody.cursor).toBeTruthy();
+
+		const second = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo&limit=2&cursor=${encodeURIComponent(firstBody.cursor)}`,
+		);
+		const secondBody = (await second.json()) as { releases: Array<{ version: string }> };
+		expect(secondBody.releases.map((r) => r.version)).toEqual(["1.2.0", "1.1.0"]);
+	});
 });
 
 describe("getLatestRelease", () => {
@@ -359,6 +598,82 @@ describe("getLatestRelease", () => {
 		);
 		expect(res.status).toBe(404);
 	});
+
+	it("skips a hard-blocked highest release in favour of the next-best one", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo", latestVersion: "2.0.0" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "2.0.0" });
+		await seedLabelState({ uri: releaseUri("demo", "2.0.0"), val: "malware" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["version"]).toBe("1.0.0");
+	});
+
+	it("returns 404 when every release is hard-blocked", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo", latestVersion: "1.0.0" });
+		await seedRelease({ version: "1.0.0" });
+		await seedLabelState({ uri: releaseUri("demo", "1.0.0"), val: "malware" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("respects packages.latest_version via the fast path when the accepted policy is empty, even with block labels elsewhere", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo", latestVersion: "1.0.0" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "2.0.0" });
+		// A hard-block label exists, and would exclude 2.0.0 under the
+		// authoritative path — but the empty explicit header disables
+		// enforcement entirely, so this should never be consulted.
+		await seedLabelState({ uri: releaseUri("demo", "2.0.0"), val: "malware" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+			{ headers: { "atproto-accept-labelers": "" } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["version"]).toBe("1.0.0");
+	});
+
+	it("returns 404 on a package-cascade block even when the release itself carries no label", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo", latestVersion: "1.0.0" });
+		await seedRelease({ version: "1.0.0" });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("ignores a release-scope label whose CID no longer matches the current release", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo", latestVersion: "1.0.0" });
+		await seedRelease({ version: "1.0.0", cid: "bafcurrent" });
+		await seedLabelState({
+			uri: releaseUri("demo", "1.0.0"),
+			val: "malware",
+			cid: "bafstale",
+		});
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["version"]).toBe("1.0.0");
+	});
 });
 
 describe("searchPackages", () => {
@@ -404,10 +719,11 @@ describe("searchPackages", () => {
 		expect(overlap).toEqual([]);
 	});
 
-	it("hides a package with an active trusted security-yanked label", async () => {
+	it("hides a package with an active default-accepted !takedown label", async () => {
+		await seedLabeler(LABELER_DID, true);
 		await seedPackage({ slug: "risky" });
 		await seedPackage({ slug: "safe" });
-		await seedLabelState({ uri: packageUri("risky"), val: "security-yanked" });
+		await seedLabelState({ uri: packageUri("risky"), val: "!takedown" });
 
 		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
 		const body = (await res.json()) as { packages: Array<{ slug: string }> };
@@ -415,6 +731,7 @@ describe("searchPackages", () => {
 	});
 
 	it("does not hide a package whose takedown expired, even when the raw exp string compares lexically after now", async () => {
+		await seedLabeler(LABELER_DID, true);
 		await seedPackage({ slug: "recovered" });
 		await seedLabelState({
 			uri: packageUri("recovered"),
@@ -427,13 +744,77 @@ describe("searchPackages", () => {
 		expect(body.packages.map((p) => p.slug)).toEqual(["recovered"]);
 	});
 
-	it("ignores blocking labels from untrusted sources", async () => {
+	it("ignores blocking labels from a source outside the accepted policy", async () => {
+		// Configured but untrusted — the missing-header default only picks up
+		// `trusted = 1` labelers, so this source's label doesn't enforce.
+		await seedLabeler(LABELER_DID, false);
 		await seedPackage({ slug: "demo" });
-		await seedLabelState({ uri: packageUri("demo"), val: "!takedown", trusted: false });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown" });
 
 		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
 		const body = (await res.json()) as { packages: Array<{ slug: string }> };
 		expect(body.packages.map((p) => p.slug)).toEqual(["demo"]);
+	});
+
+	it("enforces a takedown from an explicitly accepted untrusted source", async () => {
+		await seedLabeler(UNTRUSTED_LABELER_DID, false);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({
+			uri: packageUri("demo"),
+			val: "!takedown",
+			src: UNTRUSTED_LABELER_DID,
+		});
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`, {
+			headers: { "atproto-accept-labelers": UNTRUSTED_LABELER_DID },
+		});
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toEqual([]);
+	});
+
+	it("disables enforcement and skips hydration with an explicit empty header", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`, {
+			headers: { "atproto-accept-labelers": "" },
+		});
+		const body = (await res.json()) as { packages: Array<{ slug: string; labels: unknown[] }> };
+		expect(body.packages.map((p) => p.slug)).toEqual(["demo"]);
+		expect(body.packages[0]!.labels).toEqual([]);
+	});
+
+	it("does not hide a package whose label is CID-bound to a stale CID", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo", cid: "bafcurrent" });
+		await seedLabelState({ uri: packageUri("demo"), val: "!takedown", cid: "bafstale" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toEqual(["demo"]);
+	});
+
+	it("hides every package under a publisher DID with an active takedown", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ did: DID_A, slug: "a1" });
+		await seedPackage({ did: DID_A, slug: "a2" });
+		await seedPackage({ did: DID_B, slug: "b1" });
+		await seedLabelState({ uri: DID_A, val: "!takedown" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toEqual(["b1"]);
+	});
+
+	it("hides a package with an active publisher-compromised label", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPackage({ slug: "demo" });
+		await seedLabelState({ uri: packageUri("demo"), val: "publisher-compromised" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toEqual([]);
 	});
 
 	it("doesn't blow up on FTS-unsafe query chars (defensive quoting)", async () => {

--- a/apps/aggregator/test/request-policy.test.ts
+++ b/apps/aggregator/test/request-policy.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Request-scoped labeler-policy resolution (W4.4): the deployment default
+ * when `atproto-accept-labelers` is absent, explicit-header parsing and
+ * availability filtering, and the response-side `atproto-content-labelers` /
+ * CORS surface `router.ts` builds around it. Handlers don't yet act on the
+ * resolved policy (W4.5/W4.6) — these tests only exercise resolution and
+ * the header contract, via `getPackage` as a cheap endpoint.
+ */
+
+import { NSID } from "@emdash-cms/registry-lexicons";
+import { applyD1Migrations, env, SELF } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+
+const NOW = new Date("2026-07-11T12:00:00.000Z");
+const TRUSTED_DID = "did:web:trusted-labeler.example";
+const UNTRUSTED_DID = "did:web:untrusted-labeler.example";
+const UNKNOWN_DID = "did:web:unknown-labeler.example";
+// No package is seeded for this DID/slug; the handler 404s, but resolution
+// and header-setting happen in `handleXrpc` regardless of the response.
+const GET_PACKAGE_URL = `https://test/xrpc/${NSID.aggregatorGetPackage}?did=did:plc:read000000000000000000aa&slug=missing`;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+	await testEnv.DB.prepare("DELETE FROM labelers").run();
+});
+
+async function seedLabeler(did: string, trusted: boolean): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO labelers (did, endpoint, signing_key, signing_key_id, trusted, added_at, last_resolved_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			did,
+			"https://labeler.example",
+			"unused-in-tests",
+			`${did}#atproto_label`,
+			trusted ? 1 : 0,
+			NOW.toISOString(),
+			NOW.toISOString(),
+		)
+		.run();
+}
+
+describe("request labeler policy", () => {
+	it("defaults to every trusted labeler with redact:true when the header is missing", async () => {
+		await seedLabeler(TRUSTED_DID, true);
+		await seedLabeler(UNTRUSTED_DID, false);
+
+		const res = await SELF.fetch(GET_PACKAGE_URL);
+		expect(res.headers.get("atproto-content-labelers")).toBe(`${TRUSTED_DID};redact`);
+	});
+
+	it("disables the default set and omits the response header when the header is present but empty", async () => {
+		await seedLabeler(TRUSTED_DID, true);
+
+		const res = await SELF.fetch(GET_PACKAGE_URL, {
+			headers: { "atproto-accept-labelers": "" },
+		});
+		expect(res.headers.has("atproto-content-labelers")).toBe(false);
+	});
+
+	it("400s with an InvalidRequest envelope on malformed header syntax", async () => {
+		const res = await SELF.fetch(GET_PACKAGE_URL, {
+			headers: { "atproto-accept-labelers": "not-a-valid-did" },
+		});
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string; message?: string };
+		expect(body.error).toBe("InvalidRequest");
+		expect(typeof body.message).toBe("string");
+	});
+
+	it("merges repeated DIDs in the explicit header, OR-ing redact", async () => {
+		await seedLabeler(TRUSTED_DID, true);
+
+		const res = await SELF.fetch(GET_PACKAGE_URL, {
+			headers: { "atproto-accept-labelers": `${TRUSTED_DID}, ${TRUSTED_DID};redact` },
+		});
+		expect(res.headers.get("atproto-content-labelers")).toBe(`${TRUSTED_DID};redact`);
+	});
+
+	it("omits an unavailable DID from the explicit header", async () => {
+		await seedLabeler(TRUSTED_DID, true);
+
+		const res = await SELF.fetch(GET_PACKAGE_URL, {
+			headers: { "atproto-accept-labelers": `${UNKNOWN_DID}, ${TRUSTED_DID}` },
+		});
+		expect(res.headers.get("atproto-content-labelers")).toBe(TRUSTED_DID);
+	});
+
+	it("accepts and echoes an explicit untrusted-but-configured DID", async () => {
+		await seedLabeler(UNTRUSTED_DID, false);
+
+		const res = await SELF.fetch(GET_PACKAGE_URL, {
+			headers: { "atproto-accept-labelers": UNTRUSTED_DID },
+		});
+		expect(res.headers.get("atproto-content-labelers")).toBe(UNTRUSTED_DID);
+	});
+
+	it("lists the right allow/expose headers on the OPTIONS preflight", async () => {
+		const res = await SELF.fetch(GET_PACKAGE_URL, { method: "OPTIONS" });
+		expect(res.status).toBe(204);
+		expect(res.headers.get("access-control-allow-headers")).toBe(
+			"content-type, atproto-accept-labelers",
+		);
+		expect(res.headers.get("access-control-expose-headers")).toBe(
+			"atproto-content-labelers, content-language",
+		);
+	});
+});

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/searchPackages.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/searchPackages.json
@@ -5,7 +5,7 @@
 	"defs": {
 		"main": {
 			"type": "query",
-			"description": "Returns a paginated list of packages matching the query and filters. Results that are subject to a hard-enforcement label (e.g. !takedown, security:yanked) from a trusted labeler the request accepts are filtered out; other label state is hydrated on each result.",
+			"description": "Returns a paginated list of packages matching the query and filters. Results carrying a hard-block label (e.g. !takedown, publisher-compromised) from a source the request's accepted-labeler policy covers are excluded; other label state is hydrated on each result.",
 			"parameters": {
 				"type": "params",
 				"properties": {

--- a/packages/registry-moderation/src/did.ts
+++ b/packages/registry-moderation/src/did.ts
@@ -1,0 +1,1 @@
+export const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -190,6 +190,15 @@ const RELEASE_VALUES = new Set<string>([
 	...WARNINGS,
 ]);
 
+/** Values that hard-block at package or publisher scope; search excludes subjects carrying them. */
+export const PACKAGE_SCOPE_BLOCK_VALUES: readonly string[] = ["!takedown", "publisher-compromised"];
+/** Values that make an individual release ineligible under official policy. */
+export const RELEASE_BLOCK_VALUES: readonly string[] = [
+	...AUTOMATED_BLOCKS,
+	"security-yanked",
+	"!takedown",
+];
+
 interface ParsedInstant {
 	seconds: bigint;
 	fraction: string;

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -3,6 +3,14 @@ import { fromString as cidFromString, toString as cidToString } from "@atcute/ci
 import { P256PrivateKey, P256PublicKey, parsePublicMultikey } from "@atcute/crypto";
 import { fromBase64Url, toBase64Url } from "@atcute/multibase";
 
+import { DID } from "./did.js";
+
+export {
+	InvalidAcceptLabelersHeaderError,
+	parseAcceptLabelersHeader,
+	serializeContentLabelersHeader,
+} from "./labeler-headers.js";
+
 export type ModerationLabelValue =
 	| "assessment-error"
 	| "assessment-overridden"
@@ -193,7 +201,6 @@ interface LabelReduction {
 }
 
 const RFC3339 = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
-const DID = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const P256_ORDER = BigInt("0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
 const LABEL_FIELDS = new Set(["ver", "src", "uri", "cid", "val", "neg", "cts", "exp"]);
 const SIGNED_LABEL_FIELDS = new Set([...LABEL_FIELDS, "sig"]);

--- a/packages/registry-moderation/src/labeler-headers.ts
+++ b/packages/registry-moderation/src/labeler-headers.ts
@@ -1,0 +1,188 @@
+import { DID } from "./did.js";
+import type { AcceptedLabelerPolicy } from "./index.js";
+
+/** Indicates that an `atproto-accept-labelers` header value has invalid RFC 8941 syntax. */
+export class InvalidAcceptLabelersHeaderError extends TypeError {
+	constructor(message: string) {
+		super(message);
+		this.name = "InvalidAcceptLabelersHeaderError";
+	}
+}
+
+interface Cursor {
+	value: string;
+	index: number;
+}
+
+type BareItem =
+	| { kind: "boolean"; value: boolean }
+	| { kind: "token"; value: string }
+	| { kind: "string"; value: string };
+
+// RFC 8941 §3.3.4 sf-token, extended with ":" and "/" as the grammar requires.
+const TOKEN_CHAR = /^[A-Za-z*][!#$%&'*+\-.^_`|~0-9A-Za-z:/]*/;
+// RFC 8941 §3.1.2 key: (lcalpha / "*") *(lcalpha / DIGIT / "_" / "-" / "." / "*").
+const PARAM_KEY = /^[a-z*][a-z0-9_.\-*]*/;
+const LEADING_OWS = /^[ \t]*/;
+const BLANK_HEADER_VALUE = /^[ \t]*$/;
+
+function remaining(cursor: Cursor): string {
+	return cursor.value.slice(cursor.index);
+}
+
+function atEnd(cursor: Cursor): boolean {
+	return cursor.index >= cursor.value.length;
+}
+
+// RFC 9110 §5.6.3 OWS = *( SP / HTAB ), used between sf-list members.
+function consumeOws(cursor: Cursor): void {
+	const match = LEADING_OWS.exec(remaining(cursor))!;
+	cursor.index += match[0].length;
+}
+
+// RFC 8941 §4.2.3.2 only allows *SP (no HTAB) directly after ";".
+function consumeSpaces(cursor: Cursor): void {
+	while (cursor.value[cursor.index] === " ") cursor.index += 1;
+}
+
+function parseDidToken(cursor: Cursor): string {
+	const match = TOKEN_CHAR.exec(remaining(cursor));
+	if (!match) throw new InvalidAcceptLabelersHeaderError("expected a labeler DID");
+	const token = match[0];
+	cursor.index += token.length;
+	if (!DID.test(token)) throw new InvalidAcceptLabelersHeaderError(`invalid labeler DID: ${token}`);
+	return token;
+}
+
+function parseQuotedString(cursor: Cursor): string {
+	cursor.index += 1; // opening DQUOTE
+	let result = "";
+	for (;;) {
+		if (atEnd(cursor))
+			throw new InvalidAcceptLabelersHeaderError("unterminated quoted string in parameter value");
+		const char = cursor.value[cursor.index]!;
+		if (char === '"') {
+			cursor.index += 1;
+			return result;
+		}
+		if (char === "\\") {
+			const escaped = cursor.value[cursor.index + 1];
+			if (escaped !== '"' && escaped !== "\\")
+				throw new InvalidAcceptLabelersHeaderError(
+					"invalid escape sequence in quoted string parameter value",
+				);
+			result += escaped;
+			cursor.index += 2;
+			continue;
+		}
+		const code = char.charCodeAt(0);
+		if (code < 0x20 || code === 0x7f)
+			throw new InvalidAcceptLabelersHeaderError(
+				"invalid character in quoted string parameter value",
+			);
+		result += char;
+		cursor.index += 1;
+	}
+}
+
+function parseBareItem(cursor: Cursor): BareItem {
+	const rest = remaining(cursor);
+	if (rest.startsWith("?")) {
+		const flag = rest[1];
+		if (flag !== "0" && flag !== "1")
+			throw new InvalidAcceptLabelersHeaderError("invalid boolean parameter value");
+		cursor.index += 2;
+		return { kind: "boolean", value: flag === "1" };
+	}
+	if (rest.startsWith('"')) return { kind: "string", value: parseQuotedString(cursor) };
+	const tokenMatch = TOKEN_CHAR.exec(rest);
+	if (tokenMatch) {
+		cursor.index += tokenMatch[0].length;
+		return { kind: "token", value: tokenMatch[0] };
+	}
+	throw new InvalidAcceptLabelersHeaderError("invalid parameter value");
+}
+
+function parseParameters(cursor: Cursor): Map<string, BareItem> {
+	const params = new Map<string, BareItem>();
+	while (remaining(cursor).startsWith(";")) {
+		cursor.index += 1;
+		consumeSpaces(cursor);
+		const keyMatch = PARAM_KEY.exec(remaining(cursor));
+		if (!keyMatch) throw new InvalidAcceptLabelersHeaderError("expected a parameter key after ';'");
+		const key = keyMatch[0];
+		cursor.index += key.length;
+		let paramValue: BareItem = { kind: "boolean", value: true };
+		if (remaining(cursor).startsWith("=")) {
+			cursor.index += 1;
+			paramValue = parseBareItem(cursor);
+		}
+		params.set(key, paramValue);
+	}
+	return params;
+}
+
+/**
+ * Parses an `atproto-accept-labelers` header VALUE. The caller resolves the
+ * missing-header case to deployment defaults before calling; an empty or
+ * whitespace-only value means "no accepted labelers" and returns [].
+ */
+export function parseAcceptLabelersHeader(value: string): AcceptedLabelerPolicy[] {
+	if (BLANK_HEADER_VALUE.test(value)) return [];
+
+	const cursor: Cursor = { value, index: 0 };
+	consumeOws(cursor);
+
+	const order: string[] = [];
+	// Union merge: an explicit later `?0` never un-sets an earlier true, since
+	// redact is a "does any accepted policy for this DID ask to redact" flag.
+	const redactByDid = new Map<string, boolean>();
+
+	for (;;) {
+		const did = parseDidToken(cursor);
+		const params = parseParameters(cursor);
+		const redactParam = params.get("redact");
+		let redact = false;
+		if (redactParam !== undefined) {
+			if (redactParam.kind !== "boolean")
+				throw new InvalidAcceptLabelersHeaderError(
+					`redact parameter for ${did} must be a boolean (?0 or ?1)`,
+				);
+			redact = redactParam.value;
+		}
+		const existing = redactByDid.get(did);
+		if (existing === undefined) order.push(did);
+		redactByDid.set(did, existing === true || redact);
+
+		consumeOws(cursor);
+		if (atEnd(cursor)) break;
+		if (cursor.value[cursor.index] !== ",")
+			throw new InvalidAcceptLabelersHeaderError(
+				`unexpected character at position ${cursor.index} in atproto-accept-labelers header`,
+			);
+		cursor.index += 1;
+		consumeOws(cursor);
+		if (atEnd(cursor))
+			throw new InvalidAcceptLabelersHeaderError(
+				"trailing comma in atproto-accept-labelers header",
+			);
+	}
+
+	return order.map((did) => ({ did, redact: redactByDid.get(did)! }));
+}
+
+/**
+ * Serializes the sources actually considered into `atproto-content-labelers`
+ * form. An empty policy list serializes to "" -- callers omit the header
+ * entirely in that case rather than sending an empty header value.
+ */
+export function serializeContentLabelersHeader(policies: readonly AcceptedLabelerPolicy[]): string {
+	const order: string[] = [];
+	const redactByDid = new Map<string, boolean>();
+	for (const policy of policies) {
+		const existing = redactByDid.get(policy.did);
+		if (existing === undefined) order.push(policy.did);
+		redactByDid.set(policy.did, existing === true || policy.redact);
+	}
+	return order.map((did) => (redactByDid.get(did) ? `${did};redact` : did)).join(", ");
+}

--- a/packages/registry-moderation/tests/labeler-headers.test.ts
+++ b/packages/registry-moderation/tests/labeler-headers.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	InvalidAcceptLabelersHeaderError,
+	parseAcceptLabelersHeader,
+	serializeContentLabelersHeader,
+	type AcceptedLabelerPolicy,
+} from "../src/index.js";
+
+const alice = "did:example:alice";
+const bob = "did:example:bob";
+
+describe("parseAcceptLabelersHeader", () => {
+	it("treats an empty or whitespace-only value as no accepted labelers", () => {
+		expect(parseAcceptLabelersHeader("")).toEqual([]);
+		expect(parseAcceptLabelersHeader("   ")).toEqual([]);
+		expect(parseAcceptLabelersHeader("\t \t")).toEqual([]);
+	});
+
+	it("parses a single DID with no parameters", () => {
+		expect(parseAcceptLabelersHeader(alice)).toEqual([{ did: alice, redact: false }]);
+	});
+
+	it("parses a single DID with a bare redact parameter", () => {
+		expect(parseAcceptLabelersHeader(`${alice};redact`)).toEqual([{ did: alice, redact: true }]);
+	});
+
+	it("parses redact=?1 as true", () => {
+		expect(parseAcceptLabelersHeader(`${alice};redact=?1`)).toEqual([{ did: alice, redact: true }]);
+	});
+
+	it("parses redact=?0 as false but keeps the entry", () => {
+		expect(parseAcceptLabelersHeader(`${alice};redact=?0`)).toEqual([
+			{ did: alice, redact: false },
+		]);
+	});
+
+	it("parses multiple DIDs preserving order", () => {
+		expect(parseAcceptLabelersHeader(`${bob}, ${alice}`)).toEqual([
+			{ did: bob, redact: false },
+			{ did: alice, redact: false },
+		]);
+	});
+
+	describe("duplicate DID redact merge", () => {
+		it("plain then redact merges to true", () => {
+			expect(parseAcceptLabelersHeader(`${alice}, ${alice};redact`)).toEqual([
+				{ did: alice, redact: true },
+			]);
+		});
+
+		it("redact then plain merges to true", () => {
+			expect(parseAcceptLabelersHeader(`${alice};redact, ${alice}`)).toEqual([
+				{ did: alice, redact: true },
+			]);
+		});
+
+		it("redact then explicit ?0 does not un-set true", () => {
+			expect(parseAcceptLabelersHeader(`${alice};redact, ${alice};redact=?0`)).toEqual([
+				{ did: alice, redact: true },
+			]);
+		});
+
+		it("?0 then ?0 stays false", () => {
+			expect(parseAcceptLabelersHeader(`${alice};redact=?0, ${alice};redact=?0`)).toEqual([
+				{ did: alice, redact: false },
+			]);
+		});
+
+		it("preserves first-occurrence order across a run of duplicates", () => {
+			expect(parseAcceptLabelersHeader(`${bob}, ${alice}, ${bob};redact`)).toEqual([
+				{ did: bob, redact: true },
+				{ did: alice, redact: false },
+			]);
+		});
+	});
+
+	describe("OWS tolerance", () => {
+		it("allows spaces around the list-separating comma", () => {
+			expect(parseAcceptLabelersHeader(`${alice} , ${bob}`)).toEqual([
+				{ did: alice, redact: false },
+				{ did: bob, redact: false },
+			]);
+		});
+
+		it("allows tabs around the list-separating comma", () => {
+			expect(parseAcceptLabelersHeader(`${alice}\t,\t${bob}`)).toEqual([
+				{ did: alice, redact: false },
+				{ did: bob, redact: false },
+			]);
+		});
+
+		it("allows a space between ';' and the parameter key", () => {
+			expect(parseAcceptLabelersHeader(`${alice}; redact`)).toEqual([{ did: alice, redact: true }]);
+		});
+
+		it("rejects a tab between ';' and the parameter key", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice};\tredact`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects whitespace before ';' since parameters must directly follow the item", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice} ;redact`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("tolerates leading and trailing OWS around the whole header value", () => {
+			expect(parseAcceptLabelersHeader(`  ${alice}  `)).toEqual([{ did: alice, redact: false }]);
+		});
+	});
+
+	describe("unknown parameters are ignored", () => {
+		it("ignores a bare unknown key", () => {
+			expect(parseAcceptLabelersHeader(`${alice};foo`)).toEqual([{ did: alice, redact: false }]);
+		});
+
+		it("ignores an unknown key with a boolean value", () => {
+			expect(parseAcceptLabelersHeader(`${alice};foo=?0`)).toEqual([{ did: alice, redact: false }]);
+		});
+
+		it("ignores an unknown key with a token value", () => {
+			expect(parseAcceptLabelersHeader(`${alice};foo=bar`)).toEqual([
+				{ did: alice, redact: false },
+			]);
+		});
+
+		it("ignores an unknown key with a quoted string value, including escapes", () => {
+			expect(parseAcceptLabelersHeader(`${alice};foo="quoted \\" string"`)).toEqual([
+				{ did: alice, redact: false },
+			]);
+		});
+
+		it("still honours redact alongside an ignored unknown parameter", () => {
+			expect(parseAcceptLabelersHeader(`${alice};foo=bar;redact`)).toEqual([
+				{ did: alice, redact: true },
+			]);
+		});
+	});
+
+	describe("invalid syntax", () => {
+		it("rejects an empty list member from a leading comma", () => {
+			expect(() => parseAcceptLabelersHeader(`,${alice}`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects an empty list member from a trailing comma", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice},`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects an empty list member between two commas", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice},,${bob}`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects a bare parameter with no preceding DID", () => {
+			expect(() => parseAcceptLabelersHeader(";redact")).toThrow(InvalidAcceptLabelersHeaderError);
+		});
+
+		it("rejects a non-DID token", () => {
+			expect(() => parseAcceptLabelersHeader("notadid")).toThrow(InvalidAcceptLabelersHeaderError);
+		});
+
+		it("rejects an uppercase DID method", () => {
+			expect(() => parseAcceptLabelersHeader("did:UPPER:x")).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects a DID with an empty method-specific id", () => {
+			expect(() => parseAcceptLabelersHeader("did:example:")).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects redact=1 (not an RFC 8941 boolean)", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice};redact=1`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects redact as a quoted string", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice};redact="true"`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects an unterminated quoted string", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice};foo="unterminated`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects an invalid parameter key starting with uppercase", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice};Redact`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects an invalid parameter key starting with a digit", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice};9x`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+
+		it("rejects a trailing ';' with no key", () => {
+			expect(() => parseAcceptLabelersHeader(`${alice};`)).toThrow(
+				InvalidAcceptLabelersHeaderError,
+			);
+		});
+	});
+});
+
+describe("serializeContentLabelersHeader", () => {
+	it("serializes an empty list to an empty string", () => {
+		expect(serializeContentLabelersHeader([])).toBe("");
+	});
+
+	it("serializes a plain DID without a redact parameter", () => {
+		expect(serializeContentLabelersHeader([{ did: alice, redact: false }])).toBe(alice);
+	});
+
+	it("serializes a redacted DID with the ;redact parameter", () => {
+		expect(serializeContentLabelersHeader([{ did: alice, redact: true }])).toBe(`${alice};redact`);
+	});
+
+	it("serializes a mix of plain and redacted DIDs joined by ', '", () => {
+		expect(
+			serializeContentLabelersHeader([
+				{ did: alice, redact: false },
+				{ did: bob, redact: true },
+			]),
+		).toBe(`${alice}, ${bob};redact`);
+	});
+
+	it("dedupes and merges redact with union semantics before serializing", () => {
+		expect(
+			serializeContentLabelersHeader([
+				{ did: alice, redact: false },
+				{ did: alice, redact: true },
+			]),
+		).toBe(`${alice};redact`);
+	});
+
+	function dedupe(policies: readonly AcceptedLabelerPolicy[]): AcceptedLabelerPolicy[] {
+		const order: string[] = [];
+		const redactByDid = new Map<string, boolean>();
+		for (const policy of policies) {
+			const existing = redactByDid.get(policy.did);
+			if (existing === undefined) order.push(policy.did);
+			redactByDid.set(policy.did, existing === true || policy.redact);
+		}
+		return order.map((did) => ({ did, redact: redactByDid.get(did)! }));
+	}
+
+	describe("round-trip stability", () => {
+		const cases: AcceptedLabelerPolicy[][] = [
+			[],
+			[{ did: alice, redact: false }],
+			[{ did: alice, redact: true }],
+			[
+				{ did: alice, redact: false },
+				{ did: bob, redact: true },
+			],
+			[
+				{ did: bob, redact: true },
+				{ did: alice, redact: false },
+				{ did: bob, redact: false },
+			],
+		];
+
+		for (const [index, policies] of cases.entries()) {
+			it(`round-trips case ${index}`, () => {
+				const serialized = serializeContentLabelersHeader(policies);
+				expect(parseAcceptLabelersHeader(serialized)).toEqual(dedupe(policies));
+			});
+		}
+	});
+});

--- a/packages/registry-moderation/tests/moderation.test.ts
+++ b/packages/registry-moderation/tests/moderation.test.ts
@@ -6,6 +6,8 @@ import {
 	createLabelSigner,
 	evaluateReleaseModeration,
 	verifyLabel,
+	PACKAGE_SCOPE_BLOCK_VALUES,
+	RELEASE_BLOCK_VALUES,
 	type LabelDidDocument,
 	type ModerationLabel,
 	type VerifiedModerationLabel,
@@ -336,6 +338,29 @@ describe("release moderation", () => {
 		expect(() =>
 			evaluate([label({ val: "assessment-passed", cts: "0000-01-01T00:00:00+01:00" })]),
 		).toThrow(TypeError);
+	});
+});
+
+describe("exported hard-block value sets", () => {
+	it("blocks every RELEASE_BLOCK_VALUES value on the exact release", () => {
+		for (const value of RELEASE_BLOCK_VALUES) {
+			const result = evaluate([label({ val: "assessment-passed" }), label({ val: value })]);
+			expect(result.eligibility, `${value} should block the release`).toBe("blocked");
+		}
+	});
+
+	it("blocks every PACKAGE_SCOPE_BLOCK_VALUES value on the publisher DID", () => {
+		for (const value of PACKAGE_SCOPE_BLOCK_VALUES) {
+			const publisherLabel = label({ val: value, uri: context.publisherDid, cid: undefined });
+			const result = evaluate([label({ val: "assessment-passed" }), publisherLabel]);
+			expect(result.eligibility, `${value} should block via the publisher DID`).toBe("blocked");
+		}
+	});
+
+	it("blocks a package-URI !takedown", () => {
+		const packageTakedown = label({ val: "!takedown", uri: context.package.uri, cid: undefined });
+		const result = evaluate([label({ val: "assessment-passed" }), packageTakedown]);
+		expect(result.eligibility).toBe("blocked");
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Implements the aggregator's label-aware read path — W1.6 and W4.4–W4.6 from the labelling-service plan (#1909) — in three commits:

- **Accepted-labeler header parsing** (`@emdash-cms/registry-moderation`): `parseAcceptLabelersHeader` / `serializeContentLabelersHeader`, RFC 8941 list grammar restricted to the forms the ATProto label spec uses, strict DID validation, first-occurrence ordering, union merge of repeated-DID `redact` flags, typed syntax errors.
- **Request-boundary policy** (W4.4): `handleXrpc` resolves the policy once per request. Missing header → deployment defaults (every `labelers` row with `trusted = 1`, `redact: true`); explicitly empty → no accepted sources (no enforcement, no hydration); malformed → 400 `InvalidRequest`; requested DIDs without a `labelers` row are silently omitted. The response reports the sources actually considered via `atproto-content-labelers`, now correctly CORS-exposed (the previous `expose-headers` entry echoed the request header, which was meaningless). Also exports the package-scope and release-scope hard-block vocabulary from the shared moderation package, fixing the existing drift where the search SQL was missing `publisher-compromised`.
- **Enforcement + hydration** (W4.5/W4.6): search and latest-release selection exclude hard-blocked subjects in parameterized SQL (CID-bound labels apply only to the subject's current CID; package/publisher blocks cascade to releases). All five read endpoints hydrate active labels from accepted sources onto views, batched per page (no N+1; 3–4 queries per request). Redaction: an accepted source with `redact: true` holding an active `!takedown` makes the subject indistinguishable from absence — 404 on `getPackage`/`resolvePackage`, omission in `listReleases`, and a 404 for a release list whose *parent package* is redacted (a 200-empty would leak existence). `getLatestRelease` skips the `packages.latest_version` fast path whenever an accepted policy is in force, since the pointer is not label-aware.

Adversarial review findings fixed pre-merge: a silent redaction bypass where the 64-label wire cap could truncate away the `!takedown` before the redaction decision (hydration now returns untruncated sets; the cap applies only at the view boundary, both regression-tested), and the `listReleases` existence leak above.

Decisions needing maintainer ratification (all flagged in review):

1. **Default policy**: missing header resolves to trusted labelers with `redact: true`.
2. **Trust gates defaults only**: an explicitly requested, configured-but-untrusted labeler is honored — persisted `trusted` is provenance, not request authorization (per the W0.3 audit).
3. **`sync.getRecord` intentionally serves records for redacted subjects** (raw CAR bytes, publicly cached). Recommendation: keep — it is the sync/verification layer, the record remains available from the publisher's own PDS regardless, and consumers auditing labels need to fetch the subject record. Flagged by adversarial review as needing an explicit decision rather than an implicit passthrough.
4. **Read-path SQL enforcement is deliberately broader than `evaluateReleaseModeration`** (documented in `label-enforcement.ts`): value/subject pairings the evaluator would reject still exclude, always in the over-hide direction. The evaluator remains the only eligibility engine; no positive-assessment requirement ships in this PR (shadow phase).

Implementation PRs target `feat/plugin-registry-labelling-service` per the umbrella PR. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n is n/a — no UI changes. Changesets included for the two published packages that changed (`@emdash-cms/registry-moderation` ×2, `@emdash-cms/registry-lexicons`); the aggregator is private.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (design, review, fixes) and Sonnet/Opus subagents (implementation, adversarial review)

## Screenshots / test output

- `pnpm --filter @emdash-cms/aggregator test`: 15 files, 296 tests pass (41 header-parser tests, 7 request-policy contract tests, 24 enforcement/hydration/redaction tests incl. the truncation-bypass and existence-leak regressions)
- `pnpm --filter @emdash-cms/registry-moderation test`: 114 pass; `--filter @emdash-cms/registry-lexicons test`: 14 pass
- Typecheck clean; `pnpm lint:quick` 0 diagnostics; type-aware `lint:json` has no findings in any touched file
- Query counts per read request under a non-empty policy: getPackage 3, listReleases 4, getLatestRelease 3, searchPackages ~3 — hydration is one batched query per page

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-aggregator-reads-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-aggregator-reads`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
