### PR TITLE
feat(labeler): operational events, outbox, and automation kill-switch (W9.6 PR-0)

### DIFF
--- a/apps/labeler/migrations/0005_operational_events.sql
+++ b/apps/labeler/migrations/0005_operational_events.sql
@@ -46,6 +46,8 @@ END;
 CREATE INDEX idx_operational_events_created ON operational_events(created_at_epoch_ms DESC);
 CREATE INDEX idx_operational_events_severity
 	ON operational_events(severity, created_at_epoch_ms DESC);
+CREATE INDEX idx_operational_events_action ON operational_events(action_id)
+	WHERE action_id IS NOT NULL;
 
 CREATE TABLE notification_outbox (
 	id TEXT PRIMARY KEY,
@@ -61,6 +63,7 @@ CREATE TABLE notification_outbox (
 
 CREATE INDEX idx_notification_outbox_pending
 	ON notification_outbox(state, created_at_epoch_ms) WHERE state = 'pending';
+CREATE INDEX idx_notification_outbox_event ON notification_outbox(event_id);
 
 CREATE TABLE automation_state (
 	id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -80,3 +83,5 @@ ALTER TABLE dead_letters ADD COLUMN resolved_at TEXT;
 ALTER TABLE dead_letters ADD COLUMN resolved_by_action_id TEXT REFERENCES operator_actions(id);
 
 CREATE INDEX idx_dead_letters_status ON dead_letters(status, received_at);
+CREATE INDEX idx_dead_letters_resolved_action ON dead_letters(resolved_by_action_id)
+	WHERE resolved_by_action_id IS NOT NULL;

--- a/apps/labeler/migrations/0005_operational_events.sql
+++ b/apps/labeler/migrations/0005_operational_events.sql
@@ -1,0 +1,82 @@
+-- Operational-alert subsystem (spec §11.3/§18.2/§22). Three concerns land
+-- together so later W9.6 PRs are code-only:
+--
+--   * `operational_events`  — append-only operator/deployment alert stream,
+--     the source of truth W11.3 alarms read (severity IN ('critical','high')).
+--     Distinct from `operator_actions` (who did what) and the publisher-facing
+--     `notifications` table (W10). Written atomically with the operator_actions
+--     row + the effect by `commitMutation`; immutable like the other audit logs.
+--   * `notification_outbox` — mutable per-(event, channel) delivery state W11.3
+--     drains and flips. Mirrors the operator_actions(immutable)/notifications
+--     (mutable) split: a delivery failure never rolls back the event or label.
+--   * `automation_state`    — the singleton ingestion kill-switch (id = 1,
+--     mirroring `signing_state`), checked by the discovery consumer.
+--
+-- The `dead_letters` ALTERs (forward-only, additive) give operators retry /
+-- quarantine controls without recreating the table.
+--
+-- Timestamp columns that queries order on gain an integer `*_epoch_ms`
+-- sibling, matching 0003/0004 (RFC 3339 strings compare incorrectly across
+-- timezone offsets in SQL).
+
+CREATE TABLE operational_events (
+	id TEXT PRIMARY KEY,
+	event_type TEXT NOT NULL,
+	severity TEXT NOT NULL CHECK (severity IN ('critical', 'high', 'info')),
+	action_id TEXT REFERENCES operator_actions(id),
+	subject_uri TEXT,
+	label_value TEXT,
+	payload_json TEXT NOT NULL DEFAULT '{}',
+	created_at TEXT NOT NULL,
+	created_at_epoch_ms INTEGER NOT NULL
+);
+
+CREATE TRIGGER operational_events_immutable_update
+BEFORE UPDATE ON operational_events
+BEGIN
+	SELECT RAISE(ABORT, 'operational events are immutable');
+END;
+
+CREATE TRIGGER operational_events_immutable_delete
+BEFORE DELETE ON operational_events
+BEGIN
+	SELECT RAISE(ABORT, 'operational events are immutable');
+END;
+
+CREATE INDEX idx_operational_events_created ON operational_events(created_at_epoch_ms DESC);
+CREATE INDEX idx_operational_events_severity
+	ON operational_events(severity, created_at_epoch_ms DESC);
+
+CREATE TABLE notification_outbox (
+	id TEXT PRIMARY KEY,
+	event_id TEXT NOT NULL REFERENCES operational_events(id),
+	channel TEXT NOT NULL,
+	state TEXT NOT NULL DEFAULT 'pending' CHECK (state IN ('pending', 'sent', 'failed')),
+	attempts INTEGER NOT NULL DEFAULT 0,
+	last_error TEXT,
+	created_at TEXT NOT NULL,
+	created_at_epoch_ms INTEGER NOT NULL,
+	sent_at TEXT
+);
+
+CREATE INDEX idx_notification_outbox_pending
+	ON notification_outbox(state, created_at_epoch_ms) WHERE state = 'pending';
+
+CREATE TABLE automation_state (
+	id INTEGER PRIMARY KEY CHECK (id = 1),
+	paused INTEGER NOT NULL DEFAULT 0 CHECK (paused IN (0, 1)),
+	paused_reason TEXT,
+	paused_by_action_id TEXT REFERENCES operator_actions(id),
+	updated_at TEXT NOT NULL,
+	updated_at_epoch_ms INTEGER NOT NULL
+);
+
+INSERT INTO automation_state (id, paused, updated_at, updated_at_epoch_ms)
+	VALUES (1, 0, '1970-01-01T00:00:00.000Z', 0);
+
+ALTER TABLE dead_letters ADD COLUMN status TEXT NOT NULL DEFAULT 'new'
+	CHECK (status IN ('new', 'retried', 'quarantined'));
+ALTER TABLE dead_letters ADD COLUMN resolved_at TEXT;
+ALTER TABLE dead_letters ADD COLUMN resolved_by_action_id TEXT REFERENCES operator_actions(id);
+
+CREATE INDEX idx_dead_letters_status ON dead_letters(status, received_at);

--- a/apps/labeler/src/automation-state.ts
+++ b/apps/labeler/src/automation-state.ts
@@ -1,0 +1,65 @@
+/**
+ * Global automation kill-switch (spec §11.3). A single `automation_state` row
+ * (`id = 1`, seeded by migration 0005) gates the discovery consumer's ingestion
+ * path; manual/admin issuance is never gated by it, so an emergency `!takedown`
+ * stays issuable during an incident.
+ */
+
+/**
+ * Raised when the pause flag cannot be read (missing singleton row or a D1
+ * error). The discovery consumer maps this to retry — automation must never
+ * issue past an unreadable switch, so the read fails closed.
+ */
+export class AutomationStateUnavailableError extends Error {
+	override readonly name = "AutomationStateUnavailableError";
+}
+
+export interface AutomationPauseUpdate {
+	paused: boolean;
+	reason: string | null;
+	actionId: string;
+	now: Date;
+}
+
+/**
+ * Reads the kill-switch. Fails closed: a missing singleton row or a read error
+ * throws rather than reporting "not paused", so the ingestion path can only
+ * proceed on a positive, successful read of `paused = 0`.
+ */
+export async function isAutomationPaused(db: D1Database): Promise<boolean> {
+	let row: { paused: number } | null;
+	try {
+		row = await db
+			.prepare(`SELECT paused FROM automation_state WHERE id = 1`)
+			.first<{ paused: number }>();
+	} catch (error) {
+		throw new AutomationStateUnavailableError("automation_state is unreadable", { cause: error });
+	}
+	if (!row) throw new AutomationStateUnavailableError("automation_state singleton row is missing");
+	return row.paused === 1;
+}
+
+/**
+ * Effect statement for a pause or resume. Idempotent — pausing an already-paused
+ * switch is a harmless re-write. Batched with the operator_actions row (and, for
+ * a pause, an `automation-paused` operational event) by `commitMutation`.
+ */
+export function buildAutomationPauseUpdate(
+	db: D1Database,
+	input: AutomationPauseUpdate,
+): D1PreparedStatement {
+	return db
+		.prepare(
+			`UPDATE automation_state
+			 SET paused = ?, paused_reason = ?, paused_by_action_id = ?,
+			     updated_at = ?, updated_at_epoch_ms = ?
+			 WHERE id = 1`,
+		)
+		.bind(
+			input.paused ? 1 : 0,
+			input.reason,
+			input.actionId,
+			input.now.toISOString(),
+			input.now.getTime(),
+		);
+}

--- a/apps/labeler/src/discovery-consumer.ts
+++ b/apps/labeler/src/discovery-consumer.ts
@@ -45,6 +45,7 @@ import {
 	transitionAssessmentState,
 	type Assessment,
 } from "./assessment-store.js";
+import { AutomationStateUnavailableError, isAutomationPaused } from "./automation-state.js";
 import { getLabelerIdentityConfig, type LabelerConfig } from "./config.js";
 import type { DiscoveryJob } from "./env.js";
 import {
@@ -223,10 +224,33 @@ export async function processDiscoveryMessage(
 	}
 
 	try {
+		if (await readAutomationPaused(deps.db)) {
+			// Ingestion is paused (spec §11.3): retry so the event isn't lost —
+			// resume re-drives it. Manual/admin issuance stays available because
+			// the switch is checked here, not in the signing layer.
+			controller.retry();
+			return;
+		}
 		await verifyAndCreateRun(uri, job, deps, now());
 		controller.ack();
 	} catch (err) {
 		await classifyDiscoveryError(err, job, deps, controller, now());
+	}
+}
+
+/**
+ * Reads the automation kill-switch, failing closed: an unreadable switch
+ * becomes a `LabelIssuanceUnavailableError` so `classifyDiscoveryError` retries
+ * rather than letting ingestion issue past a switch it could not read.
+ */
+async function readAutomationPaused(db: D1Database): Promise<boolean> {
+	try {
+		return await isAutomationPaused(db);
+	} catch (err) {
+		if (err instanceof AutomationStateUnavailableError) {
+			throw new LabelIssuanceUnavailableError("automation pause state unreadable", { cause: err });
+		}
+		throw err;
 	}
 }
 

--- a/apps/labeler/src/operational-events.ts
+++ b/apps/labeler/src/operational-events.ts
@@ -1,0 +1,267 @@
+import { ulid } from "ulidx";
+
+/**
+ * The operational-alert vocabulary, grown by W9.6. Validated in app code (the
+ * mutation handlers are the only writers), so the `operational_events.event_type`
+ * column carries no SQL CHECK and each workstream stays purely additive.
+ */
+export type OperationalEventType =
+	| "emergency-takedown"
+	| "publisher-compromised"
+	| "automation-paused"
+	| "automation-resumed"
+	| "dead-letter-retried"
+	| "dead-letter-quarantined";
+
+export type OperationalEventSeverity = "critical" | "high" | "info";
+
+/**
+ * The alert deliverable's public-safe body (spec §18.2): subject URI and label
+ * value live in dedicated columns; this carries the operator reason only. It has
+ * no field for findings, private detail, or evidence refs — the type is the
+ * enforcement, so an event can never smuggle exploit detail into an outbound
+ * notification.
+ */
+export interface OperationalEventPayload {
+	reason?: string;
+}
+
+export interface OperationalEventInsert {
+	id: string;
+	eventType: OperationalEventType;
+	severity: OperationalEventSeverity;
+	actionId?: string | null;
+	subjectUri?: string | null;
+	labelValue?: string | null;
+	payload: OperationalEventPayload;
+	now: Date;
+	/**
+	 * When set, the INSERT becomes an `INSERT ... SELECT ... WHERE EXISTS` gated
+	 * on an `issued_labels` row carrying this `action_id`. Batched after the
+	 * label's issuance statements, the EXISTS sees the just-inserted label; if
+	 * that label was suppressed in-batch (a signing-state race), the event does
+	 * not insert either — so no alert fires for a label that never landed.
+	 */
+	gateOnIssuedLabelActionId?: number;
+}
+
+export interface OutboxInsert {
+	eventId: string;
+	channel: string;
+	now: Date;
+	/** Same in-batch label gating as {@link OperationalEventInsert}. */
+	gateOnIssuedLabelActionId?: number;
+}
+
+export interface StoredOperationalEvent {
+	id: string;
+	eventType: string;
+	severity: string;
+	actionId: string | null;
+	subjectUri: string | null;
+	labelValue: string | null;
+	payloadJson: string;
+	createdAt: string;
+	createdAtEpochMs: number;
+}
+
+export interface StoredOutboxEntry {
+	id: string;
+	eventId: string;
+	channel: string;
+	state: string;
+	attempts: number;
+	lastError: string | null;
+	createdAt: string;
+	createdAtEpochMs: number;
+	sentAt: string | null;
+}
+
+interface OperationalEventRow {
+	id: string;
+	event_type: string;
+	severity: string;
+	action_id: string | null;
+	subject_uri: string | null;
+	label_value: string | null;
+	payload_json: string;
+	created_at: string;
+	created_at_epoch_ms: number;
+}
+
+interface OutboxRow {
+	id: string;
+	event_id: string;
+	channel: string;
+	state: string;
+	attempts: number;
+	last_error: string | null;
+	created_at: string;
+	created_at_epoch_ms: number;
+	sent_at: string | null;
+}
+
+export function newOperationalEventId(): string {
+	return `oev_${ulid()}`;
+}
+
+export function newNotificationOutboxId(): string {
+	return `nob_${ulid()}`;
+}
+
+/**
+ * Insert for one operational event. Batched with the operator_actions row + the
+ * effect statements by `commitMutation`; never run alone for an issuance event.
+ * When `gateOnIssuedLabelActionId` is set the insert is gated on the label's
+ * in-batch existence (see {@link OperationalEventInsert}); otherwise it is a
+ * plain INSERT for events with no issued label (pause/resume, DLQ controls).
+ */
+export function buildOperationalEventInsert(
+	db: D1Database,
+	input: OperationalEventInsert,
+): D1PreparedStatement {
+	const columns = `id, event_type, severity, action_id, subject_uri, label_value,
+		 payload_json, created_at, created_at_epoch_ms`;
+	const values: (string | number | null)[] = [
+		input.id,
+		input.eventType,
+		input.severity,
+		input.actionId ?? null,
+		input.subjectUri ?? null,
+		input.labelValue ?? null,
+		JSON.stringify(input.payload),
+		input.now.toISOString(),
+		input.now.getTime(),
+	];
+
+	if (input.gateOnIssuedLabelActionId !== undefined) {
+		return db
+			.prepare(
+				`INSERT INTO operational_events (${columns})
+				 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
+				 WHERE EXISTS (SELECT 1 FROM issued_labels WHERE action_id = ?)`,
+			)
+			.bind(...values, input.gateOnIssuedLabelActionId);
+	}
+
+	return db
+		.prepare(
+			`INSERT INTO operational_events (${columns})
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(...values);
+}
+
+/**
+ * Insert for one delivery-queue row (one per event + channel). Gated identically
+ * to {@link buildOperationalEventInsert}: a signing-suppressed batch queues no
+ * notification. `state` and `attempts` fall to their column defaults.
+ */
+export function buildOutboxInsert(db: D1Database, input: OutboxInsert): D1PreparedStatement {
+	const values: (string | number)[] = [
+		newNotificationOutboxId(),
+		input.eventId,
+		input.channel,
+		input.now.toISOString(),
+		input.now.getTime(),
+	];
+
+	if (input.gateOnIssuedLabelActionId !== undefined) {
+		return db
+			.prepare(
+				`INSERT INTO notification_outbox (id, event_id, channel, created_at, created_at_epoch_ms)
+				 SELECT ?, ?, ?, ?, ?
+				 WHERE EXISTS (SELECT 1 FROM issued_labels WHERE action_id = ?)`,
+			)
+			.bind(...values, input.gateOnIssuedLabelActionId);
+	}
+
+	return db
+		.prepare(
+			`INSERT INTO notification_outbox (id, event_id, channel, created_at, created_at_epoch_ms)
+			 VALUES (?, ?, ?, ?, ?)`,
+		)
+		.bind(...values);
+}
+
+/** Operational-event page, newest first over `idx_operational_events_created`. */
+export async function getOperationalEvents(
+	db: D1Database,
+	options: { limit: number },
+): Promise<StoredOperationalEvent[]> {
+	const rows = await db
+		.prepare(
+			`SELECT id, event_type, severity, action_id, subject_uri, label_value,
+			 payload_json, created_at, created_at_epoch_ms
+			 FROM operational_events
+			 ORDER BY created_at_epoch_ms DESC, id DESC
+			 LIMIT ?`,
+		)
+		.bind(options.limit)
+		.all<OperationalEventRow>();
+	return (rows.results ?? []).map(rowToStoredEvent);
+}
+
+/** Events emitted by a single operator action, newest first. */
+export async function getOperationalEventsByActionId(
+	db: D1Database,
+	actionId: string,
+): Promise<StoredOperationalEvent[]> {
+	const rows = await db
+		.prepare(
+			`SELECT id, event_type, severity, action_id, subject_uri, label_value,
+			 payload_json, created_at, created_at_epoch_ms
+			 FROM operational_events
+			 WHERE action_id = ?
+			 ORDER BY created_at_epoch_ms DESC, id DESC`,
+		)
+		.bind(actionId)
+		.all<OperationalEventRow>();
+	return (rows.results ?? []).map(rowToStoredEvent);
+}
+
+/** Outbox rows for one event, oldest first. */
+export async function getOutboxForEvent(
+	db: D1Database,
+	eventId: string,
+): Promise<StoredOutboxEntry[]> {
+	const rows = await db
+		.prepare(
+			`SELECT id, event_id, channel, state, attempts, last_error,
+			 created_at, created_at_epoch_ms, sent_at
+			 FROM notification_outbox
+			 WHERE event_id = ?
+			 ORDER BY created_at_epoch_ms ASC, id ASC`,
+		)
+		.bind(eventId)
+		.all<OutboxRow>();
+	return (rows.results ?? []).map(rowToStoredOutbox);
+}
+
+function rowToStoredEvent(row: OperationalEventRow): StoredOperationalEvent {
+	return {
+		id: row.id,
+		eventType: row.event_type,
+		severity: row.severity,
+		actionId: row.action_id,
+		subjectUri: row.subject_uri,
+		labelValue: row.label_value,
+		payloadJson: row.payload_json,
+		createdAt: row.created_at,
+		createdAtEpochMs: row.created_at_epoch_ms,
+	};
+}
+
+function rowToStoredOutbox(row: OutboxRow): StoredOutboxEntry {
+	return {
+		id: row.id,
+		eventId: row.event_id,
+		channel: row.channel,
+		state: row.state,
+		attempts: row.attempts,
+		lastError: row.last_error,
+		createdAt: row.created_at,
+		createdAtEpochMs: row.created_at_epoch_ms,
+		sentAt: row.sent_at,
+	};
+}

--- a/apps/labeler/test/automation-state.test.ts
+++ b/apps/labeler/test/automation-state.test.ts
@@ -1,0 +1,110 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+	AutomationStateUnavailableError,
+	buildAutomationPauseUpdate,
+	isAutomationPaused,
+} from "../src/automation-state.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+const NOW = new Date("2026-07-13T00:00:00.000Z");
+const ACTION_ID = "oact_automationtest";
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+	await insertOperatorAction(ACTION_ID);
+});
+
+afterEach(async () => {
+	await buildAutomationPauseUpdate(testEnv.DB, {
+		paused: false,
+		reason: null,
+		actionId: ACTION_ID,
+		now: NOW,
+	}).run();
+});
+
+/** Seeds an `operator_actions` row so pause/resume FK references resolve. */
+async function insertOperatorAction(id: string): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO operator_actions
+		 (id, actor_type, actor_id, role, action, reason, idempotency_key,
+		  request_fingerprint, created_at, created_at_epoch_ms)
+		 VALUES (?, 'human', 'u', 'admin', 'pause-issuance', 'r', ?, 'fp',
+		         '2026-07-13T00:00:00.000Z', 0)`,
+	)
+		.bind(id, `key-${id}`)
+		.run();
+}
+
+describe("isAutomationPaused", () => {
+	it("reads false for the seeded (unpaused) singleton row", async () => {
+		expect(await isAutomationPaused(testEnv.DB)).toBe(false);
+	});
+
+	it("round-trips a pause and a resume through the update builder", async () => {
+		await buildAutomationPauseUpdate(testEnv.DB, {
+			paused: true,
+			reason: "incident-42",
+			actionId: ACTION_ID,
+			now: NOW,
+		}).run();
+		expect(await isAutomationPaused(testEnv.DB)).toBe(true);
+
+		const paused = await testEnv.DB.prepare(
+			`SELECT paused, paused_reason, paused_by_action_id FROM automation_state WHERE id = 1`,
+		).first<{ paused: number; paused_reason: string; paused_by_action_id: string }>();
+		expect(paused).toEqual({
+			paused: 1,
+			paused_reason: "incident-42",
+			paused_by_action_id: ACTION_ID,
+		});
+
+		await buildAutomationPauseUpdate(testEnv.DB, {
+			paused: false,
+			reason: null,
+			actionId: ACTION_ID,
+			now: NOW,
+		}).run();
+		expect(await isAutomationPaused(testEnv.DB)).toBe(false);
+	});
+
+	it("fails closed when the singleton row is missing", async () => {
+		await testEnv.DB.prepare(`DELETE FROM automation_state WHERE id = 1`).run();
+		try {
+			await expect(isAutomationPaused(testEnv.DB)).rejects.toBeInstanceOf(
+				AutomationStateUnavailableError,
+			);
+		} finally {
+			await testEnv.DB.prepare(
+				`INSERT INTO automation_state (id, paused, updated_at, updated_at_epoch_ms)
+				 VALUES (1, 0, '1970-01-01T00:00:00.000Z', 0)`,
+			).run();
+		}
+	});
+
+	it("fails closed when the read throws", async () => {
+		const brokenDb = {
+			prepare() {
+				return {
+					bind() {
+						return this;
+					},
+					first(): Promise<never> {
+						return Promise.reject(new Error("D1_ERROR: connection lost"));
+					},
+				};
+			},
+		} as unknown as D1Database;
+
+		await expect(isAutomationPaused(brokenDb)).rejects.toBeInstanceOf(
+			AutomationStateUnavailableError,
+		);
+	});
+});

--- a/apps/labeler/test/discovery-consumer.test.ts
+++ b/apps/labeler/test/discovery-consumer.test.ts
@@ -6,7 +6,7 @@ import {
 	type LabelSigner,
 } from "@emdash-cms/registry-moderation";
 import { applyD1Migrations, env } from "cloudflare:test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import {
 	automatedIdempotencyKey,
@@ -14,6 +14,7 @@ import {
 	initialTriggerId,
 } from "../src/assessment-lifecycle.js";
 import { getAssessmentByRunKey, getCurrentAssessment } from "../src/assessment-store.js";
+import { buildAutomationPauseUpdate } from "../src/automation-state.js";
 import {
 	type DiscoveryConsumerDeps,
 	type MessageController,
@@ -567,5 +568,118 @@ describe("getCurrentAssessment", () => {
 			cid: job.cid,
 		});
 		expect(pointer).toBeNull();
+	});
+});
+
+describe("processDiscoveryMessage: automation kill-switch", () => {
+	const NOW = new Date("2026-07-13T00:00:00.000Z");
+	const ACTION_ID = "oact_pausetest";
+
+	beforeAll(async () => {
+		await testEnv.DB.prepare(
+			`INSERT INTO operator_actions
+			 (id, actor_type, actor_id, role, action, reason, idempotency_key,
+			  request_fingerprint, created_at, created_at_epoch_ms)
+			 VALUES (?, 'human', 'u', 'admin', 'pause-issuance', 'r', ?, 'fp',
+			         '2026-07-13T00:00:00.000Z', 0)`,
+		)
+			.bind(ACTION_ID, `key-${ACTION_ID}`)
+			.run();
+	});
+
+	async function setPaused(paused: boolean): Promise<void> {
+		await buildAutomationPauseUpdate(testEnv.DB, {
+			paused,
+			reason: paused ? "incident" : null,
+			actionId: ACTION_ID,
+			now: NOW,
+		}).run();
+	}
+
+	afterEach(async () => {
+		await setPaused(false);
+	});
+
+	it("retries and creates no run while ingestion is paused", async () => {
+		const job = await jobFor({ rkey: rkey() });
+		const deps = await buildDeps();
+		const msg = new FakeMessage();
+		await setPaused(true);
+
+		await processDiscoveryMessage(job, msg, { ...deps, verify: verifiedFor(job) });
+
+		expect(msg.retried).toBe(1);
+		expect(msg.acked).toBe(0);
+		const subject = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM subjects WHERE uri = ?`)
+			.bind(uriFor(job))
+			.first<{ n: number }>();
+		expect(subject?.n).toBe(0);
+	});
+
+	it("processes normally once resumed", async () => {
+		const job = await jobFor({ rkey: rkey() });
+		const deps = await buildDeps();
+
+		await setPaused(true);
+		const first = new FakeMessage();
+		await processDiscoveryMessage(job, first, { ...deps, verify: verifiedFor(job) });
+		expect(first.retried).toBe(1);
+
+		await setPaused(false);
+		const second = new FakeMessage();
+		await processDiscoveryMessage(job, second, { ...deps, verify: verifiedFor(job) });
+
+		expect(second.acked).toBe(1);
+		expect(second.retried).toBe(0);
+		const assessment = await getAssessmentByRunKey(testEnv.DB, await runKeyFor(job));
+		expect(assessment?.state).toBe("pending");
+	});
+
+	it("retries when the switch is unreadable (fails closed)", async () => {
+		const job = await jobFor({ rkey: rkey() });
+		const deps = await buildDeps();
+		const msg = new FakeMessage();
+		await testEnv.DB.prepare(`DELETE FROM automation_state WHERE id = 1`).run();
+
+		try {
+			await processDiscoveryMessage(job, msg, { ...deps, verify: verifiedFor(job) });
+			expect(msg.retried).toBe(1);
+			expect(msg.acked).toBe(0);
+			const subject = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM subjects WHERE uri = ?`)
+				.bind(uriFor(job))
+				.first<{ n: number }>();
+			expect(subject?.n).toBe(0);
+		} finally {
+			await testEnv.DB.prepare(
+				`INSERT INTO automation_state (id, paused, updated_at, updated_at_epoch_ms)
+				 VALUES (1, 0, '1970-01-01T00:00:00.000Z', 0)`,
+			).run();
+		}
+	});
+
+	it("does not gate the delete branch while ingestion is paused", async () => {
+		const job = await jobFor({ rkey: rkey() });
+		const deps = await buildDeps();
+		await processDiscoveryMessage(job, new FakeMessage(), { ...deps, verify: verifiedFor(job) });
+
+		await setPaused(true);
+		const deleteJob: DiscoveryJob = { ...job, operation: "delete", cid: "" };
+		const msg = new FakeMessage();
+		await processDiscoveryMessage(deleteJob, msg, {
+			...deps,
+			confirmDeleted: () => Promise.resolve(true),
+		});
+
+		expect(msg.acked).toBe(1);
+		expect(msg.retried).toBe(0);
+		const after = await getAssessmentByRunKey(testEnv.DB, await runKeyFor(job));
+		expect(after?.state).toBe("cancelled");
+		const negated = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels
+			 WHERE uri = ? AND val = 'assessment-pending' ORDER BY sequence DESC LIMIT 1`,
+		)
+			.bind(uriFor(job))
+			.first<{ neg: number }>();
+		expect(negated?.neg).toBe(1);
 	});
 });

--- a/apps/labeler/test/operational-events.test.ts
+++ b/apps/labeler/test/operational-events.test.ts
@@ -1,0 +1,282 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+	buildOperationalEventInsert,
+	buildOutboxInsert,
+	getOperationalEvents,
+	getOperationalEventsByActionId,
+	getOutboxForEvent,
+	newOperationalEventId,
+	type OperationalEventInsert,
+} from "../src/operational-events.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+let counter = 0;
+
+function eventInput(overrides: Partial<OperationalEventInsert> = {}): OperationalEventInsert {
+	counter++;
+	return {
+		id: newOperationalEventId(),
+		eventType: "emergency-takedown",
+		severity: "critical",
+		actionId: null,
+		subjectUri: `did:plc:publisher${counter}`,
+		labelValue: "!takedown",
+		payload: { reason: `incident ${counter}` },
+		now: new Date("2026-07-13T00:00:00.000Z"),
+		...overrides,
+	};
+}
+
+/** Seeds an `operator_actions` row so an event's `action_id` FK resolves. */
+async function insertOperatorAction(id: string): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO operator_actions
+		 (id, actor_type, actor_id, role, action, reason, idempotency_key,
+		  request_fingerprint, created_at, created_at_epoch_ms)
+		 VALUES (?, 'human', 'u', 'admin', 'takedown', 'r', ?, 'fp',
+		         '2026-07-13T00:00:00.000Z', 0)`,
+	)
+		.bind(id, `key-${id}`)
+		.run();
+}
+
+/**
+ * Inserts an `issued_labels` row (via its `issuance_actions` parent) carrying
+ * the given `action_id`, so the gated builders' `WHERE EXISTS` sees a label.
+ */
+async function insertIssuedLabel(actionId: number): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO issuance_actions (id, actor, type, reason, idempotency_key, created_at)
+		 VALUES (?, ?, 'manual-label', 'takedown', ?, '2026-07-13T00:00:00.000Z')`,
+	)
+		.bind(actionId, "did:web:labels.emdashcms.com", `gate-key-${actionId}`)
+		.run();
+	await testEnv.DB.prepare(
+		`INSERT INTO issued_labels (action_id, ver, src, uri, val, cts, sig, signing_key_id)
+		 VALUES (?, 1, 'did:web:labels.emdashcms.com', 'did:plc:sub', '!takedown',
+		         '2026-07-13T00:00:00.000Z', X'00', 'did:web:labels.emdashcms.com#atproto_label')`,
+	)
+		.bind(actionId)
+		.run();
+}
+
+describe("operational_events store", () => {
+	it("inserts and reads back an event newest-first", async () => {
+		const input = eventInput({ severity: "high", eventType: "automation-paused" });
+		await buildOperationalEventInsert(testEnv.DB, input).run();
+
+		const [stored] = await getOperationalEvents(testEnv.DB, { limit: 1 });
+		expect(stored).toMatchObject({
+			id: input.id,
+			eventType: "automation-paused",
+			severity: "high",
+			subjectUri: input.subjectUri,
+			labelValue: "!takedown",
+			payloadJson: JSON.stringify(input.payload),
+		});
+	});
+
+	it("stores a null action_id, subject, and label for a system event", async () => {
+		const input = eventInput({
+			eventType: "automation-resumed",
+			severity: "info",
+			actionId: null,
+			subjectUri: null,
+			labelValue: null,
+			payload: {},
+		});
+		await buildOperationalEventInsert(testEnv.DB, input).run();
+
+		const [stored] = await getOperationalEvents(testEnv.DB, { limit: 1 });
+		expect(stored).toMatchObject({
+			actionId: null,
+			subjectUri: null,
+			labelValue: null,
+			payloadJson: "{}",
+		});
+	});
+
+	it("reads events by action id", async () => {
+		const actionId = `oact_events${counter}`;
+		const otherId = `oact_other${counter}`;
+		await insertOperatorAction(actionId);
+		await insertOperatorAction(otherId);
+		await buildOperationalEventInsert(testEnv.DB, eventInput({ actionId })).run();
+		await buildOperationalEventInsert(testEnv.DB, eventInput({ actionId })).run();
+		await buildOperationalEventInsert(testEnv.DB, eventInput({ actionId: otherId })).run();
+
+		const rows = await getOperationalEventsByActionId(testEnv.DB, actionId);
+		expect(rows).toHaveLength(2);
+		expect(rows.every((r) => r.actionId === actionId)).toBe(true);
+	});
+
+	it("rejects UPDATE on a recorded event (immutable log)", async () => {
+		const input = eventInput();
+		await buildOperationalEventInsert(testEnv.DB, input).run();
+
+		await expect(
+			testEnv.DB.prepare("UPDATE operational_events SET severity = 'info' WHERE id = ?")
+				.bind(input.id)
+				.run(),
+		).rejects.toThrow(/immutable/);
+	});
+
+	it("rejects DELETE on a recorded event (immutable log)", async () => {
+		const input = eventInput();
+		await buildOperationalEventInsert(testEnv.DB, input).run();
+
+		await expect(
+			testEnv.DB.prepare("DELETE FROM operational_events WHERE id = ?").bind(input.id).run(),
+		).rejects.toThrow(/immutable/);
+	});
+});
+
+describe("label-gated event + outbox inserts", () => {
+	it("inserts the event and outbox row when the gated label exists", async () => {
+		const gateActionId = 8001;
+		await insertIssuedLabel(gateActionId);
+
+		const input = eventInput({ gateOnIssuedLabelActionId: gateActionId });
+		await buildOperationalEventInsert(testEnv.DB, input).run();
+		await buildOutboxInsert(testEnv.DB, {
+			eventId: input.id,
+			channel: "deployment-alert",
+			now: input.now,
+			gateOnIssuedLabelActionId: gateActionId,
+		}).run();
+
+		const eventCount = await testEnv.DB.prepare(
+			`SELECT COUNT(*) AS n FROM operational_events WHERE id = ?`,
+		)
+			.bind(input.id)
+			.first<{ n: number }>();
+		expect(eventCount?.n).toBe(1);
+
+		const outbox = await getOutboxForEvent(testEnv.DB, input.id);
+		expect(outbox).toHaveLength(1);
+		expect(outbox[0]).toMatchObject({
+			eventId: input.id,
+			channel: "deployment-alert",
+			state: "pending",
+			attempts: 0,
+		});
+	});
+
+	it("inserts neither event nor outbox row when the gated label is absent", async () => {
+		const gateActionId = 9999; // no issued_labels row references this
+		const input = eventInput({ gateOnIssuedLabelActionId: gateActionId });
+
+		await buildOperationalEventInsert(testEnv.DB, input).run();
+		await buildOutboxInsert(testEnv.DB, {
+			eventId: input.id,
+			channel: "deployment-alert",
+			now: input.now,
+			gateOnIssuedLabelActionId: gateActionId,
+		}).run();
+
+		const eventCount = await testEnv.DB.prepare(
+			`SELECT COUNT(*) AS n FROM operational_events WHERE id = ?`,
+		)
+			.bind(input.id)
+			.first<{ n: number }>();
+		expect(eventCount?.n).toBe(0);
+
+		const outbox = await getOutboxForEvent(testEnv.DB, input.id);
+		expect(outbox).toHaveLength(0);
+	});
+
+	it("sees a label inserted earlier in the same db.batch", async () => {
+		const gateActionId = 8100;
+		// Parent issuance_actions row is committed first; the issued_labels insert
+		// itself rides in the same batch as the gated event + outbox, so the
+		// EXISTS must observe an in-batch (uncommitted) sibling insert.
+		await testEnv.DB.prepare(
+			`INSERT INTO issuance_actions (id, actor, type, reason, idempotency_key, created_at)
+			 VALUES (?, ?, 'manual-label', 'takedown', ?, '2026-07-13T00:00:00.000Z')`,
+		)
+			.bind(gateActionId, "did:web:labels.emdashcms.com", `batch-key-${gateActionId}`)
+			.run();
+
+		const input = eventInput({ gateOnIssuedLabelActionId: gateActionId });
+		await testEnv.DB.batch([
+			testEnv.DB.prepare(
+				`INSERT INTO issued_labels (action_id, ver, src, uri, val, cts, sig, signing_key_id)
+				 VALUES (?, 1, 'did:web:labels.emdashcms.com', 'did:plc:sub', '!takedown',
+				         '2026-07-13T00:00:00.000Z', X'00', 'did:web:labels.emdashcms.com#atproto_label')`,
+			).bind(gateActionId),
+			buildOperationalEventInsert(testEnv.DB, input),
+			buildOutboxInsert(testEnv.DB, {
+				eventId: input.id,
+				channel: "deployment-alert",
+				now: input.now,
+				gateOnIssuedLabelActionId: gateActionId,
+			}),
+		]);
+
+		const eventCount = await testEnv.DB.prepare(
+			`SELECT COUNT(*) AS n FROM operational_events WHERE id = ?`,
+		)
+			.bind(input.id)
+			.first<{ n: number }>();
+		expect(eventCount?.n).toBe(1);
+		expect(await getOutboxForEvent(testEnv.DB, input.id)).toHaveLength(1);
+	});
+
+	it("inserts neither row when the label is suppressed within the same db.batch", async () => {
+		const gateActionId = 8200; // no issued_labels insert rides in the batch
+		const input = eventInput({ gateOnIssuedLabelActionId: gateActionId });
+		await testEnv.DB.batch([
+			buildOperationalEventInsert(testEnv.DB, input),
+			buildOutboxInsert(testEnv.DB, {
+				eventId: input.id,
+				channel: "deployment-alert",
+				now: input.now,
+				gateOnIssuedLabelActionId: gateActionId,
+			}),
+		]);
+
+		const eventCount = await testEnv.DB.prepare(
+			`SELECT COUNT(*) AS n FROM operational_events WHERE id = ?`,
+		)
+			.bind(input.id)
+			.first<{ n: number }>();
+		expect(eventCount?.n).toBe(0);
+		expect(await getOutboxForEvent(testEnv.DB, input.id)).toHaveLength(0);
+	});
+});
+
+describe("dead_letters operational columns (0005)", () => {
+	it("defaults status to 'new' with null resolution columns", async () => {
+		await testEnv.DB.prepare(
+			`INSERT INTO dead_letters (did, collection, rkey, reason, payload, received_at)
+			 VALUES ('did:plc:x', 'com.example', 'r1', 'UNEXPECTED_ERROR', X'00', '2026-07-13T00:00:00.000Z')`,
+		).run();
+
+		const row = await testEnv.DB.prepare(
+			`SELECT status, resolved_at, resolved_by_action_id FROM dead_letters
+			 WHERE reason = 'UNEXPECTED_ERROR' AND rkey = 'r1'`,
+		).first<{ status: string; resolved_at: string | null; resolved_by_action_id: string | null }>();
+		expect(row).toEqual({ status: "new", resolved_at: null, resolved_by_action_id: null });
+	});
+
+	it("rejects an out-of-domain status", async () => {
+		await expect(
+			testEnv.DB.prepare(
+				`INSERT INTO dead_letters (did, collection, rkey, reason, payload, received_at, status)
+				 VALUES ('did:plc:x', 'com.example', 'r2', 'UNEXPECTED_ERROR', X'00', '2026-07-13T00:00:00.000Z', 'bogus')`,
+			).run(),
+		).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

First of the W9.6 (admin-only emergency actions) PRs: the **backend foundation** the takedown, pause/resume, and dead-letter controls build on. No endpoints, no console changes — schema and builders only, plus the one enforcement point that belongs with the schema.

Migration `0005_operational_events.sql` (conventions from `0004`):

- **`operational_events`** — the append-only high-severity alert stream (immutability triggers reject UPDATE/DELETE). This is the source of truth W11.3 wires deployment alarms onto; distinct from `operator_actions` (who did what) and the publisher-facing notifications (W10). `payload_json` is typed as `{ reason?: string }` — no field for private evidence exists (spec §18.2).
- **`notification_outbox`** — mutable per-(event, channel) delivery state W11.3 drains; a delivery failure never rolls back the event or the label.
- **`automation_state`** — the global automation kill-switch singleton (`id = 1`, seeded unpaused).
- **`dead_letters`** — additive `status` (default `'new'`, backfills existing rows) / `resolved_at` / `resolved_by_action_id` columns + status index, for the retry/quarantine controls.

Builders (`operational-events.ts`, `automation-state.ts`) return bare `D1PreparedStatement`s so the later endpoint PRs can hand them to `commitMutation` as effect statements, keeping the audit-atomicity invariant. The event and outbox inserts take an optional **gate on an issued label's in-batch existence** (`INSERT … SELECT … WHERE EXISTS`): if a signing-state rotation suppresses the label INSERT mid-batch, the event and outbox rows also don't insert — so no "takedown issued" alert can ever be queued for a takedown that never landed (the W9.4/W9.5 phantom-success guard, extended to the alert stream).

The kill-switch enforcement lands here too, since it's consumer-side, not endpoint-side: `processDiscoveryMessage` checks `isAutomationPaused` at the top of its create branch. Per the ratified decisions (2026-07-13): **global scope, ingestion-only** — the signing layer is untouched, so manual/admin issuance and operator reruns stay available mid-incident; **fail-closed** — a paused or *unreadable* switch both route to `controller.retry()`, never past the gate; **consumer-retry** mechanism — a long pause drains to the DLQ, recovered by resume + the PR-3 retry control. The delete branch is deliberately ungated (verified deletes still cancel + negate during a pause), locked in by a test.

Adversarially reviewed by an independent Opus pass targeting fail-open paths, in-batch `WHERE EXISTS` semantics, and migration safety: **no blockers** — it confirmed `verifyAndCreateRun` has exactly one (gated) caller and automated create issuance has no other entry point, the gate can't be satisfied by another action's label (`action_id` is UNIQUE), and `isAutomationPaused` genuinely throws on both missing-row and D1-error. Its two test-honesty fixes are included: the T1 gate is now proven inside a real `db.batch` (both the label-present and label-suppressed compositions), and the delete-branch exemption has an explicit test. One forward-looking note (recorded in the plan): future automated issuance paths — notably the W7/W8 orchestrator finalization — will not inherit the consumer-side gate and must add their own check.

Stacked directly on the integration branch. Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — backend only, no UI. Changeset n/a — `apps/labeler` is a private, unpublished Worker app.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Opus 4.8 (design, implementation, adversarial review, coordination)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker **462 pass** (27 files; new suites for the event/outbox builders incl. the in-batch gate compositions, the fail-closed kill-switch, and the consumer's pause/unreadable/delete-exemption behavior), console **14 pass** (untouched)
- Typecheck (both projects) clean; lint: 0 diagnostics in `apps/labeler`

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-ops-foundation-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-ops-foundation`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
