### PR TITLE
feat(labeler): mutation guard and operator action audit (W9.2)

### DIFF
--- a/apps/labeler/migrations/0004_operator_actions.sql
+++ b/apps/labeler/migrations/0004_operator_actions.sql
@@ -1,0 +1,49 @@
+-- Immutable operator-action audit log (spec §12/§14.4/§22): one append-only
+-- row per state-changing operator mutation, written atomically with the
+-- mutation's effect by `commitMutation`. Distinct from `issuance_actions`
+-- (the signing-layer record, keyed by the labeler DID): this answers "which
+-- operator did what, under which role, why" — including actions that issue no
+-- label at all (rerun, pause/resume, DLQ controls). `id` is the
+-- `operatorTriggerId` anchor a rerun (§7) attaches to.
+--
+-- Timestamp columns that queries order on gain an integer `*_epoch_ms`
+-- sibling, matching 0003 (RFC 3339 strings compare incorrectly across
+-- timezone offsets in SQL).
+
+CREATE TABLE operator_actions (
+	id TEXT PRIMARY KEY,
+	actor_type TEXT NOT NULL CHECK (actor_type IN ('human', 'service')),
+	actor_id TEXT NOT NULL,
+	actor_email TEXT,
+	actor_common_name TEXT,
+	role TEXT NOT NULL CHECK (role IN ('admin', 'reviewer')),
+	action TEXT NOT NULL,
+	subject_uri TEXT,
+	subject_cid TEXT,
+	label_value TEXT,
+	reason TEXT NOT NULL,
+	idempotency_key TEXT NOT NULL UNIQUE,
+	request_fingerprint TEXT NOT NULL,
+	result_json TEXT,
+	metadata_json TEXT NOT NULL DEFAULT '{}',
+	created_at TEXT NOT NULL,
+	created_at_epoch_ms INTEGER NOT NULL
+);
+
+CREATE TRIGGER operator_actions_immutable_update
+BEFORE UPDATE ON operator_actions
+BEGIN
+	SELECT RAISE(ABORT, 'operator actions are immutable');
+END;
+
+CREATE TRIGGER operator_actions_immutable_delete
+BEFORE DELETE ON operator_actions
+BEGIN
+	SELECT RAISE(ABORT, 'operator actions are immutable');
+END;
+
+CREATE INDEX idx_operator_actions_created ON operator_actions(created_at_epoch_ms DESC);
+CREATE INDEX idx_operator_actions_subject
+	ON operator_actions(subject_uri, subject_cid, created_at_epoch_ms DESC);
+CREATE INDEX idx_operator_actions_actor
+	ON operator_actions(actor_id, created_at_epoch_ms DESC);

