### PR TITLE
feat(plugins): opt-in raw request body for native plugin routes

### DIFF
--- a/.changeset/plugin-route-raw-body.md
+++ b/.changeset/plugin-route-raw-body.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds opt-in raw request body access for native plugin routes: set `rawBody: true` on a route to receive the unparsed body as `ctx.rawBody`, enabling webhook signature verification and non-JSON payloads.

--- a/.changeset/plugin-route-raw-body.md
+++ b/.changeset/plugin-route-raw-body.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds opt-in raw request body access for native plugin routes: set `rawBody: true` on a route to receive the unparsed body as `ctx.rawBody`, enabling webhook signature verification and non-JSON payloads. The error thrown when a handler reads the already-consumed request body now points to this escape hatch.

--- a/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
@@ -151,6 +151,29 @@ Key details of this configuration:
 - **`id`, `version`, and `capabilities` appear twice.** Once on the descriptor, once on `definePlugin()`. They should match. The descriptor's copy is what `astro.config.mjs` sees at build time; the `definePlugin()` copy is what runs at request time.
 - **Native route handlers take a single argument** — `(ctx: RouteContext)` where `ctx.input`, `ctx.request`, and `ctx.requestMeta` are merged with the regular `PluginContext` properties. This is the opposite of standard format's two-argument shape. See [API routes](/plugins/creating-plugins/api-routes/) for the full surface (everything else is identical).
 
+## Raw request bodies (webhook signatures)
+
+The dispatcher parses the request body before your handler runs and exposes it as `ctx.input`; the body stream is consumed, so `ctx.request.text()` is unavailable. That's fine for normal routes — but webhook providers (Stripe, GitHub, Svix, …) sign the _exact raw bytes_ of the delivery, and an HMAC computed over a re-serialized `ctx.input` will never match.
+
+Routes that need the unparsed body opt in with `rawBody: true`:
+
+```typescript
+routes: {
+	"webhooks/provider": {
+		public: true,
+		rawBody: true,
+		handler: async (ctx) => {
+			const signature = ctx.request.headers.get("X-Signature") ?? "";
+			await verifyHmac(ctx.rawBody ?? "", signature, secret); // throw on mismatch
+			const event = JSON.parse(ctx.rawBody ?? "{}");
+			// ...
+		},
+	},
+},
+```
+
+`ctx.rawBody` is the body exactly as received. `ctx.input` still works as usual (parsed from the same buffer). Non-JSON payloads — e.g. form-encoded webhook deliveries — arrive with `ctx.input` undefined but `ctx.rawBody` intact, so the handler can parse them itself. The flag is native-format only; sandboxed plugins receive requests across a serialization boundary and don't support it yet.
+
 ## Plugin id rules
 
 The `id` field must match `/^[a-z][a-z0-9_-]*$/` — start with a lowercase letter, then letters, digits, hyphens, or underscores. The id is used as a single path segment in plugin route URLs and as part of generated SQL identifiers for plugin storage indexes, so anything outside that pattern fails at runtime. The following values show which ids are accepted:

--- a/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
@@ -153,7 +153,7 @@ Key details of this configuration:
 
 ## Raw request bodies (webhook signatures)
 
-The dispatcher parses the request body before your handler runs and exposes it as `ctx.input`; the body stream is consumed, so `ctx.request.text()` is unavailable. That's fine for normal routes — but webhook providers (Stripe, GitHub, Svix, …) sign the _exact raw bytes_ of the delivery, and an HMAC computed over a re-serialized `ctx.input` will never match.
+The dispatcher parses the request body before your handler runs and exposes it as `ctx.input`; the body stream is consumed, so `ctx.request.text()` is unavailable. That's fine for normal routes — but webhook providers (Stripe, GitHub, Svix, …) sign the payload _exactly as delivered_, and an HMAC computed over a re-serialized `ctx.input` will never match (whitespace and key order don't survive a parse/stringify round-trip).
 
 Routes that need the unparsed body opt in with `rawBody: true`:
 
