### PR TITLE
feat(labeler): reviewer rerun and false-positive override (W9.5)

### DIFF
--- a/apps/labeler/console/src/api/client.test.ts
+++ b/apps/labeler/console/src/api/client.test.ts
@@ -141,4 +141,89 @@ describe("fetch client label actions", () => {
 		expect(url).toContain("cid=bafy");
 		expect(url).toContain("neg=true");
 	});
+
+	it("POSTs a rerun with the CSRF header, JSON content type, and threaded key", async () => {
+		stubFetch(() => Response.json({ data: { actionId: "oact_1", runId: "asmt_1" } }));
+		const action = {
+			confirmation: "bafy",
+			reason: "reassess",
+			idempotencyKey: input.idempotencyKey,
+		};
+		const result = await fetchClient.rerunAssessment("asmt_target", action);
+		expect(result).toMatchObject({ actionId: "oact_1", runId: "asmt_1" });
+		const call = calls[0]!;
+		expect(call.url).toBe("/admin/api/assessments/asmt_target/rerun");
+		expect(call.init.method).toBe("POST");
+		const headers = new Headers(call.init.headers);
+		expect(headers.get("X-EmDash-Request")).toBe("1");
+		expect(headers.get("Content-Type")).toBe("application/json");
+		expect(JSON.parse(call.init.body as string)).toMatchObject(action);
+	});
+
+	it("POSTs an override to the override route with the negate set", async () => {
+		stubFetch(() => Response.json({ data: { actionId: "oact_1", negated: ["malware"] } }));
+		await fetchClient.overrideAssessment("asmt_target", {
+			confirmation: "bafy",
+			reason: "false positive",
+			idempotencyKey: input.idempotencyKey,
+			negate: ["malware", "data-exfiltration"],
+		});
+		expect(calls[0]!.url).toBe("/admin/api/assessments/asmt_target/override");
+		expect(JSON.parse(calls[0]!.init.body as string).negate).toEqual([
+			"malware",
+			"data-exfiltration",
+		]);
+	});
+
+	it("POSTs an override-retract to the override-retract route", async () => {
+		stubFetch(() => Response.json({ data: { actionId: "oact_1" } }));
+		await fetchClient.retractOverride("asmt_target", {
+			confirmation: "bafy",
+			reason: "override was wrong",
+			idempotencyKey: input.idempotencyKey,
+		});
+		expect(calls[0]!.url).toBe("/admin/api/assessments/asmt_target/override-retract");
+		expect(calls[0]!.init.method).toBe("POST");
+	});
+
+	it("GETs subject labels with the CID", async () => {
+		stubFetch(() => Response.json({ data: [{ val: "assessment-overridden", active: true }] }));
+		const labels = await fetchClient.getSubjectLabels(input.uri, "bafy");
+		expect(labels).toEqual([{ val: "assessment-overridden", active: true }]);
+		const url = calls[0]!.url;
+		expect(url).toContain(`/admin/api/subjects/${encodeURIComponent(input.uri)}/labels?`);
+		expect(url).toContain("cid=bafy");
+	});
+
+	it("builds the override-effect-preview query with repeated negate params", async () => {
+		stubFetch(() =>
+			Response.json({ data: { labelEffect: "pass", scope: "cid-bound", supersedes: [] } }),
+		);
+		await fetchClient.previewOverrideEffect({
+			uri: input.uri,
+			cid: "bafy",
+			negate: ["malware", "impersonation"],
+		});
+		const url = calls[0]!.url;
+		expect(url).toContain("/admin/api/labels/override-effect-preview?");
+		expect(url).toContain("negate=malware");
+		expect(url).toContain("negate=impersonation");
+	});
+
+	it("surfaces a 409 idempotency conflict message", async () => {
+		stubFetch(() =>
+			Response.json(
+				{ error: { code: "IDEMPOTENCY_KEY_CONFLICT", message: "key already used" } },
+				{ status: 409 },
+			),
+		);
+		await expect(
+			fetchClient.overrideAssessment("asmt_target", {
+				confirmation: "bafy",
+				reason: "x",
+				idempotencyKey: input.idempotencyKey,
+				negate: ["malware"],
+			}),
+		).rejects.toThrow("key already used");
+	});
 });