--- a/apps/labeler/src/mutation-guard.ts
+++ b/apps/labeler/src/mutation-guard.ts
@@ -1,0 +1,305 @@
+import { ulid } from "ulidx";
+
+import {
+	AccessAuthError,
+	hasRole,
+	verifyAccessRequest,
+	type AccessAuthConfig,
+	type AccessKeyResolver,
+	type OperatorIdentity,
+	type OperatorRole,
+} from "./access-auth.js";
+import {
+	buildOperatorActionInsert,
+	computeRequestFingerprint,
+	getOperatorActionByKey,
+	isIdempotencyKeyConflict,
+	type OperatorActionType,
+} from "./operator-actions.js";
+
+export { type OperatorActionType } from "./operator-actions.js";
+
+/** Custom header (reusing emdash-core's convention) whose presence proves a
+ * non-simple request the browser could only send same-origin. Value must be "1". */
+export const OPERATOR_REQUEST_HEADER = "X-EmDash-Request";
+
+const REASON_MAX_LENGTH = 1_000;
+const IDEMPOTENCY_KEY = /^[A-Za-z0-9._:-]{8,200}$/;
+const QUOTED_VALUE = /^"(.*)"$/;
+
+export type MutationGuardCode =
+	| "UNSUPPORTED_MEDIA_TYPE"
+	| "CROSS_ORIGIN"
+	| "CSRF_HEADER_MISSING"
+	| "UNAUTHENTICATED"
+	| "FORBIDDEN_ROLE"
+	| "INVALID_BODY"
+	| "IDEMPOTENCY_KEY_CONFLICT";
+
+const GUARD_ERROR: Readonly<Record<MutationGuardCode, { status: number; message: string }>> = {
+	UNSUPPORTED_MEDIA_TYPE: { status: 415, message: "Request must be application/json" },
+	CROSS_ORIGIN: { status: 403, message: "Cross-origin request rejected" },
+	CSRF_HEADER_MISSING: { status: 403, message: "Missing required request header" },
+	UNAUTHENTICATED: { status: 401, message: "Operator authentication required" },
+	FORBIDDEN_ROLE: { status: 403, message: "Insufficient role for this action" },
+	INVALID_BODY: { status: 400, message: "Request body is invalid" },
+	IDEMPOTENCY_KEY_CONFLICT: {
+		status: 409,
+		message: "Idempotency key already used for a different request",
+	},
+};
+
+/**
+ * Guard rejection. Messages are static per code — they never echo the token,
+ * request body, or header values, so `toResponse` cannot leak attacker- or
+ * operator-supplied content.
+ */
+export class MutationGuardError extends Error {
+	override readonly name = "MutationGuardError";
+	readonly code: MutationGuardCode;
+	readonly status: number;
+
+	constructor(code: MutationGuardCode) {
+		const { status, message } = GUARD_ERROR[code];
+		super(message);
+		this.code = code;
+		this.status = status;
+	}
+
+	toResponse(): Response {
+		// Same wire shape as core's apiError: { error: { code, message } }.
+		return Response.json(
+			{ error: { code: this.code, message: this.message } },
+			{ status: this.status },
+		);
+	}
+}
+
+export interface MutationGuardDeps {
+	db: D1Database;
+	config: AccessAuthConfig;
+	keys: AccessKeyResolver;
+	now: () => Date;
+	/** Defaults to the request URL's origin; override for proxy edge cases. */
+	expectedOrigin?: string;
+}
+
+export interface MutationSpec<TBody> {
+	action: OperatorActionType;
+	requiredRole: OperatorRole;
+	/** Validates and normalizes endpoint fields; throws
+	 * `MutationGuardError("INVALID_BODY")` on bad input. `reason` and
+	 * `idempotencyKey` are validated by the guard, not here. */
+	parseBody: (raw: Record<string, unknown>) => TBody;
+	auditFields: (body: TBody) => {
+		subjectUri?: string;
+		subjectCid?: string;
+		labelValue?: string;
+		metadata?: Record<string, unknown>;
+	};
+}
+
+export interface MutationContext<TBody> {
+	identity: OperatorIdentity;
+	/** The role the actor actually held to satisfy the requirement: `requiredRole`
+	 * when held directly, otherwise `admin` via inheritance. */
+	role: OperatorRole;
+	body: TBody;
+	reason: string;
+	idempotencyKey: string;
+	fingerprint: string;
+	/** Pre-minted; becomes `operator_actions.id` and the `operatorTriggerId` anchor. */
+	actionId: string;
+	now: Date;
+}
+
+export type MutationOutcome<TBody> =
+	| { outcome: "proceed"; ctx: MutationContext<TBody> }
+	/** Prior action found; the route returns `result` as-is. Carries only the
+	 * stored result and its id — never the audit record's `reason` or fingerprint. */
+	| { outcome: "replay"; result: unknown; actionId: string };
+
+/**
+ * The seven mutation protections (spec §12), run in a fail-fast order that
+ * puts cheap transport/CSRF checks before signature verification: content
+ * type, same-origin, CSRF header, freshly verified Access identity, role,
+ * body/reason/idempotency-key validation, then the idempotency lookup. A
+ * matching prior action short-circuits to `replay`; otherwise the caller runs
+ * its effect and commits through `commitMutation`.
+ */
+export async function guardMutation<TBody>(
+	request: Request,
+	spec: MutationSpec<TBody>,
+	deps: MutationGuardDeps,
+): Promise<MutationOutcome<TBody>> {
+	assertJsonContentType(request);
+	assertSameOrigin(request, deps.expectedOrigin ?? new URL(request.url).origin);
+	assertCsrfHeader(request);
+
+	let identity: OperatorIdentity;
+	try {
+		identity = await verifyAccessRequest(request, deps.config, deps.keys);
+	} catch (error) {
+		if (error instanceof AccessAuthError) throw new MutationGuardError("UNAUTHENTICATED");
+		throw error;
+	}
+
+	if (!hasRole(identity, spec.requiredRole)) throw new MutationGuardError("FORBIDDEN_ROLE");
+	// The role the actor actually held to pass the check, for the audit row: the
+	// requirement when held directly, otherwise `admin` — inheritance (admin
+	// satisfying a reviewer gate) is the only other way `hasRole` returns true.
+	const authorizedRole: OperatorRole = identity.roles.includes(spec.requiredRole)
+		? spec.requiredRole
+		: "admin";
+
+	const raw = await parseJsonBody(request);
+	const reason = validateReason(raw.reason);
+	const idempotencyKey = validateIdempotencyKey(raw.idempotencyKey);
+	const body = spec.parseBody(raw);
+
+	const fingerprint = await computeRequestFingerprint(
+		spec.action,
+		isRecord(body) ? { ...body, reason } : { reason },
+	);
+	const existing = await getOperatorActionByKey(deps.db, idempotencyKey);
+	if (existing) {
+		if (existing.requestFingerprint !== fingerprint)
+			throw new MutationGuardError("IDEMPOTENCY_KEY_CONFLICT");
+		return {
+			outcome: "replay",
+			result: existing.resultJson === null ? null : JSON.parse(existing.resultJson),
+			actionId: existing.id,
+		};
+	}
+
+	return {
+		outcome: "proceed",
+		ctx: {
+			identity,
+			role: authorizedRole,
+			body,
+			reason,
+			idempotencyKey,
+			fingerprint,
+			actionId: `oact_${ulid()}`,
+			now: deps.now(),
+		},
+	};
+}
+
+/**
+ * Atomically commits the audit row and its effect in a single `db.batch`. The
+ * audit insert is a plain INSERT, so a duplicate `idempotency_key` raises a
+ * UNIQUE violation that aborts the whole batch — the effect statements roll back
+ * with it, meaning a request that loses the key race can never commit a side
+ * effect (regardless of whether the effect is itself idempotent). On that
+ * conflict we read the winning row back: a matching fingerprint means an
+ * identical request already committed, so we return its stored result (replay);
+ * a differing fingerprint is genuine key reuse → `IDEMPOTENCY_KEY_CONFLICT`.
+ * This is the only sanctioned commit path, so an effect can never land without
+ * its audit row.
+ */
+export async function commitMutation<TBody, TResult>(
+	db: D1Database,
+	ctx: MutationContext<TBody>,
+	spec: MutationSpec<TBody>,
+	effect: readonly D1PreparedStatement[],
+	result: TResult,
+): Promise<TResult> {
+	const audit = spec.auditFields(ctx.body);
+	const insert = buildOperatorActionInsert(db, {
+		id: ctx.actionId,
+		actorType: ctx.identity.kind,
+		actorId: ctx.identity.sub,
+		actorEmail: ctx.identity.kind === "human" ? ctx.identity.email : null,
+		actorCommonName: ctx.identity.kind === "service" ? ctx.identity.commonName : null,
+		role: ctx.role,
+		action: spec.action,
+		subjectUri: audit.subjectUri ?? null,
+		subjectCid: audit.subjectCid ?? null,
+		labelValue: audit.labelValue ?? null,
+		reason: ctx.reason,
+		idempotencyKey: ctx.idempotencyKey,
+		requestFingerprint: ctx.fingerprint,
+		resultJson: JSON.stringify(result),
+		metadataJson: JSON.stringify(audit.metadata ?? {}),
+		createdAt: ctx.now.toISOString(),
+		createdAtEpochMs: ctx.now.getTime(),
+	});
+
+	try {
+		await db.batch([insert, ...effect]);
+	} catch (error) {
+		if (!isIdempotencyKeyConflict(error)) throw error;
+		// Our audit insert hit the unique key, so the batch — including our effect
+		// — rolled back. A concurrent or prior request with this key won; read it
+		// back to replay its result or report a genuine content conflict.
+		const stored = await getOperatorActionByKey(db, ctx.idempotencyKey);
+		if (!stored) throw error;
+		if (stored.requestFingerprint !== ctx.fingerprint)
+			throw new MutationGuardError("IDEMPOTENCY_KEY_CONFLICT");
+		if (stored.resultJson === null) return result;
+		const winnerResult: TResult = JSON.parse(stored.resultJson);
+		return winnerResult;
+	}
+
+	return result;
+}
+
+function assertJsonContentType(request: Request): void {
+	const header = request.headers.get("Content-Type");
+	if (header === null) throw new MutationGuardError("UNSUPPORTED_MEDIA_TYPE");
+	const [rawMedia, ...params] = header.split(";");
+	if ((rawMedia ?? "").trim().toLowerCase() !== "application/json")
+		throw new MutationGuardError("UNSUPPORTED_MEDIA_TYPE");
+	for (const param of params) {
+		const eq = param.indexOf("=");
+		if (eq === -1) continue;
+		if (param.slice(0, eq).trim().toLowerCase() !== "charset") continue;
+		const charset = param
+			.slice(eq + 1)
+			.trim()
+			.toLowerCase()
+			.replace(QUOTED_VALUE, "$1");
+		if (charset !== "utf-8") throw new MutationGuardError("UNSUPPORTED_MEDIA_TYPE");
+	}
+}
+
+function assertSameOrigin(request: Request, expectedOrigin: string): void {
+	const origin = request.headers.get("Origin");
+	if (origin !== null && origin !== expectedOrigin) throw new MutationGuardError("CROSS_ORIGIN");
+	const site = request.headers.get("Sec-Fetch-Site");
+	if (site !== null && site !== "same-origin") throw new MutationGuardError("CROSS_ORIGIN");
+}
+
+function assertCsrfHeader(request: Request): void {
+	if (request.headers.get(OPERATOR_REQUEST_HEADER) !== "1")
+		throw new MutationGuardError("CSRF_HEADER_MISSING");
+}
+
+async function parseJsonBody(request: Request): Promise<Record<string, unknown>> {
+	let parsed: unknown;
+	try {
+		parsed = await request.json();
+	} catch {
+		throw new MutationGuardError("INVALID_BODY");
+	}
+	if (!isRecord(parsed) || Array.isArray(parsed)) throw new MutationGuardError("INVALID_BODY");
+	return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function validateReason(value: unknown): string {
+	if (typeof value !== "string" || value.trim().length === 0 || value.length > REASON_MAX_LENGTH)
+		throw new MutationGuardError("INVALID_BODY");
+	return value;
+}
+
+function validateIdempotencyKey(value: unknown): string {
+	if (typeof value !== "string" || !IDEMPOTENCY_KEY.test(value))
+		throw new MutationGuardError("INVALID_BODY");
+	return value;
+}

--- a/apps/labeler/src/mutation-guard.ts
+++ b/apps/labeler/src/mutation-guard.ts
@@ -167,7 +167,9 @@ export async function guardMutation<TBody>(
 			throw new MutationGuardError("IDEMPOTENCY_KEY_CONFLICT");
 		return {
 			outcome: "replay",
-			result: existing.resultJson === null ? null : JSON.parse(existing.resultJson),
+			// A NULL stored result_json is the serialization of `undefined`; surface
+			// that stored value so a replay matches the original response exactly.
+			result: existing.resultJson === null ? undefined : JSON.parse(existing.resultJson),
 			actionId: existing.id,
 		};
 	}
@@ -207,6 +209,9 @@ export async function commitMutation<TBody, TResult>(
 	result: TResult,
 ): Promise<TResult> {
 	const audit = spec.auditFields(ctx.body);
+	// `JSON.stringify(undefined)` is `undefined`, which D1 refuses to bind; store
+	// it as SQL NULL. The read-back paths deserialize NULL back to `undefined`.
+	const resultJson: string | undefined = JSON.stringify(result);
 	const insert = buildOperatorActionInsert(db, {
 		id: ctx.actionId,
 		actorType: ctx.identity.kind,
@@ -221,7 +226,7 @@ export async function commitMutation<TBody, TResult>(
 		reason: ctx.reason,
 		idempotencyKey: ctx.idempotencyKey,
 		requestFingerprint: ctx.fingerprint,
-		resultJson: JSON.stringify(result),
+		resultJson: resultJson ?? null,
 		metadataJson: JSON.stringify(audit.metadata ?? {}),
 		createdAt: ctx.now.toISOString(),
 		createdAtEpochMs: ctx.now.getTime(),
@@ -238,8 +243,11 @@ export async function commitMutation<TBody, TResult>(
 		if (!stored) throw error;
 		if (stored.requestFingerprint !== ctx.fingerprint)
 			throw new MutationGuardError("IDEMPOTENCY_KEY_CONFLICT");
-		if (stored.resultJson === null) return result;
-		const winnerResult: TResult = JSON.parse(stored.resultJson);
+		// Return the winner's STORED result, never our own. A NULL stored
+		// result_json is the serialization of `undefined`, so it deserializes back
+		// to `undefined` — two identical requests must not observably disagree.
+		const winnerResult: TResult =
+			stored.resultJson === null ? undefined : JSON.parse(stored.resultJson);
 		return winnerResult;
 	}
 
@@ -252,16 +260,23 @@ function assertJsonContentType(request: Request): void {
 	const [rawMedia, ...params] = header.split(";");
 	if ((rawMedia ?? "").trim().toLowerCase() !== "application/json")
 		throw new MutationGuardError("UNSUPPORTED_MEDIA_TYPE");
+	// The only parameter permitted is a single `charset=utf-8` (case-insensitive,
+	// optionally quoted). Any other parameter name, a malformed parameter, or a
+	// repeated charset is rejected — a bare trailing `;` carries no parameter.
+	let seenCharset = false;
 	for (const param of params) {
+		if (param.trim() === "") continue;
 		const eq = param.indexOf("=");
-		if (eq === -1) continue;
-		if (param.slice(0, eq).trim().toLowerCase() !== "charset") continue;
+		if (eq === -1) throw new MutationGuardError("UNSUPPORTED_MEDIA_TYPE");
+		if (param.slice(0, eq).trim().toLowerCase() !== "charset" || seenCharset)
+			throw new MutationGuardError("UNSUPPORTED_MEDIA_TYPE");
 		const charset = param
 			.slice(eq + 1)
 			.trim()
 			.toLowerCase()
 			.replace(QUOTED_VALUE, "$1");
 		if (charset !== "utf-8") throw new MutationGuardError("UNSUPPORTED_MEDIA_TYPE");
+		seenCharset = true;
 	}
 }
 

--- a/apps/labeler/src/operator-actions.ts
+++ b/apps/labeler/src/operator-actions.ts
@@ -1,0 +1,207 @@
+import type { OperatorRole } from "./access-auth.js";
+
+/**
+ * The operator-action vocabulary, grown by W9.4–W9.6. Validated in app code
+ * (the guard is the only writer), so the `operator_actions.action` column
+ * carries no SQL CHECK and each workstream stays purely additive.
+ */
+export type OperatorActionType =
+	| "label-issue"
+	| "label-retract"
+	| "assessment-rerun"
+	| "unblock-override"
+	| "override-retract"
+	| "takedown"
+	| "publisher-compromised"
+	| "pause-issuance"
+	| "resume-issuance"
+	| "dlq-retry"
+	| "dlq-quarantine";
+
+export interface StoredOperatorAction {
+	id: string;
+	actorType: "human" | "service";
+	actorId: string;
+	actorEmail: string | null;
+	actorCommonName: string | null;
+	role: OperatorRole;
+	action: string;
+	subjectUri: string | null;
+	subjectCid: string | null;
+	labelValue: string | null;
+	reason: string;
+	idempotencyKey: string;
+	requestFingerprint: string;
+	resultJson: string | null;
+	metadataJson: string;
+	createdAt: string;
+	createdAtEpochMs: number;
+}
+
+interface OperatorActionRow {
+	id: string;
+	actor_type: "human" | "service";
+	actor_id: string;
+	actor_email: string | null;
+	actor_common_name: string | null;
+	role: OperatorRole;
+	action: string;
+	subject_uri: string | null;
+	subject_cid: string | null;
+	label_value: string | null;
+	reason: string;
+	idempotency_key: string;
+	request_fingerprint: string;
+	result_json: string | null;
+	metadata_json: string;
+	created_at: string;
+	created_at_epoch_ms: number;
+}
+
+export interface OperatorActionInsert {
+	id: string;
+	actorType: "human" | "service";
+	actorId: string;
+	actorEmail: string | null;
+	actorCommonName: string | null;
+	role: OperatorRole;
+	action: OperatorActionType;
+	subjectUri: string | null;
+	subjectCid: string | null;
+	labelValue: string | null;
+	reason: string;
+	idempotencyKey: string;
+	requestFingerprint: string;
+	resultJson: string | null;
+	metadataJson: string;
+	createdAt: string;
+	createdAtEpochMs: number;
+}
+
+/**
+ * Insert for one audit row. A duplicate `idempotency_key` raises a UNIQUE
+ * violation that aborts the enclosing `db.batch`, rolling its effect statements
+ * back with it — so a request that loses the key race cannot commit a side
+ * effect. `commitMutation` catches that violation (see `isIdempotencyKeyConflict`)
+ * and reads the winning row back to resolve replay vs conflict. Batched with its
+ * effect statements; never run alone.
+ */
+export function buildOperatorActionInsert(
+	db: D1Database,
+	input: OperatorActionInsert,
+): D1PreparedStatement {
+	return db
+		.prepare(
+			`INSERT INTO operator_actions
+			 (id, actor_type, actor_id, actor_email, actor_common_name, role, action,
+			  subject_uri, subject_cid, label_value, reason, idempotency_key,
+			  request_fingerprint, result_json, metadata_json, created_at, created_at_epoch_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			input.id,
+			input.actorType,
+			input.actorId,
+			input.actorEmail,
+			input.actorCommonName,
+			input.role,
+			input.action,
+			input.subjectUri,
+			input.subjectCid,
+			input.labelValue,
+			input.reason,
+			input.idempotencyKey,
+			input.requestFingerprint,
+			input.resultJson,
+			input.metadataJson,
+			input.createdAt,
+			input.createdAtEpochMs,
+		);
+}
+
+export async function getOperatorActionByKey(
+	db: D1Database,
+	idempotencyKey: string,
+): Promise<StoredOperatorAction | null> {
+	const row = await db
+		.prepare(
+			`SELECT id, actor_type, actor_id, actor_email, actor_common_name, role, action,
+			 subject_uri, subject_cid, label_value, reason, idempotency_key,
+			 request_fingerprint, result_json, metadata_json, created_at, created_at_epoch_ms
+			 FROM operator_actions WHERE idempotency_key = ?`,
+		)
+		.bind(idempotencyKey)
+		.first<OperatorActionRow>();
+	return row ? rowToStoredOperatorAction(row) : null;
+}
+
+/**
+ * True when `error` is the D1 UNIQUE violation on `operator_actions.idempotency_key`.
+ * Matches the qualified column so it does not catch the `id` primary-key conflict
+ * or any other constraint — `commitMutation` uses it to tell a duplicate-key race
+ * (recoverable via read-back) apart from a genuine failure it must rethrow.
+ */
+export function isIdempotencyKeyConflict(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		error.message.includes("UNIQUE constraint failed: operator_actions.idempotency_key")
+	);
+}
+
+/**
+ * Request fingerprint: SHA-256 hex over canonical JSON (recursively sorted
+ * object keys) of `{ action, ...normalizedBody }` with `idempotencyKey`
+ * removed. Two requests replaying the same idempotency key must produce the
+ * same fingerprint; any material difference (reason, subject, label, endpoint
+ * fields) yields a different one and the guard reports a conflict.
+ */
+export async function computeRequestFingerprint(
+	action: OperatorActionType,
+	normalizedBody: Record<string, unknown>,
+): Promise<string> {
+	const material: Record<string, unknown> = { action };
+	for (const [key, value] of Object.entries(normalizedBody)) {
+		if (key === "idempotencyKey") continue;
+		material[key] = value;
+	}
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(canonicalize(material)),
+	);
+	return toHex(new Uint8Array(digest));
+}
+
+function canonicalize(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+	if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+	const entries = Object.entries(value)
+		.filter(([, v]) => v !== undefined)
+		.toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+	return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`;
+}
+
+function toHex(bytes: Uint8Array): string {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function rowToStoredOperatorAction(row: OperatorActionRow): StoredOperatorAction {
+	return {
+		id: row.id,
+		actorType: row.actor_type,
+		actorId: row.actor_id,
+		actorEmail: row.actor_email,
+		actorCommonName: row.actor_common_name,
+		role: row.role,
+		action: row.action,
+		subjectUri: row.subject_uri,
+		subjectCid: row.subject_cid,
+		labelValue: row.label_value,
+		reason: row.reason,
+		idempotencyKey: row.idempotency_key,
+		requestFingerprint: row.request_fingerprint,
+		resultJson: row.result_json,
+		metadataJson: row.metadata_json,
+		createdAt: row.created_at,
+		createdAtEpochMs: row.created_at_epoch_ms,
+	};
+}

--- a/apps/labeler/test/mutation-guard.test.ts
+++ b/apps/labeler/test/mutation-guard.test.ts
@@ -1,0 +1,658 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { AccessAuthConfig, AccessKeyResolver } from "../src/access-auth.js";
+import {
+	commitMutation,
+	guardMutation,
+	MutationGuardError,
+	OPERATOR_REQUEST_HEADER,
+	type MutationGuardCode,
+	type MutationGuardDeps,
+	type MutationSpec,
+} from "../src/mutation-guard.js";
+import { getOperatorActionByKey } from "../src/operator-actions.js";
+
+const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
+const AUDIENCE = "test-audience";
+const ORIGIN = "https://labeler.example.com";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+
+let signKey: CryptoKey;
+let resolver: AccessKeyResolver;
+let adminToken: string;
+let reviewerToken: string;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+	const pair = await generateKeyPair("RS256");
+	signKey = pair.privateKey;
+	resolver = (async () => pair.publicKey) as AccessKeyResolver;
+	adminToken = await mintToken({ email: "admin@example.com" });
+	reviewerToken = await mintToken({ email: "reviewer@example.com" });
+});
+
+async function mintToken(claims: Record<string, unknown>): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	return new SignJWT({ sub: "user-sub-1", ...claims })
+		.setProtectedHeader({ alg: "RS256" })
+		.setIssuer(TEAM_DOMAIN)
+		.setAudience(AUDIENCE)
+		.setIssuedAt(now)
+		.setExpirationTime(now + 3600)
+		.sign(signKey);
+}
+
+function baseConfig(): AccessAuthConfig {
+	return {
+		teamDomain: TEAM_DOMAIN,
+		audience: AUDIENCE,
+		admins: ["admin@example.com"],
+		reviewers: ["reviewer@example.com"],
+	};
+}
+
+function deps(overrides: Partial<MutationGuardDeps> = {}): MutationGuardDeps {
+	return {
+		db: testEnv.DB,
+		config: baseConfig(),
+		keys: resolver,
+		now: () => new Date("2026-07-12T00:00:00.000Z"),
+		expectedOrigin: ORIGIN,
+		...overrides,
+	};
+}
+
+interface TestBody {
+	subjectUri: string;
+	labelValue: string;
+}
+
+function testSpec(overrides: Partial<MutationSpec<TestBody>> = {}): MutationSpec<TestBody> {
+	return {
+		action: "label-issue",
+		requiredRole: "reviewer",
+		parseBody: (raw) => {
+			const { subjectUri, labelValue } = raw;
+			if (typeof subjectUri !== "string" || typeof labelValue !== "string")
+				throw new MutationGuardError("INVALID_BODY");
+			return { subjectUri, labelValue };
+		},
+		auditFields: (body) => ({ subjectUri: body.subjectUri, labelValue: body.labelValue }),
+		...overrides,
+	};
+}
+
+let keyCounter = 0;
+
+function validBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	keyCounter++;
+	return {
+		subjectUri: "at://did:plc:x/com.emdashcms.experimental.package.release/pkg:1.0.0",
+		labelValue: "security-yanked",
+		reason: "malware found in the release artifact",
+		idempotencyKey: `idem-${keyCounter}-abcdefgh`,
+		...overrides,
+	};
+}
+
+interface RequestOptions {
+	token?: string;
+	contentType?: string | null;
+	csrf?: string | null;
+	origin?: string;
+	secFetchSite?: string;
+	body?: unknown;
+	rawBody?: string;
+	spoofEmail?: string;
+}
+
+function buildRequest(opts: RequestOptions = {}): Request {
+	const headers = new Headers();
+	const contentType = opts.contentType === undefined ? "application/json" : opts.contentType;
+	if (contentType !== null) headers.set("Content-Type", contentType);
+	const csrf = opts.csrf === undefined ? "1" : opts.csrf;
+	if (csrf !== null) headers.set(OPERATOR_REQUEST_HEADER, csrf);
+	if (opts.token !== undefined) headers.set("Cf-Access-Jwt-Assertion", opts.token);
+	if (opts.origin !== undefined) headers.set("Origin", opts.origin);
+	if (opts.secFetchSite !== undefined) headers.set("Sec-Fetch-Site", opts.secFetchSite);
+	if (opts.spoofEmail !== undefined)
+		headers.set("Cf-Access-Authenticated-User-Email", opts.spoofEmail);
+	const body = opts.rawBody ?? (opts.body === undefined ? undefined : JSON.stringify(opts.body));
+	return new Request(`${ORIGIN}/admin/api/labels`, { method: "POST", headers, body });
+}
+
+async function expectRejection<TBody>(
+	request: Request,
+	spec: MutationSpec<TBody>,
+	guardDeps: MutationGuardDeps,
+	code: MutationGuardCode,
+	status: number,
+): Promise<void> {
+	await expect(guardMutation(request, spec, guardDeps)).rejects.toMatchObject({ code, status });
+}
+
+/** Idempotent effect keyed by the operator idempotency key, so a concurrent
+ * duplicate that shares the key does not double-apply. Its row count is the
+ * observable "did the effect run" signal. */
+function effectFor(key: string): D1PreparedStatement[] {
+	return [
+		testEnv.DB.prepare(
+			`INSERT INTO ingest_state (source, cursor, updated_at) VALUES (?, ?, ?)
+			 ON CONFLICT(source) DO NOTHING`,
+		).bind(`effect:${key}`, "cursor-1", "2026-07-12T00:00:00.000Z"),
+	];
+}
+
+async function effectRowCount(key: string): Promise<number> {
+	const row = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM ingest_state WHERE source = ?`)
+		.bind(`effect:${key}`)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+/** A NON-idempotent effect: a plain INSERT (no ON CONFLICT) committing a distinct
+ * row per caller. Proves the loser's effect is rolled back, not merely
+ * de-duplicated, when its audit insert loses the idempotency-key race. */
+function nonIdempotentEffect(key: string, tag: string): D1PreparedStatement[] {
+	return [
+		testEnv.DB.prepare(
+			`INSERT INTO ingest_state (source, cursor, updated_at) VALUES (?, 'cursor-1', '2026-07-12T00:00:00.000Z')`,
+		).bind(`nonidem:${key}:${tag}`),
+	];
+}
+
+async function nonIdempotentRowCount(key: string): Promise<number> {
+	const row = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM ingest_state WHERE source LIKE ?`)
+		.bind(`nonidem:${key}:%`)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+describe("guardMutation — JSON content type", () => {
+	it("rejects a missing content type", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, contentType: null, body: validBody() }),
+			testSpec(),
+			deps(),
+			"UNSUPPORTED_MEDIA_TYPE",
+			415,
+		);
+	});
+
+	it("rejects text/plain", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, contentType: "text/plain", body: validBody() }),
+			testSpec(),
+			deps(),
+			"UNSUPPORTED_MEDIA_TYPE",
+			415,
+		);
+	});
+
+	it("rejects application/x-www-form-urlencoded", async () => {
+		await expectRejection(
+			buildRequest({
+				token: adminToken,
+				contentType: "application/x-www-form-urlencoded",
+				body: validBody(),
+			}),
+			testSpec(),
+			deps(),
+			"UNSUPPORTED_MEDIA_TYPE",
+			415,
+		);
+	});
+
+	it("rejects a non-utf-8 charset", async () => {
+		await expectRejection(
+			buildRequest({
+				token: adminToken,
+				contentType: "application/json; charset=latin1",
+				body: validBody(),
+			}),
+			testSpec(),
+			deps(),
+			"UNSUPPORTED_MEDIA_TYPE",
+			415,
+		);
+	});
+
+	it("accepts application/json with a utf-8 charset parameter", async () => {
+		const outcome = await guardMutation(
+			buildRequest({
+				token: adminToken,
+				contentType: "application/json; charset=utf-8",
+				body: validBody(),
+			}),
+			testSpec(),
+			deps(),
+		);
+		expect(outcome.outcome).toBe("proceed");
+	});
+});
+
+describe("guardMutation — same-origin", () => {
+	it("rejects a mismatching Origin", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, origin: "https://evil.example.com", body: validBody() }),
+			testSpec(),
+			deps(),
+			"CROSS_ORIGIN",
+			403,
+		);
+	});
+
+	it("rejects a cross-site Sec-Fetch-Site", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, secFetchSite: "cross-site", body: validBody() }),
+			testSpec(),
+			deps(),
+			"CROSS_ORIGIN",
+			403,
+		);
+	});
+
+	it("accepts a request with neither Origin nor Sec-Fetch-Site (non-browser client)", async () => {
+		const outcome = await guardMutation(
+			buildRequest({ token: adminToken, body: validBody() }),
+			testSpec(),
+			deps(),
+		);
+		expect(outcome.outcome).toBe("proceed");
+	});
+
+	it("accepts a matching Origin and same-origin Sec-Fetch-Site", async () => {
+		const outcome = await guardMutation(
+			buildRequest({
+				token: adminToken,
+				origin: ORIGIN,
+				secFetchSite: "same-origin",
+				body: validBody(),
+			}),
+			testSpec(),
+			deps(),
+		);
+		expect(outcome.outcome).toBe("proceed");
+	});
+
+	it("defaults expectedOrigin to the request URL origin", async () => {
+		const outcome = await guardMutation(
+			buildRequest({ token: adminToken, origin: ORIGIN, body: validBody() }),
+			testSpec(),
+			deps({ expectedOrigin: undefined }),
+		);
+		expect(outcome.outcome).toBe("proceed");
+	});
+});
+
+describe("guardMutation — CSRF header", () => {
+	it("rejects a missing X-EmDash-Request header", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, csrf: null, body: validBody() }),
+			testSpec(),
+			deps(),
+			"CSRF_HEADER_MISSING",
+			403,
+		);
+	});
+
+	it("rejects a wrong X-EmDash-Request value", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, csrf: "0", body: validBody() }),
+			testSpec(),
+			deps(),
+			"CSRF_HEADER_MISSING",
+			403,
+		);
+	});
+});
+
+describe("guardMutation — Access identity", () => {
+	it("rejects a request with no assertion header", async () => {
+		await expectRejection(
+			buildRequest({ body: validBody() }),
+			testSpec(),
+			deps(),
+			"UNAUTHENTICATED",
+			401,
+		);
+	});
+
+	it("rejects an invalid assertion (delegated to W9.1 verification)", async () => {
+		await expectRejection(
+			buildRequest({ token: "not-a-jwt", body: validBody() }),
+			testSpec(),
+			deps(),
+			"UNAUTHENTICATED",
+			401,
+		);
+	});
+
+	it("never derives identity from a spoofed plaintext email header", async () => {
+		await expectRejection(
+			buildRequest({ spoofEmail: "admin@example.com", body: validBody() }),
+			testSpec(),
+			deps(),
+			"UNAUTHENTICATED",
+			401,
+		);
+	});
+});
+
+describe("guardMutation — role", () => {
+	it("rejects a reviewer attempting an admin-required action", async () => {
+		await expectRejection(
+			buildRequest({ token: reviewerToken, body: validBody() }),
+			testSpec({ requiredRole: "admin" }),
+			deps(),
+			"FORBIDDEN_ROLE",
+			403,
+		);
+	});
+
+	it("lets an admin satisfy a reviewer requirement via inheritance", async () => {
+		const outcome = await guardMutation(
+			buildRequest({ token: adminToken, body: validBody() }),
+			testSpec({ requiredRole: "reviewer" }),
+			deps(),
+		);
+		expect(outcome.outcome).toBe("proceed");
+		if (outcome.outcome !== "proceed") return;
+		// Recorded as the role the admin actually held, not the reviewer gate level.
+		expect(outcome.ctx.role).toBe("admin");
+	});
+});
+
+describe("guardMutation — body validation", () => {
+	it("rejects a non-object body", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, rawBody: "[]" }),
+			testSpec(),
+			deps(),
+			"INVALID_BODY",
+			400,
+		);
+	});
+
+	it("rejects an unparseable body", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, rawBody: "{not json" }),
+			testSpec(),
+			deps(),
+			"INVALID_BODY",
+			400,
+		);
+	});
+
+	it("rejects an empty, whitespace, or overlong reason", async () => {
+		for (const reason of ["", "   ", "x".repeat(1001)]) {
+			await expectRejection(
+				buildRequest({ token: adminToken, body: validBody({ reason }) }),
+				testSpec(),
+				deps(),
+				"INVALID_BODY",
+				400,
+			);
+		}
+	});
+
+	it("rejects a malformed idempotency key", async () => {
+		for (const idempotencyKey of ["short", "has spaces!", "a".repeat(201)]) {
+			await expectRejection(
+				buildRequest({ token: adminToken, body: validBody({ idempotencyKey }) }),
+				testSpec(),
+				deps(),
+				"INVALID_BODY",
+				400,
+			);
+		}
+	});
+
+	it("rejects endpoint fields that fail spec.parseBody", async () => {
+		await expectRejection(
+			buildRequest({ token: adminToken, body: validBody({ labelValue: 42 }) }),
+			testSpec(),
+			deps(),
+			"INVALID_BODY",
+			400,
+		);
+	});
+});
+
+describe("guardMutation — happy path", () => {
+	it("returns proceed with a fully populated context", async () => {
+		const body = validBody();
+		const outcome = await guardMutation(
+			buildRequest({ token: adminToken, body }),
+			testSpec({ requiredRole: "admin" }),
+			deps(),
+		);
+		expect(outcome.outcome).toBe("proceed");
+		if (outcome.outcome !== "proceed") return;
+		expect(outcome.ctx.identity).toMatchObject({ kind: "human", email: "admin@example.com" });
+		expect(outcome.ctx.role).toBe("admin");
+		expect(outcome.ctx.reason).toBe(body.reason);
+		expect(outcome.ctx.idempotencyKey).toBe(body.idempotencyKey);
+		expect(outcome.ctx.body).toEqual({ subjectUri: body.subjectUri, labelValue: body.labelValue });
+		expect(outcome.ctx.actionId).toMatch(/^oact_/);
+		expect(outcome.ctx.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+		expect(outcome.ctx.now.toISOString()).toBe("2026-07-12T00:00:00.000Z");
+	});
+});
+
+describe("guardMutation — idempotency replay and conflict", () => {
+	it("replays a recorded action without re-running the effect", async () => {
+		const body = validBody();
+		const first = await guardMutation(
+			buildRequest({ token: adminToken, body }),
+			testSpec(),
+			deps(),
+		);
+		expect(first.outcome).toBe("proceed");
+		if (first.outcome !== "proceed") return;
+
+		const result = await commitMutation(
+			testEnv.DB,
+			first.ctx,
+			testSpec(),
+			effectFor(body.idempotencyKey as string),
+			{ issued: first.ctx.actionId },
+		);
+		expect(result).toEqual({ issued: first.ctx.actionId });
+		expect(await effectRowCount(body.idempotencyKey as string)).toBe(1);
+
+		const replay = await guardMutation(
+			buildRequest({ token: adminToken, body }),
+			testSpec(),
+			deps(),
+		);
+		expect(replay.outcome).toBe("replay");
+		if (replay.outcome !== "replay") return;
+		// Narrowed payload: only the stored result and its id, never reason/fingerprint.
+		expect(replay).toEqual({
+			outcome: "replay",
+			result: { issued: first.ctx.actionId },
+			actionId: first.ctx.actionId,
+		});
+		expect(replay).not.toHaveProperty("action");
+		// The route returns on replay and never commits again, so the effect count is unchanged.
+		expect(await effectRowCount(body.idempotencyKey as string)).toBe(1);
+	});
+
+	it("rejects a replay with the same key but a different request", async () => {
+		const body = validBody();
+		const first = await guardMutation(
+			buildRequest({ token: adminToken, body }),
+			testSpec(),
+			deps(),
+		);
+		if (first.outcome !== "proceed") {
+			expect.unreachable();
+			return;
+		}
+		await commitMutation(
+			testEnv.DB,
+			first.ctx,
+			testSpec(),
+			effectFor(body.idempotencyKey as string),
+			{
+				ok: true,
+			},
+		);
+
+		await expectRejection(
+			buildRequest({ token: adminToken, body: { ...body, labelValue: "package-disputed" } }),
+			testSpec(),
+			deps(),
+			"IDEMPOTENCY_KEY_CONFLICT",
+			409,
+		);
+	});
+});
+
+describe("commitMutation", () => {
+	it("writes the audit row atomically with its effect", async () => {
+		const body = validBody();
+		const outcome = await guardMutation(
+			buildRequest({ token: adminToken, body }),
+			testSpec(),
+			deps(),
+		);
+		if (outcome.outcome !== "proceed") {
+			expect.unreachable();
+			return;
+		}
+		const result = await commitMutation(
+			testEnv.DB,
+			outcome.ctx,
+			testSpec(),
+			effectFor(body.idempotencyKey as string),
+			{ issued: true },
+		);
+		expect(result).toEqual({ issued: true });
+
+		const stored = await getOperatorActionByKey(testEnv.DB, body.idempotencyKey as string);
+		expect(stored).not.toBeNull();
+		expect(stored!.id).toBe(outcome.ctx.actionId);
+		expect(stored!.action).toBe("label-issue");
+		// Admin actor clearing a reviewer gate via inheritance: the immutable row
+		// records the role the actor actually held (admin), never the gate level.
+		expect(stored!.role).toBe("admin");
+		expect(stored!.subjectUri).toBe(body.subjectUri);
+		expect(stored!.labelValue).toBe(body.labelValue);
+		expect(stored!.reason).toBe(body.reason);
+		expect(await effectRowCount(body.idempotencyKey as string)).toBe(1);
+	});
+
+	it("records the directly-held role, not always admin", async () => {
+		const body = validBody();
+		const outcome = await guardMutation(
+			buildRequest({ token: reviewerToken, body }),
+			testSpec(),
+			deps(),
+		);
+		if (outcome.outcome !== "proceed") {
+			expect.unreachable();
+			return;
+		}
+		expect(outcome.ctx.role).toBe("reviewer");
+		await commitMutation(
+			testEnv.DB,
+			outcome.ctx,
+			testSpec(),
+			effectFor(body.idempotencyKey as string),
+			{
+				issued: true,
+			},
+		);
+		const stored = await getOperatorActionByKey(testEnv.DB, body.idempotencyKey as string);
+		expect(stored!.role).toBe("reviewer");
+	});
+
+	it("does not double-apply concurrent duplicates and returns the same result", async () => {
+		const body = validBody();
+		const g1 = await guardMutation(buildRequest({ token: adminToken, body }), testSpec(), deps());
+		const g2 = await guardMutation(buildRequest({ token: adminToken, body }), testSpec(), deps());
+		if (g1.outcome !== "proceed" || g2.outcome !== "proceed") {
+			expect.unreachable();
+			return;
+		}
+
+		const key = body.idempotencyKey as string;
+		const [r1, r2] = await Promise.all([
+			commitMutation(testEnv.DB, g1.ctx, testSpec(), nonIdempotentEffect(key, "1"), {
+				winner: g1.ctx.actionId,
+			}),
+			commitMutation(testEnv.DB, g2.ctx, testSpec(), nonIdempotentEffect(key, "2"), {
+				winner: g2.ctx.actionId,
+			}),
+		]);
+
+		const stored = await getOperatorActionByKey(testEnv.DB, key);
+		expect(stored).not.toBeNull();
+		expect([g1.ctx.actionId, g2.ctx.actionId]).toContain(stored!.id);
+		const winnerResult = JSON.parse(stored!.resultJson!) as unknown;
+		expect(r1).toEqual(winnerResult);
+		expect(r2).toEqual(winnerResult);
+		// Only the winner's effect committed; the loser's batch — including its
+		// distinct, non-idempotent effect row — rolled back.
+		expect(await nonIdempotentRowCount(key)).toBe(1);
+	});
+
+	it("rejects concurrent duplicates that share a key but differ in content", async () => {
+		const key = `idem-conflict-${Date.now()}-abcd`;
+		const bodyA = validBody({ idempotencyKey: key, labelValue: "security-yanked" });
+		const bodyB = validBody({ idempotencyKey: key, labelValue: "package-disputed" });
+		const gA = await guardMutation(
+			buildRequest({ token: adminToken, body: bodyA }),
+			testSpec(),
+			deps(),
+		);
+		const gB = await guardMutation(
+			buildRequest({ token: adminToken, body: bodyB }),
+			testSpec(),
+			deps(),
+		);
+		if (gA.outcome !== "proceed" || gB.outcome !== "proceed") {
+			expect.unreachable();
+			return;
+		}
+
+		const settled = await Promise.allSettled([
+			commitMutation(testEnv.DB, gA.ctx, testSpec(), nonIdempotentEffect(key, "A"), { v: "A" }),
+			commitMutation(testEnv.DB, gB.ctx, testSpec(), nonIdempotentEffect(key, "B"), { v: "B" }),
+		]);
+
+		const fulfilled = settled.filter((r) => r.status === "fulfilled");
+		const rejected = settled.filter((r) => r.status === "rejected");
+		expect(fulfilled).toHaveLength(1);
+		expect(rejected).toHaveLength(1);
+		const reason = (rejected[0] as PromiseRejectedResult).reason;
+		expect(reason).toBeInstanceOf(MutationGuardError);
+		expect(reason).toMatchObject({ code: "IDEMPOTENCY_KEY_CONFLICT", status: 409 });
+		// F1 regression: the losing request's NON-idempotent effect was rolled back
+		// with its aborted batch. Exactly one effect row exists — the loser that got
+		// the 409 committed nothing. (Under the old ON CONFLICT insert this was 2.)
+		expect(await nonIdempotentRowCount(key)).toBe(1);
+	});
+});
+
+describe("MutationGuardError", () => {
+	it("renders a JSON error response that omits request content", async () => {
+		const error = new MutationGuardError("IDEMPOTENCY_KEY_CONFLICT");
+		const response = error.toResponse();
+		expect(response.status).toBe(409);
+		expect(response.headers.get("Content-Type")).toContain("application/json");
+		expect(await response.json()).toEqual({
+			error: { code: "IDEMPOTENCY_KEY_CONFLICT", message: expect.any(String) },
+		});
+	});
+});

--- a/apps/labeler/test/mutation-guard.test.ts
+++ b/apps/labeler/test/mutation-guard.test.ts
@@ -237,6 +237,36 @@ describe("guardMutation — JSON content type", () => {
 		);
 		expect(outcome.outcome).toBe("proceed");
 	});
