### PR TITLE
fix(redirects): prevent circular redirect loop when a slug rename is reverted

### DIFF
--- a/.changeset/auto-redirect-revert-loop.md
+++ b/.changeset/auto-redirect-revert-loop.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes a circular redirect loop when a slug rename is reverted. Renaming a slug back to a previous value now removes the stale redirect that shadowed the restored URL, so the page stays reachable.

--- a/packages/core/src/database/repositories/redirect.ts
+++ b/packages/core/src/database/repositories/redirect.ts
@@ -347,7 +347,11 @@ export class RedirectRepository {
 	/**
 	 * Create an auto-redirect when a content slug changes.
 	 * Uses the collection's URL pattern to compute old/new URLs.
-	 * Collapses existing redirect chains pointing to the old URL.
+	 * Collapses existing redirect chains pointing to the old URL and
+	 * removes redirects that would shadow the now-live new URL, so a
+	 * rename that is later reverted cannot form a loop (#1986).
+	 *
+	 * Returns null when old and new URL are identical (nothing to redirect).
 	 */
 	async createAutoRedirect(
 		collection: string,
@@ -355,7 +359,7 @@ export class RedirectRepository {
 		newSlug: string,
 		contentId: string,
 		urlPattern: string | null,
-	): Promise<Redirect> {
+	): Promise<Redirect | null> {
 		const oldUrl = urlPattern
 			? urlPattern.replace("{slug}", oldSlug).replace("{id}", contentId)
 			: `/${collection}/${oldSlug}`;
@@ -363,8 +367,16 @@ export class RedirectRepository {
 			? urlPattern.replace("{slug}", newSlug).replace("{id}", contentId)
 			: `/${collection}/${newSlug}`;
 
+		// A redirect from a URL to itself would make the page unreachable
+		if (oldUrl === newUrl) return null;
+
 		// Collapse chains: update any existing redirects pointing to the old URL
 		await this.collapseChains(oldUrl, newUrl);
+
+		// The new URL serves live content again — any redirect from it would
+		// shadow the page. This also removes the self-redirect that chain
+		// collapsing produces when a rename A → B is reverted (A → A).
+		await this.db.deleteFrom("_emdash_redirects").where("source", "=", newUrl).execute();
 
 		// Check if a redirect from this source already exists
 		const existing = await this.findBySource(oldUrl);

--- a/packages/core/tests/integration/redirects/redirect-repository.test.ts
+++ b/packages/core/tests/integration/redirects/redirect-repository.test.ts
@@ -425,6 +425,48 @@ describe("RedirectRepository", () => {
 			expect(fromA).toHaveLength(1);
 			expect(fromA[0]!.destination).toBe("/blog/c");
 		});
+
+		it("does not create a loop when a slug rename is reverted (#1986)", async () => {
+			// Rename A -> B, then revert B -> A
+			await repo.createAutoRedirect("posts", "a", "b", "id1", "/blog/{slug}");
+			await repo.createAutoRedirect("posts", "b", "a", "id1", "/blog/{slug}");
+
+			// The restored slug A must not be shadowed by any redirect
+			expect(await repo.findBySource("/blog/a")).toBeNull();
+
+			// The old slug B still redirects to A
+			const fromB = await repo.findBySource("/blog/b");
+			expect(fromB!.destination).toBe("/blog/a");
+
+			// No redirect anywhere is a self-redirect
+			const all = await repo.findMany({});
+			for (const r of all.items) {
+				expect(r.source).not.toBe(r.destination);
+			}
+		});
+
+		it("does not create a loop when reverting after a rename chain", async () => {
+			// A -> B -> C, then revert C -> A
+			await repo.createAutoRedirect("posts", "a", "b", "id1", "/blog/{slug}");
+			await repo.createAutoRedirect("posts", "b", "c", "id1", "/blog/{slug}");
+			await repo.createAutoRedirect("posts", "c", "a", "id1", "/blog/{slug}");
+
+			expect(await repo.findBySource("/blog/a")).toBeNull();
+
+			const fromB = await repo.findBySource("/blog/b");
+			expect(fromB!.destination).toBe("/blog/a");
+
+			const fromC = await repo.findBySource("/blog/c");
+			expect(fromC!.destination).toBe("/blog/a");
+		});
+
+		it("is a no-op when old and new slug resolve to the same URL", async () => {
+			const redirect = await repo.createAutoRedirect("posts", "a", "a", "id1", "/blog/{slug}");
+
+			expect(redirect).toBeNull();
+			const all = await repo.findMany({});
+			expect(all.items).toHaveLength(0);
+		});
 	});
 
 	// --- 404 log ------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the circular redirect loop reported in #1986. When a published item's slug is renamed A → B, an auto-redirect `A → B` is created. Reverting the slug back (B → A) created `B → A`, while the chain-collapsing step turned the original redirect into the self-redirect `A → A` — leaving the page at slug A unreachable.

`createAutoRedirect` now:

- deletes any existing redirect whose **source** matches the new (now live) URL after collapsing chains — the new URL serves real content again, so a redirect from it would only shadow the page, and
- skips creating a redirect entirely when old and new URL are identical.

Rename chains stay collapsed: after `A → B → C → A`, both `/b` and `/c` point at `/a`, and `/a` has no redirect.

Closes #1986

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5

## Screenshots / test output

Regression tests in `redirect-repository.test.ts` (fail on `main`, pass with this fix):

- `does not create a loop when a slug rename is reverted (#1986)`
- `does not create a loop when reverting after a rename chain`
- `is a no-op when old and new slug resolve to the same URL`

```
 Test Files  3 passed (3)
      Tests  62 passed (62)
```