--- a/apps/labeler/console/src/api/client.ts
+++ b/apps/labeler/console/src/api/client.ts
@@ -7,6 +7,7 @@ import {
 	FIXTURE_SYSTEM_STATUS,
 } from "../fixtures/index.js";
 import type {
+	AssessmentActionInput,
 	AssessmentRun,
 	EffectPreview,
 	EffectPreviewParams,
@@ -16,9 +17,15 @@ import type {
 	ListAssessmentsParams,
 	ListAuditLogParams,
 	OperatorAction,
+	OverrideActionInput,
+	OverrideEffectPreviewParams,
+	OverrideResult,
+	OverrideRetractResult,
 	OperatorFinding,
 	Page,
+	RerunResult,
 	SubjectHistoryView,
+	SubjectLabel,
 	SystemStatusSnapshot,
 	WhoamiIdentity,
 } from "./types.js";
@@ -35,12 +42,17 @@ export interface LabelerConsoleClient {
 	listFindings(assessmentId: string): Promise<OperatorFinding[]>;
 	listLabels(assessmentId: string): Promise<IssuedLabel[]>;
 	getSubjectHistory(uri: string): Promise<SubjectHistoryView | null>;
+	getSubjectLabels(uri: string, cid?: string): Promise<SubjectLabel[]>;
 	listAuditLog(params?: ListAuditLogParams): Promise<Page<OperatorAction>>;
 	getSystemStatus(): Promise<SystemStatusSnapshot>;
 	whoami(): Promise<WhoamiIdentity>;
 	previewEffect(params: EffectPreviewParams): Promise<EffectPreview>;
+	previewOverrideEffect(params: OverrideEffectPreviewParams): Promise<EffectPreview>;
 	issueLabel(input: LabelActionInput): Promise<IssuedLabelDescriptor>;
 	retractLabel(input: LabelActionInput): Promise<IssuedLabelDescriptor>;
+	rerunAssessment(id: string, input: AssessmentActionInput): Promise<RerunResult>;
+	overrideAssessment(id: string, input: OverrideActionInput): Promise<OverrideResult>;
+	retractOverride(id: string, input: AssessmentActionInput): Promise<OverrideRetractResult>;
 }
 
 interface ApiErrorBody {
@@ -63,16 +75,13 @@ function consoleApiFetch(path: string, init?: RequestInit): Promise<Response> {
 /** POST a state-changing label action. `consoleApiFetch` already sets the CSRF
  * header and same-origin credentials; this adds the JSON content type the
  * mutation guard requires and threads the client-minted idempotency key. */
-async function postLabelAction(
-	path: string,
-	input: LabelActionInput,
-): Promise<IssuedLabelDescriptor> {
+async function postAction<T>(path: string, input: unknown, fallback: string): Promise<T> {
 	const response = await consoleApiFetch(path, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(input),
 	});
-	return parseJson(response, "Failed to submit label action");
+	return parseJson(response, fallback);
 }
 
 async function parseJson<T>(response: Response, fallback: string): Promise<T> {
@@ -122,6 +131,15 @@ export function createFetchClient(): LabelerConsoleClient {
 			if (response.status === 404) return null;
 			return parseJson(response, "Failed to load subject history");
 		},
+		async getSubjectLabels(uri, cid) {
+			const search = new URLSearchParams();
+			if (cid) search.set("cid", cid);
+			const query = search.toString();
+			const response = await consoleApiFetch(
+				`/subjects/${encodeURIComponent(uri)}/labels${query ? `?${query}` : ""}`,
+			);
+			return parseJson(response, "Failed to load subject labels");
+		},
 		async listAuditLog(params = {}) {
 			const search = new URLSearchParams();
 			if (params.cursor) search.set("cursor", params.cursor);
@@ -146,11 +164,42 @@ export function createFetchClient(): LabelerConsoleClient {
 			const response = await consoleApiFetch(`/labels/effect-preview?${search.toString()}`);
 			return parseJson(response, "Failed to preview effect");
 		},
+		async previewOverrideEffect(params) {
+			const search = new URLSearchParams();
+			search.set("uri", params.uri);
+			search.set("cid", params.cid);
+			for (const val of params.negate) search.append("negate", val);
+			const response = await consoleApiFetch(
+				`/labels/override-effect-preview?${search.toString()}`,
+			);
+			return parseJson(response, "Failed to preview override effect");
+		},
 		async issueLabel(input) {
-			return postLabelAction("/labels/issue", input);
+			return postAction("/labels/issue", input, "Failed to submit label action");
 		},
 		async retractLabel(input) {
-			return postLabelAction("/labels/retract", input);
+			return postAction("/labels/retract", input, "Failed to submit label action");
+		},
+		async rerunAssessment(id, input) {
+			return postAction(
+				`/assessments/${encodeURIComponent(id)}/rerun`,
+				input,
+				"Failed to rerun assessment",
+			);
+		},
+		async overrideAssessment(id, input) {
+			return postAction(
+				`/assessments/${encodeURIComponent(id)}/override`,
+				input,
+				"Failed to override assessment",
+			);
+		},
+		async retractOverride(id, input) {
+			return postAction(
+				`/assessments/${encodeURIComponent(id)}/override-retract`,
+				input,
+				"Failed to retract override",
+			);
 		},
 	};
 }
@@ -178,6 +227,9 @@ export function createFixtureClient(): LabelerConsoleClient {
 		async getSubjectHistory(uri) {
 			return FIXTURE_SUBJECT_HISTORY[uri] ?? null;
 		},
+		async getSubjectLabels() {
+			return [];
+		},
 		async listAuditLog() {
 			return { items: [...FIXTURE_OPERATOR_ACTIONS] };
 		},
@@ -201,6 +253,9 @@ export function createFixtureClient(): LabelerConsoleClient {
 				after: null,
 			};
 		},
+		async previewOverrideEffect() {
+			return { labelEffect: "pass", scope: "cid-bound", supersedes: [], before: null, after: null };
+		},
 		async issueLabel(input) {
 			return {
 				actionId: "oact_fixture",
@@ -221,6 +276,35 @@ export function createFixtureClient(): LabelerConsoleClient {
 				neg: true,
 				cts: new Date().toISOString(),
 				effect: input.val === "security-yanked" ? "block" : "warn",
+			};
+		},
+		async rerunAssessment() {
+			return {
+				actionId: "oact_fixture",
+				runId: "asmt_fixture",
+				triggerId: "operator:oact_fixture",
+				uri: "at://did:plc:x/com.emdashcms.experimental.package.release/rk1",
+				cid: "bafyfixture",
+				cts: new Date().toISOString(),
+			};
+		},
+		async overrideAssessment(_id, input) {
+			return {
+				actionId: "oact_fixture",
+				uri: "at://did:plc:x/com.emdashcms.experimental.package.release/rk1",
+				cid: "bafyfixture",
+				negated: input.negate,
+				issued: ["assessment-passed", "assessment-overridden"],
+				cts: new Date().toISOString(),
+			};
+		},
+		async retractOverride() {
+			return {
+				actionId: "oact_fixture",
+				uri: "at://did:plc:x/com.emdashcms.experimental.package.release/rk1",
+				cid: "bafyfixture",
+				negated: ["assessment-passed", "assessment-overridden"],
+				cts: new Date().toISOString(),
 			};
 		},
 	};

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -226,6 +226,70 @@ export interface IssuedLabelDescriptor {
 	effect: string;
 }
 
+/**
+ * The active label state for a subject `(src, uri)` at a CID from
+ * `GET /admin/api/subjects/:uri/labels?cid=` — the current stream winner per
+ * value, including the manual/override labels that carry no `assessment_id` and
+ * so never appear in the assessment-scoped label list. `active` already encodes
+ * non-negated + unexpired + CID-applicable. */
+export interface SubjectLabel {
+	val: string;
+	cid: string | null;
+	active: boolean;
+	neg: boolean;
+	cts: string;
+	exp: string | null;
+	sequence: number;
+}
+
+/** Body shared by the rerun and override-retract actions: a required reason, a
+ * server-validated typed CID confirmation, and a client-minted idempotency key
+ * (ULID) reused across retries so a network retry replays rather than repeats. */
+export interface AssessmentActionInput {
+	confirmation: string;
+	reason: string;
+	idempotencyKey: string;
+}
+
+/** Override body: adds the observed active automated block set, validated
+ * server-side against live label state (a stale set is rejected). */
+export interface OverrideActionInput extends AssessmentActionInput {
+	negate: string[];
+}
+
+/** Idempotent rerun result — the new run + its immutable operator trigger. */
+export interface RerunResult {
+	actionId: string;
+	runId: string;
+	triggerId: string;
+	uri: string;
+	cid: string;
+	cts: string;
+}
+
+export interface OverrideResult {
+	actionId: string;
+	uri: string;
+	cid: string;
+	negated: string[];
+	issued: string[];
+	cts: string;
+}
+
+export interface OverrideRetractResult {
+	actionId: string;
+	uri: string;
+	cid: string;
+	negated: string[];
+	cts: string;
+}
+
+export interface OverrideEffectPreviewParams {
+	uri: string;
+	cid: string;
+	negate: string[];
+}
+
 export interface ListAssessmentsParams {
 	state?: PublicAssessmentState;
 	cursor?: string;

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -237,6 +237,9 @@ export interface SubjectLabel {
 	cid: string | null;
 	active: boolean;
 	neg: boolean;
+	/** Whether the stream head was issued by automation — only automated heads
+	 * are in the override's negatable set; a manual head unblocks via retract. */
+	automated: boolean;
 	cts: string;
 	exp: string | null;
 	sequence: number;

--- a/apps/labeler/console/src/components/AssessmentActionDialog.tsx
+++ b/apps/labeler/console/src/components/AssessmentActionDialog.tsx
@@ -1,0 +1,139 @@
+import { Button, Dialog, Input, InputArea } from "@cloudflare/kumo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+import type { OverrideRetractResult, RerunResult } from "../api/types.js";
+
+interface AssessmentActionDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	mode: "rerun" | "override-retract";
+	assessmentId: string;
+	subjectUri: string;
+	/** The exact release CID — the typed confirmation the reviewer must match. */
+	subjectCid: string;
+	/** TanStack Query keys to invalidate on success so the new state renders. */
+	invalidateKeys: readonly (readonly unknown[])[];
+}
+
+const COPY = {
+	rerun: {
+		title: "Rerun assessment",
+		description:
+			"Creates a fresh assessment run for this exact release and re-issues assessment-pending. The release becomes ineligible until the new run completes.",
+		submit: "Rerun",
+		variant: "primary" as const,
+	},
+	"override-retract": {
+		title: "Retract override",
+		description:
+			"Negates assessment-passed and assessment-overridden. The release returns to blocked (missing assessment pass). The original automated blocks stay negated — rerun to re-surface real findings.",
+		submit: "Retract override",
+		variant: "destructive" as const,
+	},
+};
+
+/**
+ * The §11.4 ceremony for the two single-purpose assessment actions (rerun,
+ * override-retract): a required reason and a server-validated typed CID
+ * confirmation, no effect preview (the effect is stated in the description). The
+ * idempotency key is minted per open and reused across retries so a network
+ * retry replays rather than repeats.
+ */
+export function AssessmentActionDialog({
+	open,
+	onOpenChange,
+	mode,
+	assessmentId,
+	subjectUri,
+	subjectCid,
+	invalidateKeys,
+}: AssessmentActionDialogProps) {
+	const queryClient = useQueryClient();
+	const copy = COPY[mode];
+	const [reason, setReason] = useState("");
+	const [confirmation, setConfirmation] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setReason("");
+		setConfirmation("");
+	}, [open]);
+
+	const mutation = useMutation<RerunResult | OverrideRetractResult>({
+		mutationFn: () => {
+			const input = { confirmation, reason, idempotencyKey };
+			return mode === "rerun"
+				? apiClient.rerunAssessment(assessmentId, input)
+				: apiClient.retractOverride(assessmentId, input);
+		},
+		onSuccess: async () => {
+			await Promise.all(
+				invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+			);
+			onOpenChange(false);
+		},
+	});
+
+	const confirmationMatches = confirmation === subjectCid && subjectCid.length > 0;
+	const canSubmit = reason.trim().length > 0 && confirmationMatches && !mutation.isPending;
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange} role="alertdialog">
+			<Dialog className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto p-6" size="lg">
+				<Dialog.Title className="text-lg font-semibold">{copy.title}</Dialog.Title>
+				<Dialog.Description className="break-all font-mono text-xs text-kumo-subtle">
+					{subjectUri}
+				</Dialog.Description>
+
+				<p className="text-sm text-kumo-subtle">{copy.description}</p>
+
+				<InputArea
+					label="Reason"
+					value={reason}
+					onValueChange={setReason}
+					placeholder="Why this action is being taken"
+				/>
+
+				<Input
+					label="Type the release CID to confirm"
+					value={confirmation}
+					onChange={(event) => {
+						setConfirmation(event.target.value);
+					}}
+					placeholder={subjectCid}
+					error={
+						confirmation.length > 0 && !confirmationMatches
+							? "Does not match the release CID"
+							: undefined
+					}
+				/>
+
+				{mutation.isError && (
+					<p className="text-sm text-kumo-danger">
+						{mutation.error instanceof Error ? mutation.error.message : "Action failed"}
+					</p>
+				)}
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+						Cancel
+					</Dialog.Close>
+					<Button
+						variant={copy.variant}
+						disabled={!canSubmit}
+						onClick={() => {
+							mutation.mutate();
+						}}
+					>
+						{mutation.isPending ? "Submitting…" : copy.submit}
+					</Button>
+				</div>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/apps/labeler/console/src/components/OverrideDialog.tsx
+++ b/apps/labeler/console/src/components/OverrideDialog.tsx
@@ -1,0 +1,191 @@
+import { Badge, Button, Dialog, Input, InputArea, Loader } from "@cloudflare/kumo";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+import type { ReleaseModeration } from "../api/types.js";
+
+interface OverrideDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	assessmentId: string;
+	subjectUri: string;
+	subjectCid: string;
+	/** The active automated blocking labels to negate — the full observed set;
+	 * the server validates it equals live state. */
+	blocks: readonly string[];
+	invalidateKeys: readonly (readonly unknown[])[];
+}
+
+function ModerationSummary({ label, value }: { label: string; value: ReleaseModeration | null }) {
+	return (
+		<div className="flex flex-col gap-1">
+			<span className="text-xs text-kumo-subtle">{label}</span>
+			{value ? (
+				<div className="flex flex-wrap items-center gap-1.5">
+					<Badge variant={value.eligibility === "eligible" ? "info" : "neutral"}>
+						{value.eligibility}
+					</Badge>
+					{value.blockingLabels.map((v) => (
+						<Badge key={`b-${v}`} variant="neutral">
+							{v}
+						</Badge>
+					))}
+					{value.suppressedLabels.map((v) => (
+						<Badge key={`s-${v}`} variant="neutral">
+							{v} (suppressed)
+						</Badge>
+					))}
+				</div>
+			) : (
+				<span className="text-sm text-kumo-subtle">Not a release subject</span>
+			)}
+		</div>
+	);
+}
+
+/**
+ * The false-positive override ceremony (spec §7.1/§11.4): shows the exact release,
+ * the full set of active automated blocks that will be negated, the server-derived
+ * before→after effect (blocked → eligible-manual-override with the blocks
+ * suppressed), and a warning that a later admin takedown still blocks. A required
+ * reason and a typed CID confirmation gate submit; the idempotency key is minted
+ * per open and reused across retries.
+ */
+export function OverrideDialog({
+	open,
+	onOpenChange,
+	assessmentId,
+	subjectUri,
+	subjectCid,
+	blocks,
+	invalidateKeys,
+}: OverrideDialogProps) {
+	const queryClient = useQueryClient();
+	const [reason, setReason] = useState("");
+	const [confirmation, setConfirmation] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setReason("");
+		setConfirmation("");
+	}, [open]);
+
+	const previewQuery = useQuery({
+		queryKey: ["override-effect-preview", subjectUri, subjectCid, [...blocks].toSorted()],
+		queryFn: () =>
+			apiClient.previewOverrideEffect({ uri: subjectUri, cid: subjectCid, negate: [...blocks] }),
+		enabled: open,
+	});
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			apiClient.overrideAssessment(assessmentId, {
+				confirmation,
+				reason,
+				idempotencyKey,
+				negate: [...blocks],
+			}),
+		onSuccess: async () => {
+			await Promise.all(
+				invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+			);
+			onOpenChange(false);
+		},
+	});
+
+	const confirmationMatches = confirmation === subjectCid && subjectCid.length > 0;
+	const canSubmit = reason.trim().length > 0 && confirmationMatches && !mutation.isPending;
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange} role="alertdialog">
+			<Dialog className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto p-6" size="lg">
+				<Dialog.Title className="text-lg font-semibold">Override (unblock) release</Dialog.Title>
+				<Dialog.Description className="break-all font-mono text-xs text-kumo-subtle">
+					{subjectUri}
+				</Dialog.Description>
+				<p className="font-mono text-xs text-kumo-subtle">CID: {subjectCid}</p>
+
+				<div className="flex flex-col gap-1">
+					<span className="text-xs text-kumo-subtle">
+						Automated blocks to negate as false positives
+					</span>
+					{blocks.length > 0 ? (
+						<div className="flex flex-wrap gap-1.5">
+							{blocks.map((val) => (
+								<Badge key={val} variant="neutral">
+									{val}
+								</Badge>
+							))}
+						</div>
+					) : (
+						<span className="text-sm text-kumo-subtle">No active automated blocks.</span>
+					)}
+				</div>
+
+				{previewQuery.isLoading ? (
+					<div className="flex justify-center py-4">
+						<Loader />
+					</div>
+				) : previewQuery.data ? (
+					<div className="grid grid-cols-2 gap-3 rounded-lg bg-kumo-elevated p-3">
+						<ModerationSummary label="Before" value={previewQuery.data.before} />
+						<ModerationSummary label="After" value={previewQuery.data.after} />
+					</div>
+				) : previewQuery.isError ? (
+					<p className="text-sm text-kumo-danger">Could not load the override effect preview.</p>
+				) : null}
+
+				<p className="rounded-lg bg-kumo-elevated p-3 text-sm text-kumo-subtle">
+					An override does not shield against a later administrator takedown or security-yank — a
+					manual block still blocks this release.
+				</p>
+
+				<InputArea
+					label="Reason"
+					value={reason}
+					onValueChange={setReason}
+					placeholder="Why these findings are false positives"
+				/>
+
+				<Input
+					label="Type the release CID to confirm"
+					value={confirmation}
+					onChange={(event) => {
+						setConfirmation(event.target.value);
+					}}
+					placeholder={subjectCid}
+					error={
+						confirmation.length > 0 && !confirmationMatches
+							? "Does not match the release CID"
+							: undefined
+					}
+				/>
+
+				{mutation.isError && (
+					<p className="text-sm text-kumo-danger">
+						{mutation.error instanceof Error ? mutation.error.message : "Override failed"}
+					</p>
+				)}
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+						Cancel
+					</Dialog.Close>
+					<Button
+						variant="primary"
+						disabled={!canSubmit}
+						onClick={() => {
+							mutation.mutate();
+						}}
+					>
+						{mutation.isPending ? "Submitting…" : "Override"}
+					</Button>
+				</div>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/apps/labeler/console/src/labels.ts
+++ b/apps/labeler/console/src/labels.ts
@@ -1,3 +1,4 @@
+import { automatedBlockCategories, MODERATION_POLICY } from "../../src/policy.js";
 import type { IssuableLabel } from "./api/types.js";
 
 /**
@@ -37,20 +38,12 @@ export const PACKAGE_ISSUABLE_LABELS: readonly IssuableLabel[] = [
 ];
 
 /** The automated blocking label vocabulary (policy `category: automated-block`),
- * mirrored so the console can list a release's active blocks for the override
- * ceremony. Presentation only — the server re-derives the authoritative set from
- * live label state and rejects a stale submission. */
-export const AUTOMATED_BLOCK_LABELS: ReadonlySet<string> = new Set([
-	"malware",
-	"data-exfiltration",
-	"credential-harvesting",
-	"supply-chain-compromise",
-	"critical-vulnerability",
-	"artifact-integrity-failure",
-	"invalid-bundle",
-	"undeclared-access",
-	"impersonation",
-]);
+ * derived from the bundled policy fixture with the server's own helper so a
+ * fixture change reaches the override ceremony without a code edit. Presentation
+ * only — the server re-derives the authoritative set from live label state and
+ * rejects a stale submission. */
+export const AUTOMATED_BLOCK_LABELS: ReadonlySet<string> =
+	automatedBlockCategories(MODERATION_POLICY);
 
 export function isAutomatedBlock(val: string): boolean {
 	return AUTOMATED_BLOCK_LABELS.has(val);

--- a/apps/labeler/console/src/labels.ts
+++ b/apps/labeler/console/src/labels.ts
@@ -36,6 +36,26 @@ export const PACKAGE_ISSUABLE_LABELS: readonly IssuableLabel[] = [
 	{ val: "package-disputed", scope: "uri-wide" },
 ];
 
+/** The automated blocking label vocabulary (policy `category: automated-block`),
+ * mirrored so the console can list a release's active blocks for the override
+ * ceremony. Presentation only — the server re-derives the authoritative set from
+ * live label state and rejects a stale submission. */
+export const AUTOMATED_BLOCK_LABELS: ReadonlySet<string> = new Set([
+	"malware",
+	"data-exfiltration",
+	"credential-harvesting",
+	"supply-chain-compromise",
+	"critical-vulnerability",
+	"artifact-integrity-failure",
+	"invalid-bundle",
+	"undeclared-access",
+	"impersonation",
+]);
+
+export function isAutomatedBlock(val: string): boolean {
+	return AUTOMATED_BLOCK_LABELS.has(val);
+}
+
 const RELEASE_SCOPES = new Map(RELEASE_ISSUABLE_LABELS.map((entry) => [entry.val, entry.scope]));
 
 /** The ceremony scope for a value already active on a release, so a retract

--- a/apps/labeler/console/src/routes/AssessmentDetail.tsx
+++ b/apps/labeler/console/src/routes/AssessmentDetail.tsx
@@ -5,11 +5,18 @@ import { useState, type ReactNode } from "react";
 
 import { apiClient } from "../api/client.js";
 import type { IssuableLabel } from "../api/types.js";
+import { AssessmentActionDialog } from "../components/AssessmentActionDialog.js";
 import { FindingCard } from "../components/FindingCard.js";
 import { LabelActionDialog } from "../components/LabelActionDialog.js";
+import { OverrideDialog } from "../components/OverrideDialog.js";
 import { QueryError } from "../components/QueryError.js";
 import { StateBadge } from "../components/StateBadge.js";
-import { isReleaseRetractable, RELEASE_ISSUABLE_LABELS, releaseLabelScope } from "../labels.js";
+import {
+	isAutomatedBlock,
+	isReleaseRetractable,
+	RELEASE_ISSUABLE_LABELS,
+	releaseLabelScope,
+} from "../labels.js";
 import { shellRoute } from "./root.js";
 
 function MetaRow({ label, value }: { label: string; value: ReactNode }) {
@@ -56,8 +63,19 @@ function AssessmentDetail() {
 	const { data: whoami } = useQuery({ queryKey: ["whoami"], queryFn: () => apiClient.whoami() });
 	const canAct = whoami?.roles.includes("reviewer") || whoami?.roles.includes("admin") || false;
 
+	const subjectUri = assessment?.uri;
+	const subjectCid = assessment?.cid;
+	const { data: subjectLabels } = useQuery({
+		queryKey: ["subject-labels", subjectUri, subjectCid],
+		queryFn: () => apiClient.getSubjectLabels(subjectUri!, subjectCid),
+		enabled: !!subjectUri,
+	});
+
 	const [issueOpen, setIssueOpen] = useState(false);
 	const [retractTarget, setRetractTarget] = useState<IssuableLabel | null>(null);
+	const [rerunOpen, setRerunOpen] = useState(false);
+	const [overrideOpen, setOverrideOpen] = useState(false);
+	const [overrideRetractOpen, setOverrideRetractOpen] = useState(false);
 
 	if (isAssessmentError) {
 		return <QueryError title="Failed to load assessment" error={assessmentError} />;
@@ -76,6 +94,19 @@ function AssessmentDetail() {
 	if (!assessment) {
 		return <div className="p-8 text-center text-sm text-kumo-subtle">Assessment not found.</div>;
 	}
+
+	const activeSubjectLabels = subjectLabels ?? [];
+	const activeBlocks = activeSubjectLabels
+		.filter((label) => label.active && isAutomatedBlock(label.val))
+		.map((label) => label.val);
+	const hasActiveOverride = activeSubjectLabels.some(
+		(label) => label.val === "assessment-overridden" && label.active,
+	);
+	const actionInvalidateKeys: readonly (readonly unknown[])[] = [
+		["assessment", id, "labels"],
+		["assessment", id],
+		["subject-labels", assessment.uri, assessment.cid],
+	];
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -127,9 +158,46 @@ function AssessmentDetail() {
 				)}
 			</LayerCard>
 
+			{canAct && (
+				<div className="flex flex-wrap gap-2">
+					<Button variant="secondary" onClick={() => setRerunOpen(true)}>
+						Rerun
+					</Button>
+					{activeBlocks.length > 0 && (
+						<Button variant="secondary" onClick={() => setOverrideOpen(true)}>
+							Override (unblock)
+						</Button>
+					)}
+					{hasActiveOverride && (
+						<Button variant="destructive" onClick={() => setOverrideRetractOpen(true)}>
+							Retract override
+						</Button>
+					)}
+				</div>
+			)}
+
+			<section className="flex flex-col gap-3">
+				<h2 className="text-lg font-semibold">Active labels for this release</h2>
+				{activeSubjectLabels.length === 0 ? (
+					<p className="text-sm text-kumo-subtle">No active labels for this release.</p>
+				) : (
+					<div className="flex flex-wrap gap-2">
+						{activeSubjectLabels.map((label) => (
+							<Badge
+								key={`${label.val}-${label.sequence}`}
+								variant={label.active ? "info" : "neutral"}
+							>
+								{label.val}
+								{!label.active && (label.neg ? " (retracted)" : " (inactive)")}
+							</Badge>
+						))}
+					</div>
+				)}
+			</section>
+
 			<section className="flex flex-col gap-3">
 				<div className="flex items-center justify-between">
-					<h2 className="text-lg font-semibold">Labels</h2>
+					<h2 className="text-lg font-semibold">Labels issued by this run</h2>
 					{canAct && (
 						<Button variant="secondary" onClick={() => setIssueOpen(true)}>
 							Issue label
@@ -174,10 +242,7 @@ function AssessmentDetail() {
 						subjectUri={assessment.uri}
 						subjectCid={assessment.cid}
 						issuable={RELEASE_ISSUABLE_LABELS}
-						invalidateKeys={[
-							["assessment", id, "labels"],
-							["assessment", id],
-						]}
+						invalidateKeys={actionInvalidateKeys}
 					/>
 					<LabelActionDialog
 						open={retractTarget !== null}
@@ -188,10 +253,34 @@ function AssessmentDetail() {
 						subjectUri={assessment.uri}
 						subjectCid={assessment.cid}
 						{...(retractTarget ? { target: retractTarget } : {})}
-						invalidateKeys={[
-							["assessment", id, "labels"],
-							["assessment", id],
-						]}
+						invalidateKeys={actionInvalidateKeys}
+					/>
+					<AssessmentActionDialog
+						open={rerunOpen}
+						onOpenChange={setRerunOpen}
+						mode="rerun"
+						assessmentId={id}
+						subjectUri={assessment.uri}
+						subjectCid={assessment.cid}
+						invalidateKeys={actionInvalidateKeys}
+					/>
+					<OverrideDialog
+						open={overrideOpen}
+						onOpenChange={setOverrideOpen}
+						assessmentId={id}
+						subjectUri={assessment.uri}
+						subjectCid={assessment.cid}
+						blocks={activeBlocks}
+						invalidateKeys={actionInvalidateKeys}
+					/>
+					<AssessmentActionDialog
+						open={overrideRetractOpen}
+						onOpenChange={setOverrideRetractOpen}
+						mode="override-retract"
+						assessmentId={id}
+						subjectUri={assessment.uri}
+						subjectCid={assessment.cid}
+						invalidateKeys={actionInvalidateKeys}
 					/>
 				</>
 			)}

--- a/apps/labeler/console/src/routes/AssessmentDetail.tsx
+++ b/apps/labeler/console/src/routes/AssessmentDetail.tsx
@@ -96,8 +96,10 @@ function AssessmentDetail() {
 	}
 
 	const activeSubjectLabels = subjectLabels ?? [];
+	// `automated` matches the server's negatable-set semantics: a manually-headed
+	// block is not override-negatable (its unblock path is the label retract).
 	const activeBlocks = activeSubjectLabels
-		.filter((label) => label.active && isAutomatedBlock(label.val))
+		.filter((label) => label.active && label.automated && isAutomatedBlock(label.val))
 		.map((label) => label.val);
 	const hasActiveOverride = activeSubjectLabels.some(
 		(label) => label.val === "assessment-overridden" && label.active,

--- a/apps/labeler/src/assessment-store.ts
+++ b/apps/labeler/src/assessment-store.ts
@@ -831,6 +831,11 @@ export interface LabelStreamWinner {
 	 * `neg: true, active: false`; carried so the operator subject view can show
 	 * "retracted" distinctly from an unexpired/CID-mismatched inactive winner. */
 	neg: boolean;
+	/** Whether the stream head was issued by automation. The override's
+	 * negatable set (`getNegatableAutomatedLabels`) only spans automated heads,
+	 * so the console must not offer the override for a manually-headed block —
+	 * that path is the label-level retract. */
+	automated: boolean;
 	active: boolean;
 }
 
