### PR TITLE
chore(flue-review): switch reviewer to GLM-5.2 with reduced reasoning

### DIFF
--- a/infra/flue-review/.flue/workflows/review.ts
+++ b/infra/flue-review/.flue/workflows/review.ts
@@ -3,13 +3,29 @@
 // Reviews one pull request and returns structured findings plus a verdict. No
 // firecracker container: the PR is hydrated into a durable cf-shell Workspace
 // (DO SQLite + R2 for large files) via JS git, and the agent inspects it with a
-// Worker-Loader-backed `code` tool. It does NOT post to GitHub: the orchestrator
-// (the workflow's trusted DO code) posts with a write-scoped installation token,
-// so no secret is ever reachable by the model.
+// Worker-Loader-backed `code` tool. It does NOT post to GitHub: the workflow's
+// trusted Action code posts with a write-scoped installation token, so no
+// secret is ever reachable by the model.
+//
+// @flue 1.0 workflow model: the agent (execution policy + sandbox) is defined
+// with `defineAgent`, and the finite behavior is an inline Action bound with
+// `defineWorkflow`. The Action's `run` receives `{ harness, log, input }` --
+// deliberately NOT platform bindings -- so env-scoped work (repo hydration,
+// GitHub auth) reads the bindings back through `getCloudflareContext()`. The
+// Workspace is keyed by the Durable Object identity so the sandbox built in the
+// agent initializer and the clone performed in the Action target the exact same
+// DO SQLite + R2 namespace.
 
 import { WorkspaceFileSystem } from "@cloudflare/shell";
 import { createGit } from "@cloudflare/shell/git";
-import { createAgent, type FlueContext, type WorkflowRouteHandler } from "@flue/runtime";
+import {
+	defineAgent,
+	defineWorkflow,
+	type ActionContext,
+	type WorkflowRouteHandler,
+} from "@flue/runtime";
+import { getCloudflareContext, getDurableObjectIdentity } from "@flue/runtime/cloudflare";
+import * as v from "valibot";
 
 import { withCapacityRetry } from "../lib/capacity.js";
 import {
@@ -25,15 +41,17 @@ import { reviewResultSchema, type ReviewResult } from "../lib/review-schema.js";
 import { getDefaultWorkspace, getShellSandbox } from "../sandboxes/cloudflare-shell.js";
 import review from "../skills/review/SKILL.md" with { type: "skill" };
 
-interface ReviewPayload {
-	prNumber: number;
-	prTitle: string;
-	prBody: string;
-	headRef: string;
-	baseRef: string;
-	owner: string;
-	repo: string;
-}
+const reviewPayloadSchema = v.object({
+	prNumber: v.number(),
+	prTitle: v.string(),
+	prBody: v.string(),
+	headRef: v.string(),
+	baseRef: v.string(),
+	owner: v.string(),
+	repo: v.string(),
+});
+
+type ReviewPayload = v.InferOutput<typeof reviewPayloadSchema>;
 
 const REPO_DIR = "/repo";
 const DIFF_PATH = `${REPO_DIR}/.flue-pr.diff`;
@@ -63,38 +81,30 @@ function assertSafe(payload: ReviewPayload): void {
 	}
 }
 
