### PR TITLE
feat(labeler): reviewer label issue/retract actions (W9.4)

### DIFF
--- a/apps/labeler/console/src/api/client.test.ts
+++ b/apps/labeler/console/src/api/client.test.ts
@@ -112,6 +112,23 @@ describe("fetch client label actions", () => {
 		await expect(fetchClient.issueLabel(input)).rejects.toThrow("does not match");
 	});
 
+	it("surfaces a retryable 503 as an error, not a false success", async () => {
+		stubFetch(() =>
+			Response.json(
+				{
+					error: {
+						code: "LABEL_ISSUANCE_UNAVAILABLE",
+						message: "Label issuance is temporarily unavailable; retry.",
+					},
+				},
+				{ status: 503 },
+			),
+		);
+		await expect(fetchClient.issueLabel(input)).rejects.toThrow(
+			"Label issuance is temporarily unavailable; retry.",
+		);
+	});
+
 	it("builds the effect-preview query string", async () => {
 		stubFetch(() =>
 			Response.json({ data: { labelEffect: "block", scope: "cid-bound", supersedes: [] } }),

--- a/apps/labeler/console/src/api/client.test.ts
+++ b/apps/labeler/console/src/api/client.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createFixtureClient } from "./client.js";
+import { createFetchClient, createFixtureClient } from "./client.js";
+import type { LabelActionInput } from "./types.js";
 
 const apiClient = createFixtureClient();
 
@@ -38,5 +39,89 @@ describe("fixture client", () => {
 		const history = await apiClient.getSubjectHistory(assessment!.uri);
 		expect(history?.subject.uri).toBe(assessment!.uri);
 		expect(history?.assessments.some((a) => a.id === assessment!.id)).toBe(true);
+	});
+});
+
+describe("fetch client label actions", () => {
+	const fetchClient = createFetchClient();
+	let calls: { url: string; init: RequestInit }[];
+
+	function stubFetch(response: () => Response) {
+		calls = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn((url: string, init: RequestInit) => {
+				calls.push({ url, init });
+				return Promise.resolve(response());
+			}),
+		);
+	}
+
+	const input: LabelActionInput = {
+		uri: "at://did:plc:x/com.emdashcms.experimental.package.release/rk1",
+		val: "security-yanked",
+		confirmation: "rk1",
+		reason: "withdrawing",
+		idempotencyKey: "01HZY9K0ULIDXULIDXULIDX00",
+	};
+
+	beforeEach(() => {
+		stubFetch(() =>
+			Response.json({ data: { actionId: "oact_1", val: "security-yanked", neg: false } }),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("POSTs an issue with the CSRF header, JSON content type, and threaded key", async () => {
+		const result = await fetchClient.issueLabel(input);
+		expect(result).toMatchObject({ actionId: "oact_1", val: "security-yanked" });
+		expect(calls).toHaveLength(1);
+		const call = calls[0]!;
+		expect(call.url).toBe("/admin/api/labels/issue");
+		expect(call.init.method).toBe("POST");
+		const headers = new Headers(call.init.headers);
+		expect(headers.get("X-EmDash-Request")).toBe("1");
+		expect(headers.get("Content-Type")).toBe("application/json");
+		expect(JSON.parse(call.init.body as string)).toMatchObject({
+			uri: input.uri,
+			val: input.val,
+			confirmation: input.confirmation,
+			reason: input.reason,
+			idempotencyKey: input.idempotencyKey,
+		});
+	});
+
+	it("POSTs a retract to the retract route", async () => {
+		await fetchClient.retractLabel(input);
+		expect(calls[0]!.url).toBe("/admin/api/labels/retract");
+		expect(calls[0]!.init.method).toBe("POST");
+	});
+
+	it("surfaces the server error message on a failed action", async () => {
+		stubFetch(() =>
+			Response.json(
+				{ error: { code: "CONFIRMATION_MISMATCH", message: "does not match" } },
+				{
+					status: 400,
+				},
+			),
+		);
+		await expect(fetchClient.issueLabel(input)).rejects.toThrow("does not match");
+	});
+
+	it("builds the effect-preview query string", async () => {
+		stubFetch(() =>
+			Response.json({ data: { labelEffect: "block", scope: "cid-bound", supersedes: [] } }),
+		);
+		await fetchClient.previewEffect({ uri: input.uri, val: "malware", cid: "bafy", neg: true });
+		const url = calls[0]!.url;
+		expect(url).toContain("/admin/api/labels/effect-preview?");
+		expect(url).toContain(`uri=${encodeURIComponent(input.uri)}`);
+		expect(url).toContain("val=malware");
+		expect(url).toContain("cid=bafy");
+		expect(url).toContain("neg=true");
 	});
 });

--- a/apps/labeler/console/src/api/client.ts
+++ b/apps/labeler/console/src/api/client.ts
@@ -8,7 +8,11 @@ import {
 } from "../fixtures/index.js";
 import type {
 	AssessmentRun,
+	EffectPreview,
+	EffectPreviewParams,
 	IssuedLabel,
+	IssuedLabelDescriptor,
+	LabelActionInput,
 	ListAssessmentsParams,
 	ListAuditLogParams,
 	OperatorAction,
@@ -16,6 +20,7 @@ import type {
 	Page,
 	SubjectHistoryView,
 	SystemStatusSnapshot,
+	WhoamiIdentity,
 } from "./types.js";
 
 export const CONSOLE_API_BASE = "/admin/api";
@@ -32,6 +37,10 @@ export interface LabelerConsoleClient {
 	getSubjectHistory(uri: string): Promise<SubjectHistoryView | null>;
 	listAuditLog(params?: ListAuditLogParams): Promise<Page<OperatorAction>>;
 	getSystemStatus(): Promise<SystemStatusSnapshot>;
+	whoami(): Promise<WhoamiIdentity>;
+	previewEffect(params: EffectPreviewParams): Promise<EffectPreview>;
+	issueLabel(input: LabelActionInput): Promise<IssuedLabelDescriptor>;
+	retractLabel(input: LabelActionInput): Promise<IssuedLabelDescriptor>;
 }
 
 interface ApiErrorBody {
@@ -49,6 +58,21 @@ function consoleApiFetch(path: string, init?: RequestInit): Promise<Response> {
 	const headers = new Headers(init?.headers);
 	headers.set("X-EmDash-Request", "1");
 	return fetch(`${CONSOLE_API_BASE}${path}`, { ...init, headers, credentials: "same-origin" });
+}
+
+/** POST a state-changing label action. `consoleApiFetch` already sets the CSRF
+ * header and same-origin credentials; this adds the JSON content type the
+ * mutation guard requires and threads the client-minted idempotency key. */
+async function postLabelAction(
+	path: string,
+	input: LabelActionInput,
+): Promise<IssuedLabelDescriptor> {
+	const response = await consoleApiFetch(path, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(input),
+	});
+	return parseJson(response, "Failed to submit label action");
 }
 
 async function parseJson<T>(response: Response, fallback: string): Promise<T> {
@@ -109,6 +133,25 @@ export function createFetchClient(): LabelerConsoleClient {
 			const response = await consoleApiFetch("/status");
 			return parseJson(response, "Failed to load system status");
 		},
+		async whoami() {
+			const response = await consoleApiFetch("/whoami");
+			return parseJson(response, "Failed to load identity");
+		},
+		async previewEffect(params) {
+			const search = new URLSearchParams();
+			search.set("uri", params.uri);
+			search.set("val", params.val);
+			if (params.cid) search.set("cid", params.cid);
+			if (params.neg) search.set("neg", "true");
+			const response = await consoleApiFetch(`/labels/effect-preview?${search.toString()}`);
+			return parseJson(response, "Failed to preview effect");
+		},
+		async issueLabel(input) {
+			return postLabelAction("/labels/issue", input);
+		},
+		async retractLabel(input) {
+			return postLabelAction("/labels/retract", input);
+		},
 	};
 }
 
@@ -140,6 +183,45 @@ export function createFixtureClient(): LabelerConsoleClient {
 		},
 		async getSystemStatus() {
 			return FIXTURE_SYSTEM_STATUS;
+		},
+		async whoami() {
+			return {
+				kind: "human",
+				principal: "reviewer@example.com",
+				sub: "dev-reviewer",
+				roles: ["reviewer"],
+			};
+		},
+		async previewEffect(params) {
+			return {
+				labelEffect: params.val === "security-yanked" ? "block" : "warn",
+				scope: params.cid ? "cid-bound" : "uri-wide",
+				supersedes: [],
+				before: null,
+				after: null,
+			};
+		},
+		async issueLabel(input) {
+			return {
+				actionId: "oact_fixture",
+				val: input.val,
+				uri: input.uri,
+				cid: input.cid ?? null,
+				neg: false,
+				cts: new Date().toISOString(),
+				effect: input.val === "security-yanked" ? "block" : "warn",
+			};
+		},
+		async retractLabel(input) {
+			return {
+				actionId: "oact_fixture",
+				val: input.val,
+				uri: input.uri,
+				cid: input.cid ?? null,
+				neg: true,
+				cts: new Date().toISOString(),
+				effect: input.val === "security-yanked" ? "block" : "warn",
+			};
 		},
 	};
 }

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -142,6 +142,90 @@ export interface Page<T> {
 	nextCursor?: string;
 }
 
