### PR TITLE
feat(registry): enforce moderation labels in clients

### DIFF
--- a/.changeset/quiet-labels-moderate.md
+++ b/.changeset/quiet-labels-moderate.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-client": patch
+---
+
+Adds release moderation evaluation over hydrated aggregator labels and exposes the atproto-content-labelers response header.

--- a/.changeset/tame-labels-hydrated.md
+++ b/.changeset/tame-labels-hydrated.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-moderation": patch
+---
+
+Adds `evaluateHydratedReleaseModeration` for evaluating aggregator-hydrated labels that carry no signature.

--- a/.changeset/tame-labels-hydrated.md
+++ b/.changeset/tame-labels-hydrated.md
@@ -2,4 +2,4 @@
 "@emdash-cms/registry-moderation": patch
 ---
 
-Adds `evaluateHydratedReleaseModeration` for evaluating aggregator-hydrated labels that carry no signature.
+Adds `evaluateHydratedReleaseModeration` for evaluating aggregator-hydrated labels that carry no signature, and `isModerationBlocking`, the canonical blocking predicate for enforcement consumers.

--- a/.changeset/tidy-labels-enforce.md
+++ b/.changeset/tidy-labels-enforce.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Registry install and update now evaluate the full moderation label set (package and publisher cascades, CID-bound labels, negation and expiry) instead of a single yanked-label string match. The update-check and artifact proxy endpoints also gate on this evaluation.

--- a/.changeset/tidy-plugins-eligible.md
+++ b/.changeset/tidy-plugins-eligible.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-cli": patch
+---
+
+Search and info now show moderation eligibility for registry packages instead of raw label values.