-// cf-shell agent: hydrate the PR into the durable Workspace via JS git (shallow
-// clone of base, then fetch + checkout the PR head -- refs/pull/N/head covers
-// fork PRs), then expose the Workspace through the Worker-Loader `code` tool.
-// Large objects (the git packfile) spill to R2 (see the workspace `name`).
-const reviewAgent = createAgent<ReviewPayload, Env>(async ({ id, env, payload }) => {
-	const workspace = getDefaultWorkspace(env.REVIEW_WORKSPACE, `review-${id}`);
-	const fs = new WorkspaceFileSystem(workspace);
+// Stable per-run Workspace name shared by the agent initializer (sandbox) and
+// the Action (clone). Both run inside the same workflow-run Durable Object and
+// therefore share one DO SqlStorage regardless of this name -- SQLite isolation
+// comes from the per-run DO, not the name. The name only keys the R2 large-file
+// spill prefix (r2://<name>/...) and observability, so the two call sites must
+// derive it identically, otherwise the sandbox and the clone would look for
+// spilled git objects under different prefixes. The DO id is a run-unique,
+// retry-stable key (same runId -> same DO).
+function workspaceName(): string {
+	return `review-${getDurableObjectIdentity().id}`;
+}
 
-	if (payload && !(await workspace.exists(HYDRATED))) {
-		const cloneUrl = `https://github.com/${payload.owner}/${payload.repo}.git`;
-		const git = createGit(fs);
-		await git.clone({
-			url: cloneUrl,
-			dir: REPO_DIR,
-			branch: payload.baseRef,
-			singleBranch: true,
-			depth: 1,
-		});
-		const fetched = await git.fetch({
-			ref: `pull/${payload.prNumber}/head`,
-			depth: 1,
-			dir: REPO_DIR,
-		});
-		if (fetched.fetchHead) {
-			await git.checkout({ ref: fetched.fetchHead, dir: REPO_DIR, force: true });
-		}
-		await workspace.writeFile(HYDRATED, new Date().toISOString());
-	}
-
+// The agent: execution policy (model, reasoning effort) plus the cf-shell
+// sandbox built from the platform bindings. Repo hydration cannot live here --
+// the initializer has no access to the PR payload -- so it moves into the
+// Action's `run` below, which shares this sandbox via the same Workspace name.
+const reviewAgent = defineAgent<Env>(({ env }) => {
+	const workspace = getDefaultWorkspace(env.REVIEW_WORKSPACE, workspaceName());
 	return {
-		// Kimi (k2.7-code) via the Workers AI binding: no model API key needed.
-		model: "cloudflare/@cf/moonshotai/kimi-k2.7-code",
+		// GLM-5.2 via the Workers AI binding: no model API key needed. A reasoning
+		// model, so `thinkingLevel` maps to `reasoning_effort` on the call; "low"
+		// keeps it from over-deliberating on straightforward diffs.
+		model: "cloudflare/@cf/zai-org/glm-5.2",
+		thinkingLevel: "low",
 		sandbox: getShellSandbox({ workspace, loader: env.LOADER }),
 		cwd: REPO_DIR,
 		instructions: [
@@ -107,8 +117,6 @@ const reviewAgent = createAgent<ReviewPayload, Env>(async ({ id, env, payload })
 		skills: [review],
 	};
 });
-
-export const route: WorkflowRouteHandler = async (_c, next) => next();
 
 function buildPrContext(payload: ReviewPayload, priorReview?: string): string {
 	const lines = [
@@ -127,11 +135,45 @@ function buildPrContext(payload: ReviewPayload, priorReview?: string): string {
 	return lines.join("\n");
 }
 
-export async function run(ctx: FlueContext<ReviewPayload, Env>): Promise<ReviewResult> {
-	const { init, payload, env } = ctx;
+// Hydrate the PR into the durable Workspace via JS git (shallow clone of base,
+// then fetch + checkout the PR head -- refs/pull/N/head covers fork PRs). Large
+// objects (the git packfile) spill to R2 under the workspace name. Idempotent:
+// a HYDRATED marker skips re-cloning on workflow re-entry.
+async function hydrate(env: Env, payload: ReviewPayload): Promise<void> {
+	const workspace = getDefaultWorkspace(env.REVIEW_WORKSPACE, workspaceName());
+	if (await workspace.exists(HYDRATED)) return;
+
+	const fs = new WorkspaceFileSystem(workspace);
+	const cloneUrl = `https://github.com/${payload.owner}/${payload.repo}.git`;
+	const git = createGit(fs);
+	await git.clone({
+		url: cloneUrl,
+		dir: REPO_DIR,
+		branch: payload.baseRef,
+		singleBranch: true,
+		depth: 1,
+	});
+	const fetched = await git.fetch({
+		ref: `pull/${payload.prNumber}/head`,
+		depth: 1,
+		dir: REPO_DIR,
+	});
+	if (fetched.fetchHead) {
+		await git.checkout({ ref: fetched.fetchHead, dir: REPO_DIR, force: true });
+	}
+	await workspace.writeFile(HYDRATED, new Date().toISOString());
+}
+
+async function run(context: ActionContext<typeof reviewPayloadSchema>): Promise<ReviewResult> {
+	const payload = context.input;
 	assertSafe(payload);
 
-	// GitHub access lives only in this trusted DO code, never in the agent's
+	// ActionContext intentionally excludes platform bindings; read them back
+	// through the Cloudflare context established for this workflow run.
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+	const env = getCloudflareContext().env as unknown as Env;
+
+	// GitHub access lives only in this trusted Action code, never in the agent's
 	// workspace. Without app creds (local dev) we skip posting and return.
 	const creds = readAppCreds(env);
 	let token: string | undefined;
@@ -144,13 +186,15 @@ export async function run(ctx: FlueContext<ReviewPayload, Env>): Promise<ReviewR
 	}
 
 	try {
-		// init() hydrates the Workspace (clone + checkout the PR head).
-		const harness = await init(reviewAgent);
-		const session = await harness.session();
+		// Hydrate the Workspace (clone + checkout the PR head) into the same DO
+		// SQLite + R2 namespace the agent's sandbox reads from.
+		await hydrate(env, payload);
+
+		const session = await context.harness.session();
 
 		// Stage the canonical unified diff into the Workspace (no `git` in cf-shell).
 		const diff = await fetchUnifiedDiff(payload.owner, payload.repo, payload.prNumber, token);
-		await harness.fs.writeFile(DIFF_PATH, diff);
+		await context.harness.fs.writeFile(DIFF_PATH, diff);
 
 		const { data } = await withCapacityRetry(
 			(signal) =>
@@ -171,9 +215,9 @@ export async function run(ctx: FlueContext<ReviewPayload, Env>): Promise<ReviewR
 			{
 				label: `review#${payload.prNumber}`,
 				attempts: 3,
-				perAttemptTimeoutMs: 20 * 60_000,
+				perAttemptTimeoutMs: 30 * 60_000,
 				onRetry: ({ attempt, delayMs, error }) =>
-					ctx.log.warn?.("[review] model over capacity, backing off", {
+					context.log.warn?.("[review] model over capacity, backing off", {
 						prNumber: payload.prNumber,
 						attempt,
 						delayMs,
@@ -210,3 +254,14 @@ export async function run(ctx: FlueContext<ReviewPayload, Env>): Promise<ReviewR
 		}
 	}
 }
+
+export default defineWorkflow({
+	agent: reviewAgent,
+	input: reviewPayloadSchema,
+	output: reviewResultSchema,
+	run,
+});
+
+// Enable POST /workflows/review (the internal admission route the webhook
+// handler calls). Pass-through: admission control lives in the webhook handler.
+export const route: WorkflowRouteHandler = async (_c, next) => next();

--- a/infra/flue-review/package.json
+++ b/infra/flue-review/package.json
@@ -11,14 +11,14 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@flue/cli": "1.0.0-beta.1",
+		"@flue/cli": "1.0.0-beta.9",
 		"typescript": "catalog:",
 		"wrangler": "catalog:"
 	},
 	"dependencies": {
 		"@cloudflare/codemode": "^0.4.1",
 		"@cloudflare/shell": "^0.4.0",
-		"@flue/runtime": "1.0.0-beta.1",
+		"@flue/runtime": "1.0.0-beta.9",
 		"agents": "^0.14.5",
 		"hono": "^4.12.23",
 		"valibot": "^1.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1012,8 +1012,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@flue/runtime':
-        specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+        specifier: 1.0.0-beta.9
+        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
       agents:
         specifier: ^0.14.5
         version: 0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@4.20260305.1)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.1)
@@ -1025,8 +1025,8 @@ importers:
         version: 1.4.1(typescript@6.0.3)
     devDependencies:
       '@flue/cli':
-        specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260305.1))(ws@8.21.0)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+        specifier: 1.0.0-beta.9
+        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260305.1))(ws@8.21.0)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -3908,6 +3908,7 @@ packages:
   '@durable-streams/client@0.2.6':
     resolution: {integrity: sha512-uHKKbWpsKLhFMeGjG0PgM6LXE3oEIi7FHKlJZkmYGxcqd4Yjjd/QEvnQnDzteRP4Av1uJVM8qjTL7kfKsgeS/w==}
     engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@e18e/eslint-plugin@0.5.1':
     resolution: {integrity: sha512-mqUozeyNI9xvJbjrOO7y765dT7Kud3bwCm/DHwctxdEngPdJWQaS9BNGgpM1wCCzZfOtlKQh4ZRhm3VRomT9KA==}
@@ -3920,13 +3921,14 @@ packages:
       oxlint:
         optional: true
 
-  '@earendil-works/pi-agent-core@0.79.4':
-    resolution: {integrity: sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A==}
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.79.4':
-    resolution: {integrity: sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw==}
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
     engines: {node: '>=22.19.0'}
+    hasBin: true
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -4477,16 +4479,17 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@flue/cli@1.0.0-beta.1':
-    resolution: {integrity: sha512-XbSsn7Nl2/J80Y+7Ph7tLF0Y3+doVdBXD8rPikuaMeq4mhHYSn5DjOwgXS2+TdzKcpOKyNVwttORyoVAjWdbtA==}
+  '@flue/cli@1.0.0-beta.9':
+    resolution: {integrity: sha512-RPv28ecD7lQ2XBZbuohte3rXDqHHrdXTpCGC5mSxYQsEkOeDN2LOmImQZbJqCrkIAFmMgntzOhaF2+14R61C4Q==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@flue/runtime@1.0.0-beta.9':
+    resolution: {integrity: sha512-ksh0ZkTVyqQnGvU3OnbVX6luAJwe6tt8q7O0vn99b7Cx6XcPTXzY/YEkXrOtCHzV6ZwfSdO9ZfaWbhTD1tdQuQ==}
     engines: {node: '>=22.19.0'}
 
-  '@flue/runtime@1.0.0-beta.1':
-    resolution: {integrity: sha512-Ts5Za1j6uhjfby0JUut7MaoWpTXP+RCGA7EiZBMYkX/PCpwInVAVjdAxknmOilCdqx4MvsonjZG1VrQQlxFIRA==}
-    engines: {node: '>=22.19.0'}
-
-  '@flue/sdk@1.0.0-beta.1':
-    resolution: {integrity: sha512-61VS3lcPey8ZHLGC6lk94yzuNxSHqaROqmgrswnoH2E/1ILR+ZYoLmKYTbQuOi0lulBl/ykh1WlvTQztFg2/nA==}
+  '@flue/sdk@1.0.0-beta.9':
+    resolution: {integrity: sha512-EkGWF1Yw6baM4ekmp+3xFkc+LmDKcIAA0KQSZSpaSqQRYyixXB+IwEbhePS83HCgrR0/jup9l8rgld4Q2IGNOw==}
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -4898,8 +4901,13 @@ packages:
   '@microsoft/fetch-event-source@2.0.1':
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
 
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
@@ -4985,6 +4993,10 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@optique/core@1.0.2':
     resolution: {integrity: sha512-znsqMmjAdeOgSJzdJlpZpgAscojwQmeQYXzYnuEKllz5VCj6WyEkdzU4QuvJQtWQY3ve2taXwudEBRur0VHBOQ==}
@@ -8450,10 +8462,6 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
-    engines: {node: '>=18.0.0'}
-
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -8521,6 +8529,7 @@ packages:
 
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
 
   fast-xml-parser@5.8.0:
     resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
@@ -8884,10 +8893,6 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.7.0:
-    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -9099,6 +9104,7 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -9592,6 +9598,7 @@ packages:
   miniflare@4.20260609.0:
     resolution: {integrity: sha512-4ZfNh9ACDa/mKKQvTSO2vigyQS2MB7dEU02KRPle4FqL7S6nek+2Fq6WGzazZbt1OORYgb4OGVLnOCx+My2NNA==}
     engines: {node: '>=22.0.0'}
+    hasBin: true
 
   miniflare@4.20260611.0:
     resolution: {integrity: sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==}
@@ -9695,10 +9702,6 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
 
   nanoid@3.3.15:
@@ -10168,10 +10171,6 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -10592,6 +10591,7 @@ packages:
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.55.2:
     resolution: {integrity: sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg==}
@@ -10653,6 +10653,7 @@ packages:
 
   seek-bzip@2.0.0:
     resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -11828,6 +11829,7 @@ packages:
   workerd@1.20260609.1:
     resolution: {integrity: sha512-KF/Y/8f4VoXCk87NuU6RqmO0X5fdzcrxU3XzAgoPUpnH9t1ZyzRgX1O/9sJvjItxroCBTEBzKssda02Dz9i6BA==}
     engines: {node: '>=16'}
+    hasBin: true
 
   workerd@1.20260611.1:
     resolution: {integrity: sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==}
@@ -11950,6 +11952,7 @@ packages:
   yaml@2.7.1:
     resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
     engines: {node: '>= 14'}
+    hasBin: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -14133,9 +14136,9 @@ snapshots:
     optionalDependencies:
       oxlint: 1.73.0(oxlint-tsgolint@0.24.0)
 
-  '@earendil-works/pi-agent-core@0.79.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)':
+  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -14147,12 +14150,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)':
+  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.1)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))
-      '@mistralai/mistralai': 2.2.1
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -14479,8 +14483,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.15
-      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss: 8.5.16
+      postcss-nested: 6.2.0(postcss@8.5.16)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
@@ -14522,14 +14526,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@flue/cli@1.0.0-beta.1(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260305.1))(ws@8.21.0)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
+  '@flue/cli@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(typebox@1.1.38)(typescript@6.0.3)(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260305.1))(ws@8.21.0)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
     dependencies:
       '@cloudflare/vite-plugin': 1.40.1(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260305.1))