@@ -172,7 +172,7 @@ routes: {
 },
 ```
 
-`ctx.rawBody` is the body exactly as received. `ctx.input` still works as usual (parsed from the same buffer). Non-JSON payloads — e.g. form-encoded webhook deliveries — arrive with `ctx.input` undefined but `ctx.rawBody` intact, so the handler can parse them itself. The flag is native-format only; sandboxed plugins receive requests across a serialization boundary and don't support it yet.
+`ctx.rawBody` is the delivered body as a UTF-8 decoded string — webhook payloads are UTF-8 text in practice, so signature libraries that accept a string (or `new TextEncoder().encode(ctx.rawBody)`) work directly; binary bodies are not preserved byte-exactly. `ctx.input` still works as usual (parsed from the same buffer). Non-JSON payloads — e.g. form-encoded webhook deliveries — arrive with `ctx.input` undefined but `ctx.rawBody` intact, so the handler can parse them itself. The flag is native-format only; sandboxed plugins receive requests across a serialization boundary and don't support it yet.
 
 ## Plugin id rules
 

--- a/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
@@ -165,6 +165,29 @@ The equivalent sandboxed handler receives `(routeCtx, ctx)` as two arguments. Au
 	Capabilities gate the APIs exposed through `ctx`, but a native plugin has no isolation boundary. It can import host packages, access environment variables, call `fetch()` directly, and affect the host process. Install native packages only from publishers you trust.
 </Aside>
 
+### Raw request bodies (webhook signatures)
+
+The dispatcher parses the request body before your handler runs and exposes it as `ctx.input`; the body stream is consumed, so `ctx.request.text()` is unavailable. That's fine for normal routes — but webhook providers (Stripe, GitHub, Svix, …) sign the payload they send as UTF-8 text, and an HMAC computed over a re-serialized `ctx.input` will never match (whitespace and key order don't survive a parse/stringify round-trip).
+
+Routes that need the unparsed body opt in with `rawBody: true`:
+
+```typescript
+routes: {
+	"webhooks/provider": {
+		public: true,
+		rawBody: true,
+		handler: async (ctx) => {
+			const signature = ctx.request.headers.get("X-Signature") ?? "";
+			await verifyHmac(ctx.rawBody ?? "", signature, secret); // throw on mismatch
+			const event = JSON.parse(ctx.rawBody ?? "{}");
+			// ...
+		},
+	},
+},
+```
+
+`ctx.rawBody` is the delivered body as a UTF-8 decoded string — webhook payloads are UTF-8 text in practice, so signature libraries that accept a string (or `new TextEncoder().encode(ctx.rawBody)`) work directly; binary bodies are not preserved byte-exactly. `ctx.input` still works as usual (parsed from the same buffer). Non-JSON payloads — e.g. form-encoded webhook deliveries — arrive with `ctx.input` undefined but `ctx.rawBody` intact, so the handler can parse them itself. The flag is native-format only; sandboxed plugins receive requests across a serialization boundary and don't support it yet.
+
 ## Add another surface
 
 - [React admin pages and widgets](/plugins/creating-native-plugins/react-admin/) covers settings, custom pages, dashboard widgets, editor panels, and list columns.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -3343,8 +3343,9 @@ export class EmDashRuntime {
 			const routeKey = path.replace(LEADING_SLASH_PATTERN, "");
 
 			// Buffer the body as text so routes with `rawBody: true` can see the
-			// exact bytes (webhook signature verification); parse JSON from the
-			// same buffer for `ctx.input`.
+			// payload exactly as delivered — as a UTF-8 decoded string, which is
+			// what webhook signature verification needs in practice; parse JSON
+			// from the same buffer for `ctx.input`.
 			let body: unknown = undefined;
 			let rawBody: string | undefined;
 			try {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -3342,14 +3342,19 @@ export class EmDashRuntime {
 
 			const routeKey = path.replace(LEADING_SLASH_PATTERN, "");
 
+			// Buffer the body as text so routes with `rawBody: true` can see the
+			// exact bytes (webhook signature verification); parse JSON from the
+			// same buffer for `ctx.input`.
 			let body: unknown = undefined;
+			let rawBody: string | undefined;
 			try {
-				body = await request.json();
+				rawBody = await request.text();
+				if (rawBody) body = JSON.parse(rawBody);
 			} catch {
-				// No body or not JSON
+				// No body or not JSON — rawBody (when read) is still passed through
 			}
 
-			return routeRegistry.invoke(pluginId, routeKey, { request, body });
+			return routeRegistry.invoke(pluginId, routeKey, { request, body, rawBody });
 		}
 
 		// Check sandboxed (marketplace) plugins second

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -217,6 +217,7 @@ import { extractRequestMeta, sanitizeHeadersForSandbox } from "./plugins/request
 import {
 	buildRouteMeta,
 	parseRouteInput,
+	parseRouteInputWithRaw,
 	PluginRouteRegistry,
 	toRouteCallerInfo,
 	type RouteCallerInput,
@@ -3693,10 +3694,13 @@ export class EmDashRuntime {
 
 			const routeKey = path.replace(LEADING_SLASH_PATTERN, "");
 
-			// Body methods parse JSON; GET/HEAD/DELETE parse the query string (#2146).
-			const body = await parseRouteInput(request);
+			// Body methods buffer the body text once so routes with `rawBody: true`
+			// can see the UTF-8 decoded payload (webhook signature verification)
+			// and parse JSON for `ctx.input` from the same buffer; GET/HEAD/DELETE
+			// parse the query string instead.
+			const { body, rawBody } = await parseRouteInputWithRaw(request);
 
-			return routeRegistry.invoke(pluginId, routeKey, { request, body, user: caller });
+			return routeRegistry.invoke(pluginId, routeKey, { request, body, user: caller, rawBody });
 		}
 
 		// Check sandboxed (marketplace) plugins second

--- a/packages/core/src/plugins/routes.ts
+++ b/packages/core/src/plugins/routes.ts
@@ -38,7 +38,8 @@ function guardConsumedRequestBody(request: Request): Request {
 					throw new Error(
 						`[emdash] ctx.request.${prop}() is not available inside a plugin route handler: ` +
 							`EmDash has already parsed the request body and exposes it as ctx.input. ` +
-							`Read ctx.input instead of ctx.request.${prop}().`,
+							`Read ctx.input instead of ctx.request.${prop}() — or set rawBody: true ` +
+							`on the route and read ctx.rawBody if you need the unparsed body.`,
 					);
 				};
 			}
@@ -78,6 +79,8 @@ export interface InvokeRouteOptions {
 	request: Request;
 	/** Request body (already parsed) */
 	body?: unknown;
+	/** Unparsed request body; forwarded to the handler only for routes with `rawBody: true` */
+	rawBody?: string;
 }
 
 /**
@@ -141,6 +144,8 @@ export class PluginRouteHandler {
 			// (#1293). Metadata extraction uses the original request (headers only).
 			request: guardConsumedRequestBody(options.request),
 			requestMeta: extractRequestMeta(options.request, this.trustedProxyHeaders),
+			// Only routes that opt in see the raw body (signature verification).
+			rawBody: route.rawBody === true ? options.rawBody : undefined,
 		};
 
 		// Execute handler

--- a/packages/core/src/plugins/routes.ts
+++ b/packages/core/src/plugins/routes.ts
@@ -41,7 +41,8 @@ function guardConsumedRequestBody(request: Request): Request {
 					throw new Error(
 						`[emdash] ctx.request.${prop}() is not available inside a plugin route handler: ` +
 							`EmDash has already parsed the request body and exposes it as ctx.input. ` +
-							`Read ctx.input instead of ctx.request.${prop}().`,
+							`Read ctx.input instead of ctx.request.${prop}() — or set rawBody: true ` +
+							`on the route and read ctx.rawBody if you need the unparsed body.`,
 					);
 				};
 			}
@@ -101,13 +102,29 @@ const BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
  * schemas work; a single key stays a scalar.
  */
 export async function parseRouteInput(request: Request): Promise<unknown> {
+	return (await parseRouteInputWithRaw(request)).body;
+}
+
+/**
+ * Like {@link parseRouteInput}, but for body methods also returns the body
+ * text the input was parsed from, so routes with `rawBody: true` can see the
+ * UTF-8 decoded payload (e.g. for webhook signature verification). One
+ * `text()` read, one buffer — no extra I/O. `rawBody` stays undefined for
+ * bodyless methods.
+ */
+export async function parseRouteInputWithRaw(
+	request: Request,
+): Promise<{ body: unknown; rawBody?: string }> {
 	if (BODY_METHODS.has(request.method.toUpperCase())) {
+		let rawBody: string | undefined;
+		let body: unknown;
 		try {
-			return await request.json();
+			rawBody = await request.text();
+			if (rawBody) body = JSON.parse(rawBody);
 		} catch {
-			// No body or not JSON
-			return undefined;
+			// No body or not JSON — rawBody (when read) is still passed through
 		}
+		return { body, rawBody };
 	}
 
 	const params = new URL(request.url).searchParams;
@@ -116,7 +133,7 @@ export async function parseRouteInput(request: Request): Promise<unknown> {
 		const values = params.getAll(key);
 		input[key] = values.length > 1 ? values : values[0];
 	}
-	return input;
+	return { body: input };
 }
 
 /**
@@ -174,6 +191,8 @@ export interface InvokeRouteOptions {
 	 * `ctx.user`. Undefined for public routes and unbound machine tokens.
 	 */
 	user?: UserInfo;
+	/** Unparsed request body; forwarded to the handler only for routes with `rawBody: true` */
+	rawBody?: string;
 }
 
 /**
@@ -238,6 +257,8 @@ export class PluginRouteHandler {
 			request: guardConsumedRequestBody(options.request),
 			requestMeta: extractRequestMeta(options.request, this.trustedProxyHeaders),
 			user: options.user,
+			// Only routes that opt in see the raw body (signature verification).
+			rawBody: route.rawBody === true ? options.rawBody : undefined,
 		};
 
 		// Execute handler

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1160,6 +1160,12 @@ export interface RouteContext<TInput = unknown> extends PluginContext {
 	request: Request;
 	/** Normalized request metadata (IP, user agent, geo) */
 	requestMeta: RequestMeta;
+	/**
+	 * The unparsed request body, exactly as received. Only populated when the
+	 * route sets `rawBody: true` — needed to verify webhook signatures, which
+	 * are HMACs over the raw bytes (a re-serialized `ctx.input` never matches).
+	 */
+	rawBody?: string;
 }
 
 /**
@@ -1173,6 +1179,12 @@ export interface PluginRoute<TInput = unknown> {
 	 * Public routes skip session/token auth and CSRF checks.
 	 */
 	public?: boolean;
+	/**
+	 * Expose the unparsed request body as `ctx.rawBody`, alongside the parsed
+	 * `ctx.input`. Opt-in so the body string is only retained where a handler
+	 * actually needs it (webhook signature verification, non-JSON payloads).
+	 */
+	rawBody?: boolean;
 	/** Route handler */
 	handler: (ctx: RouteContext<TInput>) => Promise<unknown>;
 }

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1161,9 +1161,12 @@ export interface RouteContext<TInput = unknown> extends PluginContext {
 	/** Normalized request metadata (IP, user agent, geo) */
 	requestMeta: RequestMeta;
 	/**
-	 * The unparsed request body, exactly as received. Only populated when the
-	 * route sets `rawBody: true` — needed to verify webhook signatures, which
-	 * are HMACs over the raw bytes (a re-serialized `ctx.input` never matches).
+	 * The unparsed request body as a UTF-8 decoded string. Only populated when
+	 * the route sets `rawBody: true` — needed to verify webhook signatures,
+	 * which are computed over the delivered payload (a re-serialized
+	 * `ctx.input` never matches, since whitespace and key order don't survive
+	 * a parse/stringify round-trip). Webhook payloads are UTF-8 text in
+	 * practice; binary bodies are not preserved byte-exactly.
 	 */
 	rawBody?: string;
 }

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1218,6 +1218,15 @@ export interface RouteContext<TInput = unknown> extends PluginContext {
 	 * identity for the current request, not a user directory lookup.
 	 */
 	user?: UserInfo;
+	/**
+	 * The unparsed request body as a UTF-8 decoded string. Only populated when
+	 * the route sets `rawBody: true` — needed to verify webhook signatures,
+	 * which are computed over the delivered payload (a re-serialized
+	 * `ctx.input` never matches, since whitespace and key order don't survive
+	 * a parse/stringify round-trip). Webhook payloads are UTF-8 text in
+	 * practice; binary bodies are not preserved byte-exactly.
+	 */
+	rawBody?: string;
 }
 
 /**
@@ -1240,6 +1249,12 @@ export interface PluginRoute<TInput = unknown> {
 	 * keep the default `private, no-store`. Errors are never cached.
 	 */
 	cacheControl?: string;
+	/**
+	 * Expose the unparsed request body as `ctx.rawBody`, alongside the parsed
+	 * `ctx.input`. Opt-in so the body string is only retained where a handler
+	 * actually needs it (webhook signature verification, non-JSON payloads).
+	 */
+	rawBody?: boolean;
 	/** Route handler */
 	handler: (ctx: RouteContext<TInput>) => Promise<unknown>;
 }

--- a/packages/core/tests/integration/runtime/plugin-raw-body-route.test.ts
+++ b/packages/core/tests/integration/runtime/plugin-raw-body-route.test.ts
@@ -1,0 +1,118 @@
+/**
+ * End-to-end wiring for plugin-route `rawBody`.
+ *
+ * The route-layer unit tests pass `rawBody` into `PluginRouteHandler.invoke`
+ * manually; this test exercises the real path — `EmDashRuntime.
+ * handlePluginApiRoute` reading the request stream once, parsing `ctx.input`
+ * from the same buffer, and forwarding the raw string only to routes that
+ * opted in with `rawBody: true`.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import Database from "better-sqlite3";
+import { SqliteDialect } from "kysely";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import type { RuntimeDependencies } from "../../../src/emdash-runtime.js";
+import { definePlugin } from "../../../src/plugins/define-plugin.js";
+
+/** What the handler saw for the last invocation, keyed by route name. */
+const seen = new Map<string, { rawBody?: string; input?: unknown }>();
+
+function createDeps(): RuntimeDependencies {
+	const entrypoint = `test-plugin-raw-body-${randomUUID()}`;
+	return {
+		config: {
+			database: { entrypoint, config: {}, type: "sqlite" },
+			storage: { entrypoint, config: {} },
+		},
+		plugins: [
+			definePlugin({
+				id: "webhook-demo",
+				version: "1.0.0",
+				capabilities: [],
+				routes: {
+					webhook: {
+						rawBody: true,
+						handler: async (ctx) => {
+							seen.set("webhook", { rawBody: ctx.rawBody, input: ctx.input });
+							return { ok: true };
+						},
+					},
+					normal: {
+						handler: async (ctx) => {
+							seen.set("normal", { rawBody: ctx.rawBody, input: ctx.input });
+							return { ok: true };
+						},
+					},
+				},
+			}),
+		],
+		createDialect: () => new SqliteDialect({ database: new Database(":memory:") }),
+		createStorage: null,
+		sandboxEnabled: false,
+		sandboxedPluginEntries: [],
+		createSandboxRunner: null,
+	};
+}
+
+function post(runtime: EmDashRuntime, route: string, body?: string) {
+	return runtime.handlePluginApiRoute(
+		"webhook-demo",
+		"POST",
+		`/${route}`,
+		new Request(`http://test.local/_emdash/api/plugins/webhook-demo/${route}`, {
+			method: "POST",
+			body,
+		}),
+	);
+}
+
+describe("EmDashRuntime.handlePluginApiRoute — rawBody", () => {
+	let runtime: EmDashRuntime;
+
+	beforeAll(async () => {
+		runtime = await EmDashRuntime.create(createDeps());
+	});
+
+	afterAll(async () => {
+		await runtime.stopCron();
+	});
+
+	it("delivers the unparsed body string and the parsed input from the same buffer", async () => {
+		// Whitespace and key order must survive: a signature computed over a
+		// re-serialized ctx.input would not match this string.
+		const raw = `{"b": 2,  "a":1}`;
+		const result = await post(runtime, "webhook", raw);
+
+		expect(result.success).toBe(true);
+		expect(seen.get("webhook")).toEqual({ rawBody: raw, input: { a: 1, b: 2 } });
+	});
+
+	it("delivers non-JSON bodies with input undefined", async () => {
+		const raw = "event=order.paid&id=42";
+		const result = await post(runtime, "webhook", raw);
+
+		expect(result.success).toBe(true);
+		expect(seen.get("webhook")).toEqual({ rawBody: raw, input: undefined });
+	});
+
+	it("leaves rawBody undefined without a request body", async () => {
+		const result = await post(runtime, "webhook");
+
+		expect(result.success).toBe(true);
+		const call = seen.get("webhook");
+		expect(call?.rawBody).toBeFalsy();
+		expect(call?.input).toBeUndefined();
+	});
+
+	it("does not expose rawBody to routes without the flag", async () => {
+		const raw = `{"a":1}`;
+		const result = await post(runtime, "normal", raw);
+
+		expect(result.success).toBe(true);
+		expect(seen.get("normal")).toEqual({ rawBody: undefined, input: { a: 1 } });
+	});
+});

