### PR TITLE
feat(labeler): versioned policy resolver (W8.5)

### DIFF
--- a/apps/labeler/src/assessment-orchestrator.ts
+++ b/apps/labeler/src/assessment-orchestrator.ts
@@ -25,9 +25,9 @@ import {
 	type Assessment,
 } from "./assessment-store.js";
 import type { LabelerConfig } from "./config.js";
-import type { FindingSeverity } from "./evidence.js";
 import { allowedFindingCategories, validateFindings, type NormalizedFinding } from "./findings.js";
-import { automatedBlockCategories, type ModerationPolicy } from "./policy.js";
+import { resolvePolicyOutcome, type OutcomeLabel, type PolicyOutcome } from "./policy-resolver.js";
+import type { ModerationPolicy } from "./policy.js";
 import {
 	buildIssuanceStatements,
 	type AutomatedIssuanceAction,
@@ -60,54 +60,6 @@ export interface OrchestratorStages {
 	dependency: StageAdapter;
 	codeAi: StageAdapter;
 	imageAi: StageAdapter;
-}
-
-export interface OutcomeLabel {
-	val: string;
-	findingCategory?: string;
-	severity?: FindingSeverity;
-}
-
-export interface PolicyOutcome {
-	toState: "passed" | "warned" | "blocked";
-	labels: readonly OutcomeLabel[];
-}
-
-/**
- * Pure resolution per spec §9.9 order (blocking findings first, then
- * warnings, else pass). A stub — W7/W8 replace this with the real policy
- * engine; this PR only needs enough to exercise the orchestrator's
- * finalization/negation plumbing in tests.
- */
-export function resolvePolicyOutcome(
-	findings: readonly StageFinding[],
-	policy: ModerationPolicy,
-): PolicyOutcome {
-	const blockCategories = automatedBlockCategories(policy);
-	const blockingVals = [
-		...new Set(
-			findings
-				.filter((f) => f.severity === "critical" && blockCategories.has(f.category))
-				.map((f) => f.category),
-		),
-	];
-	if (blockingVals.length > 0) {
-		return {
-			toState: "blocked",
-			labels: blockingVals.map((val) => ({ val, findingCategory: val, severity: "critical" })),
-		};
-	}
-	const warningVals = [
-		...new Set(
-			findings
-				.filter((f) => policy.labelsByValue.get(f.category)?.category === "warning")
-				.map((f) => f.category),
-		),
-	];
-	if (warningVals.length > 0) {
-		return { toState: "warned", labels: warningVals.map((val) => ({ val })) };
-	}
-	return { toState: "passed", labels: [{ val: "assessment-passed" }] };
 }
 
 const STAGE_ORDER = ["acquire", "deterministic", "dependency", "codeAi", "imageAi"] as const;

--- a/apps/labeler/src/policy-resolver.ts
+++ b/apps/labeler/src/policy-resolver.ts
@@ -1,0 +1,122 @@
+/**
+ * Versioned policy resolver (plan W8.5, spec §9.9 steps 4–7): pure
+ * resolution of a run's validated `NormalizedFinding[]` under a
+ * `ModerationPolicy` into a `PolicyOutcome`. No DB, no I/O — the orchestrator
+ * (`assessment-orchestrator.ts`) owns everything else in §9.9 (staleness,
+ * transient exhaustion, negation, persistence, notification).
+ */
+
+import type { FindingSeverity } from "./evidence.js";
+import type { NormalizedFinding } from "./findings.js";
+import {
+	automatedBlockCategories,
+	warningCategories,
+	type LabelDefinition,
+	type ModerationPolicy,
+} from "./policy.js";
+
+export interface OutcomeLabel {
+	val: string;
+	findingCategory?: string;
+	severity?: FindingSeverity;
+}
+
+export interface PolicyOutcome {
+	toState: "passed" | "warned" | "blocked";
+	labels: readonly OutcomeLabel[];
+}
+
+const SEVERITY_RANK: Record<FindingSeverity, number> = {
+	critical: 4,
+	high: 3,
+	medium: 2,
+	low: 1,
+	info: 0,
+};
+
+function higherSeverity(a: FindingSeverity, b: FindingSeverity): FindingSeverity {
+	return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
+}
+
+/** A finding's category only maps to a label proposal if that label permits
+ * automated issuance on a release subject — a defensive filter on top of
+ * W8.1 validation's allowed-category set. */
+function permitsAutomatedRelease(definition: LabelDefinition | undefined): boolean {
+	if (!definition) return false;
+	return definition.subjectRules.some(
+		(rule) => rule.subject === "release" && rule.issuanceModes.includes("automated"),
+	);
+}
+
+/** Spec §9.9 steps 4–5: source/severity rule for whether an automated-block
+ * category finding actually blocks. `history` never blocks (plan W8.4). */
+function isBlockingFinding(finding: NormalizedFinding): boolean {
+	if (finding.source === "deterministic" || finding.source === "capability") return true;
+	if (finding.source === "model" || finding.source === "image")
+		return finding.severity === "critical";
+	return false;
+}
+
+function addOrMergeLabel(
+	labels: OutcomeLabel[],
+	index: Map<string, OutcomeLabel>,
+	finding: NormalizedFinding,
+): void {
+	const existing = index.get(finding.category);
+	if (existing) {
+		existing.severity = higherSeverity(existing.severity ?? finding.severity, finding.severity);
+		return;
+	}
+	const label: OutcomeLabel = {
+		val: finding.category,
+		findingCategory: finding.category,
+		severity: finding.severity,
+	};
+	labels.push(label);
+	index.set(finding.category, label);
+}
+
+/**
+ * Pure resolution per spec §9.9 steps 4–7. Output order is deterministic:
+ * blocking labels first, then warnings, then `assessment-passed`, each group
+ * in first-citation order (input finding order).
+ */
+export function resolvePolicyOutcome(
+	findings: readonly NormalizedFinding[],
+	policy: ModerationPolicy,
+): PolicyOutcome {
+	const blockCategories = automatedBlockCategories(policy);
+	const warnCategories = warningCategories(policy);
+
+	const blockingLabels: OutcomeLabel[] = [];
+	const warningLabels: OutcomeLabel[] = [];
+	const blockingIndex = new Map<string, OutcomeLabel>();
+	const warningIndex = new Map<string, OutcomeLabel>();
+
+	for (const finding of findings) {
+		// History may recommend operator review but cannot automatically
+		// produce package/publisher labels (plan W8.4) — excluded before any
+		// mapping.
+		if (finding.source === "history") continue;
+		if (!permitsAutomatedRelease(policy.labelsByValue.get(finding.category))) continue;
+
+		if (blockCategories.has(finding.category)) {
+			if (isBlockingFinding(finding)) addOrMergeLabel(blockingLabels, blockingIndex, finding);
+			continue;
+		}
+		if (warnCategories.has(finding.category)) {
+			addOrMergeLabel(warningLabels, warningIndex, finding);
+		}
+	}
+
+	if (blockingLabels.length > 0) {
+		// Step 6 is unconditional: warnings accompany a blocked outcome too.
+		return { toState: "blocked", labels: [...blockingLabels, ...warningLabels] };
+	}
+	if (warningLabels.length > 0) {
+		// An assessment may pass and warn at the same time (spec §9.9):
+		// `assessment-passed` means no hard-blocking condition.
+		return { toState: "warned", labels: [...warningLabels, { val: "assessment-passed" }] };
+	}
+	return { toState: "passed", labels: [{ val: "assessment-passed" }] };
+}

--- a/apps/labeler/test/assessment-orchestrator.test.ts
+++ b/apps/labeler/test/assessment-orchestrator.test.ts
@@ -221,7 +221,7 @@ describe("AssessmentOrchestrator: happy path", () => {
 });
 
 describe("AssessmentOrchestrator: warning findings", () => {
-	it("finalizes warned and issues the warning label", async () => {
+	it("finalizes warned and issues the warning label alongside assessment-passed", async () => {
 		const run = await pendingRun({ name: "warn", cidValue: await cid("warn") });
 		const stages: OrchestratorStages = {
 			...stubStages,
@@ -239,6 +239,212 @@ describe("AssessmentOrchestrator: warning findings", () => {
 			.bind(run.uri, run.cid)
 			.first<{ neg: number }>();
 		expect(label?.neg).toBe(0);
+		const passed = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'assessment-passed'`,
+		)
+			.bind(run.uri, run.cid)
+			.first<{ neg: number }>();
+		expect(passed?.neg).toBe(0);
+	});
+
+	it("negates a superseded warning label while keeping assessment-passed active across the new run", async () => {
+		const name = "warn-then-clean";
+		const cidValue = await cid(name);
+		const uri = releaseUri(name);
+		await createSubject(testEnv.DB, {
+			uri,
+			cid: cidValue,
+			did: PUBLISHER_DID,
+			collection: "com.emdashcms.experimental.package.release",
+			rkey: `${name}:1.0.0`,
+		});
+
+		const firstRunKey = await computeRunKey({
+			uri,
+			cid: cidValue,
+			policyVersion: MODERATION_POLICY.policyVersion,
+			modelId: "unassigned",
+			promptHash: "unassigned",
+			scannerSetVersion: "unassigned",
+			triggerId: initialTriggerId(cidValue),
+		});
+		const { assessment: first } = await createAssessmentRun(testEnv.DB, {
+			runKey: firstRunKey,
+			uri,
+			cid: cidValue,
+			trigger: "initial",
+			triggerId: initialTriggerId(cidValue),
+			policyVersion: MODERATION_POLICY.policyVersion,
+			coverageJson: "{}",
+		});
+		await transitionAssessmentState(testEnv.DB, {
+			id: first.id,
+			from: "observed",
+			to: "verifying",
+		});
+		await transitionAssessmentState(testEnv.DB, { id: first.id, from: "verifying", to: "pending" });
+		const warningStages: OrchestratorStages = {
+			...stubStages,
+			deterministic: () =>
+				Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+		};
+		const firstResult = await (await buildOrchestrator(warningStages)).runAssessment(first.id);
+		expect(firstResult.state).toBe("warned");
+
+		const secondRunKey = await computeRunKey({
+			uri,
+			cid: cidValue,
+			policyVersion: MODERATION_POLICY.policyVersion,
+			modelId: "unassigned",
+			promptHash: "unassigned",
+			scannerSetVersion: "unassigned",
+			triggerId: operatorTriggerId("op-rerun-1"),
+		});
+		const { assessment: second } = await createAssessmentRun(testEnv.DB, {
+			runKey: secondRunKey,
+			uri,
+			cid: cidValue,
+			trigger: "operator",
+			triggerId: operatorTriggerId("op-rerun-1"),
+			policyVersion: MODERATION_POLICY.policyVersion,
+			coverageJson: "{}",
+		});
+		await transitionAssessmentState(testEnv.DB, {
+			id: second.id,
+			from: "observed",
+			to: "verifying",
+		});
+		await transitionAssessmentState(testEnv.DB, {
+			id: second.id,
+			from: "verifying",
+			to: "pending",
+		});
+		const secondResult = await (await buildOrchestrator(stubStages)).runAssessment(second.id);
+		expect(secondResult.state).toBe("passed");
+
+		const obfuscated = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'obfuscated-code'
+			 ORDER BY sequence DESC LIMIT 1`,
+		)
+			.bind(uri, cidValue)
+			.first<{ neg: number }>();
+		expect(obfuscated?.neg).toBe(1);
+
+		const passed = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'assessment-passed'
+			 ORDER BY sequence DESC LIMIT 1`,
+		)
+			.bind(uri, cidValue)
+			.first<{ neg: number }>();
+		expect(passed?.neg).toBe(0);
+	});
+
+	it("negates a superseded assessment-passed when a blocking run supersedes a warned run", async () => {
+		const name = "warn-then-block";
+		const cidValue = await cid(name);
+		const uri = releaseUri(name);
+		await createSubject(testEnv.DB, {
+			uri,
+			cid: cidValue,
+			did: PUBLISHER_DID,
+			collection: "com.emdashcms.experimental.package.release",
+			rkey: `${name}:1.0.0`,
+		});
+
+		const firstRunKey = await computeRunKey({
+			uri,
+			cid: cidValue,
+			policyVersion: MODERATION_POLICY.policyVersion,
+			modelId: "unassigned",
+			promptHash: "unassigned",
+			scannerSetVersion: "unassigned",
+			triggerId: initialTriggerId(cidValue),
+		});
+		const { assessment: first } = await createAssessmentRun(testEnv.DB, {
+			runKey: firstRunKey,
+			uri,
+			cid: cidValue,
+			trigger: "initial",
+			triggerId: initialTriggerId(cidValue),
+			policyVersion: MODERATION_POLICY.policyVersion,
+			coverageJson: "{}",
+		});
+		await transitionAssessmentState(testEnv.DB, {
+			id: first.id,
+			from: "observed",
+			to: "verifying",
+		});
+		await transitionAssessmentState(testEnv.DB, { id: first.id, from: "verifying", to: "pending" });
+		const warningStages: OrchestratorStages = {
+			...stubStages,
+			deterministic: () =>
+				Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+		};
+		const firstResult = await (await buildOrchestrator(warningStages)).runAssessment(first.id);
+		expect(firstResult.state).toBe("warned");
+
+		const secondRunKey = await computeRunKey({
+			uri,
+			cid: cidValue,
+			policyVersion: MODERATION_POLICY.policyVersion,
+			modelId: "unassigned",
+			promptHash: "unassigned",
+			scannerSetVersion: "unassigned",
+			triggerId: operatorTriggerId("op-rerun-2"),
+		});
+		const { assessment: second } = await createAssessmentRun(testEnv.DB, {
+			runKey: secondRunKey,
+			uri,
+			cid: cidValue,
+			trigger: "operator",
+			triggerId: operatorTriggerId("op-rerun-2"),
+			policyVersion: MODERATION_POLICY.policyVersion,
+			coverageJson: "{}",
+		});
+		await transitionAssessmentState(testEnv.DB, {
+			id: second.id,
+			from: "observed",
+			to: "verifying",
+		});
+		await transitionAssessmentState(testEnv.DB, {
+			id: second.id,
+			from: "verifying",
+			to: "pending",
+		});
+		const blockingStages: OrchestratorStages = {
+			...stubStages,
+			deterministic: () =>
+				Promise.resolve([finding({ category: "malware", severity: "critical" })]),
+		};
+		const secondResult = await (await buildOrchestrator(blockingStages)).runAssessment(second.id);
+		expect(secondResult.state).toBe("blocked");
+
+		// The stale assessment-passed from the warned run must be negated: a
+		// blocked release satisfying clients' install-eligibility gate through
+		// a leftover pass would be a critical bypass.
+		const passedAfterBlock = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'assessment-passed'
+			 ORDER BY sequence DESC LIMIT 1`,
+		)
+			.bind(uri, cidValue)
+			.first<{ neg: number }>();
+		expect(passedAfterBlock?.neg).toBe(1);
+
+		const blocked = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'malware'
+			 ORDER BY sequence DESC LIMIT 1`,
+		)
+			.bind(uri, cidValue)
+			.first<{ neg: number }>();
+		expect(blocked?.neg).toBe(0);
+
+		const staleWarning = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'obfuscated-code'
+			 ORDER BY sequence DESC LIMIT 1`,
+		)
+			.bind(uri, cidValue)
+			.first<{ neg: number }>();
+		expect(staleWarning?.neg).toBe(1);
 	});
 });
 
@@ -290,6 +496,30 @@ describe("AssessmentOrchestrator: permanent deterministic failure", () => {
 			.filter((v) => !v.startsWith("assessment-"));
 		expect(blockVals).toContain("malware");
 		expect(blockVals).toContain("supply-chain-compromise");
+	});
+
+	it("issues warning labels alongside a blocking label, and no assessment-passed", async () => {
+		const run = await pendingRun({ name: "block-and-warn", cidValue: await cid("block-and-warn") });
+		const stages: OrchestratorStages = {
+			...stubStages,
+			deterministic: () =>
+				Promise.resolve([finding({ category: "malware", severity: "critical" })]),
+			codeAi: () => Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+		};
+		const orchestrator = await buildOrchestrator(stages);
+
+		const result = await orchestrator.runAssessment(run.id);
+
+		expect(result.state).toBe("blocked");
+		const vals = await testEnv.DB.prepare(
+			`SELECT val FROM issued_labels WHERE uri = ? AND cid = ? AND neg = 0 ORDER BY val`,
+		)
+			.bind(run.uri, run.cid)
+			.all<{ val: string }>();
+		const issued = (vals.results ?? []).map((r) => r.val);
+		expect(issued).toContain("malware");
+		expect(issued).toContain("obfuscated-code");
+		expect(issued).not.toContain("assessment-passed");
 	});
 });
 

--- a/apps/labeler/test/policy-resolver.test.ts
+++ b/apps/labeler/test/policy-resolver.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedFinding } from "../src/findings.js";
+import { resolvePolicyOutcome } from "../src/policy-resolver.js";
+import { MODERATION_POLICY, parseModerationPolicy } from "../src/policy.js";
+
+function finding(overrides: Partial<NormalizedFinding> & { category: string }): NormalizedFinding {
+	return {
+		source: "deterministic",
+		severity: "medium",
+		title: "test finding",
+		publicSummary: "test finding",
+		privateDetail: "test finding detail",
+		evidenceRefs: [],
+		...overrides,
+	};
+}
+
+describe("resolvePolicyOutcome: blocking", () => {
+	it("blocks on a deterministic finding at any severity", () => {
+		const outcome = resolvePolicyOutcome(
+			[finding({ source: "deterministic", category: "undeclared-access", severity: "low" })],
+			MODERATION_POLICY,
+		);
+		expect(outcome.toState).toBe("blocked");
+		expect(outcome.labels).toEqual([
+			{ val: "undeclared-access", findingCategory: "undeclared-access", severity: "low" },
+		]);
+	});
+
+	it("blocks on a critical model finding but not a high-severity one", () => {
+		const critical = resolvePolicyOutcome(
+			[finding({ source: "model", category: "malware", severity: "critical" })],
+			MODERATION_POLICY,
+		);
+		expect(critical.toState).toBe("blocked");
+
+		const high = resolvePolicyOutcome(
+			[finding({ source: "model", category: "malware", severity: "high" })],
+			MODERATION_POLICY,
+		);
+		expect(high.toState).toBe("passed");
+		expect(high.labels).toEqual([{ val: "assessment-passed" }]);
+	});
+
+	it("blocks on a critical image finding", () => {
+		const outcome = resolvePolicyOutcome(
+			[finding({ source: "image", category: "impersonation", severity: "critical" })],
+			MODERATION_POLICY,
+		);
+		expect(outcome.toState).toBe("blocked");
+	});
+
+	it("never blocks or labels a history finding, regardless of category or severity", () => {
+		const outcome = resolvePolicyOutcome(
+			[finding({ source: "history", category: "malware", severity: "critical" })],
+			MODERATION_POLICY,
+		);
+		expect(outcome.toState).toBe("passed");
+		expect(outcome.labels).toEqual([{ val: "assessment-passed" }]);
+	});
+});
+
+describe("resolvePolicyOutcome: warnings", () => {
+	it("warns on a low-severity model finding and still issues assessment-passed", () => {
+		const outcome = resolvePolicyOutcome(
+			[finding({ source: "model", category: "low-quality", severity: "info" })],
+			MODERATION_POLICY,
+		);
+		expect(outcome.toState).toBe("warned");
+		expect(outcome.labels).toEqual([
+			{ val: "low-quality", findingCategory: "low-quality", severity: "info" },
+			{ val: "assessment-passed" },
+		]);
+	});
+
+	it("passes and warns at the same time when only a warning finding is present", () => {
+		const outcome = resolvePolicyOutcome(
+			[finding({ category: "obfuscated-code", severity: "medium" })],
+			MODERATION_POLICY,
+		);
+		expect(outcome.toState).toBe("warned");
+		expect(outcome.labels.map((l) => l.val)).toEqual(["obfuscated-code", "assessment-passed"]);
+	});
+});
+
+describe("resolvePolicyOutcome: blocked outcomes still carry their warnings", () => {
+	it("issues warning labels alongside blocking labels, with no assessment-passed", () => {
+		const outcome = resolvePolicyOutcome(
+			[
+				finding({ source: "deterministic", category: "malware", severity: "critical" }),
+				finding({ source: "model", category: "obfuscated-code", severity: "medium" }),
+			],
+			MODERATION_POLICY,
+		);
+		expect(outcome.toState).toBe("blocked");
+		expect(outcome.labels.map((l) => l.val)).toEqual(["malware", "obfuscated-code"]);
+	});
+});
+
+describe("resolvePolicyOutcome: dedup and severity aggregation", () => {
+	it("dedupes two findings citing the same blocking category into one label", () => {
+		const outcome = resolvePolicyOutcome(
+			[
+				finding({ source: "deterministic", category: "malware", severity: "critical" }),
+				finding({ source: "model", category: "malware", severity: "critical" }),
+			],
+			MODERATION_POLICY,
+		);
+		expect(outcome.labels).toEqual([
+			{ val: "malware", findingCategory: "malware", severity: "critical" },
+		]);
+	});
+
+	it("carries the highest severity among findings that dedupe into one warning label", () => {
+		const outcome = resolvePolicyOutcome(
+			[
+				finding({ category: "obfuscated-code", severity: "low" }),
+				finding({ category: "obfuscated-code", severity: "high" }),
+			],
+			MODERATION_POLICY,
+		);
+		expect(outcome.labels[0]).toEqual({
+			val: "obfuscated-code",
+			findingCategory: "obfuscated-code",
+			severity: "high",
+		});
+	});
+});
+
+describe("resolvePolicyOutcome: issuance-rule filter", () => {
+	it("produces no label for a finding citing a block category without automated release issuance", () => {
+		const policy = parseModerationPolicy({
+			policyVersion: "test",
+			labelerDid: "did:web:example",
+			labels: [
+				{
+					value: "reviewer-only-block",
+					category: "automated-block",
+					officialEffect: "block",
+					subjectRules: [{ subject: "release", cidRule: "required", issuanceModes: ["reviewer"] }],
+				},
+			],
+		});
+		const outcome = resolvePolicyOutcome(
+			[finding({ source: "deterministic", category: "reviewer-only-block", severity: "critical" })],
+			policy,
+		);
+		expect(outcome.toState).toBe("passed");
+		expect(outcome.labels).toEqual([{ val: "assessment-passed" }]);
+	});
+});
+
+describe("resolvePolicyOutcome: no findings", () => {
+	it("passes with only assessment-passed", () => {
+		const outcome = resolvePolicyOutcome([], MODERATION_POLICY);
+		expect(outcome.toState).toBe("passed");
+		expect(outcome.labels).toEqual([{ val: "assessment-passed" }]);
+	});
+});
+
+describe("resolvePolicyOutcome: determinism", () => {
+	it("orders labels blocking-first, then warnings, then assessment-passed, in first-citation order across repeated runs", () => {
+		const findings = [
+			finding({ source: "model", category: "obfuscated-code", severity: "low" }),
+			finding({ source: "deterministic", category: "supply-chain-compromise", severity: "high" }),
+			finding({ source: "deterministic", category: "malware", severity: "critical" }),
+			finding({ source: "model", category: "privacy-risk", severity: "medium" }),
+		];
+		const expected = [
+			{
+				val: "supply-chain-compromise",
+				findingCategory: "supply-chain-compromise",
+				severity: "high",
+			},
+			{ val: "malware", findingCategory: "malware", severity: "critical" },
+			{ val: "obfuscated-code", findingCategory: "obfuscated-code", severity: "low" },
+			{ val: "privacy-risk", findingCategory: "privacy-risk", severity: "medium" },
+		];
+		for (let i = 0; i < 5; i++) {
+			const outcome = resolvePolicyOutcome(findings, MODERATION_POLICY);
+			expect(outcome.labels).toEqual(expected);
+		}
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds the labeler's **versioned policy resolver** — plan item W8.5, spec §9.9 steps 4–7. Replaces the orchestrator's stub `resolvePolicyOutcome` (marked "W7/W8 replace this with the real policy engine") with the real resolver in `policy-resolver.ts`, consuming validated `NormalizedFinding[]` (W8.1) under the versioned `ModerationPolicy`.

Resolution rules:

- **Source-aware blocking bar.** `deterministic`/`capability` findings citing an `automated-block` category block at **any severity** — deterministic adapters only cite a block category when the condition definitively holds, so the category is the assertion. `model`/`image` findings block only at `critical` (spec step 5's bar for AI judgment). `history` findings **never** produce labels (plan W8.4: history may recommend review but cannot label).
- **`assessment-passed` issues whenever nothing blocks — including on warned outcomes.** Spec: "An assessment may pass and warn at the same time." This is a behavioral fix over the stub, and it matters: clients gate installability on an active `assessment-passed` (#1972), so warned-but-passing releases must carry it. A new supersession regression test pins the security-critical inverse — **a blocking run negates a prior warned run's `assessment-passed`** (the negation query has no category filter, so eligibility labels negate like descriptive ones; the test guards against a future "optimization" quietly changing that into an install-eligibility bypass).
- **Blocked outcomes still carry their warning labels** (step 6 is unconditional). No `assessment-passed`.
- **Dedup + metadata**: one label per category, `severity` = highest among citing findings; deterministic ordering (blocking → warnings → `assessment-passed`, first-citation order within groups).
- **Issuance filter**: only labels whose policy `subjectRules` permit `automated` issuance on a `release` subject can be machine-proposed — a defensive layer on top of W8.1 validation.

No confidence thresholds are introduced — the spec doesn't define them; that's future policy-version material.

**Reviewer note (pre-existing, out of scope):** `validateAutomatedProposal` in `service.ts` (used by the standalone `issueAutomatedAssessmentLabel` path, not by `finalize`) requires `critical` severity for automated-block labels, which now disagrees with the resolver's spec-correct any-severity-deterministic rule. Nothing routes finalize through it today; flagged for a follow-up Discussion rather than changed here.

The orchestrator diff is exactly the stub + type deletion and the import swap; lifecycle steps 1–3/8–11 (staleness, retries, negation, persistence) are untouched. No migration, no lexicon change, no public-API change.

Reviewed with an opus adversarial pass that traced the warned→blocked supersession path end-to-end (no hole — and it drove the regression test that now pins it).

Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n and changeset are n/a — this touches only `apps/labeler`, a private, unpublished Worker app (no admin UI, not on npm).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (design, review coordination, regression test), an Opus 4.8 subagent (adversarial review), and a Sonnet subagent (implementation)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: 274 pass (18 files) — 12 new resolver-matrix tests (source×severity×category blocking bars, history exclusion, pass+warn coexistence, blocked+warn, dedup/severity aggregation, issuance filter, ordering determinism) + 3 orchestrator tests (warned issues `assessment-passed`; blocked issues warnings without it; **warned→blocked supersession negates the stale `assessment-passed`**)
- Typecheck clean; `pnpm lint:json` diagnostics unchanged at 19 (0 in `apps/labeler`)