-      '@flue/runtime': 1.0.0-beta.1(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
-      '@flue/sdk': 1.0.0-beta.1
+      '@flue/runtime': 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+      '@flue/sdk': 1.0.0-beta.9
+      '@hono/node-server': 2.0.4(hono@4.12.23)
       '@vercel/detect-agent': 1.2.3
+      debug: 4.4.3
       minisearch: 7.2.0
       package-up: 5.0.0
+      picocolors: 1.1.1
+      ulidx: 2.4.1
       valibot: 1.4.1(typescript@6.0.3)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -14542,6 +14550,7 @@ snapshots:
       - bufferutil
       - effect
       - esbuild
+      - hono
       - jiti
       - less
       - sass
@@ -14563,10 +14572,10 @@ snapshots:
       - zod-openapi
       - zod-to-json-schema
 
-  '@flue/runtime@1.0.0-beta.1(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
+  '@flue/runtime@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.1.38)(typescript@6.0.3)(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)
-      '@earendil-works/pi-ai': 0.79.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)
+      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.0)(zod@4.4.1)
       '@hono/node-server': 2.0.4(hono@4.12.23)
       '@hono/standard-validator': 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.23)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
@@ -14598,7 +14607,7 @@ snapshots:
       - zod-openapi
       - zod-to-json-schema
 
