### PR TITLE
feat(admin): localize plugin admin page labels via the shared Lingui instance

### DIFF
--- a/.changeset/localized-plugin-page-labels.md
+++ b/.changeset/localized-plugin-page-labels.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": minor
 ---
 
-Plugin admin page labels in the sidebar and command palette are now run through the admin's Lingui instance, so plugins that load a message catalog (with the English label as the message id) get localized navigation. Labels without a catalog entry render unchanged.
+Plugin admin page labels in the sidebar and command palette are now run through the admin's Lingui instance. Plugins that load a message catalog (with the English label as the message id) get localized navigation, and labels matching one of the admin's own messages (such as "Settings") follow the admin locale automatically. Labels without a catalog entry render unchanged.

--- a/.changeset/localized-plugin-page-labels.md
+++ b/.changeset/localized-plugin-page-labels.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Plugin admin page labels in the sidebar and command palette are now run through the admin's Lingui instance, so plugins that load a message catalog (with the English label as the message id) get localized navigation. Labels without a catalog entry render unchanged.

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -83,7 +83,7 @@ admin: {
 }
 ```
 
-Declare labels in English. The admin runs them through its shared [Lingui](https://lingui.dev/) instance before rendering the sidebar and command palette, so a plugin that loads its own message catalog — with the English label as the message id — gets localized navigation for free. Labels without a catalog entry render as declared.
+Declare labels in English. The admin runs them through its shared [Lingui](https://lingui.dev/) instance before rendering the sidebar and command palette, so a plugin that loads its own message catalog — with the English label as the message id — gets localized navigation for free. Labels that match one of the admin's own messages (`Settings`, `Dashboard`, …) pick up the admin's translations even without a plugin catalog; labels with no catalog entry anywhere render as declared.
 
 ```typescript title="src/admin.tsx"
 import { i18n } from "@lingui/core";

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -90,8 +90,8 @@ import { i18n } from "@lingui/core";
 
 // Merge the plugin's compiled catalog into the admin's i18n instance.
 // "Reports" now renders as "Berichte" when the admin locale is German.