--- a/.opencode/plans/plugin-registry-labelling-service/gate-0/contracts.md
+++ b/.opencode/plans/plugin-registry-labelling-service/gate-0/contracts.md
@@ -9,6 +9,7 @@ Companions: [implementation spec](../spec.md), [implementation plan](../implemen
 - 2026-07-10 (#1926): the unshipped surface was standardized on US `labeler` spelling. The ratified public NSIDs are `com.emdashcms.experimental.labeler.*`; identifiers in this document were updated to match.
 - 2026-07-10 (#1917): the implemented evaluator added `applicableLabels: ModerationLabel[]` to `ReleaseModeration` for consumer display.
 - The ratified fixtures moved from this folder into product paths: `apps/labeler/fixtures/moderation-policy.json` and `packages/registry-moderation/tests/fixtures/moderation-cases.json`.
+- 2026-07-12 (W5 enforcement PR): the corpus's `oldPackageCid` value (`...moixb`, two occurrences in `eligible-package-mismatched-cid-label-ignored`) was not a decodable CID — a latent defect in the originally ratified corpus, inert until the hydrated evaluation path added structural CID validation. Corrected to a verified round-tripping CID (`...moixe`); the case's expected outcome is unchanged.
 
 ## Scope
 

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -50,6 +50,7 @@ import { checkEnvCompatibility, findSkippedEnvConstraints } from "@emdash-cms/re
 import type { HostEnv } from "@emdash-cms/registry-client/env";
 import {
 	evaluateReleaseViews,
+	isModerationBlocking,
 	resolveAcceptedPolicy,
 } from "@emdash-cms/registry-client/moderation";
 import type { ReleaseEligibility } from "@emdash-cms/registry-client/moderation";
@@ -614,8 +615,9 @@ interface ReleaseEligibilityError {
 /**
  * Gate a release against the shared moderation evaluator (release, package,
  * and publisher label cascade; CID-bound labels; negation and expiry -- see
- * `evaluateReleaseViews`). Blocks only on a manual/automated block or a
- * redact-flagged takedown. An eligibility of `"blocked"` driven solely by
+ * `evaluateReleaseViews`). Blocks per `isModerationBlocking`: an applicable
+ * blocking label, a redact-flagged takedown, or a fail-closed label-state
+ * collision. An eligibility of `"blocked"` driven solely by
  * `missing-assessment-pass` (no accepted labeler has passed this release) is
  * NOT a block here -- that positive-assessment gate isn't shipped yet, and
  * would require labels verified through `verifyLabel`, not this
@@ -651,14 +653,7 @@ function assertReleaseEligible(input: {
 		accepted,
 	});
 
-	// Keyed off blockingLabels/redacted, never eligibility: the evaluator
-	// ranks pending/error above automated blocks, so a malware label with a
-	// co-present assessment-pending yields eligibility "pending" while
-	// blockingLabels still carries the block. Empty blockingLabels covers
-	// missing-assessment-pass and pure pending/error, which must not block
-	// until the positive-assessment gate ships.
-	const blocked = moderation.blockingLabels.length > 0 || moderation.redacted;
-	if (!blocked) return null;
+	if (!isModerationBlocking(moderation)) return null;
 
 	const yanked = moderation.blockingLabels.includes("security-yanked");
 	return {
@@ -1800,9 +1795,9 @@ export interface RegistryUpdateCheck {
 /**
  * Package view stub for evaluating an update-check entry's release-scope
  * moderation without the extra `getPackage` round trip a bulk check can't
- * afford. `uri`/`cid` never match a real label (labels always carry a real
- * `at://` URI or DID), so the package/publisher cascade is inert here by
- * construction rather than by omission of input.
+ * afford. The empty `uri`/`cid` never match a real label, so only the
+ * package-scope cascade is excluded; publisher-scope labels riding on the
+ * release response still evaluate through the real `publisherDid`.
  */
 function releaseOnlyPackageViewStub(publisherDid: Did, slug: string): ValidatedPackageView {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- `uri`/`cid` are branded FormattedStringSchema types; this stub is never validated as a real record, only compared against label uris that can never equal these placeholders

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -651,9 +651,13 @@ function assertReleaseEligible(input: {
 		accepted,
 	});
 
-	const blocked =
-		(moderation.eligibility === "blocked" && moderation.blockingLabels.length > 0) ||
-		moderation.redacted;
+	// Keyed off blockingLabels/redacted, never eligibility: the evaluator
+	// ranks pending/error above automated blocks, so a malware label with a
+	// co-present assessment-pending yields eligibility "pending" while
+	// blockingLabels still carries the block. Empty blockingLabels covers
+	// missing-assessment-pass and pure pending/error, which must not block
+	// until the positive-assessment gate ships.
+	const blocked = moderation.blockingLabels.length > 0 || moderation.redacted;
 	if (!blocked) return null;
 
 	const yanked = moderation.blockingLabels.includes("security-yanked");
@@ -1780,6 +1784,11 @@ export interface RegistryUpdateCheck {
 	 * package/publisher label cascade needs a separate `getPackage` fetch per
 	 * plugin, which this bulk check intentionally doesn't make. `undefined`
 	 * when moderation couldn't be evaluated for this entry.
+	 *
+	 * Consumers must key any blocked indicator off
+	 * `blockingLabels.length > 0`, never `eligibility` — with no accepted
+	 * labeler having passed a release, `eligibility` is "blocked" via
+	 * missing-assessment-pass even for a clean plugin.
 	 */
 	moderation?: {
 		eligibility: ReleaseEligibility;

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -8,9 +8,11 @@
  *      aggregator's `resolvePackage` XRPC.
  *   2. Look up the requested release (or the policy-filtered latest one)
  *      via `getLatestRelease` / `listReleases`.
- *   3. Reject the install if the aggregator surfaces a `security:yanked`
- *      hard-enforcement label or the release is below the configured
- *      minimum release age.
+ *   3. Reject the install if `assertReleaseEligible` finds the release
+ *      blocked by the full moderation evaluator (release/package/publisher
+ *      label cascade, CID-bound labels, negation and expiry -- see
+ *      `@emdash-cms/registry-client`'s `evaluateReleaseViews`) or the
+ *      release is below the configured minimum release age.
  *   4. Fetch the bundle artifact, walking aggregator mirrors first and
  *      falling back to the publisher-declared URL.
  *   5. Verify the artifact's multibase checksum against the signed
@@ -40,8 +42,17 @@
 
 import { ClientResponseError, ClientValidationError } from "@atcute/client";
 import type { Did } from "@atcute/lexicons";
+import type {
+	ValidatedPackageView,
+	ValidatedReleaseView,
+} from "@emdash-cms/registry-client/discovery";
 import { checkEnvCompatibility, findSkippedEnvConstraints } from "@emdash-cms/registry-client/env";
 import type { HostEnv } from "@emdash-cms/registry-client/env";
+import {
+	evaluateReleaseViews,
+	resolveAcceptedPolicy,
+} from "@emdash-cms/registry-client/moderation";
+import type { ReleaseEligibility } from "@emdash-cms/registry-client/moderation";
 import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
@@ -590,6 +601,75 @@ export function assertEnvCompatible(
 	};
 }
 
+/**
+ * The shape of an eligibility rejection returned in the install/update
+ * `RELEASE_YANKED` / `RELEASE_BLOCKED` / `REGISTRY_POLICY_INVALID` error.
+ */
+interface ReleaseEligibilityError {
+	code: "RELEASE_YANKED" | "RELEASE_BLOCKED" | "REGISTRY_POLICY_INVALID";
+	message: string;
+	details?: { eligibility: ReleaseEligibility; reasonCodes: string[]; blockingLabels: string[] };
+}
+
+/**
+ * Gate a release against the shared moderation evaluator (release, package,
+ * and publisher label cascade; CID-bound labels; negation and expiry -- see
+ * `evaluateReleaseViews`). Blocks only on a manual/automated block or a
+ * redact-flagged takedown. An eligibility of `"blocked"` driven solely by
+ * `missing-assessment-pass` (no accepted labeler has passed this release) is
+ * NOT a block here -- that positive-assessment gate isn't shipped yet, and
+ * would require labels verified through `verifyLabel`, not this
+ * aggregator-hydrated path.
+ *
+ * Returns `null` when the release is not blocked, or a structured error to
+ * return directly from the handler.
+ */
+function assertReleaseEligible(input: {
+	packageView: ValidatedPackageView;
+	releaseView: ValidatedReleaseView;
+	publisherDid: string;
+	configuredAcceptLabelers: string | undefined;
+	contentLabelersHeader: string | undefined;
+}): ReleaseEligibilityError | null {
+	let accepted: ReturnType<typeof resolveAcceptedPolicy>;
+	try {
+		accepted = resolveAcceptedPolicy({
+			configuredAcceptLabelers: input.configuredAcceptLabelers,
+			contentLabelersHeader: input.contentLabelersHeader,
+		});
+	} catch (err) {
+		return {
+			code: "REGISTRY_POLICY_INVALID",
+			message: err instanceof Error ? err.message : "Invalid registry.acceptLabelers configuration",
+		};
+	}
+
+	const moderation = evaluateReleaseViews({
+		packageView: input.packageView,
+		releaseView: input.releaseView,
+		publisherDid: input.publisherDid,
+		accepted,
+	});
+
+	const blocked =
+		(moderation.eligibility === "blocked" && moderation.blockingLabels.length > 0) ||
+		moderation.redacted;
+	if (!blocked) return null;
+
+	const yanked = moderation.blockingLabels.includes("security-yanked");
+	return {
+		code: yanked ? "RELEASE_YANKED" : "RELEASE_BLOCKED",
+		message: yanked
+			? "This release has been withdrawn (security-yanked label)."
+			: "This release is blocked by registry moderation labels.",
+		details: {
+			eligibility: moderation.eligibility,
+			reasonCodes: moderation.reasonCodes,
+			blockingLabels: moderation.blockingLabels,
+		},
+	};
+}
+
 // ── Install ────────────────────────────────────────────────────────
 
 export async function handleRegistryInstall(
@@ -660,10 +740,17 @@ export async function handleRegistryInstall(
 	// deadline. Defends against a slow-loris aggregator stalling the
 	// install before the artifact phase begins.
 	const aggregatorDeadline = Date.now() + AGGREGATOR_TOTAL_BUDGET_MS;
+	// Captures the aggregator's `atproto-content-labelers` response header --
+	// the labeler policy it actually applied -- for `assertReleaseEligible`
+	// below. Precedence over the configured value: see `resolveAcceptedPolicy`.
+	let contentLabelersHeader: string | undefined;
 	const discovery = new DiscoveryClient({
 		aggregatorUrl: registryConfig.aggregatorUrl,
 		acceptLabelers: registryConfig.acceptLabelers,
 		fetch: timedFetch(aggregatorDeadline),
+		onResponseMeta: (meta) => {
+			contentLabelersHeader = meta.contentLabelers ?? contentLabelersHeader;
+		},
 	});
 
 	// Basic shape check on the DID. The browser is expected to send a
@@ -788,24 +875,17 @@ export async function handleRegistryInstall(
 
 		const version = releaseView.version;
 
-		// Step 3: takedown label check (hard-enforced via aggregator's
-		// `atproto-accept-labelers` filtering, but we belt-and-suspenders
-		// the package-level labels too).
-		const yanked = (packageView.labels ?? []).some(
-			(l: { val?: string }) => l.val === "security:yanked",
-		);
-		const releaseYanked = (releaseView.labels ?? []).some(
-			(l: { val?: string }) => l.val === "security:yanked",
-		);
-		if (yanked || releaseYanked) {
-			return {
-				success: false,
-				error: {
-					code: "RELEASE_YANKED",
-					message: "This release has been withdrawn (security:yanked label).",
-				},
-			};
-		}
+		// Step 3: moderation eligibility (hard-enforced via aggregator's
+		// `atproto-accept-labelers` filtering, but we belt-and-suspenders the
+		// full release/package/publisher label cascade here too).
+		const eligibilityError = assertReleaseEligible({
+			packageView,
+			releaseView,
+			publisherDid,
+			configuredAcceptLabelers: registryConfig.acceptLabelers,
+			contentLabelersHeader,
+		});
+		if (eligibilityError) return { success: false, error: eligibilityError };
 
 		// Step 3b: environment compatibility. The signed release record may
 		// carry a `requires` block (`env:emdash`, `env:astro`, ...). Refuse
@@ -1380,10 +1460,14 @@ export async function handleRegistryUpdate(
 
 		const { DiscoveryClient } = await import("@emdash-cms/registry-client/discovery");
 		const aggregatorDeadline = Date.now() + AGGREGATOR_TOTAL_BUDGET_MS;
+		let contentLabelersHeader: string | undefined;
 		const discovery = new DiscoveryClient({
 			aggregatorUrl: registryConfig.aggregatorUrl,
 			acceptLabelers: registryConfig.acceptLabelers,
 			fetch: timedFetch(aggregatorDeadline),
+			onResponseMeta: (meta) => {
+				contentLabelersHeader = meta.contentLabelers ?? contentLabelersHeader;
+			},
 		});
 
 		// Resolve target release. Explicit version → paginate listReleases;
@@ -1459,16 +1543,27 @@ export async function handleRegistryUpdate(
 			};
 		}
 
-		// Yanked label check (mirrors install).
-		const releaseYanked = (releaseView.labels ?? []).some(
-			(l: { val?: string }) => l.val === "security:yanked",
-		);
-		if (releaseYanked) {
+		// Moderation eligibility (mirrors install). Update previously checked
+		// only the release's own labels; fetching the package view here adds
+		// the package/publisher cascade that release-only check was missing.
+		const packageView = await discovery.getPackage({ did: publisherDid, slug });
+		if (packageView.did !== publisherDid || packageView.slug !== slug) {
 			return {
 				success: false,
-				error: { code: "YANKED", message: "Release has been yanked by a trusted labeler" },
+				error: {
+					code: "AGGREGATOR_IDENTITY_MISMATCH",
+					message: "Aggregator returned a package view for a different publisher or slug.",
+				},
 			};
 		}
+		const eligibilityError = assertReleaseEligible({
+			packageView,
+			releaseView,
+			publisherDid,
+			configuredAcceptLabelers: registryConfig.acceptLabelers,
+			contentLabelersHeader,
+		});
+		if (eligibilityError) return { success: false, error: eligibilityError };
 
 		// Environment compatibility gate. An ungated update could otherwise
 		// land a version whose `requires` the host doesn't satisfy. Same
@@ -1678,6 +1773,38 @@ export interface RegistryUpdateCheck {
 	 */
 	hasCapabilityChanges: boolean;
 	hasRouteVisibilityChanges: boolean;
+	/**
+	 * Moderation state of the latest release, evaluated from the labels that
+	 * ride on the same `getLatestRelease` response the version comparison
+	 * already needed -- no extra aggregator call. Release-scope only: the
+	 * package/publisher label cascade needs a separate `getPackage` fetch per
+	 * plugin, which this bulk check intentionally doesn't make. `undefined`
+	 * when moderation couldn't be evaluated for this entry.
+	 */
+	moderation?: {
+		eligibility: ReleaseEligibility;
+		blockingLabels: string[];
+		warningLabels: string[];
+	};
+}
+
+/**
+ * Package view stub for evaluating an update-check entry's release-scope
+ * moderation without the extra `getPackage` round trip a bulk check can't
+ * afford. `uri`/`cid` never match a real label (labels always carry a real
+ * `at://` URI or DID), so the package/publisher cascade is inert here by
+ * construction rather than by omission of input.
+ */
+function releaseOnlyPackageViewStub(publisherDid: Did, slug: string): ValidatedPackageView {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- `uri`/`cid` are branded FormattedStringSchema types; this stub is never validated as a real record, only compared against label uris that can never equal these placeholders
+	return {
+		uri: "",
+		cid: "",
+		did: publisherDid,
+		slug,
+		indexedAt: new Date(0).toISOString(),
+		profile: null,
+	} as unknown as ValidatedPackageView;
 }
 
 /**
@@ -1706,26 +1833,73 @@ export async function handleRegistryUpdateCheck(
 			return { success: true, data: { items: [] } };
 		}
 
+		// Validate the configured acceptLabelers once, up front. A malformed
+		// value would otherwise throw identically on every loop iteration,
+		// silently blanking the moderation field for every plugin one at a
+		// time instead of surfacing a single clear config error.
+		try {
+			resolveAcceptedPolicy({ configuredAcceptLabelers: registryConfig.acceptLabelers });
+		} catch (err) {
+			return {
+				success: false,
+				error: {
+					code: "REGISTRY_POLICY_INVALID",
+					message:
+						err instanceof Error ? err.message : "Invalid registry.acceptLabelers configuration",
+				},
+			};
+		}
+
 		const { DiscoveryClient } = await import("@emdash-cms/registry-client/discovery");
 		const aggregatorDeadline = Date.now() + AGGREGATOR_TOTAL_BUDGET_MS;
+		let contentLabelersHeader: string | undefined;
 		const discovery = new DiscoveryClient({
 			aggregatorUrl: registryConfig.aggregatorUrl,
 			acceptLabelers: registryConfig.acceptLabelers,
 			fetch: timedFetch(aggregatorDeadline),
+			onResponseMeta: (meta) => {
+				contentLabelersHeader = meta.contentLabelers ?? contentLabelersHeader;
+			},
 		});
 
 		const items: RegistryUpdateCheck[] = [];
 		for (const plugin of registryPlugins) {
 			if (!plugin.registryPublisherDid || !plugin.registrySlug) continue;
 			try {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- DID string was validated by the install handler
+				const publisherDid = plugin.registryPublisherDid as Did;
 				const releaseView = await discovery.getLatestRelease({
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- DID string was validated by the install handler
-					did: plugin.registryPublisherDid as Did,
+					did: publisherDid,
 					package: plugin.registrySlug,
 				});
 				const latest = releaseView.version;
 				if (!latest) continue;
 				const installed = plugin.version;
+
+				let moderation: RegistryUpdateCheck["moderation"];
+				try {
+					const accepted = resolveAcceptedPolicy({
+						configuredAcceptLabelers: registryConfig.acceptLabelers,
+						contentLabelersHeader,
+					});
+					const result = evaluateReleaseViews({
+						packageView: releaseOnlyPackageViewStub(publisherDid, plugin.registrySlug),
+						releaseView,
+						publisherDid,
+						accepted,
+					});
+					moderation = {
+						eligibility: result.eligibility,
+						blockingLabels: result.blockingLabels,
+						warningLabels: result.warningLabels,
+					};
+				} catch (moderationErr) {
+					console.warn(
+						`[registry-update-check] Failed to evaluate moderation for ${plugin.pluginId}:`,
+						moderationErr,
+					);
+				}
+
 				items.push({
 					pluginId: plugin.pluginId,
 					installed,
@@ -1733,6 +1907,7 @@ export async function handleRegistryUpdateCheck(
 					hasUpdate: latest !== installed,
 					hasCapabilityChanges: false,
 					hasRouteVisibilityChanges: false,
+					moderation,
 				});
 			} catch (err) {
 				// Skip plugins that can't be checked. Don't fail the whole

--- a/packages/core/src/astro/routes/api/admin/plugins/registry/artifact.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/registry/artifact.ts
@@ -22,6 +22,10 @@
  */
 
 import type { Did } from "@atcute/lexicons";
+import {
+	evaluateReleaseViews,
+	resolveAcceptedPolicy,
+} from "@emdash-cms/registry-client/moderation";
 import type { APIRoute } from "astro";
 
 import { requirePerm } from "#api/authorize.js";
@@ -202,7 +206,10 @@ export const GET: APIRoute = async ({ url, locals }) => {
 		if (resolved === null) {
 			return apiError("ARTIFACT_NOT_FOUND", "Artifact not found", 404);
 		}
-		declaredUrl = resolved;
+		if (resolved.blocked) {
+			return apiError("RELEASE_BLOCKED", "Release is blocked by registry moderation", 404);
+		}
+		declaredUrl = resolved.url;
 	} catch {
 		return apiError("ARTIFACT_RESOLVE_FAILED", "Failed to resolve artifact", 502);
 	}
@@ -290,10 +297,18 @@ export const GET: APIRoute = async ({ url, locals }) => {
 	}
 };
 
+/** Result of resolving an artifact's declared URL: the URL plus whether its release is moderation-blocked. */
+interface ResolvedArtifact {
+	url: string;
+	blocked: boolean;
+}
+
 /**
  * Resolve the declared artifact URL for `(did, slug, version, kind, index)`
- * from the aggregator's release record. Mirrors the install handler's release
- * lookup. Returns `null` when the package/release/artifact isn't found.
+ * from the aggregator's release record, and gate it through the same
+ * moderation evaluator the install/update handlers use. Mirrors the install
+ * handler's release lookup. Returns `null` when the package/release/artifact
+ * isn't found.
  *
  * Self-contained to this route: the install/update handlers are intentionally
  * left untouched, so a small amount of resolution-pattern duplication is
@@ -306,20 +321,26 @@ async function resolveArtifactUrl(
 	version: string | undefined,
 	kind: string,
 	index: number,
-): Promise<string | null> {
+): Promise<ResolvedArtifact | null> {
 	// Lazy-load the discovery client so the `@atcute/client` dependency only
 	// loads when the registry path is exercised.
 	const { DiscoveryClient } = await import("@emdash-cms/registry-client/discovery");
 
 	const aggregatorDeadline = Date.now() + AGGREGATOR_TOTAL_BUDGET_MS;
+	let contentLabelersHeader: string | undefined;
 	const discovery = new DiscoveryClient({
 		aggregatorUrl: registryConfig.aggregatorUrl,
 		acceptLabelers: registryConfig.acceptLabelers,
 		fetch: timedFetch(aggregatorDeadline),
+		onResponseMeta: (meta) => {
+			contentLabelersHeader = meta.contentLabelers ?? contentLabelersHeader;
+		},
 	});
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- DID shape validated by the route before this call
 	const publisherDid = did as Did;
+
+	const packageView = await discovery.getPackage({ did: publisherDid, slug });
 
 	const releaseView = await (async () => {
 		if (!version) {
@@ -349,7 +370,19 @@ async function resolveArtifactUrl(
 
 	if (!releaseView?.release) return null;
 
-	return resolveDeclaredUrl(releaseView.release.artifacts, kind, index);
+	const url = resolveDeclaredUrl(releaseView.release.artifacts, kind, index);
+	if (url === null) return null;
+
+	const accepted = resolveAcceptedPolicy({
+		configuredAcceptLabelers: registryConfig.acceptLabelers,
+		contentLabelersHeader,
+	});
+	const moderation = evaluateReleaseViews({ packageView, releaseView, publisherDid, accepted });
+	const blocked =
+		(moderation.eligibility === "blocked" && moderation.blockingLabels.length > 0) ||
+		moderation.redacted;
+
+	return { url, blocked };
 }
 
 /**

--- a/packages/core/src/astro/routes/api/admin/plugins/registry/artifact.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/registry/artifact.ts
@@ -24,6 +24,7 @@
 import type { Did } from "@atcute/lexicons";
 import {
 	evaluateReleaseViews,
+	isModerationBlocking,
 	resolveAcceptedPolicy,
 } from "@emdash-cms/registry-client/moderation";
 import type { APIRoute } from "astro";
@@ -378,11 +379,7 @@ async function resolveArtifactUrl(
 		contentLabelersHeader,
 	});
 	const moderation = evaluateReleaseViews({ packageView, releaseView, publisherDid, accepted });
-	// Never keyed off eligibility: a co-present assessment-pending/error label
-	// re-ranks eligibility while blockingLabels still carries the block.
-	const blocked = moderation.blockingLabels.length > 0 || moderation.redacted;
-
-	return { url, blocked };
+	return { url, blocked: isModerationBlocking(moderation) };
 }
 
 /**

--- a/packages/core/src/astro/routes/api/admin/plugins/registry/artifact.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/registry/artifact.ts
@@ -378,9 +378,9 @@ async function resolveArtifactUrl(
 		contentLabelersHeader,
 	});
 	const moderation = evaluateReleaseViews({ packageView, releaseView, publisherDid, accepted });
-	const blocked =
-		(moderation.eligibility === "blocked" && moderation.blockingLabels.length > 0) ||
-		moderation.redacted;
+	// Never keyed off eligibility: a co-present assessment-pending/error label
+	// re-ranks eligibility while blockingLabels still carries the block.
+	const blocked = moderation.blockingLabels.length > 0 || moderation.redacted;
 
 	return { url, blocked };
 }

--- a/packages/core/tests/unit/api/registry-artifact-proxy.test.ts
+++ b/packages/core/tests/unit/api/registry-artifact-proxy.test.ts
@@ -274,6 +274,113 @@ describe("registry artifact proxy", () => {
 		expect(res.status).toBe(404);
 	});
 
+	// ── moderation gate ─────────────────────────────────────────────────
+
+	const LABELER = "did:plc:labeler-a";
+	const PACKAGE_URI = "at://did:plc:abc123/com.emdashcms.experimental.package.profile/myplugin";
+	const PACKAGE_CID = "bafyreiclpjmh2e5ug4oufdmfnz4r4a6o2lrfu5hzgopzjlb3u2v5il5z4a";
+	const RELEASE_URI =
+		"at://did:plc:abc123/com.emdashcms.experimental.package.release/myplugin:1.0.0";
+	const RELEASE_CID = "bafyreig5l2zfc7l5m4zq3r6v4s2wqkd3j7yq5x7x6n2j4h5r3p6s7t2w4e";
+
+	function moderationLabel(overrides: Record<string, unknown> = {}) {
+		return {
+			ver: 1,
+			src: LABELER,
+			uri: RELEASE_URI,
+			cid: RELEASE_CID,
+			cts: "2026-07-10T12:00:00.000Z",
+			...overrides,
+		};
+	}
+
+	it("returns 404 when the release is blocked by a moderation label, without fetching the image", async () => {
+		getPackage.mockResolvedValueOnce({
+			uri: PACKAGE_URI,
+			cid: PACKAGE_CID,
+			did: "did:plc:abc123",
+			slug: "myplugin",
+			indexedAt: "2026-07-01T00:00:00.000Z",
+			profile: {},
+			labels: [],
+		});
+		getLatestRelease.mockResolvedValueOnce({
+			did: "did:plc:abc123",
+			package: "myplugin",
+			version: mockReleaseVersion,
+			uri: RELEASE_URI,
+			cid: RELEASE_CID,
+			labels: [moderationLabel({ val: "malware" })],
+			release: { version: mockReleaseVersion, artifacts: mockArtifacts },
+		});
+		const fetchMock = vi.fn(async () => imageResponse(PNG_1x1)) as typeof globalThis.fetch;
+		globalThis.fetch = fetchMock;
+		const res = await GET(
+			makeContext(DEFAULT_PARAMS, adminUser, {
+				aggregatorUrl: AGGREGATOR_URL,
+				acceptLabelers: LABELER,
+			}),
+		);
+		expect(res.status).toBe(404);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 for a redact-flagged takedown label", async () => {
+		getPackage.mockResolvedValueOnce({
+			uri: PACKAGE_URI,
+			cid: PACKAGE_CID,
+			did: "did:plc:abc123",
+			slug: "myplugin",
+			indexedAt: "2026-07-01T00:00:00.000Z",
+			profile: {},
+			labels: [],
+		});
+		getLatestRelease.mockResolvedValueOnce({
+			did: "did:plc:abc123",
+			package: "myplugin",
+			version: mockReleaseVersion,
+			uri: RELEASE_URI,
+			cid: RELEASE_CID,
+			labels: [moderationLabel({ val: "!takedown", cid: undefined })],
+			release: { version: mockReleaseVersion, artifacts: mockArtifacts },
+		});
+		const fetchMock = vi.fn(async () => imageResponse(PNG_1x1)) as typeof globalThis.fetch;
+		globalThis.fetch = fetchMock;
+		const res = await GET(
+			makeContext(DEFAULT_PARAMS, adminUser, {
+				aggregatorUrl: AGGREGATOR_URL,
+				acceptLabelers: `${LABELER};redact`,
+			}),
+		);
+		expect(res.status).toBe(404);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("does not block when no acceptLabelers policy is configured (no client-side enforcement)", async () => {
+		getPackage.mockResolvedValueOnce({
+			uri: PACKAGE_URI,
+			cid: PACKAGE_CID,
+			did: "did:plc:abc123",
+			slug: "myplugin",
+			indexedAt: "2026-07-01T00:00:00.000Z",
+			profile: {},
+			labels: [],
+		});
+		getLatestRelease.mockResolvedValueOnce({
+			did: "did:plc:abc123",
+			package: "myplugin",
+			version: mockReleaseVersion,
+			uri: RELEASE_URI,
+			cid: RELEASE_CID,
+			labels: [moderationLabel({ val: "malware" })],
+			release: { version: mockReleaseVersion, artifacts: mockArtifacts },
+		});
+		const fetchMock = vi.fn(async () => imageResponse(PNG_1x1)) as typeof globalThis.fetch;
+		globalThis.fetch = fetchMock;
+		const res = await GET(makeContext(DEFAULT_PARAMS, adminUser, AGGREGATOR_URL));
+		expect(res.status).toBe(200);
+	});
+
 	// ── content-type allowlist ─────────────────────────────────────────
 
 	it("allows AVIF", async () => {

--- a/packages/core/tests/unit/api/registry-env-gate-handler.test.ts
+++ b/packages/core/tests/unit/api/registry-env-gate-handler.test.ts
@@ -90,6 +90,17 @@ describe("handleRegistryUpdate env gate", () => {
 		getLatestRelease.mockReset();
 		listReleases.mockReset();
 		getPackage.mockReset();
+		// The moderation eligibility gate (which runs before the env gate)
+		// fetches the package view too. No labels -> not blocked, so it's a
+		// no-op for these env-gate assertions.
+		getPackage.mockResolvedValue({
+			uri: `at://${PUBLISHER}/com.emdashcms.experimental.package.profile/${SLUG}`,
+			cid: "bafyreigallerystubcidnotreallyacidjustaplaceholderstring1234",
+			did: PUBLISHER,
+			slug: SLUG,
+			indexedAt: "2026-01-01T00:00:00.000Z",
+			profile: null,
+		});
 		fetchSpy = vi.fn(() => {
 			throw new Error("artifact fetch must not run when the env gate rejects");
 		});

--- a/packages/core/tests/unit/api/registry-moderation-gate-handler.test.ts
+++ b/packages/core/tests/unit/api/registry-moderation-gate-handler.test.ts
@@ -237,6 +237,28 @@ describe("registry moderation eligibility gate", () => {
 			expect(errored.error?.code).not.toBe("RELEASE_BLOCKED");
 		});
 
+		it("blocks a malware label even when a co-present pending or error label re-ranks eligibility", async () => {
+			getPackage.mockResolvedValue(packageView());
+
+			getLatestRelease.mockResolvedValue(
+				releaseView([label({ val: "malware" }), label({ val: "assessment-pending" })]),
+			);
+			const pending = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+			expect(pending.error?.code).toBe("RELEASE_BLOCKED");
+
+			getLatestRelease.mockResolvedValue(
+				releaseView([label({ val: "malware" }), label({ val: "assessment-error" })]),
+			);
+			const errored = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+			expect(errored.error?.code).toBe("RELEASE_BLOCKED");
+		});
+
 		it("does not block when no acceptLabelers policy is configured (no client-side enforcement)", async () => {
 			getPackage.mockResolvedValue(packageView());
 			getLatestRelease.mockResolvedValue(releaseView([label({ val: "malware" })]));

--- a/packages/core/tests/unit/api/registry-moderation-gate-handler.test.ts
+++ b/packages/core/tests/unit/api/registry-moderation-gate-handler.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Registry moderation eligibility gate wired through the real handlers.
+ *
+ * Drives `handleRegistryInstall`, `handleRegistryUpdate`, and
+ * `handleRegistryUpdateCheck` end-to-end with a mocked `DiscoveryClient` so
+ * the shared evaluator (release/package/publisher label cascade, CID-bound
+ * labels) blocks install/update *before any artifact fetch*, and that an
+ * eligibility of "blocked" driven solely by `missing-assessment-pass`
+ * (today's default -- no labels flow in production yet) does NOT block.
+ */
+
+import BetterSqlite3 from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import type { Database as DbSchema } from "../../../src/database/types.js";
+import type { SandboxRunner } from "../../../src/plugins/sandbox/types.js";
+import { PluginStateRepository } from "../../../src/plugins/state.js";
+import type { Storage } from "../../../src/storage/types.js";
+
+/** A storage stub: present so the null-storage guard passes, never exercised. */
+const stubStorage = {
+	async download() {
+		throw new Error("not implemented");
+	},
+} as unknown as Storage;
+
+const getLatestRelease = vi.fn();
+const listReleases = vi.fn();
+const getPackage = vi.fn();
+
+vi.mock("@emdash-cms/registry-client/discovery", () => ({
+	DiscoveryClient: class {
+		getLatestRelease = getLatestRelease;
+		listReleases = listReleases;
+		getPackage = getPackage;
+	},
+}));
+
+const PUBLISHER = "did:plc:abc";
+const SLUG = "gallery";
+const LABELER = "did:plc:labeler-a";
+const PACKAGE_URI = `at://${PUBLISHER}/com.emdashcms.experimental.package.profile/${SLUG}`;
+// Real, decodable DASL CIDs -- the moderation evaluator structurally
+// validates each label's `cid`.
+const PACKAGE_CID = "bafyreiclpjmh2e5ug4oufdmfnz4r4a6o2lrfu5hzgopzjlb3u2v5il5z4a";
+const RELEASE_VERSION = "2.0.0";
+const RELEASE_URI = `at://${PUBLISHER}/com.emdashcms.experimental.package.release/${SLUG}:${RELEASE_VERSION}`;
+const RELEASE_CID = "bafyreig5l2zfc7l5m4zq3r6v4s2wqkd3j7yq5x7x6n2j4h5r3p6s7t2w4e";
+const STALE_RELEASE_CID = "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixa";
+
+/** Config accepting `LABELER`'s labels -- without this, no label is ever considered (see decision 3). */
+const CONFIG = { aggregatorUrl: "https://aggregator.test", acceptLabelers: LABELER };
+
+function label(overrides: Record<string, unknown> = {}) {
+	return {
+		ver: 1,
+		src: LABELER,
+		uri: RELEASE_URI,
+		cid: RELEASE_CID,
+		cts: "2026-07-10T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+function packageView(labels: unknown[] = []) {
+	return {
+		uri: PACKAGE_URI,
+		cid: PACKAGE_CID,
+		did: PUBLISHER,
+		slug: SLUG,
+		indexedAt: "2026-07-01T00:00:00.000Z",
+		profile: {},
+		labels,
+	};
+}
+
+function releaseView(labels: unknown[] = []) {
+	return {
+		did: PUBLISHER,
+		package: SLUG,
+		version: RELEASE_VERSION,
+		uri: RELEASE_URI,
+		cid: RELEASE_CID,
+		labels,
+		mirrors: [],
+		release: {
+			package: SLUG,
+			version: RELEASE_VERSION,
+			// A real declared artifact URL: if the gate failed to abort, the
+			// handler would proceed to fetch this, tripping the `fetch` spy.
+			artifacts: {
+				package: {
+					url: "https://artifacts.test/gallery-2.0.0.tar.gz",
+					checksum: "sha256-deadbeef",
+				},
+			},
+		},
+	};
+}
+
+describe("registry moderation eligibility gate", () => {
+	let db: Kysely<DbSchema>;
+	let handleRegistryInstall: typeof import("../../../src/api/handlers/registry.js").handleRegistryInstall;
+	let handleRegistryUpdate: typeof import("../../../src/api/handlers/registry.js").handleRegistryUpdate;
+	let handleRegistryUpdateCheck: typeof import("../../../src/api/handlers/registry.js").handleRegistryUpdateCheck;
+	const stubSandbox = { isAvailable: () => true } as unknown as SandboxRunner;
+	let fetchSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		({ handleRegistryInstall, handleRegistryUpdate, handleRegistryUpdateCheck } =
+			await import("../../../src/api/handlers/registry.js"));
+		const sqlite = new BetterSqlite3(":memory:");
+		db = new Kysely<DbSchema>({ dialect: new SqliteDialect({ database: sqlite }) });
+		await runMigrations(db);
+
+		getLatestRelease.mockReset();
+		listReleases.mockReset();
+		getPackage.mockReset();
+		fetchSpy = vi.fn(() => {
+			throw new Error("artifact fetch must not run when the moderation gate rejects");
+		});
+		vi.stubGlobal("fetch", fetchSpy);
+	});
+
+	afterEach(async () => {
+		vi.unstubAllGlobals();
+		await db.destroy();
+	});
+
+	describe("handleRegistryInstall", () => {
+		it("blocks with RELEASE_BLOCKED before any artifact fetch on an automated-block label", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "malware" })]));
+
+			const result = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe("RELEASE_BLOCKED");
+			expect(result.error?.details).toMatchObject({ blockingLabels: ["malware"] });
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it("blocks with RELEASE_YANKED when security-yanked is among the blocking labels", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "security-yanked" })]));
+
+			const result = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe("RELEASE_YANKED");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it("cascades a package-URI takedown label from the package view", async () => {
+			getPackage.mockResolvedValue(
+				packageView([label({ uri: PACKAGE_URI, cid: undefined, val: "!takedown" })]),
+			);
+			getLatestRelease.mockResolvedValue(releaseView());
+
+			const result = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe("RELEASE_BLOCKED");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it("cascades a publisher-DID compromise label", async () => {
+			getPackage.mockResolvedValue(
+				packageView([label({ uri: PUBLISHER, cid: undefined, val: "publisher-compromised" })]),
+			);
+			getLatestRelease.mockResolvedValue(releaseView());
+
+			const result = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe("RELEASE_BLOCKED");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it("does not block on a CID-stale label that no longer matches the release", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(
+				releaseView([label({ val: "malware", cid: STALE_RELEASE_CID })]),
+			);
+
+			const result = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+
+			expect(result.error?.code).not.toBe("RELEASE_BLOCKED");
+			expect(result.error?.code).not.toBe("RELEASE_YANKED");
+		});
+
+		it("does not block a warning-only release", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "suspicious-code" })]));
+
+			const result = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+
+			expect(result.error?.code).not.toBe("RELEASE_BLOCKED");
+			expect(result.error?.code).not.toBe("RELEASE_YANKED");
+		});
+
+		it("does not block pending or error assessment labels", async () => {
+			getPackage.mockResolvedValue(packageView());
+
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "assessment-pending" })]));
+			const pending = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+			expect(pending.error?.code).not.toBe("RELEASE_BLOCKED");
+
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "assessment-error" })]));
+			const errored = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+			expect(errored.error?.code).not.toBe("RELEASE_BLOCKED");
+		});
+
+		it("does not block when no acceptLabelers policy is configured (no client-side enforcement)", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "malware" })]));
+
+			const result = await handleRegistryInstall(
+				db,
+				stubStorage,
+				stubSandbox,
+				{ aggregatorUrl: "https://aggregator.test" },
+				{ did: PUBLISHER, slug: SLUG },
+			);
+
+			expect(result.error?.code).not.toBe("RELEASE_BLOCKED");
+		});
+	});
+
+	describe("handleRegistryUpdate", () => {
+		beforeEach(async () => {
+			const repo = new PluginStateRepository(db);
+			await repo.upsert("r_gallery000000000", "1.0.0", "active", {
+				source: "registry",
+				registryPublisherDid: PUBLISHER,
+				registrySlug: SLUG,
+			});
+		});
+
+		it("blocks with RELEASE_BLOCKED before any artifact fetch on an automated-block label", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "malware" })]));
+
+			const result = await handleRegistryUpdate(
+				db,
+				stubStorage,
+				stubSandbox,
+				CONFIG,
+				"r_gallery000000000",
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe("RELEASE_BLOCKED");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it("blocks with RELEASE_YANKED when security-yanked is among the blocking labels", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "security-yanked" })]));
+
+			const result = await handleRegistryUpdate(
+				db,
+				stubStorage,
+				stubSandbox,
+				CONFIG,
+				"r_gallery000000000",
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe("RELEASE_YANKED");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it("cascades a package/publisher-scope block that release-only checking used to miss", async () => {
+			getPackage.mockResolvedValue(
+				packageView([label({ uri: PACKAGE_URI, cid: undefined, val: "!takedown" })]),
+			);
+			getLatestRelease.mockResolvedValue(releaseView());
+
+			const result = await handleRegistryUpdate(
+				db,
+				stubStorage,
+				stubSandbox,
+				CONFIG,
+				"r_gallery000000000",
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error?.code).toBe("RELEASE_BLOCKED");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it("does not block a warning-only release", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "suspicious-code" })]));
+
+			const result = await handleRegistryUpdate(
+				db,
+				stubStorage,
+				stubSandbox,
+				CONFIG,
+				"r_gallery000000000",
+			);
+
+			expect(result.error?.code).not.toBe("RELEASE_BLOCKED");
+			expect(result.error?.code).not.toBe("RELEASE_YANKED");
+		});
+
+		it("does not block on a CID-stale label that no longer matches the release", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(
+				releaseView([label({ val: "malware", cid: STALE_RELEASE_CID })]),
+			);
+
+			const result = await handleRegistryUpdate(
+				db,
+				stubStorage,
+				stubSandbox,
+				CONFIG,
+				"r_gallery000000000",
+			);
+
+			expect(result.error?.code).not.toBe("RELEASE_BLOCKED");
+			expect(result.error?.code).not.toBe("RELEASE_YANKED");
+		});
+	});
+
+	describe("handleRegistryUpdateCheck", () => {
+		beforeEach(async () => {
+			const repo = new PluginStateRepository(db);
+			await repo.upsert("r_gallery000000000", "1.0.0", "active", {
+				source: "registry",
+				registryPublisherDid: PUBLISHER,
+				registrySlug: SLUG,
+			});
+		});
+
+		it("carries the moderation field for a blocked latest release, without an extra getPackage call", async () => {
+			getLatestRelease.mockResolvedValue(releaseView([label({ val: "malware" })]));
+
+			const result = await handleRegistryUpdateCheck(db, CONFIG);
+
+			expect(result.success).toBe(true);
+			if (!result.success) throw new Error("unreachable");
+			expect(result.data.items).toHaveLength(1);
+			expect(result.data.items[0]?.moderation?.eligibility).toBe("blocked");
+			expect(result.data.items[0]?.moderation?.blockingLabels).toContain("malware");
+			expect(getPackage).not.toHaveBeenCalled();
+		});
+
+		it("carries a defined moderation field for a clean release with no labels", async () => {
+			getLatestRelease.mockResolvedValue(releaseView());
+
+			const result = await handleRegistryUpdateCheck(db, CONFIG);
+
+			expect(result.success).toBe(true);
+			if (!result.success) throw new Error("unreachable");
+			expect(result.data.items[0]?.moderation).toBeDefined();
+			expect(result.data.items[0]?.moderation?.blockingLabels).toEqual([]);
+		});
+	});
+});