@@ -859,10 +864,11 @@ export async function getActiveLabelState(
 	const now = input.now ?? new Date();
 	const rows = await db
 		.prepare(
-			`SELECT val, neg, cid, cts, exp, sequence
-			 FROM issued_labels
-			 WHERE src = ? AND uri = ?
-			 ORDER BY sequence ASC`,
+			`SELECT l.val, l.neg, l.cid, l.cts, l.exp, l.sequence, a.type AS action_type
+			 FROM issued_labels l
+			 JOIN issuance_actions a ON a.id = l.action_id
+			 WHERE l.src = ? AND l.uri = ?
+			 ORDER BY l.sequence ASC`,
 		)
 		.bind(input.src, input.uri)
 		.all<{
@@ -872,6 +878,7 @@ export async function getActiveLabelState(
 			cts: string;
 			exp: string | null;
 			sequence: number;
+			action_type: string;
 		}>();
 	const winners = new Map<string, LabelStreamWinner>();
 	for (const row of rows.results ?? []) {
@@ -885,6 +892,7 @@ export async function getActiveLabelState(
 			exp: row.exp,
 			sequence: row.sequence,
 			neg: row.neg === 1,
+			automated: row.action_type === "automated-assessment",
 			active,
 		});
 	}

--- a/apps/labeler/src/assessment-store.ts
+++ b/apps/labeler/src/assessment-store.ts
@@ -190,16 +190,18 @@ export interface CreateAssessmentRunResult {
 }
 
 /**
- * Idempotent run creation keyed on `run_key`: redelivery of the same logical
- * trigger observes the existing run rather than creating a second one.
+ * The idempotent `INSERT ... WHERE NOT EXISTS(run_key)` for one assessment run,
+ * as a bare prepared statement the caller mints the `id` for and batches
+ * alongside its own statements (plan W9.5 rerun: the run row commits in the same
+ * `db.batch` as the operator audit row and the `assessment-pending` label).
+ * `createAssessmentRun` is the self-executing variant used by discovery.
  */
-export async function createAssessmentRun(
+export function buildAssessmentRunStatement(
 	db: D1Database,
-	input: CreateAssessmentRunInput,
-): Promise<CreateAssessmentRunResult> {
-	const id = `asmt_${ulid()}`;
+	input: CreateAssessmentRunInput & { id: string },
+): D1PreparedStatement {
 	const now = input.now ?? new Date();
-	await db
+	return db
 		.prepare(
 			`INSERT INTO assessments
 			 (id, run_key, uri, cid, artifact_id, artifact_checksum, state, trigger, trigger_id,
@@ -209,7 +211,7 @@ export async function createAssessmentRun(
 			 WHERE NOT EXISTS (SELECT 1 FROM assessments WHERE run_key = ?)`,
 		)
 		.bind(
-			id,
+			input.id,
 			input.runKey,
 			input.uri,
 			input.cid,
@@ -224,8 +226,19 @@ export async function createAssessmentRun(
 			now.toISOString(),
 			now.getTime(),
 			input.runKey,
-		)
-		.run();
+		);
+}
+
+/**
+ * Idempotent run creation keyed on `run_key`: redelivery of the same logical
+ * trigger observes the existing run rather than creating a second one.
+ */
+export async function createAssessmentRun(
+	db: D1Database,
+	input: CreateAssessmentRunInput,
+): Promise<CreateAssessmentRunResult> {
+	const id = `asmt_${ulid()}`;
+	await buildAssessmentRunStatement(db, { ...input, id }).run();
 	const assessment = await getAssessmentByRunKey(db, input.runKey);
 	if (!assessment) throw new Error("assessment run did not persist");
 	return { assessment, created: assessment.id === id };
@@ -336,6 +349,44 @@ export async function transitionAssessmentState(
 	const assessment = await getAssessment(db, input.id);
 	if (!assessment) throw new Error("assessment disappeared after a successful transition");
 	return assessment;
+}
+
+/**
+ * Advances a freshly-created run from `observed` through `verifying` to
+ * `pending`, tolerating a concurrent invocation that already did some or all of
+ * the work (a redelivered rerun re-drives this and must converge, not throw).
+ * Used off the response path after a rerun's run row and `assessment-pending`
+ * label commit — the label re-gates the release atomically; this bookkeeping CAS
+ * follows. Mirrors the discovery consumer's inline advance.
+ */
+export async function advanceAssessmentToPending(
+	db: D1Database,
+	assessment: Assessment,
+	now: Date,
+): Promise<void> {
+	let current = assessment;
+	if (current.state === "observed")
+		current = await transitionOrObserveState(db, current, "observed", "verifying", now);
+	if (current.state === "verifying")
+		await transitionOrObserveState(db, current, "verifying", "pending", now);
+}
+
+async function transitionOrObserveState(
+	db: D1Database,
+	assessment: Assessment,
+	from: AssessmentState,
+	to: AssessmentState,
+	now: Date,
+): Promise<Assessment> {
+	try {
+		return await transitionAssessmentState(db, { id: assessment.id, from, to, now });
+	} catch (err) {
+		if (!(err instanceof AssessmentTransitionConflictError)) throw err;
+		const current = await getAssessment(db, assessment.id);
+		if (!current)
+			throw new Error(`assessment ${assessment.id} disappeared mid-transition`, { cause: err });
+		return current;
+	}
 }
 
 export interface CurrentAssessmentPointer {
@@ -776,6 +827,10 @@ export interface LabelStreamWinner {
 	cts: string;
 	exp: string | null;
 	sequence: number;
+	/** Whether the stream head is a negation. A retracted label reports
+	 * `neg: true, active: false`; carried so the operator subject view can show
+	 * "retracted" distinctly from an unexpired/CID-mismatched inactive winner. */
+	neg: boolean;
 	active: boolean;
 }
 
@@ -829,6 +884,7 @@ export async function getActiveLabelState(
 			cts: row.cts,
 			exp: row.exp,
 			sequence: row.sequence,
+			neg: row.neg === 1,
 			active,
 		});
 	}

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -47,6 +47,7 @@ import { computeEffectPreview, computeOverrideEffectPreview } from "./label-effe
 import { MutationGuardError } from "./mutation-guard.js";
 import { getOperatorActionsPage } from "./operator-actions.js";
 import { guardRead, ReadGuardError, type ReadGuardDeps } from "./operator-read-guard.js";
+import { assertNegatableBlockSet, NegatableBlockSetError } from "./service.js";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
@@ -367,8 +368,9 @@ async function handleEffectPreview(
 
 /** Multi-overlay override preview: `?uri=&cid=&negate=v1&negate=v2` grounds the
  * post-override release state (blocked → eligible-manual-override) the reviewer
- * confirms before submitting. The `negate` set is echoed from the subject-label
- * read; the server re-derives the authoritative set at submit time. */
+ * confirms before submitting. The `negate` set is validated against the live
+ * negatable set with the same check the submit endpoint runs, so the preview
+ * can never render an outcome the submit would reject. */
 async function handleOverrideEffectPreview(
 	request: Request,
 	url: URL,
@@ -381,6 +383,12 @@ async function handleOverrideEffectPreview(
 		throw new ReadGuardError("INVALID_REQUEST");
 	const negate = url.searchParams.getAll("negate");
 	if (negate.some((val) => val.length === 0)) throw new ReadGuardError("INVALID_REQUEST");
+	try {
+		await assertNegatableBlockSet(deps.db, deps.labelerDid, { uri, cid }, negate);
+	} catch (error) {
+		if (error instanceof NegatableBlockSetError) throw new ReadGuardError("INVALID_REQUEST");
+		throw error;
+	}
 
 	const preview = await computeOverrideEffectPreview(
 		deps.db,

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -22,6 +22,7 @@ import {
 } from "./assessment-cursor.js";
 import {
 	countInFlightAssessments,
+	getActiveLabelState,
 	getAllLabelsForAssessment,
 	getAssessment,
 	getAssessmentsForUri,
@@ -37,11 +38,12 @@ import {
 	serializeIssuedLabel,
 	serializeOperatorActionView,
 	serializeOperatorFinding,
+	serializeSubjectLabel,
 	serializeSubjectRecord,
 	type Page,
 } from "./console-serialize.js";
 import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
-import { computeEffectPreview } from "./label-effect-preview.js";
+import { computeEffectPreview, computeOverrideEffectPreview } from "./label-effect-preview.js";
 import { MutationGuardError } from "./mutation-guard.js";
 import { getOperatorActionsPage } from "./operator-actions.js";
 import { guardRead, ReadGuardError, type ReadGuardDeps } from "./operator-read-guard.js";
@@ -112,21 +114,21 @@ function matchRoute(
 			return () => handleListFindings(request, deps, id);
 		if (id !== undefined && segments.length === 3 && segments[2] === "labels")
 			return () => handleListLabels(request, deps, id);
-	} else if (segments[0] === "subjects" && segments.length === 2 && segments[1] !== undefined) {
+	} else if (segments[0] === "subjects" && segments[1] !== undefined) {
 		const uri = decodeSubjectUri(segments[1]);
-		return () => handleGetSubjectHistory(request, deps, uri);
+		if (segments.length === 2) return () => handleGetSubjectHistory(request, deps, uri);
+		if (segments.length === 3 && segments[2] === "labels")
+			return () => handleGetSubjectLabels(request, url, deps, uri);
 	} else if (segments[0] === "audit-log" && segments.length === 1) {
 		return () => handleListAuditLog(request, url, deps);
 	} else if (segments[0] === "status" && segments.length === 1) {
 		return () => handleGetStatus(request, deps);
 	} else if (segments[0] === "whoami" && segments.length === 1) {
 		return () => handleWhoami(request, identity);
-	} else if (
-		segments[0] === "labels" &&
-		segments.length === 2 &&
-		segments[1] === "effect-preview"
-	) {
-		return () => handleEffectPreview(request, url, deps);
+	} else if (segments[0] === "labels" && segments.length === 2) {
+		if (segments[1] === "effect-preview") return () => handleEffectPreview(request, url, deps);
+		if (segments[1] === "override-effect-preview")
+			return () => handleOverrideEffectPreview(request, url, deps);
 	}
 
 	throw new ReadGuardError("NOT_FOUND");
@@ -255,6 +257,37 @@ async function handleGetSubjectHistory(
 	});
 }
 
+/**
+ * Active label state for a subject `(labelerDid, uri)` at a CID — the current
+ * stream winner per value, including the manual/override labels that carry no
+ * `assessment_id` and so never surface in the assessment-scoped label list. The
+ * CID is `?cid=` or falls back to the current observed subject CID; a URI never
+ * observed (and no CID given) is a 404, matching the subject-history route.
+ */
+async function handleGetSubjectLabels(
+	request: Request,
+	url: URL,
+	deps: ConsoleApiDeps,
+	uri: string,
+): Promise<Response> {
+	requireGet(request);
+	const cidParam = url.searchParams.get("cid");
+	if (cidParam !== null && cidParam.length === 0) throw new ReadGuardError("INVALID_REQUEST");
+	let cid = cidParam ?? undefined;
+	if (cid === undefined) {
+		const subject = await getCurrentSubjectByUri(deps.db, uri);
+		if (!subject) throw new ReadGuardError("NOT_FOUND");
+		cid = subject.cid;
+	}
+	const winners = await getActiveLabelState(deps.db, {
+		src: deps.labelerDid,
+		uri,
+		cid,
+		now: new Date(),
+	});
+	return jsonData(Array.from(winners.values(), serializeSubjectLabel));
+}
+
 async function handleListAuditLog(
 	request: Request,
 	url: URL,
@@ -328,6 +361,34 @@ async function handleEffectPreview(
 		new Date(),
 	);
 	// An unknown label value has no policy definition to preview.
+	if (!preview) throw new ReadGuardError("INVALID_REQUEST");
+	return jsonData(preview);
+}
+
+/** Multi-overlay override preview: `?uri=&cid=&negate=v1&negate=v2` grounds the
+ * post-override release state (blocked → eligible-manual-override) the reviewer
+ * confirms before submitting. The `negate` set is echoed from the subject-label
+ * read; the server re-derives the authoritative set at submit time. */
+async function handleOverrideEffectPreview(
+	request: Request,
+	url: URL,
+	deps: ConsoleApiDeps,
+): Promise<Response> {
+	requireGet(request);
+	const uri = url.searchParams.get("uri");
+	const cid = url.searchParams.get("cid");
+	if (uri === null || uri.length === 0 || cid === null || cid.length === 0)
+		throw new ReadGuardError("INVALID_REQUEST");
+	const negate = url.searchParams.getAll("negate");
+	if (negate.some((val) => val.length === 0)) throw new ReadGuardError("INVALID_REQUEST");
+
+	const preview = await computeOverrideEffectPreview(
+		deps.db,
+		deps.labelerDid,
+		{ uri, cid, negate },
+		new Date(),
+	);
+	// A non-release subject (or one never observed) has no override to preview.
 	if (!preview) throw new ReadGuardError("INVALID_REQUEST");
 	return jsonData(preview);
 }

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -13,8 +13,20 @@
  */
 
 import type { LabelSigner } from "@emdash-cms/registry-moderation";
+import { ulid } from "ulidx";
 
 import type { AccessAuthConfig, AccessKeyResolver } from "./access-auth.js";
+import {
+	automatedIdempotencyKey,
+	computeRunKey,
+	operatorTriggerId,
+} from "./assessment-lifecycle.js";
+import {
+	advanceAssessmentToPending,
+	buildAssessmentRunStatement,
+	getAssessment,
+	type Assessment,
+} from "./assessment-store.js";
 import type { LabelerIdentityConfig } from "./config.js";
 import {
 	commitMutation,
@@ -24,16 +36,29 @@ import {
 	type MutationSpec,
 } from "./mutation-guard.js";
 import { ReadGuardError } from "./operator-read-guard.js";
-import { getLabelDefinition } from "./policy.js";
+import { getLabelDefinition, MODERATION_POLICY } from "./policy.js";
 import {
+	assertNegatableBlockSet,
 	LabelIssuanceUnavailableError,
+	NegatableBlockSetError,
+	overridePieceKey,
 	parseSubjectKind,
+	prepareAutomatedLabelIssuance,
 	prepareManualLabelIssuance,
+	prepareOverrideIssuance,
 	readIssuedLabelByActionKey,
 	type AllowedLabelProposal,
 	type AuthorizedIssuanceAction,
 } from "./service.js";
 import { createLabelPublisher } from "./subscribe-labels.js";
+
+/** Model/prompt/scanner-set run-key components for an operator rerun. Like
+ * discovery's, these are stable stubs until W7/W8 wire real stage adapters; the
+ * run's identity comes from the operator trigger, so these need only be
+ * deterministic across replays. */
+const RERUN_MODEL_ID = "unassigned";
+const RERUN_PROMPT_HASH = "unassigned";
+const RERUN_SCANNER_SET_VERSION = "unassigned";
 
 const ADMIN_API_PREFIX = /^\/admin\/api\/?/;
 
@@ -117,9 +142,16 @@ export async function handleConsoleMutation(
 	try {
 		const url = new URL(request.url);
 		const segments = url.pathname.replace(ADMIN_API_PREFIX, "").split("/").filter(Boolean);
-		if (segments[0] !== "labels" || segments.length !== 2) throw new ReadGuardError("NOT_FOUND");
-		if (segments[1] === "issue") return await runLabelMutation(request, deps, false);
-		if (segments[1] === "retract") return await runLabelMutation(request, deps, true);
+		if (segments[0] === "labels" && segments.length === 2) {
+			if (segments[1] === "issue") return await runLabelMutation(request, deps, false);
+			if (segments[1] === "retract") return await runLabelMutation(request, deps, true);
+		}
+		if (segments[0] === "assessments" && segments.length === 3 && segments[1] !== undefined) {
+			const id = segments[1];
+			if (segments[2] === "rerun") return await runRerun(request, deps, id);
+			if (segments[2] === "override") return await runOverride(request, deps, id);
+			if (segments[2] === "override-retract") return await runOverrideRetract(request, deps, id);
+		}
 		throw new ReadGuardError("NOT_FOUND");
 	} catch (error) {
 		if (
@@ -128,6 +160,11 @@ export async function handleConsoleMutation(
 			error instanceof LabelMutationError
 		)
 			return error.toResponse();
+		// A submitted override negation set that isn't exactly the live automated
+		// block set is a 400 — the reviewer acted on a stale view (a block cleared
+		// or appeared since the console loaded) or a crafted set.
+		if (error instanceof NegatableBlockSetError)
+			return new MutationGuardError("INVALID_BODY").toResponse();
 		// Transient signing-state unavailability (issuance paused, key stale, or the
 		// in-batch signing guard suppressing the label under a rotation race) is
 		// retryable — surface a 503 rather than a misleading 500 or a phantom 200.
@@ -163,7 +200,7 @@ async function runLabelMutation(
 	};
 	const outcome = await guardMutation(request, spec, guardDeps);
 	if (outcome.outcome === "replay") {
-		await assertIssuancePersisted(deps.db, outcome.actionId);
+		await assertIssuancePersisted(deps.db, [outcome.actionId]);
 		return jsonData(outcome.result);
 	}
 
@@ -202,7 +239,7 @@ async function runLabelMutation(
 		effect: getLabelDefinition(proposal.val)?.officialEffect ?? "",
 	};
 	const returned = await commitMutation(deps.db, ctx, spec, statements, descriptor);
-	await assertIssuancePersisted(deps.db, returned.actionId);
+	await assertIssuancePersisted(deps.db, [returned.actionId]);
 	deps.defer(deps.afterCommit(ctx.actionId));
 	return jsonData(returned);
 }
@@ -219,10 +256,18 @@ async function runLabelMutation(
  * Keying on the committed action id distinguishes a genuine suppression (no
  * label) from a concurrent-race loss (the winner's action id, whose label is
  * present).
+ *
+ * For a multi-label batch (W9.5 override: `N` negations + the eligibility pair;
+ * override-retract: two negations; rerun: the pending label) every issuance key
+ * must persist — a mid-batch signing-state suppression drops all of them
+ * together while the audit row commits, so a single missing key is enough to
+ * treat the whole action as not-persisted and 503-retry.
  */
-async function assertIssuancePersisted(db: D1Database, actionId: string): Promise<void> {
-	if (!(await readIssuedLabelByActionKey(db, actionId)))
-		throw new LabelIssuanceUnavailableError("label issuance did not persist");
+async function assertIssuancePersisted(db: D1Database, issuanceKeys: string[]): Promise<void> {
+	for (const key of issuanceKeys) {
+		if (!(await readIssuedLabelByActionKey(db, key)))
+			throw new LabelIssuanceUnavailableError("label issuance did not persist");
+	}
 }
 
 function makeSpec(neg: boolean): MutationSpec<LabelActionBody> {
@@ -303,6 +348,11 @@ function optionalString(value: unknown): string | undefined {
 	return value;
 }
 
+function requireStringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) throw new MutationGuardError("INVALID_BODY");
+	return value.map((entry) => requireString(entry));
+}
+
 function jsonData<T>(data: T): Response {
 	return Response.json({ data }, { headers: { "cache-control": "no-store" } });
 }
@@ -324,4 +374,396 @@ export async function publishAfterCommit(env: Env, actionId: string): Promise<vo
 	} catch (error) {
 		console.error("[console-mutation] publish failed", error);
 	}
+}
+
+// ─── W9.5: assessment rerun + false-positive override ───────────────────────
+
+/** The URL path's assessment id, folded into the parsed body so it joins the
+ * request fingerprint — a replayed key must target the same assessment. */
+interface AssessmentActionBody {
+	assessmentId: string;
+	/** The release CID, server-validated against the loaded assessment. */
+	confirmation: string;
+}
+
+interface OverrideActionBody extends AssessmentActionBody {
+	/** The active automated blocking labels the reviewer observed; validated
+	 * against the live negatable set before signing. */
+	negate: string[];
+}
+
+/** Idempotent rerun result (no `sequence`; assigned post-commit). */
+interface RerunDescriptor {
+	actionId: string;
+	runId: string;
+	triggerId: string;
+	uri: string;
+	cid: string;
+	cts: string;
+}
+
+interface OverrideDescriptor {
+	actionId: string;
+	uri: string;
+	cid: string;
+	negated: string[];
+	issued: string[];
+	cts: string;
+}
+
+interface OverrideRetractDescriptor {
+	actionId: string;
+	uri: string;
+	cid: string;
+	negated: string[];
+	cts: string;
+}
+
+const OVERRIDE_RETRACT_PAIR = ["assessment-passed", "assessment-overridden"] as const;
+
+function guardDepsOf(deps: ConsoleMutationDeps): MutationGuardDeps {
+	return { db: deps.db, config: deps.accessConfig, keys: deps.keys, now: deps.now };
+}
+
+/** Loads the assessment named in the path; a malformed id or a missing row is a
+ * 404 (`getAssessment` throws `TypeError` on a bad id). */
+async function loadAssessment(db: D1Database, id: string): Promise<Assessment> {
+	let assessment: Assessment | null;
+	try {
+		assessment = await getAssessment(db, id);
+	} catch (error) {
+		if (error instanceof TypeError) throw new ReadGuardError("NOT_FOUND");
+		throw error;
+	}
+	if (!assessment) throw new ReadGuardError("NOT_FOUND");
+	return assessment;
+}
+
+/** CID-bound confirmation ceremony: the typed confirmation must be the exact
+ * release CID from the loaded assessment (the W9.4 check, resolved server-side
+ * from the assessment rather than an echoed body CID). */
+function assertConfirmationCid(confirmation: string, cid: string): void {
+	if (confirmation !== cid) throw new LabelMutationError("CONFIRMATION_MISMATCH");
+}
+
+/** The stored `result_json` this handler itself wrote on the original commit,
+ * trusted on replay. */
+function storedDescriptor<T>(result: unknown): T {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- our own stored descriptor
+	return result as T;
+}
+
+function overrideIssuanceKeys(
+	actionId: string,
+	negated: readonly string[],
+	issued: readonly string[],
+): string[] {
+	return [
+		...negated.map((val) => overridePieceKey(actionId, val, true)),
+		...issued.map((val) => overridePieceKey(actionId, val, false)),
+	];
+}
+
+function rerunRunKey(uri: string, cid: string, triggerId: string): Promise<string> {
+	return computeRunKey({
+		uri,
+		cid,
+		policyVersion: MODERATION_POLICY.policyVersion,
+		modelId: RERUN_MODEL_ID,
+		promptHash: RERUN_PROMPT_HASH,
+		scannerSetVersion: RERUN_SCANNER_SET_VERSION,
+		triggerId,
+	});
+}
+
+/** Off-response tail (re-driven on replay, all pieces idempotent): advance the
+ * fresh run `observed → pending` and publish the pending label. The label is in
+ * the atomic batch, so the release re-gates to pending atomically with the audit
+ * row; only this internal state advance is deferred. */
+function deferRerunTail(deps: ConsoleMutationDeps, runId: string, pendingKey: string): void {
+	deps.defer(
+		(async () => {
+			try {
+				const run = await getAssessment(deps.db, runId);
+				if (run) await advanceAssessmentToPending(deps.db, run, deps.now());
+			} catch (error) {
+				console.error("[console-mutation] rerun advance failed", error);
+			}
+			await deps.afterCommit(pendingKey);
+		})(),
+	);
+}
+
+function deferPublishAll(deps: ConsoleMutationDeps, issuanceKeys: readonly string[]): void {
+	deps.defer(Promise.all(issuanceKeys.map((key) => deps.afterCommit(key))));
+}
+
+/**
+ * `POST /admin/api/assessments/:id/rerun` — mints the immutable operator trigger
+ * (`operator:<actionId>`), creates a fresh run for the assessment's exact URI+CID
+ * anchored to that trigger, and re-issues `assessment-pending`, all in one atomic
+ * batch with the audit row (spec §10/§11.2). Production wiring stops at pending
+ * (as initial discovery does today), so the run sits at `pending` until W7/W8
+ * supply stage adapters.
+ */
+async function runRerun(
+	request: Request,
+	deps: ConsoleMutationDeps,
+	id: string,
+): Promise<Response> {
+	const spec: MutationSpec<AssessmentActionBody> = {
+		action: "assessment-rerun",
+		requiredRole: "reviewer",
+		parseBody: (raw) => ({ assessmentId: id, confirmation: requireString(raw.confirmation) }),
+		auditFields: () => ({}),
+	};
+	const outcome = await guardMutation(request, spec, guardDepsOf(deps));
+	if (outcome.outcome === "replay") {
+		const stored = storedDescriptor<RerunDescriptor>(outcome.result);
+		const pendingKey = automatedIdempotencyKey(
+			await rerunRunKey(stored.uri, stored.cid, stored.triggerId),
+			"assessment-pending",
+			false,
+		);
+		await assertIssuancePersisted(deps.db, [pendingKey]);
+		deferRerunTail(deps, stored.runId, pendingKey);
+		return jsonData(stored);
+	}
+
+	const { ctx } = outcome;
+	const assessment = await loadAssessment(deps.db, id);
+	assertConfirmationCid(ctx.body.confirmation, assessment.cid);
+
+	const triggerId = operatorTriggerId(ctx.actionId);
+	const runKey = await rerunRunKey(assessment.uri, assessment.cid, triggerId);
+	const runId = `asmt_${ulid()}`;
+	const pendingKey = automatedIdempotencyKey(runKey, "assessment-pending", false);
+
+	const runStatement = buildAssessmentRunStatement(deps.db, {
+		id: runId,
+		runKey,
+		uri: assessment.uri,
+		cid: assessment.cid,
+		trigger: "operator",
+		triggerId,
+		policyVersion: MODERATION_POLICY.policyVersion,
+		modelId: RERUN_MODEL_ID,
+		promptHash: RERUN_PROMPT_HASH,
+		coverageJson: "{}",
+		now: ctx.now,
+	});
+	const signer = await deps.createSigner();
+	const pending = await prepareAutomatedLabelIssuance(
+		deps.db,
+		deps.config,
+		signer,
+		{
+			actor: deps.config.labelerDid,
+			type: "automated-assessment",
+			assessmentId: runId,
+			reason: ctx.reason,
+			idempotencyKey: pendingKey,
+		},
+		{ uri: assessment.uri, cid: assessment.cid, val: "assessment-pending" },
+		ctx.now,
+	);
+
+	const descriptor: RerunDescriptor = {
+		actionId: ctx.actionId,
+		runId,
+		triggerId,
+		uri: assessment.uri,
+		cid: assessment.cid,
+		cts: ctx.now.toISOString(),
+	};
+	const commitSpec: MutationSpec<AssessmentActionBody> = {
+		...spec,
+		auditFields: () => ({
+			subjectUri: assessment.uri,
+			subjectCid: assessment.cid,
+			labelValue: "assessment-pending",
+			metadata: { runId, triggerId },
+		}),
+	};
+	// The run row precedes the pending issuance in the batch so the
+	// `issuance_actions.assessment_id → runId` FK resolves within the transaction.
+	const returned = await commitMutation(
+		deps.db,
+		ctx,
+		commitSpec,
+		[runStatement, ...pending.statements],
+		descriptor,
+	);
+	// Derive the persistence + tail keys from the committed descriptor, not the
+	// locally built ones: on a concurrent-key race `commitMutation` returns the
+	// winner's stored descriptor, whose run + pending label are the ones on disk.
+	const committedPendingKey = automatedIdempotencyKey(
+		await rerunRunKey(returned.uri, returned.cid, returned.triggerId),
+		"assessment-pending",
+		false,
+	);
+	await assertIssuancePersisted(deps.db, [committedPendingKey]);
+	deferRerunTail(deps, returned.runId, committedPendingKey);
+	return jsonData(returned);
+}
+
+/**
+ * `POST /admin/api/assessments/:id/override` — the atomic false-positive unblock
+ * (spec §7.1/§20.2). One `commitMutation` batch commits the audit row, `N`
+ * negations of the live automated blocking labels for the exact URI+CID, and the
+ * `assessment-passed` + `assessment-overridden` eligibility pair. The submitted
+ * `negate` set must equal the live negatable automated-block set (else 400) so
+ * the reviewer cannot override against a stale view.
+ */
+async function runOverride(
+	request: Request,
+	deps: ConsoleMutationDeps,
+	id: string,
+): Promise<Response> {
+	const spec: MutationSpec<OverrideActionBody> = {
+		action: "unblock-override",
+		requiredRole: "reviewer",
+		parseBody: (raw) => ({
+			assessmentId: id,
+			confirmation: requireString(raw.confirmation),
+			negate: requireStringArray(raw.negate),
+		}),
+		auditFields: () => ({}),
+	};
+	const outcome = await guardMutation(request, spec, guardDepsOf(deps));
+	if (outcome.outcome === "replay") {
+		const stored = storedDescriptor<OverrideDescriptor>(outcome.result);
+		const keys = overrideIssuanceKeys(stored.actionId, stored.negated, stored.issued);
+		await assertIssuancePersisted(deps.db, keys);
+		deferPublishAll(deps, keys);
+		return jsonData(stored);
+	}
+
+	const { ctx } = outcome;
+	const assessment = await loadAssessment(deps.db, id);
+	assertConfirmationCid(ctx.body.confirmation, assessment.cid);
+	// Throws NegatableBlockSetError (→ 400) unless the submitted set is exactly
+	// the live automated-block set for the exact URI+CID.
+	await assertNegatableBlockSet(
+		deps.db,
+		deps.config.labelerDid,
+		{ uri: assessment.uri, cid: assessment.cid },
+		ctx.body.negate,
+	);
+
+	const signer = await deps.createSigner();
+	const overrideStatements = await prepareOverrideIssuance(
+		deps.db,
+		deps.config,
+		signer,
+		{
+			actor: deps.config.labelerDid,
+			type: "manual-label",
+			reason: ctx.reason,
+			idempotencyKey: ctx.actionId,
+		},
+		{ uri: assessment.uri, cid: assessment.cid, negate: ctx.body.negate },
+		ctx.now,
+	);
+
+	const descriptor: OverrideDescriptor = {
+		actionId: ctx.actionId,
+		uri: assessment.uri,
+		cid: assessment.cid,
+		negated: [...ctx.body.negate],
+		issued: [...OVERRIDE_RETRACT_PAIR],
+		cts: ctx.now.toISOString(),
+	};
+	const commitSpec: MutationSpec<OverrideActionBody> = {
+		...spec,
+		auditFields: () => ({
+			subjectUri: assessment.uri,
+			subjectCid: assessment.cid,
+			labelValue: "assessment-overridden",
+			metadata: { negated: descriptor.negated, issued: descriptor.issued },
+		}),
+	};
+	const returned = await commitMutation(deps.db, ctx, commitSpec, overrideStatements, descriptor);
+	// Keys from the committed descriptor (winner's on a race), not the loser's.
+	const committedKeys = overrideIssuanceKeys(returned.actionId, returned.negated, returned.issued);
+	await assertIssuancePersisted(deps.db, committedKeys);
+	deferPublishAll(deps, committedKeys);
+	return jsonData(returned);
+}
+
+/**
+ * `POST /admin/api/assessments/:id/override-retract` — negates only the
+ * `assessment-passed` + `assessment-overridden` override pair in one batch. The
+ * originally-negated automated blocks stay negated (retraction does not re-issue
+ * them — that would mint automated findings as permanent manual labels); the
+ * release returns to `blocked` / `missing-assessment-pass`. A rerun re-surfaces
+ * real findings with correct automated provenance.
+ */
+async function runOverrideRetract(
+	request: Request,
+	deps: ConsoleMutationDeps,
+	id: string,
+): Promise<Response> {
+	const spec: MutationSpec<AssessmentActionBody> = {
+		action: "override-retract",
+		requiredRole: "reviewer",
+		parseBody: (raw) => ({ assessmentId: id, confirmation: requireString(raw.confirmation) }),
+		auditFields: () => ({}),
+	};
+	const outcome = await guardMutation(request, spec, guardDepsOf(deps));
+	if (outcome.outcome === "replay") {
+		const stored = storedDescriptor<OverrideRetractDescriptor>(outcome.result);
+		const keys = stored.negated.map((val) => overridePieceKey(stored.actionId, val, true));
+		await assertIssuancePersisted(deps.db, keys);
+		deferPublishAll(deps, keys);
+		return jsonData(stored);
+	}
+
+	const { ctx } = outcome;
+	const assessment = await loadAssessment(deps.db, id);
+	assertConfirmationCid(ctx.body.confirmation, assessment.cid);
+
+	const signer = await deps.createSigner();
+	const statements: D1PreparedStatement[] = [];
+	for (const val of OVERRIDE_RETRACT_PAIR) {
+		const built = await prepareManualLabelIssuance(
+			deps.db,
+			deps.config,
+			signer,
+			{
+				actor: deps.config.labelerDid,
+				type: "manual-label",
+				reason: ctx.reason,
+				idempotencyKey: overridePieceKey(ctx.actionId, val, true),
+			},
+			{ uri: assessment.uri, val, cid: assessment.cid, neg: true },
+			ctx.now,
+		);
+		statements.push(...built.statements);
+	}
+
+	const descriptor: OverrideRetractDescriptor = {
+		actionId: ctx.actionId,
+		uri: assessment.uri,
+		cid: assessment.cid,
+		negated: [...OVERRIDE_RETRACT_PAIR],
+		cts: ctx.now.toISOString(),
+	};
+	const commitSpec: MutationSpec<AssessmentActionBody> = {
+		...spec,
+		auditFields: () => ({
+			subjectUri: assessment.uri,
+			subjectCid: assessment.cid,
+			labelValue: "assessment-overridden",
+			metadata: { negated: descriptor.negated },
+		}),
+	};
+	const returned = await commitMutation(deps.db, ctx, commitSpec, statements, descriptor);
+	// Keys from the committed descriptor (winner's on a race), not the loser's.
+	const committedKeys = returned.negated.map((val) =>
+		overridePieceKey(returned.actionId, val, true),
+	);
+	await assertIssuancePersisted(deps.db, committedKeys);
+	deferPublishAll(deps, committedKeys);
+	return jsonData(returned);
 }

--- a/apps/labeler/src/console-serialize.ts
+++ b/apps/labeler/src/console-serialize.ts
@@ -21,6 +21,7 @@ import type { AssessmentState, PublicAssessmentState } from "./assessment-lifecy
 import type {
 	AssessmentFinding,
 	AssessmentIssuedLabel,
+	LabelStreamWinner,
 	ListedAssessment,
 	Subject,
 } from "./assessment-store.js";
@@ -70,6 +71,19 @@ export interface IssuedLabel {
 	cts: string;
 	exp: string | null;
 	neg: boolean;
+	sequence: number;
+}
+
+/** The active label state for a subject `(src, uri)` at a CID — the current
+ * stream winner per value, including manual/override labels that carry no
+ * `assessment_id` and so never appear in the assessment-scoped label list. */
+export interface SubjectLabel {
+	val: string;
+	cid: string | null;
+	active: boolean;
+	neg: boolean;
+	cts: string;
+	exp: string | null;
 	sequence: number;
 }
 
@@ -162,6 +176,18 @@ export function serializeIssuedLabel(label: AssessmentIssuedLabel): IssuedLabel 
 		exp: label.exp,
 		neg: label.neg,
 		sequence: label.sequence,
+	};
+}
+
+export function serializeSubjectLabel(winner: LabelStreamWinner): SubjectLabel {
+	return {
+		val: winner.val,
+		cid: winner.cid,
+		active: winner.active,
+		neg: winner.neg,
+		cts: winner.cts,
+		exp: winner.exp,
+		sequence: winner.sequence,
 	};
 }
 

--- a/apps/labeler/src/console-serialize.ts
+++ b/apps/labeler/src/console-serialize.ts
@@ -82,6 +82,7 @@ export interface SubjectLabel {
 	cid: string | null;
 	active: boolean;
 	neg: boolean;
+	automated: boolean;
 	cts: string;
 	exp: string | null;
 	sequence: number;
@@ -185,6 +186,7 @@ export function serializeSubjectLabel(winner: LabelStreamWinner): SubjectLabel {
 		cid: winner.cid,
 		active: winner.active,
 		neg: winner.neg,
+		automated: winner.automated,
 		cts: winner.cts,
 		exp: winner.exp,
 		sequence: winner.sequence,

--- a/apps/labeler/src/label-effect-preview.ts
+++ b/apps/labeler/src/label-effect-preview.ts
@@ -155,3 +155,110 @@ export async function computeEffectPreview(
 
 	return preview;
 }
+
+export interface OverrideEffectPreviewParams {
+	uri: string;
+	cid: string;
+	negate: readonly string[];
+}
+
+/**
+ * Multi-overlay effect preview for a reviewer false-positive override (plan
+ * W9.5): the post-override release state the console shows before submit (§11.4).
+ * Grounds in the same `getActiveLabelState` → `evaluateHydratedReleaseModeration`
+ * machinery as `computeEffectPreview`, but overlays every override event at once
+ * — each `negate` val as a negation, plus `assessment-passed` +
+ * `assessment-overridden`. `before` is the current (blocked) state; `after` is
+ * `eligible` / `eligible-manual-override` with the blocks suppressed. Returns
+ * `null` when the subject is not an observed release (the caller maps that to a
+ * 400).
+ */
+export async function computeOverrideEffectPreview(
+	db: D1Database,
+	labelerDid: string,
+	params: OverrideEffectPreviewParams,
+	now: Date,
+): Promise<EffectPreview | null> {
+	const subject = await getCurrentSubjectByUri(db, params.uri);
+	const isRelease =
+		parseSubjectKind(params.uri) === "release" && subject?.collection.endsWith(".release") === true;
+	if (!isRelease || !subject) return null;
+
+	const active = await getActiveLabelState(db, {
+		src: labelerDid,
+		uri: params.uri,
+		cid: params.cid,
+		now,
+	});
+
+	const supersedes: SupersededLabel[] = [];
+	const activeLabels: ModerationLabel[] = [];
+	for (const winner of active.values()) {
+		if (!winner.active) continue;
+		activeLabels.push({
+			ver: 1,
+			src: labelerDid,
+			uri: params.uri,
+			...(winner.cid === null ? {} : { cid: winner.cid }),
+			val: winner.val,
+			cts: winner.cts,
+			...(winner.exp === null ? {} : { exp: winner.exp }),
+		});
+		if (params.negate.includes(winner.val))
+			supersedes.push({ val: winner.val, cid: winner.cid, sequence: winner.sequence });
+	}
+
+	const overlays: ModerationLabel[] = [
+		...params.negate.map((val) => ({
+			ver: 1 as const,
+			src: labelerDid,
+			uri: params.uri,
+			cid: params.cid,
+			val,
+			neg: true as const,
+			cts: now.toISOString(),
+		})),
+		...(["assessment-passed", "assessment-overridden"] as const).map((val) => ({
+			ver: 1 as const,
+			src: labelerDid,
+			uri: params.uri,
+			cid: params.cid,
+			val,
+			cts: now.toISOString(),
+		})),
+	];
+
+	const preview: EffectPreview = {
+		labelEffect: getLabelDefinition("assessment-overridden")?.officialEffect ?? "pass",
+		scope: "cid-bound",
+		supersedes,
+		before: null,
+		after: null,
+	};
+
+	const context = {
+		publisherDid: subject.did,
+		package: { uri: params.uri, cid: params.cid },
+		release: { uri: params.uri, cid: params.cid },
+	};
+	const acceptedLabelers = [{ did: labelerDid, redact: false }];
+	try {
+		preview.before = evaluateHydratedReleaseModeration({
+			acceptedLabelers,
+			context,
+			evaluatedAt: now,
+			labels: activeLabels,
+		});
+		preview.after = evaluateHydratedReleaseModeration({
+			acceptedLabelers,
+			context,
+			evaluatedAt: now,
+			labels: [...activeLabels, ...overlays],
+		});
+	} catch {
+		preview.before = null;
+		preview.after = null;
+	}
+
+	return preview;
+}

--- a/apps/labeler/src/service.ts
+++ b/apps/labeler/src/service.ts
@@ -1,6 +1,7 @@
 import type { LabelSigner, SignedLabel } from "@emdash-cms/registry-moderation";
 
 import { ASSESSMENT_ID } from "./assessment-lifecycle.js";
+import { getNegatableAutomatedLabels } from "./assessment-store.js";
 import type { LabelerConfig } from "./config.js";
 import type { FindingSeverity } from "./evidence.js";
 import { getLabelDefinition, type SubjectKind } from "./policy.js";
@@ -402,6 +403,156 @@ export async function prepareManualLabelIssuance(
 	validateAction(action);
 	validateManualProposal(proposal);
 	return buildIssuanceStatements(db, config, signer, action, proposal, now, true);
+}
+
+/**
+ * Automated analog of `prepareManualLabelIssuance`: validates + signs an
+ * automated-assessment issuance without executing the batch, returning the
+ * `IssuanceStatements` a caller commits alongside its own statements (plan W9.5
+ * rerun commits the `assessment-pending` label in the same `db.batch` as the
+ * operator audit row and the new run). `publicationPending` is `true` — the
+ * caller publishes post-commit.
+ */
+export async function prepareAutomatedLabelIssuance(
+	db: D1Database,
+	config: LabelerConfig,
+	signer: LabelSigner,
+	action: AutomatedIssuanceAction,
+	proposal: AutomatedLabelProposal,
+	now: Date,
+): Promise<IssuanceStatements> {
+	if (signer.issuerDid !== config.labelerDid)
+		throw new TypeError("signer issuer does not match the configured labeler DID");
+	validateKeyVersion(config.signingKeyVersion);
+	validateAutomatedAction(action);
+	validateAutomatedProposal(proposal);
+	return buildIssuanceStatements(db, config, signer, action, proposal, now, true);
+}
+
+export interface OverrideIssuanceSpec {
+	uri: string;
+	cid: string;
+	/** The automated blocking labels to negate; must equal the live negatable
+	 * automated-block set for `(labelerDid, uri, cid)` (validated here). */
+	negate: readonly string[];
+}
+
+/** The reviewer override pair, issued together as the eligibility half of an
+ * unblock (spec §7.1/§20.2). Order is load-bearing only for the descriptor. */
+const OVERRIDE_ELIGIBILITY_LABELS = ["assessment-passed", "assessment-overridden"] as const;
+
+/**
+ * The distinct signing idempotency key for one label piece of a multi-label
+ * operator action, derived from the single action's base key. Each `(val,
+ * direction)` pair is unique within an override or retract, so every piece gets
+ * its own `issuance_actions` + `issued_labels` row — a shared key would trip
+ * `buildIssuanceStatements`' single-label-per-action guard. Shared with the
+ * console handler so the post-commit persistence check reconstructs the same
+ * keys on replay.
+ */
+export function overridePieceKey(base: string, val: string, neg: boolean): string {
+	return `${base}:${val}:${neg ? "neg" : "pos"}`;
+}
+
+/**
+ * Composes the reviewer false-positive override (plan W9.5) as one signed,
+ * batchable statement set: `N` negations of the live automated blocking labels
+ * for the exact release `(uri, cid)`, then the `assessment-passed` +
+ * `assessment-overridden` eligibility pair. All pieces derive a distinct
+ * issuance idempotency key from the single operator action (`${base}:${val}:
+ * ${neg}`) so each gets its own `issuance_actions` + `issued_labels` row — a
+ * shared key would trip `buildIssuanceStatements`' single-label-per-action
+ * guard and silently drop all but the first.
+ *
+ * The negations are §20.2-authorized, not reviewer-issuance-mode labels, so they
+ * bypass `validateManualProposal` (which requires a `reviewer`/`admin` mode the
+ * automated blocks lack) and sign through `buildIssuanceStatements` directly.
+ * The two eligibility labels go through the normal manual path. The submitted
+ * `negate` set is validated against the live `getNegatableAutomatedLabels`
+ * (filtered to `automated-block`), so a stale or crafted set is rejected before
+ * signing rather than negating a different set than the reviewer saw.
+ */
+export async function prepareOverrideIssuance(
+	db: D1Database,
+	config: LabelerConfig,
+	signer: LabelSigner,
+	action: AuthorizedIssuanceAction,
+	spec: OverrideIssuanceSpec,
+	now: Date,
+): Promise<D1PreparedStatement[]> {
+	if (signer.issuerDid !== config.labelerDid)
+		throw new TypeError("signer issuer does not match the configured labeler DID");
+	validateKeyVersion(config.signingKeyVersion);
+	validateAction(action);
+	if (parseSubjectKind(spec.uri) !== "release")
+		throw new TypeError("override must target a release record");
+	if (spec.cid.length === 0) throw new TypeError("override must include a release CID");
+
+	const statements: D1PreparedStatement[] = [];
+
+	for (const val of spec.negate) {
+		const definition = getLabelDefinition(val);
+		if (!definition || definition.category !== "automated-block")
+			throw new TypeError(`${val} is not an automated blocking label`);
+		const built = await buildIssuanceStatements(
+			db,
+			config,
+			signer,
+			{ ...action, idempotencyKey: overridePieceKey(action.idempotencyKey, val, true) },
+			{ uri: spec.uri, val, cid: spec.cid, neg: true },
+			now,
+			true,
+		);
+		statements.push(...built.statements);
+	}
+
+	for (const val of OVERRIDE_ELIGIBILITY_LABELS) {
+		const built = await prepareManualLabelIssuance(
+			db,
+			config,
+			signer,
+			{ ...action, idempotencyKey: overridePieceKey(action.idempotencyKey, val, false) },
+			{ uri: spec.uri, val, cid: spec.cid, neg: false },
+			now,
+		);
+		statements.push(...built.statements);
+	}
+
+	return statements;
+}
+
+/**
+ * Validates that a submitted override `negate` set is exactly the live
+ * negatable automated-block set for `(src, uri, cid)`. Returns the authoritative
+ * live vals (sorted) when they match; throws when the submitted set omits an
+ * active block, includes a non-active/warning/manual-headed val, or is otherwise
+ * not identical — so a reviewer can never override against a stale view.
+ */
+export async function assertNegatableBlockSet(
+	db: D1Database,
+	src: string,
+	subject: { uri: string; cid: string },
+	submitted: readonly string[],
+): Promise<string[]> {
+	const live = (await getNegatableAutomatedLabels(db, { src, uri: subject.uri, cid: subject.cid }))
+		.map((label) => label.val)
+		.filter((val) => getLabelDefinition(val)?.category === "automated-block");
+	const liveSet = new Set(live);
+	const submittedSet = new Set(submitted);
+	const identical =
+		liveSet.size === submittedSet.size && [...liveSet].every((val) => submittedSet.has(val));
+	if (!identical || submitted.length !== submittedSet.size)
+		throw new NegatableBlockSetError("submitted block set does not match live automated blocks");
+	return live.toSorted();
+}
+
+/**
+ * The submitted override negation set is not exactly the live automated-block
+ * set. Message is static — it never echoes the submitted vals. Callers map this
+ * to a 400 `INVALID_BODY`.
+ */
+export class NegatableBlockSetError extends Error {
+	override readonly name = "NegatableBlockSetError";
 }
 
 export async function issueAutomatedAssessmentLabel(

--- a/apps/labeler/test/console-assessment-mutations.test.ts
+++ b/apps/labeler/test/console-assessment-mutations.test.ts
@@ -794,6 +794,39 @@ describe("subject-label read + override effect preview", () => {
 		expect(byVal.get("malware")?.neg).toBe(true);
 	});
 
+	it("reports head provenance so a manually-headed block is not offered for override", async () => {
+		const { id, uri } = await seedRun("subject-provenance");
+		await seedAutomatedBlock(uri, id, "malware");
+		const manual = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "impersonation",
+				cid: CID,
+				confirmation: CID,
+				reason: "manually flagged impersonation",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(manual.status).toBe(200);
+
+		const response = await handleConsoleApi(
+			getReq(`/admin/api/subjects/${encodeURIComponent(uri)}/labels?cid=${CID}`),
+			readDeps(),
+		);
+		const labels = await bodyData<{ val: string; active: boolean; automated: boolean }[]>(
+			response,
+		);
+		const byVal = new Map(labels.map((label) => [label.val, label]));
+		expect(byVal.get("malware")).toMatchObject({ active: true, automated: true });
+		expect(byVal.get("impersonation")).toMatchObject({ active: true, automated: false });
+
+		// The provenance flag keeps the console's offer aligned with the server's
+		// negatable set: the manual head is rejected, the automated-only set proceeds.
+		expect((await override(id, uri, ["malware", "impersonation"])).status).toBe(400);
+		expect((await override(id, uri, ["malware"])).status).toBe(200);
+	});
+
 	it("grounds the override preview before→after in the evaluator", async () => {
 		const { id, uri } = await seedRun("override-preview");
 		await seedAutomatedBlock(uri, id, "malware");

--- a/apps/labeler/test/console-assessment-mutations.test.ts
+++ b/apps/labeler/test/console-assessment-mutations.test.ts
@@ -852,4 +852,39 @@ describe("subject-label read + override effect preview", () => {
 		expect(preview.after?.reasonCodes).toContain("eligible-manual-override");
 		expect(preview.after?.blockingLabels).not.toContain("malware");
 	});
+
+	it("rejects a preview whose negate set the submit endpoint would reject", async () => {
+		const { id, uri } = await seedRun("preview-mismatch");
+		await seedAutomatedBlock(uri, id, "malware");
+		const manual = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "impersonation",
+				cid: CID,
+				confirmation: CID,
+				reason: "manually flagged",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(manual.status).toBe(200);
+
+		// A manually-headed block and an incomplete set both fail the same
+		// live-set check the submit runs, so the preview cannot over-promise.
+		const withManualHead = await handleConsoleApi(
+			getReq(
+				`/admin/api/labels/override-effect-preview?uri=${encodeURIComponent(uri)}&cid=${CID}&negate=malware&negate=impersonation`,
+			),
+			readDeps(),
+		);
+		expect(withManualHead.status).toBe(400);
+
+		const liveSet = await handleConsoleApi(
+			getReq(
+				`/admin/api/labels/override-effect-preview?uri=${encodeURIComponent(uri)}&cid=${CID}&negate=malware`,
+			),
+			readDeps(),
+		);
+		expect(liveSet.status).toBe(200);
+	});
 });

--- a/apps/labeler/test/console-assessment-mutations.test.ts
+++ b/apps/labeler/test/console-assessment-mutations.test.ts
@@ -1,0 +1,741 @@
+import {
+	createLabelSigner,
+	evaluateHydratedReleaseModeration,
+	type LabelDidDocument,
+	type ModerationLabel,
+} from "@emdash-cms/registry-moderation";
+import { applyD1Migrations, env } from "cloudflare:test";
+import { generateKeyPair, SignJWT } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { AccessKeyResolver } from "../src/access-auth.js";
+import { computeRunKey, initialTriggerId } from "../src/assessment-lifecycle.js";
+import {
+	createAssessmentRun,
+	createSubject,
+	getActiveLabelState,
+	getAssessment,
+	getCurrentAssessment,
+} from "../src/assessment-store.js";
+import { handleConsoleApi, type ConsoleApiDeps } from "../src/console-api.js";
+import { handleConsoleMutation, type ConsoleMutationDeps } from "../src/console-mutation-api.js";
+import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
+import { issueAutomatedAssessmentLabel, issueManualLabel } from "../src/service.js";
+
+const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
+const AUDIENCE = "test-audience";
+const ORIGIN = "https://labeler.example.com";
+const LABELER_DID = "did:web:labels.emdashcms.com";
+const LABELER_SERVICE_URL = "https://labels.emdashcms.com";
+const PUBLISHER_DID = "did:plc:publisher000000000000000000";
+const PRIVATE_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE";
+const MULTIKEY = "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ";
+const CID = "bafkreif4oaymum54i5qefbwoblrt5zasfjhpyhyvacpseqtehi3queew5m";
+
+const CONFIG = {
+	labelerDid: LABELER_DID,
+	signingKeyVersion: "v1",
+	serviceUrl: LABELER_SERVICE_URL,
+	signingPublicKeyMultibase: MULTIKEY,
+};
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+
+let resolver: AccessKeyResolver;
+let signKey: CryptoKey;
+let reviewerToken: string;
+let keySeq = 0;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+	const pair = await generateKeyPair("RS256");
+	signKey = pair.privateKey;
+	resolver = (async () => pair.publicKey) as AccessKeyResolver;
+	reviewerToken = await mintToken({ email: "reviewer@example.com" });
+});
+
+async function mintToken(claims: Record<string, unknown>): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	return new SignJWT({ sub: "user-sub-1", ...claims })
+		.setProtectedHeader({ alg: "RS256" })
+		.setIssuer(TEAM_DOMAIN)
+		.setAudience(AUDIENCE)
+		.setIssuedAt(now)
+		.setExpirationTime(now + 3600)
+		.sign(signKey);
+}
+
+function labelerDidDocument(): LabelDidDocument {
+	return {
+		id: LABELER_DID,
+		verificationMethod: [
+			{
+				id: `${LABELER_DID}#atproto_label`,
+				type: "Multikey",
+				controller: LABELER_DID,
+				publicKeyMultibase: MULTIKEY,
+			},
+		],
+	};
+}
+
+function testSigner() {
+	return createLabelSigner({
+		issuerDid: LABELER_DID,
+		privateKey: PRIVATE_KEY,
+		resolveDid: async () => labelerDidDocument(),
+	});
+}
+
+function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): ConsoleMutationDeps {
+	return {
+		db: testEnv.DB,
+		accessConfig: {
+			teamDomain: TEAM_DOMAIN,
+			audience: AUDIENCE,
+			admins: ["admin@example.com"],
+			reviewers: ["reviewer@example.com"],
+		},
+		keys: resolver,
+		config: CONFIG,
+		createSigner: () => testSigner(),
+		now: () => new Date(),
+		afterCommit: async () => {},
+		defer: (work) => {
+			void work;
+		},
+		...overrides,
+	};
+}
+
+function readDeps(overrides: Partial<ConsoleApiDeps> = {}): ConsoleApiDeps {
+	return {
+		db: testEnv.DB,
+		config: {
+			teamDomain: TEAM_DOMAIN,
+			audience: AUDIENCE,
+			admins: ["admin@example.com"],
+			reviewers: ["reviewer@example.com"],
+		},
+		keys: resolver,
+		expectedOrigin: ORIGIN,
+		labelerDid: LABELER_DID,
+		jetstreamConnected: async () => true,
+		...overrides,
+	};
+}
+
+function post(path: string, body: unknown): Request {
+	const headers = new Headers();
+	headers.set(OPERATOR_REQUEST_HEADER, "1");
+	headers.set("Content-Type", "application/json");
+	headers.set("Cf-Access-Jwt-Assertion", reviewerToken);
+	return new Request(`${ORIGIN}${path}`, { method: "POST", headers, body: JSON.stringify(body) });
+}
+
+function getReq(path: string): Request {
+	const headers = new Headers();
+	headers.set(OPERATOR_REQUEST_HEADER, "1");
+	headers.set("Cf-Access-Jwt-Assertion", reviewerToken);
+	return new Request(`${ORIGIN}${path}`, { method: "GET", headers });
+}
+
+/** A POST carrying an optional operator token — omit it for an unauthenticated
+ * request, or pass a non-reviewer token for an under-privileged one. */
+function postWithToken(path: string, body: unknown, token: string | null): Request {
+	const headers = new Headers();
+	headers.set(OPERATOR_REQUEST_HEADER, "1");
+	headers.set("Content-Type", "application/json");
+	if (token !== null) headers.set("Cf-Access-Jwt-Assertion", token);
+	return new Request(`${ORIGIN}${path}`, { method: "POST", headers, body: JSON.stringify(body) });
+}
+
+function releaseUri(rkey: string): string {
+	return `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.release/${rkey}`;
+}
+
+function nextKey(): string {
+	keySeq += 1;
+	return `idem-key-${keySeq.toString().padStart(6, "0")}`;
+}
+
+/** Seeds a verified release subject and an initial assessment run for it,
+ * returning the run id + subject URI. */
+async function seedRun(rkey: string, cid = CID): Promise<{ id: string; uri: string }> {
+	const uri = releaseUri(rkey);
+	await createSubject(testEnv.DB, {
+		uri,
+		cid,
+		did: PUBLISHER_DID,
+		collection: "com.emdashcms.experimental.package.release",
+		rkey,
+		now: new Date("2026-07-08T08:00:00.000Z"),
+	});
+	const triggerId = initialTriggerId(cid);
+	const runKey = await computeRunKey({
+		uri,
+		cid,
+		policyVersion: "v1",
+		modelId: "m",
+		promptHash: "p",
+		scannerSetVersion: "v1",
+		triggerId,
+	});
+	const { assessment } = await createAssessmentRun(testEnv.DB, {
+		runKey,
+		uri,
+		cid,
+		trigger: "initial",
+		triggerId,
+		policyVersion: "v1",
+		coverageJson: "{}",
+		now: new Date("2026-07-08T08:05:00.000Z"),
+	});
+	return { id: assessment.id, uri };
+}
+
+/** Issues a positive automated blocking label from a run, so the release is
+ * blocked and the val becomes a negatable automated block. */
+async function seedAutomatedBlock(uri: string, assessmentId: string, val: string): Promise<void> {
+	await issueAutomatedAssessmentLabel(
+		testEnv.DB,
+		CONFIG,
+		await testSigner(),
+		{
+			actor: LABELER_DID,
+			type: "automated-assessment",
+			assessmentId,
+			reason: `seed ${val}`,
+			idempotencyKey: `auto-${val}-${Math.random()}`,
+		},
+		{ uri, cid: CID, val, findingCategory: val, severity: "critical" },
+	);
+}
+
+async function countRows(sql: string, ...binds: unknown[]): Promise<number> {
+	const row = await testEnv.DB.prepare(sql)
+		.bind(...binds)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+async function bodyData<T>(response: Response): Promise<T> {
+	const parsed = (await response.json()) as { data: T };
+	return parsed.data;
+}
+
+async function bodyError(response: Response): Promise<{ code: string; message: string }> {
+	const parsed = (await response.json()) as { error: { code: string; message: string } };
+	return parsed.error;
+}
+
+/** Reduces the subject's active label state through the release evaluator, the
+ * same grounding the effect preview uses. */
+async function evaluateSubject(uri: string, cid = CID) {
+	const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid });
+	const labels: ModerationLabel[] = [];
+	for (const winner of winners.values()) {
+		if (!winner.active) continue;
+		labels.push({
+			ver: 1,
+			src: LABELER_DID,
+			uri,
+			...(winner.cid === null ? {} : { cid: winner.cid }),
+			val: winner.val,
+			cts: winner.cts,
+			...(winner.exp === null ? {} : { exp: winner.exp }),
+		});
+	}
+	return evaluateHydratedReleaseModeration({
+		acceptedLabelers: [{ did: LABELER_DID, redact: false }],
+		context: { publisherDid: PUBLISHER_DID, package: { uri, cid }, release: { uri, cid } },
+		evaluatedAt: new Date(),
+		labels,
+	});
+}
+
+async function override(
+	id: string,
+	uri: string,
+	negate: string[],
+	deps = mutationDeps(),
+): Promise<Response> {
+	return handleConsoleMutation(
+		post(`/admin/api/assessments/${id}/override`, {
+			confirmation: CID,
+			reason: "false positives, unblocking",
+			idempotencyKey: nextKey(),
+			negate,
+		}),
+		deps,
+	);
+}
+
+describe("rerun", () => {
+	it("mints the operator trigger, a fresh run, and re-pends without moving the current pointer", async () => {
+		const { id, uri } = await seedRun("rerun-basic");
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, {
+				confirmation: CID,
+				reason: "re-assess this release",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<{ runId: string; triggerId: string; uri: string }>(response);
+		expect(descriptor.runId).toMatch(/^asmt_/);
+		expect(descriptor.runId).not.toBe(id);
+
+		const run = await getAssessment(testEnv.DB, descriptor.runId);
+		expect(run?.trigger).toBe("operator");
+		expect(run?.triggerId).toBe(descriptor.triggerId);
+		expect(descriptor.triggerId.startsWith("operator:")).toBe(true);
+		// run_key deterministically binds to the operator trigger.
+		expect(run?.runKey).toBe(
+			await computeRunKey({
+				uri,
+				cid: CID,
+				policyVersion: run!.policyVersion,
+				modelId: "unassigned",
+				promptHash: "unassigned",
+				scannerSetVersion: "unassigned",
+				triggerId: descriptor.triggerId,
+			}),
+		);
+
+		// An active assessment-pending re-gates the release.
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("assessment-pending")?.active).toBe(true);
+
+		// One audit row, one distinct run, current pointer never moved (none set).
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE action = 'assessment-rerun'`),
+		).toBe(1);
+		expect(await getCurrentAssessment(testEnv.DB, { src: LABELER_DID, uri, cid: CID })).toBeNull();
+	});
+
+	it("a second rerun creates another distinct run", async () => {
+		const { id } = await seedRun("rerun-twice");
+		const first = await bodyData<{ runId: string }>(
+			await handleConsoleMutation(
+				post(`/admin/api/assessments/${id}/rerun`, {
+					confirmation: CID,
+					reason: "first",
+					idempotencyKey: nextKey(),
+				}),
+				mutationDeps(),
+			),
+		);
+		const second = await bodyData<{ runId: string }>(
+			await handleConsoleMutation(
+				post(`/admin/api/assessments/${id}/rerun`, {
+					confirmation: CID,
+					reason: "second",
+					idempotencyKey: nextKey(),
+				}),
+				mutationDeps(),
+			),
+		);
+		expect(second.runId).not.toBe(first.runId);
+	});
+
+	it("re-drives the idempotent tail on replay and returns the stored descriptor", async () => {
+		const { id } = await seedRun("rerun-replay");
+		const key = nextKey();
+		const body = { confirmation: CID, reason: "replay me", idempotencyKey: key };
+		const first = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, body),
+			mutationDeps(),
+		);
+		const firstText = await first.text();
+		const second = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, body),
+			mutationDeps(),
+		);
+		expect(second.status).toBe(200);
+		expect(await second.text()).toBe(firstText);
+		// No second run created.
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
+		).toBe(1);
+	});
+
+	it("rejects a confirmation that is not the release CID", async () => {
+		const { id } = await seedRun("rerun-conf");
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, {
+				confirmation: "not-the-cid",
+				reason: "bad confirm",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("CONFIRMATION_MISMATCH");
+	});
+
+	it("404s an unknown assessment id", async () => {
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/asmt_00000000000000000000000000/rerun`, {
+				confirmation: CID,
+				reason: "no such run",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(404);
+	});
+});
+
+describe("override", () => {
+	it("commits N negations + the eligibility pair + one audit row atomically", async () => {
+		const { id, uri } = await seedRun("override-atomic");
+		await seedAutomatedBlock(uri, id, "malware");
+		await seedAutomatedBlock(uri, id, "data-exfiltration");
+		expect((await evaluateSubject(uri)).eligibility).toBe("blocked");
+
+		const response = await override(id, uri, ["malware", "data-exfiltration"]);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<{ negated: string[]; issued: string[] }>(response);
+		expect(descriptor.negated.toSorted()).toEqual(["data-exfiltration", "malware"]);
+		expect(descriptor.issued).toEqual(["assessment-passed", "assessment-overridden"]);
+
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE action = 'unblock-override'`),
+		).toBe(1);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND neg = 1 AND val IN ('malware','data-exfiltration')`,
+				uri,
+			),
+		).toBe(2);
+
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("malware")?.active).toBe(false);
+		expect(winners.get("data-exfiltration")?.active).toBe(false);
+		expect(winners.get("assessment-passed")?.active).toBe(true);
+		expect(winners.get("assessment-overridden")?.active).toBe(true);
+
+		const evaluated = await evaluateSubject(uri);
+		expect(evaluated.eligibility).toBe("eligible");
+		expect(evaluated.reasonCodes).toContain("eligible-manual-override");
+	});
+
+	it("503s and commits no eligibility labels when the batch is suppressed mid-commit", async () => {
+		const { id, uri } = await seedRun("override-phantom");
+		await seedAutomatedBlock(uri, id, "malware");
+		const key = nextKey();
+		const body = {
+			confirmation: CID,
+			reason: "rotation lands mid-override",
+			idempotencyKey: key,
+			negate: ["malware"],
+		};
+		const suppressed = new Proxy(testEnv.DB, {
+			get(target, prop, receiver) {
+				if (prop === "batch")
+					return (statements: D1PreparedStatement[]) => target.batch([statements[0]!]);
+				const value: unknown = Reflect.get(target, prop, receiver);
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		});
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override`, body),
+			mutationDeps({ db: suppressed }),
+		);
+		expect(response.status).toBe(503);
+		expect((await bodyError(response)).code).toBe("LABEL_ISSUANCE_UNAVAILABLE");
+		// Audit row committed (unguarded), but no eligibility labels persisted.
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
+		).toBe(1);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = 'assessment-overridden'`,
+				uri,
+			),
+		).toBe(0);
+
+		// Replay re-runs the multi-label persistence check and also 503s.
+		const retry = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override`, body),
+			mutationDeps(),
+		);
+		expect(retry.status).toBe(503);
+	});
+
+	it("rejects a negate set that is not exactly the live automated-block set", async () => {
+		const { id, uri } = await seedRun("override-staleset");
+		await seedAutomatedBlock(uri, id, "malware");
+		await seedAutomatedBlock(uri, id, "data-exfiltration");
+
+		// Omits an active block.
+		expect((await override(id, uri, ["malware"])).status).toBe(400);
+		// Includes a warning.
+		expect((await override(id, uri, ["malware", "data-exfiltration", "low-quality"])).status).toBe(
+			400,
+		);
+		// Includes a non-active val.
+		expect(
+			(await override(id, uri, ["malware", "data-exfiltration", "impersonation"])).status,
+		).toBe(400);
+		// The exact live set proceeds.
+		expect((await override(id, uri, ["data-exfiltration", "malware"])).status).toBe(200);
+	});
+
+	it("returns the byte-identical descriptor on replay without a second effect", async () => {
+		const { id, uri } = await seedRun("override-replay");
+		await seedAutomatedBlock(uri, id, "malware");
+		const key = nextKey();
+		const body = {
+			confirmation: CID,
+			reason: "once",
+			idempotencyKey: key,
+			negate: ["malware"],
+		};
+		const first = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override`, body),
+			mutationDeps(),
+		);
+		const firstText = await first.text();
+		const second = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override`, body),
+			mutationDeps(),
+		);
+		expect(await second.text()).toBe(firstText);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = 'assessment-overridden'`,
+				uri,
+			),
+		).toBe(1);
+	});
+
+	it("409s the same key with a different negate set", async () => {
+		const { id, uri } = await seedRun("override-conflict");
+		await seedAutomatedBlock(uri, id, "malware");
+		await seedAutomatedBlock(uri, id, "data-exfiltration");
+		const key = nextKey();
+		const first = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override`, {
+				confirmation: CID,
+				reason: "first",
+				idempotencyKey: key,
+				negate: ["malware", "data-exfiltration"],
+			}),
+			mutationDeps(),
+		);
+		expect(first.status).toBe(200);
+		const second = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override`, {
+				confirmation: CID,
+				reason: "first",
+				idempotencyKey: key,
+				negate: ["malware"],
+			}),
+			mutationDeps(),
+		);
+		expect(second.status).toBe(409);
+		expect((await bodyError(second)).code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+	});
+});
+
+describe("override authorization", () => {
+	it("rejects an unauthenticated or under-privileged override before any signing", async () => {
+		const { id, uri } = await seedRun("override-authz");
+		await seedAutomatedBlock(uri, id, "malware");
+		const outsiderToken = await mintToken({ email: "outsider@example.com" });
+
+		const unauth = await handleConsoleMutation(
+			postWithToken(
+				`/admin/api/assessments/${id}/override`,
+				{ confirmation: CID, reason: "no creds", idempotencyKey: nextKey(), negate: ["malware"] },
+				null,
+			),
+			mutationDeps(),
+		);
+		expect(unauth.status).toBe(401);
+
+		const forbidden = await handleConsoleMutation(
+			postWithToken(
+				`/admin/api/assessments/${id}/override`,
+				{ confirmation: CID, reason: "wrong role", idempotencyKey: nextKey(), negate: ["malware"] },
+				outsiderToken,
+			),
+			mutationDeps(),
+		);
+		expect(forbidden.status).toBe(403);
+
+		// Neither attempt reached the signer: no audit row, no eligibility pair, and
+		// the block is untouched.
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operator_actions WHERE action = 'unblock-override' AND subject_uri = ?`,
+				uri,
+			),
+		).toBe(0);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = 'assessment-overridden'`,
+				uri,
+			),
+		).toBe(0);
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("malware")?.active).toBe(true);
+	});
+});
+
+describe("override permanence (§10)", () => {
+	it("keeps a later automated block visible but inert, and refuses automation negating the pass", async () => {
+		const { id, uri } = await seedRun("override-permanence");
+		await seedAutomatedBlock(uri, id, "malware");
+		expect((await override(id, uri, ["malware"])).status).toBe(200);
+
+		// A fresh automated malware positive (a rerun re-detect) after the override.
+		await issueAutomatedAssessmentLabel(
+			testEnv.DB,
+			CONFIG,
+			await testSigner(),
+			{
+				actor: LABELER_DID,
+				type: "automated-assessment",
+				assessmentId: id,
+				reason: "re-detected",
+				idempotencyKey: `redetect-${Math.random()}`,
+			},
+			{ uri, cid: CID, val: "malware", findingCategory: "malware", severity: "critical" },
+		);
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("malware")?.active).toBe(true);
+
+		const evaluated = await evaluateSubject(uri);
+		expect(evaluated.eligibility).toBe("eligible");
+		expect(evaluated.suppressedLabels).toContain("malware");
+
+		// Automation cannot negate the manual override pair.
+		await expect(
+			issueAutomatedAssessmentLabel(
+				testEnv.DB,
+				CONFIG,
+				await testSigner(),
+				{
+					actor: LABELER_DID,
+					type: "automated-assessment",
+					assessmentId: id,
+					reason: "try to undo",
+					idempotencyKey: `undo-${Math.random()}`,
+				},
+				{ uri, cid: CID, val: "assessment-passed", neg: true },
+			),
+		).rejects.toThrow("cannot negate the manually-issued label");
+	});
+
+	it("lets a manual security-yanked block despite the override", async () => {
+		const { id, uri } = await seedRun("override-manualblock");
+		await seedAutomatedBlock(uri, id, "malware");
+		expect((await override(id, uri, ["malware"])).status).toBe(200);
+
+		await issueManualLabel(
+			testEnv.DB,
+			CONFIG,
+			await testSigner(),
+			{ actor: LABELER_DID, type: "manual-label", reason: "yank", idempotencyKey: nextKey() },
+			{ uri, val: "security-yanked" },
+		);
+		const evaluated = await evaluateSubject(uri);
+		expect(evaluated.eligibility).toBe("blocked");
+		expect(evaluated.blockingLabels).toContain("security-yanked");
+	});
+});
+
+describe("override-retract", () => {
+	it("negates only the pair, leaves the blocks negated, and returns blocked/missing-pass", async () => {
+		const { id, uri } = await seedRun("retract-flow");
+		await seedAutomatedBlock(uri, id, "malware");
+		expect((await override(id, uri, ["malware"])).status).toBe(200);
+
+		const retract = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override-retract`, {
+				confirmation: CID,
+				reason: "override was wrong",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(retract.status).toBe(200);
+
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("assessment-passed")?.active).toBe(false);
+		expect(winners.get("assessment-overridden")?.active).toBe(false);
+		// The original block stays negated — retraction does not re-issue it.
+		expect(winners.get("malware")?.active).toBe(false);
+
+		const evaluated = await evaluateSubject(uri);
+		expect(evaluated.eligibility).toBe("blocked");
+		expect(evaluated.reasonCodes).toContain("missing-assessment-pass");
+
+		// A rerun then re-pends.
+		const rerun = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, {
+				confirmation: CID,
+				reason: "reassess after retract",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(rerun.status).toBe(200);
+		const after = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(after.get("assessment-pending")?.active).toBe(true);
+	});
+});
+
+describe("subject-label read + override effect preview", () => {
+	it("returns the active winners including the manual override labels", async () => {
+		const { id, uri } = await seedRun("subject-labels");
+		await seedAutomatedBlock(uri, id, "malware");
+		expect((await override(id, uri, ["malware"])).status).toBe(200);
+
+		const response = await handleConsoleApi(
+			getReq(`/admin/api/subjects/${encodeURIComponent(uri)}/labels?cid=${CID}`),
+			readDeps(),
+		);
+		expect(response.status).toBe(200);
+		const labels = await bodyData<{ val: string; active: boolean; neg: boolean }[]>(response);
+		const byVal = new Map(labels.map((label) => [label.val, label]));
+		expect(byVal.get("assessment-passed")?.active).toBe(true);
+		expect(byVal.get("assessment-overridden")?.active).toBe(true);
+		expect(byVal.get("malware")?.active).toBe(false);
+		expect(byVal.get("malware")?.neg).toBe(true);
+	});
+
+	it("grounds the override preview before→after in the evaluator", async () => {
+		const { id, uri } = await seedRun("override-preview");
+		await seedAutomatedBlock(uri, id, "malware");
+
+		const response = await handleConsoleApi(
+			getReq(
+				`/admin/api/labels/override-effect-preview?uri=${encodeURIComponent(uri)}&cid=${CID}&negate=malware`,
+			),
+			readDeps(),
+		);
+		expect(response.status).toBe(200);
+		const preview = await bodyData<{
+			supersedes: { val: string }[];
+			before: { eligibility: string; blockingLabels: string[] } | null;
+			after: { eligibility: string; reasonCodes: string[]; blockingLabels: string[] } | null;
+		}>(response);
+		expect(preview.before?.eligibility).toBe("blocked");
+		expect(preview.before?.blockingLabels).toContain("malware");
+		// The override negates the block, so `after` no longer blocks on it — the
+		// negated block shows as a superseded label, not a suppressed one.
+		expect(preview.supersedes.map((s) => s.val)).toContain("malware");
+		expect(preview.after?.eligibility).toBe("eligible");
+		expect(preview.after?.reasonCodes).toContain("eligible-manual-override");
+		expect(preview.after?.blockingLabels).not.toContain("malware");
+	});
+});

--- a/apps/labeler/test/console-assessment-mutations.test.ts
+++ b/apps/labeler/test/console-assessment-mutations.test.ts
@@ -365,6 +365,40 @@ describe("rerun", () => {
 		).toBe(1);
 	});
 
+	it("503s and creates no run when the batch is suppressed mid-commit", async () => {
+		const { id, uri } = await seedRun("rerun-phantom");
+		const key = nextKey();
+		const body = { confirmation: CID, reason: "rotation lands mid-rerun", idempotencyKey: key };
+		const suppressed = new Proxy(testEnv.DB, {
+			get(target, prop, receiver) {
+				if (prop === "batch")
+					return (statements: D1PreparedStatement[]) => target.batch([statements[0]!]);
+				const value: unknown = Reflect.get(target, prop, receiver);
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		});
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, body),
+			mutationDeps({ db: suppressed }),
+		);
+		expect(response.status).toBe(503);
+		expect((await bodyError(response)).code).toBe("LABEL_ISSUANCE_UNAVAILABLE");
+		// Audit row committed (unguarded), but no fresh run and no re-pend.
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
+		).toBe(1);
+		expect(await countRows(`SELECT COUNT(*) n FROM assessments WHERE uri = ?`, uri)).toBe(1);
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("assessment-pending")?.active ?? false).toBe(false);
+
+		// Replay reconstructs the pending key and re-runs the persistence check.
+		const retry = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, body),
+			mutationDeps(),
+		);
+		expect(retry.status).toBe(503);
+	});
+
 	it("rejects a confirmation that is not the release CID", async () => {
 		const { id } = await seedRun("rerun-conf");
 		const response = await handleConsoleMutation(
@@ -691,6 +725,53 @@ describe("override-retract", () => {
 		expect(rerun.status).toBe(200);
 		const after = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
 		expect(after.get("assessment-pending")?.active).toBe(true);
+	});
+
+	it("rejects a confirmation that is not the release CID", async () => {
+		const { id, uri } = await seedRun("retract-conf");
+		await seedAutomatedBlock(uri, id, "malware");
+		expect((await override(id, uri, ["malware"])).status).toBe(200);
+
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override-retract`, {
+				confirmation: "not-the-cid",
+				reason: "bad confirm",
+				idempotencyKey: nextKey(),
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("CONFIRMATION_MISMATCH");
+		// The pair is untouched.
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("assessment-overridden")?.active).toBe(true);
+	});
+
+	it("409s the same key with a different fingerprint", async () => {
+		const { id, uri } = await seedRun("retract-conflict");
+		await seedAutomatedBlock(uri, id, "malware");
+		expect((await override(id, uri, ["malware"])).status).toBe(200);
+
+		const key = nextKey();
+		const first = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override-retract`, {
+				confirmation: CID,
+				reason: "first",
+				idempotencyKey: key,
+			}),
+			mutationDeps(),
+		);
+		expect(first.status).toBe(200);
+		const second = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/override-retract`, {
+				confirmation: CID,
+				reason: "different reason",
+				idempotencyKey: key,
+			}),
+			mutationDeps(),
+		);
+		expect(second.status).toBe(409);
+		expect((await bodyError(second)).code).toBe("IDEMPOTENCY_KEY_CONFLICT");
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Adds plan item W9.5 — two reviewer actions on an assessment: **re-run** and **false-positive override**. Both go through the W9.2 mutation guard and commit their label rows atomically with the operator audit row in a single `commitMutation` batch.

**Re-run** (`POST /admin/api/assessments/{id}/rerun`) advances a settled assessment back to `pending` (`advanceAssessmentToPending`) so the pipeline re-evaluates it. Per the ratified decision, rerun-to-pending is accepted as-is — no attempt to diff against the prior run.

**False-positive override** (`POST /admin/api/assessments/{id}/override`) is the interesting one: it negates **every live automated block** on the subject and issues the eligibility pair (`assessment-passed` + `assessment-overridden`) in **one atomic batch**. `prepareOverrideIssuance` signs the N block-negations via `buildIssuanceStatements` directly and the eligibility pair through the manual issuance path, each piece keyed distinctly (`${actionId}:${val}:${neg ? "neg" : "pos"}`) so replay and race-loser skipping stay deterministic across the whole multi-label set. Override permanence (§10) needs no evaluator change: a later automated block is still *emitted* but resolves inert because the pass/override pair outranks it, and `assertAutomatedNegationAllowed` refuses any automation attempt to negate the human pass.

Ratified decisions folded in (2026-07-13):

1. **Rerun-to-pending accepted** — re-running simply re-queues; no prior-run diffing.
2. **Override negates all live blocks, server-validated confirmation** — the operator retypes the exact CID, validated server-side and folded into the idempotency fingerprint; the override is CID-bound.
3. **Override-retract leaves blocks negated** — retracting the override does *not* resurrect the negated automated blocks; the subject settles into a **safe-blocked** resting state (blocks negated, no eligibility) rather than snapping back to blocked.

Correctness and guarding:

- **No phantom success, generalized to N labels.** The W9.4 audit-without-label guard is now `assertIssuancePersisted(string[])`, applied symmetrically on **both** the proceed and replay paths. If a signing-key rotation raced such that the guarded issuance INSERTs matched zero rows while the unguarded audit row committed, the handler returns `LABEL_ISSUANCE_UNAVAILABLE` (503, retryable) instead of a 200 that falsely claims the release is cleared.
- **Subject+CID label read** (`getActiveLabelState`) surfaces manual and override labels in the console's assessment/subject views, so a reviewer sees the true resting state before and after acting.

Console: an override dialog and a rerun/action dialog on assessment detail, with the typed-CID confirmation, client-generated ULID idempotency keys, and 409/503 surfaced as retryable. Plain English strings (the console is not localized, per the W9.3 decision).

**Adversarially reviewed** by an independent Opus pass focused on the multi-label atomic composition, the §10 automated-negation-proof property, replay determinism across the N+2 statement set, and unauthenticated/under-privileged reach. Verdict: **no blockers** — the signing crown jewels hold. Its one finding was a test-honesty gap: the override endpoint had no test proving it rejects an unauthenticated (401) or under-privileged (403) caller *before* signing. That test is added, asserting zero side effects (no audit row, no eligibility label, block untouched) on both rejection paths.

Three **informational** notes it raised, **not** addressed here (surfaced for a call, none security-impacting):

1. **Rerun has no rate limit** — a reviewer could re-queue repeatedly. Reviewer-gated and idempotency-keyed, but a per-subject cooldown is worth considering as a later hardening pass.
2. **Stuck-503 within a dialog session** (inherited from W9.4) — if the phantom-success guard fires, retrying the *same* idempotency key keeps returning 503; recovery is a fresh key, which the console mints on dialog reopen.
3. **Rerun replay reconstructs its pending key from `MODERATION_POLICY.policyVersion`** — a policy-version bump between the original commit and a replay would spuriously 503. Static within a deploy, so low risk; noted rather than defended.

Stacked directly on the integration branch (W9.1–W9.4 merged). Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — no admin UI; the labeler console is deliberately not localized (decision 2026-07-13). Changeset n/a — `apps/labeler` is a private, unpublished Worker app; the policy fixture it bundles is internal.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Claude Fable 5 (coordination), Opus 4.8 subagents (design, implementation, adversarial review)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker **459 pass** (26 files — the `console-assessment-mutations` suite covers rerun-to-pending, multi-block atomic override, the eligibility pair, override permanence (§10), override-retract → safe-blocked, replay determinism, the 503 suppression guard on both paths, and the new override-authorization rejections), console **20 pass**
- Typecheck (both projects) clean; `console:build` succeeds; lint: 0 diagnostics in `apps/labeler`

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-override-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-override`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