-  '@flue/sdk@1.0.0-beta.1':
+  '@flue/sdk@1.0.0-beta.9':
     dependencies:
       '@durable-streams/client': 0.2.6
 
@@ -15073,11 +15082,14 @@ snapshots:
 
   '@microsoft/fetch-event-source@2.0.1': {}
 
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
       ws: 8.21.0
       zod: 4.4.1
       zod-to-json-schema: 3.25.1(zod@4.4.1)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -15117,7 +15129,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.12.23
@@ -15201,6 +15213,8 @@ snapshots:
       fastq: 1.17.1
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@optique/core@1.0.2': {}
 
@@ -18877,13 +18891,11 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
-  eventsource-parser@3.0.8: {}
-
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
 
   expand-template@2.0.3: {}
 
@@ -19509,10 +19521,6 @@ snapshots:
       '@babel/runtime': 7.28.6
 
   iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -20601,8 +20609,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@3.3.12: {}
-
   nanoid@3.3.15: {}
 
   nanoid@5.1.11: {}
@@ -21085,9 +21091,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-nested@6.2.0(postcss@8.5.15):
+  postcss-nested@6.2.0(postcss@8.5.16):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.16
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.0.10:
@@ -21103,12 +21109,6 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -21365,7 +21365,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.0
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc@1.2.8:


