### PR TITLE
feat(labeler): normalized finding contract (W8.1)

### DIFF
--- a/apps/labeler/src/assessment-orchestrator.ts
+++ b/apps/labeler/src/assessment-orchestrator.ts
@@ -20,11 +20,13 @@ import {
 	getAssessment,
 	getNegatableAutomatedLabels,
 	isSubjectCurrent,
+	listEvidenceObjectIds,
 	transitionAssessmentState,
 	type Assessment,
 } from "./assessment-store.js";
 import type { LabelerConfig } from "./config.js";
 import type { FindingSeverity } from "./evidence.js";
+import { allowedFindingCategories, validateFindings, type NormalizedFinding } from "./findings.js";
 import { automatedBlockCategories, type ModerationPolicy } from "./policy.js";
 import {
 	buildIssuanceStatements,
@@ -32,18 +34,12 @@ import {
 	type AutomatedLabelProposal,
 } from "./service.js";
 
-export interface StageFinding {
-	source: string;
-	/** A label value from the policy vocabulary (matches
-	 * `AutomatedLabelProposal.findingCategory` / warning label values). */
-	category: string;
-	severity: FindingSeverity;
-	confidence?: number;
-	title: string;
-	publicSummary: string;
-	privateDetail: string;
-	evidenceRefs: readonly string[];
-}
+/**
+ * A stage's finding is the canonical normalized contract (`findings.ts`).
+ * `category` is a label value from the policy vocabulary (matches
+ * `AutomatedLabelProposal.findingCategory` / warning label values).
+ */
+export type StageFinding = NormalizedFinding;
 
 /** Thrown by a stage adapter for a retryable infrastructure failure
  * (network, model/scanner unavailability). Anything else a stage throws is
@@ -181,6 +177,19 @@ export class AssessmentOrchestrator {
 			}
 		}
 
+		// validateFindings throws on a malformed finding; uncaught, it aborts the
+		// run (assessment stays `running`, like any non-transient stage error).
+		// Resolution and persistence below read validatedFindings, never the raw
+		// stage output.
+		let validatedFindings: NormalizedFinding[] = [];
+		if (!transientExhausted) {
+			const resolvableEvidenceIds = await listEvidenceObjectIds(this.db, assessment.id);
+			validatedFindings = validateFindings(findings, {
+				allowedCategories: allowedFindingCategories(this.policy),
+				resolvableEvidenceIds,
+			});
+		}
+
 		// Re-read subject currency immediately before finalizing: a deleted or
 		// CID-superseded subject finalizes as `stale` — no labels, pointer
 		// untouched.
@@ -199,7 +208,9 @@ export class AssessmentOrchestrator {
 			return transitionAssessmentState(this.db, { id: runId, from: "running", to: "stale", now });
 		}
 
-		const outcome = transientExhausted ? null : resolvePolicyOutcome(findings, this.policy);
+		const outcome = transientExhausted
+			? null
+			: resolvePolicyOutcome(validatedFindings, this.policy);
 		return this.finalize(assessment, outcome, now);
 	}
 

--- a/apps/labeler/src/assessment-store.ts
+++ b/apps/labeler/src/assessment-store.ts
@@ -541,6 +541,18 @@ export async function recordFinding(db: D1Database, input: RecordFindingInput): 
 	return id;
 }
 
+/** Evidence object ids recorded for a run, for validating a finding's `evidenceRefs`. */
+export async function listEvidenceObjectIds(
+	db: D1Database,
+	assessmentId: string,
+): Promise<ReadonlySet<string>> {
+	const rows = await db
+		.prepare(`SELECT id FROM evidence_objects WHERE assessment_id = ?`)
+		.bind(assessmentId)
+		.all<{ id: string }>();
+	return new Set((rows.results ?? []).map((row) => row.id));
+}
+
 export interface RecordEvidenceObjectInput {
 	assessmentId: string;
 	kind: string;

--- a/apps/labeler/src/evidence.ts
+++ b/apps/labeler/src/evidence.ts
@@ -1,3 +1,5 @@
+import type { FindingSource, FindingSourceMetadata } from "./findings.js";
+
 export type FindingSeverity = "critical" | "high" | "medium" | "low" | "info";
 
 /**
@@ -28,6 +30,11 @@ export interface PrivateFindingRecord {
 	publicSummary: string;
 	privateDetail: string;
 	evidenceRefs: readonly string[];
+	source?: FindingSource;
+	confidence?: number;
+	affectedFiles?: readonly string[];
+	affectedImages?: readonly string[];
+	sourceMetadata?: FindingSourceMetadata;
 }
 
 export interface PublicFindingPayload {

--- a/apps/labeler/src/findings.ts
+++ b/apps/labeler/src/findings.ts
@@ -1,0 +1,278 @@
+/**
+ * Normalized finding contract (plan W8.1, spec §9.6): the canonical shape
+ * every analysis stage (deterministic, capability, model, image, history)
+ * produces. `validateFinding`/`validateFindings` enforce it against the
+ * policy-derived allowed-category set and a run's recorded evidence objects
+ * before an assessment finalizes — an invalid finding is a stage-adapter
+ * bug, not a retryable condition.
+ */
+
+import type { FindingSeverity, PrivateFindingRecord, PublicFindingView } from "./evidence.js";
+import { toPublicFinding } from "./evidence.js";
+import { automatedBlockCategories, warningCategories, type ModerationPolicy } from "./policy.js";
+
+export type FindingSource = "deterministic" | "capability" | "model" | "image" | "history";
+
+const MAX_TITLE_LENGTH = 512;
+const MAX_SUMMARY_LENGTH = 4096;
+const MAX_METADATA_FIELD_LENGTH = 256;
+const MAX_ARRAY_ENTRIES = 512;
+const MAX_ARRAY_ENTRY_LENGTH = 1024;
+
+export interface ToolFindingMetadata {
+	kind: "tool";
+	tool: string;
+	version: string;
+}
+
+export interface ModelFindingMetadata {
+	kind: "model";
+	modelId: string;
+	promptVersion: string;
+}
+
+/** Deterministic/capability/history stages report the tool that produced the
+ * finding; model/image stages report the model and prompt version. */
+export type FindingSourceMetadata = ToolFindingMetadata | ModelFindingMetadata;
+
+export interface NormalizedFinding {
+	source: FindingSource;
+	/** A label value from the policy vocabulary — validated against
+	 * `allowedFindingCategories` (automated-block ∪ warning), never the
+	 * eligibility or manual-system label values. */
+	category: string;
+	severity: FindingSeverity;
+	confidence?: number;
+	title: string;
+	publicSummary: string;
+	privateDetail: string;
+	evidenceRefs: readonly string[];
+	affectedFiles?: readonly string[];
+	affectedImages?: readonly string[];
+	sourceMetadata?: FindingSourceMetadata;
+}
+
+/**
+ * The full set of label values a finding's `category` may cite (spec §9.6's
+ * `AllowedFindingCategory`): automated-block ∪ warning, derived from the
+ * versioned policy rather than hardcoded so a policy change flows through.
+ */
+export function allowedFindingCategories(policy: ModerationPolicy): ReadonlySet<string> {
+	return new Set([...automatedBlockCategories(policy), ...warningCategories(policy)]);
+}
+
+export class FindingValidationError extends Error {
+	override readonly name = "FindingValidationError";
+}
+
+export interface ValidateFindingOptions {
+	allowedCategories: ReadonlySet<string>;
+	resolvableEvidenceIds: ReadonlySet<string>;
+}
+
+export function validateFinding(finding: unknown, opts: ValidateFindingOptions): NormalizedFinding {
+	if (!isRecord(finding)) throw new FindingValidationError("finding must be an object");
+
+	const source = finding.source;
+	if (typeof source !== "string" || !isFindingSource(source))
+		throw new FindingValidationError(`finding.source is invalid: ${String(source)}`);
+
+	const category = finding.category;
+	if (typeof category !== "string" || !opts.allowedCategories.has(category))
+		throw new FindingValidationError(
+			`finding.category is not an allowed finding category: ${String(category)}`,
+		);
+
+	const severity = finding.severity;
+	if (typeof severity !== "string" || !isFindingSeverity(severity))
+		throw new FindingValidationError(`finding.severity is invalid: ${String(severity)}`);
+
+	const confidence = finding.confidence;
+	if (
+		confidence !== undefined &&
+		(typeof confidence !== "number" ||
+			!Number.isFinite(confidence) ||
+			confidence < 0 ||
+			confidence > 1)
+	)
+		throw new FindingValidationError("finding.confidence must be a finite number in [0, 1]");
+
+	const title = requireBoundedString(finding.title, "finding.title", MAX_TITLE_LENGTH);
+	const publicSummary = requireBoundedString(
+		finding.publicSummary,
+		"finding.publicSummary",
+		MAX_SUMMARY_LENGTH,
+	);
+	const privateDetail = requireBoundedString(
+		finding.privateDetail,
+		"finding.privateDetail",
+		MAX_SUMMARY_LENGTH,
+	);
+
+	const evidenceRefs = requireStringArray(finding.evidenceRefs, "finding.evidenceRefs");
+	for (const ref of evidenceRefs) {
+		if (!opts.resolvableEvidenceIds.has(ref))
+			throw new FindingValidationError(
+				`finding.evidenceRefs references an unresolved evidence object id: ${ref}`,
+			);
+	}
+
+	const affectedFiles =
+		finding.affectedFiles === undefined
+			? undefined
+			: requireStringArray(finding.affectedFiles, "finding.affectedFiles");
+	const affectedImages =
+		finding.affectedImages === undefined
+			? undefined
+			: requireStringArray(finding.affectedImages, "finding.affectedImages");
+	const sourceMetadata =
+		finding.sourceMetadata === undefined
+			? undefined
+			: validateSourceMetadata(finding.sourceMetadata);
+
+	return {
+		source,
+		category,
+		severity,
+		...(confidence !== undefined ? { confidence } : {}),
+		title,
+		publicSummary,
+		privateDetail,
+		evidenceRefs,
+		...(affectedFiles !== undefined ? { affectedFiles } : {}),
+		...(affectedImages !== undefined ? { affectedImages } : {}),
+		...(sourceMetadata !== undefined ? { sourceMetadata } : {}),
+	};
+}
+
+/** Validates each finding in order, throwing on the first failure with its index. */
+export function validateFindings(
+	findings: readonly unknown[],
+	opts: ValidateFindingOptions,
+): NormalizedFinding[] {
+	const validated: NormalizedFinding[] = [];
+	for (const [index, finding] of findings.entries()) {
+		try {
+			validated.push(validateFinding(finding, opts));
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new FindingValidationError(`findings[${index}]: ${message}`);
+		}
+	}
+	return validated;
+}
+
+/**
+ * Projects a validated finding to the public boundary by routing it through
+ * `evidence.ts`'s never-typed `PrivateFindingRecord` -> `PublicFindingView`
+ * narrowing — this function never constructs a `PublicFindingView` literal
+ * itself, so a private field can't leak by drifting out of sync with
+ * `toPublicFinding`.
+ */
+export function toPublicFindingView(
+	finding: NormalizedFinding,
+	id: string,
+	assessmentId: string,
+): PublicFindingView {
+	const record: PrivateFindingRecord = {
+		id,
+		assessmentId,
+		category: finding.category,
+		severity: finding.severity,
+		title: finding.title,
+		publicSummary: finding.publicSummary,
+		privateDetail: finding.privateDetail,
+		evidenceRefs: finding.evidenceRefs,
+		source: finding.source,
+		...(finding.confidence !== undefined ? { confidence: finding.confidence } : {}),
+		...(finding.affectedFiles !== undefined ? { affectedFiles: finding.affectedFiles } : {}),
+		...(finding.affectedImages !== undefined ? { affectedImages: finding.affectedImages } : {}),
+		...(finding.sourceMetadata !== undefined ? { sourceMetadata: finding.sourceMetadata } : {}),
+	};
+	return toPublicFinding(record);
+}
+
+function isFindingSource(value: string): value is FindingSource {
+	return (
+		value === "deterministic" ||
+		value === "capability" ||
+		value === "model" ||
+		value === "image" ||
+		value === "history"
+	);
+}
+
+function isFindingSeverity(value: string): value is FindingSeverity {
+	return (
+		value === "critical" ||
+		value === "high" ||
+		value === "medium" ||
+		value === "low" ||
+		value === "info"
+	);
+}
+
+function validateSourceMetadata(value: unknown): FindingSourceMetadata {
+	if (!isRecord(value))
+		throw new FindingValidationError("finding.sourceMetadata must be an object");
+	const kind = value.kind;
+	if (kind === "tool") {
+		return {
+			kind,
+			tool: requireBoundedString(
+				value.tool,
+				"finding.sourceMetadata.tool",
+				MAX_METADATA_FIELD_LENGTH,
+			),
+			version: requireBoundedString(
+				value.version,
+				"finding.sourceMetadata.version",
+				MAX_METADATA_FIELD_LENGTH,
+			),
+		};
+	}
+	if (kind === "model") {
+		return {
+			kind,
+			modelId: requireBoundedString(
+				value.modelId,
+				"finding.sourceMetadata.modelId",
+				MAX_METADATA_FIELD_LENGTH,
+			),
+			promptVersion: requireBoundedString(
+				value.promptVersion,
+				"finding.sourceMetadata.promptVersion",
+				MAX_METADATA_FIELD_LENGTH,
+			),
+		};
+	}
+	throw new FindingValidationError(`finding.sourceMetadata.kind is invalid: ${String(kind)}`);
+}
+
+function requireBoundedString(value: unknown, field: string, maxLength: number): string {
+	if (typeof value !== "string" || value.trim().length === 0)
+		throw new FindingValidationError(`${field} must be a non-empty string`);
+	if (value.length > maxLength)
+		throw new FindingValidationError(`${field} must be at most ${maxLength} characters`);
+	return value;
+}
+
+function requireStringArray(value: unknown, field: string): readonly string[] {
+	if (!Array.isArray(value))
+		throw new FindingValidationError(`${field} must be an array of strings`);
+	if (value.length > MAX_ARRAY_ENTRIES)
+		throw new FindingValidationError(`${field} must have at most ${MAX_ARRAY_ENTRIES} entries`);
+	for (const entry of value) {
+		if (typeof entry !== "string" || entry.length === 0)
+			throw new FindingValidationError(`${field} must be an array of non-empty strings`);
+		if (entry.length > MAX_ARRAY_ENTRY_LENGTH)
+			throw new FindingValidationError(
+				`${field} entries must be at most ${MAX_ARRAY_ENTRY_LENGTH} characters`,
+			);
+	}
+	return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/labeler/src/findings.ts
+++ b/apps/labeler/src/findings.ts
@@ -270,7 +270,7 @@ function requireStringArray(value: unknown, field: string): readonly string[] {
 				`${field} entries must be at most ${MAX_ARRAY_ENTRY_LENGTH} characters`,
 			);
 	}
-	return value;
+	return [...value];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/labeler/src/policy.ts
+++ b/apps/labeler/src/policy.ts
@@ -59,6 +59,20 @@ export function automatedBlockCategories(policy: ModerationPolicy): ReadonlySet<
 	return categories;
 }
 
+/**
+ * Warning finding categories: the label vocabulary this policy treats as
+ * non-blocking concerns. A finding must cite one of these to justify a
+ * warning label. Together with `automatedBlockCategories`, this forms the
+ * full set of label values a finding's `category` may cite (spec §9.6).
+ */
+export function warningCategories(policy: ModerationPolicy): ReadonlySet<string> {
+	const categories = new Set<string>();
+	for (const label of policy.labels) {
+		if (label.category === "warning") categories.add(label.value);
+	}
+	return categories;
+}
+
 export function parseModerationPolicy(value: unknown): ModerationPolicy {
 	if (!isRecord(value)) throw new TypeError("moderation policy must be an object");
 	if (typeof value.policyVersion !== "string" || value.policyVersion.length === 0)

--- a/apps/labeler/test/assessment-orchestrator.test.ts
+++ b/apps/labeler/test/assessment-orchestrator.test.ts
@@ -23,6 +23,7 @@ import {
 	getCurrentAssessment,
 	transitionAssessmentState,
 } from "../src/assessment-store.js";
+import { FindingValidationError } from "../src/findings.js";
 import { MODERATION_POLICY } from "../src/policy.js";
 import { issueManualLabel } from "../src/service.js";
 import { initializeSigningState } from "../src/signing-rotation.js";
@@ -148,7 +149,7 @@ async function buildOrchestrator(
 
 function finding(overrides: Partial<StageFinding> & { category: string }): StageFinding {
 	return {
-		source: "test-stage",
+		source: "deterministic",
 		severity: "medium",
 		title: "test finding",
 		publicSummary: "test finding",
@@ -420,6 +421,51 @@ describe("AssessmentOrchestrator: deleted or superseded subject", () => {
 		const result = await orchestrator.runAssessment(run.id);
 
 		expect(result.state).toBe("stale");
+	});
+});
+
+describe("AssessmentOrchestrator: invalid findings", () => {
+	it("aborts the run, leaving it running, when a stage returns a finding outside the allowed category set", async () => {
+		const run = await pendingRun({
+			name: "invalid-category",
+			cidValue: await cid("invalid-category"),
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			deterministic: () =>
+				Promise.resolve([finding({ category: "not-a-real-label", severity: "critical" })]),
+		};
+		const orchestrator = await buildOrchestrator(stages);
+
+		await expect(orchestrator.runAssessment(run.id)).rejects.toThrow(FindingValidationError);
+
+		const assessment = await getAssessment(testEnv.DB, run.id);
+		expect(assessment?.state).toBe("running");
+		expect(assessment?.completedAt).toBeNull();
+	});
+
+	it("aborts the run when a finding cites an evidence reference this run never recorded", async () => {
+		const run = await pendingRun({
+			name: "unresolved-evidence",
+			cidValue: await cid("unresolved-evidence"),
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			deterministic: () =>
+				Promise.resolve([
+					finding({
+						category: "obfuscated-code",
+						severity: "medium",
+						evidenceRefs: ["evid_never_recorded"],
+					}),
+				]),
+		};
+		const orchestrator = await buildOrchestrator(stages);
+
+		await expect(orchestrator.runAssessment(run.id)).rejects.toThrow(FindingValidationError);
+
+		const assessment = await getAssessment(testEnv.DB, run.id);
+		expect(assessment?.state).toBe("running");
 	});
 });
 

--- a/apps/labeler/test/findings.test.ts
+++ b/apps/labeler/test/findings.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+
+import type { PublicFindingView } from "../src/evidence.js";
+import {
+	allowedFindingCategories,
+	FindingValidationError,
+	toPublicFindingView,
+	validateFinding,
+	validateFindings,
+	type NormalizedFinding,
+} from "../src/findings.js";
+import { MODERATION_POLICY, parseModerationPolicy } from "../src/policy.js";
+
+function baseFinding(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+	return {
+		source: "deterministic",
+		category: "obfuscated-code",
+		severity: "medium",
+		title: "test finding",
+		publicSummary: "test finding summary",
+		privateDetail: "test finding detail with a denylist match",
+		evidenceRefs: [],
+		...overrides,
+	};
+}
+
+const ALLOWED_CATEGORIES = allowedFindingCategories(MODERATION_POLICY);
+const NO_EVIDENCE = new Set<string>();
+
+describe("allowedFindingCategories", () => {
+	it("derives automated-block union warning values from the fixture, excluding eligibility and manual-system", () => {
+		expect(ALLOWED_CATEGORIES.has("malware")).toBe(true);
+		expect(ALLOWED_CATEGORIES.has("impersonation")).toBe(true);
+		expect(ALLOWED_CATEGORIES.has("obfuscated-code")).toBe(true);
+		expect(ALLOWED_CATEGORIES.has("low-quality")).toBe(true);
+		expect(ALLOWED_CATEGORIES.has("assessment-passed")).toBe(false);
+		expect(ALLOWED_CATEGORIES.has("assessment-pending")).toBe(false);
+		expect(ALLOWED_CATEGORIES.has("!takedown")).toBe(false);
+		expect(ALLOWED_CATEGORIES.has("security-yanked")).toBe(false);
+		expect(ALLOWED_CATEGORIES.has("package-disputed")).toBe(false);
+	});
+
+	it("changes when the policy changes, rather than staying hardcoded", () => {
+		const variant = parseModerationPolicy({
+			policyVersion: "variant",
+			labelerDid: "did:web:example",
+			labels: [
+				{
+					value: "only-warning",
+					category: "warning",
+					officialEffect: "warn",
+					subjectRules: [{ subject: "release", cidRule: "required", issuanceModes: ["automated"] }],
+				},
+			],
+		});
+		const categories = allowedFindingCategories(variant);
+		expect(categories.has("only-warning")).toBe(true);
+		expect(categories.has("malware")).toBe(false);
+	});
+});
+
+describe("validateFinding", () => {
+	it("passes a valid finding for each FindingSource", () => {
+		for (const source of ["deterministic", "capability", "model", "image", "history"]) {
+			const finding = validateFinding(baseFinding({ source }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			});
+			expect(finding.source).toBe(source);
+		}
+	});
+
+	it("throws on an unknown category", () => {
+		expect(() =>
+			validateFinding(baseFinding({ category: "not-a-real-label" }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+	});
+
+	it("throws on an eligibility or manual-system category, since those are never finding-derived", () => {
+		expect(() =>
+			validateFinding(baseFinding({ category: "assessment-passed" }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+		expect(() =>
+			validateFinding(baseFinding({ category: "security-yanked" }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+	});
+
+	it("throws on an invalid severity", () => {
+		expect(() =>
+			validateFinding(baseFinding({ severity: "catastrophic" }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+	});
+
+	it("accepts confidence at the boundaries and absent, rejects out-of-range or non-finite", () => {
+		for (const confidence of [0, 1, 0.5, undefined]) {
+			expect(() =>
+				validateFinding(baseFinding({ confidence }), {
+					allowedCategories: ALLOWED_CATEGORIES,
+					resolvableEvidenceIds: NO_EVIDENCE,
+				}),
+			).not.toThrow();
+		}
+		for (const confidence of [1.5, -0.1, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(() =>
+				validateFinding(baseFinding({ confidence }), {
+					allowedCategories: ALLOWED_CATEGORIES,
+					resolvableEvidenceIds: NO_EVIDENCE,
+				}),
+			).toThrow(FindingValidationError);
+		}
+	});
+
+	it("throws when an evidence reference does not resolve to a recorded evidence object", () => {
+		expect(() =>
+			validateFinding(baseFinding({ evidenceRefs: ["evid_missing"] }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+	});
+
+	it("passes when every evidence reference resolves", () => {
+		const finding = validateFinding(baseFinding({ evidenceRefs: ["evid_01example"] }), {
+			allowedCategories: ALLOWED_CATEGORIES,
+			resolvableEvidenceIds: new Set(["evid_01example"]),
+		});
+		expect(finding.evidenceRefs).toEqual(["evid_01example"]);
+	});
+
+	it("throws on a blank title", () => {
+		expect(() =>
+			validateFinding(baseFinding({ title: "   " }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+	});
+
+	it("throws on an oversized public summary", () => {
+		expect(() =>
+			validateFinding(baseFinding({ publicSummary: "x".repeat(4097) }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+	});
+
+	it("bounds affected-file/image and evidence arrays by entry length, count, and non-emptiness", () => {
+		const opts = { allowedCategories: ALLOWED_CATEGORIES, resolvableEvidenceIds: NO_EVIDENCE };
+		expect(() => validateFinding(baseFinding({ affectedFiles: ["x".repeat(1025)] }), opts)).toThrow(
+			FindingValidationError,
+		);
+		expect(() =>
+			validateFinding(baseFinding({ affectedImages: Array.from({ length: 513 }).fill("a") }), opts),
+		).toThrow(FindingValidationError);
+		expect(() => validateFinding(baseFinding({ affectedFiles: [""] }), opts)).toThrow(
+			FindingValidationError,
+		);
+		const ok = validateFinding(baseFinding({ affectedFiles: ["src/index.ts"] }), opts);
+		expect(ok.affectedFiles).toEqual(["src/index.ts"]);
+	});
+
+	it("validates a typed sourceMetadata shape", () => {
+		const withTool = validateFinding(
+			baseFinding({ sourceMetadata: { kind: "tool", tool: "semgrep", version: "1.2.3" } }),
+			{ allowedCategories: ALLOWED_CATEGORIES, resolvableEvidenceIds: NO_EVIDENCE },
+		);
+		expect(withTool.sourceMetadata).toEqual({ kind: "tool", tool: "semgrep", version: "1.2.3" });
+
+		const withModel = validateFinding(
+			baseFinding({
+				sourceMetadata: { kind: "model", modelId: "claude-opus-4", promptVersion: "v3" },
+			}),
+			{ allowedCategories: ALLOWED_CATEGORIES, resolvableEvidenceIds: NO_EVIDENCE },
+		);
+		expect(withModel.sourceMetadata).toEqual({
+			kind: "model",
+			modelId: "claude-opus-4",
+			promptVersion: "v3",
+		});
+
+		expect(() =>
+			validateFinding(baseFinding({ sourceMetadata: { kind: "unknown-kind" } }), {
+				allowedCategories: ALLOWED_CATEGORIES,
+				resolvableEvidenceIds: NO_EVIDENCE,
+			}),
+		).toThrow(FindingValidationError);
+	});
+});
+
+describe("validateFindings", () => {
+	it("validates every finding and returns them in order", () => {
+		const findings = validateFindings(
+			[baseFinding({ category: "obfuscated-code" }), baseFinding({ category: "malware" })],
+			{ allowedCategories: ALLOWED_CATEGORIES, resolvableEvidenceIds: NO_EVIDENCE },
+		);
+		expect(findings.map((f) => f.category)).toEqual(["obfuscated-code", "malware"]);
+	});
+
+	it("throws on the first bad element, naming its index", () => {
+		expect(() =>
+			validateFindings(
+				[baseFinding(), baseFinding({ category: "not-a-real-label" }), baseFinding()],
+				{ allowedCategories: ALLOWED_CATEGORIES, resolvableEvidenceIds: NO_EVIDENCE },
+			),
+		).toThrow("findings[1]");
+	});
+});
+
+describe("public projection", () => {
+	const FINDING: NormalizedFinding = {
+		source: "model",
+		category: "malware",
+		severity: "critical",
+		confidence: 0.9,
+		title: "known malicious pattern",
+		publicSummary: "the bundle matched a known malicious pattern",
+		privateDetail: "sha256 abc123 matches denylist entry NASTY-001",
+		evidenceRefs: ["evid_01example"],
+		sourceMetadata: { kind: "model", modelId: "claude-opus-4", promptVersion: "v3" },
+	};
+
+	it("carries no privateDetail or evidenceRefs in the public view", () => {
+		const publicView = toPublicFindingView(FINDING, "find_01example", "asmt_01example");
+		expect(publicView).not.toHaveProperty("privateDetail");
+		expect(publicView).not.toHaveProperty("evidenceRefs");
+		expect(publicView).toEqual({
+			id: "find_01example",
+			assessmentId: "asmt_01example",
+			category: "malware",
+			severity: "critical",
+			title: "known malicious pattern",
+			publicSummary: "the bundle matched a known malicious pattern",
+		});
+	});
+
+	it("does not leak private detail into the serialized public payload", () => {
+		const publicView = toPublicFindingView(FINDING, "find_01example", "asmt_01example");
+		expect(JSON.stringify(publicView)).not.toContain("denylist");
+	});
+
+	it("type-rejects a NormalizedFinding passed directly to the public serializer", () => {
+		// @ts-expect-error a normalized finding carries privateDetail/evidenceRefs and must not satisfy the public view
+		const rejected: PublicFindingView = FINDING;
+		expect(rejected).toBeDefined();
+	});
+});

--- a/apps/labeler/test/findings.test.ts
+++ b/apps/labeler/test/findings.test.ts
@@ -172,6 +172,14 @@ describe("validateFinding", () => {
 		expect(ok.affectedFiles).toEqual(["src/index.ts"]);
 	});
 
+	it("decouples validated arrays from the caller's input array", () => {
+		const opts = { allowedCategories: ALLOWED_CATEGORIES, resolvableEvidenceIds: NO_EVIDENCE };
+		const affectedFiles = ["src/index.ts"];
+		const finding = validateFinding(baseFinding({ affectedFiles }), opts);
+		affectedFiles.push("src/mutated.ts");
+		expect(finding.affectedFiles).toEqual(["src/index.ts"]);
+	});
+
 	it("validates a typed sourceMetadata shape", () => {
 		const withTool = validateFinding(
 			baseFinding({ sourceMetadata: { kind: "tool", tool: "semgrep", version: "1.2.3" } }),


### PR DESCRIPTION
## What does this PR do?

Adds the labeler's **normalized finding contract** — plan item W8.1. This is the single validated shape every analysis stage (deterministic, capability, model, image, history) produces, and the gate that enforces it before an assessment finalizes. It's the foundation the W7 (deterministic + capability) and W8 (AI code + image) analyses populate and the operator console (W9.3) reads.

- **`findings.ts`** — `NormalizedFinding` (source, policy-validated `category`, severity, optional confidence, public/private summaries, evidence refs, optional affected files/images, and a discriminated `sourceMetadata` — `tool` for deterministic/capability/history, `model` for model/image). `validateFinding` / `validateFindings` throw `FindingValidationError` on an unknown category, a source/severity outside the enums, a confidence outside `[0,1]`, an evidence ref that doesn't resolve to a recorded evidence object, or malformed/oversized strings — and return an object built solely from validated locals (unexpected input fields are dropped, never passed through).
- **Policy-derived category allowlist** — `allowedFindingCategories(policy)` = the automated-block ∪ warning label values (via the new `warningCategories`, mirroring `automatedBlockCategories`), derived from the versioned policy rather than hardcoded. Eligibility and manual-system label values are not finding-derivable.
- **Public boundary preserved** — `toPublicFindingView` routes through `evidence.ts`'s existing `never`-typed `PrivateFindingRecord → PublicFindingView` narrowing rather than constructing a public view itself, so a private field can't leak by drifting out of sync. `PublicFindingView` is unchanged; `PrivateFindingRecord` gains the new optional fields but still carries the non-optional `privateDetail`/`evidenceRefs` that make it non-assignable to the public view.
- **Enforced in the pipeline** — the (test-only, behind the production boundary) orchestrator's `StageFinding` is now `NormalizedFinding`, and it validates collected findings against the policy allowlist + the run's recorded evidence ids before finalizing. An invalid finding is a **non-retryable** error (a stage-adapter bug), so it aborts the run rather than retrying.

No migration (the `findings` table already exists), no lexicon change, no public-API change (findings are internal evidence — the public `publicAssessment` has no findings array).

Reviewed with a focused adversarial (opus) pass targeting the private→public boundary, validation bypass, and the orchestrator wiring before opening.

Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n and changeset are n/a — this touches only `apps/labeler`, a private, unpublished Worker app (no admin UI, not on npm).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Opus 4.8 (design, review) and Sonnet/Opus subagents (implementation, adversarial review)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: 150 pass (130 pre-existing + 20 new — 18 for the finding contract/validation/boundary, 2 for the orchestrator abort-on-invalid path)
- Typecheck clean; `pnpm lint:json` diagnostics unchanged at 19 (all pre-existing, 0 in `apps/labeler`)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-finding-contracts-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-finding-contracts`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
