### PR TITLE
feat(auth): add required passkey verification

### DIFF
--- a/.changeset/passkey-uv-context.md
+++ b/.changeset/passkey-uv-context.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/auth": minor
+---
+
+Adds configurable passkey user verification and typed, versioned WebAuthn challenge context while preserving preferred verification by default.

--- a/packages/auth/src/passkey/authenticate.test.ts
+++ b/packages/auth/src/passkey/authenticate.test.ts
@@ -8,8 +8,18 @@ import {
 import { describe, it, expect, vi } from "vitest";
 
 import type { AuthAdapter, Credential } from "../types.js";
-import { authenticateWithPasskey, PasskeyAuthenticationError } from "./authenticate.js";
-import type { ChallengeStore } from "./types.js";
+import {
+	authenticateWithPasskey,
+	generateAuthenticationOptions,
+	PasskeyAuthenticationError,
+	verifyAuthenticationResponse,
+} from "./authenticate.js";
+import {
+	bindChallengeContext,
+	defineChallengeContext,
+	encodeChallengeContext,
+} from "./challenge-context.js";
+import type { AtomicChallengeStore, ChallengeStore } from "./types.js";
 
 const credential: Credential = {
 	id: "registered-credential",
@@ -51,7 +61,9 @@ function base64url(bytes: Uint8Array): string {
 	return Buffer.from(bytes).toString("base64url");
 }
 
-function createValidAssertion(opts: { rpId?: string; origin?: string } = {}) {
+function createValidAssertion(
+	opts: { rpId?: string; origin?: string; userVerified?: boolean; challenge?: string } = {},
+) {
 	const rpId = opts.rpId ?? config.rpId;
 	const origin = opts.origin ?? config.origins[0];
 	if (!origin) throw new Error("origin must be defined for createValidAssertion");
@@ -66,7 +78,7 @@ function createValidAssertion(opts: { rpId?: string; origin?: string } = {}) {
 		Buffer.from(jwk.x, "base64url"),
 		Buffer.from(jwk.y, "base64url"),
 	]);
-	const challenge = base64url(Buffer.from("test-challenge"));
+	const challenge = opts.challenge ?? base64url(Buffer.from("test-challenge"));
 	const clientDataJSON = Buffer.from(
 		JSON.stringify({
 			type: "webauthn.get",
@@ -77,7 +89,8 @@ function createValidAssertion(opts: { rpId?: string; origin?: string } = {}) {
 	const rpIdHash = createHash("sha256").update(rpId).digest();
 	const signatureCounter = Buffer.alloc(4);
 	signatureCounter.writeUInt32BE(1);
-	const authenticatorData = Buffer.concat([rpIdHash, Buffer.from([0x01]), signatureCounter]);
+	const flags = opts.userVerified ? 0x05 : 0x01;
+	const authenticatorData = Buffer.concat([rpIdHash, Buffer.from([flags]), signatureCounter]);
 	const signatureMessage = createAssertionSignatureMessage(authenticatorData, clientDataJSON);
 	const signatureBytes = sign("sha256", signatureMessage, privateKey);
 
@@ -103,6 +116,18 @@ function createValidAssertion(opts: { rpId?: string; origin?: string } = {}) {
 		} satisfies ChallengeStore,
 	};
 }
+
+const approvalContext = defineChallengeContext("release-approval", 1, (value) => {
+	if (
+		typeof value !== "object" ||
+		value === null ||
+		Array.isArray(value) ||
+		typeof (value as Record<string, unknown>).intentId !== "string"
+	) {
+		throw new Error("Invalid approval context");
+	}
+	return { intentId: (value as Record<string, string>).intentId };
+});
 
 function createValidRS256Assertion(opts: { rpId?: string; origin?: string } = {}) {
 	const rpId = opts.rpId ?? config.rpId;
@@ -160,6 +185,123 @@ function createValidRS256Assertion(opts: { rpId?: string; origin?: string } = {}
 }
 
 describe("authenticateWithPasskey", () => {
+	it.each(["preferred", "required", "discouraged"] as const)(
+		"wires %s user verification into authentication options",
+		async (userVerification) => {
+			const options = await generateAuthenticationOptions(
+				{ ...config, userVerification },
+				[],
+				createChallengeStore(),
+			);
+
+			expect(options.userVerification).toBe(userVerification);
+		},
+	);
+
+	it("defaults authentication options to preferred user verification", async () => {
+		const options = await generateAuthenticationOptions(config, [], createChallengeStore());
+
+		expect(options.userVerification).toBe("preferred");
+	});
+
+	it("rejects an assertion without UV when user verification is required", async () => {
+		const { credential: validCredential, response, challengeStore } = createValidAssertion();
+
+		await expect(
+			verifyAuthenticationResponse(
+				{ ...config, userVerification: "required" },
+				response,
+				validCredential,
+				challengeStore,
+			),
+		).rejects.toMatchObject({ code: "user_verification_not_verified" });
+	});
+
+	it("accepts an assertion with UV when user verification is required", async () => {
+		const {
+			credential: validCredential,
+			response,
+			challengeStore,
+		} = createValidAssertion({
+			userVerified: true,
+		});
+
+		await expect(
+			verifyAuthenticationResponse(
+				{ ...config, userVerification: "required" },
+				response,
+				validCredential,
+				challengeStore,
+			),
+		).resolves.toMatchObject({ credentialId: validCredential.id });
+	});
+
+	it("returns typed context after atomic challenge consumption", async () => {
+		const initial = createValidAssertion({ userVerified: true });
+		const generated = await generateAuthenticationOptions(
+			{ ...config, userVerification: "required" },
+			[initial.credential],
+			initial.challengeStore,
+			bindChallengeContext(approvalContext, { intentId: "intent_1" }),
+		);
+		const store: ChallengeStore = initial.challengeStore;
+		const stored = vi.mocked(store.set).mock.calls[0]?.[1];
+		if (!stored) throw new Error("Expected challenge data to be stored");
+		const { credential: validCredential, response } = createValidAssertion({
+			userVerified: true,
+			challenge: generated.challenge,
+		});
+		const atomicStore = {
+			...initial.challengeStore,
+			consume: vi.fn(async () => stored),
+		} satisfies AtomicChallengeStore;
+
+		await expect(
+			verifyAuthenticationResponse(
+				{ ...config, userVerification: "required" },
+				response,
+				validCredential,
+				atomicStore,
+				approvalContext,
+			),
+		).resolves.toMatchObject({ challengeContext: { intentId: "intent_1" } });
+		expect(atomicStore.consume).toHaveBeenCalledWith(generated.challenge);
+		expect(initial.challengeStore.delete).not.toHaveBeenCalled();
+	});
+
+	it("rejects stored context that does not match the signed challenge", async () => {
+		const initial = createValidAssertion({ userVerified: true });
+		const generated = await generateAuthenticationOptions(
+			{ ...config, userVerification: "required" },
+			[initial.credential],
+			initial.challengeStore,
+			bindChallengeContext(approvalContext, { intentId: "intent_1" }),
+		);
+		const store: ChallengeStore = initial.challengeStore;
+		const stored = vi.mocked(store.set).mock.calls[0]?.[1];
+		if (!stored) throw new Error("Expected challenge data to be stored");
+		const { credential: validCredential, response } = createValidAssertion({
+			userVerified: true,
+			challenge: generated.challenge,
+		});
+		const atomicStore = {
+			...initial.challengeStore,
+			consume: vi.fn(async () => ({
+				...stored,
+				context: encodeChallengeContext(approvalContext, { intentId: "intent_2" }),
+			})),
+		} satisfies AtomicChallengeStore;
+
+		await expect(
+			verifyAuthenticationResponse(
+				{ ...config, userVerification: "required" },
+				response,
+				validCredential,
+				atomicStore,
+				approvalContext,
+			),
+		).rejects.toMatchObject({ code: "context_binding_mismatch" });
+	});
 	it("throws a typed passkey auth error for malformed assertion payloads", async () => {
 		try {
 			await authenticateWithPasskey(

--- a/packages/auth/src/passkey/authenticate.test.ts
+++ b/packages/auth/src/passkey/authenticate.test.ts
@@ -269,6 +269,42 @@ describe("authenticateWithPasskey", () => {
 		expect(initial.challengeStore.delete).not.toHaveBeenCalled();
 	});
 
+	it.each([
+		["undefined", undefined],
+		["non-callable", "not-a-function"],
+	] as const)("rejects a typed-context store with %s consume", async (_label, consume) => {
+		const initial = createValidAssertion({ userVerified: true });
+		const generated = await generateAuthenticationOptions(
+			{ ...config, userVerification: "required" },
+			[initial.credential],
+			initial.challengeStore,
+			bindChallengeContext(approvalContext, { intentId: "intent_1" }),
+		);
+		const { credential: validCredential, response } = createValidAssertion({
+			userVerified: true,
+			challenge: generated.challenge,
+		});
+		const malformedStore = {
+			...initial.challengeStore,
+			consume,
+		} as unknown as AtomicChallengeStore;
+
+		await expect(
+			verifyAuthenticationResponse(
+				{ ...config, userVerification: "required" },
+				response,
+				validCredential,
+				malformedStore,
+				approvalContext,
+			),
+		).rejects.toMatchObject({
+			code: "invalid_response",
+			message: "Typed challenge context requires an atomic challenge store",
+		});
+		expect(initial.challengeStore.get).not.toHaveBeenCalled();
+		expect(initial.challengeStore.delete).not.toHaveBeenCalled();
+	});
+
 	it("rejects stored context that does not match the signed challenge", async () => {
 		const initial = createValidAssertion({ userVerified: true });
 		const generated = await generateAuthenticationOptions(

--- a/packages/auth/src/passkey/authenticate.ts
+++ b/packages/auth/src/passkey/authenticate.ts
@@ -29,12 +29,21 @@ import {
 
 import { generateToken } from "../tokens.js";
 import type { Credential, AuthAdapter, User } from "../types.js";
+import {
+	createContextBoundChallenge,
+	decodeChallengeContext,
+	encodeChallengeContext,
+	verifyContextBoundChallenge,
+} from "./challenge-context.js";
+import type { ChallengeContextBinding, ChallengeContextCodec } from "./challenge-context.js";
 import type {
 	AuthenticationOptions,
 	AuthenticationResponse,
 	VerifiedAuthentication,
 	ChallengeStore,
 	PasskeyConfig,
+	AtomicChallengeStore,
+	VerifiedAuthenticationWithContext,
 } from "./types.js";
 
 const CHALLENGE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -49,6 +58,7 @@ export type PasskeyAuthenticationErrorCode =
 	| "invalid_origin"
 	| "invalid_rp_id_hash"
 	| "user_presence_not_verified"
+	| "user_verification_not_verified"
 	| "invalid_signature_counter"
 	| "invalid_signature"
 	| "unsupported_algorithm"
@@ -100,24 +110,32 @@ function decodeAssertionSignature(signature: Uint8Array) {
 /**
  * Generate authentication options for signing in with a passkey
  */
-export async function generateAuthenticationOptions(
+export async function generateAuthenticationOptions<Type extends string, Context>(
 	config: PasskeyConfig,
 	credentials: Credential[],
 	challengeStore: ChallengeStore,
+	challengeContext?: ChallengeContextBinding<Type, Context>,
 ): Promise<AuthenticationOptions> {
-	const challenge = generateToken();
+	const serializedContext = challengeContext
+		? encodeChallengeContext(challengeContext.codec, challengeContext.value)
+		: undefined;
+	const nonce = generateToken();
+	const challenge = serializedContext
+		? createContextBoundChallenge(nonce, serializedContext)
+		: nonce;
 
 	// Store challenge for verification
 	await challengeStore.set(challenge, {
 		type: "authentication",
 		expiresAt: Date.now() + CHALLENGE_TTL,
+		...(serializedContext ? { context: serializedContext } : {}),
 	});
 
 	return {
 		challenge,
 		rpId: config.rpId,
 		timeout: 60000,
-		userVerification: "preferred",
+		userVerification: config.userVerification ?? "preferred",
 		allowCredentials:
 			credentials.length > 0
 				? credentials.map((cred) => ({
@@ -132,12 +150,26 @@ export async function generateAuthenticationOptions(
 /**
  * Verify an authentication response
  */
-export async function verifyAuthenticationResponse(
+export function verifyAuthenticationResponse<Type extends string, Context>(
+	config: PasskeyConfig,
+	response: AuthenticationResponse,
+	credential: Credential,
+	challengeStore: AtomicChallengeStore,
+	challengeContext: ChallengeContextCodec<Type, Context>,
+): Promise<VerifiedAuthenticationWithContext<Context>>;
+export function verifyAuthenticationResponse(
 	config: PasskeyConfig,
 	response: AuthenticationResponse,
 	credential: Credential,
 	challengeStore: ChallengeStore,
-): Promise<VerifiedAuthentication> {
+): Promise<VerifiedAuthentication>;
+export async function verifyAuthenticationResponse<Type extends string, Context>(
+	config: PasskeyConfig,
+	response: AuthenticationResponse,
+	credential: Credential,
+	challengeStore: ChallengeStore,
+	challengeContext?: ChallengeContextCodec<Type, Context>,
+): Promise<VerifiedAuthentication | VerifiedAuthenticationWithContext<Context>> {
 	const { clientDataJSON, authenticatorData, signature, clientData } =
 		decodeAuthenticationResponse(response);
 
@@ -148,7 +180,16 @@ export async function verifyAuthenticationResponse(
 
 	// Verify challenge - convert Uint8Array back to base64url string (no padding, matching stored format)
 	const challengeString = encodeBase64urlNoPadding(clientData.challenge);
-	const challengeData = await challengeStore.get(challengeString);
+	if (challengeContext && !("consume" in challengeStore)) {
+		throw new PasskeyAuthenticationError(
+			"invalid_response",
+			"Typed challenge context requires an atomic challenge store",
+		);
+	}
+	const atomicStore = challengeStore as Partial<AtomicChallengeStore>;
+	const challengeData = atomicStore.consume
+		? await atomicStore.consume(challengeString)
+		: await challengeStore.get(challengeString);
 	if (!challengeData) {
 		throw new PasskeyAuthenticationError("challenge_not_found", "Challenge not found or expired");
 	}
@@ -156,12 +197,30 @@ export async function verifyAuthenticationResponse(
 		throw new PasskeyAuthenticationError("invalid_challenge_type", "Invalid challenge type");
 	}
 	if (challengeData.expiresAt < Date.now()) {
-		await challengeStore.delete(challengeString);
+		if (!atomicStore.consume) await challengeStore.delete(challengeString);
 		throw new PasskeyAuthenticationError("challenge_expired", "Challenge expired");
 	}
 
 	// Delete challenge (single-use)
-	await challengeStore.delete(challengeString);
+	if (!atomicStore.consume) await challengeStore.delete(challengeString);
+	let contextResult: { present: false } | { present: true; value: Context } = {
+		present: false,
+	};
+	if (challengeData.context !== undefined) {
+		if (!challengeContext) {
+			throw new PasskeyAuthenticationError(
+				"invalid_response",
+				"Challenge context decoder required",
+			);
+		}
+		verifyContextBoundChallenge(challengeString, challengeData.context);
+		contextResult = {
+			present: true,
+			value: decodeChallengeContext(challengeData.context, challengeContext),
+		};
+	} else if (challengeContext) {
+		throw new PasskeyAuthenticationError("invalid_response", "Challenge context not found");
+	}
 
 	// Verify origin against the accepted list
 	if (!config.origins.includes(clientData.origin)) {
@@ -184,6 +243,12 @@ export async function verifyAuthenticationResponse(
 		throw new PasskeyAuthenticationError(
 			"user_presence_not_verified",
 			"User presence not verified",
+		);
+	}
+	if (config.userVerification === "required" && !authData.userVerified) {
+		throw new PasskeyAuthenticationError(
+			"user_verification_not_verified",
+			"User verification not verified",
 		);
 	}
 
@@ -233,10 +298,11 @@ export async function verifyAuthenticationResponse(
 		throw new PasskeyAuthenticationError("invalid_signature", "Invalid signature");
 	}
 
-	return {
+	const verified: VerifiedAuthentication = {
 		credentialId: response.id,
 		newCounter: authData.signatureCounter,
 	};
+	return !contextResult.present ? verified : { ...verified, challengeContext: contextResult.value };
 }
 
 /**

--- a/packages/auth/src/passkey/authenticate.ts
+++ b/packages/auth/src/passkey/authenticate.ts
@@ -180,15 +180,16 @@ export async function verifyAuthenticationResponse<Type extends string, Context>
 
 	// Verify challenge - convert Uint8Array back to base64url string (no padding, matching stored format)
 	const challengeString = encodeBase64urlNoPadding(clientData.challenge);
-	if (challengeContext && !("consume" in challengeStore)) {
+	const consume = "consume" in challengeStore ? challengeStore.consume : undefined;
+	const consumesAtomically = typeof consume === "function";
+	if (challengeContext && !consumesAtomically) {
 		throw new PasskeyAuthenticationError(
 			"invalid_response",
 			"Typed challenge context requires an atomic challenge store",
 		);
 	}
-	const atomicStore = challengeStore as Partial<AtomicChallengeStore>;
-	const challengeData = atomicStore.consume
-		? await atomicStore.consume(challengeString)
+	const challengeData = consumesAtomically
+		? await consume.call(challengeStore, challengeString)
 		: await challengeStore.get(challengeString);
 	if (!challengeData) {
 		throw new PasskeyAuthenticationError("challenge_not_found", "Challenge not found or expired");
@@ -197,12 +198,12 @@ export async function verifyAuthenticationResponse<Type extends string, Context>
 		throw new PasskeyAuthenticationError("invalid_challenge_type", "Invalid challenge type");
 	}
 	if (challengeData.expiresAt < Date.now()) {
-		if (!atomicStore.consume) await challengeStore.delete(challengeString);
+		if (!consumesAtomically) await challengeStore.delete(challengeString);
 		throw new PasskeyAuthenticationError("challenge_expired", "Challenge expired");
 	}
 
 	// Delete challenge (single-use)
-	if (!atomicStore.consume) await challengeStore.delete(challengeString);
+	if (!consumesAtomically) await challengeStore.delete(challengeString);
 	let contextResult: { present: false } | { present: true; value: Context } = {
 		present: false,
 	};

--- a/packages/auth/src/passkey/challenge-context.test.ts
+++ b/packages/auth/src/passkey/challenge-context.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import {
+	bindChallengeContext,
+	decodeChallengeContext,
+	defineChallengeContext,
+	encodeChallengeContext,
+} from "./challenge-context.js";
+import type { SerializedChallengeContext } from "./challenge-context.js";
+
+function parseObject(value: unknown): Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error("Expected an object");
+	}
+	return value as Record<string, unknown>;
+}
+
+const approvalContext = defineChallengeContext("release-approval", 1, (value) => {
+	const object = parseObject(value);
+	if (typeof object.intentId !== "string" || object.action !== "approve") {
+		throw new Error("Invalid approval context");
+	}
+	return { action: "approve" as const, intentId: object.intentId };
+});
+
+const enrolmentContext = defineChallengeContext("passkey-enrolment", 1, (value) => {
+	const object = parseObject(value);
+	if (typeof object.approverDid !== "string") throw new Error("Invalid enrolment context");
+	return { approverDid: object.approverDid };
+});
+
+describe("challenge context", () => {
+	it("round-trips typed context with deterministic serialization", () => {
+		const first = encodeChallengeContext(approvalContext, {
+			intentId: "intent_1",
+			action: "approve",
+		});
+		const second = encodeChallengeContext(approvalContext, {
+			action: "approve",
+			intentId: "intent_1",
+		});
+
+		expect(first).toBe(second);
+		expect(decodeChallengeContext(first, approvalContext)).toEqual({
+			action: "approve",
+			intentId: "intent_1",
+		});
+		expectTypeOf(first).toEqualTypeOf<SerializedChallengeContext<"release-approval">>();
+		const binding = bindChallengeContext(approvalContext, {
+			action: "approve",
+			intentId: "intent_1",
+		});
+		expectTypeOf(binding.value.action).toEqualTypeOf<"approve">();
+
+		// @ts-expect-error Ceremony brands prevent typed serialized values being interchanged.
+		const wrongContext: SerializedChallengeContext<"passkey-enrolment"> = first;
+		expect(wrongContext).toBe(first);
+	});
+
+	it("rejects malformed serialized values", () => {
+		expect(() => decodeChallengeContext("not base64url!", approvalContext)).toThrow(
+			/Malformed challenge context/,
+		);
+		expect(() =>
+			decodeChallengeContext(Buffer.from("not json").toString("base64url"), approvalContext),
+		).toThrow(/Malformed challenge context/);
+	});
+
+	it("rejects non-canonical serialized values", () => {
+		const nonCanonical = Buffer.from(
+			JSON.stringify({
+				version: 1,
+				type: "release-approval",
+				context: { intentId: "intent_1", action: "approve" },
+			}),
+		).toString("base64url");
+
+		expect(() => decodeChallengeContext(nonCanonical, approvalContext)).toThrow(
+			/Malformed challenge context/,
+		);
+	});
+
+	it("rejects version mismatches", () => {
+		const versionTwo = defineChallengeContext("release-approval", 2, approvalContext.parse);
+		const serialized = encodeChallengeContext(versionTwo, {
+			action: "approve",
+			intentId: "intent_1",
+		});
+
+		expect(() => decodeChallengeContext(serialized, approvalContext)).toThrow(
+			/Challenge context version mismatch/,
+		);
+	});
+
+	it("rejects ceremony type mismatches", () => {
+		const serialized = encodeChallengeContext(enrolmentContext, {
+			approverDid: "did:plc:approver",
+		});
+
+		expect(() => decodeChallengeContext(serialized, approvalContext)).toThrow(
+			/Challenge context type mismatch/,
+		);
+	});
+
+	it("validates decoded context with the codec", () => {
+		const invalid = encodeChallengeContext(
+			defineChallengeContext("release-approval", 1, (value) => value),
+			{ action: "reject", intentId: "intent_1" },
+		);
+
+		expect(() => decodeChallengeContext(invalid, approvalContext)).toThrow(
+			/Invalid approval context/,
+		);
+	});
+});

--- a/packages/auth/src/passkey/challenge-context.ts
+++ b/packages/auth/src/passkey/challenge-context.ts
@@ -1,0 +1,215 @@
+import { sha256 } from "@oslojs/crypto/sha2";
+import { decodeBase64urlIgnorePadding, encodeBase64urlNoPadding } from "@oslojs/encoding";
+
+declare const challengeContextType: unique symbol;
+const CONTEXT_TYPE_PATTERN = /^[a-z][a-z0-9._:-]{0,127}$/i;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const MAX_SERIALIZED_CONTEXT_LENGTH = 16 * 1024;
+const CONTEXT_CHALLENGE_VERSION = 1;
+
+export type SerializedChallengeContext<Type extends string = string> = string & {
+	readonly [challengeContextType]: Type;
+};
+
+export interface ChallengeContextCodec<Type extends string, Context> {
+	readonly type: Type;
+	readonly version: number;
+	readonly parse: (value: unknown) => Context;
+}
+
+export interface ChallengeContextBinding<Type extends string, Context> {
+	readonly codec: ChallengeContextCodec<Type, Context>;
+	readonly value: Context;
+}
+
+export type ChallengeContextErrorCode =
+	| "malformed_context"
+	| "context_type_mismatch"
+	| "context_version_mismatch"
+	| "context_binding_mismatch";
+
+export class ChallengeContextError extends Error {
+	constructor(
+		public readonly code: ChallengeContextErrorCode,
+		message: string,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "ChallengeContextError";
+	}
+}
+
+export function defineChallengeContext<Type extends string, Context>(
+	type: Type,
+	version: number,
+	parse: (value: unknown) => Context,
+): ChallengeContextCodec<Type, Context> {
+	if (!CONTEXT_TYPE_PATTERN.test(type)) {
+		throw new Error("Challenge context type must be a non-empty stable identifier");
+	}
+	if (!Number.isSafeInteger(version) || version < 1) {
+		throw new Error("Challenge context version must be a positive safe integer");
+	}
+	return { type, version, parse };
+}
+
+export function bindChallengeContext<Type extends string, Context>(
+	codec: ChallengeContextCodec<Type, Context>,
+	value: NoInfer<Context>,
+): ChallengeContextBinding<Type, Context> {
+	return { codec, value };
+}
+
+function canonicalize(value: unknown): unknown {
+	if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) throw new TypeError("Challenge context numbers must be finite");
+		return value;
+	}
+	if (Array.isArray(value)) return value.map(canonicalize);
+	if (typeof value === "object") {
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) {
+			throw new TypeError("Challenge context must contain only plain objects");
+		}
+		const result: Record<string, unknown> = Object.create(null);
+		const entries = Object.entries(value).toSorted(([left], [right]) =>
+			left < right ? -1 : left > right ? 1 : 0,
+		);
+		for (const [key, item] of entries) {
+			if (item === undefined) throw new TypeError("Challenge context cannot contain undefined");
+			result[key] = canonicalize(item);
+		}
+		return result;
+	}
+	throw new TypeError("Challenge context must be JSON-serializable");
+}
+
+function serializeEnvelope(type: string, version: number, context: unknown): string {
+	return JSON.stringify({ context: canonicalize(context), type, version });
+}
+
+export function encodeChallengeContext<Type extends string, Context>(
+	codec: ChallengeContextCodec<Type, Context>,
+	context: NoInfer<Context>,
+): SerializedChallengeContext<Type> {
+	const serialized = serializeEnvelope(codec.type, codec.version, context);
+	const encoded = encodeBase64urlNoPadding(new TextEncoder().encode(serialized));
+	if (encoded.length > MAX_SERIALIZED_CONTEXT_LENGTH) {
+		throw new TypeError("Challenge context exceeds the maximum serialized size");
+	}
+	// The runtime value remains a string; the brand prevents cross-purpose assignment.
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+	return encoded as SerializedChallengeContext<Type>;
+}
+
+export function createContextBoundChallenge(nonce: string, serializedContext: string): string {
+	const contextDigest = encodeBase64urlNoPadding(
+		sha256(new TextEncoder().encode(serializedContext)),
+	);
+	const serialized = JSON.stringify({
+		contextDigest,
+		nonce,
+		version: CONTEXT_CHALLENGE_VERSION,
+	});
+	return encodeBase64urlNoPadding(new TextEncoder().encode(serialized));
+}
+
+export function verifyContextBoundChallenge(challenge: string, serializedContext: string): void {
+	let value: unknown;
+	try {
+		if (!BASE64URL_PATTERN.test(challenge)) throw malformedContext();
+		const bytes = decodeBase64urlIgnorePadding(challenge);
+		if (encodeBase64urlNoPadding(bytes) !== challenge) throw malformedContext();
+		value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+	} catch (error) {
+		if (error instanceof ChallengeContextError) throw error;
+		throw malformedContext(error);
+	}
+	if (!isRecord(value)) {
+		throw malformedContext();
+	}
+	const envelope = value;
+	if (
+		Object.keys(envelope).length !== 3 ||
+		typeof envelope.contextDigest !== "string" ||
+		typeof envelope.nonce !== "string" ||
+		envelope.nonce.length !== 43 ||
+		!BASE64URL_PATTERN.test(envelope.nonce) ||
+		envelope.version !== CONTEXT_CHALLENGE_VERSION
+	) {
+		throw malformedContext();
+	}
+	const canonical = createContextBoundChallenge(envelope.nonce, serializedContext);
+	if (canonical !== challenge) {
+		throw new ChallengeContextError(
+			"context_binding_mismatch",
+			"Challenge context does not match challenge",
+		);
+	}
+}
+
+function malformedContext(cause?: unknown): ChallengeContextError {
+	return new ChallengeContextError("malformed_context", "Malformed challenge context", { cause });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function decodeChallengeContext<Type extends string, Context>(
+	serialized: string,
+	codec: ChallengeContextCodec<Type, Context>,
+): Context {
+	let value: unknown;
+	try {
+		if (serialized.length > MAX_SERIALIZED_CONTEXT_LENGTH || !BASE64URL_PATTERN.test(serialized)) {
+			throw malformedContext();
+		}
+		const bytes = decodeBase64urlIgnorePadding(serialized);
+		if (encodeBase64urlNoPadding(bytes) !== serialized) throw malformedContext();
+		value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+	} catch (error) {
+		if (error instanceof ChallengeContextError) throw error;
+		throw malformedContext(error);
+	}
+
+	if (!isRecord(value)) {
+		throw malformedContext();
+	}
+	const envelope = value;
+	if (
+		Object.keys(envelope).length !== 3 ||
+		!("context" in envelope) ||
+		typeof envelope.type !== "string" ||
+		typeof envelope.version !== "number"
+	) {
+		throw malformedContext();
+	}
+	if (envelope.type !== codec.type) {
+		throw new ChallengeContextError(
+			"context_type_mismatch",
+			`Challenge context type mismatch: expected ${codec.type}`,
+		);
+	}
+	if (envelope.version !== codec.version) {
+		throw new ChallengeContextError(
+			"context_version_mismatch",
+			`Challenge context version mismatch: expected ${codec.version}`,
+		);
+	}
+
+	let canonical: string;
+	try {
+		canonical = encodeBase64urlNoPadding(
+			new TextEncoder().encode(
+				serializeEnvelope(envelope.type, envelope.version, envelope.context),
+			),
+		);
+	} catch (error) {
+		throw malformedContext(error);
+	}
+	if (canonical !== serialized) throw malformedContext();
+
+	return codec.parse(envelope.context);
+}

--- a/packages/auth/src/passkey/index.ts
+++ b/packages/auth/src/passkey/index.ts
@@ -6,13 +6,30 @@ export type {
 	RegistrationOptions,
 	RegistrationResponse,
 	VerifiedRegistration,
+	VerifiedRegistrationWithContext,
 	AuthenticationOptions,
 	AuthenticationResponse,
 	VerifiedAuthentication,
+	VerifiedAuthenticationWithContext,
 	ChallengeStore,
+	AtomicChallengeStore,
 	ChallengeData,
 	PasskeyConfig,
 } from "./types.js";
+
+export type {
+	ChallengeContextBinding,
+	ChallengeContextCodec,
+	ChallengeContextErrorCode,
+	SerializedChallengeContext,
+} from "./challenge-context.js";
+export {
+	bindChallengeContext,
+	ChallengeContextError,
+	decodeChallengeContext,
+	defineChallengeContext,
+	encodeChallengeContext,
+} from "./challenge-context.js";
 
 export {
 	generateRegistrationOptions,

--- a/packages/auth/src/passkey/register.test.ts
+++ b/packages/auth/src/passkey/register.test.ts
@@ -5,7 +5,7 @@ import { encodeBase64urlNoPadding } from "@oslojs/encoding";
 import { parseAttestationObject, coseAlgorithmRS256, COSEKeyType } from "@oslojs/webauthn";
 import { describe, expect, it, vi } from "vitest";
 
-import { verifyRegistrationResponse } from "./register.js";
+import { generateRegistrationOptions, verifyRegistrationResponse } from "./register.js";
 import type { ChallengeStore, PasskeyConfig } from "./types.js";
 
 /**
@@ -47,6 +47,65 @@ vi.mock("@oslojs/webauthn", async (importOriginal) => {
 });
 
 describe("verifyRegistrationResponse", () => {
+	it.each(["preferred", "required", "discouraged"] as const)(
+		"wires %s user verification into registration options",
+		async (userVerification) => {
+			const options = await generateRegistrationOptions(
+				{ ...config, userVerification },
+				{ id: "user_1", email: "user@example.com", name: "User" },
+				[],
+				makeChallengeStore(),
+			);
+
+			expect(options.authenticatorSelection?.userVerification).toBe(userVerification);
+		},
+	);
+
+	it("defaults registration options to preferred user verification", async () => {
+		const options = await generateRegistrationOptions(
+			config,
+			{ id: "user_1", email: "user@example.com", name: "User" },
+			[],
+			makeChallengeStore(),
+		);
+
+		expect(options.authenticatorSelection?.userVerification).toBe("preferred");
+	});
+
+	it("rejects registration without UV when user verification is required", async () => {
+		const challenge = encodeBase64urlNoPadding(new TextEncoder().encode("test-challenge"));
+		const clientDataJSON = Buffer.from(
+			JSON.stringify({
+				type: "webauthn.create",
+				challenge,
+				origin: "https://example.com",
+			}),
+		);
+		vi.mocked(parseAttestationObject).mockReturnValueOnce({
+			authenticatorData: {
+				verifyRelyingPartyIdHash: () => true,
+				userPresent: true,
+				userVerified: false,
+			},
+			attestationStatement: { format: "none" },
+		} as any);
+
+		await expect(
+			verifyRegistrationResponse(
+				{ ...config, userVerification: "required" },
+				{
+					id: "test-credential",
+					rawId: "test-credential",
+					type: "public-key",
+					response: {
+						clientDataJSON: base64url(clientDataJSON),
+						attestationObject: "AA",
+					},
+				},
+				makeChallengeStore(),
+			),
+		).rejects.toThrow("User verification not verified");
+	});
 	it("rejects an origin not in the accepted list", async () => {
 		const challenge = encodeBase64urlNoPadding(new TextEncoder().encode("test-challenge"));
 		const clientDataJSON = Buffer.from(
@@ -118,7 +177,7 @@ describe("verifyRegistrationResponse", () => {
 		} as any);
 
 		const result = await verifyRegistrationResponse(
-			config,
+			{ ...config, userVerification: "required" },
 			{
 				id: "test-credential",
 				rawId: "test-credential",

--- a/packages/auth/src/passkey/register.test.ts
+++ b/packages/auth/src/passkey/register.test.ts
@@ -5,8 +5,9 @@ import { encodeBase64urlNoPadding } from "@oslojs/encoding";
 import { parseAttestationObject, coseAlgorithmRS256, COSEKeyType } from "@oslojs/webauthn";
 import { describe, expect, it, vi } from "vitest";
 
+import { bindChallengeContext, defineChallengeContext } from "./challenge-context.js";
 import { generateRegistrationOptions, verifyRegistrationResponse } from "./register.js";
-import type { ChallengeStore, PasskeyConfig } from "./types.js";
+import type { AtomicChallengeStore, ChallengeStore, PasskeyConfig } from "./types.js";
 
 /**
  * Locks in origin-check parity with `authenticate.ts`. The two functions
@@ -21,6 +22,8 @@ const config: PasskeyConfig = {
 	rpId: "example.com",
 	origins: ["https://example.com"],
 };
+
+const enrolmentContext = defineChallengeContext("passkey-enrolment", 1, (value) => value);
 
 function base64url(bytes: Uint8Array): string {
 	return Buffer.from(bytes).toString("base64url");
@@ -70,6 +73,50 @@ describe("verifyRegistrationResponse", () => {
 		);
 
 		expect(options.authenticatorSelection?.userVerification).toBe("preferred");
+	});
+
+	it.each([
+		["undefined", undefined],
+		["non-callable", "not-a-function"],
+	] as const)("rejects a typed-context store with %s consume", async (_label, consume) => {
+		const challengeStore = makeChallengeStore();
+		const options = await generateRegistrationOptions(
+			config,
+			{ id: "user_1", email: "user@example.com", name: "User" },
+			[],
+			challengeStore,
+			bindChallengeContext(enrolmentContext, { approverDid: "did:plc:approver" }),
+		);
+		const clientDataJSON = Buffer.from(
+			JSON.stringify({
+				type: "webauthn.create",
+				challenge: options.challenge,
+				origin: "https://example.com",
+			}),
+		);
+		const malformedStore = {
+			...challengeStore,
+			consume,
+		} as unknown as AtomicChallengeStore;
+
+		await expect(
+			verifyRegistrationResponse(
+				config,
+				{
+					id: "test-credential",
+					rawId: "test-credential",
+					type: "public-key",
+					response: {
+						clientDataJSON: base64url(clientDataJSON),
+						attestationObject: "AA",
+					},
+				},
+				malformedStore,
+				enrolmentContext,
+			),
+		).rejects.toThrow("Typed challenge context requires an atomic challenge store");
+		expect(challengeStore.get).not.toHaveBeenCalled();
+		expect(challengeStore.delete).not.toHaveBeenCalled();
 	});
 
 	it("rejects registration without UV when user verification is required", async () => {

--- a/packages/auth/src/passkey/register.ts
+++ b/packages/auth/src/passkey/register.ts
@@ -21,12 +21,21 @@ import {
 
 import { generateToken } from "../tokens.js";
 import type { Credential, NewCredential, AuthAdapter, User, DeviceType } from "../types.js";
+import {
+	createContextBoundChallenge,
+	decodeChallengeContext,
+	encodeChallengeContext,
+	verifyContextBoundChallenge,
+} from "./challenge-context.js";
+import type { ChallengeContextBinding, ChallengeContextCodec } from "./challenge-context.js";
 import type {
 	RegistrationOptions,
 	RegistrationResponse,
 	VerifiedRegistration,
 	ChallengeStore,
 	PasskeyConfig,
+	AtomicChallengeStore,
+	VerifiedRegistrationWithContext,
 } from "./types.js";
 
 const CHALLENGE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -36,19 +45,27 @@ export type { PasskeyConfig };
 /**
  * Generate registration options for creating a new passkey
  */
-export async function generateRegistrationOptions(
+export async function generateRegistrationOptions<Type extends string, Context>(
 	config: PasskeyConfig,
 	user: Pick<User, "id" | "email" | "name">,
 	existingCredentials: Credential[],
 	challengeStore: ChallengeStore,
+	challengeContext?: ChallengeContextBinding<Type, Context>,
 ): Promise<RegistrationOptions> {
-	const challenge = generateToken();
+	const serializedContext = challengeContext
+		? encodeChallengeContext(challengeContext.codec, challengeContext.value)
+		: undefined;
+	const nonce = generateToken();
+	const challenge = serializedContext
+		? createContextBoundChallenge(nonce, serializedContext)
+		: nonce;
 
 	// Store challenge for verification
 	await challengeStore.set(challenge, {
 		type: "registration",
 		userId: user.id,
 		expiresAt: Date.now() + CHALLENGE_TTL,
+		...(serializedContext ? { context: serializedContext } : {}),
 	});
 
 	// Encode user ID as base64url
@@ -74,7 +91,7 @@ export async function generateRegistrationOptions(
 		attestation: "none", // We don't need attestation for our use case
 		authenticatorSelection: {
 			residentKey: "preferred", // Allow discoverable credentials
-			userVerification: "preferred",
+			userVerification: config.userVerification ?? "preferred",
 		},
 		excludeCredentials: existingCredentials.map((cred) => ({
 			type: "public-key" as const,
@@ -87,11 +104,23 @@ export async function generateRegistrationOptions(
 /**
  * Verify a registration response and extract credential data
  */
-export async function verifyRegistrationResponse(
+export function verifyRegistrationResponse<Type extends string, Context>(
+	config: PasskeyConfig,
+	response: RegistrationResponse,
+	challengeStore: AtomicChallengeStore,
+	challengeContext: ChallengeContextCodec<Type, Context>,
+): Promise<VerifiedRegistrationWithContext<Context>>;
+export function verifyRegistrationResponse(
 	config: PasskeyConfig,
 	response: RegistrationResponse,
 	challengeStore: ChallengeStore,
-): Promise<VerifiedRegistration> {
+): Promise<VerifiedRegistration>;
+export async function verifyRegistrationResponse<Type extends string, Context>(
+	config: PasskeyConfig,
+	response: RegistrationResponse,
+	challengeStore: ChallengeStore,
+	challengeContext?: ChallengeContextCodec<Type, Context>,
+): Promise<VerifiedRegistration | VerifiedRegistrationWithContext<Context>> {
 	// Decode the response
 	const clientDataJSON = decodeBase64urlIgnorePadding(response.response.clientDataJSON);
 	const attestationObject = decodeBase64urlIgnorePadding(response.response.attestationObject);
@@ -106,7 +135,13 @@ export async function verifyRegistrationResponse(
 
 	// Verify challenge - convert Uint8Array back to base64url string (no padding, matching stored format)
 	const challengeString = encodeBase64urlNoPadding(clientData.challenge);
-	const challengeData = await challengeStore.get(challengeString);
+	if (challengeContext && !("consume" in challengeStore)) {
+		throw new Error("Typed challenge context requires an atomic challenge store");
+	}
+	const atomicStore = challengeStore as Partial<AtomicChallengeStore>;
+	const challengeData = atomicStore.consume
+		? await atomicStore.consume(challengeString)
+		: await challengeStore.get(challengeString);
 	if (!challengeData) {
 		throw new Error("Challenge not found or expired");
 	}
@@ -114,12 +149,25 @@ export async function verifyRegistrationResponse(
 		throw new Error("Invalid challenge type");
 	}
 	if (challengeData.expiresAt < Date.now()) {
-		await challengeStore.delete(challengeString);
+		if (!atomicStore.consume) await challengeStore.delete(challengeString);
 		throw new Error("Challenge expired");
 	}
 
 	// Delete challenge (single-use)
-	await challengeStore.delete(challengeString);
+	if (!atomicStore.consume) await challengeStore.delete(challengeString);
+	let contextResult: { present: false } | { present: true; value: Context } = {
+		present: false,
+	};
+	if (challengeData.context !== undefined) {
+		if (!challengeContext) throw new Error("Challenge context decoder required");
+		verifyContextBoundChallenge(challengeString, challengeData.context);
+		contextResult = {
+			present: true,
+			value: decodeChallengeContext(challengeData.context, challengeContext),
+		};
+	} else if (challengeContext) {
+		throw new Error("Challenge context not found");
+	}
 
 	// Verify origin against the accepted list
 	if (!config.origins.includes(clientData.origin)) {
@@ -145,6 +193,9 @@ export async function verifyRegistrationResponse(
 	// Verify flags
 	if (!authenticatorData.userPresent) {
 		throw new Error("User presence not verified");
+	}
+	if (config.userVerification === "required" && !authenticatorData.userVerified) {
+		throw new Error("User verification not verified");
 	}
 
 	// Extract credential data
@@ -192,7 +243,7 @@ export async function verifyRegistrationResponse(
 	const deviceType: DeviceType = "singleDevice";
 	const backedUp = false;
 
-	return {
+	const verified: VerifiedRegistration = {
 		credentialId: response.id,
 		publicKey: encodedPublicKey,
 		algorithm,
@@ -201,6 +252,7 @@ export async function verifyRegistrationResponse(
 		backedUp,
 		transports: response.response.transports ?? [],
 	};
+	return !contextResult.present ? verified : { ...verified, challengeContext: contextResult.value };
 }
 
 /**

--- a/packages/auth/src/passkey/register.ts
+++ b/packages/auth/src/passkey/register.ts
@@ -135,12 +135,13 @@ export async function verifyRegistrationResponse<Type extends string, Context>(
 
 	// Verify challenge - convert Uint8Array back to base64url string (no padding, matching stored format)
 	const challengeString = encodeBase64urlNoPadding(clientData.challenge);
-	if (challengeContext && !("consume" in challengeStore)) {
+	const consume = "consume" in challengeStore ? challengeStore.consume : undefined;
+	const consumesAtomically = typeof consume === "function";
+	if (challengeContext && !consumesAtomically) {
 		throw new Error("Typed challenge context requires an atomic challenge store");
 	}
-	const atomicStore = challengeStore as Partial<AtomicChallengeStore>;
-	const challengeData = atomicStore.consume
-		? await atomicStore.consume(challengeString)
+	const challengeData = consumesAtomically
+		? await consume.call(challengeStore, challengeString)
 		: await challengeStore.get(challengeString);
 	if (!challengeData) {
 		throw new Error("Challenge not found or expired");
@@ -149,12 +150,12 @@ export async function verifyRegistrationResponse<Type extends string, Context>(
 		throw new Error("Invalid challenge type");
 	}
 	if (challengeData.expiresAt < Date.now()) {
-		if (!atomicStore.consume) await challengeStore.delete(challengeString);
+		if (!consumesAtomically) await challengeStore.delete(challengeString);
 		throw new Error("Challenge expired");
 	}
 
 	// Delete challenge (single-use)
-	if (!atomicStore.consume) await challengeStore.delete(challengeString);
+	if (!consumesAtomically) await challengeStore.delete(challengeString);
 	let contextResult: { present: false } | { present: true; value: Context } = {
 		present: false,
 	};

--- a/packages/auth/src/passkey/types.ts
+++ b/packages/auth/src/passkey/types.ts
@@ -60,6 +60,10 @@ export interface VerifiedRegistration {
 	transports: AuthenticatorTransport[];
 }
 
+export type VerifiedRegistrationWithContext<Context> = VerifiedRegistration & {
+	challengeContext: Context;
+};
+
 // ============================================================================
 // Authentication (Using an existing passkey)
 // ============================================================================
@@ -94,6 +98,10 @@ export interface VerifiedAuthentication {
 	newCounter: number;
 }
 
+export type VerifiedAuthenticationWithContext<Context> = VerifiedAuthentication & {
+	challengeContext: Context;
+};
+
 // ============================================================================
 // Challenge storage
 // ============================================================================
@@ -104,10 +112,17 @@ export interface ChallengeStore {
 	delete(challenge: string): Promise<void>;
 }
 
+/** A store that removes and returns a challenge in one atomic operation. */
+export interface AtomicChallengeStore extends ChallengeStore {
+	consume(challenge: string): Promise<ChallengeData | null>;
+}
+
 export interface ChallengeData {
 	type: "registration" | "authentication";
 	userId?: string; // For registration, the user being registered
 	expiresAt: number;
+	/** Canonical output from `encodeChallengeContext`. */
+	context?: string;
 }
 
 // ============================================================================
@@ -124,4 +139,6 @@ export interface PasskeyConfig {
 	 * sharing `rpId` (e.g. apex + preview subdomain).
 	 */
 	origins: string[];
+	/** Defaults to `preferred` for backwards compatibility. */
+	userVerification?: "discouraged" | "preferred" | "required";
 }


### PR DESCRIPTION
## What does this PR do?

Implements W3.6 from the delegated release plan. It adds configurable WebAuthn user verification and typed, versioned challenge contexts, with required UV enforced during both registration and authentication verification and atomic challenge consumption for context-bound ceremonies. Existing CMS behavior remains `preferred` by default.

Part of #1908 and implements the approved protocol in #1870.

Closes: N/A, integration work for #1908.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs. N/A: no admin UI changes.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion. N/A: maintainer-owned implementation of approved RFC #1870 under umbrella #1908.

## AI-generated code disclosure

- [x] This PR includes AI-generated code, model/tool: OpenCode with GPT-5.6-sol plus independent adversarial and review agents.

## Screenshots / test output

No visual changes.

- Full monorepo build and typecheck pass.
- Auth package: 80 tests pass.
- Type-aware lint reports 0 diagnostics.
- Formatting and diff checks pass.
- Publint passes; `attw` crashes internally with `Cannot read properties of undefined (reading 'filename')`.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-delegated-release-service-12-passkey-uv-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/delegated-release-service-12-passkey-uv`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
