### PR TITLE
feat(labeler): Cloudflare Access operator authentication (W9.1)

### DIFF
--- a/apps/labeler/package.json
+++ b/apps/labeler/package.json
@@ -25,6 +25,7 @@
 		"@atcute/xrpc-server": "catalog:",
 		"@emdash-cms/registry-lexicons": "workspace:*",
 		"@emdash-cms/registry-moderation": "workspace:*",
+		"jose": "^6.1.3",
 		"ulidx": "^2.4.1"
 	},
 	"devDependencies": {

--- a/apps/labeler/src/access-auth.ts
+++ b/apps/labeler/src/access-auth.ts
@@ -1,0 +1,145 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+export type OperatorRole = "admin" | "reviewer";
+
+export type OperatorIdentity =
+	| { kind: "human"; email: string; sub: string; roles: readonly OperatorRole[] }
+	| { kind: "service"; commonName: string; sub: string; roles: readonly OperatorRole[] };
+
+export interface AccessAuthConfig {
+	teamDomain: string;
+	audience: string;
+	admins: readonly string[];
+	reviewers: readonly string[];
+}
+
+export class AccessAuthError extends Error {
+	readonly reason: "missing-token" | "invalid-token";
+
+	constructor(reason: "missing-token" | "invalid-token", message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.reason = reason;
+	}
+}
+
+export type AccessKeyResolver = Parameters<typeof jwtVerify>[1];
+
+export function parseAccessAuthConfig(value: unknown): AccessAuthConfig {
+	if (!isRecord(value)) throw new TypeError("Access auth config must be an object");
+	const teamDomain = value.teamDomain;
+	if (typeof teamDomain !== "string" || teamDomain.length === 0)
+		throw new TypeError("Access auth config teamDomain must be a non-empty string");
+	let teamDomainUrl: URL;
+	try {
+		teamDomainUrl = new URL(teamDomain);
+	} catch {
+		throw new TypeError("Access auth config teamDomain must be an HTTPS URL");
+	}
+	if (teamDomainUrl.protocol !== "https:")
+		throw new TypeError("Access auth config teamDomain must be an HTTPS URL");
+	const audience = value.audience;
+	if (typeof audience !== "string" || audience.length === 0)
+		throw new TypeError("Access auth config audience must be a non-empty string");
+	return {
+		teamDomain,
+		audience,
+		admins: parseStringArray(value.admins, "admins"),
+		reviewers: parseStringArray(value.reviewers, "reviewers"),
+	};
+}
+
+function parseStringArray(value: unknown, field: string): readonly string[] {
+	if (!Array.isArray(value)) throw new TypeError(`Access auth config ${field} must be an array`);
+	if (!value.every((entry): entry is string => typeof entry === "string" && entry.length > 0))
+		throw new TypeError(`Access auth config ${field} must contain non-empty strings`);
+	return value;
+}
+
+const ACCESS_JWKS_CACHE_KEY = Symbol.for("emdash-labeler:access-jwks");
+type AccessJwksCache = Map<string, AccessKeyResolver>;
+
+export function getAccessKeyResolver(teamDomain: string): AccessKeyResolver {
+	const g = globalThis as Record<symbol, unknown>;
+	// Cached on globalThis (Symbol.for) so Vite SSR chunk duplication and isolate
+	// reuse share one resolver per team domain; createRemoteJWKSet already
+	// handles kid rotation and cooldown internally.
+	const cache: AccessJwksCache =
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern
+		(g[ACCESS_JWKS_CACHE_KEY] as AccessJwksCache | undefined) ??
+		(() => {
+			const c: AccessJwksCache = new Map();
+			g[ACCESS_JWKS_CACHE_KEY] = c;
+			return c;
+		})();
+	let resolver = cache.get(teamDomain);
+	if (!resolver) {
+		resolver = createRemoteJWKSet(new URL(`${teamDomain}/cdn-cgi/access/certs`));
+		cache.set(teamDomain, resolver);
+	}
+	return resolver;
+}
+
+export async function verifyAccessRequest(
+	request: Request,
+	config: AccessAuthConfig,
+	keys: AccessKeyResolver,
+): Promise<OperatorIdentity> {
+	// Identity comes only from a verified assertion; other headers (e.g.
+	// Cf-Access-Authenticated-User-Email) are attacker-controlled and never read.
+	const token = request.headers.get("Cf-Access-Jwt-Assertion");
+	if (!token) throw new AccessAuthError("missing-token", "Access assertion header is missing");
+
+	let payload: Record<string, unknown>;
+	try {
+		const result = await jwtVerify(token, keys, {
+			algorithms: ["RS256"],
+			requiredClaims: ["exp"],
+			issuer: config.teamDomain,
+			audience: config.audience,
+		});
+		payload = result.payload;
+	} catch (cause) {
+		throw new AccessAuthError("invalid-token", "Access assertion failed verification", { cause });
+	}
+
+	const sub = payload.sub;
+	if (typeof sub !== "string" || sub.length === 0)
+		throw new AccessAuthError("invalid-token", "Access assertion is missing sub");
+
+	const commonName = payload.common_name;
+	const email = payload.email;
+
+	let identity: OperatorIdentity;
+	if (typeof commonName === "string" && commonName.length > 0) {
+		identity = { kind: "service", commonName, sub, roles: [] };
+	} else if (typeof email === "string" && email.length > 0) {
+		identity = { kind: "human", email, sub, roles: [] };
+	} else {
+		throw new AccessAuthError(
+			"invalid-token",
+			"Access assertion has neither email nor common_name",
+		);
+	}
+
+	const principal = identity.kind === "service" ? identity.commonName : identity.email;
+	const principals = new Set<string>([principal, ...groupPrincipals(payload.groups)]);
+	const roles: OperatorRole[] = [];
+	if (config.admins.some((admin) => principals.has(admin))) roles.push("admin");
+	if (config.reviewers.some((reviewer) => principals.has(reviewer))) roles.push("reviewer");
+
+	return { ...identity, roles };
+}
+
+function groupPrincipals(groups: unknown): readonly string[] {
+	if (!Array.isArray(groups)) return [];
+	return groups.filter((entry): entry is string => typeof entry === "string");
+}
+
+export function hasRole(identity: OperatorIdentity, role: OperatorRole): boolean {
+	if (identity.roles.includes(role)) return true;
+	return role === "reviewer" && identity.roles.includes("admin");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/labeler/src/access-auth.ts
+++ b/apps/labeler/src/access-auth.ts
@@ -33,15 +33,22 @@ export function parseAccessAuthConfig(value: unknown): AccessAuthConfig {
 	try {
 		teamDomainUrl = new URL(teamDomain);
 	} catch {
-		throw new TypeError("Access auth config teamDomain must be an HTTPS URL");
+		throw new TypeError("Access auth config teamDomain must be an HTTPS origin");
 	}
-	if (teamDomainUrl.protocol !== "https:")
-		throw new TypeError("Access auth config teamDomain must be an HTTPS URL");
+	if (
+		teamDomainUrl.protocol !== "https:" ||
+		teamDomainUrl.username !== "" ||
+		teamDomainUrl.password !== "" ||
+		teamDomainUrl.search !== "" ||
+		teamDomainUrl.hash !== "" ||
+		teamDomainUrl.pathname !== "/"
+	)
+		throw new TypeError("Access auth config teamDomain must be an HTTPS origin");
 	const audience = value.audience;
 	if (typeof audience !== "string" || audience.length === 0)
 		throw new TypeError("Access auth config audience must be a non-empty string");
 	return {
-		teamDomain,
+		teamDomain: teamDomainUrl.origin,
 		audience,
 		admins: parseStringArray(value.admins, "admins"),
 		reviewers: parseStringArray(value.reviewers, "reviewers"),
@@ -73,7 +80,7 @@ export function getAccessKeyResolver(teamDomain: string): AccessKeyResolver {
 		})();
 	let resolver = cache.get(teamDomain);
 	if (!resolver) {
-		resolver = createRemoteJWKSet(new URL(`${teamDomain}/cdn-cgi/access/certs`));
+		resolver = createRemoteJWKSet(new URL("/cdn-cgi/access/certs", teamDomain));
 		cache.set(teamDomain, resolver);
 	}
 	return resolver;
@@ -132,7 +139,7 @@ export async function verifyAccessRequest(
 
 function groupPrincipals(groups: unknown): readonly string[] {
 	if (!Array.isArray(groups)) return [];
-	return groups.filter((entry): entry is string => typeof entry === "string");
+	return groups.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 }
 
 export function hasRole(identity: OperatorIdentity, role: OperatorRole): boolean {

--- a/apps/labeler/test/access-auth.test.ts
+++ b/apps/labeler/test/access-auth.test.ts
@@ -1,0 +1,424 @@
+import { generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+	AccessAuthError,
+	getAccessKeyResolver,
+	hasRole,
+	parseAccessAuthConfig,
+	verifyAccessRequest,
+} from "../src/access-auth.js";
+import type { AccessAuthConfig, AccessKeyResolver, OperatorIdentity } from "../src/access-auth.js";
+
+const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
+const AUDIENCE = "test-audience";
+
+function baseConfig(overrides: Partial<AccessAuthConfig> = {}): AccessAuthConfig {
+	return {
+		teamDomain: TEAM_DOMAIN,
+		audience: AUDIENCE,
+		admins: ["admin@example.com", "emdash-labeler-admins"],
+		reviewers: ["reviewer@example.com", "emdash-labeler-reviewers"],
+		...overrides,
+	};
+}
+
+interface MintOverrides {
+	sub?: string;
+	email?: string;
+	common_name?: string;
+	groups?: unknown;
+	issuer?: string;
+	audience?: string;
+	expiresInSeconds?: number;
+	notBeforeInSeconds?: number;
+}
+
+async function mintToken(overrides: MintOverrides, signKey: CryptoKey): Promise<string> {
+	const {
+		issuer = TEAM_DOMAIN,
+		audience = AUDIENCE,
+		expiresInSeconds = 3600,
+		notBeforeInSeconds,
+		...claims
+	} = overrides;
+	const now = Math.floor(Date.now() / 1000);
+	let jwt = new SignJWT({ sub: "user-sub-1", ...claims })
+		.setProtectedHeader({ alg: "RS256" })
+		.setIssuer(issuer)
+		.setAudience(audience)
+		.setIssuedAt(now)
+		.setExpirationTime(now + expiresInSeconds);
+	if (notBeforeInSeconds !== undefined) jwt = jwt.setNotBefore(now + notBeforeInSeconds);
+	return jwt.sign(signKey);
+}
+
+function requestWith(headers: Record<string, string>): Request {
+	return new Request("https://labeler.example.com/admin", { headers });
+}
+
+let signKey: CryptoKey;
+let otherKey: CryptoKey;
+let resolver: AccessKeyResolver;
+
+beforeAll(async () => {
+	const pair = await generateKeyPair("RS256");
+	signKey = pair.privateKey;
+	// Local resolver mimicking jose's remote-JWKS signature: (protectedHeader, token) => key.
+	resolver = (async () => pair.publicKey) as AccessKeyResolver;
+
+	const otherPair = await generateKeyPair("RS256");
+	otherKey = otherPair.privateKey;
+});
+
+describe("verifyAccessRequest", () => {
+	it("accepts a valid human token and maps roles from the email allowlist", async () => {
+		const token = await mintToken({ email: "admin@example.com" }, signKey);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identity).toEqual<OperatorIdentity>({
+			kind: "human",
+			email: "admin@example.com",
+			sub: "user-sub-1",
+			roles: ["admin"],
+		});
+	});
+
+	it("accepts a valid service token identified by common_name", async () => {
+		const token = await mintToken({ common_name: "ci-automation" }, signKey);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig({ admins: ["ci-automation"] }),
+			resolver,
+		);
+		expect(identity).toEqual<OperatorIdentity>({
+			kind: "service",
+			commonName: "ci-automation",
+			sub: "user-sub-1",
+			roles: ["admin"],
+		});
+	});
+
+	it("maps roles from a groups claim", async () => {
+		const token = await mintToken(
+			{ email: "someone@example.com", groups: ["emdash-labeler-reviewers"] },
+			signKey,
+		);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identity.roles).toEqual(["reviewer"]);
+	});
+
+	it("grants only reviewer role for a reviewer-only principal", async () => {
+		const token = await mintToken({ email: "reviewer@example.com" }, signKey);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identity.roles).toEqual(["reviewer"]);
+		expect(hasRole(identity, "reviewer")).toBe(true);
+		expect(hasRole(identity, "admin")).toBe(false);
+	});
+
+	it("grants no roles when the principal matches neither list", async () => {
+		const token = await mintToken({ email: "nobody@example.com" }, signKey);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identity.roles).toEqual([]);
+	});
+
+	it("treats admin as inheriting reviewer capability via hasRole", async () => {
+		const token = await mintToken({ email: "admin@example.com" }, signKey);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig(),
+			resolver,
+		);
+		expect(hasRole(identity, "admin")).toBe(true);
+		expect(hasRole(identity, "reviewer")).toBe(true);
+	});
+
+	it("rejects a token with the wrong audience", async () => {
+		const token = await mintToken(
+			{ email: "admin@example.com", audience: "wrong-audience" },
+			signKey,
+		);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects a token with the wrong issuer", async () => {
+		const token = await mintToken(
+			{ email: "admin@example.com", issuer: "https://not-the-team.cloudflareaccess.com" },
+			signKey,
+		);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects an expired token", async () => {
+		const token = await mintToken({ email: "admin@example.com", expiresInSeconds: -60 }, signKey);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects a token that is not yet valid (nbf in the future)", async () => {
+		const token = await mintToken(
+			{ email: "admin@example.com", notBeforeInSeconds: 3600 },
+			signKey,
+		);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects a token signed by a different key", async () => {
+		const token = await mintToken({ email: "admin@example.com" }, otherKey);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects a token signed with a non-RS256 algorithm even when its key verifies", async () => {
+		const ecPair = await generateKeyPair("ES256");
+		const ecResolver = (async () => ecPair.publicKey) as AccessKeyResolver;
+		const now = Math.floor(Date.now() / 1000);
+		const token = await new SignJWT({ sub: "user-sub-1", email: "admin@example.com" })
+			.setProtectedHeader({ alg: "ES256" })
+			.setIssuer(TEAM_DOMAIN)
+			.setAudience(AUDIENCE)
+			.setIssuedAt(now)
+			.setExpirationTime(now + 3600)
+			.sign(ecPair.privateKey);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				ecResolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects an HS256 token even when the resolved key would verify the signature", async () => {
+		const secret = crypto.getRandomValues(new Uint8Array(32));
+		const hmacResolver = (async () => secret) as AccessKeyResolver;
+		const now = Math.floor(Date.now() / 1000);
+		const token = await new SignJWT({ sub: "user-sub-1", email: "admin@example.com" })
+			.setProtectedHeader({ alg: "HS256" })
+			.setIssuer(TEAM_DOMAIN)
+			.setAudience(AUDIENCE)
+			.setIssuedAt(now)
+			.setExpirationTime(now + 3600)
+			.sign(secret);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				hmacResolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects an unsigned alg:none token", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const encode = (value: unknown): string =>
+			btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(value))))
+				.replace(/\+/g, "-")
+				.replace(/\//g, "_")
+				.replace(/=+$/, "");
+		const header = encode({ alg: "none", typ: "JWT" });
+		const payload = encode({
+			sub: "user-sub-1",
+			email: "admin@example.com",
+			iss: TEAM_DOMAIN,
+			aud: AUDIENCE,
+			exp: now + 3600,
+		});
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": `${header}.${payload}.` }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects a token that omits the exp claim", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const token = await new SignJWT({ sub: "user-sub-1", email: "admin@example.com" })
+			.setProtectedHeader({ alg: "RS256" })
+			.setIssuer(TEAM_DOMAIN)
+			.setAudience(AUDIENCE)
+			.setIssuedAt(now)
+			.sign(signKey);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects a missing assertion header", async () => {
+		await expect(
+			verifyAccessRequest(requestWith({}), baseConfig(), resolver),
+		).rejects.toMatchObject({ reason: "missing-token" });
+	});
+
+	it("never trusts a spoofed identity header without a verified assertion", async () => {
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Authenticated-User-Email": "admin@example.com" }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "missing-token" });
+	});
+
+	it("rejects a token with neither email nor common_name", async () => {
+		const token = await mintToken({}, signKey);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("rejects a garbage assertion header", async () => {
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": "not-a-jwt" }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
+	});
+
+	it("ignores a groups claim of the wrong shape without crashing", async () => {
+		const stringShape = await mintToken(
+			{ email: "reviewer@example.com", groups: "emdash-labeler-reviewers" },
+			signKey,
+		);
+		const numberArrayShape = await mintToken(
+			{ email: "reviewer@example.com", groups: [1, 2, 3] },
+			signKey,
+		);
+
+		const identityA = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": stringShape }),
+			baseConfig(),
+			resolver,
+		);
+		const identityB = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": numberArrayShape }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identityA.roles).toEqual(["reviewer"]);
+		expect(identityB.roles).toEqual(["reviewer"]);
+	});
+
+	it("never includes the raw token in a thrown error message", async () => {
+		const token = await mintToken({ email: "admin@example.com" }, otherKey);
+		try {
+			await verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			);
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(AccessAuthError);
+			expect((error as Error).message).not.toContain(token);
+		}
+	});
+});
+
+describe("parseAccessAuthConfig", () => {
+	const validRaw = {
+		teamDomain: TEAM_DOMAIN,
+		audience: AUDIENCE,
+		admins: ["emdash-labeler-admins"],
+		reviewers: ["emdash-labeler-reviewers"],
+	};
+
+	it("parses a valid config", () => {
+		expect(parseAccessAuthConfig(validRaw)).toEqual(
+			baseConfig({ admins: validRaw.admins, reviewers: validRaw.reviewers }),
+		);
+	});
+
+	it("rejects a missing or empty teamDomain", () => {
+		expect(() => parseAccessAuthConfig({ ...validRaw, teamDomain: "" })).toThrow(TypeError);
+		expect(() => parseAccessAuthConfig({ ...validRaw, teamDomain: undefined })).toThrow(TypeError);
+	});
+
+	it("rejects a non-https teamDomain", () => {
+		expect(() =>
+			parseAccessAuthConfig({
+				...validRaw,
+				teamDomain: "http://example-team.cloudflareaccess.com",
+			}),
+		).toThrow(TypeError);
+	});
+
+	it("rejects a missing audience", () => {
+		expect(() => parseAccessAuthConfig({ ...validRaw, audience: "" })).toThrow(TypeError);
+	});
+
+	it("rejects non-array or empty-string admins/reviewers entries", () => {
+		expect(() => parseAccessAuthConfig({ ...validRaw, admins: "not-an-array" })).toThrow(TypeError);
+		expect(() => parseAccessAuthConfig({ ...validRaw, admins: [""] })).toThrow(TypeError);
+		expect(() => parseAccessAuthConfig({ ...validRaw, reviewers: [123] })).toThrow(TypeError);
+	});
+});
+
+describe("getAccessKeyResolver", () => {
+	it("returns the same resolver instance for the same team domain", () => {
+		const first = getAccessKeyResolver(TEAM_DOMAIN);
+		const second = getAccessKeyResolver(TEAM_DOMAIN);
+		expect(first).toBe(second);
+	});
+
+	it("returns distinct resolvers for distinct team domains", () => {
+		const first = getAccessKeyResolver(TEAM_DOMAIN);
+		const second = getAccessKeyResolver("https://other-team.cloudflareaccess.com");
+		expect(first).not.toBe(second);
+	});
+});

