### PR TITLE
feat(labeler): admin emergency takedown and publisher-compromised actions (W9.6 PR-1)

### DIFF
--- a/apps/labeler/console/src/api/client.ts
+++ b/apps/labeler/console/src/api/client.ts
@@ -11,6 +11,8 @@ import type {
 	AssessmentRun,
 	EffectPreview,
 	EffectPreviewParams,
+	EmergencyActionInput,
+	EmergencyActionKind,
 	IssuedLabel,
 	IssuedLabelDescriptor,
 	LabelActionInput,
@@ -53,7 +55,21 @@ export interface LabelerConsoleClient {
 	rerunAssessment(id: string, input: AssessmentActionInput): Promise<RerunResult>;
 	overrideAssessment(id: string, input: OverrideActionInput): Promise<OverrideResult>;
 	retractOverride(id: string, input: AssessmentActionInput): Promise<OverrideRetractResult>;
+	emergencyAction(
+		kind: EmergencyActionKind,
+		mode: "issue" | "retract",
+		input: EmergencyActionInput,
+	): Promise<IssuedLabelDescriptor>;
 }
+
+/** The admin-only emergency endpoints, keyed by action and direction. */
+const EMERGENCY_PATHS: Record<EmergencyActionKind, { issue: string; retract: string }> = {
+	takedown: { issue: "/emergency/takedown", retract: "/emergency/takedown-retract" },
+	"publisher-compromised": {
+		issue: "/emergency/publisher-compromised",
+		retract: "/emergency/publisher-compromised-retract",
+	},
+};
 
 interface ApiErrorBody {
 	error?: { code?: string; message?: string };
@@ -201,6 +217,9 @@ export function createFetchClient(): LabelerConsoleClient {
 				"Failed to retract override",
 			);
 		},
+		async emergencyAction(kind, mode, input) {
+			return postAction(EMERGENCY_PATHS[kind][mode], input, "Failed to submit emergency action");
+		},
 	};
 }
 
@@ -305,6 +324,17 @@ export function createFixtureClient(): LabelerConsoleClient {
 				cid: "bafyfixture",
 				negated: ["assessment-passed", "assessment-overridden"],
 				cts: new Date().toISOString(),
+			};
+		},
+		async emergencyAction(kind, mode, input) {
+			return {
+				actionId: "oact_fixture",
+				val: kind === "takedown" ? "!takedown" : "publisher-compromised",
+				uri: input.uri,
+				cid: null,
+				neg: mode === "retract",
+				cts: new Date().toISOString(),
+				effect: kind === "takedown" ? "redact" : "block",
 			};
 		},
 	};

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -293,6 +293,26 @@ export interface OverrideEffectPreviewParams {
 	negate: string[];
 }
 
+/** The emergency action vocabulary (admin-only). `takedown` is the URI-wide
+ * `!takedown` on a release, package, or publisher; `publisher-compromised`
+ * targets a publisher DID. */
+export type EmergencyActionKind = "takedown" | "publisher-compromised";
+
+/**
+ * Body for the admin-only emergency endpoints (`POST /admin/api/emergency/*`).
+ * The two typed ceremony fields — `subjectConfirmation` (the record rkey or the
+ * publisher DID's final segment) and `intent` (the server-constant phrase) — are
+ * both server-validated pre-signing and both fold into the request fingerprint.
+ * The client mirrors the checks for UX; the server is authoritative.
+ */
+export interface EmergencyActionInput {
+	uri: string;
+	subjectConfirmation: string;
+	intent: string;
+	reason: string;
+	idempotencyKey: string;
+}
+
 export interface ListAssessmentsParams {
 	state?: PublicAssessmentState;
 	cursor?: string;

--- a/apps/labeler/console/src/components/EmergencyActionDialog.test.tsx
+++ b/apps/labeler/console/src/components/EmergencyActionDialog.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import type { EmergencyActionInput, EmergencyActionKind } from "../api/types.js";
+import { EmergencyActionDialog } from "./EmergencyActionDialog.js";
+
+vi.mock("../api/client.js", () => ({
+	apiClient: { emergencyAction: vi.fn() },
+}));
+
+const emergencyAction = vi.mocked(apiClient.emergencyAction);
+
+const RELEASE_URI = "at://did:plc:x/com.emdashcms.experimental.package.release/rk1";
+
+interface RenderOverrides {
+	kind?: EmergencyActionKind;
+	mode?: "issue" | "retract";
+	subjectUri?: string;
+	subjectConfirmationExpected?: string;
+}
+
+function renderDialog(overrides: RenderOverrides = {}) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const onOpenChange = vi.fn();
+	render(
+		<QueryClientProvider client={client}>
+			<EmergencyActionDialog
+				open
+				onOpenChange={onOpenChange}
+				kind={overrides.kind ?? "takedown"}
+				mode={overrides.mode ?? "issue"}
+				subjectUri={overrides.subjectUri ?? RELEASE_URI}
+				subjectConfirmationExpected={overrides.subjectConfirmationExpected ?? "rk1"}
+				invalidateKeys={[]}
+			/>
+		</QueryClientProvider>,
+	);
+	return { onOpenChange };
+}
+
+function fill(reason: string, subject: string, intent: string) {
+	fireEvent.change(screen.getByPlaceholderText("Why this emergency action is being taken"), {
+		target: { value: reason },
+	});
+	fireEvent.change(screen.getByPlaceholderText("rk1"), { target: { value: subject } });
+	fireEvent.change(screen.getByPlaceholderText("CONFIRM TAKEDOWN"), { target: { value: intent } });
+}
+
+afterEach(() => {
+	emergencyAction.mockReset();
+});
+
+describe("EmergencyActionDialog", () => {
+	it("keeps submit disabled until the reason and both typed confirmations match", () => {
+		renderDialog();
+		const submit = screen.getByRole("button", { name: "Take down" }) as HTMLButtonElement;
+		expect(submit.disabled).toBe(true);
+
+		fill("incident", "rk1", "CONFIRM TAKEDOWN");
+		expect(submit.disabled).toBe(false);
+	});
+
+	it("submits with both ceremony fields once they match", async () => {
+		emergencyAction.mockResolvedValue({
+			actionId: "oact_1",
+			val: "!takedown",
+			uri: RELEASE_URI,
+			cid: null,
+			neg: false,
+			cts: "2026-07-13T00:00:00.000Z",
+			effect: "redact",
+		});
+		renderDialog();
+		fill("incident", "rk1", "CONFIRM TAKEDOWN");
+		fireEvent.click(screen.getByRole("button", { name: "Take down" }));
+
+		await waitFor(() => {
+			expect(emergencyAction).toHaveBeenCalledWith(
+				"takedown",
+				"issue",
+				expect.objectContaining<Partial<EmergencyActionInput>>({
+					uri: RELEASE_URI,
+					subjectConfirmation: "rk1",
+					intent: "CONFIRM TAKEDOWN",
+					reason: "incident",
+				}),
+			);
+		});
+	});
+
+	it("rejects a wrong intent phrase (disabled + error, never submits)", () => {
+		renderDialog();
+		fill("incident", "rk1", "CONFIRM COMPROMISE");
+		const submit = screen.getByRole("button", { name: "Take down" }) as HTMLButtonElement;
+		expect(submit.disabled).toBe(true);
+		expect(screen.getByText("Does not match the required phrase")).toBeTruthy();
+		fireEvent.click(submit);
+		expect(emergencyAction).not.toHaveBeenCalled();
+	});
+
+	it("rejects a wrong subject confirmation (disabled + error)", () => {
+		renderDialog();
+		fireEvent.change(screen.getByPlaceholderText("Why this emergency action is being taken"), {
+			target: { value: "incident" },
+		});
+		fireEvent.change(screen.getByPlaceholderText("rk1"), { target: { value: "wrong-rkey" } });
+		fireEvent.change(screen.getByPlaceholderText("CONFIRM TAKEDOWN"), {
+			target: { value: "CONFIRM TAKEDOWN" },
+		});
+		const submit = screen.getByRole("button", { name: "Take down" }) as HTMLButtonElement;
+		expect(submit.disabled).toBe(true);
+		expect(screen.getByText("Does not match the subject")).toBeTruthy();
+	});
+
+	it("uses the CONFIRM RETRACT intent and retract copy in retract mode", () => {
+		renderDialog({ mode: "retract" });
+		expect(screen.getByRole("button", { name: "Retract takedown" })).toBeTruthy();
+		expect(screen.getByPlaceholderText("CONFIRM RETRACT")).toBeTruthy();
+	});
+
+	it("uses the CONFIRM COMPROMISE intent for publisher-compromised", () => {
+		renderDialog({
+			kind: "publisher-compromised",
+			subjectUri: "did:plc:publisher000",
+			subjectConfirmationExpected: "publisher000",
+		});
+		expect(screen.getByText("Mark publisher compromised")).toBeTruthy();
+		expect(screen.getByPlaceholderText("CONFIRM COMPROMISE")).toBeTruthy();
+	});
+});

