### PR TITLE
fix: add spacing before Admin link in blog template

### DIFF
--- a/templates/blog-cloudflare/src/styles/theme.css
+++ b/templates/blog-cloudflare/src/styles/theme.css
@@ -26,3 +26,7 @@
 
 :root {
 }
+
+.nav-admin {
+  margin-inline-start: var(--spacing-5);
+}

--- a/templates/blog-cloudflare/src/styles/theme.css
+++ b/templates/blog-cloudflare/src/styles/theme.css
@@ -28,5 +28,5 @@
 }
 
 .nav-admin {
-  margin-inline-start: var(--spacing-5);
+	margin-inline-start: var(--spacing-5);
 }

--- a/templates/blog/src/styles/theme.css
+++ b/templates/blog/src/styles/theme.css
@@ -26,3 +26,8 @@
 
 :root {
 }
+
+/* Keep the signed-in Admin link separated from the primary navigation. */
+.nav-admin {
+  margin-inline-start: var(--spacing-5);
+}

--- a/templates/blog/src/styles/theme.css
+++ b/templates/blog/src/styles/theme.css
@@ -29,5 +29,5 @@
 
 /* Keep the signed-in Admin link separated from the primary navigation. */
 .nav-admin {
-  margin-inline-start: var(--spacing-5);
+	margin-inline-start: var(--spacing-5);
 }


### PR DESCRIPTION
The Admin link currently renders directly after the final navigation item as `PostsAdmin`.

This adds spacing before the Admin link in the blog template while preserving the existing mobile layout.

The change is made in `theme.css` so it can flow to the Cloudflare template through the normal template sync.

## What does this PR do?

Fixes the blog template navigation so the signed-in Admin link no longer renders directly after the final menu item as PostsAdmin.

Adds spacing through theme.css while preserving the existing mobile layout. The change can flow to the Cloudflare template through the normal template sync.

## Type of change

- [x] Bug fix

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] No translation changes are required
- [x] No changeset is required for this CSS-only template fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — Codex / GPT-5.6 Luna
- [x] I have read [CONTRIBUTING.md]