--- a/apps/labeler/test/access-auth.test.ts
+++ b/apps/labeler/test/access-auth.test.ts
@@ -354,6 +354,20 @@ describe("verifyAccessRequest", () => {
 		expect(identityB.roles).toEqual(["reviewer"]);
 	});
 
+	it("does not treat an empty-string group entry as a principal", async () => {
+		const token = await mintToken(
+			{ email: "nobody@example.com", groups: ["", "not-a-configured-group"] },
+			signKey,
+		);
+		// An empty-string allowlist entry can only match if an empty group leaks in as a principal.
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig({ admins: [""] }),
+			resolver,
+		);
+		expect(identity.roles).toEqual([]);
+	});
+
 	it("never includes the raw token in a thrown error message", async () => {
 		const token = await mintToken({ email: "admin@example.com" }, otherKey);
 		try {
@@ -396,6 +410,24 @@ describe("parseAccessAuthConfig", () => {
 				teamDomain: "http://example-team.cloudflareaccess.com",
 			}),
 		).toThrow(TypeError);
+	});
+
+	it("rejects a teamDomain that is not a bare origin", () => {
+		for (const teamDomain of [
+			"https://example-team.cloudflareaccess.com/cdn-cgi/access/certs",
+			"https://user:pass@example-team.cloudflareaccess.com",
+			"https://example-team.cloudflareaccess.com?foo=bar",
+			"https://example-team.cloudflareaccess.com#frag",
+		])
+			expect(() => parseAccessAuthConfig({ ...validRaw, teamDomain })).toThrow(TypeError);
+	});
+
+	it("accepts a trailing-slash teamDomain and normalizes it to a bare origin", () => {
+		const config = parseAccessAuthConfig({
+			...validRaw,
+			teamDomain: `${TEAM_DOMAIN}/`,
+		});
+		expect(config.teamDomain).toBe(TEAM_DOMAIN);
 	});
 
 	it("rejects a missing audience", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@emdash-cms/registry-moderation':
         specifier: workspace:*
         version: link:../../packages/registry-moderation
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
       ulidx:
         specifier: ^2.4.1
         version: 2.4.1


### PR DESCRIPTION
## What does this PR do?

Adds the labeler operator console's **Cloudflare Access authentication module** — plan item W9.1, spec §12. `verifyAccessRequest` establishes an `OperatorIdentity` from the `Cf-Access-Jwt-Assertion` header before any console route (W9.2+) will permit moderation actions.

Design:

- **Identity comes only from a cryptographically verified assertion.** The module reads exactly one header — `Cf-Access-Jwt-Assertion` — and verifies it with jose against Cloudflare Access's remote JWKS (`${teamDomain}/cdn-cgi/access/certs`). Plaintext identity headers like `Cf-Access-Authenticated-User-Email` are attacker-spoofable and are never read; a test pins that a request carrying only the plaintext header fails with `missing-token`.
- **Exact issuer/audience pinning, zero clock tolerance.** `issuer` = team domain, `audience` = the Access application AUD tag; `exp`/`nbf` enforced with jose's default zero tolerance. `algorithms` is pinned to `["RS256"]` and `exp` is a required claim — both defense-in-depth (alg-confusion and `alg:none` are already structurally rejected by jose's JWKS key selector, and Access always sets `exp`), so a future resolver change fails hard instead of quietly widening acceptance.
- **Human vs service-token identities.** A `common_name` claim yields a `service` identity, `email` a `human` one; neither yields an identity without a non-empty `sub`. Roles (`admin`/`reviewer`) are mapped by exact `Set` membership of the principal plus signed `groups` claims against config allowlists — empty allowlists fail closed, and `hasRole` gives admins reviewer capability by inheritance.
- **JWKS resolver cached on `globalThis`** (`Symbol.for`, keyed by team domain) so Vite SSR chunk duplication and isolate reuse share one resolver; jose handles kid rotation and cooldown internally.
- **`parseAccessAuthConfig`** validates the deployment config up front: HTTPS team domain, non-empty audience, non-empty string allowlists.