--- a/apps/labeler/console/src/components/EmergencyActionDialog.tsx
+++ b/apps/labeler/console/src/components/EmergencyActionDialog.tsx
@@ -1,0 +1,184 @@
+import { Button, Dialog, Input, InputArea } from "@cloudflare/kumo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+import type { EmergencyActionKind } from "../api/types.js";
+
+interface EmergencyActionDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	kind: EmergencyActionKind;
+	mode: "issue" | "retract";
+	subjectUri: string;
+	/** The typed subject identifier the operator must retype: the record rkey for
+	 * a release/package, the publisher DID's final `:`-segment for a publisher. */
+	subjectConfirmationExpected: string;
+	invalidateKeys: readonly (readonly unknown[])[];
+}
+
+/** The server-constant intent phrases, mirrored client-side for UX. The server
+ * (`assertEmergencyConfirmation`) is authoritative and rejects a mismatch. */
+const INTENT: Record<EmergencyActionKind, { issue: string; retract: string }> = {
+	takedown: { issue: "CONFIRM TAKEDOWN", retract: "CONFIRM RETRACT" },
+	"publisher-compromised": { issue: "CONFIRM COMPROMISE", retract: "CONFIRM RETRACT" },
+};
+
+const COPY: Record<
+	EmergencyActionKind,
+	Record<"issue" | "retract", { title: string; description: string; submit: string }>
+> = {
+	takedown: {
+		issue: {
+			title: "Emergency takedown",
+			description:
+				"Issues !takedown on this subject. It redacts the subject from official clients across all releases and stays active until an administrator retracts it.",
+			submit: "Take down",
+		},
+		retract: {
+			title: "Retract takedown",
+			description:
+				"Negates !takedown. The subject returns to its pre-takedown state — any automated blocks that were live before re-expose. Nothing is re-issued.",
+			submit: "Retract takedown",
+		},
+	},
+	"publisher-compromised": {
+		issue: {
+			title: "Mark publisher compromised",
+			description:
+				"Issues publisher-compromised on the publisher DID. Every release from this publisher is blocked until an administrator retracts it.",
+			submit: "Mark compromised",
+		},
+		retract: {
+			title: "Retract publisher-compromised",
+			description: "Negates publisher-compromised for this publisher DID.",
+			submit: "Retract",
+		},
+	},
+};
+
+/**
+ * The high-friction admin ceremony for the emergency actions (spec §11.3/§18.2,
+ * design §3): a required reason plus TWO typed confirmations — the subject
+ * identifier and the fixed intent phrase — both server-validated pre-signing.
+ * Danger-styled; the idempotency key is minted per open and reused across
+ * retries so a network retry replays rather than double-issues.
+ */
+export function EmergencyActionDialog({
+	open,
+	onOpenChange,
+	kind,
+	mode,
+	subjectUri,
+	subjectConfirmationExpected,
+	invalidateKeys,
+}: EmergencyActionDialogProps) {
+	const queryClient = useQueryClient();
+	const copy = COPY[kind][mode];
+	const expectedIntent = INTENT[kind][mode];
+	const [reason, setReason] = useState("");
+	const [subjectConfirmation, setSubjectConfirmation] = useState("");
+	const [intent, setIntent] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setReason("");
+		setSubjectConfirmation("");
+		setIntent("");
+	}, [open]);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			apiClient.emergencyAction(kind, mode, {
+				uri: subjectUri,
+				subjectConfirmation,
+				intent,
+				reason,
+				idempotencyKey,
+			}),
+		onSuccess: async () => {
+			await Promise.all(
+				invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+			);
+			onOpenChange(false);
+		},
+	});
+
+	const subjectMatches =
+		subjectConfirmation === subjectConfirmationExpected && subjectConfirmationExpected.length > 0;
+	const intentMatches = intent === expectedIntent;
+	const canSubmit =
+		reason.trim().length > 0 && subjectMatches && intentMatches && !mutation.isPending;
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange} role="alertdialog">
+			<Dialog className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto p-6" size="lg">
+				<Dialog.Title className="text-lg font-semibold text-kumo-danger">{copy.title}</Dialog.Title>
+				<Dialog.Description className="break-all font-mono text-xs text-kumo-subtle">
+					{subjectUri}
+				</Dialog.Description>
+
+				<p className="rounded-lg bg-kumo-elevated p-3 text-sm text-kumo-subtle">
+					{copy.description}
+				</p>
+
+				<InputArea
+					label="Reason"
+					value={reason}
+					onValueChange={setReason}
+					placeholder="Why this emergency action is being taken"
+				/>
+
+				<Input
+					label="Type the subject identifier to confirm"
+					value={subjectConfirmation}
+					onChange={(event) => {
+						setSubjectConfirmation(event.target.value);
+					}}
+					placeholder={subjectConfirmationExpected}
+					error={
+						subjectConfirmation.length > 0 && !subjectMatches
+							? "Does not match the subject"
+							: undefined
+					}
+				/>
+
+				<Input
+					label={`Type ${expectedIntent} to confirm`}
+					value={intent}
+					onChange={(event) => {
+						setIntent(event.target.value);
+					}}
+					placeholder={expectedIntent}
+					error={
+						intent.length > 0 && !intentMatches ? "Does not match the required phrase" : undefined
+					}
+				/>
+
+				{mutation.isError && (
+					<p className="text-sm text-kumo-danger">
+						{mutation.error instanceof Error ? mutation.error.message : "Emergency action failed"}
+					</p>
+				)}
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+						Cancel
+					</Dialog.Close>
+					<Button
+						variant="destructive"
+						disabled={!canSubmit}
+						onClick={() => {
+							mutation.mutate();
+						}}
+					>
+						{mutation.isPending ? "Submitting…" : copy.submit}
+					</Button>
+				</div>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/apps/labeler/console/src/routes/SubjectHistory.tsx
+++ b/apps/labeler/console/src/routes/SubjectHistory.tsx
@@ -4,12 +4,29 @@ import { createRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { apiClient } from "../api/client.js";
-import type { IssuableLabel } from "../api/types.js";
+import type { EmergencyActionKind, IssuableLabel, SubjectLabel } from "../api/types.js";
+import { EmergencyActionDialog } from "../components/EmergencyActionDialog.js";
 import { LabelActionDialog } from "../components/LabelActionDialog.js";
 import { QueryError } from "../components/QueryError.js";
 import { StateBadge } from "../components/StateBadge.js";
 import { PACKAGE_ISSUABLE_LABELS, RELEASE_ISSUABLE_LABELS } from "../labels.js";
 import { shellRoute } from "./root.js";
+
+/** A publisher's typed confirmation is its DID's final `:`-segment. */
+function didFinalSegment(did: string): string {
+	return did.split(":").at(-1) ?? "";
+}
+
+function isLabelActive(labels: readonly SubjectLabel[] | undefined, val: string): boolean {
+	return (labels ?? []).some((label) => label.val === val && label.active);
+}
+
+interface EmergencyTarget {
+	kind: EmergencyActionKind;
+	mode: "issue" | "retract";
+	uri: string;
+	confirm: string;
+}
 
 /** URI-wide (record-level) issuable labels for a subject, chosen by its
  * collection: a release record can be security-yanked, a package profile can be
@@ -35,7 +52,22 @@ function SubjectHistory() {
 	});
 	const { data: whoami } = useQuery({ queryKey: ["whoami"], queryFn: () => apiClient.whoami() });
 	const canAct = whoami?.roles.includes("reviewer") || whoami?.roles.includes("admin") || false;
+	const isAdmin = whoami?.roles.includes("admin") ?? false;
+
+	const subjectRecord = history?.subject;
+	const { data: recordLabels } = useQuery({
+		queryKey: ["subject-labels", subjectRecord?.uri, subjectRecord?.cid],
+		queryFn: () => apiClient.getSubjectLabels(subjectRecord!.uri, subjectRecord!.cid),
+		enabled: isAdmin && !!subjectRecord,
+	});
+	const { data: publisherLabels } = useQuery({
+		queryKey: ["publisher-labels", subjectRecord?.did],
+		queryFn: () => apiClient.getSubjectLabels(subjectRecord!.did),
+		enabled: isAdmin && !!subjectRecord,
+	});
+
 	const [issueOpen, setIssueOpen] = useState(false);
+	const [emergency, setEmergency] = useState<EmergencyTarget | null>(null);
 
 	if (isError) {
 		return <QueryError title="Failed to load subject history" error={error} />;
@@ -57,6 +89,15 @@ function SubjectHistory() {
 
 	const { subject, assessments } = history;
 	const uriWideLabels = uriWideLabelsFor(subject.collection);
+	const publisherSegment = didFinalSegment(subject.did);
+	const recordTakenDown = isLabelActive(recordLabels, "!takedown");
+	const publisherTakenDown = isLabelActive(publisherLabels, "!takedown");
+	const publisherCompromised = isLabelActive(publisherLabels, "publisher-compromised");
+	const emergencyInvalidateKeys: readonly (readonly unknown[])[] = [
+		["subject-history", uri],
+		["subject-labels", subject.uri, subject.cid],
+		["publisher-labels", subject.did],
+	];
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -79,6 +120,74 @@ function SubjectHistory() {
 					</Button>
 				)}
 			</div>
+
+			{isAdmin && (
+				<LayerCard className="flex flex-col gap-3 border border-kumo-danger p-4">
+					<div className="flex items-center gap-2">
+						<h2 className="text-lg font-semibold text-kumo-danger">Emergency actions</h2>
+						{recordTakenDown && (
+							<span className="text-sm text-kumo-danger">This record is taken down.</span>
+						)}
+					</div>
+					<div className="flex flex-wrap gap-2">
+						<Button
+							variant={recordTakenDown ? "secondary" : "destructive"}
+							onClick={() =>
+								setEmergency({
+									kind: "takedown",
+									mode: recordTakenDown ? "retract" : "issue",
+									uri: subject.uri,
+									confirm: subject.rkey,
+								})
+							}
+						>
+							{recordTakenDown ? "Retract record takedown" : "Take down record"}
+						</Button>
+						<Button
+							variant={publisherTakenDown ? "secondary" : "destructive"}
+							onClick={() =>
+								setEmergency({
+									kind: "takedown",
+									mode: publisherTakenDown ? "retract" : "issue",
+									uri: subject.did,
+									confirm: publisherSegment,
+								})
+							}
+						>
+							{publisherTakenDown ? "Retract publisher takedown" : "Take down publisher"}
+						</Button>
+						<Button
+							variant={publisherCompromised ? "secondary" : "destructive"}
+							onClick={() =>
+								setEmergency({
+									kind: "publisher-compromised",
+									mode: publisherCompromised ? "retract" : "issue",
+									uri: subject.did,
+									confirm: publisherSegment,
+								})
+							}
+						>
+							{publisherCompromised
+								? "Retract publisher-compromised"
+								: "Mark publisher compromised"}
+						</Button>
+					</div>
+				</LayerCard>
+			)}
+
+			{emergency && (
+				<EmergencyActionDialog
+					open
+					onOpenChange={(open) => {
+						if (!open) setEmergency(null);
+					}}
+					kind={emergency.kind}
+					mode={emergency.mode}
+					subjectUri={emergency.uri}
+					subjectConfirmationExpected={emergency.confirm}
+					invalidateKeys={emergencyInvalidateKeys}
+				/>
+			)}
 
 			{canAct && uriWideLabels.length > 0 && (
 				<LabelActionDialog

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -47,7 +47,7 @@ import { computeEffectPreview, computeOverrideEffectPreview } from "./label-effe
 import { MutationGuardError } from "./mutation-guard.js";
 import { getOperatorActionsPage } from "./operator-actions.js";
 import { guardRead, ReadGuardError, type ReadGuardDeps } from "./operator-read-guard.js";
-import { assertNegatableBlockSet, NegatableBlockSetError } from "./service.js";
+import { assertNegatableBlockSet, NegatableBlockSetError, parseSubjectKind } from "./service.js";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
@@ -263,7 +263,10 @@ async function handleGetSubjectHistory(
  * stream winner per value, including the manual/override labels that carry no
  * `assessment_id` and so never surface in the assessment-scoped label list. The
  * CID is `?cid=` or falls back to the current observed subject CID; a URI never
- * observed (and no CID given) is a 404, matching the subject-history route.
+ * observed (and no CID given) is a 404, matching the subject-history route. A
+ * publisher (bare DID) subject has no record row and no CID; its labels
+ * (`!takedown`, `publisher-compromised`) are URI-wide, so an empty CID key
+ * resolves their active state without a record lookup.
  */
 async function handleGetSubjectLabels(
 	request: Request,
@@ -276,9 +279,13 @@ async function handleGetSubjectLabels(
 	if (cidParam !== null && cidParam.length === 0) throw new ReadGuardError("INVALID_REQUEST");
 	let cid = cidParam ?? undefined;
 	if (cid === undefined) {
-		const subject = await getCurrentSubjectByUri(deps.db, uri);
-		if (!subject) throw new ReadGuardError("NOT_FOUND");
-		cid = subject.cid;
+		if (parseSubjectKind(uri) === "publisher") {
+			cid = "";
+		} else {
+			const subject = await getCurrentSubjectByUri(deps.db, uri);
+			if (!subject) throw new ReadGuardError("NOT_FOUND");
+			cid = subject.cid;
+		}
 	}
 	const winners = await getActiveLabelState(deps.db, {
 		src: deps.labelerDid,

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -35,6 +35,12 @@ import {
 	type MutationGuardDeps,
 	type MutationSpec,
 } from "./mutation-guard.js";
+import {
+	buildOperationalEventInsert,
+	buildOutboxInsert,
+	newOperationalEventId,
+	type OperationalEventType,
+} from "./operational-events.js";
 import { ReadGuardError } from "./operator-read-guard.js";
 import { getLabelDefinition, MODERATION_POLICY } from "./policy.js";
 import {
@@ -151,6 +157,16 @@ export async function handleConsoleMutation(
 			if (segments[2] === "rerun") return await runRerun(request, deps, id);
 			if (segments[2] === "override") return await runOverride(request, deps, id);
 			if (segments[2] === "override-retract") return await runOverrideRetract(request, deps, id);
+		}
+		if (segments[0] === "emergency" && segments.length === 2) {
+			if (segments[1] === "takedown")
+				return await runEmergencyAction(request, deps, "takedown", false);
+			if (segments[1] === "takedown-retract")
+				return await runEmergencyAction(request, deps, "takedown", true);
+			if (segments[1] === "publisher-compromised")
+				return await runEmergencyAction(request, deps, "publisher-compromised", false);
+			if (segments[1] === "publisher-compromised-retract")
+				return await runEmergencyAction(request, deps, "publisher-compromised", true);
 		}
 		throw new ReadGuardError("NOT_FOUND");
 	} catch (error) {
@@ -766,4 +782,200 @@ async function runOverrideRetract(
 	await assertIssuancePersisted(deps.db, committedKeys);
 	deferPublishAll(deps, committedKeys);
 	return jsonData(returned);
+}
+
+// ─── W9.6: admin-only emergency actions (!takedown, publisher-compromised) ───
+
+type EmergencyAction = "takedown" | "publisher-compromised";
+
+const EMERGENCY_VALUE: Record<EmergencyAction, string> = {
+	takedown: "!takedown",
+	"publisher-compromised": "publisher-compromised",
+};
+
+const EMERGENCY_EVENT_TYPE: Record<EmergencyAction, OperationalEventType> = {
+	takedown: "emergency-takedown",
+	"publisher-compromised": "publisher-compromised",
+};
+
+/** The second typed ceremony field: a server constant the operator must retype
+ * verbatim, distinct per action and per direction so a scripted client cannot
+ * skip the ceremony and a retract cannot be replayed as an issuance. */
+const EMERGENCY_INTENT: Record<EmergencyAction, { issue: string; retract: string }> = {
+	takedown: { issue: "CONFIRM TAKEDOWN", retract: "CONFIRM RETRACT" },
+	"publisher-compromised": { issue: "CONFIRM COMPROMISE", retract: "CONFIRM RETRACT" },
+};
+
+const EMERGENCY_CHANNEL = "deployment-alert";
+
+/**
+ * The two-field emergency ceremony body (design §3). `val` and `neg` are fixed
+ * by the endpoint, not read from the client, so the wire body carries only the
+ * subject and the two typed confirmations. Both `subjectConfirmation` and
+ * `intent` are part of the parsed body, so both fold into the request
+ * fingerprint (`computeRequestFingerprint` hashes the whole normalized body) —
+ * a replay must resend identical values.
+ */
+interface EmergencyActionBody {
+	uri: string;
+	val: string;
+	neg: boolean;
+	subjectConfirmation: string;
+	intent: string;
+}
+
+/** The idempotent emergency result — the same shape as a label descriptor
+ * (`cid` is always null: every emergency label is URI-wide / DID-subject). */
+type EmergencyDescriptor = IssuedLabelDescriptor;
+
+/**
+ * `POST /admin/api/emergency/{takedown,publisher-compromised}` and their
+ * `-retract` siblings — the admin-only crown-jewel actions (spec §11.3/§18.2,
+ * design §2–§4). Issuance flows through `prepareManualLabelIssuance` unchanged;
+ * the delta from the reviewer issue endpoint is the `admin` role, the
+ * admin-issuable policy gate, the two-field ceremony, and the label-gated
+ * operational event + notification outbox committed in the same atomic batch.
+ * Retraction is the same path with `neg: true` and a `CONFIRM RETRACT` intent;
+ * its resting state is the subject's pre-takedown computed state (the automated
+ * labels, never negated, re-expose — nothing is re-issued).
+ */
+async function runEmergencyAction(
+	request: Request,
+	deps: ConsoleMutationDeps,
+	action: EmergencyAction,
+	neg: boolean,
+): Promise<Response> {
+	const val = EMERGENCY_VALUE[action];
+	const spec: MutationSpec<EmergencyActionBody> = {
+		action,
+		requiredRole: "admin",
+		parseBody: (raw) => {
+			const body: EmergencyActionBody = {
+				uri: requireString(raw.uri),
+				val,
+				neg,
+				subjectConfirmation: requireString(raw.subjectConfirmation),
+				intent: requireString(raw.intent),
+			};
+			assertAdminIssuable(body);
+			assertEmergencyConfirmation(body, action, neg);
+			return body;
+		},
+		auditFields: (body) => ({
+			subjectUri: body.uri,
+			labelValue: val,
+			metadata: { neg, effect: getLabelDefinition(val)?.officialEffect ?? null },
+		}),
+	};
+
+	const outcome = await guardMutation(request, spec, guardDepsOf(deps));
+	if (outcome.outcome === "replay") {
+		const stored = storedDescriptor<EmergencyDescriptor>(outcome.result);
+		await assertIssuancePersisted(deps.db, [stored.actionId]);
+		return jsonData(stored);
+	}
+
+	const { ctx } = outcome;
+	const signer = await deps.createSigner();
+	const issuance = await prepareManualLabelIssuance(
+		deps.db,
+		deps.config,
+		signer,
+		{
+			actor: deps.config.labelerDid,
+			type: "manual-label",
+			reason: ctx.reason,
+			idempotencyKey: ctx.actionId,
+		},
+		{ uri: ctx.body.uri, val, neg },
+		ctx.now,
+	);
+
+	// The event + outbox are gated on the label's in-batch existence keyed by the
+	// issuance idempotency key (= this action id): a signing-state race that
+	// suppresses the label INSERT drops the event and outbox with it, so no
+	// "takedown issued" alert fires for a takedown that never landed (T1).
+	const eventId = newOperationalEventId();
+	const eventInsert = buildOperationalEventInsert(deps.db, {
+		id: eventId,
+		eventType: EMERGENCY_EVENT_TYPE[action],
+		severity: neg ? "high" : "critical",
+		actionId: ctx.actionId,
+		subjectUri: ctx.body.uri,
+		labelValue: val,
+		payload: { reason: ctx.reason },
+		now: ctx.now,
+		gateOnIssuedLabelActionKey: ctx.actionId,
+	});
+	const outboxInsert = buildOutboxInsert(deps.db, {
+		eventId,
+		channel: EMERGENCY_CHANNEL,
+		now: ctx.now,
+		gateOnIssuedLabelActionKey: ctx.actionId,
+	});
+
+	const descriptor: EmergencyDescriptor = {
+		actionId: ctx.actionId,
+		val,
+		uri: ctx.body.uri,
+		cid: null,
+		neg,
+		cts: ctx.now.toISOString(),
+		effect: getLabelDefinition(val)?.officialEffect ?? "",
+	};
+	const returned = await commitMutation(
+		deps.db,
+		ctx,
+		spec,
+		[...issuance.statements, eventInsert, outboxInsert],
+		descriptor,
+	);
+	await assertIssuancePersisted(deps.db, [returned.actionId]);
+	deps.defer(deps.afterCommit(returned.actionId));
+	return jsonData(returned);
+}
+
+/**
+ * The admin issuance gate, policy-driven like `assertW94Issuable` but requiring
+ * the matched `subjectRule` to grant `admin`: `!takedown` on a release, package,
+ * or publisher; `publisher-compromised` on a publisher. Every emergency label is
+ * `cidRule: forbidden`, and the wire body carries no CID, so scope is satisfied
+ * structurally. A subject the value does not grant `admin` for (e.g.
+ * `publisher-compromised` on a release) is a clean 400 before signing.
+ */
+function assertAdminIssuable(body: EmergencyActionBody): void {
+	const definition = getLabelDefinition(body.val);
+	if (!definition) throw new MutationGuardError("INVALID_BODY");
+	const subject = parseSubjectKind(body.uri);
+	if (subject === null) throw new MutationGuardError("INVALID_BODY");
+	const rule = definition.subjectRules.find((candidate) => candidate.subject === subject);
+	if (!rule || !rule.issuanceModes.includes("admin")) throw new MutationGuardError("INVALID_BODY");
+}
+
+/**
+ * The two-field ceremony (design §3), enforced in code, not prompt text. The
+ * typed subject identifier is the record rkey for a release/package and the
+ * DID's final `:`-segment for a publisher, tying the confirmation to the parsed
+ * subject kind — a URI whose kind mismatches the typed identifier fails (T7).
+ * The typed intent must equal the server constant for this action + direction.
+ * Both errors are the static `CONFIRMATION_MISMATCH`, which never echoes the
+ * typed value.
+ */
+function assertEmergencyConfirmation(
+	body: EmergencyActionBody,
+	action: EmergencyAction,
+	neg: boolean,
+): void {
+	const subject = parseSubjectKind(body.uri);
+	const expectedSubject = subject === "publisher" ? didFinalSegment(body.uri) : rkeyOf(body.uri);
+	if (body.subjectConfirmation !== expectedSubject)
+		throw new LabelMutationError("CONFIRMATION_MISMATCH");
+	const expectedIntent = EMERGENCY_INTENT[action][neg ? "retract" : "issue"];
+	if (body.intent !== expectedIntent) throw new LabelMutationError("CONFIRMATION_MISMATCH");
+}
+
+/** A publisher subject's typed confirmation is its DID's final `:`-segment (the
+ * PLC/web identifier), not a resolved handle. */
+function didFinalSegment(uri: string): string {
+	return uri.split(":").at(-1) ?? "";
 }

--- a/apps/labeler/src/operational-events.ts
+++ b/apps/labeler/src/operational-events.ts
@@ -43,6 +43,16 @@ export interface OperationalEventInsert {
 	 * not insert either — so no alert fires for a label that never landed.
 	 */
 	gateOnIssuedLabelActionId?: number;
+	/**
+	 * The same in-batch label gate keyed on the issuance action's idempotency
+	 * key rather than the numeric `issuance_actions.id`. The real issuance path
+	 * (`prepareManualLabelIssuance`) lets D1 autoincrement `issuance_actions.id`,
+	 * so the numeric id is unknown before the batch commits — but the idempotency
+	 * key is the caller-minted operator action id. The gate joins through
+	 * `issuance_actions` to reach the label, so a signing-suppressed batch (no
+	 * `issued_labels` row) inserts neither the event nor its outbox row.
+	 */
+	gateOnIssuedLabelActionKey?: string;
 }
 
 export interface OutboxInsert {
@@ -51,6 +61,8 @@ export interface OutboxInsert {
 	now: Date;
 	/** Same in-batch label gating as {@link OperationalEventInsert}. */
 	gateOnIssuedLabelActionId?: number;
+	/** Same in-batch label gating as {@link OperationalEventInsert.gateOnIssuedLabelActionKey}. */
+	gateOnIssuedLabelActionKey?: string;
 }
 
 export interface StoredOperationalEvent {
@@ -134,6 +146,20 @@ export function buildOperationalEventInsert(
 		input.now.getTime(),
 	];
 
+	if (input.gateOnIssuedLabelActionKey !== undefined) {
+		return db
+			.prepare(
+				`INSERT INTO operational_events (${columns})
+				 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
+				 WHERE EXISTS (
+					SELECT 1 FROM issued_labels l
+					JOIN issuance_actions a ON a.id = l.action_id
+					WHERE a.idempotency_key = ?
+				 )`,
+			)
+			.bind(...values, input.gateOnIssuedLabelActionKey);
+	}
+
 	if (input.gateOnIssuedLabelActionId !== undefined) {
 		return db
 			.prepare(
@@ -165,6 +191,20 @@ export function buildOutboxInsert(db: D1Database, input: OutboxInsert): D1Prepar
 		input.now.toISOString(),
 		input.now.getTime(),
 	];
+
+	if (input.gateOnIssuedLabelActionKey !== undefined) {
+		return db
+			.prepare(
+				`INSERT INTO notification_outbox (id, event_id, channel, created_at, created_at_epoch_ms)
+				 SELECT ?, ?, ?, ?, ?
+				 WHERE EXISTS (
+					SELECT 1 FROM issued_labels l
+					JOIN issuance_actions a ON a.id = l.action_id
+					WHERE a.idempotency_key = ?
+				 )`,
+			)
+			.bind(...values, input.gateOnIssuedLabelActionKey);
+	}
 
 	if (input.gateOnIssuedLabelActionId !== undefined) {
 		return db

--- a/apps/labeler/test/console-api.test.ts
+++ b/apps/labeler/test/console-api.test.ts
@@ -500,6 +500,32 @@ describe("handleConsoleApi — findings and labels", () => {
 		expect(labels.length).toBe(3);
 		expect(labels.some((l) => l.neg === true)).toBe(true);
 	});
+
+	it("resolves URI-wide labels for a bare-DID publisher subject with no cid", async () => {
+		const publisherDid = "did:plc:pppppppppppppppppppppppp";
+		await testEnv.DB.prepare(
+			`INSERT INTO issuance_actions (id, actor, type, reason, idempotency_key, created_at)
+			 VALUES (2001, ?, 'manual-label', 'r', 'idem-pub-2001', '2026-07-09T00:00:00.000Z')`,
+		)
+			.bind(LABELER_DID)
+			.run();
+		await testEnv.DB.prepare(
+			`INSERT INTO issued_labels (action_id, ver, src, uri, cid, val, neg, cts, sig, signing_key_id)
+			 VALUES (2001, 1, ?, ?, NULL, 'publisher-compromised', 0, '2026-07-09T00:00:00.000Z', ?, 'v1')`,
+		)
+			.bind(LABELER_DID, publisherDid, new Uint8Array([0]))
+			.run();
+
+		const res = await handleConsoleApi(
+			req(`/admin/api/subjects/${encodeURIComponent(publisherDid)}/labels`, {
+				token: reviewerToken,
+			}),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+		const labels = (await body(res)).data as { val: string; active: boolean }[];
+		expect(labels.find((l) => l.val === "publisher-compromised")?.active).toBe(true);
+	});
 });
 
 describe("handleConsoleApi — subject history", () => {

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -9,7 +9,12 @@ import { generateKeyPair, SignJWT } from "jose";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import type { AccessKeyResolver } from "../src/access-auth.js";
-import { createSubject, getActiveLabelState } from "../src/assessment-store.js";
+import { computeRunKey, initialTriggerId } from "../src/assessment-lifecycle.js";
+import {
+	createAssessmentRun,
+	createSubject,
+	getActiveLabelState,
+} from "../src/assessment-store.js";
 import { handleConsoleApi, type ConsoleApiDeps } from "../src/console-api.js";
 import {
 	handleConsoleMutation,
@@ -17,7 +22,7 @@ import {
 	type IssuedLabelDescriptor,
 } from "../src/console-mutation-api.js";
 import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
-import { issueManualLabel } from "../src/service.js";
+import { issueAutomatedAssessmentLabel, issueManualLabel } from "../src/service.js";
 
 const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
 const AUDIENCE = "test-audience";
@@ -732,5 +737,558 @@ describe("console reads: effect preview", () => {
 	it("rejects an unknown label value", async () => {
 		const response = await preview(releaseUri("preview-unknown"), "not-a-label");
 		expect(response.status).toBe(400);
+	});
+});
+
+// ─── W9.6: admin-only emergency actions ─────────────────────────────────────
+
+const PUBLISHER_SEGMENT = PUBLISHER_DID.split(":").at(-1)!;
+
+/** Seeds a real automated `malware` block (via an assessment, satisfying the
+ * `issuance_actions.assessment_id` FK) so a takedown/retract test rests on a
+ * genuine automated block, not a hand-inserted row. */
+async function seedAutomatedBlock(uri: string, cid: string): Promise<void> {
+	await createSubject(testEnv.DB, {
+		uri,
+		cid,
+		did: PUBLISHER_DID,
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: uri.split("/").at(-1)!,
+		now: new Date("2026-07-08T08:00:00.000Z"),
+	});
+	const triggerId = initialTriggerId(cid);
+	const runKey = await computeRunKey({
+		uri,
+		cid,
+		policyVersion: "v1",
+		modelId: "m",
+		promptHash: "p",
+		scannerSetVersion: "v1",
+		triggerId,
+	});
+	const { assessment } = await createAssessmentRun(testEnv.DB, {
+		runKey,
+		uri,
+		cid,
+		trigger: "initial",
+		triggerId,
+		policyVersion: "v1",
+		coverageJson: "{}",
+	});
+	await issueAutomatedAssessmentLabel(
+		testEnv.DB,
+		CONFIG,
+		await testSigner(),
+		{
+			actor: LABELER_DID,
+			type: "automated-assessment",
+			assessmentId: assessment.id,
+			reason: "automated block",
+			idempotencyKey: nextKey(),
+		},
+		{ uri, cid, val: "malware", findingCategory: "malware", severity: "critical" },
+		new Date("2026-07-08T09:00:00.000Z"),
+	);
+}
+
+/** Reads the issued labels for a URI as evaluator input, newest last — the
+ * grounded label set the aggregator evaluator reduces (sigs are irrelevant to
+ * label semantics). */
+async function moderationLabelsFor(uri: string): Promise<ModerationLabel[]> {
+	const rows = await testEnv.DB.prepare(
+		`SELECT src, uri, cid, val, neg, cts FROM issued_labels WHERE uri = ? ORDER BY sequence ASC`,
+	)
+		.bind(uri)
+		.all<{ src: string; uri: string; cid: string | null; val: string; neg: number; cts: string }>();
+	return (rows.results ?? []).map((row) => ({
+		ver: 1,
+		src: row.src,
+		uri: row.uri,
+		...(row.cid === null ? {} : { cid: row.cid }),
+		val: row.val,
+		...(row.neg === 1 ? { neg: true } : {}),
+		cts: row.cts,
+	}));
+}
+
+async function eventCount(actionId: string): Promise<number> {
+	return countRows(`SELECT COUNT(*) n FROM operational_events WHERE action_id = ?`, actionId);
+}
+
+async function outboxCount(actionId: string): Promise<number> {
+	return countRows(
+		`SELECT COUNT(*) n FROM notification_outbox nob
+		 JOIN operational_events oe ON oe.id = nob.event_id
+		 WHERE oe.action_id = ?`,
+		actionId,
+	);
+}
+
+function emergency(
+	path: string,
+	body: Record<string, unknown>,
+	token: string | null = adminToken,
+): Request {
+	return post(path, { reason: "incident response", idempotencyKey: nextKey(), ...body }, { token });
+}
+
+describe("console mutation: emergency issuance (admin)", () => {
+	it("issues !takedown URI-wide on a release with the atomic event + outbox", async () => {
+		const uri = await seedReleaseSubject("emrg-td-release");
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: "emrg-td-release",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<IssuedLabelDescriptor>(response);
+		expect(descriptor).toMatchObject({
+			val: "!takedown",
+			uri,
+			cid: null,
+			neg: false,
+			effect: "redact",
+		});
+
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = '!takedown' AND neg = 0`,
+				uri,
+			),
+		).toBe(1);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operational_events
+				 WHERE action_id = ? AND event_type = 'emergency-takedown' AND severity = 'critical'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+		expect(await outboxCount(descriptor.actionId)).toBe(1);
+
+		// T8: the alert payload carries the operator reason only — no evidence fields.
+		const event = await testEnv.DB.prepare(
+			`SELECT payload_json, subject_uri, label_value FROM operational_events WHERE action_id = ?`,
+		)
+			.bind(descriptor.actionId)
+			.first<{ payload_json: string; subject_uri: string; label_value: string }>();
+		expect(event).toMatchObject({ subject_uri: uri, label_value: "!takedown" });
+		expect(JSON.parse(event!.payload_json)).toEqual({ reason: "incident response" });
+	});
+
+	it("issues !takedown on a package profile (rkey confirmation)", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri: profileUri("emrg-td-pkg"),
+				subjectConfirmation: "emrg-td-pkg",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		expect((await bodyData<IssuedLabelDescriptor>(response)).val).toBe("!takedown");
+	});
+
+	it("issues !takedown on a publisher DID (final-segment confirmation)", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri: PUBLISHER_DID,
+				subjectConfirmation: PUBLISHER_SEGMENT,
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		expect((await bodyData<IssuedLabelDescriptor>(response)).uri).toBe(PUBLISHER_DID);
+	});
+
+	it("issues publisher-compromised on a publisher DID", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/publisher-compromised", {
+				uri: PUBLISHER_DID,
+				subjectConfirmation: PUBLISHER_SEGMENT,
+				intent: "CONFIRM COMPROMISE",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<IssuedLabelDescriptor>(response);
+		expect(descriptor).toMatchObject({
+			val: "publisher-compromised",
+			uri: PUBLISHER_DID,
+			neg: false,
+		});
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operational_events
+				 WHERE action_id = ? AND event_type = 'publisher-compromised' AND severity = 'critical'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+	});
+
+	it("rejects publisher-compromised targeting a release (no admin rule for that subject)", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/publisher-compromised", {
+				uri: releaseUri("emrg-pc-release"),
+				subjectConfirmation: "emrg-pc-release",
+				intent: "CONFIRM COMPROMISE",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("INVALID_BODY");
+	});
+});
+
+describe("console mutation: emergency authorization (per-endpoint, pre-effect)", () => {
+	const cases = [
+		{
+			path: "/admin/api/emergency/takedown",
+			uri: () => PUBLISHER_DID,
+			conf: PUBLISHER_SEGMENT,
+			intent: "CONFIRM TAKEDOWN",
+		},
+		{
+			path: "/admin/api/emergency/takedown-retract",
+			uri: () => PUBLISHER_DID,
+			conf: PUBLISHER_SEGMENT,
+			intent: "CONFIRM RETRACT",
+		},
+		{
+			path: "/admin/api/emergency/publisher-compromised",
+			uri: () => PUBLISHER_DID,
+			conf: PUBLISHER_SEGMENT,
+			intent: "CONFIRM COMPROMISE",
+		},
+		{
+			path: "/admin/api/emergency/publisher-compromised-retract",
+			uri: () => PUBLISHER_DID,
+			conf: PUBLISHER_SEGMENT,
+			intent: "CONFIRM RETRACT",
+		},
+	];
+
+	it.each(cases)(
+		"rejects a reviewer with zero side effects: $path",
+		async ({ path, uri, conf, intent }) => {
+			const before = {
+				actions: await countRows(`SELECT COUNT(*) n FROM operator_actions`),
+				labels: await countRows(`SELECT COUNT(*) n FROM issued_labels`),
+				events: await countRows(`SELECT COUNT(*) n FROM operational_events`),
+				outbox: await countRows(`SELECT COUNT(*) n FROM notification_outbox`),
+			};
+			const response = await handleConsoleMutation(
+				emergency(path, { uri: uri(), subjectConfirmation: conf, intent }, reviewerToken),
+				mutationDeps(),
+			);
+			expect(response.status).toBe(403);
+			expect((await bodyError(response)).code).toBe("FORBIDDEN_ROLE");
+			expect(await countRows(`SELECT COUNT(*) n FROM operator_actions`)).toBe(before.actions);
+			expect(await countRows(`SELECT COUNT(*) n FROM issued_labels`)).toBe(before.labels);
+			expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(before.events);
+			expect(await countRows(`SELECT COUNT(*) n FROM notification_outbox`)).toBe(before.outbox);
+		},
+	);
+
+	it.each(cases)(
+		"accepts an admin (the 403 is the role, not a broken endpoint): $path",
+		async ({ path, uri, conf, intent }) => {
+			const response = await handleConsoleMutation(
+				emergency(path, { uri: uri(), subjectConfirmation: conf, intent }, adminToken),
+				mutationDeps(),
+			);
+			expect(response.status).toBe(200);
+		},
+	);
+
+	it("rejects an unauthenticated caller with zero side effects (401)", async () => {
+		const before = {
+			actions: await countRows(`SELECT COUNT(*) n FROM operator_actions`),
+			labels: await countRows(`SELECT COUNT(*) n FROM issued_labels`),
+			events: await countRows(`SELECT COUNT(*) n FROM operational_events`),
+			outbox: await countRows(`SELECT COUNT(*) n FROM notification_outbox`),
+		};
+		const response = await handleConsoleMutation(
+			emergency(
+				"/admin/api/emergency/takedown",
+				{ uri: PUBLISHER_DID, subjectConfirmation: PUBLISHER_SEGMENT, intent: "CONFIRM TAKEDOWN" },
+				null,
+			),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(401);
+		expect(await countRows(`SELECT COUNT(*) n FROM operator_actions`)).toBe(before.actions);
+		expect(await countRows(`SELECT COUNT(*) n FROM issued_labels`)).toBe(before.labels);
+		expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(before.events);
+		expect(await countRows(`SELECT COUNT(*) n FROM notification_outbox`)).toBe(before.outbox);
+	});
+});
+
+describe("console mutation: emergency ceremony", () => {
+	it("rejects a wrong subject confirmation without echoing the typed value (400)", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri: releaseUri("emrg-conf"),
+				subjectConfirmation: "not-the-rkey",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		const error = await bodyError(response);
+		expect(error.code).toBe("CONFIRMATION_MISMATCH");
+		expect(error.message).not.toContain("not-the-rkey");
+	});
+
+	it("rejects a wrong intent phrase (400)", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri: releaseUri("emrg-intent"),
+				subjectConfirmation: "emrg-intent",
+				intent: "CONFIRM COMPROMISE",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("CONFIRMATION_MISMATCH");
+	});
+
+	it("rejects a missing intent (400)", async () => {
+		const response = await handleConsoleMutation(
+			post(
+				"/admin/api/emergency/takedown",
+				{
+					uri: releaseUri("emrg-nointent"),
+					subjectConfirmation: "emrg-nointent",
+					reason: "no intent",
+					idempotencyKey: nextKey(),
+				},
+				{ token: adminToken },
+			),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects the issue intent on a retract endpoint (400)", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri: PUBLISHER_DID,
+				subjectConfirmation: PUBLISHER_SEGMENT,
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("CONFIRMATION_MISMATCH");
+	});
+
+	it("T7: a release URI confirmed with a DID segment fails (subject-kind confusion)", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri: releaseUri("emrg-t7"),
+				subjectConfirmation: PUBLISHER_SEGMENT,
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(400);
+		expect((await bodyError(response)).code).toBe("CONFIRMATION_MISMATCH");
+	});
+});
+
+describe("console mutation: emergency replay and phantom success", () => {
+	it("emits exactly one operational event + outbox row across a replay", async () => {
+		const uri = await seedReleaseSubject("emrg-replay");
+		const key = nextKey();
+		const request = () =>
+			post(
+				"/admin/api/emergency/takedown",
+				{
+					uri,
+					subjectConfirmation: "emrg-replay",
+					intent: "CONFIRM TAKEDOWN",
+					reason: "replay incident",
+					idempotencyKey: key,
+				},
+				{ token: adminToken },
+			);
+		const first = await handleConsoleMutation(request(), mutationDeps());
+		const firstBody = await first.text();
+		const second = await handleConsoleMutation(request(), mutationDeps());
+		expect(second.status).toBe(200);
+		expect(await second.text()).toBe(firstBody);
+
+		const descriptor = JSON.parse(firstBody).data as IssuedLabelDescriptor;
+		expect(await eventCount(descriptor.actionId)).toBe(1);
+		expect(await outboxCount(descriptor.actionId)).toBe(1);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = '!takedown'`,
+				uri,
+			),
+		).toBe(1);
+	});
+
+	it("503s with no label, event, or outbox when the batch is suppressed, and re-503s on replay (T1)", async () => {
+		const uri = await seedReleaseSubject("emrg-phantom");
+		const key = nextKey();
+		const body = {
+			uri,
+			subjectConfirmation: "emrg-phantom",
+			intent: "CONFIRM TAKEDOWN",
+			reason: "rotation mid-issuance",
+			idempotencyKey: key,
+		};
+		const response = await handleConsoleMutation(
+			post("/admin/api/emergency/takedown", body, { token: adminToken }),
+			mutationDeps({ db: suppressIssuanceDb(testEnv.DB) }),
+		);
+		expect(response.status).toBe(503);
+		expect((await bodyError(response)).code).toBe("LABEL_ISSUANCE_UNAVAILABLE");
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operator_actions WHERE idempotency_key = ?`, key),
+		).toBe(1);
+		expect(await countRows(`SELECT COUNT(*) n FROM issued_labels WHERE uri = ?`, uri)).toBe(0);
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operational_events WHERE subject_uri = ?`, uri),
+		).toBe(0);
+
+		const outboxBefore = await countRows(`SELECT COUNT(*) n FROM notification_outbox`);
+		const retry = await handleConsoleMutation(
+			post("/admin/api/emergency/takedown", body, { token: adminToken }),
+			mutationDeps(),
+		);
+		expect(retry.status).toBe(503);
+		expect((await bodyError(retry)).code).toBe("LABEL_ISSUANCE_UNAVAILABLE");
+		expect(await countRows(`SELECT COUNT(*) n FROM issued_labels WHERE uri = ?`, uri)).toBe(0);
+		expect(
+			await countRows(`SELECT COUNT(*) n FROM operational_events WHERE subject_uri = ?`, uri),
+		).toBe(0);
+		expect(await countRows(`SELECT COUNT(*) n FROM notification_outbox`)).toBe(outboxBefore);
+	});
+});
+
+describe("console mutation: emergency retract resting state", () => {
+	it("re-exposes pre-takedown automated blocks and re-issues nothing (evaluator agrees)", async () => {
+		const uri = releaseUri("emrg-rest");
+		await seedAutomatedBlock(uri, CID);
+
+		const takedown = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: "emrg-rest",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(takedown.status).toBe(200);
+
+		const redacted = evaluateHydratedReleaseModeration({
+			acceptedLabelers: [{ did: LABELER_DID, redact: true }],
+			context: {
+				publisherDid: PUBLISHER_DID,
+				package: { uri, cid: CID },
+				release: { uri, cid: CID },
+			},
+			evaluatedAt: new Date(),
+			labels: await moderationLabelsFor(uri),
+		});
+		expect(redacted.redacted).toBe(true);
+
+		const retract = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: "emrg-rest",
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(retract.status).toBe(200);
+		expect((await bodyData<IssuedLabelDescriptor>(retract)).neg).toBe(true);
+
+		// Resting state: the takedown is inactive, the automated malware block is
+		// active again (it was never negated), and nothing was re-issued for it.
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("!takedown")?.active).toBe(false);
+		expect(winners.get("malware")?.active).toBe(true);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM issued_labels WHERE uri = ? AND val = 'malware'`,
+				uri,
+			),
+		).toBe(1);
+
+		const atRest = evaluateHydratedReleaseModeration({
+			acceptedLabelers: [{ did: LABELER_DID, redact: true }],
+			context: {
+				publisherDid: PUBLISHER_DID,
+				package: { uri, cid: CID },
+				release: { uri, cid: CID },
+			},
+			evaluatedAt: new Date(),
+			labels: await moderationLabelsFor(uri),
+		});
+		expect(atRest.redacted).toBe(false);
+		expect(atRest.eligibility).toBe("blocked");
+		expect(atRest.blockingLabels).toContain("malware");
+	});
+
+	it("emits a high-severity operational event for a retract", async () => {
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri: PUBLISHER_DID,
+				subjectConfirmation: PUBLISHER_SEGMENT,
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<IssuedLabelDescriptor>(response);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operational_events WHERE action_id = ? AND severity = 'high'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+	});
+});
+
+describe("console mutation: emergency §10 automation interaction", () => {
+	it("automation cannot negate an admin-issued !takedown", async () => {
+		const uri = await seedReleaseSubject("emrg-s10");
+		const takedown = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: "emrg-s10",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(takedown.status).toBe(200);
+
+		// The automated issuance path refuses the emergency vocabulary outright, so
+		// automation can never reach — let alone negate — a manually-headed takedown.
+		await expect(
+			issueAutomatedAssessmentLabel(
+				testEnv.DB,
+				CONFIG,
+				await testSigner(),
+				{
+					actor: LABELER_DID,
+					type: "automated-assessment",
+					assessmentId: `asmt_${"0".repeat(26)}`,
+					reason: "automated negation attempt",
+					idempotencyKey: nextKey(),
+				},
+				{ uri, cid: CID, val: "!takedown", neg: true },
+			),
+		).rejects.toThrow();
+
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("!takedown")?.active).toBe(true);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

W9.6 PR-1 — the **admin-only emergency actions**. Four endpoints issue and retract `!takedown` (on a release, package, or publisher subject) and `publisher-compromised` (on a DID), each through the W9.2 mutation guard as one atomic `commitMutation` batch: the signed label, a **critical-severity operational event**, and a `deployment-alert` outbox row (W11.3 drains it) all commit together, or none do.

Building on PR-0 (#2024) and W9.5 (#2023):

- **Admin-only, checked pre-effect.** Every endpoint sets `requiredRole: "admin"` on its spec; `guardMutation` verifies the Access identity and role *before* body parsing, signing, or any write. A reviewer gets 403 and an unauthenticated caller 401 with provably zero side effects (no `operator_actions`, `issued_labels`, `operational_events`, or `notification_outbox` row). `hasRole` has no reviewer→admin path.
- **High-friction typed ceremony.** The body carries two server-validated fields: `subjectConfirmation` (the release/package **rkey**, or the publisher **DID's final segment** — no fragile handle resolution) and `intent` (a server-constant phrase bound per action *and* direction: `CONFIRM TAKEDOWN` / `CONFIRM COMPROMISE` / `CONFIRM RETRACT`). Both are validated before signing, both fold into the idempotency fingerprint, and the error is a static `CONFIRMATION_MISMATCH` that never echoes the typed value. An issue-intent on a retract endpoint, or a takedown phrase for a compromise, is rejected.
- **No phantom alert.** The event and outbox inserts gate on the label's in-batch existence (`WHERE EXISTS (issued_labels JOIN issuance_actions ON … WHERE idempotency_key = ?)`), keyed on the issuance idempotency key — see the PR-0 correction below. If a signing-key rotation suppresses the label mid-batch, neither the event nor the outbox row inserts, and `assertIssuancePersisted` returns 503 on both the proceed and replay paths. No "takedown issued" alert can ever fire for a takedown that never landed.
- **Retract restores the pre-takedown state.** `!takedown` is admin-retractable (same ceremony, `CONFIRM RETRACT`); retraction issues a single `neg:true` label and re-exposes whatever automated blocks were live before — they were never negated, so nothing is re-issued and the evaluator resolves the subject to its real state (blocked, not redacted, not eligible). Publisher/package takedown is **one** URI-wide/DID label — no cascade to per-release labels, so there is no partial-application surface.
- **§10 holds:** automation cannot negate an admin `!takedown` — the automated path rejects the emergency vocabulary outright, with the in-batch guard as backstop.

Console: an **admin-only "Emergency actions" card** on the subject/publisher view with the two-typed-field danger dialog (record takedown, publisher takedown, publisher-compromised — issue and retract, state-gated by the subject-label read with a "taken down" indicator). Admin visibility is cosmetic via `/whoami`; the server is authoritative. Plain English strings (console unlocalized, W9.3 decision), RTL-safe logical Tailwind, `role="alertdialog"`.

**No policy fixture change:** `!takedown` and `publisher-compromised` already carry `admin` issuance modes at `policyVersion 2026-07-10.experimental.3`; the delta from W9.4's issue endpoint is purely the `admin` role gate + ceremony + gated event/outbox.

### PR-0 correction (worth a look)

PR-0's phantom-success gate keyed on the numeric `issuance_actions.id`, but the real issuance path lets D1 autoincrement that id in-batch — so it's unknowable to a handler and undrivable. This PR adds an **additive** `gateOnIssuedLabelActionKey` that gates on the UNIQUE issuance idempotency key (= the operator action id, minted before commit) via a join to the label. PR-0's numeric gate and its five tests are untouched. `issuance_actions.idempotency_key` is UNIQUE and equals this action's id, so the gate can only ever match *this* action's own label.

### Two decisions for a reviewer (non-blocking)

Surfaced by the independent adversarial pass; neither is a security issue (both fail safe), so I've left the behavior as-is pending your call:

1. **Retract with no active takedown succeeds** as a no-op `neg` label *and still emits a high-severity operational event + alert*. It fails safe (moves toward less restriction), but a spurious critical-adjacent alert for a no-op is operational noise. Option: guard retract on an active positive and 404/409 otherwise. I lean toward adding the guard in PR-2/PR-3 once the DLQ/alert plumbing is fuller, but happy to do it here if you'd rather.
2. **`operator_actions.action` is `takedown` / `publisher-compromised` for both issue and retract** — direction lives in `metadata.neg`. This matches the ratified `OperatorActionType` set (no separate retract types), but an auditor filtering by `action` can't distinguish issue from retract without reading metadata. Flagging for audit-observability; changing it means new action-union members (touches the frozen `operator-actions.ts`).

**Adversarially reviewed** by an independent Opus pass targeting authz-before-effect on all four endpoints, ceremony bypass, the T1 key-gate composition, subject-kind confusion (T7), retract resting state, §10, and replay-exactly-once: **no blockers**, crown jewels confirmed. Its one test-symmetry note (the 401 test asserted status only) is folded in — that test now asserts zero side effects too.

Stacked on the integration branch (W9.5 + PR-0 merged). Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — the labeler console is deliberately not localized (decision 2026-07-13). Changeset n/a — `apps/labeler` is a private, unpublished Worker app.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Opus 4.8 (design, implementation, adversarial review, coordination)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker **507 pass** (28 files; the `console-mutation-api` suite adds 24 emergency-action tests — per-endpoint reviewer/unauth zero-side-effect, admin-accepts, ceremony rejections, T1 phantom + replay-exactly-one-event, T7 subject confusion, retract resting state, §10), console **26 pass** (6 new for the emergency dialog)
- Typecheck (both projects) clean; `console:build` succeeds; lint: 0 diagnostics in `apps/labeler`

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-emergency-actions-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-emergency-actions`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