-const catalogs: Record<string, Record<string, string[]>> = {
-	de: { Reports: ["Berichte"], Settings: ["Einstellungen"] },
+const catalogs: Record<string, Record<string, string>> = {
+	de: { Reports: "Berichte", Settings: "Einstellungen" },
 };
 
 function mergeCatalog() {

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -83,6 +83,28 @@ admin: {
 }
 ```
 
+Declare labels in English. The admin runs them through its shared [Lingui](https://lingui.dev/) instance before rendering the sidebar and command palette, so a plugin that loads its own message catalog — with the English label as the message id — gets localized navigation for free. Labels without a catalog entry render as declared.
+
+```typescript title="src/admin.tsx"
+import { i18n } from "@lingui/core";
+
+// Merge the plugin's compiled catalog into the admin's i18n instance.
+// "Reports" now renders as "Berichte" when the admin locale is German.
+const catalogs: Record<string, Record<string, string[]>> = {
+	de: { Reports: ["Berichte"], Settings: ["Einstellungen"] },
+};
+
+function mergeCatalog() {
+	const messages = catalogs[i18n.locale];
+	if (messages && !("Reports" in i18n.messages)) i18n.load(i18n.locale, messages);
+}
+
+mergeCatalog();
+// The admin's locale switcher *replaces* the catalog on change, so re-merge.
+// The sentinel check above keeps this from recursing (load() fires "change").
+i18n.on("change", mergeCatalog);
+```
+
 ### Page component
 
 The following component reads and saves settings through the plugin API hook:

--- a/packages/admin/src/components/AdminCommandPalette.tsx
+++ b/packages/admin/src/components/AdminCommandPalette.tsx
@@ -295,11 +295,12 @@ function filterNavItems(
 
 export function AdminCommandPalette({ manifest }: AdminCommandPaletteProps) {
 	const { t } = useLingui();
-	// `_` (not `i18n`) is the nav-items memo dependency: the i18n instance is
-	// a stable singleton, while the provider re-binds `_` on every locale or
-	// catalog change — exactly the invalidation the plugin labels need. The
-	// macro useLingui() omits `_`, so it comes from the runtime hook.
-	const { _: translateDynamic } = useLinguiContext();
+	// The runtime hook (the macro useLingui() omits `_`): `_` translates the
+	// dynamic plugin labels, and both it and `i18n.locale` invalidate the
+	// nav-items memo below. `i18n.locale` is the documented signal for locale
+	// switches; the `_` rebind covers catalog merges that arrive without a
+	// locale change (plugins load their catalogs asynchronously).
+	const { _: translateDynamic, i18n } = useLinguiContext();
 	const [open, setOpen] = React.useState(false);
 	const [query, setQuery] = React.useState("");
 	const navigate = useNavigate();
@@ -326,7 +327,7 @@ export function AdminCommandPalette({ manifest }: AdminCommandPaletteProps) {
 	// Build navigation items
 	const allNavItems = React.useMemo(
 		() => buildNavItems(manifest, userRole, translateDynamic),
-		[manifest, userRole, translateDynamic],
+		[manifest, userRole, translateDynamic, i18n.locale],
 	);
 
 	// Filter nav items based on query

--- a/packages/admin/src/components/AdminCommandPalette.tsx
+++ b/packages/admin/src/components/AdminCommandPalette.tsx
@@ -8,6 +8,7 @@
 import { CommandPalette } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
+import { useLingui as useLinguiContext } from "@lingui/react";
 import { useLingui } from "@lingui/react/macro";
 import {
 	SquaresFour,
@@ -30,6 +31,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { apiFetch, type AdminManifest } from "../lib/api/client.js";
 import { useCurrentUser } from "../lib/api/current-user";
+import { resolvePluginPageLabel } from "./Sidebar";
 
 /** Subset of manifest fields used by the palette (matches `Shell` props shape). */
 type CommandPaletteManifest = {
@@ -124,7 +126,11 @@ async function searchContent(query: string): Promise<SearchResponse> {
 	return body.data;
 }
 
-function buildNavItems(manifest: CommandPaletteManifest, userRole: number): NavItem[] {
+function buildNavItems(
+	manifest: CommandPaletteManifest,
+	userRole: number,
+	translateLabel: (id: string) => string,
+): NavItem[] {
 	const items: NavItem[] = [
 		{
 			id: "dashboard",
@@ -253,12 +259,9 @@ function buildNavItems(manifest: CommandPaletteManifest, userRole: number): NavI
 		if (config.enabled === false) continue;
 		if (config.adminPages && config.adminPages.length > 0) {
 			for (const page of config.adminPages) {
-				const label =
-					page.label ||
-					pluginId
-						.split("-")
-						.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-						.join(" ");
+				// Same treatment as the sidebar: declared labels go through the
+				// shared i18n instance so plugin catalogs can localize them.
+				const label = resolvePluginPageLabel(page.label, pluginId, translateLabel);
 
 				items.push({
 					id: `plugin-${pluginId}-${page.path}`,
@@ -292,6 +295,11 @@ function filterNavItems(
 
 export function AdminCommandPalette({ manifest }: AdminCommandPaletteProps) {
 	const { t } = useLingui();
+	// `_` (not `i18n`) is the nav-items memo dependency: the i18n instance is
+	// a stable singleton, while the provider re-binds `_` on every locale or
+	// catalog change — exactly the invalidation the plugin labels need. The
+	// macro useLingui() omits `_`, so it comes from the runtime hook.
+	const { _: translateDynamic } = useLinguiContext();
 	const [open, setOpen] = React.useState(false);
 	const [query, setQuery] = React.useState("");
 	const navigate = useNavigate();
@@ -316,7 +324,10 @@ export function AdminCommandPalette({ manifest }: AdminCommandPaletteProps) {
 	const isPendingSearch = isWaitingForDebounce || isSearching;
 
 	// Build navigation items
-	const allNavItems = React.useMemo(() => buildNavItems(manifest, userRole), [manifest, userRole]);
+	const allNavItems = React.useMemo(
+		() => buildNavItems(manifest, userRole, translateDynamic),
+		[manifest, userRole, translateDynamic],
+	);
 
 	// Filter nav items based on query
 	const filteredNavItems = React.useMemo(

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -272,7 +272,10 @@ function NavIcon({ icon: Icon, className }: { icon: React.ElementType; className
  * Resolve the display label for a plugin admin page (sidebar + command
  * palette). Declared labels are run through the shared Lingui instance:
  * plugins that load their own catalog — with the English label as msgid —
- * get localized nav items, and labels without a catalog entry fall back to
+ * get localized nav items. The catalog is shared with the admin, so common
+ * labels like "Settings" pick up the admin's own translations even without
+ * a plugin catalog (deliberate: a localized admin shouldn't show stray
+ * English nav items). Labels with no catalog entry anywhere fall back to
  * the literal string. Pages without a label prettify the plugin id
  * ("my-shop" → "My Shop").
  */

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -268,6 +268,26 @@ function NavIcon({ icon: Icon, className }: { icon: React.ElementType; className
 	);
 }
 
+/**
+ * Resolve the display label for a plugin admin page (sidebar + command
+ * palette). Declared labels are run through the shared Lingui instance:
+ * plugins that load their own catalog — with the English label as msgid —
+ * get localized nav items, and labels without a catalog entry fall back to
+ * the literal string. Pages without a label prettify the plugin id
+ * ("my-shop" → "My Shop").
+ */
+export function resolvePluginPageLabel(
+	label: string | undefined,
+	pluginId: string,
+	translate: (id: string) => string,
+): string {
+	if (label) return translate(label);
+	return pluginId
+		.split("-")
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(" ");
+}
+
 /** Resolves a nav item's route path by substituting $param placeholders. */
 function resolveItemPath(item: NavItem): string {
 	let path = item.to;
@@ -290,7 +310,7 @@ function isItemActive(itemPath: string, currentPath: string): boolean {
  * Admin sidebar navigation using kumo's Sidebar compound component.
  */
 export function SidebarNav({ manifest }: SidebarNavProps) {
-	const { t } = useLingui();
+	const { t, i18n } = useLingui();
 	const location = useLocation();
 	const currentPath = location.pathname;
 	const pluginAdmins = usePluginAdmins();
@@ -387,12 +407,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 			const isBlocksMode = config.adminMode === "blocks";
 			for (const page of config.adminPages) {
 				if (!isBlocksMode && !resolvePluginPagePath(pluginPages, page.path)) continue;
-				const label =
-					page.label ||
-					pluginId
-						.split("-")
-						.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-						.join(" ");
+				const label = resolvePluginPageLabel(page.label, pluginId, (id) => i18n._(id));
 				pluginItems.push({
 					to: `/plugins/${pluginId}${page.path}`,
 					label,

--- a/packages/admin/tests/components/Sidebar.test.tsx
+++ b/packages/admin/tests/components/Sidebar.test.tsx
@@ -31,6 +31,7 @@ import {
 	BYLINE_SCHEMA_NAV_ITEM,
 	filterNavItemsByRole,
 	resolveNavIcon,
+	resolvePluginPageLabel,
 	toPhosphorIconName,
 } from "../../src/components/Sidebar";
 import { render } from "../utils/render.tsx";
@@ -94,6 +95,30 @@ describe("filterNavItemsByRole", () => {
 		// must strip every gated entry at role=0.
 		const visible = filterNavItemsByRole(items, 0).map((i) => i.to);
 		expect(visible).toEqual(["/"]);
+	});
+});
+
+describe("resolvePluginPageLabel", () => {
+	// Simulates a plugin that loaded its Lingui catalog into the shared i18n
+	// instance: known msgids translate, unknown ones return the msgid itself
+	// (exactly i18n._'s fallback behavior).
+	const translate = (id: string) => (id === "Orders" ? "Bestellungen" : id);
+
+	it("translates a declared label through the shared i18n instance", () => {
+		expect(resolvePluginPageLabel("Orders", "my-shop", translate)).toBe("Bestellungen");
+	});
+
+	it("falls back to the literal label when no catalog entry exists", () => {
+		// Plugins without a Lingui catalog must render exactly what they
+		// declared — the identity lookup keeps this fully backwards compatible.
+		expect(resolvePluginPageLabel("Products", "my-shop", translate)).toBe("Products");
+	});
+
+	it("prettifies the plugin id when no label is declared (untranslated)", () => {
+		// The fallback is derived from the package id, not author-provided
+		// English — never run it through the catalog.
+		expect(resolvePluginPageLabel(undefined, "my-shop", translate)).toBe("My Shop");
+		expect(resolvePluginPageLabel(undefined, "orders", translate)).toBe("Orders");
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Plugin `adminPages` labels were rendered verbatim in the sidebar and command palette, so a fully localized admin still showed hard-coded English nav items for plugins — even when the plugin localizes everything inside its pages by merging a Lingui catalog into the shared `i18n` instance.

This PR runs declared labels through `i18n._()` at render time in both places, via a new shared `resolvePluginPageLabel()` helper (deduplicates the previously copy-pasted label logic):

- Plugins that load a catalog (English label as msgid) get localized navigation.
- Labels matching one of the admin's own messages (e.g. "Settings") follow the admin locale automatically, so a localized admin no longer shows stray English nav items.
- Labels with no catalog entry anywhere render unchanged (`i18n._()` falls back to the msgid) — existing plugins are unaffected.
- The prettified-plugin-id fallback (no label declared) is not translated, since it's derived from the package name rather than authored English.

Reactivity: the sidebar re-renders through `useLingui()`'s context on every locale/catalog change; the palette's nav-item memo depends on the context's `_` binding, which the provider recreates on each change.

The "React admin" plugin guide now documents the contract and shows the catalog-merge pattern (including re-merging on the locale switcher's catalog replacement).

Discussion: https://github.com/emdash-cms/emdash/discussions/2012

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/2012

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable

## Screenshots / test output

New unit tests for `resolvePluginPageLabel` (translated label / untranslated fallback / plugin-id prettification); full `@emdash-cms/admin` suite passes locally:

```
Test Files  89 passed (89)
     Tests  1103 passed (1103)
```

Verified end to end against a real plugin that merges its own Lingui catalog: sidebar and ⌘K palette entries switch language together with the rest of the admin.