### PR TITLE
feat(core): add media usage repair tooling

### DIFF
--- a/.changeset/media-repair-cli.md
+++ b/.changeset/media-repair-cli.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds `emdash media repair-usage` for repairing content media usage indexes by collection or across all collections from the CLI; automation should parse the JSON `status` because partial and stale repairs exit successfully.

--- a/.changeset/media-repair-cli.md
+++ b/.changeset/media-repair-cli.md
@@ -2,4 +2,4 @@
 "emdash": minor
 ---
 
-Adds `emdash media repair-usage` for repairing content media usage indexes by collection or across all collections from the CLI; automation should parse the JSON `status` because partial and stale repairs exit successfully.
+Adds `emdash media repair-usage` and the `media_usage_repair` MCP tool for repairing content media usage indexes by collection or across all collections; automation should inspect the structured repair status because non-complete results can still be successful invocations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
       - run: pnpm --filter emdash exec vitest run --config vitest.smoke.config.ts
         env:
           DATABASE_URL: postgres://postgres:test@localhost:5432/emdash_smoke
@@ -174,7 +173,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
       - run: pnpm --filter emdash exec vitest run --config vitest.integration.config.ts
 
   test-browser:

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -19,24 +19,25 @@ Run commands with `npx emdash` or add scripts to `package.json`. The binary is a
 
 ## Authentication
 
-Commands that talk to a running EmDash instance resolve authentication in this order:
+Commands using the shared remote client resolve authentication in this order:
 
 1. **`--token` flag** — explicit token on the command line
 2. **`EMDASH_TOKEN` env var**
 3. **Stored credentials** from `~/.config/emdash/auth.json` (saved by `emdash login`)
 4. **Dev bypass** — if the URL is localhost and no token is available, automatically authenticates via the dev bypass endpoint
 
-Most commands accept `--url` (default `http://localhost:4321`) and `--token` flags. When targeting a local dev server, no token is needed.
+These commands accept `--url` (from `EMDASH_URL`, falling back to `http://localhost:4321`) and `--token` flags. Authentication commands have their own connection options. When targeting a local dev server, no token is needed.
 
 ## Common Flags
 
-These flags are available on all remote commands:
+These flags are available on commands using the shared remote client:
 
-| Flag      | Alias | Description                 | Default                  |
-| --------- | ----- | --------------------------- | ------------------------ |
-| `--url`   | `-u`  | EmDash instance URL       | `http://localhost:4321`  |
-| `--token` | `-t`  | Auth token                  | From env/stored creds    |
-| `--json`  |       | Output as JSON (for piping) | Auto-detected from TTY   |
+| Flag                    | Alias | Description                            | Default                          |
+| ----------------------- | ----- | -------------------------------------- | -------------------------------- |
+| `--url`                 | `-u`  | EmDash instance URL                    | `EMDASH_URL` or `http://localhost:4321` |
+| `--token`               | `-t`  | Auth token                             | From env/stored creds            |
+| `--header "Name: Value"` | `-H`  | Custom request header; may be repeated | From `EMDASH_HEADERS`/stored creds |
+| `--json`                |       | Output as JSON (for piping)            | Auto-detected from TTY           |
 
 ## Output
 
@@ -578,7 +579,8 @@ The command also writes a raw schema export for tooling:
 | ------------------------- | ---------------------------------------- |
 | `EMDASH_DATABASE_URL`     | Database URL (set automatically by `dev`) |
 | `EMDASH_TOKEN`            | Auth token for remote operations          |