--- a/packages/core/tests/unit/api/registry-moderation-gate-handler.test.ts
+++ b/packages/core/tests/unit/api/registry-moderation-gate-handler.test.ts
@@ -259,6 +259,20 @@ describe("registry moderation eligibility gate", () => {
 			expect(errored.error?.code).toBe("RELEASE_BLOCKED");
 		});
 
+		it("fails closed when a block label collides with a same-cts negation", async () => {
+			getPackage.mockResolvedValue(packageView());
+			getLatestRelease.mockResolvedValue(
+				releaseView([label({ val: "malware" }), label({ val: "malware", neg: true })]),
+			);
+
+			const result = await handleRegistryInstall(db, stubStorage, stubSandbox, CONFIG, {
+				did: PUBLISHER,
+				slug: SLUG,
+			});
+
+			expect(result.error?.code).toBe("RELEASE_BLOCKED");
+		});
+
 		it("does not block when no acceptLabelers policy is configured (no client-side enforcement)", async () => {
 			getPackage.mockResolvedValue(packageView());
 			getLatestRelease.mockResolvedValue(releaseView([label({ val: "malware" })]));

--- a/packages/plugin-cli/src/commands/info.ts
+++ b/packages/plugin-cli/src/commands/info.ts
@@ -10,12 +10,17 @@
  */
 
 import { isDid, isHandle } from "@atcute/lexicons/syntax";
-import { DiscoveryClient } from "@emdash-cms/registry-client";
+import {
+	DiscoveryClient,
+	evaluateReleaseViews,
+	resolveAcceptedPolicy,
+} from "@emdash-cms/registry-client";
 import { defineCommand } from "citty";
 import { consola } from "consola";
 import pc from "picocolors";
 
 import { resolveAggregatorUrl } from "../config.js";
+import { evaluatePackageModeration, renderModerationLines } from "../moderation.js";
 
 export const infoCommand = defineCommand({
 	meta: {
@@ -44,7 +49,16 @@ export const infoCommand = defineCommand({
 	},
 	async run({ args }) {
 		const aggregatorUrl = resolveAggregatorUrl(args["registry-url"]);
-		const client = new DiscoveryClient({ aggregatorUrl });
+		// No configured `acceptLabelers` here (the CLI has no persisted
+		// registry config) -- the accepted policy comes from the aggregator's
+		// response header, once a response arrives.
+		let contentLabelersHeader: string | undefined;
+		const client = new DiscoveryClient({
+			aggregatorUrl,
+			onResponseMeta: (meta) => {
+				contentLabelersHeader = meta.contentLabelers ?? contentLabelersHeader;
+			},
+		});
 
 		let result;
 		if (isDid(args.publisher)) {
@@ -95,11 +109,28 @@ export const infoCommand = defineCommand({
 		console.log(`  AT URI:    ${pc.dim(result.uri)}`);
 		console.log();
 
-		if (result.labels && result.labels.length > 0) {
-			consola.info(`Labels (${result.labels.length}):`);
-			for (const label of result.labels) {
-				console.log(`  ${pc.yellow(label.val)} ${pc.dim(`(by ${label.src})`)}`);
-			}
+		const accepted = resolveAcceptedPolicy({ contentLabelersHeader });
+
+		// Evaluate against the latest release for the full label cascade (a
+		// prospective installer wants to know about the release they'd
+		// actually get, not just the package record). Falls back to a
+		// package/publisher-only evaluation when the package has no releases
+		// yet, or the aggregator lookup fails.
+		let moderation;
+		try {
+			const releaseView = await client.getLatestRelease({ did: result.did, package: result.slug });
+			moderation = evaluateReleaseViews({
+				packageView: result,
+				releaseView,
+				publisherDid: result.did,
+				accepted,
+			});
+		} catch {
+			moderation = evaluatePackageModeration(result, accepted);
+		}
+
+		for (const line of renderModerationLines(moderation)) {
+			console.log(line);
 		}
 	},
 });

--- a/packages/plugin-cli/src/commands/search.ts
+++ b/packages/plugin-cli/src/commands/search.ts
@@ -4,12 +4,13 @@
  * Free-text search the aggregator. Read-only; no auth required.
  */
 
-import { DiscoveryClient } from "@emdash-cms/registry-client";
+import { DiscoveryClient, resolveAcceptedPolicy } from "@emdash-cms/registry-client";
 import { defineCommand } from "citty";
 import { consola } from "consola";
 import pc from "picocolors";
 
 import { resolveAggregatorUrl } from "../config.js";
+import { evaluatePackageModeration, isModerationBlocked } from "../moderation.js";
 
 export const searchCommand = defineCommand({
 	meta: {
@@ -49,7 +50,16 @@ export const searchCommand = defineCommand({
 		const aggregatorUrl = resolveAggregatorUrl(args["registry-url"]);
 		const limit = clamp(parseInt(args.limit, 10) || 25, 1, 100);
 
-		const client = new DiscoveryClient({ aggregatorUrl });
+		// No configured `acceptLabelers` here (the CLI has no persisted
+		// registry config) -- the accepted policy comes from the aggregator's
+		// response header, once a response arrives.
+		let contentLabelersHeader: string | undefined;
+		const client = new DiscoveryClient({
+			aggregatorUrl,
+			onResponseMeta: (meta) => {
+				contentLabelersHeader = meta.contentLabelers ?? contentLabelersHeader;
+			},
+		});
 		const result = await client.searchPackages({
 			q: args.query,
 			...(args.capability ? { capability: args.capability } : {}),
@@ -67,13 +77,23 @@ export const searchCommand = defineCommand({
 			return;
 		}
 
+		const accepted = resolveAcceptedPolicy({ contentLabelersHeader });
+
 		console.log();
 		for (const pkg of result.packages) {
 			// `pkg.profile` is lexicon-validated by DiscoveryClient (or null).
 			const profile = pkg.profile;
-			console.log(`${pc.bold(profile?.name ?? pkg.slug)} ${pc.dim(`(${pkg.slug})`)}`);
+			const moderation = evaluatePackageModeration(pkg, accepted);
+			const blocked = isModerationBlocked(moderation);
+			const nameLine = `${pc.bold(profile?.name ?? pkg.slug)} ${pc.dim(`(${pkg.slug})`)}`;
+			console.log(blocked ? `${nameLine} ${pc.red("[blocked]")}` : nameLine);
 			if (profile?.description) console.log(`  ${profile.description}`);
 			console.log(`  ${pc.dim(pkg.uri)}`);
+			if (blocked) {
+				console.log(
+					`  ${pc.red(`blocked: ${moderation.blockingLabels.join(", ") || "redacted"}`)}`,
+				);
+			}
 			console.log();
 		}
 

--- a/packages/plugin-cli/src/moderation.ts
+++ b/packages/plugin-cli/src/moderation.ts
@@ -1,0 +1,86 @@
+/**
+ * Registry moderation display for the CLI.
+ *
+ * The CLI never configures `acceptLabelers` -- there is no persisted
+ * registry config here -- so the accepted policy always comes from the
+ * aggregator's `atproto-content-labelers` response header (see
+ * `resolveAcceptedPolicy`'s precedence).
+ */
+
+import {
+	evaluateReleaseViews,
+	type AcceptedLabelerPolicy,
+	type ReleaseModeration,
+} from "@emdash-cms/registry-client";
+import type {
+	ValidatedPackageView,
+	ValidatedReleaseView,
+} from "@emdash-cms/registry-client/discovery";
+import pc from "picocolors";
+
+/**
+ * Evaluates a package's package/publisher-scope moderation state without a
+ * specific release in view -- used where fetching a release per package
+ * would be too expensive (e.g. bulk search results). The stub release's
+ * `uri`/`cid` can never match a real label, so release-scope automated
+ * blocks and warnings are excluded by construction, not by omission.
+ */
+export function evaluatePackageModeration(
+	packageView: ValidatedPackageView,
+	accepted: AcceptedLabelerPolicy[],
+): ReleaseModeration {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- `uri`/`cid` are branded FormattedStringSchema types; this stub is never a real record, only compared against label uris that can never equal these placeholders
+	const releaseStub = {
+		uri: "",
+		cid: "",
+		did: packageView.did,
+		package: packageView.slug,
+		version: "",
+		indexedAt: packageView.indexedAt,
+		release: null,
+	} as unknown as ValidatedReleaseView;
+
+	return evaluateReleaseViews({
+		packageView,
+		releaseView: releaseStub,
+		publisherDid: packageView.did,
+		accepted,
+	});
+}
+
+/** Whether a moderation result should be surfaced as blocking to the user. */
+export function isModerationBlocked(moderation: ReleaseModeration): boolean {
+	return (
+		(moderation.eligibility === "blocked" && moderation.blockingLabels.length > 0) ||
+		moderation.redacted
+	);
+}
+
+/**
+ * Renders human-readable moderation lines for `info`/`search` output.
+ * Returns an empty array when there's nothing worth showing -- an
+ * eligibility of "blocked" driven solely by a missing positive assessment
+ * (today's default; no labels flow in production yet) is not surfaced here.
+ */
+export function renderModerationLines(moderation: ReleaseModeration): string[] {
+	const lines: string[] = [];
+	if (isModerationBlocked(moderation)) {
+		const sources = [
+			...new Set(
+				moderation.applicableLabels
+					.filter((l) => moderation.blockingLabels.includes(l.val))
+					.map((l) => l.src),
+			),
+		];
+		const detail =
+			moderation.blockingLabels.length > 0
+				? moderation.blockingLabels.join(", ")
+				: "redacted takedown";
+		const bySources = sources.length > 0 ? ` by ${sources.join(", ")}` : "";
+		lines.push(`Moderation: ${pc.red("blocked")} (${detail})${bySources}`);
+	}
+	if (moderation.warningLabels.length > 0) {
+		lines.push(`  warnings: ${moderation.warningLabels.join(", ")}`);
+	}
+	return lines;
+}

--- a/packages/plugin-cli/src/moderation.ts
+++ b/packages/plugin-cli/src/moderation.ts
@@ -48,12 +48,12 @@ export function evaluatePackageModeration(
 	});
 }
 
-/** Whether a moderation result should be surfaced as blocking to the user. */
+/** Whether a moderation result should be surfaced as blocking to the user.
+ * Keyed off blockingLabels/redacted, never eligibility — a co-present
+ * assessment-pending/error label re-ranks eligibility while blockingLabels
+ * still carries the block. */
 export function isModerationBlocked(moderation: ReleaseModeration): boolean {
-	return (
-		(moderation.eligibility === "blocked" && moderation.blockingLabels.length > 0) ||
-		moderation.redacted
-	);
+	return moderation.blockingLabels.length > 0 || moderation.redacted;
 }
 
 /**

--- a/packages/plugin-cli/src/moderation.ts
+++ b/packages/plugin-cli/src/moderation.ts
@@ -9,6 +9,7 @@
 
 import {
 	evaluateReleaseViews,
+	isModerationBlocking,
 	type AcceptedLabelerPolicy,
 	type ReleaseModeration,
 } from "@emdash-cms/registry-client";
@@ -48,12 +49,9 @@ export function evaluatePackageModeration(
 	});
 }
 
-/** Whether a moderation result should be surfaced as blocking to the user.
- * Keyed off blockingLabels/redacted, never eligibility — a co-present
- * assessment-pending/error label re-ranks eligibility while blockingLabels
- * still carries the block. */
+/** Whether a moderation result should be surfaced as blocking to the user. */
 export function isModerationBlocked(moderation: ReleaseModeration): boolean {
-	return moderation.blockingLabels.length > 0 || moderation.redacted;
+	return isModerationBlocking(moderation);
 }
 
 /**

--- a/packages/plugin-cli/tests/registry-moderation-display.test.ts
+++ b/packages/plugin-cli/tests/registry-moderation-display.test.ts
@@ -1,0 +1,232 @@
+/**
+ * CLI moderation display: `search` marks blocked packages, `info` renders an
+ * eligibility line instead of a raw label dump. Both derive the accepted
+ * labeler policy from the aggregator's `atproto-content-labelers` response
+ * header -- the CLI never configures `acceptLabelers` itself.
+ */
+
+import { runCommand } from "citty";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { infoCommand } from "../src/commands/info.js";
+import { searchCommand } from "../src/commands/search.js";
+
+const AGGREGATOR_URL = "https://registry.test";
+const DID = "did:plc:abc123";
+const SLUG = "gallery-plugin";
+const LABELER = "did:plc:labeler-a";
+const PACKAGE_URI = `at://${DID}/com.emdashcms.experimental.package.profile/${SLUG}`;
+const PACKAGE_CID = "bafyreiclpjmh2e5ug4oufdmfnz4r4a6o2lrfu5hzgopzjlb3u2v5il5z4a";
+const RELEASE_URI = `at://${DID}/com.emdashcms.experimental.package.release/${SLUG}:1.0.0`;
+const RELEASE_CID = "bafyreig5l2zfc7l5m4zq3r6v4s2wqkd3j7yq5x7x6n2j4h5r3p6s7t2w4e";
+
+function profile(overrides: Record<string, unknown> = {}) {
+	return {
+		$type: "com.emdashcms.experimental.package.profile",
+		id: PACKAGE_URI,
+		type: "emdash-plugin",
+		license: "MIT",
+		authors: [{ name: "Alice" }],
+		security: [{ email: "security@example.com" }],
+		slug: SLUG,
+		lastUpdated: "2024-01-01T00:00:00.000Z",
+		name: "Gallery Plugin",
+		...overrides,
+	};
+}
+
+function packageView(overrides: Record<string, unknown> = {}) {
+	return {
+		uri: PACKAGE_URI,
+		cid: PACKAGE_CID,
+		did: DID,
+		slug: SLUG,
+		indexedAt: "2026-07-01T00:00:00.000Z",
+		profile: profile(),
+		labels: [],
+		...overrides,
+	};
+}
+
+function label(overrides: Record<string, unknown> = {}) {
+	return {
+		ver: 1,
+		src: LABELER,
+		uri: RELEASE_URI,
+		cid: RELEASE_CID,
+		cts: "2026-07-10T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+function releaseView(overrides: Record<string, unknown> = {}) {
+	return {
+		uri: RELEASE_URI,
+		cid: RELEASE_CID,
+		did: DID,
+		package: SLUG,
+		version: "1.0.0",
+		indexedAt: "2026-07-01T00:00:00.000Z",
+		labels: [],
+		// `v.unknown()` in the envelope schema rejects `null`; an empty object
+		// is the simplest value that passes envelope validation. The tests
+		// here evaluate moderation from `labels`, not this field.
+		release: {},
+		...overrides,
+	};
+}
+
+/**
+ * Stubs `globalThis.fetch` to serve canned XRPC responses keyed by NSID, all
+ * carrying the `atproto-content-labelers` response header the CLI relies on
+ * (it never configures `acceptLabelers` itself -- see decision 3).
+ */
+function stubAggregator(responses: Record<string, unknown>) {
+	const fetchMock = vi.fn(async (input: string | URL) => {
+		const href = typeof input === "string" ? input : input.href;
+		const nsid = new URL(href).pathname.replace(/^\/xrpc\//, "");
+		const body = responses[nsid];
+		if (body === undefined) {
+			return new Response(JSON.stringify({ error: "NotFound", message: "no fixture" }), {
+				status: 404,
+				headers: { "content-type": "application/json" },
+			});
+		}
+		return new Response(JSON.stringify(body), {
+			status: 200,
+			headers: {
+				"content-type": "application/json",
+				"atproto-content-labelers": LABELER,
+			},
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+describe("CLI registry moderation display", () => {
+	let logs: string[];
+
+	beforeEach(() => {
+		logs = [];
+		vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			logs.push(args.map(String).join(" "));
+		});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	describe("info", () => {
+		it("renders a blocked eligibility line for an automated-block label on the latest release", async () => {
+			stubAggregator({
+				"com.emdashcms.experimental.aggregator.getPackage": packageView(),
+				"com.emdashcms.experimental.aggregator.getLatestRelease": releaseView({
+					labels: [label({ val: "malware" })],
+				}),
+			});
+
+			await runCommand(infoCommand, {
+				rawArgs: [DID, SLUG, "--registry-url", AGGREGATOR_URL],
+			});
+
+			const output = logs.join("\n");
+			expect(output).toContain("Moderation:");
+			expect(output).toContain("blocked");
+			expect(output).toContain("malware");
+			expect(output).toContain(LABELER);
+			// No raw label dump.
+			expect(output).not.toContain("Labels (");
+		});
+
+		it("renders a warnings line for a warning-only release", async () => {
+			stubAggregator({
+				"com.emdashcms.experimental.aggregator.getPackage": packageView(),
+				"com.emdashcms.experimental.aggregator.getLatestRelease": releaseView({
+					labels: [label({ val: "suspicious-code" })],
+				}),
+			});
+
+			await runCommand(infoCommand, {
+				rawArgs: [DID, SLUG, "--registry-url", AGGREGATOR_URL],
+			});
+
+			const output = logs.join("\n");
+			expect(output).toContain("warnings:");
+			expect(output).toContain("suspicious-code");
+			expect(output).not.toContain("Moderation:");
+		});
+
+		it("renders nothing extra for a clean release with no labels", async () => {
+			stubAggregator({
+				"com.emdashcms.experimental.aggregator.getPackage": packageView(),
+				"com.emdashcms.experimental.aggregator.getLatestRelease": releaseView(),
+			});
+
+			await runCommand(infoCommand, {
+				rawArgs: [DID, SLUG, "--registry-url", AGGREGATOR_URL],
+			});
+
+			const output = logs.join("\n");
+			expect(output).not.toContain("Moderation:");
+			expect(output).not.toContain("warnings:");
+		});
+
+		it("falls back to package-only moderation when the package has no releases", async () => {
+			stubAggregator({
+				"com.emdashcms.experimental.aggregator.getPackage": packageView({
+					labels: [label({ uri: PACKAGE_URI, cid: undefined, val: "!takedown" })],
+				}),
+				// getLatestRelease deliberately has no fixture -> 404 -> falls back.
+			});
+
+			await runCommand(infoCommand, {
+				rawArgs: [DID, SLUG, "--registry-url", AGGREGATOR_URL],
+			});
+
+			const output = logs.join("\n");
+			expect(output).toContain("Moderation:");
+			expect(output).toContain("blocked");
+		});
+	});
+
+	describe("search", () => {
+		it("marks a blocked package inline and shows its blocking labels", async () => {
+			stubAggregator({
+				"com.emdashcms.experimental.aggregator.searchPackages": {
+					packages: [
+						packageView({
+							labels: [label({ uri: PACKAGE_URI, cid: undefined, val: "!takedown" })],
+						}),
+					],
+				},
+			});
+
+			await runCommand(searchCommand, {
+				rawArgs: ["gallery", "--registry-url", AGGREGATOR_URL],
+			});
+
+			const output = logs.join("\n");
+			expect(output).toContain("[blocked]");
+			expect(output).toContain("blocked: !takedown");
+		});
+
+		it("does not mark a clean package", async () => {
+			stubAggregator({
+				"com.emdashcms.experimental.aggregator.searchPackages": {
+					packages: [packageView()],
+				},
+			});
+
+			await runCommand(searchCommand, {
+				rawArgs: ["gallery", "--registry-url", AGGREGATOR_URL],
+			});
+
+			const output = logs.join("\n");
+			expect(output).not.toContain("[blocked]");
+		});
+	});
+});

--- a/packages/registry-client/README.md
+++ b/packages/registry-client/README.md
@@ -6,7 +6,7 @@ Atproto-aware client for the EmDash plugin registry.
 
 ## Layers
 
-This package is split into three independent surfaces. Import only the one you need.
+This package is split into four independent surfaces. Import only the one you need.
 
 ### Credentials (`@emdash-cms/registry-client/credentials`)
 
@@ -28,7 +28,14 @@ The interactive OAuth flow lives in the CLI, not here. This module accepts a pre
 
 Read-only XRPC client over an aggregator. No authentication. Used by the CLI (`emdash-plugin search`, `emdash-plugin info`) and the EmDash admin UI's install flow.
 
-The `acceptLabelers` option threads the `atproto-accept-labelers` request header through every call so callers can configure which labelers' hard-takedown labels the aggregator should apply.
+The `acceptLabelers` option threads the `atproto-accept-labelers` request header through every call so callers can configure which labelers' hard-takedown labels the aggregator should apply. The `onResponseMeta` option reports the `atproto-content-labelers` response header per call -- the labeler policy the aggregator actually applied -- for use with `resolveAcceptedPolicy` below.
+
+### Moderation (`@emdash-cms/registry-client/moderation`)
+
+Evaluates the typed moderation state -- `eligible` / `pending` / `error` / `blocked`, plus warning and suppressed labels -- of a package's release from the labels a discovery response hydrates onto its package and release views. Built on `@emdash-cms/registry-moderation`'s hydrated (structurally validated, not cryptographically verified) evaluation path, since the aggregator relays labels it does not sign for this client.
+
+- `evaluateReleaseViews({ packageView, releaseView, publisherDid, accepted, evaluatedAt? })` merges the package and release views' hydrated labels and evaluates them. A label that fails structural validation is skipped with a console warning rather than failing the whole evaluation.
+- `resolveAcceptedPolicy({ configuredAcceptLabelers?, contentLabelersHeader? })` picks the accepted-labeler policy to evaluate against: the response header when present (what the aggregator actually applied), else the configured `acceptLabelers` value, else no client-side enforcement.
 
 ## Stability
 

--- a/packages/registry-client/package.json
+++ b/packages/registry-client/package.json
@@ -24,6 +24,10 @@
 		"./env": {
 			"types": "./dist/env/index.d.ts",
 			"default": "./dist/env/index.js"
+		},
+		"./moderation": {
+			"types": "./dist/moderation.d.ts",
+			"default": "./dist/moderation.js"
 		}
 	},
 	"files": [
@@ -41,7 +45,8 @@
 		"@atcute/atproto": "catalog:",
 		"@atcute/client": "catalog:",
 		"@atcute/lexicons": "catalog:",
-		"@emdash-cms/registry-lexicons": "workspace:*"
+		"@emdash-cms/registry-lexicons": "workspace:*",
+		"@emdash-cms/registry-moderation": "workspace:*"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "catalog:",

--- a/packages/registry-client/src/discovery/index.ts
+++ b/packages/registry-client/src/discovery/index.ts
@@ -7,9 +7,12 @@
  * browser, the EmDash admin UI.
  *
  * No authentication is required for discovery: the aggregator is a public
- * read-only index. Hard-enforcement labels (`!takedown`, `security:yanked`) are
- * applied server-side based on the request's `atproto-accept-labelers` header,
- * which the aggregator client may set per-request.
+ * read-only index. Hard-enforcement labels (`!takedown`, `security-yanked`)
+ * are filtered server-side based on the request's `atproto-accept-labelers`
+ * header, which the aggregator client may set per-request. Callers evaluate
+ * the full typed moderation state of the results themselves, via
+ * `./moderation`'s `evaluateReleaseViews` over the labels each response
+ * hydrates onto its package/release views.
  */
 
 import { Client, ok, simpleFetchHandler } from "@atcute/client";
@@ -119,6 +122,16 @@ export interface DiscoveryClientOptions {
 	 * route through a specific transport.
 	 */
 	fetch?: typeof fetch;
+
+	/**
+	 * Optional callback invoked with response metadata after every request.
+	 * Currently carries the `atproto-content-labelers` response header, which
+	 * reports the labeler policy the aggregator actually applied -- callers
+	 * without a configured `acceptLabelers` use this to derive the effective
+	 * accepted policy for moderation evaluation (see `resolveAcceptedPolicy`
+	 * in `./moderation`).
+	 */
+	onResponseMeta?: (meta: { contentLabelers?: string }) => void;
 }
 
 /**
@@ -170,15 +183,22 @@ export class DiscoveryClient {
 		// *overwrite* any value the caller might have supplied: this is the
 		// aggregator's policy, not a per-request setting, and letting
 		// downstream code substitute its own labelers would defeat the
-		// point of the wrapper.
+		// point of the wrapper. The same wrapper reports the response's
+		// `atproto-content-labelers` header to `onResponseMeta` when given.
 		const acceptLabelers = this.acceptLabelers;
-		const handler: typeof baseHandler = acceptLabelers
-			? async (pathname, init) => {
-					const headers = new Headers(init.headers);
-					headers.set("atproto-accept-labelers", acceptLabelers);
-					return baseHandler(pathname, { ...init, headers });
-				}
-			: baseHandler;
+		const onResponseMeta = options.onResponseMeta;
+		const handler: typeof baseHandler =
+			acceptLabelers || onResponseMeta
+				? async (pathname, init) => {
+						const headers = new Headers(init.headers);
+						if (acceptLabelers) headers.set("atproto-accept-labelers", acceptLabelers);
+						const response = await baseHandler(pathname, { ...init, headers });
+						onResponseMeta?.({
+							contentLabelers: response.headers.get("atproto-content-labelers") ?? undefined,
+						});
+						return response;
+					}
+				: baseHandler;
 
 		this.#client = new Client({ handler });
 	}

--- a/packages/registry-client/src/index.ts
+++ b/packages/registry-client/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @emdash-cms/registry-client
  *
- * Atproto-aware client for the EmDash plugin registry. Three layers:
+ * Atproto-aware client for the EmDash plugin registry. Four layers:
  *
  *   - **Credentials** (`./credentials`): persisting the publisher's atproto
  *     session between CLI invocations. Three implementations: filesystem,
@@ -12,6 +12,10 @@
  *   - **Discovery** (`./discovery`): read-only XRPC client over an aggregator.
  *     No authentication. Used by both the CLI (`emdash-plugin search` /
  *     `emdash-plugin info`) and the EmDash admin UI's install flow.
+ *   - **Moderation** (`./moderation`): evaluates the label state a discovery
+ *     response hydrates onto its package/release views into a typed
+ *     `ReleaseModeration`, via `@emdash-cms/registry-moderation`'s hydrated
+ *     (structurally validated, not cryptographically verified) entry point.
  *
  * The two halves are deliberately decoupled so consumers that only need
  * discovery (most notably the admin UI) don't have to pull in the publishing
@@ -44,6 +48,21 @@ export {
 export { type PublishingClientFromHandlerOptions, PublishingClient } from "./publishing/index.js";
 
 export { type DiscoveryClientOptions, DiscoveryClient } from "./discovery/index.js";
+
+export {
+	type AcceptedLabelerPolicy,
+	type EvaluateReleaseViewsInput,
+	type ReleaseEligibility,
+	type ReleaseModeration,
+	type ResolveAcceptedPolicyInput,
+	evaluateHydratedReleaseModeration,
+	evaluateReleaseViews,
+	parseAcceptLabelersHeader,
+	resolveAcceptedPolicy,
+	InvalidAcceptLabelersHeaderError,
+	PACKAGE_SCOPE_BLOCK_VALUES,
+	RELEASE_BLOCK_VALUES,
+} from "./moderation.js";
 
 export {
 	type EnvMismatch,

--- a/packages/registry-client/src/index.ts
+++ b/packages/registry-client/src/index.ts
@@ -57,6 +57,7 @@ export {
 	type ResolveAcceptedPolicyInput,
 	evaluateHydratedReleaseModeration,
 	evaluateReleaseViews,
+	isModerationBlocking,
 	parseAcceptLabelersHeader,
 	resolveAcceptedPolicy,
 	InvalidAcceptLabelersHeaderError,

--- a/packages/registry-client/src/moderation.ts
+++ b/packages/registry-client/src/moderation.ts
@@ -9,6 +9,7 @@
 
 import {
 	evaluateHydratedReleaseModeration,
+	isModerationBlocking,
 	parseAcceptLabelersHeader,
 	parseModerationLabel,
 	InvalidAcceptLabelersHeaderError,
@@ -25,6 +26,7 @@ import type { ValidatedPackageView, ValidatedReleaseView } from "./discovery/ind
 
 export {
 	evaluateHydratedReleaseModeration,
+	isModerationBlocking,
 	parseAcceptLabelersHeader,
 	InvalidAcceptLabelersHeaderError,
 	PACKAGE_SCOPE_BLOCK_VALUES,

--- a/packages/registry-client/src/moderation.ts
+++ b/packages/registry-client/src/moderation.ts
@@ -1,0 +1,108 @@
+/**
+ * Release moderation evaluation over hydrated aggregator responses.
+ *
+ * The aggregator hydrates label state onto package and release views but
+ * does not sign it for this client's consumption, so evaluation goes through
+ * `@emdash-cms/registry-moderation`'s hydrated (structurally validated, not
+ * cryptographically verified) entry point rather than the branded one.
+ */
+
+import {
+	evaluateHydratedReleaseModeration,
+	parseAcceptLabelersHeader,
+	parseModerationLabel,
+	InvalidAcceptLabelersHeaderError,
+	PACKAGE_SCOPE_BLOCK_VALUES,
+	RELEASE_BLOCK_VALUES,
+	type AcceptedLabelerPolicy,
+	type ModerationLabel,
+	type ReleaseEligibility,
+	type ReleaseModeration,
+	type ReleaseSubjectContext,
+} from "@emdash-cms/registry-moderation";
+
+import type { ValidatedPackageView, ValidatedReleaseView } from "./discovery/index.js";
+
+export {
+	evaluateHydratedReleaseModeration,
+	parseAcceptLabelersHeader,
+	InvalidAcceptLabelersHeaderError,
+	PACKAGE_SCOPE_BLOCK_VALUES,
+	RELEASE_BLOCK_VALUES,
+	type AcceptedLabelerPolicy,
+	type ReleaseEligibility,
+	type ReleaseModeration,
+};
+
+export interface ResolveAcceptedPolicyInput {
+	/** The `acceptLabelers` value configured on the `DiscoveryClient`, if any. */
+	configuredAcceptLabelers?: string;
+	/** The `atproto-content-labelers` header from the aggregator's response, if any. */
+	contentLabelersHeader?: string;
+}
+
+/**
+ * Resolves the accepted-labeler policy to evaluate a response's moderation
+ * state against. The response header takes precedence when present and
+ * non-empty, since it reports what the aggregator actually applied; falling
+ * back to the configured value, then to no client-side enforcement. A
+ * malformed response header is an aggregator-side bug and is skipped with a
+ * warning rather than failing the caller; a malformed configured value is an
+ * operator misconfiguration and throws.
+ */
+export function resolveAcceptedPolicy(input: ResolveAcceptedPolicyInput): AcceptedLabelerPolicy[] {
+	if (input.contentLabelersHeader) {
+		try {
+			return parseAcceptLabelersHeader(input.contentLabelersHeader);
+		} catch (error) {
+			console.warn(
+				"[registry-client] ignoring malformed atproto-content-labelers response header:",
+				error,
+			);
+		}
+	}
+	if (input.configuredAcceptLabelers) {
+		return parseAcceptLabelersHeader(input.configuredAcceptLabelers);
+	}
+	return [];
+}
+
+export interface EvaluateReleaseViewsInput {
+	packageView: ValidatedPackageView;
+	releaseView: ValidatedReleaseView;
+	publisherDid: string;
+	accepted: AcceptedLabelerPolicy[];
+	evaluatedAt?: Date;
+}
+
+/**
+ * Assembles the release's moderation context from its package and release
+ * views and evaluates the hydrated label state they carry. A label that
+ * fails structural validation is skipped with a warning rather than failing
+ * the whole evaluation -- one bad aggregator label must not block every
+ * install.
+ */
+export function evaluateReleaseViews(input: EvaluateReleaseViewsInput): ReleaseModeration {
+	const context: ReleaseSubjectContext = {
+		publisherDid: input.publisherDid,
+		package: { uri: input.packageView.uri, cid: input.packageView.cid },
+		release: { uri: input.releaseView.uri, cid: input.releaseView.cid },
+	};
+
+	const rawLabels = [...(input.packageView.labels ?? []), ...(input.releaseView.labels ?? [])];
+	const labels: ModerationLabel[] = [];
+	for (const rawLabel of rawLabels) {
+		try {
+			labels.push(parseModerationLabel(rawLabel));
+		} catch (error) {
+			console.warn("[registry-client] skipping structurally invalid moderation label:", error);
+		}
+	}
+
+	return evaluateHydratedReleaseModeration({
+		acceptedLabelers: input.accepted,
+		context,
+		evaluatedAt: input.evaluatedAt ?? new Date(),
+		labels,
+	});
+}

--- a/packages/registry-client/tests/discovery.test.ts
+++ b/packages/registry-client/tests/discovery.test.ts
@@ -6,7 +6,9 @@ import { DiscoveryClient } from "../src/discovery/index.js";
 /**
  * Builds a fetch stub that records every call and returns canned responses.
  */
-function buildFetchStub(responses: Record<string, { status: number; body: unknown }>): {
+function buildFetchStub(
+	responses: Record<string, { status: number; body: unknown; headers?: Record<string, string> }>,
+): {
 	fetch: typeof fetch;
 	calls: Array<{ url: string; init: RequestInit | undefined }>;
 } {
@@ -24,7 +26,7 @@ function buildFetchStub(responses: Record<string, { status: number; body: unknow
 		}
 		return new Response(JSON.stringify(match.body), {
 			status: match.status,
-			headers: { "content-type": "application/json" },
+			headers: { "content-type": "application/json", ...match.headers },
 		});
 	});
 	return { fetch: fetchStub, calls };
@@ -88,6 +90,59 @@ describe("DiscoveryClient", () => {
 
 		const headers = new Headers(calls[0]!.init?.headers);
 		expect(headers.get("atproto-accept-labelers")).toBeNull();
+	});
+
+	it("reports the atproto-content-labelers response header via onResponseMeta", async () => {
+		const { fetch } = buildFetchStub({
+			"/xrpc/com.emdashcms.experimental.aggregator.searchPackages": {
+				status: 200,
+				body: { packages: [] },
+				headers: { "atproto-content-labelers": "did:plc:labeler-a;redact" },
+			},
+		});
+		const onResponseMeta = vi.fn();
+
+		const client = new DiscoveryClient({ aggregatorUrl: aggregator, fetch, onResponseMeta });
+		await client.searchPackages({ q: "x" });
+
+		expect(onResponseMeta).toHaveBeenCalledExactlyOnceWith({
+			contentLabelers: "did:plc:labeler-a;redact",
+		});
+	});
+
+	it("reports contentLabelers as undefined when the response header is absent", async () => {
+		const { fetch } = buildFetchStub({
+			"/xrpc/com.emdashcms.experimental.aggregator.searchPackages": {
+				status: 200,
+				body: { packages: [] },
+			},
+		});
+		const onResponseMeta = vi.fn();
+
+		const client = new DiscoveryClient({ aggregatorUrl: aggregator, fetch, onResponseMeta });
+		await client.searchPackages({ q: "x" });
+
+		expect(onResponseMeta).toHaveBeenCalledExactlyOnceWith({ contentLabelers: undefined });
+	});
+
+	it("still forwards atproto-accept-labelers when onResponseMeta is also configured", async () => {
+		const { fetch, calls } = buildFetchStub({
+			"/xrpc/com.emdashcms.experimental.aggregator.searchPackages": {
+				status: 200,
+				body: { packages: [] },
+			},
+		});
+
+		const client = new DiscoveryClient({
+			aggregatorUrl: aggregator,
+			acceptLabelers: "did:plc:labeler-a",
+			fetch,
+			onResponseMeta: vi.fn(),
+		});
+		await client.searchPackages({ q: "x" });
+
+		const headers = new Headers(calls[0]!.init?.headers);
+		expect(headers.get("atproto-accept-labelers")).toBe("did:plc:labeler-a");
 	});
 
 	it("throws ClientResponseError on non-2xx responses with the structured payload", async () => {

--- a/packages/registry-client/tests/moderation.test.ts
+++ b/packages/registry-client/tests/moderation.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ValidatedPackageView, ValidatedReleaseView } from "../src/discovery/index.js";
+import {
+	evaluateReleaseViews,
+	resolveAcceptedPolicy,
+	InvalidAcceptLabelersHeaderError,
+} from "../src/index.js";
+
+const labelerA = "did:plc:labeler-a";
+const publisherDid = "did:plc:ewvi7nxzyoun6zhxrhs64oiz";
+const packageUri = `at://${publisherDid}/com.emdashcms.experimental.package.profile/gallery-plugin`;
+// Real, decodable DASL CIDs -- parseModerationLabel structurally validates
+// each label's `cid`, unlike the rest of these fixtures' identifiers.
+const packageCid = "bafyreiclpjmh2e5ug4oufdmfnz4r4a6o2lrfu5hzgopzjlb3u2v5il5z4a";
+const releaseUri = `at://${publisherDid}/com.emdashcms.experimental.package.release/gallery-plugin:1.0.0`;
+const releaseCid = "bafyreig5l2zfc7l5m4zq3r6v4s2wqkd3j7yq5x7x6n2j4h5r3p6s7t2w4e";
+const staleReleaseCid = "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixa";
+
+function packageView(overrides: Partial<ValidatedPackageView> = {}): ValidatedPackageView {
+	return {
+		uri: packageUri,
+		cid: packageCid,
+		did: publisherDid,
+		slug: "gallery-plugin",
+		indexedAt: "2026-07-10T00:00:00.000Z",
+		profile: null,
+		...overrides,
+	};
+}
+
+function releaseView(overrides: Partial<ValidatedReleaseView> = {}): ValidatedReleaseView {
+	return {
+		uri: releaseUri,
+		cid: releaseCid,
+		did: publisherDid,
+		package: "gallery-plugin",
+		version: "1.0.0",
+		indexedAt: "2026-07-10T00:00:00.000Z",
+		release: null,
+		...overrides,
+	};
+}
+
+function label(overrides: Record<string, unknown>) {
+	return {
+		ver: 1,
+		src: labelerA,
+		uri: releaseUri,
+		cid: releaseCid,
+		cts: "2026-07-10T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+describe("evaluateReleaseViews", () => {
+	it("evaluates a clean release as blocked (no assessment pass)", () => {
+		const result = evaluateReleaseViews({
+			packageView: packageView(),
+			releaseView: releaseView(),
+			publisherDid,
+			accepted: [{ did: labelerA, redact: false }],
+			evaluatedAt: new Date("2026-07-10T13:00:00.000Z"),
+		});
+		expect(result.eligibility).toBe("blocked");
+		expect(result.reasonCodes).toEqual(["missing-assessment-pass"]);
+	});
+
+	it("evaluates a release-scope pass label as eligible", () => {
+		const result = evaluateReleaseViews({
+			packageView: packageView(),
+			releaseView: releaseView({ labels: [label({ val: "assessment-passed" })] }),
+			publisherDid,
+			accepted: [{ did: labelerA, redact: false }],
+			evaluatedAt: new Date("2026-07-10T13:00:00.000Z"),
+		});
+		expect(result.eligibility).toBe("eligible");
+	});
+
+	it("cascades a package-scope takedown label from the package view", () => {
+		const result = evaluateReleaseViews({
+			packageView: packageView({
+				labels: [
+					label({ uri: packageUri, cid: undefined, val: "!takedown" }),
+					label({ val: "assessment-passed" }),
+				],
+			}),
+			releaseView: releaseView({ labels: [label({ val: "assessment-passed" })] }),
+			publisherDid,
+			accepted: [{ did: labelerA, redact: false }],
+			evaluatedAt: new Date("2026-07-10T13:00:00.000Z"),
+		});
+		expect(result.eligibility).toBe("blocked");
+		expect(result.blockingLabels).toContain("!takedown");
+	});
+
+	it("cascades a publisher-scope block from either view's hydrated labels", () => {
+		const result = evaluateReleaseViews({
+			packageView: packageView({
+				labels: [label({ uri: publisherDid, cid: undefined, val: "publisher-compromised" })],
+			}),
+			releaseView: releaseView({ labels: [label({ val: "assessment-passed" })] }),
+			publisherDid,
+			accepted: [{ did: labelerA, redact: false }],
+			evaluatedAt: new Date("2026-07-10T13:00:00.000Z"),
+		});
+		expect(result.eligibility).toBe("blocked");
+		expect(result.reasonCodes).toContain("manual-block");
+	});
+
+	it("ignores a CID-bound label that no longer matches the current release CID", () => {
+		const result = evaluateReleaseViews({
+			packageView: packageView(),
+			releaseView: releaseView({
+				labels: [
+					label({ val: "assessment-passed" }),
+					label({ val: "malware", cid: staleReleaseCid }),
+				],
+			}),
+			publisherDid,
+			accepted: [{ did: labelerA, redact: false }],
+			evaluatedAt: new Date("2026-07-10T13:00:00.000Z"),
+		});
+		expect(result.eligibility).toBe("eligible");
+		expect(result.blockingLabels).toEqual([]);
+	});
+
+	it("skips a structurally invalid label and logs a warning instead of throwing", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const result = evaluateReleaseViews({
+				packageView: packageView(),
+				releaseView: releaseView({
+					labels: [
+						label({ val: "assessment-passed" }),
+						// malformed uri: not an at:// URI or DID.
+						label({ val: "malware", uri: "not a uri", cid: undefined }),
+					],
+				}),
+				publisherDid,
+				accepted: [{ did: labelerA, redact: false }],
+				evaluatedAt: new Date("2026-07-10T13:00:00.000Z"),
+			});
+			expect(result.eligibility).toBe("eligible");
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0]?.[0]).toContain("skipping structurally invalid moderation label");
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});
+
+describe("resolveAcceptedPolicy", () => {
+	it("uses the response header when present and non-empty", () => {
+		expect(
+			resolveAcceptedPolicy({
+				configuredAcceptLabelers: "did:plc:configured",
+				contentLabelersHeader: "did:plc:from-header;redact",
+			}),
+		).toEqual([{ did: "did:plc:from-header", redact: true }]);
+	});
+
+	it("falls back to the configured value when the response header is absent", () => {
+		expect(resolveAcceptedPolicy({ configuredAcceptLabelers: "did:plc:configured" })).toEqual([
+			{ did: "did:plc:configured", redact: false },
+		]);
+	});
+
+	it("falls back to the configured value when the response header is empty", () => {
+		expect(
+			resolveAcceptedPolicy({
+				configuredAcceptLabelers: "did:plc:configured",
+				contentLabelersHeader: "",
+			}),
+		).toEqual([{ did: "did:plc:configured", redact: false }]);
+	});
+
+	it("returns no client-side enforcement when neither source is set", () => {
+		expect(resolveAcceptedPolicy({})).toEqual([]);
+	});
+
+	it("warns and falls through to the configured value when the response header is malformed", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const result = resolveAcceptedPolicy({
+				configuredAcceptLabelers: "did:plc:configured",
+				contentLabelersHeader: "not a valid header !!!",
+			});
+			expect(result).toEqual([{ did: "did:plc:configured", redact: false }]);
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0]?.[0]).toContain(
+				"ignoring malformed atproto-content-labelers response header",
+			);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("throws when the configured value is malformed", () => {
+		expect(() =>
+			resolveAcceptedPolicy({ configuredAcceptLabelers: "not a valid header !!!" }),
+		).toThrow(InvalidAcceptLabelersHeaderError);
+	});
+});

--- a/packages/registry-client/tsdown.config.ts
+++ b/packages/registry-client/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 		"src/credentials/index.ts",
 		"src/discovery/index.ts",
 		"src/env/index.ts",
+		"src/moderation.ts",
 		"src/publishing/index.ts",
 	],
 	format: ["esm"],
@@ -24,5 +25,6 @@ export default defineConfig({
 		"@atcute/lexicons",
 		"@atcute/lexicons/syntax",
 		"@emdash-cms/registry-lexicons",
+		"@emdash-cms/registry-moderation",
 	],
 });

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -785,6 +785,23 @@ export function evaluateHydratedReleaseModeration(
 	return evaluateReleaseModerationCore({ ...input, labels });
 }
 
+/**
+ * The single install/serve blocking predicate for enforcement consumers
+ * during the pre-positive-assessment phase. Blocks on an applicable
+ * blocking label, a redact-flagged takedown, or a label-state collision
+ * (the ratified fail-closed state: an ambiguous block/negation stream must
+ * not resolve open). Deliberately NOT keyed on `eligibility`, which ranks
+ * pending/error above blocks and reports missing-assessment-pass as
+ * "blocked".
+ */
+export function isModerationBlocking(moderation: ReleaseModeration): boolean {
+	return (
+		moderation.blockingLabels.length > 0 ||
+		moderation.redacted ||
+		moderation.reasonCodes.includes("label-state-collision")
+	);
+}
+
 /** Verifies labels before evaluating their moderation effect for one release. */
 export async function verifyAndEvaluateReleaseModeration(
 	input: VerifyAndEvaluateReleaseModerationInput,

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -144,6 +144,13 @@ export interface VerifyAndEvaluateReleaseModerationInput extends Omit<
 	resolveDid: LabelDidResolver;
 }
 
+export interface EvaluateHydratedReleaseModerationInput extends Omit<
+	EvaluateReleaseModerationInput,
+	"labels"
+> {
+	labels: ModerationLabel[];
+}
+
 export type ReleaseEligibility = "eligible" | "pending" | "error" | "blocked";
 
 export interface ReleaseModeration {
@@ -419,6 +426,11 @@ export function parseSignedLabel(value: unknown): SignedLabel {
 	return validateLabelObject(value, true);
 }
 
+/** Parses and canonically reconstructs an unknown unsigned ATProto label v1 value. */
+export function parseModerationLabel(value: unknown): ModerationLabel {
+	return validateLabelObject(value, false);
+}
+
 /**
  * Encodes a complete signed label as deterministic canonical CBOR for digest
  * or identity use after successful verification. Encoding alone does not
@@ -634,19 +646,21 @@ function orderedValues(labels: ModerationLabel[]): string[] {
 	return values.toSorted();
 }
 
-/** Evaluates accepted, current label state for one exact package release. */
-export function evaluateReleaseModeration(
-	input: EvaluateReleaseModerationInput,
+interface EvaluateReleaseModerationCoreInput extends Omit<
+	EvaluateReleaseModerationInput,
+	"labels"
+> {
+	labels: ModerationLabel[];
+}
+
+/**
+ * Shared reduction/evaluation body for both the branded (`verifyLabel`) and
+ * hydrated entry points. Callers must validate `input.labels` -- by runtime
+ * brand or by structural parse -- before calling this.
+ */
+function evaluateReleaseModerationCore(
+	input: EvaluateReleaseModerationCoreInput,
 ): ReleaseModeration {
-	for (const label of input.labels) {
-		if (
-			typeof label !== "object" ||
-			label === null ||
-			Object.getOwnPropertyDescriptor(label, verifiedModerationLabel)?.value !== true
-		) {
-			throw new TypeError("labels must be verified by verifyLabel before moderation evaluation");
-		}
-	}
 	const policies = new Map<string, AcceptedLabelerPolicy>();
 	for (const policy of input.acceptedLabelers) {
 		const existing = policies.get(policy.did);
@@ -740,6 +754,35 @@ export function evaluateReleaseModeration(
 			(label) => label.val === "!takedown" && policies.get(label.src)?.redact === true,
 		),
 	};
+}
+
+/** Evaluates accepted, current label state for one exact package release. */
+export function evaluateReleaseModeration(
+	input: EvaluateReleaseModerationInput,
+): ReleaseModeration {
+	for (const label of input.labels) {
+		if (
+			typeof label !== "object" ||
+			label === null ||
+			Object.getOwnPropertyDescriptor(label, verifiedModerationLabel)?.value !== true
+		) {
+			throw new TypeError("labels must be verified by verifyLabel before moderation evaluation");
+		}
+	}
+	return evaluateReleaseModerationCore(input);
+}
+
+/**
+ * Evaluates release moderation from unsigned labels an aggregator response has already
+ * hydrated, trusting the aggregator for the content itself but not for label authenticity.
+ * MUST NOT be used to satisfy a positive-assessment requirement -- that gate requires labels
+ * verified through `verifyLabel`.
+ */
+export function evaluateHydratedReleaseModeration(
+	input: EvaluateHydratedReleaseModerationInput,
+): ReleaseModeration {
+	const labels = input.labels.map((label) => parseModerationLabel(label));
+	return evaluateReleaseModerationCore({ ...input, labels });
 }
 
 /** Verifies labels before evaluating their moderation effect for one release. */

--- a/packages/registry-moderation/tests/fixtures/moderation-cases.json
+++ b/packages/registry-moderation/tests/fixtures/moderation-cases.json
@@ -22,7 +22,7 @@
 			"releaseUri": "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/com.emdashcms.experimental.package.release/gallery-plugin:1.2.0",
 			"releaseCid": "bafyreig5l2zfc7l5m4zq3r6v4s2wqkd3j7yq5x7x6n2j4h5r3p6s7t2w4e",
 			"oldReleaseCid": "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixa",
-			"oldPackageCid": "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixb"
+			"oldPackageCid": "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixe"
 		},
 		"labels": []
 	},
@@ -501,7 +501,7 @@
 				{
 					"src": "A",
 					"subject": "package",
-					"cid": "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixb",
+					"cid": "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixe",
 					"val": "package-disputed",
 					"cts": "2026-07-10T10:00:00Z"
 				},

--- a/packages/registry-moderation/tests/moderation.test.ts
+++ b/packages/registry-moderation/tests/moderation.test.ts
@@ -6,6 +6,7 @@ import {
 	createLabelSigner,
 	evaluateHydratedReleaseModeration,
 	evaluateReleaseModeration,
+	isModerationBlocking,
 	verifyLabel,
 	PACKAGE_SCOPE_BLOCK_VALUES,
 	RELEASE_BLOCK_VALUES,
@@ -340,6 +341,39 @@ describe("release moderation", () => {
 		expect(() =>
 			evaluate([label({ val: "assessment-passed", cts: "0000-01-01T00:00:00+01:00" })]),
 		).toThrow(TypeError);
+	});
+});
+
+describe("isModerationBlocking", () => {
+	it("blocks on an applicable blocking label regardless of eligibility ranking", () => {
+		const result = evaluate([
+			label({ val: "malware", cid: "release-cid" }),
+			label({ val: "assessment-pending", cid: "release-cid" }),
+		]);
+		expect(result.eligibility).toBe("pending");
+		expect(isModerationBlocking(result)).toBe(true);
+	});
+
+	it("fails closed on a label-state collision", () => {
+		const result = evaluate([
+			label({ val: "malware", cid: "release-cid" }),
+			label({ val: "malware", cid: "release-cid", neg: true }),
+		]);
+		expect(result.reasonCodes).toContain("label-state-collision");
+		expect(result.blockingLabels).toEqual([]);
+		expect(isModerationBlocking(result)).toBe(true);
+	});
+
+	it("does not block missing-assessment-pass or pure pending/error states", () => {
+		const missingPass = evaluate([]);
+		expect(missingPass.eligibility).toBe("blocked");
+		expect(isModerationBlocking(missingPass)).toBe(false);
+
+		const pending = evaluate([label({ val: "assessment-pending", cid: "release-cid" })]);
+		expect(isModerationBlocking(pending)).toBe(false);
+
+		const errored = evaluate([label({ val: "assessment-error", cid: "release-cid" })]);
+		expect(isModerationBlocking(errored)).toBe(false);
 	});
 });
 

--- a/packages/registry-moderation/tests/moderation.test.ts
+++ b/packages/registry-moderation/tests/moderation.test.ts
@@ -4,12 +4,14 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import {
 	createLabelSigner,
+	evaluateHydratedReleaseModeration,
 	evaluateReleaseModeration,
 	verifyLabel,
 	PACKAGE_SCOPE_BLOCK_VALUES,
 	RELEASE_BLOCK_VALUES,
 	type LabelDidDocument,
 	type ModerationLabel,
+	type ReleaseModeration,
 	type VerifiedModerationLabel,
 } from "../src/index.js";
 
@@ -403,42 +405,69 @@ function expectedValues(references: string[]): string[] {
 	return references.map((reference) => reference.slice(reference.lastIndexOf(":") + 1)).toSorted();
 }
 
-describe("ratified moderation corpus", () => {
+interface CorpusEvaluationInput {
+	acceptedLabelers: { did: string; redact: boolean }[];
+	context: {
+		publisherDid: string;
+		package: { uri: string; cid: string };
+		release: { uri: string; cid: string };
+	};
+	evaluatedAt: string;
+	labels: ModerationLabel[];
+}
+
+function buildCorpusInput(fixtureCase: FixtureCase): CorpusEvaluationInput {
+	const subject = { ...corpus.caseDefaults.subject, ...fixtureCase.subject };
+	const labels = fixtureCase.labels ?? corpus.caseDefaults.labels;
+	return {
+		acceptedLabelers: (fixtureCase.acceptedLabellers ?? corpus.caseDefaults.acceptedLabellers).map(
+			(policy) => ({
+				did: corpus.sources[policy.src]!,
+				redact: policy.redact,
+			}),
+		),
+		context: {
+			publisherDid: subject.publisherDid!,
+			package: { uri: subject.packageUri!, cid: subject.packageCid! },
+			release: { uri: subject.releaseUri!, cid: subject.releaseCid! },
+		},
+		evaluatedAt: corpus.evaluatedAt,
+		labels: labels.map((fixtureLabel) => ({
+			ver: 1,
+			src: corpus.sources[fixtureLabel.src]!,
+			uri:
+				fixtureLabel.subject === "publisher"
+					? subject.publisherDid!
+					: fixtureLabel.subject === "package"
+						? subject.packageUri!
+						: subject.releaseUri!,
+			cid: fixtureLabel.cid,
+			val: fixtureLabel.val,
+			cts: fixtureLabel.cts,
+			neg: fixtureLabel.neg,
+			exp: fixtureLabel.exp,
+		})),
+	};
+}
+
+// The corpus runs through both entry points to prove the branded and
+// hydrated paths cannot drift: they share the same evaluation core, and
+// only their label validation differs.
+describe.each([
+	{
+		name: "evaluateReleaseModeration (branded)",
+		evaluate: (input: CorpusEvaluationInput): ReleaseModeration =>
+			evaluateReleaseModeration({ ...input, labels: input.labels.map(verified) }),
+	},
+	{
+		name: "evaluateHydratedReleaseModeration (hydrated)",
+		evaluate: (input: CorpusEvaluationInput): ReleaseModeration =>
+			evaluateHydratedReleaseModeration(input),
+	},
+])("ratified moderation corpus via $name", ({ evaluate: runEvaluation }) => {
 	for (const fixtureCase of corpus.cases) {
 		it(fixtureCase.id, () => {
-			const subject = { ...corpus.caseDefaults.subject, ...fixtureCase.subject };
-			const labels = fixtureCase.labels ?? corpus.caseDefaults.labels;
-			const result = evaluateReleaseModeration({
-				acceptedLabelers: (
-					fixtureCase.acceptedLabellers ?? corpus.caseDefaults.acceptedLabellers
-				).map((policy) => ({
-					did: corpus.sources[policy.src]!,
-					redact: policy.redact,
-				})),
-				context: {
-					publisherDid: subject.publisherDid!,
-					package: { uri: subject.packageUri!, cid: subject.packageCid! },
-					release: { uri: subject.releaseUri!, cid: subject.releaseCid! },
-				},
-				evaluatedAt: corpus.evaluatedAt,
-				labels: labels.map((fixtureLabel) =>
-					verified({
-						ver: 1,
-						src: corpus.sources[fixtureLabel.src]!,
-						uri:
-							fixtureLabel.subject === "publisher"
-								? subject.publisherDid!
-								: fixtureLabel.subject === "package"
-									? subject.packageUri!
-									: subject.releaseUri!,
-						cid: fixtureLabel.cid,
-						val: fixtureLabel.val,
-						cts: fixtureLabel.cts,
-						neg: fixtureLabel.neg,
-						exp: fixtureLabel.exp,
-					}),
-				),
-			});
+			const result = runEvaluation(buildCorpusInput(fixtureCase));
 			expect(result).toMatchObject({
 				eligibility: fixtureCase.expected.eligibility,
 				reasonCodes: fixtureCase.expected.reasonCodes,
@@ -450,4 +479,64 @@ describe("ratified moderation corpus", () => {
 			});
 		});
 	}
+});
+
+describe("evaluateHydratedReleaseModeration structural validation", () => {
+	// A real DASL CID (unlike the file-level `context`'s placeholder strings),
+	// since the hydrated path -- unlike the branded path -- structurally
+	// validates each label's `cid`.
+	const validCid = "bafkreif4oaymum54i5qefbwoblrt5zasfjhpyhyvacpseqtehi3queew5m";
+	const validContext = {
+		...context,
+		release: { ...context.release, cid: validCid },
+	};
+	const baseLabel = {
+		ver: 1 as const,
+		src: source,
+		uri: context.release.uri,
+		cid: validCid,
+		val: "assessment-passed",
+		cts: "2026-07-10T12:00:00.000Z",
+	};
+
+	function evaluateHydrated(labels: unknown[]) {
+		return evaluateHydratedReleaseModeration({
+			acceptedLabelers: [{ did: source, redact: false }],
+			context: validContext,
+			evaluatedAt: "2026-07-10T13:00:00.000Z",
+			labels: labels as ModerationLabel[],
+		});
+	}
+
+	it("accepts a well-formed unsigned label with no sig field", () => {
+		expect(evaluateHydrated([baseLabel])).toMatchObject({ eligibility: "eligible" });
+	});
+
+	it("rejects a label carrying a sig field (not a hydrated label)", () => {
+		expect(() => evaluateHydrated([{ ...baseLabel, sig: new Uint8Array(64) }])).toThrow(
+			"unsupported field: sig",
+		);
+	});
+
+	it("rejects a malformed uri", () => {
+		expect(() => evaluateHydrated([{ ...baseLabel, uri: "not a uri" }])).toThrow(
+			"label.uri must be an at:// URI or DID",
+		);
+	});
+
+	it("rejects a malformed cts timestamp", () => {
+		expect(() => evaluateHydrated([{ ...baseLabel, cts: "not-a-datetime" }])).toThrow(
+			"label.cts must be a valid RFC 3339 timestamp",
+		);
+	});
+
+	it("rejects an unknown field", () => {
+		expect(() => evaluateHydrated([{ ...baseLabel, extra: "nope" }])).toThrow(
+			"label contains unsupported field: extra",
+		);
+	});
+
+	it("rejects a non-object label", () => {
+		expect(() => evaluateHydrated(["not a label"])).toThrow("label must be an object");
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2215,6 +2215,9 @@ importers:
       '@emdash-cms/registry-lexicons':
         specifier: workspace:*
         version: link:../registry-lexicons
+      '@emdash-cms/registry-moderation':
+        specifier: workspace:*
+        version: link:../registry-moderation
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'


### PR DESCRIPTION
## What does this PR do?

Implements W5 client eligibility enforcement (minus the admin UI, which is W5.5's own PR) — the layer that decides whether an EmDash site installs a plugin. Three commits:

- **Hydrated moderation evaluation** (`@emdash-cms/registry-moderation`): `evaluateHydratedReleaseModeration` evaluates aggregator-hydrated labels that carry no signature, sharing one evaluation body with the branded `verifyLabel` path so the two cannot drift. The branded entrance and its runtime check are untouched; nothing can mint the verified brand without cryptographic verification. Also corrects a latent invalid CID in the ratified gate-0 moderation corpus (present since ratification, inert until this path added structural CID validation — recorded in the gate-0 amendments log in this diff).
- **Registry-client adapter** (`@emdash-cms/registry-client`): `evaluateReleaseViews` (subject context from validated views, tolerant of structurally invalid aggregator labels), `resolveAcceptedPolicy` (response `atproto-content-labelers` header > configured `acceptLabelers` > empty; response-header parse failure warns and falls through, configured parse failure is a loud error), and `onResponseMeta` on `DiscoveryClient` for header access. Docs cut over to the canonical vocabulary.
- **Core + CLI enforcement**: install and update gate on the shared evaluation — package and publisher cascades, CID-bound labels, negation, expiry — immediately before artifact download (fetch-tripwire tested on both paths), replacing the three raw `security:yanked` string comparisons (zero occurrences remain in core, registry-client, or plugin-cli). Update now fetches the package view (it previously saw release labels only, missing every cascade) with the same aggregator-identity cross-check as install. The artifact proxy refuses media for blocked releases. Update-check reports additive per-plugin `moderation` state with no extra network calls. The CLI renders evaluated eligibility instead of raw label dumps. Error codes unified: `RELEASE_YANKED` when `security-yanked` is among the blocking labels, else `RELEASE_BLOCKED`; malformed `acceptLabelers` config is a loud `REGISTRY_POLICY_INVALID`.

Adversarial review (opus) finding fixed pre-merge: the gate originally required `eligibility === "blocked"`, but the evaluator ranks pending/error above automated blocks — so `malware` plus a co-present `assessment-pending` (a realistic state once a newer assessment run opens against a flagged release) re-ranked eligibility and **failed the gate open**. All three consumers now key solely on `blockingLabels`/`redacted`, with a regression test for the co-present case.

Decisions needing maintainer ratification (deviations from the plan, reasoned in-thread):

1. **Hydrated-trust evaluation instead of per-request signature verification.** A compromised aggregator attacks by *omitting* labels, which verifying the labels it chose to show cannot detect; the integrity roots (signed release record, artifact checksum) are already verified in core. Signature verification is reserved for the future positive-assessment gate, where fabricating a pass is the actual threat — the branded path exists and is required for it.
2. **No enforcement flag.** The plan's "disabled production flag" applies to the positive-assessment gate (not shipped here). Blocking-label enforcement is behavior-preserving-or-stronger versus the string checks it replaces, and `missing-assessment-pass` explicitly does not block — zero production change on merge (verified: a clean release with an accepted policy installs; no labels flow in production yet regardless).
3. **Gate-0 corpus amendment**: the ratified fixture's `oldPackageCid` was not a decodable CID (hard parse failure, traced to the original ratification commit); corrected to a verified round-tripping CID with no change to any case's expected outcome.

Implementation PRs target `feat/plugin-registry-labelling-service` per the umbrella PR. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n is n/a — no admin changes in this PR (W5.5 handles the UI). Changesets included for all four published packages that changed (`@emdash-cms/registry-moderation`, `@emdash-cms/registry-client`, `emdash`, `@emdash-cms/plugin-cli`).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (design, review, fixes) and Sonnet/Opus subagents (implementation, adversarial review)

## Screenshots / test output

- Core: full unit suite 4618 passed / 3 skipped, including 16 new moderation-gate tests (install/update/update-check, cascades, CID-stale, warning/pending/error non-blocking, the co-present fail-open regression, gate-before-fetch tripwires) and 4 new artifact-proxy tests
- registry-moderation: 150 pass (ratified corpus now runs through BOTH the branded and hydrated entry points); registry-client: 85 pass; plugin-cli: 399 pass (6 new display tests)
- Typecheck clean everywhere; `pnpm lint:quick` 0 diagnostics; type-aware `lint:json` 0 findings repo-wide
- CLI rendering (verbatim): `Moderation: blocked (malware) by did:plc:labeler-a` on `info`; `[blocked]` marker + `blocked: !takedown` line on `search`; clean packages render identically to before

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-client-enforcement-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-client-enforcement`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