+export type OperatorRole = "admin" | "reviewer";
+
+/** The caller's verified identity from `/admin/api/whoami`, used only for
+ * cosmetic button gating — the server (`guardMutation`) is the enforcement
+ * boundary, so hiding a button never grants anything. */
+export interface WhoamiIdentity {
+	kind: "human" | "service";
+	principal: string;
+	sub: string;
+	roles: OperatorRole[];
+}
+
+export type ReleaseEligibility = "eligible" | "pending" | "error" | "blocked";
+
+/** Console mirror of registry-moderation's `ReleaseModeration` (redeclared, not
+ * imported — the console renders what the effect-preview endpoint returns and
+ * holds no policy logic). `applicableLabels` is opaque here; the UI shows the
+ * summarized value lists. */
+export interface ReleaseModeration {
+	eligibility: ReleaseEligibility;
+	reasonCodes: string[];
+	blockingLabels: string[];
+	stateLabels: string[];
+	warningLabels: string[];
+	suppressedLabels: string[];
+	applicableLabels: { val: string; cid?: string; neg?: boolean }[];
+	redacted: boolean;
+}
+
+export interface SupersededLabel {
+	val: string;
+	cid: string | null;
+	sequence: number;
+}
+
+/** Server-derived preview of a proposed label action's official-client effect
+ * (`GET /admin/api/labels/effect-preview`). */
+export interface EffectPreview {
+	labelEffect: string;
+	scope: "cid-bound" | "uri-wide";
+	supersedes: SupersededLabel[];
+	before: ReleaseModeration | null;
+	after: ReleaseModeration | null;
+}
+
+export interface EffectPreviewParams {
+	uri: string;
+	val: string;
+	cid?: string;
+	neg?: boolean;
+}
+
+/** A selectable label value plus its ceremony scope, for the action dialog's
+ * menu. Presentation only — the server is the authority on what a reviewer may
+ * issue (`guardMutation`), so this menu never gates anything. */
+export interface IssuableLabel {
+	val: string;
+	scope: "cid-bound" | "uri-wide";
+}
+
+/** Body for `POST /admin/api/labels/{issue,retract}`. `idempotencyKey` is minted
+ * client-side (ULID) per confirm-dialog open and reused across retries so a
+ * network retry replays rather than double-issues. */
+export interface LabelActionInput {
+	uri: string;
+	val: string;
+	cid?: string;
+	confirmation: string;
+	reason: string;
+	idempotencyKey: string;
+}
+
+/** The deterministic idempotent result returned by an issue/retract — no
+ * `sequence` (assigned by a DB trigger post-commit; two replays must agree). */
+export interface IssuedLabelDescriptor {
+	actionId: string;
+	val: string;
+	uri: string;
+	cid: string | null;
+	neg: boolean;
+	cts: string;
+	effect: string;
+}
+
 export interface ListAssessmentsParams {
 	state?: PublicAssessmentState;
 	cursor?: string;

--- a/apps/labeler/console/src/components/LabelActionDialog.tsx
+++ b/apps/labeler/console/src/components/LabelActionDialog.tsx
@@ -1,0 +1,257 @@
+import { Badge, Button, Dialog, Input, InputArea, Loader } from "@cloudflare/kumo";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+import type { EffectPreview, IssuableLabel, ReleaseModeration } from "../api/types.js";
+
+interface LabelActionDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	mode: "issue" | "retract";
+	subjectUri: string;
+	/** The release CID in view, used as the label CID for CID-bound actions. */
+	subjectCid?: string;
+	/** Menu of issuable labels for `mode: "issue"`. */
+	issuable?: readonly IssuableLabel[];
+	/** The label + scope being negated for `mode: "retract"`. */
+	target?: IssuableLabel;
+	/** TanStack Query keys to invalidate on success so the new state renders. */
+	invalidateKeys: readonly (readonly unknown[])[];
+}
+
+function rkeyOf(uri: string): string {
+	return uri.split("/").at(-1) ?? "";
+}
+
+function ModerationSummary({ label, value }: { label: string; value: ReleaseModeration | null }) {
+	return (
+		<div className="flex flex-col gap-1">
+			<span className="text-xs text-kumo-subtle">{label}</span>
+			{value ? (
+				<div className="flex flex-wrap items-center gap-1.5">
+					<Badge variant={value.eligibility === "eligible" ? "info" : "neutral"}>
+						{value.eligibility}
+					</Badge>
+					{value.blockingLabels.map((v) => (
+						<Badge key={`b-${v}`} variant="neutral">
+							{v}
+						</Badge>
+					))}
+					{value.warningLabels.map((v) => (
+						<Badge key={`w-${v}`} variant="neutral">
+							{v}
+						</Badge>
+					))}
+				</div>
+			) : (
+				<span className="text-sm text-kumo-subtle">Not a release subject</span>
+			)}
+		</div>
+	);
+}
+
+function EffectPreviewView({ preview }: { preview: EffectPreview }) {
+	return (
+		<div className="flex flex-col gap-3 rounded-lg bg-kumo-elevated p-3">
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="text-xs text-kumo-subtle">Label effect</span>
+				<Badge variant="info">{preview.labelEffect}</Badge>
+				<Badge variant="neutral">
+					{preview.scope === "cid-bound" ? "This exact release CID" : "Whole record, all CIDs"}
+				</Badge>
+			</div>
+			{preview.supersedes.length > 0 && (
+				<div className="flex flex-col gap-1">
+					<span className="text-xs text-kumo-subtle">Replaces active label</span>
+					<div className="flex flex-wrap gap-1.5">
+						{preview.supersedes.map((s) => (
+							<Badge key={`${s.val}-${s.sequence}`} variant="neutral">
+								{s.val}
+							</Badge>
+						))}
+					</div>
+				</div>
+			)}
+			<div className="grid grid-cols-2 gap-3">
+				<ModerationSummary label="Before" value={preview.before} />
+				<ModerationSummary label="After" value={preview.after} />
+			</div>
+		</div>
+	);
+}
+
+/**
+ * The §11.4 reviewer action ceremony: shows the subject, the resolved
+ * official-client effect (server-derived), the CID-bound vs URI-wide scope, a
+ * required reason, and a server-validated typed confirmation (the exact CID or
+ * the record rkey). The client mirrors the confirmation check for UX; the server
+ * is authoritative. The idempotency key is minted per open and reused across
+ * retries so a network retry replays rather than double-issues.
+ */
+export function LabelActionDialog({
+	open,
+	onOpenChange,
+	mode,
+	subjectUri,
+	subjectCid,
+	issuable,
+	target,
+	invalidateKeys,
+}: LabelActionDialogProps) {
+	const queryClient = useQueryClient();
+	const menu = issuable ?? [];
+	const [selectedVal, setSelectedVal] = useState<string>(target?.val ?? menu[0]?.val ?? "");
+	const [reason, setReason] = useState("");
+	const [confirmation, setConfirmation] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	// Reset the ceremony each time the dialog opens: a fresh idempotency key, so a
+	// reopened dialog is a genuinely new action, and cleared inputs.
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setReason("");
+		setConfirmation("");
+		setSelectedVal(target?.val ?? menu[0]?.val ?? "");
+		// menu/target are stable per open; re-running on their identity would clobber edits.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open]);
+
+	const scope: IssuableLabel["scope"] =
+		mode === "retract"
+			? (target?.scope ?? "uri-wide")
+			: (menu.find((entry) => entry.val === selectedVal)?.scope ?? "cid-bound");
+	const cid = scope === "cid-bound" ? subjectCid : undefined;
+	const expectedConfirmation = cid ?? rkeyOf(subjectUri);
+
+	const previewQuery = useQuery({
+		queryKey: ["effect-preview", subjectUri, selectedVal, cid ?? null, mode],
+		queryFn: () =>
+			apiClient.previewEffect({
+				uri: subjectUri,
+				val: selectedVal,
+				...(cid === undefined ? {} : { cid }),
+				neg: mode === "retract",
+			}),
+		enabled: open && selectedVal.length > 0,
+	});
+
+	const mutation = useMutation({
+		mutationFn: () => {
+			const input = {
+				uri: subjectUri,
+				val: selectedVal,
+				...(cid === undefined ? {} : { cid }),
+				confirmation,
+				reason,
+				idempotencyKey,
+			};
+			return mode === "retract" ? apiClient.retractLabel(input) : apiClient.issueLabel(input);
+		},
+		onSuccess: async () => {
+			await Promise.all(
+				invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+			);
+			onOpenChange(false);
+		},
+	});
+
+	const confirmationMatches =
+		confirmation === expectedConfirmation && expectedConfirmation.length > 0;
+	const canSubmit = reason.trim().length > 0 && confirmationMatches && !mutation.isPending;
+	const title = mode === "retract" ? "Retract label" : "Issue label";
+
+	return (
+		<Dialog.Root
+			open={open}
+			onOpenChange={onOpenChange}
+			role={mode === "retract" ? "alertdialog" : "dialog"}
+		>
+			<Dialog className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto p-6" size="lg">
+				<Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+				<Dialog.Description className="break-all font-mono text-xs text-kumo-subtle">
+					{subjectUri}
+				</Dialog.Description>
+
+				{mode === "issue" && menu.length > 0 && (
+					<label className="flex flex-col gap-1 text-sm">
+						<span className="text-xs text-kumo-subtle">Label</span>
+						<select
+							aria-label="Label value"
+							className="h-9 rounded-lg bg-kumo-elevated px-3 text-sm"
+							value={selectedVal}
+							onChange={(event) => {
+								setSelectedVal(event.target.value);
+								setConfirmation("");
+							}}
+						>
+							{menu.map((entry) => (
+								<option key={entry.val} value={entry.val}>
+									{entry.val}
+								</option>
+							))}
+						</select>
+					</label>
+				)}
+
+				{previewQuery.isLoading ? (
+					<div className="flex justify-center py-4">
+						<Loader />
+					</div>
+				) : previewQuery.data ? (
+					<EffectPreviewView preview={previewQuery.data} />
+				) : previewQuery.isError ? (
+					<p className="text-sm text-kumo-danger">Could not load the effect preview.</p>
+				) : null}
+
+				<InputArea
+					label="Reason"
+					value={reason}
+					onValueChange={setReason}
+					placeholder="Why this action is being taken"
+				/>
+
+				<Input
+					label={
+						scope === "cid-bound"
+							? "Type the release CID to confirm"
+							: "Type the record key to confirm"
+					}
+					value={confirmation}
+					onChange={(event) => {
+						setConfirmation(event.target.value);
+					}}
+					placeholder={expectedConfirmation}
+					error={
+						confirmation.length > 0 && !confirmationMatches
+							? "Does not match the subject"
+							: undefined
+					}
+				/>
+
+				{mutation.isError && (
+					<p className="text-sm text-kumo-danger">
+						{mutation.error instanceof Error ? mutation.error.message : "Action failed"}
+					</p>
+				)}
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+						Cancel
+					</Dialog.Close>
+					<Button
+						variant={mode === "retract" ? "destructive" : "primary"}
+						disabled={!canSubmit}
+						onClick={() => {
+							mutation.mutate();
+						}}
+					>
+						{mutation.isPending ? "Submitting…" : title}
+					</Button>
+				</div>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/apps/labeler/console/src/labels.ts
+++ b/apps/labeler/console/src/labels.ts
@@ -1,0 +1,46 @@
+import type { IssuableLabel } from "./api/types.js";
+
+/**
+ * Presentation menus for the reviewer action dialog. These mirror the ratified
+ * moderation policy's reviewer-issuable labels so the console can offer a picker,
+ * but they are NOT the enforcement boundary — the server (`assertW94Issuable` +
+ * the signing-layer `validateManualProposal`) is authoritative and rejects
+ * anything outside policy regardless of what the menu offers. A `scope` of
+ * `cid-bound` targets the exact release CID (policy `cidRule: required`);
+ * `uri-wide` targets the whole record (`cidRule: forbidden`).
+ */
+
+/** Reviewer-issuable labels on a release subject: the descriptive
+ * warning/block vocabulary (CID-bound) plus the URI-wide security yank. */
+export const RELEASE_ISSUABLE_LABELS: readonly IssuableLabel[] = [
+	{ val: "security-yanked", scope: "uri-wide" },
+	{ val: "malware", scope: "cid-bound" },
+	{ val: "data-exfiltration", scope: "cid-bound" },
+	{ val: "credential-harvesting", scope: "cid-bound" },
+	{ val: "supply-chain-compromise", scope: "cid-bound" },
+	{ val: "critical-vulnerability", scope: "cid-bound" },
+	{ val: "artifact-integrity-failure", scope: "cid-bound" },
+	{ val: "invalid-bundle", scope: "cid-bound" },
+	{ val: "undeclared-access", scope: "cid-bound" },
+	{ val: "impersonation", scope: "cid-bound" },
+	{ val: "suspicious-code", scope: "cid-bound" },
+	{ val: "obfuscated-code", scope: "cid-bound" },
+	{ val: "privacy-risk", scope: "cid-bound" },
+	{ val: "misleading-metadata", scope: "cid-bound" },
+	{ val: "low-quality", scope: "cid-bound" },
+	{ val: "broken-release", scope: "cid-bound" },
+];
+
+/** Reviewer-issuable labels on a package (profile) subject. */
+export const PACKAGE_ISSUABLE_LABELS: readonly IssuableLabel[] = [
+	{ val: "package-disputed", scope: "uri-wide" },
+];
+
+const RELEASE_SCOPES = new Map(RELEASE_ISSUABLE_LABELS.map((entry) => [entry.val, entry.scope]));
+
+/** The ceremony scope for a value already active on a release, so a retract
+ * targets the same scope it was issued at. Defaults to `cid-bound` for the
+ * descriptive vocabulary. */
+export function releaseLabelScope(val: string): IssuableLabel["scope"] {
+	return RELEASE_SCOPES.get(val) ?? "cid-bound";
+}

--- a/apps/labeler/console/src/labels.ts
+++ b/apps/labeler/console/src/labels.ts
@@ -44,3 +44,12 @@ const RELEASE_SCOPES = new Map(RELEASE_ISSUABLE_LABELS.map((entry) => [entry.val
 export function releaseLabelScope(val: string): IssuableLabel["scope"] {
 	return RELEASE_SCOPES.get(val) ?? "cid-bound";
 }
+
+/** Whether a value is reviewer-issuable on a release subject, and therefore
+ * retractable through the issue/retract endpoints. Mirrors the server's policy
+ * allow-set so the retract button renders only where the action can succeed —
+ * eligibility labels (assessment-passed/overridden/pending/error) are absent
+ * from the issuable set and are rejected by the server's `assertW94Issuable`. */
+export function isReleaseRetractable(val: string): boolean {
+	return RELEASE_SCOPES.has(val);
+}

--- a/apps/labeler/console/src/routes/AssessmentDetail.tsx
+++ b/apps/labeler/console/src/routes/AssessmentDetail.tsx
@@ -9,7 +9,7 @@ import { FindingCard } from "../components/FindingCard.js";
 import { LabelActionDialog } from "../components/LabelActionDialog.js";
 import { QueryError } from "../components/QueryError.js";
 import { StateBadge } from "../components/StateBadge.js";
-import { RELEASE_ISSUABLE_LABELS, releaseLabelScope } from "../labels.js";
+import { isReleaseRetractable, RELEASE_ISSUABLE_LABELS, releaseLabelScope } from "../labels.js";
 import { shellRoute } from "./root.js";
 
 function MetaRow({ label, value }: { label: string; value: ReactNode }) {
@@ -147,7 +147,7 @@ function AssessmentDetail() {
 						{labels.map((label) => (
 							<div key={`${label.val}-${label.sequence}`} className="flex items-center gap-1">
 								<Badge variant={label.neg ? "neutral" : "info"}>{label.val}</Badge>
-								{canAct && !label.neg && (
+								{canAct && !label.neg && isReleaseRetractable(label.val) && (
 									<Button
 										variant="ghost"
 										size="sm"

--- a/apps/labeler/console/src/routes/AssessmentDetail.tsx
+++ b/apps/labeler/console/src/routes/AssessmentDetail.tsx
@@ -1,12 +1,15 @@
-import { Badge, LayerCard, Loader } from "@cloudflare/kumo";
+import { Badge, Button, LayerCard, Loader } from "@cloudflare/kumo";
 import { useQuery } from "@tanstack/react-query";
 import { createRoute, Link } from "@tanstack/react-router";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { apiClient } from "../api/client.js";
+import type { IssuableLabel } from "../api/types.js";
 import { FindingCard } from "../components/FindingCard.js";
+import { LabelActionDialog } from "../components/LabelActionDialog.js";
 import { QueryError } from "../components/QueryError.js";
 import { StateBadge } from "../components/StateBadge.js";
+import { RELEASE_ISSUABLE_LABELS, releaseLabelScope } from "../labels.js";
 import { shellRoute } from "./root.js";
 
 function MetaRow({ label, value }: { label: string; value: ReactNode }) {
@@ -50,6 +53,11 @@ function AssessmentDetail() {
 		queryFn: () => apiClient.listLabels(id),
 		enabled: !!assessment,
 	});
+	const { data: whoami } = useQuery({ queryKey: ["whoami"], queryFn: () => apiClient.whoami() });
+	const canAct = whoami?.roles.includes("reviewer") || whoami?.roles.includes("admin") || false;
+
+	const [issueOpen, setIssueOpen] = useState(false);
+	const [retractTarget, setRetractTarget] = useState<IssuableLabel | null>(null);
 
 	if (isAssessmentError) {
 		return <QueryError title="Failed to load assessment" error={assessmentError} />;
@@ -120,7 +128,14 @@ function AssessmentDetail() {
 			</LayerCard>
 
 			<section className="flex flex-col gap-3">
-				<h2 className="text-lg font-semibold">Labels</h2>
+				<div className="flex items-center justify-between">
+					<h2 className="text-lg font-semibold">Labels</h2>
+					{canAct && (
+						<Button variant="secondary" onClick={() => setIssueOpen(true)}>
+							Issue label
+						</Button>
+					)}
+				</div>
 				{isLabelsError ? (
 					<QueryError title="Failed to load labels" error={labelsError} />
 				) : isLoadingLabels || !labels ? (
@@ -130,16 +145,56 @@ function AssessmentDetail() {
 				) : (
 					<div className="flex flex-wrap gap-2">
 						{labels.map((label) => (
-							<Badge
-								key={`${label.val}-${label.sequence}`}
-								variant={label.neg ? "neutral" : "info"}
-							>
-								{label.val}
-							</Badge>
+							<div key={`${label.val}-${label.sequence}`} className="flex items-center gap-1">
+								<Badge variant={label.neg ? "neutral" : "info"}>{label.val}</Badge>
+								{canAct && !label.neg && (
+									<Button
+										variant="ghost"
+										size="sm"
+										aria-label={`Retract ${label.val}`}
+										onClick={() =>
+											setRetractTarget({ val: label.val, scope: releaseLabelScope(label.val) })
+										}
+									>
+										Retract
+									</Button>
+								)}
+							</div>
 						))}
 					</div>
 				)}
 			</section>
+
+			{canAct && (
+				<>
+					<LabelActionDialog
+						open={issueOpen}
+						onOpenChange={setIssueOpen}
+						mode="issue"
+						subjectUri={assessment.uri}
+						subjectCid={assessment.cid}
+						issuable={RELEASE_ISSUABLE_LABELS}
+						invalidateKeys={[
+							["assessment", id, "labels"],
+							["assessment", id],
+						]}
+					/>
+					<LabelActionDialog
+						open={retractTarget !== null}
+						onOpenChange={(open) => {
+							if (!open) setRetractTarget(null);
+						}}
+						mode="retract"
+						subjectUri={assessment.uri}
+						subjectCid={assessment.cid}
+						{...(retractTarget ? { target: retractTarget } : {})}
+						invalidateKeys={[
+							["assessment", id, "labels"],
+							["assessment", id],
+						]}
+					/>
+				</>
+			)}
 
 			<section className="flex flex-col gap-3">
 				<h2 className="text-lg font-semibold">Findings</h2>

--- a/apps/labeler/console/src/routes/SubjectHistory.tsx
+++ b/apps/labeler/console/src/routes/SubjectHistory.tsx
@@ -1,11 +1,25 @@
-import { LayerCard, Loader, Table } from "@cloudflare/kumo";
+import { Button, LayerCard, Loader, Table } from "@cloudflare/kumo";
 import { useQuery } from "@tanstack/react-query";
 import { createRoute, Link } from "@tanstack/react-router";
+import { useState } from "react";
 
 import { apiClient } from "../api/client.js";
+import type { IssuableLabel } from "../api/types.js";
+import { LabelActionDialog } from "../components/LabelActionDialog.js";
 import { QueryError } from "../components/QueryError.js";
 import { StateBadge } from "../components/StateBadge.js";
+import { PACKAGE_ISSUABLE_LABELS, RELEASE_ISSUABLE_LABELS } from "../labels.js";
 import { shellRoute } from "./root.js";
+
+/** URI-wide (record-level) issuable labels for a subject, chosen by its
+ * collection: a release record can be security-yanked, a package profile can be
+ * disputed. Presentation only — the server enforces policy. */
+function uriWideLabelsFor(collection: string): readonly IssuableLabel[] {
+	if (collection.endsWith(".release"))
+		return RELEASE_ISSUABLE_LABELS.filter((entry) => entry.scope === "uri-wide");
+	if (collection.endsWith(".profile")) return PACKAGE_ISSUABLE_LABELS;
+	return [];
+}
 
 function SubjectHistory() {
 	const { uri } = subjectHistoryRoute.useParams();
@@ -19,6 +33,9 @@ function SubjectHistory() {
 		queryKey: ["subject-history", uri],
 		queryFn: () => apiClient.getSubjectHistory(uri),
 	});
+	const { data: whoami } = useQuery({ queryKey: ["whoami"], queryFn: () => apiClient.whoami() });
+	const canAct = whoami?.roles.includes("reviewer") || whoami?.roles.includes("admin") || false;
+	const [issueOpen, setIssueOpen] = useState(false);
 
 	if (isError) {
 		return <QueryError title="Failed to load subject history" error={error} />;
@@ -39,21 +56,41 @@ function SubjectHistory() {
 	}
 
 	const { subject, assessments } = history;
+	const uriWideLabels = uriWideLabelsFor(subject.collection);
 
 	return (
 		<div className="flex flex-col gap-6">
-			<div className="flex flex-col gap-1">
-				<h1 className="text-xl font-semibold">Subject history</h1>
-				<p className="font-mono text-sm">{subject.uri}</p>
-				<p className="text-sm text-kumo-subtle">
-					Current CID: <span className="font-mono">{subject.cid}</span>
-				</p>
-				{subject.deletedAt && (
-					<p className="text-sm text-kumo-danger">
-						Deleted at {new Date(subject.deletedAt).toLocaleString()}
+			<div className="flex items-start justify-between gap-4">
+				<div className="flex flex-col gap-1">
+					<h1 className="text-xl font-semibold">Subject history</h1>
+					<p className="font-mono text-sm">{subject.uri}</p>
+					<p className="text-sm text-kumo-subtle">
+						Current CID: <span className="font-mono">{subject.cid}</span>
 					</p>
+					{subject.deletedAt && (
+						<p className="text-sm text-kumo-danger">
+							Deleted at {new Date(subject.deletedAt).toLocaleString()}
+						</p>
+					)}
+				</div>
+				{canAct && uriWideLabels.length > 0 && (
+					<Button variant="secondary" onClick={() => setIssueOpen(true)}>
+						Issue record label
+					</Button>
 				)}
 			</div>
+
+			{canAct && uriWideLabels.length > 0 && (
+				<LabelActionDialog
+					open={issueOpen}
+					onOpenChange={setIssueOpen}
+					mode="issue"
+					subjectUri={subject.uri}
+					subjectCid={subject.cid}
+					issuable={uriWideLabels}
+					invalidateKeys={[["subject-history", uri]]}
+				/>
+			)}
 
 			<LayerCard className="p-0">
 				{assessments.length === 0 ? (

--- a/apps/labeler/fixtures/moderation-policy.json
+++ b/apps/labeler/fixtures/moderation-policy.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
-	"policyVersion": "2026-07-10.experimental.2",
+	"policyVersion": "2026-07-10.experimental.3",
 	"effectiveAt": "2026-07-10T00:00:00Z",
 	"labelerDid": "did:web:labels.emdashcms.com",
 	"assessmentSchemaVersion": 1,
@@ -117,7 +117,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -132,7 +132,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -147,7 +147,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -162,7 +162,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -177,7 +177,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -192,7 +192,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -207,7 +207,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -222,7 +222,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -237,7 +237,7 @@
 			"category": "automated-block",
 			"officialEffect": "block",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -252,7 +252,7 @@
 			"category": "warning",
 			"officialEffect": "warn",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -267,7 +267,7 @@
 			"category": "warning",
 			"officialEffect": "warn",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -282,7 +282,7 @@
 			"category": "warning",
 			"officialEffect": "warn",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -297,7 +297,7 @@
 			"category": "warning",
 			"officialEffect": "warn",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -312,7 +312,7 @@
 			"category": "warning",
 			"officialEffect": "warn",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{
@@ -327,7 +327,7 @@
 			"category": "warning",
 			"officialEffect": "warn",
 			"subjectRules": [
-				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated"] }
+				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],
 			"locales": [
 				{

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -13,6 +13,7 @@
  * expose the body. No route here sets a CORS header.
  */
 
+import type { OperatorIdentity } from "./access-auth.js";
 import {
 	computeFilterHash,
 	decodeCursor,
@@ -40,6 +41,7 @@ import {
 	type Page,
 } from "./console-serialize.js";
 import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
+import { computeEffectPreview } from "./label-effect-preview.js";
 import { MutationGuardError } from "./mutation-guard.js";
 import { getOperatorActionsPage } from "./operator-actions.js";
 import { guardRead, ReadGuardError, type ReadGuardDeps } from "./operator-read-guard.js";
@@ -74,11 +76,11 @@ export interface ConsoleApiDeps extends ReadGuardDeps {
  */
 export async function handleConsoleApi(request: Request, deps: ConsoleApiDeps): Promise<Response> {
 	try {
-		await guardRead(request, deps, { minRole: "reviewer" });
+		const identity = await guardRead(request, deps, { minRole: "reviewer" });
 		// `matchRoute` is synchronous, so a rejection from the handler is consumed
 		// by this `await` directly — never adopted by an intermediate async layer,
 		// which would surface a spurious unhandled rejection under workerd.
-		const handler = matchRoute(request, deps);
+		const handler = matchRoute(request, deps, identity);
 		const response = await handler();
 		return response;
 	} catch (error) {
@@ -92,7 +94,11 @@ export async function handleConsoleApi(request: Request, deps: ConsoleApiDeps): 
 	}
 }
 
-function matchRoute(request: Request, deps: ConsoleApiDeps): () => Promise<Response> {
+function matchRoute(
+	request: Request,
+	deps: ConsoleApiDeps,
+	identity: OperatorIdentity,
+): () => Promise<Response> {
 	const url = new URL(request.url);
 	// pathname keeps percent-encoding; the subject URI segment is decoded per route.
 	const segments = url.pathname.replace(ADMIN_API_PREFIX, "").split("/").filter(Boolean);
@@ -113,6 +119,14 @@ function matchRoute(request: Request, deps: ConsoleApiDeps): () => Promise<Respo
 		return () => handleListAuditLog(request, url, deps);
 	} else if (segments[0] === "status" && segments.length === 1) {
 		return () => handleGetStatus(request, deps);
+	} else if (segments[0] === "whoami" && segments.length === 1) {
+		return () => handleWhoami(request, identity);
+	} else if (
+		segments[0] === "labels" &&
+		segments.length === 2 &&
+		segments[1] === "effect-preview"
+	) {
+		return () => handleEffectPreview(request, url, deps);
 	}
 
 	throw new ReadGuardError("NOT_FOUND");
@@ -277,6 +291,51 @@ async function handleGetStatus(request: Request, deps: ConsoleApiDeps): Promise<
 		pendingAssessments,
 		deadLetterDepth,
 	});
+}
+
+/** The caller's own verified identity — kind, principal, and roles — for the
+ * console's cosmetic button gating. The server remains the enforcement boundary
+ * (`guardMutation`'s role gate); hiding a button never grants anything. */
+async function handleWhoami(request: Request, identity: OperatorIdentity): Promise<Response> {
+	requireGet(request);
+	const principal = identity.kind === "human" ? identity.email : identity.commonName;
+	return jsonData({
+		kind: identity.kind,
+		principal,
+		sub: identity.sub,
+		roles: identity.roles,
+	});
+}
+
+async function handleEffectPreview(
+	request: Request,
+	url: URL,
+	deps: ConsoleApiDeps,
+): Promise<Response> {
+	requireGet(request);
+	const uri = url.searchParams.get("uri");
+	const val = url.searchParams.get("val");
+	if (uri === null || uri.length === 0 || val === null || val.length === 0)
+		throw new ReadGuardError("INVALID_REQUEST");
+	const cid = url.searchParams.get("cid") ?? undefined;
+	if (cid !== undefined && cid.length === 0) throw new ReadGuardError("INVALID_REQUEST");
+	const neg = parseNeg(url.searchParams.get("neg"));
+
+	const preview = await computeEffectPreview(
+		deps.db,
+		deps.labelerDid,
+		{ uri, val, ...(cid === undefined ? {} : { cid }), neg },
+		new Date(),
+	);
+	// An unknown label value has no policy definition to preview.
+	if (!preview) throw new ReadGuardError("INVALID_REQUEST");
+	return jsonData(preview);
+}
+
+function parseNeg(raw: string | null): boolean {
+	if (raw === null || raw === "false") return false;
+	if (raw === "true") return true;
+	throw new ReadGuardError("INVALID_REQUEST");
 }
 
 /** Dead-letter backlog — the observable stand-in for discovery-queue depth,

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -1,0 +1,291 @@
+/**
+ * Operator console mutation API (plan W9.4). The POST counterpart of
+ * `console-api.ts`'s read dispatcher: `/admin/api/labels/issue` and
+ * `/admin/api/labels/retract` sign and persist a reviewer-authorized label
+ * through the W9.2 guard, committing the signed `issued_labels` INSERTs and the
+ * `operator_actions` audit row in one atomic `db.batch` via `commitMutation`.
+ *
+ * Retraction is a negation (`neg: true`) issuance on the same `(src, uri, val)`
+ * stream — the ATProto stream has no delete. Authorization, CSRF, idempotency,
+ * and replay are entirely the guard's; this module adds the W9.4 value allow-set
+ * (policy-driven, minus the override-coupled pair W9.5 owns) and the
+ * server-validated typed confirmation.
+ */
+
+import type { LabelSigner } from "@emdash-cms/registry-moderation";
+
+import type { AccessAuthConfig, AccessKeyResolver } from "./access-auth.js";
+import type { LabelerIdentityConfig } from "./config.js";
+import {
+	commitMutation,
+	guardMutation,
+	MutationGuardError,
+	type MutationGuardDeps,
+	type MutationSpec,
+} from "./mutation-guard.js";
+import { ReadGuardError } from "./operator-read-guard.js";
+import { getLabelDefinition } from "./policy.js";
+import {
+	parseSubjectKind,
+	prepareManualLabelIssuance,
+	readIssuedLabelByActionKey,
+	type AllowedLabelProposal,
+	type AuthorizedIssuanceAction,
+} from "./service.js";
+import { createLabelPublisher } from "./subscribe-labels.js";
+
+const ADMIN_API_PREFIX = /^\/admin\/api\/?/;
+
+/** Override-coupled labels: the atomic unblock action (W9.5) is the only path
+ * that issues these, so the standalone issue/retract endpoints reject them. */
+const OVERRIDE_COUPLED: ReadonlySet<string> = new Set([
+	"assessment-passed",
+	"assessment-overridden",
+]);
+
+export type LabelMutationCode = "CONFIRMATION_MISMATCH";
+
+/**
+ * A W9.4-specific rejection kept off `MutationGuardError` so the W9.2 guard's
+ * code union stays untouched. Same wire shape as the guard error; the message is
+ * static (never echoes the confirmation value).
+ */
+export class LabelMutationError extends Error {
+	override readonly name = "LabelMutationError";
+	readonly code: LabelMutationCode;
+	readonly status = 400;
+
+	constructor(code: LabelMutationCode) {
+		super("Typed confirmation does not match the action subject");
+		this.code = code;
+	}
+
+	toResponse(): Response {
+		return Response.json(
+			{ error: { code: this.code, message: this.message } },
+			{ status: this.status },
+		);
+	}
+}
+
+export interface LabelActionBody {
+	uri: string;
+	val: string;
+	cid?: string;
+	/** Server-validated typed confirmation: the exact CID for a CID-bound action,
+	 * the record rkey for a URI-wide one. Participates in the request fingerprint
+	 * (it is part of the parsed body), so a replay must send the same value. */
+	confirmation: string;
+}
+
+export interface ConsoleMutationDeps {
+	db: D1Database;
+	accessConfig: AccessAuthConfig;
+	keys: AccessKeyResolver;
+	config: LabelerIdentityConfig;
+	createSigner: () => Promise<LabelSigner>;
+	now: () => Date;
+	/** Broadcasts the freshly committed label off the response path (keyed on our
+	 * own action id, so a concurrent-race loser finds nothing and skips). Errors
+	 * are swallowed by the implementation — cursor replay backstops a missed frame. */
+	afterCommit: (actionId: string) => Promise<void>;
+	/** Schedules `afterCommit` without blocking the response (workerd `waitUntil`). */
+	defer: (work: Promise<unknown>) => void;
+}
+
+/**
+ * The deterministic idempotent result stored by `commitMutation` and returned to
+ * the client. Excludes `sequence` — that is assigned by a DB trigger at INSERT
+ * time and is unknowable before the batch commits, so two replays would
+ * otherwise disagree. The console re-reads the sequence from the label reads.
+ */
+export interface IssuedLabelDescriptor {
+	actionId: string;
+	val: string;
+	uri: string;
+	cid: string | null;
+	neg: boolean;
+	cts: string;
+	effect: string;
+}
+
+export async function handleConsoleMutation(
+	request: Request,
+	deps: ConsoleMutationDeps,
+): Promise<Response> {
+	try {
+		const url = new URL(request.url);
+		const segments = url.pathname.replace(ADMIN_API_PREFIX, "").split("/").filter(Boolean);
+		if (segments[0] !== "labels" || segments.length !== 2) throw new ReadGuardError("NOT_FOUND");
+		if (segments[1] === "issue") return await runLabelMutation(request, deps, false);
+		if (segments[1] === "retract") return await runLabelMutation(request, deps, true);
+		throw new ReadGuardError("NOT_FOUND");
+	} catch (error) {
+		if (
+			error instanceof MutationGuardError ||
+			error instanceof ReadGuardError ||
+			error instanceof LabelMutationError
+		)
+			return error.toResponse();
+		console.error("[console-mutation] unhandled error", error);
+		return Response.json(
+			{ error: { code: "INTERNAL", message: "Internal error" } },
+			{ status: 500 },
+		);
+	}
+}
+
+async function runLabelMutation(
+	request: Request,
+	deps: ConsoleMutationDeps,
+	neg: boolean,
+): Promise<Response> {
+	const spec = makeSpec(neg);
+	const guardDeps: MutationGuardDeps = {
+		db: deps.db,
+		config: deps.accessConfig,
+		keys: deps.keys,
+		now: deps.now,
+	};
+	const outcome = await guardMutation(request, spec, guardDeps);
+	if (outcome.outcome === "replay") return jsonData(outcome.result);
+
+	const { ctx } = outcome;
+	const signer = await deps.createSigner();
+	const action: AuthorizedIssuanceAction = {
+		actor: deps.config.labelerDid,
+		type: "manual-label",
+		reason: ctx.reason,
+		// Keying the signing-layer idempotency on the guard's unique action id
+		// makes the two idempotency layers consistent: a concurrent-race loser's
+		// issuance INSERTs (keyed by its own actionId) roll back with its audit row.
+		idempotencyKey: ctx.actionId,
+	};
+	const proposal: AllowedLabelProposal = {
+		uri: ctx.body.uri,
+		val: ctx.body.val,
+		...(ctx.body.cid === undefined ? {} : { cid: ctx.body.cid }),
+		neg,
+	};
+	const { statements } = await prepareManualLabelIssuance(
+		deps.db,
+		deps.config,
+		signer,
+		action,
+		proposal,
+		ctx.now,
+	);
+	const descriptor: IssuedLabelDescriptor = {
+		actionId: ctx.actionId,
+		val: proposal.val,
+		uri: proposal.uri,
+		cid: proposal.cid ?? null,
+		neg,
+		cts: ctx.now.toISOString(),
+		effect: getLabelDefinition(proposal.val)?.officialEffect ?? "",
+	};
+	const returned = await commitMutation(deps.db, ctx, spec, statements, descriptor);
+	deps.defer(deps.afterCommit(ctx.actionId));
+	return jsonData(returned);
+}
+
+function makeSpec(neg: boolean): MutationSpec<LabelActionBody> {
+	return {
+		action: neg ? "label-retract" : "label-issue",
+		requiredRole: "reviewer",
+		parseBody: (raw) => {
+			const body = parseLabelActionBody(raw);
+			assertW94Issuable(body);
+			assertConfirmation(body);
+			return body;
+		},
+		auditFields: (body) => ({
+			subjectUri: body.uri,
+			subjectCid: body.cid,
+			labelValue: body.val,
+			metadata: { neg, effect: getLabelDefinition(body.val)?.officialEffect ?? null },
+		}),
+	};
+}
+
+function parseLabelActionBody(raw: Record<string, unknown>): LabelActionBody {
+	const uri = requireString(raw.uri);
+	const val = requireString(raw.val);
+	const confirmation = requireString(raw.confirmation);
+	const cid = optionalString(raw.cid);
+	return { uri, val, ...(cid === undefined ? {} : { cid }), confirmation };
+}
+
+/**
+ * The W9.4 value allow-set, policy-driven so a fixture grant lights up a value
+ * with no code change: the label's `subjectRules` must grant `reviewer` for the
+ * URI's subject, the matched rule's `cidRule` must be satisfied, and the value
+ * must not be one of the override-coupled pair (W9.5). The admin-only labels
+ * (`!takedown`, `publisher-compromised`) are rejected here because their rules
+ * carry no `reviewer` mode — they are W9.6. Enforcing `cidRule` here (not only in
+ * the issuer's `validateManualProposal`) makes a scope mismatch a clean 400
+ * before signing rather than a 500 mid-issuance.
+ */
+function assertW94Issuable(body: LabelActionBody): void {
+	if (OVERRIDE_COUPLED.has(body.val)) throw new MutationGuardError("INVALID_BODY");
+	const definition = getLabelDefinition(body.val);
+	if (!definition) throw new MutationGuardError("INVALID_BODY");
+	const subject = parseSubjectKind(body.uri);
+	if (subject === null) throw new MutationGuardError("INVALID_BODY");
+	const rule = definition.subjectRules.find((candidate) => candidate.subject === subject);
+	if (!rule || !rule.issuanceModes.includes("reviewer"))
+		throw new MutationGuardError("INVALID_BODY");
+	if (rule.cidRule === "forbidden" && body.cid !== undefined)
+		throw new MutationGuardError("INVALID_BODY");
+	if (rule.cidRule === "required" && body.cid === undefined)
+		throw new MutationGuardError("INVALID_BODY");
+}
+
+/**
+ * Server-validated typed confirmation (§11.4, §20.2 "enforcement is code, not
+ * prompt text"): a CID-bound action must confirm the exact CID; a URI-wide one
+ * must confirm the record rkey (the final AT-URI path segment). A scripted
+ * client cannot skip the ceremony.
+ */
+function assertConfirmation(body: LabelActionBody): void {
+	const expected = body.cid !== undefined ? body.cid : rkeyOf(body.uri);
+	if (body.confirmation !== expected) throw new LabelMutationError("CONFIRMATION_MISMATCH");
+}
+
+function rkeyOf(uri: string): string {
+	return uri.split("/").at(-1) ?? "";
+}
+
+function requireString(value: unknown): string {
+	if (typeof value !== "string" || value.length === 0) throw new MutationGuardError("INVALID_BODY");
+	return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string" || value.length === 0) throw new MutationGuardError("INVALID_BODY");
+	return value;
+}
+
+function jsonData<T>(data: T): Response {
+	return Response.json({ data }, { headers: { "cache-control": "no-store" } });
+}
+
+/**
+ * Best-effort live broadcast of a freshly committed label, run off the response
+ * path. Keyed on the caller's own action id: a concurrent-race loser (whose
+ * batch rolled back) reads nothing and skips, so the winner alone publishes.
+ * Publication needs the trigger-assigned `sequence`, which only exists
+ * post-commit — this uses a plain read, not `postCommit()`, so a deliberately
+ * absent row is `null` (skip) rather than a signing-state diagnosis. A missed
+ * frame is recoverable: subscribers replay from their cursor on reconnect.
+ */
+export async function publishAfterCommit(env: Env, actionId: string): Promise<void> {
+	try {
+		const issued = await readIssuedLabelByActionKey(env.DB, actionId);
+		if (!issued) return;
+		await createLabelPublisher(env).publish(issued);
+	} catch (error) {
+		console.error("[console-mutation] publish failed", error);
+	}
+}

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -26,6 +26,7 @@ import {
 import { ReadGuardError } from "./operator-read-guard.js";
 import { getLabelDefinition } from "./policy.js";
 import {
+	LabelIssuanceUnavailableError,
 	parseSubjectKind,
 	prepareManualLabelIssuance,
 	readIssuedLabelByActionKey,
@@ -127,6 +128,19 @@ export async function handleConsoleMutation(
 			error instanceof LabelMutationError
 		)
 			return error.toResponse();
+		// Transient signing-state unavailability (issuance paused, key stale, or the
+		// in-batch signing guard suppressing the label under a rotation race) is
+		// retryable — surface a 503 rather than a misleading 500 or a phantom 200.
+		if (error instanceof LabelIssuanceUnavailableError)
+			return Response.json(
+				{
+					error: {
+						code: "LABEL_ISSUANCE_UNAVAILABLE",
+						message: "Label issuance is temporarily unavailable; retry.",
+					},
+				},
+				{ status: 503 },
+			);
 		console.error("[console-mutation] unhandled error", error);
 		return Response.json(
 			{ error: { code: "INTERNAL", message: "Internal error" } },
@@ -185,6 +199,16 @@ async function runLabelMutation(
 		effect: getLabelDefinition(proposal.val)?.officialEffect ?? "",
 	};
 	const returned = await commitMutation(deps.db, ctx, spec, statements, descriptor);
+	// The operator_actions audit row commits unconditionally, but the issued_labels
+	// INSERT is guarded by an in-batch signing-state condition: a key rotation
+	// landing between the signing pre-check and this batch suppresses the label as a
+	// zero-row INSERT (not an error) while the audit row lands. Verify the label
+	// persisted for the committed action so a suppressed issuance surfaces as a
+	// retryable 503, not a phantom success. Keying on the committed action id
+	// distinguishes a genuine suppression (our id, no label) from a concurrent-race
+	// loss (the winner's id, whose label is present).
+	if (!(await readIssuedLabelByActionKey(deps.db, returned.actionId)))
+		throw new LabelIssuanceUnavailableError("label issuance did not persist");
 	deps.defer(deps.afterCommit(ctx.actionId));
 	return jsonData(returned);
 }

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -162,7 +162,10 @@ async function runLabelMutation(
 		now: deps.now,
 	};
 	const outcome = await guardMutation(request, spec, guardDeps);
-	if (outcome.outcome === "replay") return jsonData(outcome.result);
+	if (outcome.outcome === "replay") {
+		await assertIssuancePersisted(deps.db, outcome.actionId);
+		return jsonData(outcome.result);
+	}
 
 	const { ctx } = outcome;
 	const signer = await deps.createSigner();
@@ -199,18 +202,27 @@ async function runLabelMutation(
 		effect: getLabelDefinition(proposal.val)?.officialEffect ?? "",
 	};
 	const returned = await commitMutation(deps.db, ctx, spec, statements, descriptor);
-	// The operator_actions audit row commits unconditionally, but the issued_labels
-	// INSERT is guarded by an in-batch signing-state condition: a key rotation
-	// landing between the signing pre-check and this batch suppresses the label as a
-	// zero-row INSERT (not an error) while the audit row lands. Verify the label
-	// persisted for the committed action so a suppressed issuance surfaces as a
-	// retryable 503, not a phantom success. Keying on the committed action id
-	// distinguishes a genuine suppression (our id, no label) from a concurrent-race
-	// loss (the winner's id, whose label is present).
-	if (!(await readIssuedLabelByActionKey(deps.db, returned.actionId)))
-		throw new LabelIssuanceUnavailableError("label issuance did not persist");
+	await assertIssuancePersisted(deps.db, returned.actionId);
 	deps.defer(deps.afterCommit(ctx.actionId));
 	return jsonData(returned);
+}
+
+/**
+ * Rejects a phantom success. The `operator_actions` audit row commits
+ * unconditionally, but the `issued_labels` INSERT is guarded by an in-batch
+ * signing-state condition — a key rotation landing between the signing pre-check
+ * and the commit suppresses the label as a zero-row INSERT (not an error) while
+ * the audit row lands, and that audit row stores the success descriptor as its
+ * result. Both the proceed path and the replay path (which the guard serves from
+ * that stored descriptor) must verify the label actually persisted for the
+ * committed action, or a retry would return the suppressed issuance as a 200.
+ * Keying on the committed action id distinguishes a genuine suppression (no
+ * label) from a concurrent-race loss (the winner's action id, whose label is
+ * present).
+ */
+async function assertIssuancePersisted(db: D1Database, actionId: string): Promise<void> {
+	if (!(await readIssuedLabelByActionKey(db, actionId)))
+		throw new LabelIssuanceUnavailableError("label issuance did not persist");
 }
 
 function makeSpec(neg: boolean): MutationSpec<LabelActionBody> {

--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -3,8 +3,9 @@ import {
 	parseAccessAuthConfig,
 	type AccessAuthConfig,
 } from "./access-auth.js";
-import { getLabelerIdentityConfig, type LabelerConfig } from "./config.js";
+import { getLabelerIdentityConfig, type LabelerIdentityConfig } from "./config.js";
 import { consoleAssetPath, handleConsoleApi, probeJetstreamConnected } from "./console-api.js";
+import { handleConsoleMutation, publishAfterCommit } from "./console-mutation-api.js";
 import { drainDiscoveryDeadLetterBatch, processDiscoveryBatch } from "./discovery-consumer.js";
 import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
 import type { DiscoveryJob } from "./env.js";
@@ -29,7 +30,7 @@ const DISCOVERY_QUEUE_NAME = "emdash-labeler-discovery";
 const DISCOVERY_DLQ_NAME = "emdash-labeler-discovery-dlq";
 
 export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
+	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		const pathname = new URL(request.url).pathname;
 		let config;
 		try {
@@ -57,7 +58,7 @@ export default {
 		// the shell needs no in-Worker auth check — the API re-verifies per
 		// request regardless (see console-api.ts / operator-read-guard.ts).
 		if (pathname === "/admin/api" || pathname.startsWith("/admin/api/"))
-			return handleConsoleApiRequest(env, request, config);
+			return handleConsoleApiRequest(env, request, config, ctx);
 		const assetPath = consoleAssetPath(pathname);
 		if (assetPath !== null) {
 			const assetUrl = new URL(request.url);
@@ -120,7 +121,8 @@ function getOperatorAccessConfig(env: Env): AccessAuthConfig {
 async function handleConsoleApiRequest(
 	env: Env,
 	request: Request,
-	config: LabelerConfig,
+	config: LabelerIdentityConfig,
+	ctx: ExecutionContext,
 ): Promise<Response> {
 	let accessConfig: AccessAuthConfig;
 	try {
@@ -131,10 +133,24 @@ async function handleConsoleApiRequest(
 			{ status: 500 },
 		);
 	}
+	const keys = getAccessKeyResolver(accessConfig.teamDomain);
+	if (request.method === "POST") {
+		return handleConsoleMutation(request, {
+			db: env.DB,
+			accessConfig,
+			keys,
+			config,
+			createSigner: async () =>
+				(await createRuntimeSigner(config, getRuntimeSigningSecret(env))).signer,
+			now: () => new Date(),
+			afterCommit: (actionId) => publishAfterCommit(env, actionId),
+			defer: (work) => ctx.waitUntil(work),
+		});
+	}
 	return handleConsoleApi(request, {
 		db: env.DB,
 		config: accessConfig,
-		keys: getAccessKeyResolver(accessConfig.teamDomain),
+		keys,
 		labelerDid: config.labelerDid,
 		jetstreamConnected: () => probeJetstreamConnected(env),
 	});

--- a/apps/labeler/src/label-effect-preview.ts
+++ b/apps/labeler/src/label-effect-preview.ts
@@ -1,0 +1,157 @@
+/**
+ * Server-derived effect preview for a proposed reviewer label action (plan
+ * W9.4, spec §11.4 "resulting official-client effect"). The console holds zero
+ * policy logic: it renders whatever this endpoint returns. Grounding is the
+ * exact machinery official clients use — `getActiveLabelState`'s canonical
+ * `(src, uri, val)` stream reduction with CID applicability, fed into
+ * `registry-moderation`'s release evaluator (the aggregator / #1972 source of
+ * truth) with the proposal overlaid as one more `(uri, val, cid, neg)` event.
+ */
+
+import {
+	evaluateHydratedReleaseModeration,
+	type ModerationLabel,
+	type ReleaseModeration,
+} from "@emdash-cms/registry-moderation";
+
+import { getActiveLabelState, getCurrentSubjectByUri } from "./assessment-store.js";
+import { getLabelDefinition } from "./policy.js";
+import { parseSubjectKind } from "./service.js";
+
+export interface EffectPreviewParams {
+	uri: string;
+	val: string;
+	cid?: string;
+	neg: boolean;
+}
+
+export interface SupersededLabel {
+	val: string;
+	cid: string | null;
+	sequence: number;
+}
+
+export interface EffectPreview {
+	/** The label's own official effect from policy (block/warn/redact/pass/…). */
+	labelEffect: string;
+	scope: "cid-bound" | "uri-wide";
+	/** The currently-active label in this value's stream that the action would
+	 * replace (a retract negates it; a re-issue supersedes it) — empty when the
+	 * value has no active label yet. */
+	supersedes: SupersededLabel[];
+	/** Resolved release moderation now, and with the proposal overlaid. Only a
+	 * release subject has a release evaluation; package/publisher subjects (and
+	 * releases with no observed subject row) report `null`. */
+	before: ReleaseModeration | null;
+	after: ReleaseModeration | null;
+}
+
+/**
+ * Computes the effect preview, or `null` when `val` is not a known policy label
+ * (the caller maps that to a 400). Every other field is best-effort: an
+ * unresolvable release context yields `before`/`after` `null` rather than
+ * failing the whole read.
+ */
+export async function computeEffectPreview(
+	db: D1Database,
+	labelerDid: string,
+	params: EffectPreviewParams,
+	now: Date,
+): Promise<EffectPreview | null> {
+	const definition = getLabelDefinition(params.val);
+	if (!definition) return null;
+
+	const scope: EffectPreview["scope"] = params.cid !== undefined ? "cid-bound" : "uri-wide";
+	const preview: EffectPreview = {
+		labelEffect: definition.officialEffect,
+		scope,
+		supersedes: [],
+		before: null,
+		after: null,
+	};
+
+	// A release evaluation needs the release CID being evaluated. For a CID-bound
+	// action it is the proposal CID; for a URI-wide action (e.g. security-yanked)
+	// it is the current release CID from the observed subject row.
+	const subject = await getCurrentSubjectByUri(db, params.uri);
+	const isRelease =
+		parseSubjectKind(params.uri) === "release" && subject?.collection.endsWith(".release") === true;
+	const contextCid = params.cid ?? subject?.cid;
+
+	if (contextCid === undefined) return preview;
+
+	const active = await getActiveLabelState(db, {
+		src: labelerDid,
+		uri: params.uri,
+		cid: contextCid,
+		now,
+	});
+	const supersededWinner = active.get(params.val);
+	if (supersededWinner && supersededWinner.active) {
+		preview.supersedes = [
+			{
+				val: supersededWinner.val,
+				cid: supersededWinner.cid,
+				sequence: supersededWinner.sequence,
+			},
+		];
+	}
+
+	if (!isRelease || !subject) return preview;
+
+	// Active winners are non-negated, unexpired, and applicable to `contextCid`,
+	// so they reconstruct as positive `ModerationLabel`s. The overlay carries a
+	// `now` cts so it wins its own `(uri, val)` stream in the re-reduction.
+	const activeLabels: ModerationLabel[] = [];
+	for (const winner of active.values()) {
+		if (!winner.active) continue;
+		activeLabels.push({
+			ver: 1,
+			src: labelerDid,
+			uri: params.uri,
+			...(winner.cid === null ? {} : { cid: winner.cid }),
+			val: winner.val,
+			cts: winner.cts,
+			...(winner.exp === null ? {} : { exp: winner.exp }),
+		});
+	}
+
+	const overlay: ModerationLabel = {
+		ver: 1,
+		src: labelerDid,
+		uri: params.uri,
+		...(params.cid === undefined ? {} : { cid: params.cid }),
+		val: params.val,
+		...(params.neg ? { neg: true } : {}),
+		cts: now.toISOString(),
+	};
+
+	const context = {
+		publisherDid: subject.did,
+		package: { uri: params.uri, cid: contextCid },
+		release: { uri: params.uri, cid: contextCid },
+	};
+	const acceptedLabelers = [{ did: labelerDid, redact: false }];
+
+	try {
+		preview.before = evaluateHydratedReleaseModeration({
+			acceptedLabelers,
+			context,
+			evaluatedAt: now,
+			labels: activeLabels,
+		});
+		preview.after = evaluateHydratedReleaseModeration({
+			acceptedLabelers,
+			context,
+			evaluatedAt: now,
+			labels: [...activeLabels, overlay],
+		});
+	} catch {
+		// A malformed URI/CID the evaluator rejects leaves before/after null; the
+		// scope + labelEffect + supersedes fields are still useful to the console.
+		preview.before = null;
+		preview.after = null;
+	}
+
+	return preview;
+}

--- a/apps/labeler/src/service.ts
+++ b/apps/labeler/src/service.ts
@@ -3,7 +3,7 @@ import type { LabelSigner, SignedLabel } from "@emdash-cms/registry-moderation";
 import { ASSESSMENT_ID } from "./assessment-lifecycle.js";
 import type { LabelerConfig } from "./config.js";
 import type { FindingSeverity } from "./evidence.js";
-import { getLabelDefinition } from "./policy.js";
+import { getLabelDefinition, type SubjectKind } from "./policy.js";
 import {
 	getSigningStatusIfInitialized,
 	recordSigningAlert,
@@ -51,7 +51,11 @@ export type IssuanceAction = AuthorizedIssuanceAction | AutomatedIssuanceAction;
 
 export interface AllowedLabelProposal {
 	uri: string;
-	val: ManualLabelValue;
+	/** Any label whose policy `subjectRules` grant a `reviewer` or `admin`
+	 * issuance mode for the parsed subject — validated in `validateManualProposal`
+	 * against the ratified fixture, not a hardcoded union, so a fixture grant lights
+	 * up a value with no code change. */
+	val: string;
 	cid?: string;
 	neg?: boolean;
 	exp?: string;
@@ -371,8 +375,33 @@ export async function issueManualLabel(
 		throw new TypeError("signer issuer does not match the configured labeler DID");
 	validateKeyVersion(config.signingKeyVersion);
 	validateAction(action);
-	validateProposal(proposal);
+	validateManualProposal(proposal);
 	return issueLabel(db, config, signer, action, proposal, now, publisher);
+}
+
+/**
+ * Prepares (validates + signs) a manual label issuance without executing the
+ * batch, returning the same `IssuanceStatements` `commitMutation` consumes so
+ * the operator console can commit the signed label INSERTs in the same atomic
+ * `db.batch` as the `operator_actions` audit row (plan W9.4). Mirrors the
+ * validation half of `issueManualLabel`; the caller owns `db.batch` and
+ * publication. `publicationPending` is `true` — the console publishes after the
+ * commit via `readIssuedLabelByActionKey`.
+ */
+export async function prepareManualLabelIssuance(
+	db: D1Database,
+	config: LabelerConfig,
+	signer: LabelSigner,
+	action: AuthorizedIssuanceAction,
+	proposal: AllowedLabelProposal,
+	now: Date,
+): Promise<IssuanceStatements> {
+	if (signer.issuerDid !== config.labelerDid)
+		throw new TypeError("signer issuer does not match the configured labeler DID");
+	validateKeyVersion(config.signingKeyVersion);
+	validateAction(action);
+	validateManualProposal(proposal);
+	return buildIssuanceStatements(db, config, signer, action, proposal, now, true);
 }
 
 export async function issueAutomatedAssessmentLabel(
@@ -462,6 +491,56 @@ async function assertAutomatedNegationAllowed(
 	}
 }
 
+/**
+ * Reads a persisted issuance as an `IssuedLabel` by its issuance-action
+ * idempotency key. Unlike `IssuanceStatements.postCommit`, a missing row
+ * returns `null` rather than re-diagnosing signing state and throwing — the
+ * console's post-commit publisher keys on its own `actionId`, so the race
+ * loser (whose batch rolled back) legitimately finds nothing and skips.
+ */
+export async function readIssuedLabelByActionKey(
+	db: D1Database,
+	idempotencyKey: string,
+): Promise<IssuedLabel | null> {
+	const row = await getIssuedLabel(db, idempotencyKey);
+	return row ? rowToIssuedLabel(row) : null;
+}
+
+function rowToIssuedLabel(stored: StoredLabelRow): IssuedLabel {
+	const action: IssuanceAction =
+		stored.type === "automated-assessment"
+			? {
+					actor: stored.actor,
+					type: "automated-assessment",
+					assessmentId: stored.assessment_id ?? "",
+					reason: stored.reason,
+					idempotencyKey: stored.idempotency_key,
+				}
+			: {
+					actor: stored.actor,
+					type: "manual-label",
+					reason: stored.reason,
+					idempotencyKey: stored.idempotency_key,
+				};
+	return {
+		action,
+		label: {
+			ver: 1,
+			src: stored.src,
+			uri: stored.uri,
+			...(stored.cid === null ? {} : { cid: stored.cid }),
+			val: stored.val,
+			...(stored.neg === 1 ? { neg: true } : {}),
+			cts: stored.cts,
+			...(stored.exp === null ? {} : { exp: stored.exp }),
+			sig: new Uint8Array(stored.sig),
+		},
+		sequence: stored.sequence,
+		signingKeyId: stored.signing_key_id,
+		signingKeyVersion: stored.signing_key_version,
+	};
+}
+
 async function getIssuedLabel(
 	db: D1Database,
 	idempotencyKey: string,
@@ -500,23 +579,7 @@ function assertMatches(
 	) {
 		throw new TypeError("idempotency key is already bound to a different issuance");
 	}
-	return {
-		action,
-		label: {
-			ver: 1,
-			src: stored.src,
-			uri: stored.uri,
-			...(stored.cid === null ? {} : { cid: stored.cid }),
-			val: stored.val,
-			...(stored.neg === 1 ? { neg: true } : {}),
-			cts: stored.cts,
-			...(stored.exp === null ? {} : { exp: stored.exp }),
-			sig: new Uint8Array(stored.sig),
-		},
-		sequence: stored.sequence,
-		signingKeyId: stored.signing_key_id,
-		signingKeyVersion: stored.signing_key_version,
-	};
+	return rowToIssuedLabel(stored);
 }
 
 function validateAction(action: AuthorizedIssuanceAction): void {
@@ -528,29 +591,60 @@ function validateAction(action: AuthorizedIssuanceAction): void {
 		throw new TypeError("action.idempotencyKey must be between 1 and 200 characters");
 }
 
-function validateProposal(proposal: AllowedLabelProposal): void {
-	const record = REGISTRY_RECORD.exec(proposal.uri);
-	const isDidSubject = DID.test(proposal.uri);
-	switch (proposal.val) {
-		case "publisher-compromised":
-			if (!isDidSubject || proposal.cid !== undefined)
-				throw new TypeError("publisher-compromised must target a DID without a CID");
-			return;
-		case "!takedown":
-			if (!isDidSubject && !record)
-				throw new TypeError("!takedown must target a DID, package profile, or release record");
-			if (proposal.cid !== undefined) throw new TypeError("!takedown must not include a CID");
-			return;
-		case "package-disputed":
-			if (!record || !record[2]!.endsWith(".profile"))
-				throw new TypeError("package-disputed must target a package profile record");
-			return;
-		case "security-yanked":
-			if (!record || !record[2]!.endsWith(".release"))
-				throw new TypeError("security-yanked must target a release record");
-			if (proposal.cid !== undefined) throw new TypeError("security-yanked must not include a CID");
-			return;
+/** Parses a label subject URI into its policy `SubjectKind`: a bare DID is a
+ * publisher, a `…package.profile` record is a package, a `…package.release`
+ * record is a release; anything else is unrecognized. */
+export function parseSubjectKind(uri: string): SubjectKind | null {
+	if (DID.test(uri)) return "publisher";
+	const record = REGISTRY_RECORD.exec(uri);
+	if (!record) return null;
+	const collection = record[2]!;
+	if (collection.endsWith(".profile")) return "package";
+	if (collection.endsWith(".release")) return "release";
+	return null;
+}
+
+function describeSubject(subject: SubjectKind): string {
+	switch (subject) {
+		case "release":
+			return "release record";
+		case "package":
+			return "package profile record";
+		case "publisher":
+			return "DID";
 	}
+}
+
+/**
+ * Manual issuance legality driven from the ratified policy fixture, mirroring
+ * `validateAutomatedProposal`: a value is manually issuable only where its
+ * `subjectRules` grant a `reviewer` or `admin` mode for the subject parsed from
+ * the URI, and the matched rule's `cidRule` decides whether a CID is forbidden
+ * (URI-wide), required (CID-bound), or optional. Keeping the issuer policy-driven
+ * means a fixture grant lights up a value with no code change, and an
+ * automated-only value (`assessment-pending`, an ungranted descriptive label)
+ * is rejected here. The per-endpoint W9.4 scope gate (override-coupled labels,
+ * role) lives in the console mutation dispatcher, not here.
+ */
+function validateManualProposal(proposal: AllowedLabelProposal): void {
+	const definition = getLabelDefinition(proposal.val);
+	if (!definition) throw new TypeError(`unknown label value: ${proposal.val}`);
+	const manualRules = definition.subjectRules.filter(
+		(rule) => rule.issuanceModes.includes("reviewer") || rule.issuanceModes.includes("admin"),
+	);
+	if (manualRules.length === 0)
+		throw new TypeError(`${proposal.val} cannot be issued through the manual path`);
+	const subject = parseSubjectKind(proposal.uri);
+	const rule =
+		subject === null ? undefined : manualRules.find((candidate) => candidate.subject === subject);
+	if (!rule) {
+		const allowed = manualRules.map((candidate) => describeSubject(candidate.subject)).join(", ");
+		throw new TypeError(`${proposal.val} must target a ${allowed}`);
+	}
+	if (rule.cidRule === "forbidden" && proposal.cid !== undefined)
+		throw new TypeError(`${proposal.val} must not include a CID`);
+	if (rule.cidRule === "required" && proposal.cid === undefined)
+		throw new TypeError(`${proposal.val} must include a CID`);
 }
 
 function validateAutomatedAction(action: AutomatedIssuanceAction): void {

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -281,14 +281,15 @@ describe("console mutation: issue/retract effect + audit atomicity", () => {
 	it("returns a retryable 503 (not a phantom 200) when the label is suppressed after the audit commits", async () => {
 		const uri = await seedReleaseSubject("phantom-suppressed");
 		const key = nextKey();
+		const body = {
+			uri,
+			val: "security-yanked",
+			confirmation: "phantom-suppressed",
+			reason: "rotation lands mid-issuance",
+			idempotencyKey: key,
+		};
 		const response = await handleConsoleMutation(
-			post("/admin/api/labels/issue", {
-				uri,
-				val: "security-yanked",
-				confirmation: "phantom-suppressed",
-				reason: "rotation lands mid-issuance",
-				idempotencyKey: key,
-			}),
+			post("/admin/api/labels/issue", body),
 			mutationDeps({ db: suppressIssuanceDb(testEnv.DB) }),
 		);
 		expect(response.status).toBe(503);
@@ -299,6 +300,22 @@ describe("console mutation: issue/retract effect + audit atomicity", () => {
 			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
 		).toBe(1);
 		expect(await countRows(`SELECT COUNT(*) n FROM issued_labels WHERE uri = ?`, uri)).toBe(0);
+
+		// A retry with the same idempotency key hits guardMutation's replay branch —
+		// which would return the stored (success) descriptor. The replay path must run
+		// the same persistence check and also 503, not a phantom 200. A plain db here:
+		// the replay short-circuits before any batch, reading the committed audit row.
+		const retry = await handleConsoleMutation(
+			post("/admin/api/labels/issue", body),
+			mutationDeps(),
+		);
+		expect(retry.status).toBe(503);
+		expect((await bodyError(retry)).code).toBe("LABEL_ISSUANCE_UNAVAILABLE");
+		// The replay wrote nothing: still no label, still exactly one audit row.
+		expect(await countRows(`SELECT COUNT(*) n FROM issued_labels WHERE uri = ?`, uri)).toBe(0);
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
+		).toBe(1);
 	});
 
 	it("writes no audit row when signing prep fails (no effect ⇒ no audit)", async () => {

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -1,0 +1,676 @@
+import {
+	createLabelSigner,
+	evaluateHydratedReleaseModeration,
+	type LabelDidDocument,
+	type ModerationLabel,
+} from "@emdash-cms/registry-moderation";
+import { applyD1Migrations, env } from "cloudflare:test";
+import { generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { AccessKeyResolver } from "../src/access-auth.js";
+import { createSubject, getActiveLabelState } from "../src/assessment-store.js";
+import { handleConsoleApi, type ConsoleApiDeps } from "../src/console-api.js";
+import {
+	handleConsoleMutation,
+	type ConsoleMutationDeps,
+	type IssuedLabelDescriptor,
+} from "../src/console-mutation-api.js";
+import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
+import { issueManualLabel } from "../src/service.js";
+
+const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
+const AUDIENCE = "test-audience";
+const ORIGIN = "https://labeler.example.com";
+const LABELER_DID = "did:web:labels.emdashcms.com";
+const LABELER_SERVICE_URL = "https://labels.emdashcms.com";
+const PUBLISHER_DID = "did:plc:publisher000000000000000000";
+const PRIVATE_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE";
+const MULTIKEY = "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ";
+const CID = "bafkreif4oaymum54i5qefbwoblrt5zasfjhpyhyvacpseqtehi3queew5m";
+const CID_2 = "bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq";
+
+const CONFIG = {
+	labelerDid: LABELER_DID,
+	signingKeyVersion: "v1",
+	serviceUrl: LABELER_SERVICE_URL,
+	signingPublicKeyMultibase: MULTIKEY,
+};
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+
+let resolver: AccessKeyResolver;
+let signKey: CryptoKey;
+let reviewerToken: string;
+let adminToken: string;
+let noRoleToken: string;
+let keySeq = 0;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+	const pair = await generateKeyPair("RS256");
+	signKey = pair.privateKey;
+	resolver = (async () => pair.publicKey) as AccessKeyResolver;
+	reviewerToken = await mintToken({ email: "reviewer@example.com" });
+	adminToken = await mintToken({ email: "admin@example.com" });
+	noRoleToken = await mintToken({ email: "nobody@example.com" });
+});
+
+async function mintToken(claims: Record<string, unknown>): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	return new SignJWT({ sub: "user-sub-1", ...claims })
+		.setProtectedHeader({ alg: "RS256" })
+		.setIssuer(TEAM_DOMAIN)
+		.setAudience(AUDIENCE)
+		.setIssuedAt(now)
+		.setExpirationTime(now + 3600)
+		.sign(signKey);
+}
+
+function labelerDidDocument(): LabelDidDocument {
+	return {
+		id: LABELER_DID,
+		verificationMethod: [
+			{
+				id: `${LABELER_DID}#atproto_label`,
+				type: "Multikey",
+				controller: LABELER_DID,
+				publicKeyMultibase: MULTIKEY,
+			},
+		],
+	};
+}
+
+function testSigner() {
+	return createLabelSigner({
+		issuerDid: LABELER_DID,
+		privateKey: PRIVATE_KEY,
+		resolveDid: async () => labelerDidDocument(),
+	});
+}
+
+function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): ConsoleMutationDeps {
+	const published: string[] = [];
+	return {
+		db: testEnv.DB,
+		accessConfig: {
+			teamDomain: TEAM_DOMAIN,
+			audience: AUDIENCE,
+			admins: ["admin@example.com"],
+			reviewers: ["reviewer@example.com"],
+		},
+		keys: resolver,
+		config: CONFIG,
+		createSigner: () => testSigner(),
+		now: () => new Date(),
+		afterCommit: async (actionId) => {
+			published.push(actionId);
+		},
+		defer: (work) => {
+			void work;
+		},
+		...overrides,
+	};
+}
+
+function readDeps(overrides: Partial<ConsoleApiDeps> = {}): ConsoleApiDeps {
+	return {
+		db: testEnv.DB,
+		config: {
+			teamDomain: TEAM_DOMAIN,
+			audience: AUDIENCE,
+			admins: ["admin@example.com"],
+			reviewers: ["reviewer@example.com"],
+		},
+		keys: resolver,
+		expectedOrigin: ORIGIN,
+		labelerDid: LABELER_DID,
+		jetstreamConnected: async () => true,
+		...overrides,
+	};
+}
+
+interface PostOptions {
+	token?: string | null;
+	csrf?: string | null;
+	contentType?: string | null;
+	origin?: string;
+}
+
+function post(path: string, body: unknown, opts: PostOptions = {}): Request {
+	const headers = new Headers();
+	const csrf = opts.csrf === undefined ? "1" : opts.csrf;
+	if (csrf !== null) headers.set(OPERATOR_REQUEST_HEADER, csrf);
+	const contentType = opts.contentType === undefined ? "application/json" : opts.contentType;
+	if (contentType !== null) headers.set("Content-Type", contentType);
+	const token = opts.token === undefined ? reviewerToken : opts.token;
+	if (token !== null) headers.set("Cf-Access-Jwt-Assertion", token);
+	if (opts.origin) headers.set("Origin", opts.origin);
+	return new Request(`${ORIGIN}${path}`, { method: "POST", headers, body: JSON.stringify(body) });
+}
+
+function getReq(path: string, token: string | null = reviewerToken): Request {
+	const headers = new Headers();
+	headers.set(OPERATOR_REQUEST_HEADER, "1");
+	if (token !== null) headers.set("Cf-Access-Jwt-Assertion", token);
+	return new Request(`${ORIGIN}${path}`, { method: "GET", headers });
+}
+
+function releaseUri(rkey: string): string {
+	return `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.release/${rkey}`;
+}
+
+function profileUri(rkey: string): string {
+	return `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.profile/${rkey}`;
+}
+
+async function seedReleaseSubject(rkey: string, cid = CID): Promise<string> {
+	const uri = releaseUri(rkey);
+	await createSubject(testEnv.DB, {
+		uri,
+		cid,
+		did: PUBLISHER_DID,
+		collection: "com.emdashcms.experimental.package.release",
+		rkey,
+		now: new Date("2026-07-08T08:00:00.000Z"),
+	});
+	return uri;
+}
+
+function nextKey(): string {
+	keySeq += 1;
+	return `idem-key-${keySeq.toString().padStart(6, "0")}`;
+}
+
+async function countRows(sql: string, ...binds: unknown[]): Promise<number> {
+	const row = await testEnv.DB.prepare(sql)
+		.bind(...binds)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+async function bodyData<T>(response: Response): Promise<T> {
+	const parsed = (await response.json()) as { data: T };
+	return parsed.data;
+}
+
+async function bodyError(response: Response): Promise<{ code: string; message: string }> {
+	const parsed = (await response.json()) as { error: { code: string; message: string } };
+	return parsed.error;
+}
+
+describe("console mutation: issue/retract effect + audit atomicity", () => {
+	it("commits the label, issuance action, and audit row with consistent linkage", async () => {
+		const uri = await seedReleaseSubject("atomicity-ok");
+		const key = nextKey();
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "atomicity-ok",
+				reason: "withdrawing for a disclosed CVE",
+				idempotencyKey: key,
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<IssuedLabelDescriptor>(response);
+		expect(descriptor).toMatchObject({
+			val: "security-yanked",
+			uri,
+			cid: null,
+			neg: false,
+			effect: "block",
+		});
+		expect(descriptor.actionId).toMatch(/^oact_/);
+		// No sequence in the idempotent result.
+		expect("sequence" in descriptor).toBe(false);
+
+		const audit = await testEnv.DB.prepare(
+			`SELECT id, action, actor_type, actor_email, role, subject_uri, subject_cid, label_value
+			 FROM operator_actions WHERE idempotency_key = ?`,
+		)
+			.bind(key)
+			.first();
+		expect(audit).toMatchObject({
+			id: descriptor.actionId,
+			action: "label-issue",
+			actor_type: "human",
+			actor_email: "reviewer@example.com",
+			role: "reviewer",
+			subject_uri: uri,
+			subject_cid: null,
+			label_value: "security-yanked",
+		});
+
+		// issuance_actions.idempotency_key === operator_actions.id === actionId.
+		const linked = await testEnv.DB.prepare(
+			`SELECT l.val, l.neg FROM issued_labels l
+			 JOIN issuance_actions a ON a.id = l.action_id
+			 WHERE a.idempotency_key = ?`,
+		)
+			.bind(descriptor.actionId)
+			.first<{ val: string; neg: number }>();
+		expect(linked).toEqual({ val: "security-yanked", neg: 0 });
+	});
+
+	it("writes no audit row when signing prep fails (no effect ⇒ no audit)", async () => {
+		const uri = await seedReleaseSubject("atomicity-fail");
+		const key = nextKey();
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "atomicity-fail",
+				reason: "prep should fail",
+				idempotencyKey: key,
+			}),
+			mutationDeps({
+				createSigner: () =>
+					Promise.resolve({
+						issuerDid: LABELER_DID,
+						sign: () => Promise.reject(new Error("signer unavailable")),
+					}),
+			}),
+		);
+		expect(response.status).toBe(500);
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
+		).toBe(0);
+	});
+});
+
+describe("console mutation: guard integration (representative)", () => {
+	const body = {
+		uri: releaseUri("guard"),
+		val: "security-yanked",
+		confirmation: "guard",
+		reason: "guard test",
+		idempotencyKey: "guard-key-000001",
+	};
+
+	it("rejects a missing CSRF header", async () => {
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", body, { csrf: null }),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(403);
+		expect((await bodyError(response)).code).toBe("CSRF_HEADER_MISSING");
+	});
+
+	it("rejects a non-JSON content type", async () => {
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", body, { contentType: "text/plain" }),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(415);
+	});
+
+	it("rejects an unauthenticated request", async () => {
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", body, { token: null }),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("rejects a caller without the reviewer role", async () => {
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", body, { token: noRoleToken }),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(403);
+		expect((await bodyError(response)).code).toBe("FORBIDDEN_ROLE");
+	});
+
+	it("lets an admin satisfy the reviewer gate and records the inherited role", async () => {
+		const uri = await seedReleaseSubject("admin-inherits");
+		const response = await handleConsoleMutation(
+			post(
+				"/admin/api/labels/issue",
+				{
+					uri,
+					val: "security-yanked",
+					confirmation: "admin-inherits",
+					reason: "admin acting as reviewer",
+					idempotencyKey: nextKey(),
+				},
+				{ token: adminToken },
+			),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const audit = await testEnv.DB.prepare(
+			`SELECT role, actor_email FROM operator_actions WHERE subject_uri = ? AND action = 'label-issue'`,
+		)
+			.bind(uri)
+			.first<{ role: string; actor_email: string }>();
+		expect(audit).toMatchObject({ role: "admin", actor_email: "admin@example.com" });
+	});
+});
+
+describe("console mutation: vocabulary and scope", () => {
+	async function issue(uri: string, val: string, confirmation: string, cid?: string) {
+		return handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val,
+				...(cid === undefined ? {} : { cid }),
+				confirmation,
+				reason: `issue ${val}`,
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+	}
+
+	it("rejects an automated-only label (assessment-pending)", async () => {
+		const response = await issue(releaseUri("vocab-pending"), "assessment-pending", CID, CID);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("INVALID_BODY");
+	});
+
+	it("rejects the override-coupled pair (assessment-passed)", async () => {
+		const response = await issue(releaseUri("vocab-passed"), "assessment-passed", CID, CID);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("INVALID_BODY");
+	});
+
+	it("rejects an admin-only label issued as reviewer (!takedown)", async () => {
+		const response = await issue(releaseUri("vocab-takedown"), "!takedown", "vocab-takedown");
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a CID on a cidRule:forbidden label (security-yanked)", async () => {
+		const response = await issue(releaseUri("vocab-yank-cid"), "security-yanked", CID, CID);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("INVALID_BODY");
+	});
+
+	it("accepts security-yanked URI-wide on a release", async () => {
+		await seedReleaseSubject("vocab-yank-ok");
+		const response = await issue(releaseUri("vocab-yank-ok"), "security-yanked", "vocab-yank-ok");
+		expect(response.status).toBe(200);
+	});
+
+	it("accepts a reviewer-granted descriptive label (malware) CID-bound", async () => {
+		await seedReleaseSubject("vocab-malware");
+		const response = await issue(releaseUri("vocab-malware"), "malware", CID, CID);
+		expect(response.status).toBe(200);
+	});
+
+	it("accepts package-disputed with and without a CID", async () => {
+		const withCid = await issue(profileUri("vocab-disputed-a"), "package-disputed", CID, CID);
+		expect(withCid.status).toBe(200);
+		const withoutCid = await issue(
+			profileUri("vocab-disputed-b"),
+			"package-disputed",
+			"vocab-disputed-b",
+		);
+		expect(withoutCid.status).toBe(200);
+	});
+});
+
+describe("console mutation: confirmation", () => {
+	it("rejects a CID-bound action whose confirmation is not the CID", async () => {
+		await seedReleaseSubject("conf-cid");
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri: releaseUri("conf-cid"),
+				val: "malware",
+				cid: CID,
+				confirmation: "not-the-cid",
+				reason: "bad confirmation",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("CONFIRMATION_MISMATCH");
+	});
+
+	it("rejects a URI-wide action whose confirmation is not the rkey", async () => {
+		await seedReleaseSubject("conf-rkey");
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri: releaseUri("conf-rkey"),
+				val: "security-yanked",
+				confirmation: "wrong-rkey",
+				reason: "bad confirmation",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("CONFIRMATION_MISMATCH");
+	});
+});
+
+describe("console mutation: retraction is negation", () => {
+	it("records a negation and the stream winner becomes inactive", async () => {
+		const uri = await seedReleaseSubject("retract-flow");
+		const issued = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "retract-flow",
+				reason: "yank it",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(issued.status).toBe(200);
+
+		const retracted = await handleConsoleMutation(
+			post("/admin/api/labels/retract", {
+				uri,
+				val: "security-yanked",
+				confirmation: "retract-flow",
+				reason: "false alarm",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(retracted.status).toBe(200);
+		const descriptor = await bodyData<IssuedLabelDescriptor>(retracted);
+		expect(descriptor.neg).toBe(true);
+
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = 'security-yanked' AND neg = 1`,
+				uri,
+			),
+		).toBe(1);
+
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("security-yanked")?.active).toBe(false);
+	});
+});
+
+describe("console mutation: replay and conflict", () => {
+	it("returns the byte-identical stored descriptor on replay without a second write", async () => {
+		const uri = await seedReleaseSubject("replay");
+		const key = nextKey();
+		const request = () =>
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "replay",
+				reason: "first and replay",
+				idempotencyKey: key,
+			});
+		const first = await handleConsoleMutation(request(), mutationDeps());
+		const firstBody = await first.text();
+		const second = await handleConsoleMutation(request(), mutationDeps());
+		const secondBody = await second.text();
+		expect(second.status).toBe(200);
+		expect(secondBody).toBe(firstBody);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = 'security-yanked'`,
+				uri,
+			),
+		).toBe(1);
+	});
+
+	it("returns 409 for the same key with a different fingerprint", async () => {
+		const uri = await seedReleaseSubject("conflict");
+		const key = nextKey();
+		const first = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "conflict",
+				reason: "original reason",
+				idempotencyKey: key,
+			}),
+			mutationDeps(),
+		);
+		expect(first.status).toBe(200);
+		const second = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "conflict",
+				reason: "different reason",
+				idempotencyKey: key,
+			}),
+			mutationDeps(),
+		);
+		expect(second.status).toBe(409);
+		expect((await bodyError(second)).code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+	});
+});
+
+describe("console reads: whoami", () => {
+	it("returns the caller kind, principal, and roles", async () => {
+		const response = await handleConsoleApi(getReq("/admin/api/whoami"), readDeps());
+		expect(response.status).toBe(200);
+		const data = await bodyData<{ kind: string; principal: string; roles: string[] }>(response);
+		expect(data).toMatchObject({
+			kind: "human",
+			principal: "reviewer@example.com",
+			roles: ["reviewer"],
+		});
+	});
+
+	it("reports admin roles for an admin caller", async () => {
+		const response = await handleConsoleApi(getReq("/admin/api/whoami", adminToken), readDeps());
+		const data = await bodyData<{ roles: string[] }>(response);
+		expect(data.roles).toEqual(["admin"]);
+	});
+});
+
+describe("console reads: effect preview", () => {
+	async function preview(uri: string, val: string, cid?: string, neg = false) {
+		const search = new URLSearchParams({ uri, val });
+		if (cid) search.set("cid", cid);
+		if (neg) search.set("neg", "true");
+		const response = await handleConsoleApi(
+			getReq(`/admin/api/labels/effect-preview?${search.toString()}`),
+			readDeps(),
+		);
+		return response;
+	}
+
+	it("grounds before/after in the aggregator evaluator for a blocked release", async () => {
+		const uri = await seedReleaseSubject("preview-block");
+		await issueManualLabel(
+			testEnv.DB,
+			CONFIG,
+			await testSigner(),
+			{
+				actor: LABELER_DID,
+				type: "manual-label",
+				reason: "seed block",
+				idempotencyKey: nextKey(),
+			},
+			{ uri, val: "malware", cid: CID },
+			new Date("2026-07-08T09:00:00.000Z"),
+		);
+
+		const response = await preview(uri, "security-yanked");
+		expect(response.status).toBe(200);
+		const data = await bodyData<{
+			labelEffect: string;
+			scope: string;
+			before: { eligibility: string; blockingLabels: string[] } | null;
+			after: { eligibility: string; blockingLabels: string[] } | null;
+		}>(response);
+		expect(data.labelEffect).toBe("block");
+		expect(data.scope).toBe("uri-wide");
+		expect(data.before?.eligibility).toBe("blocked");
+		expect(data.before?.blockingLabels).toContain("malware");
+		expect(data.after?.blockingLabels).toContain("security-yanked");
+
+		// No drift: the endpoint's `after` matches a direct evaluator call over the
+		// overlaid label set (comparing effect fields, not cts-bearing labels).
+		const activeMalware: ModerationLabel = {
+			ver: 1,
+			src: LABELER_DID,
+			uri,
+			cid: CID,
+			val: "malware",
+			cts: "2026-07-08T09:00:00.000Z",
+		};
+		const overlay: ModerationLabel = {
+			ver: 1,
+			src: LABELER_DID,
+			uri,
+			val: "security-yanked",
+			cts: "2026-07-10T00:00:00.000Z",
+		};
+		const direct = evaluateHydratedReleaseModeration({
+			acceptedLabelers: [{ did: LABELER_DID, redact: false }],
+			context: {
+				publisherDid: PUBLISHER_DID,
+				package: { uri, cid: CID },
+				release: { uri, cid: CID },
+			},
+			evaluatedAt: new Date(),
+			labels: [activeMalware, overlay],
+		});
+		expect(data.after?.eligibility).toBe(direct.eligibility);
+		expect(data.after?.blockingLabels).toEqual(direct.blockingLabels);
+	});
+
+	it("shows a retract returning the release toward eligible", async () => {
+		const uri = await seedReleaseSubject("preview-retract", CID_2);
+		const base = new Date("2026-07-08T09:00:00.000Z");
+		await issueManualLabel(
+			testEnv.DB,
+			CONFIG,
+			await testSigner(),
+			{ actor: LABELER_DID, type: "manual-label", reason: "seed pass", idempotencyKey: nextKey() },
+			{ uri, val: "assessment-passed", cid: CID_2 },
+			base,
+		);
+		await issueManualLabel(
+			testEnv.DB,
+			CONFIG,
+			await testSigner(),
+			{ actor: LABELER_DID, type: "manual-label", reason: "seed block", idempotencyKey: nextKey() },
+			{ uri, val: "malware", cid: CID_2 },
+			new Date("2026-07-08T09:05:00.000Z"),
+		);
+
+		const blocked = await bodyData<{ before: { eligibility: string } | null }>(
+			await preview(uri, "malware", CID_2),
+		);
+		expect(blocked.before?.eligibility).toBe("blocked");
+
+		const retract = await bodyData<{ after: { eligibility: string } | null }>(
+			await preview(uri, "malware", CID_2, true),
+		);
+		expect(retract.after?.eligibility).toBe("eligible");
+	});
+
+	it("rejects an unknown label value", async () => {
+		const response = await preview(releaseUri("preview-unknown"), "not-a-label");
+		expect(response.status).toBe(400);
+	});
+});

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -186,6 +186,26 @@ function nextKey(): string {
 	return `idem-key-${keySeq.toString().padStart(6, "0")}`;
 }
 
+/**
+ * Simulates the in-batch signing-guard suppression a signing-key rotation race
+ * produces: the unguarded `operator_actions` INSERT commits while the guarded
+ * `issuance_actions` / `issued_labels` INSERTs match zero rows. Wraps `batch` to
+ * run only the audit INSERT, leaving the exact "audit row present, label absent"
+ * phantom state the handler's post-commit verification must reject. Every other
+ * method (`prepare`, etc.) passes through to the real D1, so no signing_state is
+ * written and later tests stay isolated.
+ */
+function suppressIssuanceDb(db: D1Database): D1Database {
+	return new Proxy(db, {
+		get(target, prop, receiver) {
+			if (prop === "batch")
+				return (statements: D1PreparedStatement[]) => target.batch([statements[0]!]);
+			const value: unknown = Reflect.get(target, prop, receiver);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}
+
 async function countRows(sql: string, ...binds: unknown[]): Promise<number> {
 	const row = await testEnv.DB.prepare(sql)
 		.bind(...binds)
@@ -256,6 +276,29 @@ describe("console mutation: issue/retract effect + audit atomicity", () => {
 			.bind(descriptor.actionId)
 			.first<{ val: string; neg: number }>();
 		expect(linked).toEqual({ val: "security-yanked", neg: 0 });
+	});
+
+	it("returns a retryable 503 (not a phantom 200) when the label is suppressed after the audit commits", async () => {
+		const uri = await seedReleaseSubject("phantom-suppressed");
+		const key = nextKey();
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "phantom-suppressed",
+				reason: "rotation lands mid-issuance",
+				idempotencyKey: key,
+			}),
+			mutationDeps({ db: suppressIssuanceDb(testEnv.DB) }),
+		);
+		expect(response.status).toBe(503);
+		expect((await bodyError(response)).code).toBe("LABEL_ISSUANCE_UNAVAILABLE");
+		// The audit row committed (its INSERT is unguarded) but no label persisted —
+		// the exact phantom state the post-commit verification rejects.
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
+		).toBe(1);
+		expect(await countRows(`SELECT COUNT(*) n FROM issued_labels WHERE uri = ?`, uri)).toBe(0);
 	});
 
 	it("writes no audit row when signing prep fails (no effect ⇒ no audit)", async () => {

--- a/apps/labeler/test/policy.test.ts
+++ b/apps/labeler/test/policy.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("moderation policy fixture", () => {
 	it("loads the ratified fixture and exposes label lookups", () => {
-		expect(MODERATION_POLICY.policyVersion).toBe("2026-07-10.experimental.2");
+		expect(MODERATION_POLICY.policyVersion).toBe("2026-07-10.experimental.3");
 		expect(getLabelDefinition("malware")).toMatchObject({
 			value: "malware",
 			category: "automated-block",

--- a/apps/labeler/test/service.test.ts
+++ b/apps/labeler/test/service.test.ts
@@ -78,7 +78,7 @@ describe("service identity", () => {
 		expect(response.headers.get("etag")).toMatch(/^"[a-f0-9]{64}"$/);
 		expect(await response.json()).toMatchObject({
 			schemaVersion: 1,
-			policyVersion: "2026-07-10.experimental.2",
+			policyVersion: "2026-07-10.experimental.3",
 			labelerDid: LABELER_DID,
 			assessmentSchemaVersion: 1,
 		});

--- a/apps/labeler/test/xrpc-router.test.ts
+++ b/apps/labeler/test/xrpc-router.test.ts
@@ -597,7 +597,7 @@ describe("getPolicy", () => {
 		expect(response.headers.get("cache-control")).toBe("public, max-age=300");
 		expect(await response.json()).toMatchObject({
 			schemaVersion: 1,
-			policyVersion: "2026-07-10.experimental.2",
+			policyVersion: "2026-07-10.experimental.3",
 			labelerDid: LABELER_DID,
 			assessmentSchemaVersion: 1,
 		});


### PR DESCRIPTION
## What does this PR do?

Adds plan item W9.4 — the operator console's first **mutation endpoints**: reviewers issue and retract moderation labels through the W9.2 mutation guard. `POST /admin/api/labels/issue` and `POST /admin/api/labels/retract` sign a manual label and commit its rows **atomically with the operator audit row** in a single `commitMutation` batch; retract is a manual negation (`neg: true`) through the same path.

The signing path needed no refactor: `buildIssuanceStatements` already returns bare `D1PreparedStatement[]` split from the batch run, so the new `prepareManualLabelIssuance` (validation + statement build) hands those statements straight to `commitMutation` as its `effect`. Publication is deferred post-commit, keyed on the action id so a concurrent race-loser cleanly skips.

Guarding and correctness:

- Every request passes the full mutation guard (content-type, same-origin, `X-EmDash-Request`, a **freshly verified Access identity**, reviewer role) before any signing. Roles are re-derived server-side from the verified JWT — `/whoami` (new read) is used only to cosmetically gate console buttons.
- **Server-validated typed confirmation**: the operator must retype the exact CID (CID-bound actions) or rkey (URI-wide), validated server-side and folded into the idempotency fingerprint (decision 2026-07-13).
- **Vocabulary and scope are policy-driven**: `validateManualProposal` (generalized from the old hardcoded arms, mirroring the automated path) enforces the label's `subjectRule`/`cidRule`; an automated-only label or a scope mismatch is rejected at 400 before signing. Per the ratified policy edit, reviewers may issue descriptive release labels (fixture bumped to `2026-07-10.experimental.3`); a reviewer-issued label is human-retract-only (§10 — automation can never negate it).
- **Effect preview** (`GET /admin/api/labels/effect-preview`) is server-derived from the aggregator evaluator overlaying the proposed event — the console holds zero policy logic, so official-client effect can't drift from what would actually happen.
- **No phantom success**: after commit, the handler reads the label back by action id; if a signing-key rotation raced between the pre-check and the batch such that the guarded issuance INSERTs matched zero rows (a non-error in SQLite) while the unguarded audit row committed, it returns `LABEL_ISSUANCE_UNAVAILABLE` (503, retryable) instead of a 200 that falsely claims a release is blocked. Paused/stale signing on this path now returns the same retryable error rather than a generic 500.

Console: action buttons + a Kumo dialog on assessment detail and subject history, with the typed-confirmation input, the effect preview, client-generated ULID idempotency keys, and 409/503 surfaced as retryable errors. Plain English strings (the console is not localized, per the W9.3 decision).

Reviewed by an independent Opus adversarial pass: confirmed no unauthenticated/under-privileged signing path, `whoami` roles provably cosmetic, vocabulary/scope non-escapable via the widened `val`, the §10 automated-negation-proof property (tested end to end), deterministic replay, and a pure (write-free) effect preview. Its one finding — the audit-without-label phantom success — is the 503 fix above, with a test that drives the exact suppressed state and fails without the fix.

Stacked directly on the integration branch (W9.1–W9.3 merged). Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — no admin UI; the labeler console is deliberately not localized. Changeset n/a — `apps/labeler` is a private, unpublished Worker app; the policy fixture it bundles is internal.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (coordination), Opus 4.8 subagents (design, implementation, adversarial review)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker 443 pass (25 files — new `console-mutation-api` suite covers the guard integration, effect+audit atomicity, retract/negation, vocabulary/scope rejection, confirmation mismatch, replay returning the stored descriptor, effect preview, whoami, and the 503 suppression path), console 14 pass
- Typecheck (both projects) clean; `console:build` succeeds; lint: 0 diagnostics in `apps/labeler`

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-label-actions-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-label-actions`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