-| `EMDASH_URL`              | Default remote URL for `types` and `dev --types` |
+| `EMDASH_URL`              | Default URL for commands using the shared remote client |
+| `EMDASH_HEADERS`          | Newline-separated custom request headers for the shared remote client and `login` |
 | `EMDASH_ENCRYPTION_KEY`   | Key for encrypting plugin secrets at rest. Operator-provided — never stored in the database. Generate with `emdash secrets generate`. |
 | `EMDASH_PREVIEW_SECRET`   | Optional override for preview HMAC secret. When unset, EmDash generates and persists one in the options table. |
 | `EMDASH_IP_SALT`          | Optional override for the commenter-IP hash salt. When unset, EmDash generates and persists one in the options table. |

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -388,6 +388,27 @@ npx emdash media get 01MEDIA123
 npx emdash media delete 01MEDIA123
 ```
 
+#### `media repair-usage`
+
+Repair content media usage indexes for one collection or for every content collection. Use this after imports or direct database writes when usage coverage is stale or untrusted.
+
+```bash
+npx emdash media repair-usage --collection posts
+npx emdash media repair-usage --all
+npx emdash media repair-usage --all --json
+```
+
+| Option         | Alias | Description                    |
+| -------------- | ----- | ------------------------------ |
+| `--collection` | `-c`  | Repair one content collection  |
+| `--all`        |       | Repair every content collection |
+
+Pass exactly one of `--collection` or `--all`. Remote repair requires an Admin user and an auth token with the `admin` scope.
+
+All-content repair runs synchronously and can be slow or expensive on large sites. Prefer `--collection` when you only need to repair one collection.
+
+Structured `complete`, `partial`, and `stale` repair results exit `0`; structured `failed` results exit `1`. Automation and cron jobs should use `--json` and parse `status`, `failedSourceCount`, `skippedSourceCount`, and per-collection summaries instead of treating exit `0` as complete coverage.
+
 ### `emdash search`
 
 Full-text search across content.

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -64,6 +64,7 @@ In addition to scopes, some tools require a minimum RBAC role. Both must be sati
 | Settings read | Editor (40) |
 | Settings manage | Admin (50) |
 | Media upload (`media_create`) | Author (30) |
+| Media usage repair | Admin (50) |
 
 See the [Authentication guide](/guides/authentication#user-roles) for role definitions.
 
@@ -79,7 +80,7 @@ Responses follow the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) forma
 
 ## Tools
 
-The server exposes 45 tools across eight domains: content, schema, media, search, taxonomies, menus, revisions, and settings. Each tool returns results as JSON text content, or an error message with `isError: true` on failure.
+The server exposes 52 tools across eight domains: content, schema, media, search, taxonomies, menus, revisions, and settings. Each tool returns results as JSON text content, or an error message with `isError: true` on failure.
 
 ### Content Tools
 
@@ -433,6 +434,19 @@ Permanently delete a media file. Removes the database record and the file from s
 | `id` | `string` | Yes | Media item ID |
 
 **Scope:** `media:write` | **Destructive:** Yes
+
+#### `media_usage_repair`
+
+Repair content media usage indexes for one collection or every collection. Repair runs synchronously and can be slow or expensive on large sites; prefer collection scope when possible.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `scope` | `"collection" \| "all"` | Yes | Whether to repair one collection or all collections |
+| `collection` | `string` | For collection scope | Collection slug; omit when `scope` is `all` |
+
+The result has a structured `status` of `complete`, `partial`, `failed`, or `stale`, plus aggregate and per-collection source counts. All four statuses are successful MCP tool results, so callers must inspect `status` rather than relying on `isError`. Authentication, validation, or unexpected repair errors return `isError: true`.
+
+**Scope:** `admin` | **Minimum role:** Admin
 
 ### Search Tool
 

--- a/packages/core/src/cli/client-factory.ts
+++ b/packages/core/src/cli/client-factory.ts
@@ -17,7 +17,6 @@ export const connectionArgs = {
 		type: "string" as const,
 		alias: "u",
 		description: "EmDash instance URL",
-		default: "http://localhost:4321",
 	},
 	token: {
 		type: "string" as const,

--- a/packages/core/src/cli/commands/media.ts
+++ b/packages/core/src/cli/commands/media.ts
@@ -10,8 +10,11 @@ import { basename } from "node:path";
 import { defineCommand } from "citty";
 import { consola } from "consola";
 
+import type { MediaUsageRepairResponse } from "../../client/index.js";
 import { connectionArgs, createClientFromArgs } from "../client-factory.js";
 import { configureOutputMode, output } from "../output.js";
+
+const repairScopeError = "Specify exactly one of --collection or --all";
 
 const listCommand = defineCommand({
 	meta: {
@@ -155,6 +158,97 @@ const deleteCommand = defineCommand({
 	},
 });
 
+const repairUsageCommand = defineCommand({
+	meta: {
+		name: "repair-usage",
+		description: "Repair content media usage indexes",
+	},
+	args: {
+		...connectionArgs,
+		collection: {
+			type: "string",
+			alias: "c",
+			description: "Repair one content collection",
+		},
+		all: {
+			type: "boolean",
+			description: "Repair every content collection",
+		},
+	},
+	async run({ args }) {
+		configureOutputMode(args);
+
+		const hasCollection = typeof args.collection === "string";
+		const hasAll = args.all === true;
+		if (hasCollection === hasAll) {
+			consola.error(repairScopeError);
+			process.exit(1);
+		}
+
+		const client = createClientFromArgs(args);
+
+		try {
+			const result = await client.mediaRepairUsage(
+				hasCollection ? { scope: "collection", collection: args.collection } : { scope: "all" },
+			);
+
+			if (args.json || !process.stdout.isTTY) {
+				output(result, args);
+			} else {
+				printRepairUsageSummary(result);
+			}
+
+			if (result.status === "failed") {
+				process.exitCode = 1;
+			}
+		} catch (error) {
+			consola.error(
+				"Failed to repair media usage:",
+				error instanceof Error ? error.message : error,
+			);
+			process.exit(1);
+		}
+	},
+});
+
+function printRepairUsageSummary(result: MediaUsageRepairResponse): void {
+	const counts = `indexed ${result.indexedSourceCount}, failed ${result.failedSourceCount}, skipped ${result.skippedSourceCount}, deleted ${result.deletedSourceCount}`;
+	const scope =
+		result.collections.length === 1 && result.collections[0]
+			? `collection ${result.collections[0].collection}`
+			: `${result.collections.length} collections`;
+
+	if (result.status === "complete") {
+		consola.success(`Media usage repair complete for ${scope} (${counts}).`);
+		return;
+	}
+
+	const details = result.collections
+		.filter((collection) => collection.status !== "complete")
+		.map((collection) => {
+			const error = collection.lastErrorCode ? `, ${collection.lastErrorCode}` : "";
+			return `${collection.collection}: ${collection.status}${error}`;
+		})
+		.join("; ");
+	const suffix = details ? ` ${details}.` : "";
+
+	if (result.status === "stale") {
+		consola.warn(
+			`Media usage repair is stale for ${scope}; trustworthy complete coverage was not established. Rerun when writes are quiet (${counts}).${suffix}`,
+		);
+		return;
+	}
+
+	if (result.status === "partial") {
+		consola.warn(
+			`Media usage repair is partial for ${scope}; some sources or collections need attention (${counts}).${suffix}`,
+		);
+		return;
+	}
+
+	consola.warn(`Media usage repair failed for ${scope} (${counts}).${suffix}`);
+}
+
 export const mediaCommand = defineCommand({
 	meta: {
 		name: "media",
@@ -165,5 +259,6 @@ export const mediaCommand = defineCommand({
 		upload: uploadCommand,
 		get: getCommand,
 		delete: deleteCommand,
+		"repair-usage": repairUsageCommand,
 	},
 });

--- a/packages/core/src/cli/commands/media.ts
+++ b/packages/core/src/cli/commands/media.ts
@@ -10,7 +10,7 @@ import { basename } from "node:path";
 import { defineCommand } from "citty";
 import { consola } from "consola";
 
-import type { MediaUsageRepairResponse } from "../../client/index.js";
+import type { MediaUsageRepairInput, MediaUsageRepairResponse } from "../../client/index.js";
 import { connectionArgs, createClientFromArgs } from "../client-factory.js";
 import { configureOutputMode, output } from "../output.js";
 
@@ -161,7 +161,8 @@ const deleteCommand = defineCommand({
 const repairUsageCommand = defineCommand({
 	meta: {
 		name: "repair-usage",
-		description: "Repair content media usage indexes",
+		description:
+			"Repair content media usage indexes. partial/stale exit 0; automation should use --json and parse status.",
 	},
 	args: {
 		...connectionArgs,
@@ -178,9 +179,10 @@ const repairUsageCommand = defineCommand({
 	async run({ args }) {
 		configureOutputMode(args);
 
+		const hasCollectionArg = args.collection !== undefined;
 		const hasCollection = typeof args.collection === "string";
 		const hasAll = args.all === true;
-		if (hasCollection === hasAll) {
+		if ((hasCollectionArg && !hasCollection) || hasCollection === hasAll) {
 			consola.error(repairScopeError);
 			process.exit(1);
 		}
@@ -188,14 +190,15 @@ const repairUsageCommand = defineCommand({
 		const client = createClientFromArgs(args);
 
 		try {
-			const result = await client.mediaRepairUsage(
-				hasCollection ? { scope: "collection", collection: args.collection } : { scope: "all" },
-			);
+			const repairInput: MediaUsageRepairInput = hasCollection
+				? { scope: "collection", collection: args.collection }
+				: { scope: "all" };
+			const result = await client.mediaRepairUsage(repairInput);
 
 			if (args.json || !process.stdout.isTTY) {
 				output(result, args);
 			} else {
-				printRepairUsageSummary(result);
+				printRepairUsageSummary(result, repairInput);
 			}
 
 			if (result.status === "failed") {
@@ -211,16 +214,26 @@ const repairUsageCommand = defineCommand({
 	},
 });
 
-function printRepairUsageSummary(result: MediaUsageRepairResponse): void {
+type RepairUsageSummary = {
+	level: "success" | "warn";
+	message: string;
+};
+
+export function formatRepairUsageSummary(
+	result: MediaUsageRepairResponse,
+	input: MediaUsageRepairInput,
+): RepairUsageSummary {
 	const counts = `indexed ${result.indexedSourceCount}, failed ${result.failedSourceCount}, skipped ${result.skippedSourceCount}, deleted ${result.deletedSourceCount}`;
 	const scope =
-		result.collections.length === 1 && result.collections[0]
-			? `collection ${result.collections[0].collection}`
-			: `${result.collections.length} collections`;
+		input.scope === "collection"
+			? `collection ${input.collection}`
+			: `all content (${formatCollectionCount(result.collections.length)})`;
 
 	if (result.status === "complete") {
-		consola.success(`Media usage repair complete for ${scope} (${counts}).`);
-		return;
+		return {
+			level: "success",
+			message: `Media usage repair complete for ${scope} (${counts}).`,
+		};
 	}
 
 	const details = result.collections
@@ -233,20 +246,39 @@ function printRepairUsageSummary(result: MediaUsageRepairResponse): void {
 	const suffix = details ? ` ${details}.` : "";
 
 	if (result.status === "stale") {
-		consola.warn(
-			`Media usage repair is stale for ${scope}; trustworthy complete coverage was not established. Rerun when writes are quiet (${counts}).${suffix}`,
-		);
-		return;
+		return {
+			level: "warn",
+			message: `Media usage repair is stale for ${scope}; trustworthy complete coverage was not established because another writer, repair, or stale marker won the race. Rerun when writes are quiet (${counts}).${suffix}`,
+		};
 	}
 
 	if (result.status === "partial") {
-		consola.warn(
-			`Media usage repair is partial for ${scope}; some sources or collections need attention (${counts}).${suffix}`,
-		);
-		return;
+		return {
+			level: "warn",
+			message: `Media usage repair is partial for ${scope}; some sources or collections need attention (${counts}).${suffix}`,
+		};
 	}
 
-	consola.warn(`Media usage repair failed for ${scope} (${counts}).${suffix}`);
+	return {
+		level: "warn",
+		message: `Media usage repair failed for ${scope} (${counts}).${suffix}`,
+	};
+}
+
+function printRepairUsageSummary(
+	result: MediaUsageRepairResponse,
+	input: MediaUsageRepairInput,
+): void {
+	const summary = formatRepairUsageSummary(result, input);
+	if (summary.level === "success") {
+		consola.success(summary.message);
+	} else {
+		consola.warn(summary.message);
+	}
+}
+
+function formatCollectionCount(count: number): string {
+	return `${count} collection${count === 1 ? "" : "s"}`;
 }
 
 export const mediaCommand = defineCommand({

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -21,6 +21,7 @@ import {
 	contentSeoInput,
 } from "#api/schemas.js";
 
+import type { MediaUsageRepairRequest } from "../api/schemas/media-usage.js";
 import type { EmDashHandlers } from "../astro/types.js";
 import { hasScope } from "../auth/api-tokens.js";
 import { convertDataForRead, convertDataForWrite } from "../client/portable-text.js";
@@ -75,6 +76,35 @@ const settingsSeoSchema = z.object({
 		.optional()
 		.describe("Bing Webmaster Tools verification token"),
 });
+
+const mediaUsageRepairToolSchema = z
+	.object({
+		scope: z.enum(["collection", "all"]).describe("Repair one collection or all collections"),
+		collection: z
+			.string()
+			.min(1)
+			.max(63)
+			.regex(COLLECTION_SLUG_PATTERN, "Invalid collection slug")
+			.optional()
+			.describe("Collection slug; required only when scope is collection"),
+	})
+	.strict()
+	.superRefine((input, ctx) => {
+		if (input.scope === "collection" && input.collection === undefined) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["collection"],
+				message: "Collection is required when scope is collection",
+			});
+		}
+		if (input.scope === "all" && input.collection !== undefined) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["collection"],
+				message: "Collection must be omitted when scope is all",
+			});
+		}
+	});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1924,6 +1954,42 @@ export function createMcpServer(): McpServer {
 			requireOwnership(extra, authorId, "media:delete_own", "media:delete_any");
 
 			return unwrap(await ec.handleMediaDelete(args.id));
+		},
+	);
+
+	server.registerTool(
+		"media_usage_repair",
+		{
+			title: "Repair Media Usage Index",
+			description:
+				"Repair content media usage indexes for one collection or every collection. " +
+				"Returns complete, partial, failed, or stale status; inspect the structured result.",
+			inputSchema: mediaUsageRepairToolSchema,
+		},
+		async (args, extra) => {
+			requireScope(extra, "admin");
+			requireRole(extra, Role.ADMIN);
+			const ec = getEmDash(extra);
+
+			let input: MediaUsageRepairRequest;
+			if (args.scope === "collection") {
+				if (args.collection === undefined) {
+					return respondError(
+						"VALIDATION_ERROR",
+						"Collection is required when scope is collection",
+					);
+				}
+				input = { scope: "collection", collection: args.collection };
+			} else {
+				input = { scope: "all" };
+			}
+
+			try {
+				const { handleMediaUsageRepair } = await import("../api/handlers/media-usage.js");
+				return unwrap(await handleMediaUsageRepair(ec.db, input));
+			} catch (error) {
+				return respondHandlerError(error, "MEDIA_USAGE_REPAIR_ERROR");
+			}
 		},
 	);
 

--- a/packages/core/tests/integration/cli/cli.test.ts
+++ b/packages/core/tests/integration/cli/cli.test.ts
@@ -331,6 +331,14 @@ describe("CLI Integration", () => {
 			expect(result.indexedSourceCount).toBeGreaterThanOrEqual(0);
 		});
 
+		it("repairs media usage for all collections", async () => {
+			const result = await cliJson<MediaUsageRepairResponse>("media", "repair-usage", "--all");
+
+			expect(result.status).toBe("complete");
+			expect(result.collections.map(({ collection }) => collection)).toEqual(["pages", "posts"]);
+			expect(result.collections.every(({ status }) => status === "complete")).toBe(true);
+		});
+
 		it("uploads, lists, gets, and deletes media", async () => {
 			// Create a temp file to upload
 			const { writeFileSync } = await import("node:fs");

--- a/packages/core/tests/integration/cli/cli.test.ts
+++ b/packages/core/tests/integration/cli/cli.test.ts
@@ -13,6 +13,7 @@ import { promisify } from "node:util";
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
+import type { MediaUsageRepairResponse } from "../../../src/client/index.js";
 import type { TestServerContext } from "../server.js";
 import { assertNodeVersion, createTestServer } from "../server.js";
 
@@ -313,6 +314,23 @@ describe("CLI Integration", () => {
 	// -----------------------------------------------------------------------
 
 	describe("media", () => {
+		it("repairs media usage for a collection", async () => {
+			const result = await cliJson<MediaUsageRepairResponse>(
+				"media",
+				"repair-usage",
+				"--collection",
+				"posts",
+			);
+
+			expect(result.status).toBe("complete");
+			expect(result.collections).toHaveLength(1);
+			expect(result.collections[0]).toMatchObject({
+				collection: "posts",
+				status: "complete",
+			});
+			expect(result.indexedSourceCount).toBeGreaterThanOrEqual(0);
+		});
+
 		it("uploads, lists, gets, and deletes media", async () => {
 			// Create a temp file to upload
 			const { writeFileSync } = await import("node:fs");

--- a/packages/core/tests/integration/cli/media-repair-contract.test.ts
+++ b/packages/core/tests/integration/cli/media-repair-contract.test.ts
@@ -126,15 +126,18 @@ describe("CLI media usage repair contract", () => {
 		["partial", 0],
 		["stale", 0],
 		["failed", 1],
-	] as const)("classifies a structured %s repair result with exit %i", async (status, expectedCode) => {
-		response = repairResponse(status);
+	] as const)(
+		"classifies a structured %s repair result with exit %i",
+		async (status, expectedCode) => {
+			response = repairResponse(status);
 
-		const result = await runCli("media", "repair-usage", "--collection", "posts");
+			const result = await runCli("media", "repair-usage", "--collection", "posts");
 
-		expect(result.code).toBe(expectedCode);
-		expect(result.stdout).toBe(JSON.stringify(response, null, 2) + "\n");
-		expect(JSON.parse(result.stdout)).toEqual(response);
-	});
+			expect(result.code).toBe(expectedCode);
+			expect(result.stdout).toBe(JSON.stringify(response, null, 2) + "\n");
+			expect(JSON.parse(result.stdout)).toEqual(response);
+		},
+	);
 
 	async function runCli(...args: string[]): Promise<CliResult> {
 		const child = spawn(

--- a/packages/core/tests/integration/cli/media-repair-contract.test.ts
+++ b/packages/core/tests/integration/cli/media-repair-contract.test.ts
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { formatRepairUsageSummary } from "../../../src/cli/commands/media.js";
 import type {
 	MediaUsageRepairResponse,
 	MediaUsageRepairStatus,
@@ -93,6 +94,23 @@ describe("CLI media usage repair contract", () => {
 		expect(requests).toEqual([]);
 	});
 
+	it("rejects repeated collection scopes combined with all before calling the client", async () => {
+		const result = await runCli(
+			"media",
+			"repair-usage",
+			"--collection",
+			"posts",
+			"--collection",
+			"pages",
+			"--all",
+		);
+
+		expect(result.code).toBe(1);
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toContain("Specify exactly one of --collection or --all");
+		expect(requests).toEqual([]);
+	});
+
 	it("maps collection scope flags to the media repair client request", async () => {
 		const result = await runCli("media", "repair-usage", "--collection", "posts");
 
@@ -121,6 +139,31 @@ describe("CLI media usage repair contract", () => {
 		});
 	});
 
+	it("uses EMDASH_URL when --url is omitted", async () => {
+		const result = await runCliWithEnv(
+			[
+				CLI_BIN,
+				"media",
+				"repair-usage",
+				"--collection",
+				"posts",
+				"--token",
+				"test-token",
+				"--json",
+			],
+			{ EMDASH_URL: baseUrl },
+		);
+
+		expect(result.code).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual(response);
+		expect(requests).toHaveLength(1);
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: REQUEST_PATH,
+			body: { scope: "collection", collection: "posts" },
+		});
+	});
+
 	it.each([
 		["complete", 0],
 		["partial", 0],
@@ -139,14 +182,55 @@ describe("CLI media usage repair contract", () => {
 		},
 	);
 
-	async function runCli(...args: string[]): Promise<CliResult> {
-		const child = spawn(
-			"node",
-			[CLI_BIN, ...args, "--url", baseUrl, "--token", "test-token", "--json"],
-			{
-				stdio: ["ignore", "pipe", "pipe"],
-			},
+	it("formats all-content repair as all content even with one collection", () => {
+		const summary = formatRepairUsageSummary(repairResponse("complete"), { scope: "all" });
+
+		expect(summary).toEqual({
+			level: "success",
+			message:
+				"Media usage repair complete for all content (1 collection) (indexed 2, failed 0, skipped 0, deleted 0).",
+		});
+	});
+
+	it("formats stale repair with race explanation", () => {
+		const summary = formatRepairUsageSummary(repairResponse("stale"), {
+			scope: "collection",
+			collection: "posts",
+		});
+
+		expect(summary.level).toBe("warn");
+		expect(summary.message).toContain(
+			"because another writer, repair, or stale marker won the race",
 		);
+		expect(summary.message).toContain("posts: stale, CONTENT_USAGE_REPAIR_CONFLICT");
+	});
+
+	it.each([
+		["partial", "some sources or collections need attention", "INVALID_REPEATER_VALIDATION"],
+		["failed", "Media usage repair failed", "COLLECTION_NOT_FOUND"],
+	] as const)("formats %s repair with warning and error details", (status, warning, errorCode) => {
+		const summary = formatRepairUsageSummary(repairResponse(status), {
+			scope: "collection",
+			collection: "posts",
+		});
+
+		expect(summary.level).toBe("warn");
+		expect(summary.message).toContain(warning);
+		expect(summary.message).toContain(`posts: ${status}, ${errorCode}`);
+	});
+
+	async function runCli(...args: string[]): Promise<CliResult> {
+		return runCliWithEnv([CLI_BIN, ...args, "--url", baseUrl, "--token", "test-token", "--json"]);
+	}
+
+	async function runCliWithEnv(
+		args: string[],
+		env: Record<string, string> = {},
+	): Promise<CliResult> {
+		const child = spawn("node", args, {
+			env: { ...process.env, ...env },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
 		let stdout = "";
 		let stderr = "";
 		const timeout = setTimeout(() => child.kill("SIGKILL"), 15_000);

--- a/packages/core/tests/integration/cli/media-repair-contract.test.ts
+++ b/packages/core/tests/integration/cli/media-repair-contract.test.ts
@@ -1,0 +1,207 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { resolve } from "node:path";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+	MediaUsageRepairResponse,
+	MediaUsageRepairStatus,
+} from "../../../src/client/index.js";
+import { ensureBuilt } from "../server.js";
+
+const CLI_BIN = resolve(import.meta.dirname, "../../../dist/cli/index.mjs");
+const REQUEST_PATH = "/_emdash/api/admin/media-usage/repair";
+const STARTED_AT = "2026-07-07T12:00:00.000Z";
+const COMPLETED_AT = "2026-07-07T12:00:01.000Z";
+
+interface CliResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+interface RecordedRequest {
+	method: string;
+	url: string;
+	body: unknown;
+	headers: Record<string, string | string[] | undefined>;
+}
+
+describe("CLI media usage repair contract", () => {
+	let server: Server;
+	let baseUrl: string;
+	let response: MediaUsageRepairResponse;
+	let requests: RecordedRequest[];
+
+	beforeAll(async () => {
+		await ensureBuilt();
+
+		server = createServer(async (req, res) => {
+			const rawBody = await readRequestBody(req);
+			requests.push({
+				method: req.method ?? "GET",
+				url: req.url ?? "",
+				body: rawBody ? JSON.parse(rawBody) : undefined,
+				headers: req.headers,
+			});
+
+			if (req.method !== "POST" || req.url !== REQUEST_PATH) {
+				res.writeHead(404, { "content-type": "application/json" });
+				res.end(JSON.stringify({ error: { code: "NOT_FOUND", message: "Not found" } }));
+				return;
+			}
+
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(JSON.stringify({ data: response }));
+		});
+
+		server.listen(0, "127.0.0.1");
+		await once(server, "listening");
+		const address = server.address() as AddressInfo;
+		baseUrl = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterAll(async () => {
+		if (!server) return;
+		server.close();
+		await once(server, "close");
+	});
+
+	beforeEach(() => {
+		response = repairResponse("complete");
+		requests = [];
+	});
+
+	it("rejects omitted repair scope before calling the client", async () => {
+		const result = await runCli("media", "repair-usage");
+
+		expect(result.code).toBe(1);
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toContain("Specify exactly one of --collection or --all");
+		expect(requests).toEqual([]);
+	});
+
+	it("rejects collection and all repair scopes together before calling the client", async () => {
+		const result = await runCli("media", "repair-usage", "--collection", "posts", "--all");
+
+		expect(result.code).toBe(1);
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toContain("Specify exactly one of --collection or --all");
+		expect(requests).toEqual([]);
+	});
+
+	it("maps collection scope flags to the media repair client request", async () => {
+		const result = await runCli("media", "repair-usage", "--collection", "posts");
+
+		expect(result.code).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual(response);
+		expect(requests).toHaveLength(1);
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: REQUEST_PATH,
+			body: { scope: "collection", collection: "posts" },
+		});
+		expect(requests[0]?.headers["authorization"]).toBe("Bearer test-token");
+		expect(requests[0]?.headers["x-emdash-request"]).toBe("1");
+	});
+
+	it("maps all scope flags to the media repair client request", async () => {
+		const result = await runCli("media", "repair-usage", "--all");
+
+		expect(result.code).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual(response);
+		expect(requests).toHaveLength(1);
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: REQUEST_PATH,
+			body: { scope: "all" },
+		});
+	});
+
+	it.each([
+		["complete", 0],
+		["partial", 0],
+		["stale", 0],
+		["failed", 1],
+	] as const)("classifies a structured %s repair result with exit %i", async (status, expectedCode) => {
+		response = repairResponse(status);
+
+		const result = await runCli("media", "repair-usage", "--collection", "posts");
+
+		expect(result.code).toBe(expectedCode);
+		expect(result.stdout).toBe(JSON.stringify(response, null, 2) + "\n");
+		expect(JSON.parse(result.stdout)).toEqual(response);
+	});
+
+	async function runCli(...args: string[]): Promise<CliResult> {
+		const child = spawn(
+			"node",
+			[CLI_BIN, ...args, "--url", baseUrl, "--token", "test-token", "--json"],
+			{
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		let stdout = "";
+		let stderr = "";
+		const timeout = setTimeout(() => child.kill("SIGKILL"), 15_000);
+
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+
+		const [code] = (await once(child, "close")) as [number | null, NodeJS.Signals | null];
+		clearTimeout(timeout);
+
+		return { code: code ?? 1, stdout, stderr };
+	}
+});
+
+function repairResponse(status: MediaUsageRepairStatus): MediaUsageRepairResponse {
+	const lastErrorCode =
+		status === "complete"
+			? null
+			: status === "partial"
+				? "INVALID_REPEATER_VALIDATION"
+				: status === "stale"
+					? "CONTENT_USAGE_REPAIR_CONFLICT"
+					: "COLLECTION_NOT_FOUND";
+	const indexedSourceCount = status === "failed" ? 0 : 2;
+	const failedSourceCount = status === "partial" || status === "failed" ? 1 : 0;
+	const skippedSourceCount = status === "stale" ? 1 : 0;
+	const completedAt = status === "stale" ? null : COMPLETED_AT;
+
+	return {
+		status,
+		indexedSourceCount,
+		failedSourceCount,
+		skippedSourceCount,
+		deletedSourceCount: 0,
+		collections: [
+			{
+				collection: "posts",
+				status,
+				indexedSourceCount,
+				failedSourceCount,
+				skippedSourceCount,
+				deletedSourceCount: 0,
+				lastErrorCode,
+				startedAt: STARTED_AT,
+				completedAt,
+			},
+		],
+	};
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+	let body = "";
+	for await (const chunk of req) {
+		body += String(chunk);
+	}
+	return body;
+}

--- a/packages/core/tests/integration/global-setup.ts
+++ b/packages/core/tests/integration/global-setup.ts
@@ -1,0 +1,15 @@
+import { execFile } from "node:child_process";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execAsync = promisify(execFile);
+const WORKSPACE_ROOT = resolve(import.meta.dirname, "../../../..");
+
+export default async function setupIntegrationBuild(): Promise<void> {
+	console.log("[integration] Running pnpm build...");
+	await execAsync("pnpm", ["build"], {
+		cwd: WORKSPACE_ROOT,
+		timeout: 120_000,
+	});
+	console.log("[integration] Build complete.");
+}

--- a/packages/core/tests/integration/mcp/media-usage-repair.test.ts
+++ b/packages/core/tests/integration/mcp/media-usage-repair.test.ts
@@ -1,0 +1,158 @@
+import { Role } from "@emdash-cms/auth";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { MediaUsageRepairResponse } from "../../../src/api/schemas/media-usage.js";
+import type { Database } from "../../../src/database/types.js";
+import {
+	connectMcpHarness,
+	extractJson,
+	extractText,
+	type McpHarness,
+} from "../../utils/mcp-runtime.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+const ADMIN_ID = "user_admin";
+
+describe("media_usage_repair", () => {
+	let db: Kysely<Database>;
+	let harness: McpHarness | undefined;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+	});
+
+	afterEach(async () => {
+		await harness?.cleanup();
+		await teardownTestDatabase(db);
+	});
+
+	it("advertises scope and collection in its input schema", async () => {
+		harness = await connectAdminHarness(db);
+
+		const { tools } = await harness.client.listTools();
+		const tool = tools.find(({ name }) => name === "media_usage_repair");
+
+		expect(tool).toBeDefined();
+		expect(tool?.inputSchema).toMatchObject({
+			type: "object",
+			properties: {
+				scope: expect.any(Object),
+				collection: expect.any(Object),
+			},
+			required: expect.arrayContaining(["scope"]),
+		});
+	});
+
+	it("repairs one collection", async () => {
+		harness = await connectAdminHarness(db);
+
+		const result = await harness.client.callTool({
+			name: "media_usage_repair",
+			arguments: { scope: "collection", collection: "post" },
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const response = extractJson<MediaUsageRepairResponse>(result);
+		expect(response.status).toBe("complete");
+		expect(response.collections).toHaveLength(1);
+		expect(response.collections[0]).toMatchObject({ collection: "post", status: "complete" });
+	});
+
+	it("repairs all collections in deterministic order", async () => {
+		harness = await connectAdminHarness(db);
+
+		const result = await harness.client.callTool({
+			name: "media_usage_repair",
+			arguments: { scope: "all" },
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const response = extractJson<MediaUsageRepairResponse>(result);
+		expect(response.status).toBe("complete");
+		expect(response.collections.map(({ collection }) => collection)).toEqual(["page", "post"]);
+	});
+
+	it("returns an unknown collection as a structured failed repair", async () => {
+		harness = await connectAdminHarness(db);
+
+		const result = await harness.client.callTool({
+			name: "media_usage_repair",
+			arguments: { scope: "collection", collection: "missing" },
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const response = extractJson<MediaUsageRepairResponse>(result);
+		expect(response.status).toBe("failed");
+		expect(response.collections).toEqual([
+			expect.objectContaining({
+				collection: "missing",
+				status: "failed",
+				lastErrorCode: "COLLECTION_NOT_FOUND",
+			}),
+		]);
+	});
+
+	it("requires the admin token scope", async () => {
+		harness = await connectMcpHarness({
+			db,
+			userId: ADMIN_ID,
+			userRole: Role.ADMIN,
+			tokenScopes: ["media:write"],
+		});
+
+		const result = await harness.client.callTool({
+			name: "media_usage_repair",
+			arguments: { scope: "all" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect((result as { _meta?: { code?: string } })._meta?.code).toBe("INSUFFICIENT_SCOPE");
+	});
+
+	it("requires the Admin role", async () => {
+		harness = await connectMcpHarness({
+			db,
+			userId: "user_editor",
+			userRole: Role.EDITOR,
+			tokenScopes: ["admin"],
+		});
+
+		const result = await harness.client.callTool({
+			name: "media_usage_repair",
+			arguments: { scope: "all" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect((result as { _meta?: { code?: string } })._meta?.code).toBe("INSUFFICIENT_PERMISSIONS");
+	});
+
+	it.each([
+		["missing scope", {}],
+		["missing collection", { scope: "collection" }],
+		["collection supplied for all scope", { scope: "all", collection: "post" }],
+		["uppercase collection", { scope: "collection", collection: "Post" }],
+		["hyphenated collection", { scope: "collection", collection: "blog-post" }],
+		["empty collection", { scope: "collection", collection: "" }],
+		["collection longer than 63 characters", { scope: "collection", collection: "a".repeat(64) }],
+		["unknown property", { scope: "all", force: true }],
+	] as const)("rejects %s at the tool boundary", async (_case, args) => {
+		harness = await connectAdminHarness(db);
+
+		const result = await harness.client.callTool({
+			name: "media_usage_repair",
+			arguments: args,
+		});
+
+		expect(result.isError).toBe(true);
+	});
+});
+
+function connectAdminHarness(db: Kysely<Database>): Promise<McpHarness> {
+	return connectMcpHarness({
+		db,
+		userId: ADMIN_ID,
+		userRole: Role.ADMIN,
+		tokenScopes: ["admin"],
+	});
+}

--- a/packages/core/tests/integration/server.ts
+++ b/packages/core/tests/integration/server.ts
@@ -15,14 +15,11 @@
  *   await ctx.cleanup();
  */
 
-import { execFile, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { promisify } from "node:util";
 
 import { EmDashClient } from "../../src/client/index.js";
-
-const execAsync = promisify(execFile);
 
 // Test regex patterns
 const SESSION_COOKIE_REGEX = /^([^;]+)/;
@@ -97,32 +94,15 @@ export function assertNodeVersion(): void {
 // Build guard
 // ---------------------------------------------------------------------------
 
-const WORKSPACE_ROOT = resolve(import.meta.dirname, "../../../..");
 const CLI_BINARY = resolve(import.meta.dirname, "../../dist/cli/index.mjs");
 
-let buildPromise: Promise<void> | null = null;
-
 /**
- * Ensure the workspace is built before starting integration tests.
- * Runs `pnpm build` once (cached across test suites via module-level promise).
- * Skips if the CLI binary already exists.
+ * Assert the integration global setup produced the CLI binary.
  */
-export function ensureBuilt(): Promise<void> {
-	if (!buildPromise) {
-		buildPromise = doBuild();
+export async function ensureBuilt(): Promise<void> {
+	if (!existsSync(CLI_BINARY)) {
+		throw new Error("CLI binary missing after integration global setup");
 	}
-	return buildPromise;
-}
-
-async function doBuild(): Promise<void> {
-	if (existsSync(CLI_BINARY)) return;
-
-	console.log("[integration] Built artifacts missing — running pnpm build...");
-	await execAsync("pnpm", ["build"], {
-		cwd: WORKSPACE_ROOT,
-		timeout: 120_000,
-	});
-	console.log("[integration] Build complete.");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/vitest.integration.config.ts
+++ b/packages/core/vitest.integration.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		include: ["tests/integration/cli/**/*.test.ts", "tests/integration/client/**/*.test.ts"],
+		globalSetup: ["tests/integration/global-setup.ts"],
 		// These tests boot real Astro dev servers in beforeAll hooks.
 		// Default hookTimeout (10s) is too short -- server startup +
 		// migrations + seed can take 30-60s.

--- a/packages/core/vitest.smoke.config.ts
+++ b/packages/core/vitest.smoke.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		include: ["tests/integration/smoke/**/*.test.ts"],
+		globalSetup: ["tests/integration/global-setup.ts"],
 		// Smoke tests boot real Astro dev servers in beforeAll hooks.
 		// Default hookTimeout (10s) is too short -- server startup +
 		// migrations + seed can take 30-60s, especially on first run


### PR DESCRIPTION
## What does this PR do?

Adds operator-facing media usage index repair through the CLI and MCP server. Both interfaces support repairing one collection or every collection, reuse the existing repair contracts, preserve structured complete/partial/failed/stale results, and require the appropriate administrative authorization.

Includes CLI and MCP contract coverage, operator documentation, and integration-test setup that builds the workspace once per test run.

In this PR, the operators use this CLI/MCP repair tooling after imports or direct database writes; it makes the media usage index maintainable, with read APIs and the Media Library “Used in” UI still to come.

Related Discussion: https://github.com/emdash-cms/emdash/discussions/1503

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no admin UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1503

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode (GPT-5.6 Sol)
## Screenshots / test output

No visual changes.

- `pnpm typecheck`
- `pnpm lint`
- Core suite: 4,719 passed, 3 skipped
- CLI repair contract: 14 passed
- MCP repair contract: 14 passed
- MCP error/authorization suite: 14 passed