+
+	it("rejects a parameter other than charset", async () => {
+		for (const contentType of [
+			"application/json; boundary=foo",
+			"application/json; custom=bar",
+			"application/json; charset=utf-8; boundary=x",
+		]) {
+			await expectRejection(
+				buildRequest({ token: adminToken, contentType, body: validBody() }),
+				testSpec(),
+				deps(),
+				"UNSUPPORTED_MEDIA_TYPE",
+				415,
+			);
+		}
+	});
+
+	it("rejects a repeated charset parameter", async () => {
+		await expectRejection(
+			buildRequest({
+				token: adminToken,
+				contentType: "application/json; charset=utf-8; charset=utf-8",
+				body: validBody(),
+			}),
+			testSpec(),
+			deps(),
+			"UNSUPPORTED_MEDIA_TYPE",
+			415,
+		);
+	});
 });
 
 describe("guardMutation — same-origin", () => {
@@ -575,6 +605,40 @@ describe("commitMutation", () => {
 		);
 		const stored = await getOperatorActionByKey(testEnv.DB, body.idempotencyKey as string);
 		expect(stored!.role).toBe("reviewer");
+	});
+
+	it("surfaces a stored undefined result as undefined, never the caller's own result", async () => {
+		const body = validBody();
+		// Two guarded contexts obtained before either commits — both proceed.
+		const g1 = await guardMutation(buildRequest({ token: adminToken, body }), testSpec(), deps());
+		const g2 = await guardMutation(buildRequest({ token: adminToken, body }), testSpec(), deps());
+		if (g1.outcome !== "proceed" || g2.outcome !== "proceed") {
+			expect.unreachable();
+			return;
+		}
+		const key = body.idempotencyKey as string;
+
+		// Winner commits an undefined result -> stored result_json is SQL NULL.
+		const r1 = await commitMutation(testEnv.DB, g1.ctx, testSpec(), effectFor(key), undefined);
+		expect(r1).toBeUndefined();
+		expect((await getOperatorActionByKey(testEnv.DB, key))!.resultJson).toBeNull();
+
+		// commitMutation loser path: g2's insert conflicts. It must return the
+		// stored value (undefined), NOT its own supplied result.
+		const r2 = await commitMutation(testEnv.DB, g2.ctx, testSpec(), effectFor(key), {
+			loser: "own-result",
+		});
+		expect(r2).toBeUndefined();
+
+		// Guard step-7 replay path: a later same-key request replays the stored value.
+		const replay = await guardMutation(
+			buildRequest({ token: adminToken, body }),
+			testSpec(),
+			deps(),
+		);
+		expect(replay.outcome).toBe("replay");
+		if (replay.outcome !== "replay") return;
+		expect(replay.result).toBeUndefined();
 	});
 
 	it("does not double-apply concurrent duplicates and returns the same result", async () => {

--- a/apps/labeler/test/operator-actions.test.ts
+++ b/apps/labeler/test/operator-actions.test.ts
@@ -1,0 +1,234 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { operatorTriggerId } from "../src/assessment-lifecycle.js";
+import {
+	buildOperatorActionInsert,
+	computeRequestFingerprint,
+	getOperatorActionByKey,
+	isIdempotencyKeyConflict,
+	type OperatorActionInsert,
+	type StoredOperatorAction,
+} from "../src/operator-actions.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+let counter = 0;
+
+function insertInput(overrides: Partial<OperatorActionInsert> = {}): OperatorActionInsert {
+	counter++;
+	const now = new Date("2026-07-12T00:00:00.000Z");
+	return {
+		id: `oact_test${counter}`,
+		actorType: "human",
+		actorId: "user-sub-1",
+		actorEmail: "admin@example.com",
+		actorCommonName: null,
+		role: "admin",
+		action: "label-issue",
+		subjectUri: "at://did:plc:x/com.emdashcms.experimental.package.release/pkg:1.0.0",
+		subjectCid: "bafkreicid00000000000000000000000000000000000000000",
+		labelValue: "security-yanked",
+		reason: "malware in postinstall",
+		idempotencyKey: `key-${counter}-abcdefgh`,
+		requestFingerprint: `fp-${counter}`,
+		resultJson: JSON.stringify({ ok: true }),
+		metadataJson: "{}",
+		createdAt: now.toISOString(),
+		createdAtEpochMs: now.getTime(),
+		...overrides,
+	};
+}
+
+describe("operator_actions store", () => {
+	it("inserts and reads back every audit column", async () => {
+		const input = insertInput();
+		await buildOperatorActionInsert(testEnv.DB, input).run();
+
+		const stored = await getOperatorActionByKey(testEnv.DB, input.idempotencyKey);
+		expect(stored).toEqual<StoredOperatorAction>({
+			id: input.id,
+			actorType: "human",
+			actorId: input.actorId,
+			actorEmail: input.actorEmail,
+			actorCommonName: null,
+			role: "admin",
+			action: input.action,
+			subjectUri: input.subjectUri,
+			subjectCid: input.subjectCid,
+			labelValue: input.labelValue,
+			reason: input.reason,
+			idempotencyKey: input.idempotencyKey,
+			requestFingerprint: input.requestFingerprint,
+			resultJson: input.resultJson,
+			metadataJson: input.metadataJson,
+			createdAt: input.createdAt,
+			createdAtEpochMs: input.createdAtEpochMs,
+		});
+		expect(operatorTriggerId(stored!.id)).toBe(`operator:${input.id}`);
+	});
+
+	it("records a service actor with a common name and no email", async () => {
+		const input = insertInput({
+			actorType: "service",
+			actorEmail: null,
+			actorCommonName: "ci-automation",
+			role: "reviewer",
+		});
+		await buildOperatorActionInsert(testEnv.DB, input).run();
+
+		const stored = await getOperatorActionByKey(testEnv.DB, input.idempotencyKey);
+		expect(stored!.actorType).toBe("service");
+		expect(stored!.actorCommonName).toBe("ci-automation");
+		expect(stored!.actorEmail).toBeNull();
+	});
+
+	it("persists a subject-less action with NULL subject columns", async () => {
+		const input = insertInput({
+			action: "pause-issuance",
+			subjectUri: null,
+			subjectCid: null,
+			labelValue: null,
+		});
+		await buildOperatorActionInsert(testEnv.DB, input).run();
+
+		const stored = await getOperatorActionByKey(testEnv.DB, input.idempotencyKey);
+		expect(stored!.action).toBe("pause-issuance");
+		expect(stored!.subjectUri).toBeNull();
+		expect(stored!.subjectCid).toBeNull();
+		expect(stored!.labelValue).toBeNull();
+	});
+
+	it("rejects UPDATE on a recorded action (immutable log)", async () => {
+		const input = insertInput();
+		await buildOperatorActionInsert(testEnv.DB, input).run();
+
+		await expect(
+			testEnv.DB.prepare("UPDATE operator_actions SET reason = 'tampered' WHERE id = ?")
+				.bind(input.id)
+				.run(),
+		).rejects.toThrow(/immutable/);
+	});
+
+	it("rejects DELETE on a recorded action (immutable log)", async () => {
+		const input = insertInput();
+		await buildOperatorActionInsert(testEnv.DB, input).run();
+
+		await expect(
+			testEnv.DB.prepare("DELETE FROM operator_actions WHERE id = ?").bind(input.id).run(),
+		).rejects.toThrow(/immutable/);
+	});
+
+	it("rejects a duplicate idempotency key with a detectable UNIQUE violation", async () => {
+		const first = insertInput();
+		await buildOperatorActionInsert(testEnv.DB, first).run();
+
+		const second = insertInput({
+			id: "oact_second",
+			idempotencyKey: first.idempotencyKey,
+			reason: "different reason",
+			requestFingerprint: "fp-conflicting",
+		});
+
+		let caught: unknown;
+		try {
+			await buildOperatorActionInsert(testEnv.DB, second).run();
+		} catch (error) {
+			caught = error;
+		}
+		expect(isIdempotencyKeyConflict(caught)).toBe(true);
+
+		// The first row is untouched — the conflicting insert never applied.
+		const stored = await getOperatorActionByKey(testEnv.DB, first.idempotencyKey);
+		expect(stored!.id).toBe(first.id);
+		expect(stored!.reason).toBe(first.reason);
+		expect(stored!.requestFingerprint).toBe(first.requestFingerprint);
+	});
+
+	it("does not flag a primary-key conflict or an unrelated error as a key conflict", async () => {
+		const first = insertInput();
+		await buildOperatorActionInsert(testEnv.DB, first).run();
+
+		let pkError: unknown;
+		try {
+			// Reused `id`, fresh idempotency key: this is a PRIMARY KEY conflict on
+			// `id`, which must NOT be mistaken for the idempotency-key conflict.
+			await buildOperatorActionInsert(testEnv.DB, insertInput({ id: first.id })).run();
+		} catch (error) {
+			pkError = error;
+		}
+		expect(pkError).toBeInstanceOf(Error);
+		expect(isIdempotencyKeyConflict(pkError)).toBe(false);
+		expect(isIdempotencyKeyConflict(new Error("some other failure"))).toBe(false);
+		expect(isIdempotencyKeyConflict(null)).toBe(false);
+	});
+
+	it("returns null for an unknown idempotency key", async () => {
+		expect(await getOperatorActionByKey(testEnv.DB, "no-such-key-abcdefgh")).toBeNull();
+	});
+});
+
+describe("computeRequestFingerprint", () => {
+	it("is stable under top-level key reordering", async () => {
+		const a = await computeRequestFingerprint("label-issue", {
+			subjectUri: "u",
+			labelValue: "v",
+			reason: "r",
+		});
+		const b = await computeRequestFingerprint("label-issue", {
+			reason: "r",
+			labelValue: "v",
+			subjectUri: "u",
+		});
+		expect(a).toBe(b);
+	});
+
+	it("is stable under nested key reordering", async () => {
+		const a = await computeRequestFingerprint("label-issue", {
+			reason: "r",
+			metadata: { alpha: 1, beta: 2 },
+		});
+		const b = await computeRequestFingerprint("label-issue", {
+			metadata: { beta: 2, alpha: 1 },
+			reason: "r",
+		});
+		expect(a).toBe(b);
+	});
+
+	it("ignores the idempotency key", async () => {
+		const a = await computeRequestFingerprint("label-issue", {
+			reason: "r",
+			idempotencyKey: "key-one-abcdefgh",
+		});
+		const b = await computeRequestFingerprint("label-issue", {
+			reason: "r",
+			idempotencyKey: "key-two-abcdefgh",
+		});
+		expect(a).toBe(b);
+	});
+
+	it("changes when the action changes", async () => {
+		const a = await computeRequestFingerprint("label-issue", { reason: "r" });
+		const b = await computeRequestFingerprint("label-retract", { reason: "r" });
+		expect(a).not.toBe(b);
+	});
+
+	it("changes when any material field changes", async () => {
+		const base = await computeRequestFingerprint("label-issue", { reason: "r", labelValue: "v" });
+		expect(
+			await computeRequestFingerprint("label-issue", { reason: "r", labelValue: "w" }),
+		).not.toBe(base);
+		expect(
+			await computeRequestFingerprint("label-issue", { reason: "s", labelValue: "v" }),
+		).not.toBe(base);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds the labeler operator console's **mutation-protection guard and operator-action audit** — plan item W9.2, spec §12/§14.4. Every state-changing console endpoint (W9.4–W9.6) will route through `guardMutation` → `commitMutation`, so an effect physically cannot commit without passing all protections and writing its audit row.

The guard runs the ratified protections in fail-fast order:

1. **JSON content type** — media type must be `application/json` (optional `utf-8` charset only) → 415. Also a CSRF layer: HTML forms can't produce it.
2. **Same-origin** — `Origin` and `Sec-Fetch-Site` are checked when present; absence passes (non-browser clients — Access service tokens, curl — send neither, and browsers attach `Origin` to every cross-origin POST) → 403.
3. **Required custom header** (`X-EmDash-Request: 1`, core's convention) → 403. Ratified decision (2026-07-13, spec §12 updated): this replaces the CSRF token/double-submit wording — the Access assertion is not itself a CSRF defense (the edge injects it from the `CF_Authorization` cookie), but header + JSON + origin block every browser forgery vector via CORS preflight.
4. **Freshly verified Access identity** — `verifyAccessRequest` (W9.1, #2005) on every request; identity is never cached or read from a session → 401.
5. **Role check** — `hasRole` against the endpoint's required role → 403. The audit row records the role the actor actually held that satisfied the check (an admin passing a reviewer gate via inheritance is recorded as `admin` — it may not be in the reviewers list at all).
6. **Body validation** — required trimmed `reason` (≤1000 chars) and `idempotencyKey` (`^[A-Za-z0-9._:-]{8,200}$`), then the endpoint's `parseBody` → 400 with static messages that never echo request contents.
7. **Idempotency** — globally unique key with a SHA-256 request fingerprint (canonical JSON, key excluded): replay with an identical fingerprint returns the stored result without re-running the effect; a different fingerprint → 409.

`commitMutation` batches a **plain** audit insert atomically with the effect statements: a duplicate idempotency key aborts the whole batch, so a losing concurrent request can never commit a side effect — idempotent or not. The caught UNIQUE violation (matched against D1's column-qualified message, so an unrelated PK conflict is never swallowed) triggers a read-back: matching fingerprint → the winner's stored result (replay), differing → 409. This deliberately diverges from `service.ts`'s `ON CONFLICT DO NOTHING` precedent — that pattern is safe only because issuance effects are keyed-idempotent by construction, and the adversarial pass **proved** (with a probe that became a permanent regression test) that with opaque guard effects the `ON CONFLICT` form lets a conflicting loser's effect commit before its 409. Replay outcomes carry only the stored result and action id — never the full audit record — so routes physically cannot leak the private `reason`. Guard error responses use core's wire shape (`{ error: { code, message } }`).

The audit lands in a new **`operator_actions`** table (migration 0004): append-only via `BEFORE UPDATE`/`BEFORE DELETE` `RAISE(ABORT)` triggers (the `issuance_actions` convention), indefinite retention (spec §19). It is distinct from `issuance_actions` (the signing-layer audit) because operator actions like rerun and pause-issuance never issue a label and can't be represented there; its row id doubles as the `operatorTriggerId` anchor for reruns. Ratified decisions recorded in spec §14.4: the table name, nullable `subject_uri` (subject-less admin actions), and the action vocabulary as a typed union in the guard (sole writer) rather than a SQL `CHECK`.

No routes are wired yet — W9.3 mounts `/admin/api/*` and W9.4–W9.6 add the endpoints. One routing requirement this hands to W9.3, recorded in spec §12: console API routes must never emit cross-origin CORS allow headers, or the preflight defense collapses.

Implemented by an Opus subagent from an Opus-authored, Matt-ratified design, then adversarially reviewed by an independent Opus pass (bypass ordering, `Origin: null`, fingerprint canonicalization, idempotency TOCTOU, batch atomicity, test honesty).

Stacked on #2005 (merged). Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

Admin i18n and changeset are n/a — this touches only `apps/labeler`, a private, unpublished Worker app (no admin UI in this PR, not on npm). The migration is forward-only and additive (new table only).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (coordination), Opus 4.8 subagents (design, implementation, and adversarial review)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler exec vitest run`: 348 pass (21 files) — 43 new W9.2 tests: per-protection negative matrix (content-type variants incl. quoted/wrong charset; mismatching `Origin`, `Sec-Fetch-Site: cross-site`, literal `Origin: null`; missing/wrong CSRF header; missing/invalid token; reviewer vs admin gate with the inheritance case pinned in both the context and the persisted audit row; reason and key format bounds), fingerprint stability/injectivity, replay returning the stored result without re-running the effect, same-key/different-body 409, **concurrent non-idempotent effects: exactly one commits in both the same- and different-fingerprint races** (fail-without-fix verified by reverting to `ON CONFLICT`), audit immutability (`UPDATE`/`DELETE` abort), UNIQUE-violation detection pinned against the real miniflare error, spoofed plaintext identity header → 401
- Typecheck (`tsgo --noEmit`) clean; lint: 0 diagnostics in `apps/labeler` (repo baseline of 19 pre-existing `no-redundant-type-constituents` false positives in unrelated packages, unchanged)

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-mutation-guard-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-mutation-guard`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
