### PR TITLE
fix(plugins): escape LIKE metacharacters in storage startsWith queries

### DIFF
--- a/.changeset/plugin-storage-startswith-escape.md
+++ b/.changeset/plugin-storage-startswith-escape.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes plugin storage `startsWith` queries treating `%`, `_`, and `\` in the prefix as LIKE wildcards instead of literal characters.

--- a/packages/core/src/plugins/storage-query.ts
+++ b/packages/core/src/plugins/storage-query.ts
@@ -51,6 +51,15 @@ export function isStartsWithFilter(value: WhereValue): value is StartsWithFilter
 }
 
 /**
+ * Escape LIKE pattern metacharacters so a startsWith prefix matches
+ * literally. Without this, `%` and `_` in the prefix act as wildcards
+ * (e.g. `{ startsWith: "50%" }` would match "50x off").
+ */
+export function escapeLikePattern(value: string): string {
+	return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+}
+
+/**
  * Get the set of indexed fields from index declarations
  */
 export function getIndexedFields(indexes: Array<string | string[]>): Set<string> {
@@ -152,9 +161,10 @@ export function buildCondition(
 	}
 
 	if (isStartsWithFilter(value)) {
+		// ESCAPE '\' works on both SQLite and PostgreSQL.
 		return {
-			sql: `${extract} LIKE ?`,
-			params: [`${value.startsWith}%`],
+			sql: `${extract} LIKE ? ESCAPE '\\'`,
+			params: [`${escapeLikePattern(value.startsWith)}%`],
 		};
 	}
 

--- a/packages/core/tests/integration/plugins/storage.test.ts
+++ b/packages/core/tests/integration/plugins/storage.test.ts
@@ -116,6 +116,45 @@ describe("Plugin Storage Integration", () => {
 			});
 			expect(user1Pageviews.items).toHaveLength(1);
 		});
+
+		it("should treat LIKE metacharacters in startsWith prefixes literally", async () => {
+			const repo = new PluginStorageRepository<AnalyticsEvent>(db, "analytics-plugin", "events", [
+				"eventType",
+				"userId",
+				"timestamp",
+			]);
+
+			await repo.putMany([
+				{
+					id: "e1",
+					data: { eventType: "sale:50%", userId: "u1", timestamp: "2024-01-01", metadata: {} },
+				},
+				{
+					id: "e2",
+					// Would match "sale:50%" under an unescaped `%` wildcard
+					data: { eventType: "sale:50x", userId: "u1", timestamp: "2024-01-01", metadata: {} },
+				},
+				{
+					id: "e3",
+					data: { eventType: "a_b", userId: "u1", timestamp: "2024-01-01", metadata: {} },
+				},
+				{
+					id: "e4",
+					// Would match "a_b" under an unescaped `_` wildcard
+					data: { eventType: "axb", userId: "u1", timestamp: "2024-01-01", metadata: {} },
+				},
+			]);
+
+			const percent = await repo.query({ where: { eventType: { startsWith: "sale:50%" } } });
+			expect(percent.items.map((i) => i.id)).toEqual(["e1"]);
+
+			const underscore = await repo.query({ where: { eventType: { startsWith: "a_" } } });
+			expect(underscore.items.map((i) => i.id)).toEqual(["e3"]);
+
+			// Plain prefixes still match as before
+			const plain = await repo.query({ where: { eventType: { startsWith: "sale:" } } });
+			expect(plain.items).toHaveLength(2);
+		});
 	});
 
 	describe("createPluginStorageAccessor", () => {

--- a/packages/core/tests/unit/plugins/storage-query.test.ts
+++ b/packages/core/tests/unit/plugins/storage-query.test.ts
@@ -229,8 +229,14 @@ describe("storage-query", () => {
 
 		it("should handle startsWith filters", () => {
 			const result = buildCondition(db, "name", { startsWith: "foo" });
-			expect(result.sql).toBe("json_extract(data, '$.name') LIKE ?");
+			expect(result.sql).toBe("json_extract(data, '$.name') LIKE ? ESCAPE '\\'");
 			expect(result.params).toEqual(["foo%"]);
+		});
+
+		it("should escape LIKE metacharacters in startsWith prefixes", () => {
+			expect(buildCondition(db, "name", { startsWith: "50%" }).params).toEqual(["50\\%%"]);
+			expect(buildCondition(db, "name", { startsWith: "a_b" }).params).toEqual(["a\\_b%"]);
+			expect(buildCondition(db, "name", { startsWith: "c:\\dir" }).params).toEqual(["c:\\\\dir%"]);
 		});
 
 		it("should handle range filters with gt", () => {
@@ -297,7 +303,7 @@ describe("storage-query", () => {
 				count: { gte: 5 },
 			});
 			expect(result.sql).toContain("IN (?, ?)");
-			expect(result.sql).toContain("LIKE ?");
+			expect(result.sql).toContain("LIKE ? ESCAPE");
 			expect(result.sql).toContain(">= ?");
 			expect(result.params).toEqual(["active", "pending", "test%", 5]);
 		});


### PR DESCRIPTION
## What does this PR do?

The plugin storage `startsWith` query operator builds its SQL as `LIKE '<prefix>%'` without escaping the prefix. Any `%`, `_`, or `\` inside the prefix therefore acts as a LIKE wildcard instead of a literal character:

- `{ startsWith: "50%" }` matches `"50x off"`, `"50 anything"`, …
- `{ startsWith: "a_b" }` matches `"axb"`
- a trailing `\` in the prefix can corrupt the pattern

This PR escapes the prefix (`\` → `\\`, `%` → `\%`, `_` → `\_`) and adds `ESCAPE '\'` to the generated condition, which behaves identically on SQLite and PostgreSQL. Same approach the options repository already uses for its prefix scans.

Includes unit tests for the generated SQL/params and an integration test proving literal matching end-to-end.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a — no admin UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a — bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude. All changes reviewed and tested by me.

## Screenshots / test output

```
Tests  56 passed (56)  — storage-query unit tests + plugin storage integration tests
```