### PR TITLE
feat(labeler): serve the operator console and Access-guarded read API (W9.3 server)

### DIFF
--- a/apps/labeler/console/src/api/client.test.ts
+++ b/apps/labeler/console/src/api/client.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { apiClient } from "./client.js";
+import { createFixtureClient } from "./client.js";
 
-describe("fixture apiClient", () => {
+const apiClient = createFixtureClient();
+
+describe("fixture client", () => {
 	it("lists assessments newest first", async () => {
 		const page = await apiClient.listAssessments();
 		expect(page.items.length).toBeGreaterThan(0);

--- a/apps/labeler/console/src/api/client.ts
+++ b/apps/labeler/console/src/api/client.ts
@@ -20,10 +20,10 @@ import type {
 
 export const CONSOLE_API_BASE = "/admin/api";
 
-/** The console's data-access contract. `fixtureClient` below is the only
- * implementation wired up today; `createFetchClient` talks to the real
- * Worker routes once W9.4-W9.6 land — swapping `apiClient`'s assignment at
- * the bottom of this file is the only change either side needs. */
+/** The console's data-access contract. `createFetchClient` talks to the real
+ * Access-guarded `/admin/api/*` Worker routes and is what `apiClient` uses;
+ * `createFixtureClient` reads the static sample data and is kept exported for
+ * tests and offline UI work. */
 export interface LabelerConsoleClient {
 	listAssessments(params?: ListAssessmentsParams): Promise<Page<AssessmentRun>>;
 	getAssessment(id: string): Promise<AssessmentRun | null>;
@@ -64,8 +64,8 @@ async function parseJson<T>(response: Response, fallback: string): Promise<T> {
 	return body.data;
 }
 
-/** Talks to the real `/admin/api/*` routes. Not wired up yet — see
- * `apiClient` at the bottom of this file. */
+/** Talks to the real Access-guarded `/admin/api/*` routes — the client
+ * `apiClient` uses. */
 export function createFetchClient(): LabelerConsoleClient {
 	return {
 		async listAssessments(params = {}) {
@@ -112,9 +112,9 @@ export function createFetchClient(): LabelerConsoleClient {
 	};
 }
 
-/** Reads the static fixtures under src/fixtures/ — the only client wired
- * up until the labeler's `/admin/api/*` routes exist. */
-function createFixtureClient(): LabelerConsoleClient {
+/** Reads the static fixtures under src/fixtures/ — used by tests and offline
+ * UI work. */
+export function createFixtureClient(): LabelerConsoleClient {
 	return {
 		async listAssessments(params = {}) {
 			const filtered = params.state
@@ -144,4 +144,4 @@ function createFixtureClient(): LabelerConsoleClient {
 	};
 }
 
-export const apiClient: LabelerConsoleClient = createFixtureClient();
+export const apiClient: LabelerConsoleClient = createFetchClient();

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -107,15 +107,23 @@ export interface SubjectHistoryView {
 }
 
 /**
- * Placeholder shape for the append-only `operator_actions` audit table
- * (plan W9.2) — that table doesn't exist yet, so the audit log route
- * renders an empty state rather than calling this through the client.
+ * A row from the append-only `operator_actions` audit table (plan W9.2),
+ * sanitized by the server's `serializeOperatorActionView` — the internal
+ * replay fields (`idempotencyKey`, `requestFingerprint`, `resultJson`) are
+ * never sent. Actor identity is the Cloudflare Access subject (`actorId`), not
+ * a DID; humans carry `actorEmail`, service tokens carry `actorCommonName`.
  */
 export interface OperatorAction {
 	id: string;
-	actorDid: string;
+	actorType: "human" | "service";
+	actorId: string;
+	actorEmail: string | null;
+	actorCommonName: string | null;
+	role: "admin" | "reviewer";
 	action: string;
 	subjectUri: string | null;
+	subjectCid: string | null;
+	labelValue: string | null;
 	reason: string;
 	createdAt: string;
 }
@@ -124,8 +132,9 @@ export interface SystemStatusSnapshot {
 	labelerDid: string;
 	jetstreamConnected: boolean;
 	pendingAssessments: number;
-	discoveryQueueDepth: number;
-	lastReconciliationAt: string | null;
+	/** Dead-letter backlog — the observable stand-in for discovery-queue depth,
+	 * which the Queues API does not expose to the consumer Worker. */
+	deadLetterDepth: number;
 }
 
 export interface Page<T> {

--- a/apps/labeler/console/src/fixtures/operator-actions.ts
+++ b/apps/labeler/console/src/fixtures/operator-actions.ts
@@ -1,8 +1,42 @@
 import type { OperatorAction } from "../api/types.js";
+import { SUBJECT_ALPHA, SUBJECT_GAMMA } from "./subjects.js";
 
 /**
- * Empty until the `operator_actions` audit table ships (plan W9.2) —
- * the audit log route renders its empty state from this rather than
- * fabricating action history that doesn't correspond to any real schema.
+ * Sample rows from the append-only `operator_actions` audit table (plan W9.2),
+ * in the sanitized `serializeOperatorActionView` shape the server returns —
+ * newest first, no internal replay fields.
  */
-export const FIXTURE_OPERATOR_ACTIONS: readonly OperatorAction[] = [];
+export const OPERATOR_ACTION_GAMMA_RETRACT: OperatorAction = {
+	id: "oact_01J9ZK7Q2M4T8V0X2R4W6Y8B1C",
+	actorType: "human",
+	actorId: "access|8f2c1a90-6b3d-4e57-9a12-77c0de9b4a11",
+	actorEmail: "reviewer@emdashcms.com",
+	actorCommonName: null,
+	role: "reviewer",
+	action: "label-retract",
+	subjectUri: SUBJECT_GAMMA.uri,
+	subjectCid: SUBJECT_GAMMA.cid,
+	labelValue: "malware",
+	reason: "Retracting after upstream confirmed the flagged payload was a false positive.",
+	createdAt: "2026-07-12T14:02:15.000Z",
+};
+
+export const OPERATOR_ACTION_ALPHA_RERUN: OperatorAction = {
+	id: "oact_01J9YH3F5N7P9R1T3V5X7Z9A2B",
+	actorType: "service",
+	actorId: "access|ci-automation",
+	actorEmail: null,
+	actorCommonName: "ci-automation",
+	role: "admin",
+	action: "assessment-rerun",
+	subjectUri: SUBJECT_ALPHA.uri,
+	subjectCid: SUBJECT_ALPHA.cid,
+	labelValue: null,
+	reason: "Re-running against the updated policy version after the scanner upgrade.",
+	createdAt: "2026-07-11T16:40:00.000Z",
+};
+
+export const FIXTURE_OPERATOR_ACTIONS: readonly OperatorAction[] = [
+	OPERATOR_ACTION_GAMMA_RETRACT,
+	OPERATOR_ACTION_ALPHA_RERUN,
+];

--- a/apps/labeler/console/src/fixtures/system-status.ts
+++ b/apps/labeler/console/src/fixtures/system-status.ts
@@ -1,10 +1,9 @@
 import type { SystemStatusSnapshot } from "../api/types.js";
 
-/** Matches the `LABELER_DID` / discovery-queue bindings in wrangler.jsonc. */
+/** Matches the `LABELER_DID` binding in wrangler.jsonc. */
 export const FIXTURE_SYSTEM_STATUS: SystemStatusSnapshot = {
 	labelerDid: "did:web:labels.emdashcms.com",
 	jetstreamConnected: true,
 	pendingAssessments: 1,
-	discoveryQueueDepth: 3,
-	lastReconciliationAt: "2026-07-13T07:45:00.000Z",
+	deadLetterDepth: 2,
 };

--- a/apps/labeler/console/src/routes/Dashboard.tsx
+++ b/apps/labeler/console/src/routes/Dashboard.tsx
@@ -47,7 +47,7 @@ function Dashboard() {
 	return (
 		<div className="flex flex-col gap-6">
 			<h1 className="text-xl font-semibold">Dashboard</h1>
-			<Grid variant="4up" gap="base">
+			<Grid variant="3up" gap="base">
 				<StatCard
 					label="Jetstream connection"
 					value={
@@ -57,15 +57,7 @@ function Dashboard() {
 					}
 				/>
 				<StatCard label="Pending assessments" value={status.pendingAssessments} />
-				<StatCard label="Discovery queue depth" value={status.discoveryQueueDepth} />
-				<StatCard
-					label="Last reconciliation"
-					value={
-						status.lastReconciliationAt
-							? new Date(status.lastReconciliationAt).toLocaleString()
-							: "Never"
-					}
-				/>
+				<StatCard label="Dead-letter depth" value={status.deadLetterDepth} />
 			</Grid>
 			<LayerCard className="p-4 text-sm text-kumo-subtle">
 				Labeler DID: <span className="font-mono">{status.labelerDid}</span>

--- a/apps/labeler/package.json
+++ b/apps/labeler/package.json
@@ -8,7 +8,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"deploy": "vite build && wrangler deploy",
+		"deploy": "vite build && node --run console:build && wrangler deploy",
 		"typecheck": "tsgo --noEmit && tsgo --noEmit -p console/tsconfig.json",
 		"test": "vitest run && vitest run --config console/vitest.config.ts",
 		"db:migrate:local": "wrangler d1 migrations apply emdash-labeler --local",

--- a/apps/labeler/package.json
+++ b/apps/labeler/package.json
@@ -6,9 +6,9 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
+		"build": "node --run console:build && vite build",
 		"preview": "vite preview",
-		"deploy": "vite build && node --run console:build && wrangler deploy",
+		"deploy": "node --run build && wrangler deploy",
 		"typecheck": "tsgo --noEmit && tsgo --noEmit -p console/tsconfig.json",
 		"test": "vitest run && vitest run --config console/vitest.config.ts",
 		"db:migrate:local": "wrangler d1 migrations apply emdash-labeler --local",

--- a/apps/labeler/src/assessment-store.ts
+++ b/apps/labeler/src/assessment-store.ts
@@ -9,6 +9,8 @@ import {
 	type AssessmentState,
 	type PublicAssessmentState,
 } from "./assessment-lifecycle.js";
+import type { FindingSeverity } from "./evidence.js";
+import type { FindingSource } from "./findings.js";
 
 const DECISION_OUTCOME_STATES: ReadonlySet<AssessmentState> = new Set([
 	"passed",
@@ -868,6 +870,198 @@ export async function subjectWasObserved(
 		.bind(input.uri, input.cid)
 		.first();
 	return row !== null;
+}
+
+/** Full-lifecycle assessment history for a URI (all states, all CIDs),
+ * newest-first, capped at {@link SUBJECT_HISTORY_LIMIT}. Powers the operator
+ * console's subject view, which — unlike the public list — surfaces
+ * `observed`/`stale`/`cancelled` runs too. `isSuperseded` is computed inline
+ * via the same correlated subquery as {@link getAssessmentsPage}. */
+const SUBJECT_HISTORY_LIMIT = 100;
+
+export async function getAssessmentsForUri(
+	db: D1Database,
+	uri: string,
+): Promise<ListedAssessment[]> {
+	const rows = await db
+		.prepare(
+			`SELECT a.id, a.run_key, a.uri, a.cid, a.artifact_id, a.artifact_checksum, a.state,
+			 a.trigger, a.trigger_id, a.policy_version, a.model_id, a.prompt_hash,
+			 a.public_summary, a.coverage_json, a.supersedes_assessment_id,
+			 a.started_at, a.completed_at, a.created_at,
+			 ${SUPERSEDED_EXISTS_SQL} AS is_superseded
+			 FROM assessments a
+			 WHERE a.uri = ?
+			 ORDER BY a.created_at_epoch_ms DESC, a.id DESC
+			 LIMIT ?`,
+		)
+		.bind(uri, SUBJECT_HISTORY_LIMIT)
+		.all<AssessmentRow & { is_superseded: number }>();
+	return (rows.results ?? []).map((row) => ({
+		...rowToAssessment(row),
+		isSuperseded: row.is_superseded === 1,
+	}));
+}
+
+/** Count of in-flight runs (`pending` or `running`) across all subjects — the
+ * operator dashboard's "pending assessments" figure. */
+export async function countInFlightAssessments(db: D1Database): Promise<number> {
+	const row = await db
+		.prepare(`SELECT COUNT(*) AS n FROM assessments WHERE state IN ('pending', 'running')`)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+export interface Subject {
+	uri: string;
+	cid: string;
+	did: string;
+	collection: string;
+	rkey: string;
+	observedAt: string;
+	deletedAt: string | null;
+}
+
+interface SubjectRow {
+	uri: string;
+	cid: string;
+	did: string;
+	collection: string;
+	rkey: string;
+	observed_at: string;
+	deleted_at: string | null;
+}
+
+/** The current subject row at a URI: the newest non-deleted CID (same
+ * observed-then-CID tie-break as {@link isSubjectCurrent}), falling back to the
+ * newest deleted row when every CID has been tombstoned. Returns null only when
+ * the URI was never observed at all — the operator console maps that to a 404. */
+export async function getCurrentSubjectByUri(db: D1Database, uri: string): Promise<Subject | null> {
+	const row = await db
+		.prepare(
+			`SELECT uri, cid, did, collection, rkey, observed_at, deleted_at
+			 FROM subjects WHERE uri = ?
+			 ORDER BY (deleted_at IS NULL) DESC, observed_at_epoch_ms DESC, cid DESC
+			 LIMIT 1`,
+		)
+		.bind(uri)
+		.first<SubjectRow>();
+	return row
+		? {
+				uri: row.uri,
+				cid: row.cid,
+				did: row.did,
+				collection: row.collection,
+				rkey: row.rkey,
+				observedAt: row.observed_at,
+				deletedAt: row.deleted_at,
+			}
+		: null;
+}
+
+export interface AssessmentFinding {
+	id: string;
+	assessmentId: string;
+	source: FindingSource;
+	category: string;
+	severity: FindingSeverity;
+	confidence: number | null;
+	title: string;
+	publicSummary: string;
+	privateDetail: string;
+	evidenceRefs: string[];
+	createdAt: string;
+}
+
+interface FindingRow {
+	id: string;
+	assessment_id: string;
+	source: FindingSource;
+	category: string;
+	severity: FindingSeverity;
+	confidence: number | null;
+	title: string;
+	public_summary: string;
+	private_detail: string;
+	evidence_refs_json: string;
+	created_at: string;
+}
+
+/** Every finding for a run, oldest-first, with the operator-only
+ * `privateDetail`/`evidenceRefs` intact — the console serves the full record,
+ * not the public API's stripped view (spec §19.2). A malformed
+ * `evidence_refs_json` degrades to an empty list rather than throwing. */
+export async function getFindingsForAssessment(
+	db: D1Database,
+	assessmentId: string,
+): Promise<AssessmentFinding[]> {
+	const rows = await db
+		.prepare(
+			`SELECT id, assessment_id, source, category, severity, confidence, title,
+			 public_summary, private_detail, evidence_refs_json, created_at
+			 FROM findings WHERE assessment_id = ?
+			 ORDER BY created_at ASC, id ASC`,
+		)
+		.bind(assessmentId)
+		.all<FindingRow>();
+	return (rows.results ?? []).map((row) => ({
+		id: row.id,
+		assessmentId: row.assessment_id,
+		source: row.source,
+		category: row.category,
+		severity: row.severity,
+		confidence: row.confidence,
+		title: row.title,
+		publicSummary: row.public_summary,
+		privateDetail: row.private_detail,
+		evidenceRefs: parseEvidenceRefs(row.evidence_refs_json),
+		createdAt: row.created_at,
+	}));
+}
+
+function parseEvidenceRefs(json: string): string[] {
+	try {
+		const parsed: unknown = JSON.parse(json);
+		if (Array.isArray(parsed))
+			return parsed.filter((entry): entry is string => typeof entry === "string");
+	} catch {
+		// falls through to the empty default
+	}
+	return [];
+}
+
+export interface AssessmentIssuedLabel {
+	val: string;
+	cts: string;
+	exp: string | null;
+	neg: boolean;
+	sequence: number;
+}
+
+/** Every label op an assessment produced, including negations, oldest-first.
+ * Unlike {@link getLabelsForAssessment} (which filters `neg=0` for the public
+ * view), the operator console needs the full issue/retract timeline. */
+export async function getAllLabelsForAssessment(
+	db: D1Database,
+	assessmentId: string,
+): Promise<AssessmentIssuedLabel[]> {
+	const rows = await db
+		.prepare(
+			`SELECT l.val, l.cts, l.exp, l.neg, l.sequence
+			 FROM issued_labels l
+			 JOIN issuance_actions a ON a.id = l.action_id
+			 WHERE a.assessment_id = ?
+			 ORDER BY l.sequence ASC`,
+		)
+		.bind(assessmentId)
+		.all<{ val: string; cts: string; exp: string | null; neg: number; sequence: number }>();
+	return (rows.results ?? []).map((row) => ({
+		val: row.val,
+		cts: row.cts,
+		exp: row.exp,
+		neg: row.neg === 1,
+		sequence: row.sequence,
+	}));
 }
 
 function rowToAssessment(row: AssessmentRow): Assessment {

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -47,6 +47,7 @@ import { guardRead, ReadGuardError, type ReadGuardDeps } from "./operator-read-g
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 const NON_NEGATIVE_INTEGER = /^\d+$/;
+const ADMIN_API_PREFIX = /^\/admin\/api\/?/;
 
 const PUBLIC_STATES: ReadonlySet<string> = new Set([
 	"pending",
@@ -94,10 +95,7 @@ export async function handleConsoleApi(request: Request, deps: ConsoleApiDeps): 
 function matchRoute(request: Request, deps: ConsoleApiDeps): () => Promise<Response> {
 	const url = new URL(request.url);
 	// pathname keeps percent-encoding; the subject URI segment is decoded per route.
-	const segments = url.pathname
-		.replace(/^\/admin\/api\/?/, "")
-		.split("/")
-		.filter(Boolean);
+	const segments = url.pathname.replace(ADMIN_API_PREFIX, "").split("/").filter(Boolean);
 
 	if (segments[0] === "assessments") {
 		if (segments.length === 1) return () => handleListAssessments(request, url, deps);
@@ -310,10 +308,16 @@ export async function probeJetstreamConnected(env: Env): Promise<boolean> {
 	} catch {
 		// falls through to the D1 freshness fallback
 	}
-	const fresh = await env.DB.prepare(
-		`SELECT 1 FROM ingest_state
-		 WHERE source = 'jetstream' AND updated_at >= datetime('now', '-15 minutes')
-		 LIMIT 1`,
-	).first();
-	return fresh !== null;
+	try {
+		const fresh = await env.DB.prepare(
+			`SELECT 1 FROM ingest_state
+			 WHERE source = 'jetstream' AND updated_at >= datetime('now', '-15 minutes')
+			 LIMIT 1`,
+		).first();
+		return fresh !== null;
+	} catch {
+		// Neither signal is reachable; report disconnected rather than throwing and
+		// failing the whole status route on a degraded observability field.
+		return false;
+	}
 }

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -1,0 +1,319 @@
+/**
+ * Operator console read API (plan W9.3). Dispatches the seven Access-guarded,
+ * read-only `/admin/api/*` routes the console's `createFetchClient` consumes.
+ * Mirrors `xrpc-router.ts`'s hand-rolled dispatch + pure-D1-read style; each
+ * route is `guardRead` (once, at the top — every route requires the same
+ * reviewer gate) → store read → serialize → `{ data }`.
+ *
+ * Confidentiality of the private-evidence responses rests on: the edge Access
+ * policy on `/admin/*`, the per-request `verifyAccessRequest` + reviewer gate in
+ * `guardRead`, and — load-bearing, carried from W9.2 verbatim — **never emitting
+ * any `Access-Control-Allow-*` header**. A forged cross-origin GET can at most
+ * trigger a harmless read; without a CORS allow-origin the browser refuses to
+ * expose the body. No route here sets a CORS header.
+ */
+
+import {
+	computeFilterHash,
+	decodeCursor,
+	encodeCursor,
+	InvalidCursorError,
+} from "./assessment-cursor.js";
+import {
+	countInFlightAssessments,
+	getAllLabelsForAssessment,
+	getAssessment,
+	getAssessmentsForUri,
+	getAssessmentsPage,
+	getCurrentSubjectByUri,
+	getFindingsForAssessment,
+	isSuperseded,
+	type ListAssessmentsFilters,
+	type ListedAssessment,
+} from "./assessment-store.js";
+import {
+	serializeAssessmentRun,
+	serializeIssuedLabel,
+	serializeOperatorActionView,
+	serializeOperatorFinding,
+	serializeSubjectRecord,
+	type Page,
+} from "./console-serialize.js";
+import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
+import { MutationGuardError } from "./mutation-guard.js";
+import { getOperatorActionsPage } from "./operator-actions.js";
+import { guardRead, ReadGuardError, type ReadGuardDeps } from "./operator-read-guard.js";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const NON_NEGATIVE_INTEGER = /^\d+$/;
+
+const PUBLIC_STATES: ReadonlySet<string> = new Set([
+	"pending",
+	"passed",
+	"warned",
+	"blocked",
+	"error",
+	"superseded",
+]);
+
+export interface ConsoleApiDeps extends ReadGuardDeps {
+	db: D1Database;
+	labelerDid: string;
+	/** Resolves the operator dashboard's `jetstreamConnected` flag (a discovery
+	 * DO round-trip with a D1 freshness fallback). Injected so the dispatcher
+	 * stays unit-testable without a live DO. */
+	jetstreamConnected: () => Promise<boolean>;
+}
+
+/**
+ * Serves a `/admin/api/*` request. The caller (index.ts) has already matched the
+ * prefix; unmatched sub-paths 404 here. Every request is reviewer-gated before
+ * any store read runs.
+ */
+export async function handleConsoleApi(request: Request, deps: ConsoleApiDeps): Promise<Response> {
+	try {
+		await guardRead(request, deps, { minRole: "reviewer" });
+		// `matchRoute` is synchronous, so a rejection from the handler is consumed
+		// by this `await` directly — never adopted by an intermediate async layer,
+		// which would surface a spurious unhandled rejection under workerd.
+		const handler = matchRoute(request, deps);
+		const response = await handler();
+		return response;
+	} catch (error) {
+		if (error instanceof MutationGuardError || error instanceof ReadGuardError)
+			return error.toResponse();
+		console.error("[console-api] unhandled error", error);
+		return Response.json(
+			{ error: { code: "INTERNAL", message: "Internal error" } },
+			{ status: 500 },
+		);
+	}
+}
+
+function matchRoute(request: Request, deps: ConsoleApiDeps): () => Promise<Response> {
+	const url = new URL(request.url);
+	// pathname keeps percent-encoding; the subject URI segment is decoded per route.
+	const segments = url.pathname
+		.replace(/^\/admin\/api\/?/, "")
+		.split("/")
+		.filter(Boolean);
+
+	if (segments[0] === "assessments") {
+		if (segments.length === 1) return () => handleListAssessments(request, url, deps);
+		const id = segments[1];
+		if (id !== undefined && segments.length === 2)
+			return () => handleGetAssessment(request, deps, id);
+		if (id !== undefined && segments.length === 3 && segments[2] === "findings")
+			return () => handleListFindings(request, deps, id);
+		if (id !== undefined && segments.length === 3 && segments[2] === "labels")
+			return () => handleListLabels(request, deps, id);
+	} else if (segments[0] === "subjects" && segments.length === 2 && segments[1] !== undefined) {
+		const uri = decodeSubjectUri(segments[1]);
+		return () => handleGetSubjectHistory(request, deps, uri);
+	} else if (segments[0] === "audit-log" && segments.length === 1) {
+		return () => handleListAuditLog(request, url, deps);
+	} else if (segments[0] === "status" && segments.length === 1) {
+		return () => handleGetStatus(request, deps);
+	}
+
+	throw new ReadGuardError("NOT_FOUND");
+}
+
+function requireGet(request: Request): void {
+	if (request.method !== "GET") throw new ReadGuardError("METHOD_NOT_ALLOWED");
+}
+
+function decodeSubjectUri(segment: string): string {
+	try {
+		return decodeURIComponent(segment);
+	} catch {
+		throw new ReadGuardError("INVALID_REQUEST");
+	}
+}
+
+function jsonData<T>(data: T): Response {
+	// Operator data is private and volatile — never cached, never CORS-exposed.
+	return Response.json({ data }, { headers: { "cache-control": "no-store" } });
+}
+
+function parseLimit(params: URLSearchParams): number {
+	const raw = params.get("limit");
+	if (raw === null) return DEFAULT_LIMIT;
+	if (!NON_NEGATIVE_INTEGER.test(raw)) throw new ReadGuardError("INVALID_REQUEST");
+	return Math.min(Math.max(Number(raw), 1), MAX_LIMIT);
+}
+
+function parseState(params: URLSearchParams): ListAssessmentsFilters["state"] {
+	const raw = params.get("state");
+	if (raw === null) return undefined;
+	if (!PUBLIC_STATES.has(raw)) throw new ReadGuardError("INVALID_REQUEST");
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- validated against PUBLIC_STATES above
+	return raw as ListAssessmentsFilters["state"];
+}
+
+function decodeReadCursor(
+	raw: string | null,
+	filterHash: string,
+): { createdAt: string; id: string } | null {
+	try {
+		return decodeCursor(raw ?? undefined, filterHash);
+	} catch (error) {
+		if (error instanceof InvalidCursorError) throw new ReadGuardError("INVALID_CURSOR");
+		throw error;
+	}
+}
+
+async function handleListAssessments(
+	request: Request,
+	url: URL,
+	deps: ConsoleApiDeps,
+): Promise<Response> {
+	requireGet(request);
+	const filters: ListAssessmentsFilters = { state: parseState(url.searchParams) };
+	const limit = parseLimit(url.searchParams);
+	const filterHash = await computeFilterHash({ state: filters.state });
+	const keyset = decodeReadCursor(url.searchParams.get("cursor"), filterHash);
+
+	const rows = await getAssessmentsPage(deps.db, filters, keyset, limit);
+	const hasMore = rows.length > limit;
+	const page = hasMore ? rows.slice(0, limit) : rows;
+	const last = page.at(-1);
+	const body: Page<ReturnType<typeof serializeAssessmentRun>> = {
+		items: page.map(serializeAssessmentRun),
+		...(hasMore && last
+			? { nextCursor: encodeCursor({ createdAt: last.createdAt, id: last.id }, filterHash) }
+			: {}),
+	};
+	return jsonData(body);
+}
+
+async function handleGetAssessment(
+	request: Request,
+	deps: ConsoleApiDeps,
+	id: string,
+): Promise<Response> {
+	requireGet(request);
+	let row;
+	try {
+		row = await getAssessment(deps.db, id);
+	} catch (error) {
+		// getAssessment throws TypeError on a malformed id; the client maps 404 → null.
+		if (error instanceof TypeError) throw new ReadGuardError("NOT_FOUND");
+		throw error;
+	}
+	if (!row) throw new ReadGuardError("NOT_FOUND");
+	const superseded = await isSuperseded(deps.db, row.id);
+	const listed: ListedAssessment = { ...row, isSuperseded: superseded };
+	return jsonData(serializeAssessmentRun(listed));
+}
+
+async function handleListFindings(
+	request: Request,
+	deps: ConsoleApiDeps,
+	assessmentId: string,
+): Promise<Response> {
+	requireGet(request);
+	const findings = await getFindingsForAssessment(deps.db, assessmentId);
+	return jsonData(findings.map(serializeOperatorFinding));
+}
+
+async function handleListLabels(
+	request: Request,
+	deps: ConsoleApiDeps,
+	assessmentId: string,
+): Promise<Response> {
+	requireGet(request);
+	const labels = await getAllLabelsForAssessment(deps.db, assessmentId);
+	return jsonData(labels.map(serializeIssuedLabel));
+}
+
+async function handleGetSubjectHistory(
+	request: Request,
+	deps: ConsoleApiDeps,
+	uri: string,
+): Promise<Response> {
+	requireGet(request);
+	const subject = await getCurrentSubjectByUri(deps.db, uri);
+	if (!subject) throw new ReadGuardError("NOT_FOUND");
+	const assessments = await getAssessmentsForUri(deps.db, uri);
+	return jsonData({
+		subject: serializeSubjectRecord(subject),
+		assessments: assessments.map(serializeAssessmentRun),
+	});
+}
+
+async function handleListAuditLog(
+	request: Request,
+	url: URL,
+	deps: ConsoleApiDeps,
+): Promise<Response> {
+	requireGet(request);
+	const limit = parseLimit(url.searchParams);
+	const filterHash = await computeFilterHash({});
+	const keyset = decodeReadCursor(url.searchParams.get("cursor"), filterHash);
+
+	const rows = await getOperatorActionsPage(deps.db, keyset, limit);
+	const hasMore = rows.length > limit;
+	const page = hasMore ? rows.slice(0, limit) : rows;
+	const last = page.at(-1);
+	const body: Page<ReturnType<typeof serializeOperatorActionView>> = {
+		items: page.map(serializeOperatorActionView),
+		...(hasMore && last
+			? { nextCursor: encodeCursor({ createdAt: last.createdAt, id: last.id }, filterHash) }
+			: {}),
+	};
+	return jsonData(body);
+}
+
+async function handleGetStatus(request: Request, deps: ConsoleApiDeps): Promise<Response> {
+	requireGet(request);
+	const [pendingAssessments, deadLetterDepth, jetstreamConnected] = await Promise.all([
+		countInFlightAssessments(deps.db),
+		countDeadLetters(deps.db),
+		deps.jetstreamConnected(),
+	]);
+	return jsonData({
+		labelerDid: deps.labelerDid,
+		jetstreamConnected,
+		pendingAssessments,
+		deadLetterDepth,
+	});
+}
+
+/** Dead-letter backlog — the observable stand-in for discovery-queue depth,
+ * which the Queues API does not expose to the consumer Worker (spec §11.1's
+ * `/admin/system` "queue/DLQ health"). */
+async function countDeadLetters(db: D1Database): Promise<number> {
+	const row = await db.prepare(`SELECT COUNT(*) AS n FROM dead_letters`).first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/**
+ * `jetstreamConnected` probe (index.ts glue). Primary signal: the discovery
+ * DO's `{ cursor, consecutiveFailures }` status (`0` failures ⇒ connected).
+ * Fallback when the DO is unreachable/evicted: whether the D1 `ingest_state`
+ * jetstream cursor was written within the last 15 minutes — the comparison runs
+ * in SQLite so the `datetime('now')` string format never round-trips through JS.
+ */
+export async function probeJetstreamConnected(env: Env): Promise<boolean> {
+	try {
+		const id = env.LABELER_DISCOVERY_DO.idFromName(LABELER_DISCOVERY_DO_NAME);
+		const response = await env.LABELER_DISCOVERY_DO.get(id).fetch("https://do.internal/status");
+		const body: unknown = await response.json();
+		if (isRecord(body) && typeof body.consecutiveFailures === "number")
+			return body.consecutiveFailures === 0;
+	} catch {
+		// falls through to the D1 freshness fallback
+	}
+	const fresh = await env.DB.prepare(
+		`SELECT 1 FROM ingest_state
+		 WHERE source = 'jetstream' AND updated_at >= datetime('now', '-15 minutes')
+		 LIMIT 1`,
+	).first();
+	return fresh !== null;
+}

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -292,6 +292,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Maps an `/admin` console request path onto the asset binding's namespace, or
+ * returns `null` when the path is not a console asset request. The binding serves
+ * `./dist/console` one-to-one from the root, but the SPA is built with
+ * `base: "/admin/"`, so its `index.html` references `/admin/assets/*`. Without
+ * this strip the binding resolves those against `dist/console/admin/*`, misses,
+ * and hands every JS/CSS request the SPA `index.html` fallback — the shell would
+ * load but never execute. `/admin` and `/admin/` map to `/` (the shell); a deep
+ * link like `/admin/assessments/x` maps to `/assessments/x` (no such file, so the
+ * SPA fallback correctly serves the shell). `/admin/api/*` is the read API,
+ * dispatched before the asset branch, and is excluded here so an asset rewrite
+ * can never swallow an API path regardless of call order.
+ */
+export function consoleAssetPath(pathname: string): string | null {
+	if (pathname === "/admin/api" || pathname.startsWith("/admin/api/")) return null;
+	if (pathname !== "/admin" && !pathname.startsWith("/admin/")) return null;
+	const rest = pathname.slice("/admin".length);
+	return rest === "" ? "/" : rest;
+}
+
+/**
  * `jetstreamConnected` probe (index.ts glue). Primary signal: the discovery
  * DO's `{ cursor, consecutiveFailures }` status (`0` failures ⇒ connected).
  * Fallback when the DO is unreachable/evicted: whether the D1 `ingest_state`

--- a/apps/labeler/src/console-serialize.ts
+++ b/apps/labeler/src/console-serialize.ts
@@ -1,0 +1,198 @@
+/**
+ * Operator-console wire serializers (plan W9.3): stored rows → the JSON shapes
+ * the console's `createFetchClient` consumes (mirrored in
+ * `console/src/api/types.ts`). The inverse of `evidence.ts`'s public boundary —
+ * here we deliberately **include** the operator-only fields (`privateDetail`,
+ * `evidenceRefs`, `modelId`/`promptHash`, label negations), because every
+ * `/admin/api/*` route is Access-edge-gated and per-request reviewer-gated
+ * (spec §19.2: private evidence "Access is limited to reviewer/admin roles").
+ *
+ * The one non-privacy exclusion is the audit view, which drops the internal
+ * replay machinery (`idempotency_key`, `request_fingerprint`, `result_json`):
+ * those are `commitMutation` plumbing, not evidence, and never displayed.
+ *
+ * Wire types are redeclared here rather than imported from the console (which
+ * pulls in browser/React types); the two sides stay shape-compatible, with
+ * `console/src/api/types.ts` as the shared truth.
+ */
+
+import type { OperatorRole } from "./access-auth.js";
+import type { AssessmentState, PublicAssessmentState } from "./assessment-lifecycle.js";
+import type {
+	AssessmentFinding,
+	AssessmentIssuedLabel,
+	ListedAssessment,
+	Subject,
+} from "./assessment-store.js";
+import type { FindingSeverity } from "./evidence.js";
+import type { FindingSource } from "./findings.js";
+import type { StoredOperatorAction } from "./operator-actions.js";
+import { derivePublicState } from "./public-assessment.js";
+
+export interface AssessmentRun {
+	id: string;
+	runKey: string;
+	uri: string;
+	cid: string;
+	artifactId: string | null;
+	artifactChecksum: string | null;
+	state: AssessmentState;
+	publicState: PublicAssessmentState | null;
+	trigger: string;
+	triggerId: string;
+	policyVersion: string;
+	modelId: string | null;
+	promptHash: string | null;
+	publicSummary: string | null;
+	supersedesAssessmentId: string | null;
+	startedAt: string | null;
+	completedAt: string | null;
+	createdAt: string;
+	isSuperseded: boolean;
+}
+
+export interface OperatorFinding {
+	id: string;
+	assessmentId: string;
+	source: FindingSource;
+	category: string;
+	severity: FindingSeverity;
+	confidence?: number;
+	title: string;
+	publicSummary: string;
+	privateDetail: string;
+	evidenceRefs: readonly string[];
+	createdAt: string;
+}
+
+export interface IssuedLabel {
+	val: string;
+	cts: string;
+	exp: string | null;
+	neg: boolean;
+	sequence: number;
+}
+
+export interface SubjectRecord {
+	uri: string;
+	cid: string;
+	did: string;
+	collection: string;
+	rkey: string;
+	observedAt: string;
+	deletedAt: string | null;
+}
+
+export interface SubjectHistoryView {
+	subject: SubjectRecord;
+	assessments: AssessmentRun[];
+}
+
+export interface OperatorActionView {
+	id: string;
+	actorType: "human" | "service";
+	actorId: string;
+	actorEmail: string | null;
+	actorCommonName: string | null;
+	role: OperatorRole;
+	action: string;
+	subjectUri: string | null;
+	subjectCid: string | null;
+	labelValue: string | null;
+	reason: string;
+	createdAt: string;
+}
+
+export interface SystemStatusSnapshot {
+	labelerDid: string;
+	jetstreamConnected: boolean;
+	pendingAssessments: number;
+	deadLetterDepth: number;
+}
+
+export interface Page<T> {
+	items: T[];
+	nextCursor?: string;
+}
+
+export function serializeAssessmentRun(row: ListedAssessment): AssessmentRun {
+	return {
+		id: row.id,
+		runKey: row.runKey,
+		uri: row.uri,
+		cid: row.cid,
+		artifactId: row.artifactId,
+		artifactChecksum: row.artifactChecksum,
+		state: row.state,
+		publicState: derivePublicState(row.state, row.isSuperseded),
+		trigger: row.trigger,
+		triggerId: row.triggerId,
+		policyVersion: row.policyVersion,
+		modelId: row.modelId,
+		promptHash: row.promptHash,
+		publicSummary: row.publicSummary,
+		supersedesAssessmentId: row.supersedesAssessmentId,
+		startedAt: row.startedAt,
+		completedAt: row.completedAt,
+		createdAt: row.createdAt,
+		isSuperseded: row.isSuperseded,
+	};
+}
+
+export function serializeOperatorFinding(finding: AssessmentFinding): OperatorFinding {
+	return {
+		id: finding.id,
+		assessmentId: finding.assessmentId,
+		source: finding.source,
+		category: finding.category,
+		severity: finding.severity,
+		...(finding.confidence !== null ? { confidence: finding.confidence } : {}),
+		title: finding.title,
+		publicSummary: finding.publicSummary,
+		privateDetail: finding.privateDetail,
+		evidenceRefs: finding.evidenceRefs,
+		createdAt: finding.createdAt,
+	};
+}
+
+export function serializeIssuedLabel(label: AssessmentIssuedLabel): IssuedLabel {
+	return {
+		val: label.val,
+		cts: label.cts,
+		exp: label.exp,
+		neg: label.neg,
+		sequence: label.sequence,
+	};
+}
+
+export function serializeSubjectRecord(subject: Subject): SubjectRecord {
+	return {
+		uri: subject.uri,
+		cid: subject.cid,
+		did: subject.did,
+		collection: subject.collection,
+		rkey: subject.rkey,
+		observedAt: subject.observedAt,
+		deletedAt: subject.deletedAt,
+	};
+}
+
+/** Drops the internal replay fields (`idempotencyKey`, `requestFingerprint`,
+ * `resultJson`) and the epoch-ms sibling; keeps the "who did what, under which
+ * role, why" record the console displays. */
+export function serializeOperatorActionView(action: StoredOperatorAction): OperatorActionView {
+	return {
+		id: action.id,
+		actorType: action.actorType,
+		actorId: action.actorId,
+		actorEmail: action.actorEmail,
+		actorCommonName: action.actorCommonName,
+		role: action.role,
+		action: action.action,
+		subjectUri: action.subjectUri,
+		subjectCid: action.subjectCid,
+		labelValue: action.labelValue,
+		reason: action.reason,
+		createdAt: action.createdAt,
+	};
+}

--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -4,7 +4,7 @@ import {
 	type AccessAuthConfig,
 } from "./access-auth.js";
 import { getLabelerIdentityConfig, type LabelerConfig } from "./config.js";
-import { handleConsoleApi, probeJetstreamConnected } from "./console-api.js";
+import { consoleAssetPath, handleConsoleApi, probeJetstreamConnected } from "./console-api.js";
 import { drainDiscoveryDeadLetterBatch, processDiscoveryBatch } from "./discovery-consumer.js";
 import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
 import type { DiscoveryJob } from "./env.js";
@@ -58,7 +58,12 @@ export default {
 		// request regardless (see console-api.ts / operator-read-guard.ts).
 		if (pathname === "/admin/api" || pathname.startsWith("/admin/api/"))
 			return handleConsoleApiRequest(env, request, config);
-		if (pathname === "/admin" || pathname.startsWith("/admin/")) return env.ASSETS.fetch(request);
+		const assetPath = consoleAssetPath(pathname);
+		if (assetPath !== null) {
+			const assetUrl = new URL(request.url);
+			assetUrl.pathname = assetPath;
+			return env.ASSETS.fetch(new Request(assetUrl, request));
+		}
 		return new Response("emdash-labeler: not found", { status: 404 });
 	},
 

--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -1,4 +1,10 @@
-import { getLabelerIdentityConfig } from "./config.js";
+import {
+	getAccessKeyResolver,
+	parseAccessAuthConfig,
+	type AccessAuthConfig,
+} from "./access-auth.js";
+import { getLabelerIdentityConfig, type LabelerConfig } from "./config.js";
+import { handleConsoleApi, probeJetstreamConnected } from "./console-api.js";
 import { drainDiscoveryDeadLetterBatch, processDiscoveryBatch } from "./discovery-consumer.js";
 import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
 import type { DiscoveryJob } from "./env.js";
@@ -44,6 +50,15 @@ export default {
 			if (pathname === CREATE_REPORT_PATH) return rejectModerationReport(request);
 			return handleAssessmentXrpc(env, request, config);
 		}
+		// `/admin/api/*` is the Access-guarded operator read API; anything else
+		// under `/admin` is the console SPA, served (with SPA deep-link
+		// fallback) by the assets binding. The Access edge policy on `/admin/*`
+		// redirects an unauthenticated browser before it reaches the Worker, so
+		// the shell needs no in-Worker auth check — the API re-verifies per
+		// request regardless (see console-api.ts / operator-read-guard.ts).
+		if (pathname === "/admin/api" || pathname.startsWith("/admin/api/"))
+			return handleConsoleApiRequest(env, request, config);
+		if (pathname === "/admin" || pathname.startsWith("/admin/")) return env.ASSETS.fetch(request);
 		return new Response("emdash-labeler: not found", { status: 404 });
 	},
 
@@ -81,6 +96,44 @@ export default {
 		);
 	},
 };
+
+const OPERATOR_ACCESS_CONFIG_CACHE_KEY = Symbol.for("emdash-labeler:operator-access-config");
+
+/** Parse `OPERATOR_ACCESS_CONFIG` (a JSON string var) once and cache the result
+ * on `globalThis` — Vite can duplicate this module across SSR chunks, so a
+ * plain module-scope binding would parse per chunk. */
+function getOperatorAccessConfig(env: Env): AccessAuthConfig {
+	const g = globalThis as Record<symbol, unknown>;
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern
+	const cached = g[OPERATOR_ACCESS_CONFIG_CACHE_KEY] as AccessAuthConfig | undefined;
+	if (cached) return cached;
+	const parsed = parseAccessAuthConfig(JSON.parse(env.OPERATOR_ACCESS_CONFIG));
+	g[OPERATOR_ACCESS_CONFIG_CACHE_KEY] = parsed;
+	return parsed;
+}
+
+async function handleConsoleApiRequest(
+	env: Env,
+	request: Request,
+	config: LabelerConfig,
+): Promise<Response> {
+	let accessConfig: AccessAuthConfig;
+	try {
+		accessConfig = getOperatorAccessConfig(env);
+	} catch {
+		return Response.json(
+			{ error: { code: "NOT_CONFIGURED", message: "Operator console is not configured" } },
+			{ status: 500 },
+		);
+	}
+	return handleConsoleApi(request, {
+		db: env.DB,
+		config: accessConfig,
+		keys: getAccessKeyResolver(accessConfig.teamDomain),
+		labelerDid: config.labelerDid,
+		jetstreamConnected: () => probeJetstreamConnected(env),
+	});
+}
 
 function rejectModerationReport(request: Request): Response {
 	if (request.method !== "POST")

--- a/apps/labeler/src/mutation-guard.ts
+++ b/apps/labeler/src/mutation-guard.ts
@@ -280,14 +280,14 @@ function assertJsonContentType(request: Request): void {
 	}
 }
 
-function assertSameOrigin(request: Request, expectedOrigin: string): void {
+export function assertSameOrigin(request: Request, expectedOrigin: string): void {
 	const origin = request.headers.get("Origin");
 	if (origin !== null && origin !== expectedOrigin) throw new MutationGuardError("CROSS_ORIGIN");
 	const site = request.headers.get("Sec-Fetch-Site");
 	if (site !== null && site !== "same-origin") throw new MutationGuardError("CROSS_ORIGIN");
 }
 
-function assertCsrfHeader(request: Request): void {
+export function assertCsrfHeader(request: Request): void {
 	if (request.headers.get(OPERATOR_REQUEST_HEADER) !== "1")
 		throw new MutationGuardError("CSRF_HEADER_MISSING");
 }

--- a/apps/labeler/src/operator-actions.ts
+++ b/apps/labeler/src/operator-actions.ts
@@ -136,6 +136,40 @@ export async function getOperatorActionByKey(
 }
 
 /**
+ * Audit-log page, newest first, exclusive keyset on `(created_at_epoch_ms, id)`
+ * over `idx_operator_actions_created`. `keyset.createdAt` is the ISO timestamp
+ * carried in the opaque cursor; the epoch comparison derives from it via
+ * `Date.parse`, matching `getAssessmentsPage`. Fetches `limit + 1` so the caller
+ * detects a next page without a trailing COUNT.
+ */
+export async function getOperatorActionsPage(
+	db: D1Database,
+	keyset: { createdAt: string; id: string } | null,
+	limit: number,
+): Promise<StoredOperatorAction[]> {
+	const bindings: (string | number)[] = [];
+	let where = "";
+	if (keyset !== null) {
+		const epochMs = Date.parse(keyset.createdAt);
+		where = `WHERE (created_at_epoch_ms < ? OR (created_at_epoch_ms = ? AND id < ?))`;
+		bindings.push(epochMs, epochMs, keyset.id);
+	}
+	bindings.push(limit + 1);
+	const rows = await db
+		.prepare(
+			`SELECT id, actor_type, actor_id, actor_email, actor_common_name, role, action,
+			 subject_uri, subject_cid, label_value, reason, idempotency_key,
+			 request_fingerprint, result_json, metadata_json, created_at, created_at_epoch_ms
+			 FROM operator_actions ${where}
+			 ORDER BY created_at_epoch_ms DESC, id DESC
+			 LIMIT ?`,
+		)
+		.bind(...bindings)
+		.all<OperatorActionRow>();
+	return (rows.results ?? []).map(rowToStoredOperatorAction);
+}
+
+/**
  * True when `error` is the D1 UNIQUE violation on `operator_actions.idempotency_key`.
  * Matches the qualified column so it does not catch the `id` primary-key conflict
  * or any other constraint — `commitMutation` uses it to tell a duplicate-key race

--- a/apps/labeler/src/operator-read-guard.ts
+++ b/apps/labeler/src/operator-read-guard.ts
@@ -1,0 +1,90 @@
+/**
+ * Read counterpart of `guardMutation` (plan W9.3). Every `/admin/api/*` read
+ * runs the same defense-in-depth chain as a mutation, minus the body/idempotency
+ * machinery a GET has no use for: same-origin + CSRF-header transport checks
+ * (reusing the mutation guard's asserts so the CSRF/origin semantics have one
+ * source of truth), a fresh `verifyAccessRequest`, then a reviewer-role gate
+ * (admin satisfies it by inheritance — spec §19.2/§12). Returns the verified
+ * identity or throws a guard error the dispatcher renders via `toResponse`.
+ *
+ * Transport/auth rejections reuse `MutationGuardError` (`CROSS_ORIGIN`,
+ * `CSRF_HEADER_MISSING`, `UNAUTHENTICATED`, `FORBIDDEN_ROLE`); the read-only
+ * codes (`NOT_FOUND`, `INVALID_REQUEST`, `INVALID_CURSOR`, `METHOD_NOT_ALLOWED`)
+ * live on `ReadGuardError`, which shares `MutationGuardError`'s wire shape.
+ */
+
+import {
+	AccessAuthError,
+	hasRole,
+	verifyAccessRequest,
+	type AccessAuthConfig,
+	type AccessKeyResolver,
+	type OperatorIdentity,
+	type OperatorRole,
+} from "./access-auth.js";
+import { assertCsrfHeader, assertSameOrigin, MutationGuardError } from "./mutation-guard.js";
+
+export type ReadGuardCode =
+	| "NOT_FOUND"
+	| "INVALID_REQUEST"
+	| "INVALID_CURSOR"
+	| "METHOD_NOT_ALLOWED";
+
+const READ_GUARD_ERROR: Readonly<Record<ReadGuardCode, { status: number; message: string }>> = {
+	NOT_FOUND: { status: 404, message: "Resource not found" },
+	INVALID_REQUEST: { status: 400, message: "Request parameters are invalid" },
+	INVALID_CURSOR: { status: 400, message: "Cursor is invalid or does not match the request" },
+	METHOD_NOT_ALLOWED: { status: 405, message: "Method not allowed" },
+};
+
+/**
+ * Read-side guard rejection. Messages are static per code — they never echo the
+ * request, so `toResponse` cannot leak caller-supplied content. Same wire shape
+ * as `MutationGuardError` / core's `apiError`.
+ */
+export class ReadGuardError extends Error {
+	override readonly name = "ReadGuardError";
+	readonly code: ReadGuardCode;
+	readonly status: number;
+
+	constructor(code: ReadGuardCode) {
+		const { status, message } = READ_GUARD_ERROR[code];
+		super(message);
+		this.code = code;
+		this.status = status;
+	}
+
+	toResponse(): Response {
+		return Response.json(
+			{ error: { code: this.code, message: this.message } },
+			{ status: this.status },
+		);
+	}
+}
+
+export interface ReadGuardDeps {
+	config: AccessAuthConfig;
+	keys: AccessKeyResolver;
+	/** Defaults to the request URL's origin; override for proxy edge cases. */
+	expectedOrigin?: string;
+}
+
+export async function guardRead(
+	request: Request,
+	deps: ReadGuardDeps,
+	options: { minRole: OperatorRole },
+): Promise<OperatorIdentity> {
+	assertSameOrigin(request, deps.expectedOrigin ?? new URL(request.url).origin);
+	assertCsrfHeader(request);
+
+	let identity: OperatorIdentity;
+	try {
+		identity = await verifyAccessRequest(request, deps.config, deps.keys);
+	} catch (error) {
+		if (error instanceof AccessAuthError) throw new MutationGuardError("UNAUTHENTICATED");
+		throw error;
+	}
+
+	if (!hasRole(identity, options.minRole)) throw new MutationGuardError("FORBIDDEN_ROLE");
+	return identity;
+}

--- a/apps/labeler/test/console-api.test.ts
+++ b/apps/labeler/test/console-api.test.ts
@@ -1,0 +1,600 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { AccessKeyResolver } from "../src/access-auth.js";
+import { createSubject, recordFinding } from "../src/assessment-store.js";
+import { handleConsoleApi, type ConsoleApiDeps } from "../src/console-api.js";
+import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
+import { buildOperatorActionInsert, type OperatorActionType } from "../src/operator-actions.js";
+
+const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
+const AUDIENCE = "test-audience";
+const ORIGIN = "https://labeler.example.com";
+const LABELER_DID = "did:web:labels.emdashcms.com";
+
+const URI_A =
+	"at://did:plc:aaaaaaaaaaaaaaaaaaaaaaaa/com.emdashcms.experimental.package.release/rkA";
+const CID_A = "bafyreiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const URI_B =
+	"at://did:plc:bbbbbbbbbbbbbbbbbbbbbbbb/com.emdashcms.experimental.package.release/rkB";
+const CID_B = "bafyreibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const URI_S =
+	"at://did:plc:ssssssssssssssssssssssss/com.emdashcms.experimental.package.release/rkS";
+const CID_S_OLD = "bafyreisssssssssssssssssssssssssssssssssssssssssssssssold";
+const CID_S_NEW = "bafyreisssssssssssssssssssssssssssssssssssssssssssssssnew";
+
+// Assessment ids must satisfy assessment-lifecycle's ASSESSMENT_ID (ULID) regex,
+// which the detail route validates via getAssessment.
+const ASMT_PASS_A = "asmt_SQCP5CP1X1RBMM0V0TQP2WR9PD";
+const ASMT_BLOCK_B = "asmt_R79G2W700J4F005EAG66HP66JR";
+const ASMT_RUN = "asmt_34XM75YB5AJ9Z84B9EJBWM0CV1";
+const ASMT_PENDING = "asmt_RT0G62FEF7MAX2R6K0K0P3E3RN";
+const ASMT_S_STALE = "asmt_BZ7JNKG1TYRMZMVP0XQEGEC1Y7";
+const ASMT_S_PASS = "asmt_K2Y9KK9SSTD43VVT780P6HMT8A";
+const ASMT_S_CANCEL = "asmt_7ZH8QK2M4T8V0X2R4W6Y8B1C3D";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+
+let signKey: CryptoKey;
+let resolver: AccessKeyResolver;
+let reviewerToken: string;
+let adminToken: string;
+let noRoleToken: string;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+	const pair = await generateKeyPair("RS256");
+	signKey = pair.privateKey;
+	resolver = (async () => pair.publicKey) as AccessKeyResolver;
+	reviewerToken = await mintToken({ email: "reviewer@example.com" });
+	adminToken = await mintToken({ email: "admin@example.com" });
+	noRoleToken = await mintToken({ email: "nobody@example.com" });
+
+	await seedSubjects();
+	await seedAssessments();
+	await seedFindings();
+	await seedLabels();
+	await seedOperatorActions();
+	await seedDeadLetters(3);
+});
+
+async function mintToken(claims: Record<string, unknown>): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	return new SignJWT({ sub: "user-sub-1", ...claims })
+		.setProtectedHeader({ alg: "RS256" })
+		.setIssuer(TEAM_DOMAIN)
+		.setAudience(AUDIENCE)
+		.setIssuedAt(now)
+		.setExpirationTime(now + 3600)
+		.sign(signKey);
+}
+
+function deps(overrides: Partial<ConsoleApiDeps> = {}): ConsoleApiDeps {
+	return {
+		db: testEnv.DB,
+		config: {
+			teamDomain: TEAM_DOMAIN,
+			audience: AUDIENCE,
+			admins: ["admin@example.com"],
+			reviewers: ["reviewer@example.com"],
+		},
+		keys: resolver,
+		expectedOrigin: ORIGIN,
+		labelerDid: LABELER_DID,
+		jetstreamConnected: async () => true,
+		...overrides,
+	};
+}
+
+interface ReqOptions {
+	method?: string;
+	token?: string;
+	csrf?: string | null;
+	spoofEmail?: string;
+}
+
+function req(path: string, opts: ReqOptions = {}): Request {
+	const headers = new Headers();
+	const csrf = opts.csrf === undefined ? "1" : opts.csrf;
+	if (csrf !== null) headers.set(OPERATOR_REQUEST_HEADER, csrf);
+	if (opts.token !== undefined) headers.set("Cf-Access-Jwt-Assertion", opts.token);
+	if (opts.spoofEmail !== undefined)
+		headers.set("Cf-Access-Authenticated-User-Email", opts.spoofEmail);
+	return new Request(`${ORIGIN}${path}`, { method: opts.method ?? "GET", headers });
+}
+
+async function seedSubjects(): Promise<void> {
+	await createSubject(testEnv.DB, {
+		uri: URI_A,
+		cid: CID_A,
+		did: "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa",
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: "rkA",
+		now: new Date("2026-07-08T08:55:00.000Z"),
+	});
+	await createSubject(testEnv.DB, {
+		uri: URI_B,
+		cid: CID_B,
+		did: "did:plc:bbbbbbbbbbbbbbbbbbbbbbbb",
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: "rkB",
+		now: new Date("2026-07-08T09:55:00.000Z"),
+	});
+	await createSubject(testEnv.DB, {
+		uri: URI_S,
+		cid: CID_S_OLD,
+		did: "did:plc:ssssssssssssssssssssssss",
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: "rkS",
+		now: new Date("2026-07-01T10:00:00.000Z"),
+	});
+	await createSubject(testEnv.DB, {
+		uri: URI_S,
+		cid: CID_S_NEW,
+		did: "did:plc:ssssssssssssssssssssssss",
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: "rkS",
+		now: new Date("2026-07-05T10:00:00.000Z"),
+	});
+}
+
+interface SeedAssessment {
+	id: string;
+	uri: string;
+	cid: string;
+	state: string;
+	createdAt: string;
+	modelId?: string;
+	promptHash?: string;
+}
+
+async function seedAssessment(a: SeedAssessment): Promise<void> {
+	const epoch = Date.parse(a.createdAt);
+	await testEnv.DB.prepare(
+		`INSERT INTO assessments
+		 (id, run_key, uri, cid, artifact_id, artifact_checksum, state, trigger, trigger_id,
+		  policy_version, model_id, prompt_hash, public_summary, coverage_json,
+		  supersedes_assessment_id, started_at, started_at_epoch_ms, completed_at,
+		  completed_at_epoch_ms, created_at, created_at_epoch_ms)
+		 VALUES (?, ?, ?, ?, NULL, NULL, ?, 'initial', ?, '2026-07-10.experimental.2', ?, ?, NULL,
+		  '{"code":"complete","images":"not-present","metadata":"complete"}',
+		  NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+	)
+		.bind(
+			a.id,
+			`run-${a.id}`,
+			a.uri,
+			a.cid,
+			a.state,
+			`initial:${a.id}`,
+			a.modelId ?? null,
+			a.promptHash ?? null,
+			a.createdAt,
+			epoch,
+		)
+		.run();
+}
+
+async function seedAssessments(): Promise<void> {
+	await seedAssessment({
+		id: ASMT_PASS_A,
+		uri: URI_A,
+		cid: CID_A,
+		state: "passed",
+		createdAt: "2026-07-08T09:00:00.000Z",
+	});
+	await seedAssessment({
+		id: ASMT_BLOCK_B,
+		uri: URI_B,
+		cid: CID_B,
+		state: "blocked",
+		createdAt: "2026-07-08T10:00:00.000Z",
+		modelId: "@cf/meta/llama-3.1-70b-instruct",
+		promptHash: "sha256:prompt",
+	});
+	await seedAssessment({
+		id: ASMT_RUN,
+		uri: URI_A,
+		cid: CID_A,
+		state: "running",
+		createdAt: "2026-07-09T08:00:00.000Z",
+	});
+	await seedAssessment({
+		id: ASMT_PENDING,
+		uri: URI_A,
+		cid: CID_A,
+		state: "pending",
+		createdAt: "2026-07-09T09:00:00.000Z",
+	});
+	// Subject-history subject: passed + stale + cancelled across two CIDs.
+	await seedAssessment({
+		id: ASMT_S_STALE,
+		uri: URI_S,
+		cid: CID_S_OLD,
+		state: "stale",
+		createdAt: "2026-07-02T10:00:00.000Z",
+	});
+	await seedAssessment({
+		id: ASMT_S_PASS,
+		uri: URI_S,
+		cid: CID_S_NEW,
+		state: "passed",
+		createdAt: "2026-07-05T10:00:00.000Z",
+	});
+	await seedAssessment({
+		id: ASMT_S_CANCEL,
+		uri: URI_S,
+		cid: CID_S_NEW,
+		state: "cancelled",
+		createdAt: "2026-07-05T11:00:00.000Z",
+	});
+}
+
+async function seedFindings(): Promise<void> {
+	await recordFinding(testEnv.DB, {
+		assessmentId: ASMT_BLOCK_B,
+		source: "deterministic",
+		category: "malware",
+		severity: "critical",
+		title: "Known malware signature match",
+		publicSummary: "This release matches a known malware signature.",
+		privateDetail: "YARA rule stealer-generic-v3 matched dist/postinstall.js:1.",
+		evidenceRefs: ["evid_01"],
+		now: new Date("2026-07-08T10:01:00.000Z"),
+	});
+	await recordFinding(testEnv.DB, {
+		assessmentId: ASMT_BLOCK_B,
+		source: "capability",
+		category: "obfuscated-code",
+		severity: "high",
+		confidence: 0.94,
+		title: "Heavily obfuscated postinstall script",
+		publicSummary: "A postinstall script uses obfuscation techniques.",
+		privateDetail: "String-array rotation plus eval-based deobfuscation; entropy 7.91/8.",
+		evidenceRefs: ["evid_01"],
+		now: new Date("2026-07-08T10:02:00.000Z"),
+	});
+}
+
+async function seedLabel(input: {
+	actionId: number;
+	val: string;
+	neg: 0 | 1;
+	cts: string;
+}): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO issuance_actions (id, actor, type, reason, idempotency_key, created_at, assessment_id)
+		 VALUES (?, ?, 'automated-assessment', 'r', ?, ?, ?)`,
+	)
+		.bind(input.actionId, LABELER_DID, `idem-label-${input.actionId}`, input.cts, ASMT_BLOCK_B)
+		.run();
+	await testEnv.DB.prepare(
+		`INSERT INTO issued_labels (action_id, ver, src, uri, cid, val, neg, cts, sig, signing_key_id)
+		 VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, 'v1')`,
+	)
+		.bind(
+			input.actionId,
+			LABELER_DID,
+			URI_B,
+			CID_B,
+			input.val,
+			input.neg,
+			input.cts,
+			new Uint8Array([0]),
+		)
+		.run();
+}
+
+async function seedLabels(): Promise<void> {
+	await seedLabel({ actionId: 1001, val: "malware", neg: 0, cts: "2026-07-08T10:05:00.000Z" });
+	await seedLabel({
+		actionId: 1002,
+		val: "obfuscated-code",
+		neg: 0,
+		cts: "2026-07-08T10:06:00.000Z",
+	});
+	await seedLabel({ actionId: 1003, val: "malware", neg: 1, cts: "2026-07-08T10:10:00.000Z" });
+}
+
+async function seedOperatorActions(): Promise<void> {
+	const rows: { id: string; action: OperatorActionType; createdAt: string }[] = [
+		{ id: "oact_1", action: "label-issue", createdAt: "2026-07-10T01:00:00.000Z" },
+		{ id: "oact_2", action: "assessment-rerun", createdAt: "2026-07-10T02:00:00.000Z" },
+		{ id: "oact_3", action: "label-retract", createdAt: "2026-07-10T03:00:00.000Z" },
+	];
+	for (const row of rows) {
+		await buildOperatorActionInsert(testEnv.DB, {
+			id: row.id,
+			actorType: "human",
+			actorId: "access|sub-1",
+			actorEmail: "reviewer@example.com",
+			actorCommonName: null,
+			role: "reviewer",
+			action: row.action,
+			subjectUri: URI_B,
+			subjectCid: CID_B,
+			labelValue: "malware",
+			reason: "operator reason",
+			idempotencyKey: `idem-${row.id}-abcdefgh`,
+			requestFingerprint: "a".repeat(64),
+			resultJson: '{"ok":true}',
+			metadataJson: "{}",
+			createdAt: row.createdAt,
+			createdAtEpochMs: Date.parse(row.createdAt),
+		}).run();
+	}
+}
+
+async function seedDeadLetters(count: number): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		await testEnv.DB.prepare(
+			`INSERT INTO dead_letters (did, collection, rkey, reason, payload, received_at)
+			 VALUES (?, 'col', ?, 'verify-failed', ?, '2026-07-10 00:00:00')`,
+		)
+			.bind(`did:plc:dead${i}`, `rk${i}`, new Uint8Array([0]))
+			.run();
+	}
+}
+
+async function body(response: Response): Promise<{ data?: unknown; error?: { code: string } }> {
+	return response.json();
+}
+
+describe("handleConsoleApi — guard rejections", () => {
+	it("rejects a request with no assertion header (401)", async () => {
+		const res = await handleConsoleApi(req("/admin/api/assessments"), deps());
+		expect(res.status).toBe(401);
+		expect((await body(res)).error?.code).toBe("UNAUTHENTICATED");
+	});
+
+	it("rejects a spoofed email header without a verified assertion (401)", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments", { spoofEmail: "admin@example.com" }),
+			deps(),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	it("rejects an edge-authenticated identity with no role (403)", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments", { token: noRoleToken }),
+			deps(),
+		);
+		expect(res.status).toBe(403);
+		expect((await body(res)).error?.code).toBe("FORBIDDEN_ROLE");
+	});
+
+	it("rejects a missing CSRF header (403)", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments", { token: reviewerToken, csrf: null }),
+			deps(),
+		);
+		expect(res.status).toBe(403);
+		expect((await body(res)).error?.code).toBe("CSRF_HEADER_MISSING");
+	});
+
+	it("admits an admin by inheritance", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments", { token: adminToken }),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe("handleConsoleApi — method + routing", () => {
+	it("rejects a non-GET method (405)", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments", { method: "POST", token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(405);
+		expect((await body(res)).error?.code).toBe("METHOD_NOT_ALLOWED");
+	});
+
+	it("404s an unknown sub-path", async () => {
+		const res = await handleConsoleApi(req("/admin/api/nope", { token: reviewerToken }), deps());
+		expect(res.status).toBe(404);
+		expect((await body(res)).error?.code).toBe("NOT_FOUND");
+	});
+
+	it("never emits a CORS allow-origin header", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.headers.get("access-control-allow-origin")).toBeNull();
+		expect(res.headers.get("cache-control")).toBe("no-store");
+	});
+});
+
+describe("handleConsoleApi — assessments", () => {
+	it("lists decision/pending runs and filters by state", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments?state=blocked", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+		const data = (await body(res)).data as { items: { id: string; publicState: string }[] };
+		expect(data.items.map((a) => a.id)).toContain(ASMT_BLOCK_B);
+		expect(data.items.every((a) => a.publicState === "blocked")).toBe(true);
+	});
+
+	it("serves modelId/promptHash on the detail view", async () => {
+		const res = await handleConsoleApi(
+			req(`/admin/api/assessments/${ASMT_BLOCK_B}`, { token: reviewerToken }),
+			deps(),
+		);
+		const run = (await body(res)).data as {
+			modelId: string;
+			promptHash: string;
+			coverageJson?: unknown;
+		};
+		expect(run.modelId).toBe("@cf/meta/llama-3.1-70b-instruct");
+		expect(run).not.toHaveProperty("coverageJson");
+	});
+
+	it("404s an absent assessment id (client maps to null)", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments/asmt_ZZZZZZZZZZZZZZZZZZZZZZZZZZ", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("404s a malformed assessment id (client maps to null)", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments/not-a-valid-id", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("handleConsoleApi — findings and labels", () => {
+	it("serves findings with the operator-only privateDetail", async () => {
+		const res = await handleConsoleApi(
+			req(`/admin/api/assessments/${ASMT_BLOCK_B}/findings`, { token: reviewerToken }),
+			deps(),
+		);
+		const findings = (await body(res)).data as { privateDetail: string; category: string }[];
+		expect(findings.length).toBe(2);
+		expect(
+			findings.every((f) => typeof f.privateDetail === "string" && f.privateDetail.length > 0),
+		).toBe(true);
+	});
+
+	it("serves the full label history including negations", async () => {
+		const res = await handleConsoleApi(
+			req(`/admin/api/assessments/${ASMT_BLOCK_B}/labels`, { token: reviewerToken }),
+			deps(),
+		);
+		const labels = (await body(res)).data as { val: string; neg: boolean }[];
+		expect(labels.length).toBe(3);
+		expect(labels.some((l) => l.neg === true)).toBe(true);
+	});
+});
+
+describe("handleConsoleApi — subject history", () => {
+	it("returns the current CID and full-lifecycle runs (stale/cancelled visible)", async () => {
+		const res = await handleConsoleApi(
+			req(`/admin/api/subjects/${encodeURIComponent(URI_S)}`, { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+		const view = (await body(res)).data as {
+			subject: { cid: string };
+			assessments: { state: string }[];
+		};
+		expect(view.subject.cid).toBe(CID_S_NEW);
+		const states = view.assessments.map((a) => a.state);
+		expect(states).toContain("stale");
+		expect(states).toContain("cancelled");
+	});
+
+	it("404s a never-observed subject", async () => {
+		const res = await handleConsoleApi(
+			req(`/admin/api/subjects/${encodeURIComponent("at://did:plc:missing/col/rk")}`, {
+				token: reviewerToken,
+			}),
+			deps(),
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("handleConsoleApi — audit log", () => {
+	it("returns sanitized rows without the internal replay fields", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/audit-log", { token: reviewerToken }),
+			deps(),
+		);
+		const data = (await body(res)).data as { items: Record<string, unknown>[] };
+		expect(data.items.length).toBe(3);
+		const [newest] = data.items;
+		expect(newest!.id).toBe("oact_3");
+		for (const item of data.items) {
+			expect(item).not.toHaveProperty("idempotencyKey");
+			expect(item).not.toHaveProperty("requestFingerprint");
+			expect(item).not.toHaveProperty("resultJson");
+		}
+	});
+
+	it("paginates with a keyset cursor", async () => {
+		const p1 = await handleConsoleApi(
+			req("/admin/api/audit-log?limit=2", { token: reviewerToken }),
+			deps(),
+		);
+		const d1 = (await body(p1)).data as { items: { id: string }[]; nextCursor?: string };
+		expect(d1.items.map((i) => i.id)).toEqual(["oact_3", "oact_2"]);
+		expect(d1.nextCursor).toBeDefined();
+
+		const p2 = await handleConsoleApi(
+			req(`/admin/api/audit-log?limit=2&cursor=${d1.nextCursor}`, { token: reviewerToken }),
+			deps(),
+		);
+		const d2 = (await body(p2)).data as { items: { id: string }[]; nextCursor?: string };
+		expect(d2.items.map((i) => i.id)).toEqual(["oact_1"]);
+		expect(d2.nextCursor).toBeUndefined();
+	});
+});
+
+describe("handleConsoleApi — limit and cursor validation", () => {
+	it("clamps an over-max limit to 100", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments?limit=500", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it("400s a non-numeric limit", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/assessments?limit=abc", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(400);
+		expect((await body(res)).error?.code).toBe("INVALID_REQUEST");
+	});
+
+	it("400s a cursor whose filter hash no longer matches", async () => {
+		const p1 = await handleConsoleApi(
+			req("/admin/api/assessments?limit=1", { token: reviewerToken }),
+			deps(),
+		);
+		const d1 = (await body(p1)).data as { nextCursor?: string };
+		expect(d1.nextCursor).toBeDefined();
+		const res = await handleConsoleApi(
+			req(`/admin/api/assessments?state=passed&cursor=${d1.nextCursor}`, { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(400);
+		expect((await body(res)).error?.code).toBe("INVALID_CURSOR");
+	});
+});
+
+describe("handleConsoleApi — system status", () => {
+	it("grounds every field: pending count, dead-letter depth, injected jetstream flag", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/status", { token: reviewerToken }),
+			deps({ jetstreamConnected: async () => false }),
+		);
+		const status = (await body(res)).data as {
+			labelerDid: string;
+			jetstreamConnected: boolean;
+			pendingAssessments: number;
+			deadLetterDepth: number;
+		};
+		expect(status.labelerDid).toBe(LABELER_DID);
+		expect(status.jetstreamConnected).toBe(false);
+		// asmt_run (running) + asmt_pending (pending).
+		expect(status.pendingAssessments).toBe(2);
+		expect(status.deadLetterDepth).toBe(3);
+		expect(status).not.toHaveProperty("lastReconciliationAt");
+	});
+});

--- a/apps/labeler/test/console-api.test.ts
+++ b/apps/labeler/test/console-api.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import type { AccessKeyResolver } from "../src/access-auth.js";
 import { createSubject, recordFinding } from "../src/assessment-store.js";
 import {
+	consoleAssetPath,
 	handleConsoleApi,
 	probeJetstreamConnected,
 	type ConsoleApiDeps,
@@ -618,6 +619,43 @@ describe("handleConsoleApi — system status", () => {
 		expect(status.deadLetterDepth).toBe(3);
 		expect(status).not.toHaveProperty("lastReconciliationAt");
 	});
+});
+
+describe("consoleAssetPath — asset prefix rewrite", () => {
+	// The SPA is built with base "/admin/" but the asset binding serves
+	// ./dist/console one-to-one, so the /admin prefix must be stripped before
+	// ASSETS.fetch or every hashed asset falls through to the SPA shell.
+	it.each([
+		["/admin", "/"],
+		["/admin/", "/"],
+		["/admin/assets/index-abc123.js", "/assets/index-abc123.js"],
+		["/admin/assets/index-abc123.css", "/assets/index-abc123.css"],
+		["/admin/index.html", "/index.html"],
+		// Client-side deep links resolve to no file, so the SPA fallback serves
+		// the shell — the rewrite just has to land them under the binding root.
+		["/admin/assessments/abc", "/assessments/abc"],
+		["/admin/subjects", "/subjects"],
+	])("rewrites %s to %s", (input, expected) => {
+		expect(consoleAssetPath(input)).toBe(expected);
+	});
+
+	// Must NOT be treated as console assets: near-miss prefixes and the public
+	// surface stay out of the asset branch (they fall through to the 404).
+	it.each(["/adminx", "/administrator", "/admin-console", "/", "/xrpc/x", "/.well-known/did.json"])(
+		"returns null for the non-asset path %s",
+		(input) => {
+			expect(consoleAssetPath(input)).toBeNull();
+		},
+	);
+
+	// The read API is dispatched before the asset branch; the helper also
+	// excludes it so an asset rewrite can never swallow an API path.
+	it.each(["/admin/api", "/admin/api/", "/admin/api/status", "/admin/api/assessments/x"])(
+		"never treats the API path %s as an asset",
+		(input) => {
+			expect(consoleAssetPath(input)).toBeNull();
+		},
+	);
 });
 
 describe("probeJetstreamConnected — degradation", () => {

--- a/apps/labeler/test/console-api.test.ts
+++ b/apps/labeler/test/console-api.test.ts
@@ -4,7 +4,11 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import type { AccessKeyResolver } from "../src/access-auth.js";
 import { createSubject, recordFinding } from "../src/assessment-store.js";
-import { handleConsoleApi, type ConsoleApiDeps } from "../src/console-api.js";
+import {
+	handleConsoleApi,
+	probeJetstreamConnected,
+	type ConsoleApiDeps,
+} from "../src/console-api.js";
 import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
 import { buildOperatorActionInsert, type OperatorActionType } from "../src/operator-actions.js";
 
@@ -385,6 +389,23 @@ describe("handleConsoleApi — guard rejections", () => {
 		);
 		expect(res.status).toBe(200);
 	});
+
+	// The guard runs before route matching, so every family must reject an
+	// unauthenticated caller identically — no route reaches a store read (and so
+	// no private evidence) without a verified assertion.
+	it.each([
+		"/admin/api/assessments",
+		`/admin/api/assessments/${ASMT_BLOCK_B}`,
+		`/admin/api/assessments/${ASMT_BLOCK_B}/findings`,
+		`/admin/api/assessments/${ASMT_BLOCK_B}/labels`,
+		`/admin/api/subjects/${encodeURIComponent(URI_S)}`,
+		"/admin/api/audit-log",
+		"/admin/api/status",
+	])("rejects an unauthenticated request to %s (401)", async (path) => {
+		const res = await handleConsoleApi(req(path), deps());
+		expect(res.status).toBe(401);
+		expect((await body(res)).error?.code).toBe("UNAUTHENTICATED");
+	});
 });
 
 describe("handleConsoleApi — method + routing", () => {
@@ -596,5 +617,28 @@ describe("handleConsoleApi — system status", () => {
 		expect(status.pendingAssessments).toBe(2);
 		expect(status.deadLetterDepth).toBe(3);
 		expect(status).not.toHaveProperty("lastReconciliationAt");
+	});
+});
+
+describe("probeJetstreamConnected — degradation", () => {
+	it("reports disconnected (not an error) when both the DO and the D1 fallback fail", async () => {
+		const brokenEnv = {
+			LABELER_DISCOVERY_DO: {
+				idFromName: () => ({}),
+				get: () => ({
+					fetch: async () => {
+						throw new Error("DO unreachable");
+					},
+				}),
+			},
+			DB: {
+				prepare: () => ({
+					first: async () => {
+						throw new Error("no such table: ingest_state");
+					},
+				}),
+			},
+		} as unknown as Parameters<typeof probeJetstreamConnected>[0];
+		expect(await probeJetstreamConnected(brokenEnv)).toBe(false);
 	});
 });

--- a/apps/labeler/test/console-serialize.test.ts
+++ b/apps/labeler/test/console-serialize.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import type { AssessmentState } from "../src/assessment-lifecycle.js";
+import type {
+	AssessmentFinding,
+	AssessmentIssuedLabel,
+	ListedAssessment,
+	Subject,
+} from "../src/assessment-store.js";
+import {
+	serializeAssessmentRun,
+	serializeIssuedLabel,
+	serializeOperatorActionView,
+	serializeOperatorFinding,
+	serializeSubjectRecord,
+} from "../src/console-serialize.js";
+import type { StoredOperatorAction } from "../src/operator-actions.js";
+import { derivePublicState } from "../src/public-assessment.js";
+
+function listedAssessment(overrides: Partial<ListedAssessment> = {}): ListedAssessment {
+	return {
+		id: "asmt_01",
+		runKey: "run-01",
+		uri: "at://did:plc:x/com.emdashcms.experimental.package.release/rk1",
+		cid: "bafyreialpha",
+		artifactId: "artifact-1",
+		artifactChecksum: "sha256:abc",
+		state: "passed",
+		trigger: "initial",
+		triggerId: "initial:x",
+		policyVersion: "2026-07-10.experimental.2",
+		modelId: "@cf/meta/llama-3.1-70b-instruct",
+		promptHash: "sha256:prompt",
+		publicSummary: "No blocking findings.",
+		coverageJson: '{"code":"complete","images":"not-present","metadata":"complete"}',
+		supersedesAssessmentId: null,
+		startedAt: "2026-07-08T09:12:05.000Z",
+		completedAt: "2026-07-08T09:13:40.000Z",
+		createdAt: "2026-07-08T09:12:00.000Z",
+		isSuperseded: false,
+		...overrides,
+	};
+}
+
+describe("serializeAssessmentRun", () => {
+	it("omits coverageJson but keeps operator provenance (modelId/promptHash)", () => {
+		const run = serializeAssessmentRun(listedAssessment());
+		expect(run).not.toHaveProperty("coverageJson");
+		expect(run.modelId).toBe("@cf/meta/llama-3.1-70b-instruct");
+		expect(run.promptHash).toBe("sha256:prompt");
+		expect(run.isSuperseded).toBe(false);
+	});
+
+	it("computes publicState as derivePublicState(state, isSuperseded) across the state matrix", () => {
+		const states: AssessmentState[] = [
+			"observed",
+			"verifying",
+			"pending",
+			"running",
+			"passed",
+			"warned",
+			"blocked",
+			"error",
+			"stale",
+			"cancelled",
+		];
+		for (const state of states) {
+			for (const isSuperseded of [false, true]) {
+				const run = serializeAssessmentRun(listedAssessment({ state, isSuperseded }));
+				expect(run.publicState).toBe(derivePublicState(state, isSuperseded));
+			}
+		}
+	});
+
+	it("marks a superseded decision run as publicState superseded", () => {
+		const run = serializeAssessmentRun(listedAssessment({ state: "passed", isSuperseded: true }));
+		expect(run.publicState).toBe("superseded");
+	});
+});
+
+describe("serializeOperatorFinding", () => {
+	const base: AssessmentFinding = {
+		id: "find_01",
+		assessmentId: "asmt_01",
+		source: "model",
+		category: "low-quality",
+		severity: "medium",
+		confidence: 0.72,
+		title: "Packaging metadata inconsistent",
+		publicSummary: "Declared entry point does not match the bundle.",
+		privateDetail: "Model flagged package.json main field — likely a broken build step.",
+		evidenceRefs: ["evid_01"],
+		createdAt: "2026-07-12T08:06:40.000Z",
+	};
+
+	it("includes the operator-only privateDetail and evidenceRefs", () => {
+		const finding = serializeOperatorFinding(base);
+		expect(finding.privateDetail).toBe(base.privateDetail);
+		expect(finding.evidenceRefs).toEqual(["evid_01"]);
+	});
+
+	it("includes confidence when present and omits it when null", () => {
+		expect(serializeOperatorFinding(base).confidence).toBe(0.72);
+		const withoutConfidence = serializeOperatorFinding({ ...base, confidence: null });
+		expect(withoutConfidence).not.toHaveProperty("confidence");
+	});
+});
+
+describe("serializeIssuedLabel", () => {
+	it("maps the integer neg flag to a boolean", () => {
+		const label: AssessmentIssuedLabel = {
+			val: "malware",
+			cts: "2026-07-12T11:32:50.000Z",
+			exp: null,
+			neg: true,
+			sequence: 5,
+		};
+		expect(serializeIssuedLabel(label)).toEqual({
+			val: "malware",
+			cts: "2026-07-12T11:32:50.000Z",
+			exp: null,
+			neg: true,
+			sequence: 5,
+		});
+	});
+});
+
+describe("serializeSubjectRecord", () => {
+	it("maps snake_case store fields to the wire shape", () => {
+		const subject: Subject = {
+			uri: "at://did:plc:x/col/rk",
+			cid: "bafyreialpha",
+			did: "did:plc:x",
+			collection: "col",
+			rkey: "rk",
+			observedAt: "2026-07-08T09:10:00.000Z",
+			deletedAt: null,
+		};
+		expect(serializeSubjectRecord(subject)).toEqual(subject);
+	});
+});
+
+describe("serializeOperatorActionView", () => {
+	const stored: StoredOperatorAction = {
+		id: "oact_01",
+		actorType: "human",
+		actorId: "access|sub-1",
+		actorEmail: "reviewer@example.com",
+		actorCommonName: null,
+		role: "reviewer",
+		action: "label-retract",
+		subjectUri: "at://did:plc:x/col/rk",
+		subjectCid: "bafyreialpha",
+		labelValue: "malware",
+		reason: "false positive",
+		idempotencyKey: "idem-abcdefgh",
+		requestFingerprint: "a".repeat(64),
+		resultJson: '{"retracted":true}',
+		metadataJson: '{"note":"internal"}',
+		createdAt: "2026-07-12T14:02:15.000Z",
+		createdAtEpochMs: 1_752_328_935_000,
+	};
+
+	it("excludes the internal replay fields", () => {
+		const view = serializeOperatorActionView(stored);
+		expect(view).not.toHaveProperty("idempotencyKey");
+		expect(view).not.toHaveProperty("requestFingerprint");
+		expect(view).not.toHaveProperty("resultJson");
+	});
+
+	it("keeps the displayed who/what/why fields", () => {
+		const view = serializeOperatorActionView(stored);
+		expect(view).toMatchObject({
+			id: "oact_01",
+			actorType: "human",
+			actorId: "access|sub-1",
+			actorEmail: "reviewer@example.com",
+			role: "reviewer",
+			action: "label-retract",
+			subjectUri: "at://did:plc:x/col/rk",
+			subjectCid: "bafyreialpha",
+			labelValue: "malware",
+			reason: "false positive",
+			createdAt: "2026-07-12T14:02:15.000Z",
+		});
+	});
+});

--- a/apps/labeler/test/console-serialize.test.ts
+++ b/apps/labeler/test/console-serialize.test.ts
@@ -166,6 +166,8 @@ describe("serializeOperatorActionView", () => {
 		expect(view).not.toHaveProperty("idempotencyKey");
 		expect(view).not.toHaveProperty("requestFingerprint");
 		expect(view).not.toHaveProperty("resultJson");
+		expect(view).not.toHaveProperty("metadataJson");
+		expect(view).not.toHaveProperty("createdAtEpochMs");
 	});
 
 	it("keeps the displayed who/what/why fields", () => {

--- a/apps/labeler/test/operator-read-guard.test.ts
+++ b/apps/labeler/test/operator-read-guard.test.ts
@@ -1,0 +1,155 @@
+import { generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { AccessAuthConfig, AccessKeyResolver } from "../src/access-auth.js";
+import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
+import { guardRead, type ReadGuardDeps } from "../src/operator-read-guard.js";
+
+const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
+const AUDIENCE = "test-audience";
+const ORIGIN = "https://labeler.example.com";
+
+let signKey: CryptoKey;
+let resolver: AccessKeyResolver;
+let adminToken: string;
+let reviewerToken: string;
+let noRoleToken: string;
+
+beforeAll(async () => {
+	const pair = await generateKeyPair("RS256");
+	signKey = pair.privateKey;
+	resolver = (async () => pair.publicKey) as AccessKeyResolver;
+	adminToken = await mintToken({ email: "admin@example.com" });
+	reviewerToken = await mintToken({ email: "reviewer@example.com" });
+	noRoleToken = await mintToken({ email: "nobody@example.com" });
+});
+
+async function mintToken(claims: Record<string, unknown>): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	return new SignJWT({ sub: "user-sub-1", ...claims })
+		.setProtectedHeader({ alg: "RS256" })
+		.setIssuer(TEAM_DOMAIN)
+		.setAudience(AUDIENCE)
+		.setIssuedAt(now)
+		.setExpirationTime(now + 3600)
+		.sign(signKey);
+}
+
+function baseConfig(): AccessAuthConfig {
+	return {
+		teamDomain: TEAM_DOMAIN,
+		audience: AUDIENCE,
+		admins: ["admin@example.com"],
+		reviewers: ["reviewer@example.com"],
+	};
+}
+
+function deps(overrides: Partial<ReadGuardDeps> = {}): ReadGuardDeps {
+	return { config: baseConfig(), keys: resolver, expectedOrigin: ORIGIN, ...overrides };
+}
+
+interface RequestOptions {
+	token?: string;
+	csrf?: string | null;
+	origin?: string;
+	secFetchSite?: string;
+	spoofEmail?: string;
+}
+
+function buildRequest(opts: RequestOptions = {}): Request {
+	const headers = new Headers();
+	const csrf = opts.csrf === undefined ? "1" : opts.csrf;
+	if (csrf !== null) headers.set(OPERATOR_REQUEST_HEADER, csrf);
+	if (opts.token !== undefined) headers.set("Cf-Access-Jwt-Assertion", opts.token);
+	if (opts.origin !== undefined) headers.set("Origin", opts.origin);
+	if (opts.secFetchSite !== undefined) headers.set("Sec-Fetch-Site", opts.secFetchSite);
+	if (opts.spoofEmail !== undefined)
+		headers.set("Cf-Access-Authenticated-User-Email", opts.spoofEmail);
+	return new Request(`${ORIGIN}/admin/api/assessments`, { method: "GET", headers });
+}
+
+async function expectRejection(request: Request, code: string, status: number): Promise<void> {
+	await expect(guardRead(request, deps(), { minRole: "reviewer" })).rejects.toMatchObject({
+		code,
+		status,
+	});
+}
+
+describe("guardRead — transport checks", () => {
+	it("rejects a mismatching Origin", async () => {
+		await expectRejection(
+			buildRequest({ token: reviewerToken, origin: "https://evil.example.com" }),
+			"CROSS_ORIGIN",
+			403,
+		);
+	});
+
+	it("rejects a cross-site Sec-Fetch-Site", async () => {
+		await expectRejection(
+			buildRequest({ token: reviewerToken, secFetchSite: "cross-site" }),
+			"CROSS_ORIGIN",
+			403,
+		);
+	});
+
+	it("rejects a missing CSRF header", async () => {
+		await expectRejection(
+			buildRequest({ token: reviewerToken, csrf: null }),
+			"CSRF_HEADER_MISSING",
+			403,
+		);
+	});
+
+	it("rejects a wrong CSRF header value", async () => {
+		await expectRejection(
+			buildRequest({ token: reviewerToken, csrf: "0" }),
+			"CSRF_HEADER_MISSING",
+			403,
+		);
+	});
+
+	it("passes when both Origin and Sec-Fetch-Site are absent (non-browser client)", async () => {
+		const identity = await guardRead(buildRequest({ token: reviewerToken }), deps(), {
+			minRole: "reviewer",
+		});
+		expect(identity.roles).toContain("reviewer");
+	});
+});
+
+describe("guardRead — authentication", () => {
+	it("rejects a request with no assertion header", async () => {
+		await expectRejection(buildRequest({}), "UNAUTHENTICATED", 401);
+	});
+
+	it("rejects an invalid assertion", async () => {
+		await expectRejection(buildRequest({ token: "not-a-jwt" }), "UNAUTHENTICATED", 401);
+	});
+
+	it("never derives identity from a spoofed plaintext email header", async () => {
+		await expectRejection(
+			buildRequest({ spoofEmail: "admin@example.com" }),
+			"UNAUTHENTICATED",
+			401,
+		);
+	});
+});
+
+describe("guardRead — role gate", () => {
+	it("rejects an edge-authenticated identity that maps to no role", async () => {
+		await expectRejection(buildRequest({ token: noRoleToken }), "FORBIDDEN_ROLE", 403);
+	});
+
+	it("admits a reviewer", async () => {
+		const identity = await guardRead(buildRequest({ token: reviewerToken }), deps(), {
+			minRole: "reviewer",
+		});
+		expect(identity).toMatchObject({ kind: "human", email: "reviewer@example.com" });
+	});
+
+	it("admits an admin by inheritance", async () => {
+		const identity = await guardRead(buildRequest({ token: adminToken }), deps(), {
+			minRole: "reviewer",
+		});
+		expect(identity.roles).toContain("admin");
+	});
+});

--- a/apps/labeler/worker-configuration.d.ts
+++ b/apps/labeler/worker-configuration.d.ts
@@ -6,11 +6,13 @@ interface __BaseEnv_Env {
 	DB: D1Database;
 	DISCOVERY_QUEUE: Queue;
 	AI: Ai;
+	ASSETS: Fetcher;
 	LABELER_DID: "did:web:labels.emdashcms.com";
 	LABELER_SERVICE_URL: "https://labels.emdashcms.com";
 	LABEL_SIGNING_KEY_VERSION: "v1";
 	LABEL_SIGNING_PUBLIC_KEY: "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ";
 	JETSTREAM_URL: "wss://jetstream2.us-east.bsky.network/subscribe";
+	OPERATOR_ACCESS_CONFIG: "{\"teamDomain\":\"https://emdash.cloudflareaccess.com\",\"audience\":\"REPLACE_WITH_ACCESS_APP_AUD_TAG\",\"admins\":[\"emdash-labeler-admins\"],\"reviewers\":[\"emdash-labeler-reviewers\"]}";
 	LABEL_SIGNING_PRIVATE_KEY: string;
 	LABEL_SUBSCRIPTION: DurableObjectNamespace<import("./src/index").LabelSubscriptionDO>;
 	LABELER_DISCOVERY_DO: DurableObjectNamespace<import("./src/index").LabelerDiscoveryDO>;
@@ -27,7 +29,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "LABELER_DID" | "LABELER_SERVICE_URL" | "LABEL_SIGNING_KEY_VERSION" | "LABEL_SIGNING_PUBLIC_KEY" | "JETSTREAM_URL" | "LABEL_SIGNING_PRIVATE_KEY">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "LABELER_DID" | "LABELER_SERVICE_URL" | "LABEL_SIGNING_KEY_VERSION" | "LABEL_SIGNING_PUBLIC_KEY" | "JETSTREAM_URL" | "OPERATOR_ACCESS_CONFIG" | "LABEL_SIGNING_PRIVATE_KEY">> {}
 }
 
 // Begin runtime types

--- a/apps/labeler/wrangler.jsonc
+++ b/apps/labeler/wrangler.jsonc
@@ -43,6 +43,17 @@
 	"ai": {
 		"binding": "AI",
 	},
+	// Operator console SPA (apps/labeler/console), built to ./dist/console by
+	// `console:build`. `run_worker_first: true` keeps the Worker the sole
+	// router: the SPA fallback only fires where index.ts explicitly calls
+	// env.ASSETS.fetch (the /admin branch), so the public XRPC/well-known
+	// surface and the root 404 are unaffected. See W9.3 design.
+	"assets": {
+		"directory": "./dist/console",
+		"binding": "ASSETS",
+		"not_found_handling": "single-page-application",
+		"run_worker_first": true,
+	},
 	"queues": {
 		"producers": [
 			{
@@ -82,6 +93,10 @@
 		"LABEL_SIGNING_KEY_VERSION": "v1",
 		"LABEL_SIGNING_PUBLIC_KEY": "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ",
 		"JETSTREAM_URL": "wss://jetstream2.us-east.bsky.network/subscribe",
+		// Operator console Access config (parsed via parseAccessAuthConfig).
+		// Group names / audience tag are not secrets. Replace `audience` with the
+		// Access application's AUD tag and the group names with the deployment's.
+		"OPERATOR_ACCESS_CONFIG": "{\"teamDomain\":\"https://emdash.cloudflareaccess.com\",\"audience\":\"REPLACE_WITH_ACCESS_APP_AUD_TAG\",\"admins\":[\"emdash-labeler-admins\"],\"reviewers\":[\"emdash-labeler-reviewers\"]}",
 	},
 	// Required secret, declared in config so `wrangler types` generates the
 	// typed binding and `wrangler deploy` validates the secret is set on the


### PR DESCRIPTION
## What does this PR do?

Completes plan item W9.3: the labeler Worker now **serves the operator console** as static assets under `/admin` and exposes the seven **Access-guarded read-only `/admin/api/*` routes** it consumes. The console client flips from fixtures to live fetch — the one-line swap the scaffold (#2006) was designed around.

Serving: wrangler `assets` binding over `./dist/console` with `not_found_handling: "single-page-application"` and `run_worker_first: true` — the Worker owns all routing, so the public XRPC/well-known/404 surface is dispatch-identical to before (the array-form SPA fallback would have shadowed public 404s with the console shell). The SPA shell itself carries no data; Cloudflare Access at the edge covers `/admin/*` as a deployment requirement, and every API request is independently verified in-Worker regardless.

Read guard (`operator-read-guard.ts`): same-origin and `X-EmDash-Request` checks (shared with the W9.2 mutation guard's exported helpers), then a fresh `verifyAccessRequest` per request and a `reviewer` role gate (admin inherits) — all before route matching or any store read. GET-only (405 otherwise); errors use the `{ error: { code, message } }` wire shape; missing or malformed `OPERATOR_ACCESS_CONFIG` fails closed.

Routes: assessments list (state filter, keyset cursor shared with the public list), assessment detail (404 → client renders not-found), findings, labels (incl. negations), subject history, audit log, system status. Serializers whitelist fields — the operator surface deliberately includes findings' `privateDetail`/`evidenceRefs` (spec §13.2's exclusions govern public routes), while the audit view omits all five internal columns (`idempotency_key`, `request_fingerprint`, `result_json`, `metadata_json`, epoch sibling). System status reports only observable facts: jetstream connectivity (DO probe with a D1 freshness fallback that degrades to "disconnected" on store failure rather than failing the route), in-flight assessment count, and dead-letter depth.

Client updates ratified against the design's open questions: the provisional `OperatorAction` type is replaced by the real audit shape (actor is the Access `sub`; no DID), the dashboard metric is `deadLetterDepth` (grounded in the `dead_letters` table), and `lastReconciliationAt` is dropped from V1 rather than shipped as a null stub. `pnpm build` now produces the console before the worker bundle so a clean deploy always has `dist/console`; `deploy` runs the full build.

Adversarially reviewed by an independent Opus pass focused on unauthenticated reach (path normalization, encoded slashes, case tricks), public-surface regression, serialization boundaries, cursor safety, and fail-closed config: no exploitable hole; its hardening (probe degradation, per-route unauthenticated-rejection tests across all seven route families, full audit sanitization asserts) is included. One informational note it raised, not addressed: pagination cursors for two filterless endpoints share a filter hash, so a cursor is technically cross-usable between them — both are reviewer-gated and keyset-only, no security impact; per-endpoint namespacing can tidy it later.

Deploy-time prerequisites (not code): a Cloudflare Access application policy must cover `/admin/*`, and `OPERATOR_ACCESS_CONFIG.audience` ships as a placeholder that must be set to the real Access-app AUD tag. Static-asset serving and SPA deep-links are exercised by W9.7's e2e pass, not unit tests.

Stacked on #2006. Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — no admin UI; the labeler console is deliberately not localized (decision 2026-07-13). Changeset n/a — `apps/labeler` is a private, unpublished Worker app.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (coordination, reconciliation), Opus 4.8 subagents (design, implementation, adversarial review)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker 401 pass (24 files — new suites for the read guard, the seven-route dispatcher incl. per-route unauthenticated rejection and 405s, and serializer sanitization), console 9 pass
- Typecheck (both projects) clean; `console:build` and a clean-tree `pnpm build` produce `dist/console` + the worker bundle; lint: 0 diagnostics in `apps/labeler` files (one pre-existing repo diagnostic fixed in passing where the reviewed file tripped it)

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-console-server-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-console-server`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