Error surface is two static-message `AccessAuthError` reasons (`missing-token` / `invalid-token`) — token contents are never interpolated into messages.

Two independent opus adversarial passes traced the full jose verification path (key selection, key-type checks, claims validation) from installed source: no authorization path exists without a verified signature, and role claims cannot be self-escalated. Their two recommendations (RS256 pin + alg-confusion/`alg:none` regression tests) are applied here.

No routes are added yet — W9.2 (mutation protections) and W9.3 (console shell) consume this module.

Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n and changeset are n/a — this touches only `apps/labeler`, a private, unpublished Worker app (no admin UI yet, not on npm).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (design, coordination), Opus 4.8 subagents (security implementation review and hardening), and a Sonnet subagent (implementation)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: 259 pass (17 files) — new suite covers verified accept paths (human, service token, group-derived roles), and rejections for: missing header, spoofed plaintext email header only, garbage token, wrong signing key, wrong issuer, wrong audience, expired, not-yet-valid, missing sub, neither email nor common_name, malformed groups, ES256-signed token, HS256 token whose signature the resolver's key *would* verify (isolates the RS256 pin), unsigned `alg:none` token, and a token omitting `exp`
- Typecheck clean; `pnpm lint:json` diagnostics: 0
- Error messages verified to never contain token material


https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-access-auth-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-access-auth`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