--- a/packages/core/tests/integration/runtime/plugin-raw-body-route.test.ts
+++ b/packages/core/tests/integration/runtime/plugin-raw-body-route.test.ts
@@ -1,27 +1,51 @@
 /**
- * End-to-end wiring for plugin-route `rawBody`.
+ * Trusted plugin routes with `rawBody: true` must receive the delivered
+ * body as a UTF-8 string on `ctx.rawBody`, alongside the parsed `ctx.input`.
  *
- * The route-layer unit tests pass `rawBody` into `PluginRouteHandler.invoke`
- * manually; this test exercises the real path — `EmDashRuntime.
- * handlePluginApiRoute` reading the request stream once, parsing `ctx.input`
- * from the same buffer, and forwarding the raw string only to routes that
- * opted in with `rawBody: true`.
+ * The dispatcher reads `request.text()` once, parses JSON from the same
+ * buffer into `ctx.input`, and only surfaces `rawBody` to opted-in routes —
+ * the behavioral core of the raw-body feature that unit tests invoking
+ * `PluginRouteHandler.invoke` directly do not exercise.
  */
 
 import { randomUUID } from "node:crypto";
 
 import Database from "better-sqlite3";
 import { SqliteDialect } from "kysely";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { EmDashRuntime } from "../../../src/emdash-runtime.js";
 import type { RuntimeDependencies } from "../../../src/emdash-runtime.js";
 import { definePlugin } from "../../../src/plugins/define-plugin.js";