### PR DESCRIPTION
## What does this PR do?

Switches the `@emdashbot` PR reviewer from `kimi-k2.7-code` to Workers AI's `@cf/zai-org/glm-5.2`, caps its reasoning effort at `"low"` so it stops over-deliberating on straightforward diffs, and raises the per-attempt review timeout from 20 to 30 minutes.

Getting there required a framework bump. `glm-5.2` only carries the metadata flue needs (reasoning support + context window) in `pi-ai 0.80.x`, which is first pulled by `@flue/runtime`/`@flue/cli` `1.0.0-beta.9` (up from `beta.1`). On the pinned `beta.1` catalog `glm-5.2` resolves to zero metadata, so `reasoning_effort` is never sent and `thinkingLevel` is a silent no-op. beta.9 removed the old `FlueContext` / `createAgent<Payload, Env>` / `export function run(ctx)` workflow model, so `.flue/workflows/review.ts` is migrated to `defineAgent` + `defineWorkflow`:

- The **agent** holds the model, `thinkingLevel: "low"`, and the cf-shell sandbox (built from `env` in the initializer).
- The **Action** `run` performs PR hydration (git clone) and GitHub posting. Since `ActionContext` deliberately omits platform bindings, it reads `env` back through `getCloudflareContext()` and keys the durable Workspace on the per-run Durable Object id, so the sandbox and the clone share the same DO SQLite + R2 spill prefix.