+import type { Storage } from "../../../src/storage/types.js";
 
-/** What the handler saw for the last invocation, keyed by route name. */
-const seen = new Map<string, { rawBody?: string; input?: unknown }>();
+const stubStorage: Storage = {
+	async upload() {
+		throw new Error("storage not used by this test");
+	},
+	async download() {
+		throw new Error("storage not used by this test");
+	},
+	async delete() {},
+	async exists() {
+		return false;
+	},
+	async list() {
+		return { items: [] };
+	},
+	async getSignedUploadUrl() {
+		throw new Error("storage not used by this test");
+	},
+	getPublicUrl: (key) => `/media/${key}`,
+};
 
-function createDeps(): RuntimeDependencies {
+interface Captured {
+	hasRawBody: boolean;
+	rawBody: string | undefined;
+	input: unknown;
+}
+
+function createDeps(captured: Captured, rawBodyOptIn: boolean): RuntimeDependencies {
 	const entrypoint = `test-plugin-raw-body-${randomUUID()}`;
 	return {
 		config: {
@@ -30,20 +54,16 @@ function createDeps(): RuntimeDependencies {
 		},
 		plugins: [
 			definePlugin({
-				id: "webhook-demo",
+				id: "webhook-sink",
 				version: "1.0.0",
 				capabilities: [],
 				routes: {
-					webhook: {
-						rawBody: true,
+					hook: {
+						rawBody: rawBodyOptIn,
 						handler: async (ctx) => {
-							seen.set("webhook", { rawBody: ctx.rawBody, input: ctx.input });
-							return { ok: true };
-						},
-					},
-					normal: {
-						handler: async (ctx) => {
-							seen.set("normal", { rawBody: ctx.rawBody, input: ctx.input });
+							captured.hasRawBody = "rawBody" in ctx && ctx.rawBody !== undefined;
+							captured.rawBody = ctx.rawBody;
+							captured.input = ctx.input;
 							return { ok: true };
 						},
 					},
@@ -51,68 +71,80 @@ function createDeps(): RuntimeDependencies {
 			}),
 		],
 		createDialect: () => new SqliteDialect({ database: new Database(":memory:") }),
-		createStorage: null,
+		createStorage: () => stubStorage,
 		sandboxEnabled: false,
 		sandboxedPluginEntries: [],
 		createSandboxRunner: null,
 	};
 }
 
-function post(runtime: EmDashRuntime, route: string, body?: string) {
-	return runtime.handlePluginApiRoute(
-		"webhook-demo",
-		"POST",
-		`/${route}`,
-		new Request(`http://test.local/_emdash/api/plugins/webhook-demo/${route}`, {
-			method: "POST",
-			body,
-		}),
-	);
+function post(json: string): Request {
+	return new Request("http://test.local/_emdash/api/plugin/webhook-sink/hook", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: json,
+	});
 }
 
 describe("EmDashRuntime.handlePluginApiRoute — rawBody", () => {
-	let runtime: EmDashRuntime;
+	it("populates ctx.rawBody with the exact delivered text and ctx.input with parsed JSON", async () => {
+		const captured: Captured = { hasRawBody: false, rawBody: undefined, input: undefined };
+		const runtime = await EmDashRuntime.create(createDeps(captured, true));
+		try {
+			// Whitespace and key order must survive in rawBody even though
+			// ctx.input is the parsed equivalent.
+			const payload = '{  "b": 1,\n  "a": "x"  }';
+			const result = await runtime.handlePluginApiRoute(
+				"webhook-sink",
+				"POST",
+				"/hook",
+				post(payload),
+			);
 
-	beforeAll(async () => {
-		runtime = await EmDashRuntime.create(createDeps());
+			expect(result.success).toBe(true);
+			expect(captured.hasRawBody).toBe(true);
+			expect(captured.rawBody).toBe(payload);
+			expect(captured.input).toEqual({ a: "x", b: 1 });
+		} finally {
+			await runtime.stopCron();
+		}
 	});
 
-	afterAll(async () => {
-		await runtime.stopCron();
+	it("leaves ctx.input undefined for non-JSON payloads but still exposes rawBody", async () => {
+		const captured: Captured = { hasRawBody: false, rawBody: undefined, input: undefined };
+		const runtime = await EmDashRuntime.create(createDeps(captured, true));
+		try {
+			const result = await runtime.handlePluginApiRoute(
+				"webhook-sink",
+				"POST",
+				"/hook",
+				post("not json at all"),
+			);
+
+			expect(result.success).toBe(true);
+			expect(captured.rawBody).toBe("not json at all");
+			expect(captured.input).toBeUndefined();
+		} finally {
+			await runtime.stopCron();
+		}
 	});
 
-	it("delivers the unparsed body string and the parsed input from the same buffer", async () => {
-		// Whitespace and key order must survive: a signature computed over a
-		// re-serialized ctx.input would not match this string.
-		const raw = `{"b": 2,  "a":1}`;
-		const result = await post(runtime, "webhook", raw);
+	it("does not populate ctx.rawBody for routes that did not opt in", async () => {
+		const captured: Captured = { hasRawBody: false, rawBody: undefined, input: undefined };
+		const runtime = await EmDashRuntime.create(createDeps(captured, false));
+		try {
+			const result = await runtime.handlePluginApiRoute(
+				"webhook-sink",
+				"POST",
+				"/hook",
+				post('{"a":1}'),
+			);
 
-		expect(result.success).toBe(true);
-		expect(seen.get("webhook")).toEqual({ rawBody: raw, input: { a: 1, b: 2 } });
-	});
-
-	it("delivers non-JSON bodies with input undefined", async () => {
-		const raw = "event=order.paid&id=42";
-		const result = await post(runtime, "webhook", raw);
-
-		expect(result.success).toBe(true);
-		expect(seen.get("webhook")).toEqual({ rawBody: raw, input: undefined });
-	});
-
-	it("leaves rawBody undefined without a request body", async () => {
-		const result = await post(runtime, "webhook");
-
-		expect(result.success).toBe(true);
-		const call = seen.get("webhook");
-		expect(call?.rawBody).toBeFalsy();
-		expect(call?.input).toBeUndefined();
-	});
-
-	it("does not expose rawBody to routes without the flag", async () => {
-		const raw = `{"a":1}`;
-		const result = await post(runtime, "normal", raw);
-
-		expect(result.success).toBe(true);
-		expect(seen.get("normal")).toEqual({ rawBody: undefined, input: { a: 1 } });
+			expect(result.success).toBe(true);
+			expect(captured.hasRawBody).toBe(false);
+			expect(captured.input).toEqual({ a: 1 });
+		} finally {
+			await runtime.stopCron();
+		}
 	});
 });

--- a/packages/core/tests/integration/runtime/plugin-raw-body-route.test.ts
+++ b/packages/core/tests/integration/runtime/plugin-raw-body-route.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Trusted plugin routes with `rawBody: true` must receive the delivered
+ * body as a UTF-8 string on `ctx.rawBody`, alongside the parsed `ctx.input`.
+ *
+ * The dispatcher reads `request.text()` once, parses JSON from the same
+ * buffer into `ctx.input`, and only surfaces `rawBody` to opted-in routes —
+ * the behavioral core of the raw-body feature that unit tests invoking
+ * `PluginRouteHandler.invoke` directly do not exercise.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import Database from "better-sqlite3";
+import { SqliteDialect } from "kysely";
+import { describe, expect, it } from "vitest";
+
+import { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import type { RuntimeDependencies } from "../../../src/emdash-runtime.js";
+import { definePlugin } from "../../../src/plugins/define-plugin.js";
+import type { Storage } from "../../../src/storage/types.js";
+
+const stubStorage: Storage = {
+	async upload() {
+		throw new Error("storage not used by this test");
+	},
+	async download() {
+		throw new Error("storage not used by this test");
+	},
+	async delete() {},
+	async exists() {
+		return false;
+	},
+	async list() {
+		return { items: [] };
+	},
+	async getSignedUploadUrl() {
+		throw new Error("storage not used by this test");
+	},
+	getPublicUrl: (key) => `/media/${key}`,
+};
+
+interface Captured {
+	hasRawBody: boolean;
+	rawBody: string | undefined;
+	input: unknown;
+}
+
+function createDeps(captured: Captured, rawBodyOptIn: boolean): RuntimeDependencies {
+	const entrypoint = `test-plugin-raw-body-${randomUUID()}`;
+	return {
+		config: {
+			database: { entrypoint, config: {}, type: "sqlite" },
+			storage: { entrypoint, config: {} },
+		},
+		plugins: [
+			definePlugin({
+				id: "webhook-sink",
+				version: "1.0.0",
+				capabilities: [],
+				routes: {
+					hook: {
+						rawBody: rawBodyOptIn,
+						handler: async (ctx) => {
+							captured.hasRawBody = "rawBody" in ctx && ctx.rawBody !== undefined;
+							captured.rawBody = ctx.rawBody;
+							captured.input = ctx.input;
+							return { ok: true };
+						},
+					},
+				},
+			}),
+		],
+		createDialect: () => new SqliteDialect({ database: new Database(":memory:") }),
+		createStorage: () => stubStorage,
+		sandboxEnabled: false,
+		sandboxedPluginEntries: [],
+		createSandboxRunner: null,
+	};
+}
+
+function post(json: string): Request {
+	return new Request("http://test.local/_emdash/api/plugins/webhook-sink/hook", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: json,
+	});
+}
+
+describe("EmDashRuntime.handlePluginApiRoute — rawBody", () => {
+	it("populates ctx.rawBody with the exact delivered text and ctx.input with parsed JSON", async () => {
+		const captured: Captured = { hasRawBody: false, rawBody: undefined, input: undefined };
+		const runtime = await EmDashRuntime.create(createDeps(captured, true));
+		try {
+			// Whitespace and key order must survive in rawBody even though
+			// ctx.input is the parsed equivalent.
+			const payload = '{  "b": 1,\n  "a": "x"  }';
+			const result = await runtime.handlePluginApiRoute(
+				"webhook-sink",
+				"POST",
+				"/hook",
+				post(payload),
+			);
+
+			expect(result.success).toBe(true);
+			expect(captured.hasRawBody).toBe(true);
+			expect(captured.rawBody).toBe(payload);
+			expect(captured.input).toEqual({ a: "x", b: 1 });
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+
+	it("leaves ctx.input undefined for non-JSON payloads but still exposes rawBody", async () => {
+		const captured: Captured = { hasRawBody: false, rawBody: undefined, input: undefined };
+		const runtime = await EmDashRuntime.create(createDeps(captured, true));
+		try {
+			const result = await runtime.handlePluginApiRoute(
+				"webhook-sink",
+				"POST",
+				"/hook",
+				post("not json at all"),
+			);
+
+			expect(result.success).toBe(true);
+			expect(captured.rawBody).toBe("not json at all");
+			expect(captured.input).toBeUndefined();
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+
+	it("does not populate ctx.rawBody for routes that did not opt in", async () => {
+		const captured: Captured = { hasRawBody: false, rawBody: undefined, input: undefined };
+		const runtime = await EmDashRuntime.create(createDeps(captured, false));
+		try {
+			const result = await runtime.handlePluginApiRoute(
+				"webhook-sink",
+				"POST",
+				"/hook",
+				post('{"a":1}'),
+			);
+
+			expect(result.success).toBe(true);
+			expect(captured.hasRawBody).toBe(false);
+			expect(captured.input).toEqual({ a: 1 });
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+});

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -335,8 +335,9 @@ describe("PluginRouteHandler", () => {
 		});
 
 		it("exposes ctx.rawBody on routes that opt in with rawBody: true", async () => {
-			// Signature verification needs the exact raw bytes: whitespace and key
-			// order must survive, which a re-serialized ctx.input can't guarantee.
+			// Signature verification needs the payload exactly as delivered:
+			// whitespace and key order must survive, which a re-serialized
+			// ctx.input can't guarantee.
 			const raw = `{"b":2,  "a":1}`;
 			let seen: { rawBody?: string; input?: unknown } = {};
 			const plugin = createTestPlugin({

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -334,6 +334,88 @@ describe("PluginRouteHandler", () => {
 			expect(result.data).toEqual({ hasEmail: true, hasSend: true });
 		});
 
+		it("exposes ctx.rawBody on routes that opt in with rawBody: true", async () => {
+			// Signature verification needs the exact raw bytes: whitespace and key
+			// order must survive, which a re-serialized ctx.input can't guarantee.
+			const raw = `{"b":2,  "a":1}`;
+			let seen: { rawBody?: string; input?: unknown } = {};
+			const plugin = createTestPlugin({
+				routes: {
+					webhook: {
+						rawBody: true,
+						handler: async (ctx) => {
+							seen = { rawBody: ctx.rawBody, input: ctx.input };
+							return null;
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("webhook", {
+				request: new Request("http://test.com", { method: "POST", body: raw }),
+				body: JSON.parse(raw),
+				rawBody: raw,
+			});
+
+			expect(result.success).toBe(true);
+			expect(seen.rawBody).toBe(raw);
+			expect(seen.input).toEqual({ a: 1, b: 2 });
+		});
+
+		it("keeps ctx.rawBody undefined on routes without the rawBody flag", async () => {
+			let seenRawBody: string | undefined = "sentinel";
+			const plugin = createTestPlugin({
+				routes: {
+					normal: {
+						handler: async (ctx) => {
+							seenRawBody = ctx.rawBody;
+							return null;
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("normal", {
+				request: new Request("http://test.com", { method: "POST", body: "{}" }),
+				body: {},
+				rawBody: "{}",
+			});
+
+			expect(result.success).toBe(true);
+			expect(seenRawBody).toBeUndefined();
+		});
+
+		it("delivers non-JSON bodies to rawBody routes even though input is undefined", async () => {
+			// Form-encoded webhook deliveries parse to undefined today and are
+			// lost; with rawBody: true the handler can parse them itself.
+			const raw = "event=order.paid&id=42";
+			let seen: { rawBody?: string; input?: unknown } = {};
+			const plugin = createTestPlugin({
+				routes: {
+					webhook: {
+						rawBody: true,
+						handler: async (ctx) => {
+							seen = { rawBody: ctx.rawBody, input: ctx.input };
+							return null;
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("webhook", {
+				request: new Request("http://test.com", { method: "POST", body: raw }),
+				body: undefined,
+				rawBody: raw,
+			});
+
+			expect(result.success).toBe(true);
+			expect(seen.rawBody).toBe(raw);
+			expect(seen.input).toBeUndefined();
+		});
+
 		it("surfaces an actionable error when a handler reads the consumed request body (#1293)", async () => {
 			// EmDash parses the body once and exposes it as ctx.input; the same
 			// Request is then handed to the handler with its stream already spent.

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -449,6 +449,89 @@ describe("PluginRouteHandler", () => {
 			expect(result.data).toEqual({ user: null });
 		});
 
+		it("exposes ctx.rawBody on routes that opt in with rawBody: true", async () => {
+			// Signature verification needs the payload text unaltered: whitespace
+			// and key order must survive, which a re-serialized ctx.input can't
+			// guarantee.
+			const raw = `{"b":2,  "a":1}`;
+			let seen: { rawBody?: string; input?: unknown } = {};
+			const plugin = createTestPlugin({
+				routes: {
+					webhook: {
+						rawBody: true,
+						handler: async (ctx) => {
+							seen = { rawBody: ctx.rawBody, input: ctx.input };
+							return null;
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("webhook", {
+				request: new Request("http://test.com", { method: "POST", body: raw }),
+				body: JSON.parse(raw),
+				rawBody: raw,
+			});
+
+			expect(result.success).toBe(true);
+			expect(seen.rawBody).toBe(raw);
+			expect(seen.input).toEqual({ a: 1, b: 2 });
+		});
+
+		it("keeps ctx.rawBody undefined on routes without the rawBody flag", async () => {
+			let seenRawBody: string | undefined = "sentinel";
+			const plugin = createTestPlugin({
+				routes: {
+					normal: {
+						handler: async (ctx) => {
+							seenRawBody = ctx.rawBody;
+							return null;
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("normal", {
+				request: new Request("http://test.com", { method: "POST", body: "{}" }),
+				body: {},
+				rawBody: "{}",
+			});
+
+			expect(result.success).toBe(true);
+			expect(seenRawBody).toBeUndefined();
+		});
+
+		it("delivers non-JSON bodies to rawBody routes even though input is undefined", async () => {
+			// Form-encoded webhook deliveries parse to undefined and are otherwise
+			// lost; with rawBody: true the handler can parse them itself.
+			const raw = "event=order.paid&id=42";
+			let seen: { rawBody?: string; input?: unknown } = {};
+			const plugin = createTestPlugin({
+				routes: {
+					webhook: {
+						rawBody: true,
+						handler: async (ctx) => {
+							seen = { rawBody: ctx.rawBody, input: ctx.input };
+							return null;
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("webhook", {
+				request: new Request("http://test.com", { method: "POST", body: raw }),
+				body: undefined,
+				rawBody: raw,
+			});
+
+			expect(result.success).toBe(true);
+			expect(seen.rawBody).toBe(raw);
+			expect(seen.input).toBeUndefined();
+		});
+
 		it("surfaces an actionable error when a handler reads the consumed request body (#1293)", async () => {
 			// EmDash parses the body once and exposes it as ctx.input; the same
 			// Request is then handed to the handler with its stream already spent.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `rawBody: true` flag for native plugin routes. Routes that set it receive the unparsed request body as `ctx.rawBody`, alongside the parsed `ctx.input`.

**Why:** webhook providers (Stripe, GitHub, Svix, …) sign the exact raw bytes of the delivery. Since the dispatcher consumes the body stream to build `ctx.input` (and `ctx.request.text()` is guarded per #1293), plugins currently have no way to verify those signatures — an HMAC over a re-serialized `ctx.input` never matches. Non-JSON payloads (form-encoded webhook deliveries) are also silently lost today.

**How:** the dispatcher already buffers the body to parse it. It now reads `text()` once, parses `ctx.input` from the same buffer, and forwards the string only to routes that opted in. No extra I/O, no behavior change for existing routes. The #1293 guard message now points at `rawBody: true` as the escape hatch. Native format only; sandboxed plugins cross a serialization boundary and would need separate plumbing.

Discussion: https://github.com/emdash-cms/emdash/discussions/1982

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a — no admin UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1982

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude. All changes reviewed and tested by me.

## Screenshots / test output

```
tests/unit/plugins + plugin-api-route-auth: 625 passed (625)
```

New tests cover: raw body delivered on opted-in routes (byte-exact, alongside validated input), `ctx.rawBody` undefined without the flag, and non-JSON payloads reaching the handler with `input` undefined.