No functional change to the review protocol, schema, or GitHub posting path.

**Rollout note (please verify before/right after merge):** GLM-5.2's tool-calling and structured-output behavior on the Workers AI binding is not something the compiler or a local build can check. Recommend a one-PR end-to-end smoke test against `@cf/zai-org/glm-5.2` to confirm it emits schema-conformant `code`-tool calls and honors `reasoning_effort`. If reasoning is unsupported, `thinkingLevel` is silently ignored (acceptable), but confirm it does not error.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (flue-review)
- [x] `pnpm lint` passes — flue-review is lint-clean; the ~65 repo-wide `--type-aware` diagnostics are pre-existing baseline in unrelated packages, none in this change
- [ ] `pnpm test` passes — n/a, this infra worker has no test suite (`typecheck` only); verified via `flue build` + an independent cross-model review of the migration
- [x] `pnpm format` has been run (oxfmt clean)
- [ ] I have added/updated tests for my changes — n/a (no test harness for this worker)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a (no admin UI strings)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) — n/a (`@emdash-cms/flue-review` is private and unpublished)
- [ ] New features link to an approved Discussion — n/a (not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (authoring), independently reviewed with the Sonnet-family review agent

## Screenshots / test output

`pnpm typecheck`, `flue build --target cloudflare`, `oxfmt --check`, and `oxlint` all pass for `infra/flue-review`.