### PR TITLE
feat(labeler): admin pause/resume of automated issuance (W9.6 PR-2)

### DIFF
--- a/apps/labeler/console/src/api/client.ts
+++ b/apps/labeler/console/src/api/client.ts
@@ -9,6 +9,8 @@ import {
 import type {
 	AssessmentActionInput,
 	AssessmentRun,
+	AutomationToggleInput,
+	AutomationToggleResult,
 	EffectPreview,
 	EffectPreviewParams,
 	EmergencyActionInput,
@@ -60,6 +62,8 @@ export interface LabelerConsoleClient {
 		mode: "issue" | "retract",
 		input: EmergencyActionInput,
 	): Promise<IssuedLabelDescriptor>;
+	pauseAutomation(input: AutomationToggleInput): Promise<AutomationToggleResult>;
+	resumeAutomation(input: AutomationToggleInput): Promise<AutomationToggleResult>;
 }
 
 /** The admin-only emergency endpoints, keyed by action and direction. */
@@ -220,6 +224,12 @@ export function createFetchClient(): LabelerConsoleClient {
 		async emergencyAction(kind, mode, input) {
 			return postAction(EMERGENCY_PATHS[kind][mode], input, "Failed to submit emergency action");
 		},
+		async pauseAutomation(input) {
+			return postAction("/automation/pause", input, "Failed to pause automation");
+		},
+		async resumeAutomation(input) {
+			return postAction("/automation/resume", input, "Failed to resume automation");
+		},
 	};
 }
 
@@ -335,6 +345,22 @@ export function createFixtureClient(): LabelerConsoleClient {
 				neg: mode === "retract",
 				cts: new Date().toISOString(),
 				effect: kind === "takedown" ? "redact" : "block",
+			};
+		},
+		async pauseAutomation(input) {
+			return {
+				actionId: "oact_fixture",
+				paused: true,
+				reason: input.reason,
+				cts: new Date().toISOString(),
+			};
+		},
+		async resumeAutomation(input) {
+			return {
+				actionId: "oact_fixture",
+				paused: false,
+				reason: input.reason,
+				cts: new Date().toISOString(),
 			};
 		},
 	};

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -135,6 +135,11 @@ export interface SystemStatusSnapshot {
 	/** Dead-letter backlog — the observable stand-in for discovery-queue depth,
 	 * which the Queues API does not expose to the consumer Worker. */
 	deadLetterDepth: number;
+	/** The global ingestion kill-switch (spec §11.3). `pausedReason`/`pausedSince`
+	 * are non-null only while paused. */
+	automationPaused: boolean;
+	pausedReason: string | null;
+	pausedSince: string | null;
 }
 
 export interface Page<T> {
@@ -311,6 +316,23 @@ export interface EmergencyActionInput {
 	intent: string;
 	reason: string;
 	idempotencyKey: string;
+}
+
+/** Body for the admin-only pause/resume endpoints (`POST /admin/api/automation/*`).
+ * A required reason (folded into the audit row, the operational event, and — for
+ * a pause — `automation_state.paused_reason`) and a client-minted idempotency key
+ * reused across retries so a network retry replays rather than double-toggles. */
+export interface AutomationToggleInput {
+	reason: string;
+	idempotencyKey: string;
+}
+
+/** Idempotent pause/resume result — the kill-switch's post-action state. */
+export interface AutomationToggleResult {
+	actionId: string;
+	paused: boolean;
+	reason: string;
+	cts: string;
 }
 
 export interface ListAssessmentsParams {

--- a/apps/labeler/console/src/components/AutomationControl.test.tsx
+++ b/apps/labeler/console/src/components/AutomationControl.test.tsx
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { AutomationControl } from "./AutomationControl.js";
+
+vi.mock("../api/client.js", () => ({
+	apiClient: { pauseAutomation: vi.fn(), resumeAutomation: vi.fn() },
+}));
+
+const pauseAutomation = vi.mocked(apiClient.pauseAutomation);
+const resumeAutomation = vi.mocked(apiClient.resumeAutomation);
+
+interface RenderOverrides {
+	paused?: boolean;
+	pausedReason?: string | null;
+	isAdmin?: boolean;
+}
+
+function renderControl(overrides: RenderOverrides = {}) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	render(
+		<QueryClientProvider client={client}>
+			<AutomationControl
+				paused={overrides.paused ?? false}
+				pausedReason={overrides.pausedReason ?? null}
+				isAdmin={overrides.isAdmin ?? true}
+			/>
+		</QueryClientProvider>,
+	);
+}
+
+afterEach(() => {
+	pauseAutomation.mockReset();
+	resumeAutomation.mockReset();
+});
+
+describe("AutomationControl", () => {
+	it("shows Active and pauses through the required-reason dialog for an admin", async () => {
+		pauseAutomation.mockResolvedValue({
+			actionId: "oact_1",
+			paused: true,
+			reason: "incident",
+			cts: "2026-07-13T00:00:00.000Z",
+		});
+		renderControl({ paused: false });
+		expect(screen.getByText("Active")).toBeTruthy();
+
+		fireEvent.click(screen.getByRole("button", { name: "Pause ingestion" }));
+		const submit = screen.getByRole("button", { name: "Pause" }) as HTMLButtonElement;
+		expect(submit.disabled).toBe(true);
+
+		fireEvent.change(screen.getByPlaceholderText("Why ingestion is being paused"), {
+			target: { value: "incident" },
+		});
+		expect(submit.disabled).toBe(false);
+		fireEvent.click(submit);
+
+		await waitFor(() => {
+			expect(pauseAutomation).toHaveBeenCalledWith(
+				expect.objectContaining({ reason: "incident" }),
+			);
+		});
+		expect(resumeAutomation).not.toHaveBeenCalled();
+	});
+
+	it("shows Paused with the reason and resumes when paused", async () => {
+		resumeAutomation.mockResolvedValue({
+			actionId: "oact_2",
+			paused: false,
+			reason: "cleared",
+			cts: "2026-07-13T00:00:00.000Z",
+		});
+		renderControl({ paused: true, pausedReason: "incident-42" });
+		expect(screen.getByText("Paused")).toBeTruthy();
+		expect(screen.getByText("incident-42")).toBeTruthy();
+
+		fireEvent.click(screen.getByRole("button", { name: "Resume ingestion" }));
+		fireEvent.change(screen.getByPlaceholderText("Why ingestion is being resumed"), {
+			target: { value: "cleared" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+
+		await waitFor(() => {
+			expect(resumeAutomation).toHaveBeenCalledWith(
+				expect.objectContaining({ reason: "cleared" }),
+			);
+		});
+		expect(pauseAutomation).not.toHaveBeenCalled();
+	});
+
+	it("hides the toggle for a non-admin (server stays authoritative)", () => {
+		renderControl({ paused: false, isAdmin: false });
+		expect(screen.getByText("Active")).toBeTruthy();
+		expect(screen.queryByRole("button", { name: "Pause ingestion" })).toBeNull();
+	});
+});

--- a/apps/labeler/console/src/components/AutomationControl.tsx
+++ b/apps/labeler/console/src/components/AutomationControl.tsx
@@ -1,0 +1,112 @@
+import { Button, Dialog, InputArea, LayerCard } from "@cloudflare/kumo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+
+interface AutomationControlProps {
+	paused: boolean;
+	pausedReason: string | null;
+	/** Cosmetic gating from `/whoami` — the server (`guardMutation`) is the
+	 * enforcement boundary, so hiding the toggle never grants anything. */
+	isAdmin: boolean;
+}
+
+/**
+ * The admin-only global ingestion kill-switch control (spec §11.3, design §5).
+ * Shows whether automated issuance is live or paused and, for an admin, toggles
+ * it behind a required reason. Pausing halts Jetstream ingestion only — in-flight
+ * work and manual/emergency issuance stay available. The idempotency key is
+ * minted per dialog open and reused across retries so a network retry replays
+ * rather than double-toggling.
+ */
+export function AutomationControl({ paused, pausedReason, isAdmin }: AutomationControlProps) {
+	const queryClient = useQueryClient();
+	const [open, setOpen] = useState(false);
+	const [reason, setReason] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setReason("");
+	}, [open]);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			paused
+				? apiClient.resumeAutomation({ reason, idempotencyKey })
+				: apiClient.pauseAutomation({ reason, idempotencyKey }),
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({ queryKey: ["system-status"] });
+			setOpen(false);
+		},
+	});
+
+	const canSubmit = reason.trim().length > 0 && !mutation.isPending;
+
+	return (
+		<LayerCard className={`flex flex-col gap-3 p-4 ${paused ? "border border-kumo-danger" : ""}`}>
+			<div className="flex items-start justify-between gap-4">
+				<div className="flex flex-col gap-1">
+					<span className="text-sm text-kumo-subtle">Automated issuance</span>
+					<span className={`text-2xl font-semibold ${paused ? "text-kumo-danger" : ""}`}>
+						{paused ? "Paused" : "Active"}
+					</span>
+					{paused && pausedReason && (
+						<span className="text-sm text-kumo-subtle">{pausedReason}</span>
+					)}
+				</div>
+				{isAdmin && (
+					<Button variant={paused ? "primary" : "destructive"} onClick={() => setOpen(true)}>
+						{paused ? "Resume ingestion" : "Pause ingestion"}
+					</Button>
+				)}
+			</div>
+
+			<Dialog.Root open={open} onOpenChange={setOpen} role="alertdialog">
+				<Dialog className="flex flex-col gap-4 p-6" size="base">
+					<Dialog.Title className="text-lg font-semibold">
+						{paused ? "Resume automated issuance" : "Pause automated issuance"}
+					</Dialog.Title>
+					<Dialog.Description className="text-sm text-kumo-subtle">
+						{paused
+							? "Resumes Jetstream ingestion. New releases are discovered and assessed automatically again."
+							: "Halts Jetstream ingestion globally. Manual and emergency issuance are unaffected; queued releases retry until you resume."}
+					</Dialog.Description>
+
+					<InputArea
+						label="Reason"
+						value={reason}
+						onValueChange={setReason}
+						placeholder={
+							paused ? "Why ingestion is being resumed" : "Why ingestion is being paused"
+						}
+					/>
+
+					{mutation.isError && (
+						<p className="text-sm text-kumo-danger">
+							{mutation.error instanceof Error ? mutation.error.message : "Action failed"}
+						</p>
+					)}
+
+					<div className="flex justify-end gap-2">
+						<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+							Cancel
+						</Dialog.Close>
+						<Button
+							variant={paused ? "primary" : "destructive"}
+							disabled={!canSubmit}
+							onClick={() => {
+								mutation.mutate();
+							}}
+						>
+							{mutation.isPending ? "Submitting…" : paused ? "Resume" : "Pause"}
+						</Button>
+					</div>
+				</Dialog>
+			</Dialog.Root>
+		</LayerCard>
+	);
+}

--- a/apps/labeler/console/src/fixtures/system-status.ts
+++ b/apps/labeler/console/src/fixtures/system-status.ts
@@ -6,4 +6,7 @@ export const FIXTURE_SYSTEM_STATUS: SystemStatusSnapshot = {
 	jetstreamConnected: true,
 	pendingAssessments: 1,
 	deadLetterDepth: 2,
+	automationPaused: false,
+	pausedReason: null,
+	pausedSince: null,
 };

--- a/apps/labeler/console/src/routes/Dashboard.tsx
+++ b/apps/labeler/console/src/routes/Dashboard.tsx
@@ -4,6 +4,7 @@ import { createRoute } from "@tanstack/react-router";
 import * as React from "react";
 
 import { apiClient } from "../api/client.js";
+import { AutomationControl } from "../components/AutomationControl.js";
 import { QueryError } from "../components/QueryError.js";
 import { shellRoute } from "./root.js";
 
@@ -26,6 +27,8 @@ function Dashboard() {
 		queryKey: ["system-status"],
 		queryFn: () => apiClient.getSystemStatus(),
 	});
+	const { data: whoami } = useQuery({ queryKey: ["whoami"], queryFn: () => apiClient.whoami() });
+	const isAdmin = whoami?.roles.includes("admin") ?? false;
 
 	if (isError) {
 		return (
@@ -59,6 +62,11 @@ function Dashboard() {
 				<StatCard label="Pending assessments" value={status.pendingAssessments} />
 				<StatCard label="Dead-letter depth" value={status.deadLetterDepth} />
 			</Grid>
+			<AutomationControl
+				paused={status.automationPaused}
+				pausedReason={status.pausedReason}
+				isAdmin={isAdmin}
+			/>
 			<LayerCard className="p-4 text-sm text-kumo-subtle">
 				Labeler DID: <span className="font-mono">{status.labelerDid}</span>
 			</LayerCard>

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -321,9 +321,10 @@ async function handleListAuditLog(
 
 async function handleGetStatus(request: Request, deps: ConsoleApiDeps): Promise<Response> {
 	requireGet(request);
-	const [pendingAssessments, deadLetterDepth, jetstreamConnected] = await Promise.all([
+	const [pendingAssessments, deadLetterDepth, automation, jetstreamConnected] = await Promise.all([
 		countInFlightAssessments(deps.db),
 		countDeadLetters(deps.db),
+		readAutomationState(deps.db),
 		deps.jetstreamConnected(),
 	]);
 	return jsonData({
@@ -331,7 +332,22 @@ async function handleGetStatus(request: Request, deps: ConsoleApiDeps): Promise<
 		jetstreamConnected,
 		pendingAssessments,
 		deadLetterDepth,
+		automationPaused: automation.paused,
+		pausedReason: automation.reason,
+		pausedSince: automation.since,
 	});
+}
+
+/** The ingestion kill-switch state for the operator dashboard. `reason`/`since`
+ * are meaningful only while paused; both read null when ingestion is live. */
+async function readAutomationState(
+	db: D1Database,
+): Promise<{ paused: boolean; reason: string | null; since: string | null }> {
+	const row = await db
+		.prepare(`SELECT paused, paused_reason, updated_at FROM automation_state WHERE id = 1`)
+		.first<{ paused: number; paused_reason: string | null; updated_at: string }>();
+	if (!row || row.paused !== 1) return { paused: false, reason: null, since: null };
+	return { paused: true, reason: row.paused_reason, since: row.updated_at };
 }
 
 /** The caller's own verified identity — kind, principal, and roles — for the

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -27,6 +27,7 @@ import {
 	getAssessment,
 	type Assessment,
 } from "./assessment-store.js";
+import { buildAutomationPauseUpdate } from "./automation-state.js";
 import type { LabelerIdentityConfig } from "./config.js";
 import {
 	commitMutation,
@@ -167,6 +168,10 @@ export async function handleConsoleMutation(
 				return await runEmergencyAction(request, deps, "publisher-compromised", false);
 			if (segments[1] === "publisher-compromised-retract")
 				return await runEmergencyAction(request, deps, "publisher-compromised", true);
+		}
+		if (segments[0] === "automation" && segments.length === 2) {
+			if (segments[1] === "pause") return await runAutomationToggle(request, deps, true);
+			if (segments[1] === "resume") return await runAutomationToggle(request, deps, false);
 		}
 		throw new ReadGuardError("NOT_FOUND");
 	} catch (error) {
@@ -978,4 +983,73 @@ function assertEmergencyConfirmation(
  * PLC/web identifier), not a resolved handle. */
 function didFinalSegment(uri: string): string {
 	return uri.split(":").at(-1) ?? "";
+}
+
+// ─── W9.6: admin-only automation kill-switch (pause/resume ingestion) ────────
+
+/** The idempotent pause/resume result. `paused` is the switch's post-action
+ * state; `reason` echoes the operator reason folded into the audit row and the
+ * operational event. */
+interface AutomationToggleDescriptor {
+	actionId: string;
+	paused: boolean;
+	reason: string;
+	cts: string;
+}
+
+/**
+ * `POST /admin/api/automation/{pause,resume}` — the admin-only global ingestion
+ * kill-switch (spec §11.3, design §5). Flips `automation_state.paused` and emits
+ * an ungated operational event in one atomic `commitMutation` batch with the
+ * audit row. Unlike the emergency actions it issues no label: the effect is a
+ * state UPDATE plus an unconditional event insert, so there is no confirmation
+ * ceremony and no phantom-label verification. A required `reason` is the only
+ * body field and folds into the request fingerprint, so a replay must resend it.
+ *
+ * The switch gates only the discovery consumer's ingestion path — manual/admin
+ * issuance (including an emergency `!takedown`) stays available while paused.
+ * Pausing an already-paused switch is a harmless idempotent re-write; each
+ * distinct action is independently audited and emits its own event.
+ */
+async function runAutomationToggle(
+	request: Request,
+	deps: ConsoleMutationDeps,
+	paused: boolean,
+): Promise<Response> {
+	const spec: MutationSpec<Record<string, never>> = {
+		action: paused ? "pause-issuance" : "resume-issuance",
+		requiredRole: "admin",
+		parseBody: () => ({}),
+		auditFields: () => ({ metadata: { paused } }),
+	};
+
+	const outcome = await guardMutation(request, spec, guardDepsOf(deps));
+	if (outcome.outcome === "replay")
+		return jsonData(storedDescriptor<AutomationToggleDescriptor>(outcome.result));
+
+	const { ctx } = outcome;
+	const stateUpdate = buildAutomationPauseUpdate(deps.db, {
+		paused,
+		reason: paused ? ctx.reason : null,
+		actionId: ctx.actionId,
+		now: ctx.now,
+	});
+	const eventInsert = buildOperationalEventInsert(deps.db, {
+		id: newOperationalEventId(),
+		eventType: paused ? "automation-paused" : "automation-resumed",
+		severity: paused ? "high" : "info",
+		actionId: ctx.actionId,
+		payload: { reason: ctx.reason },
+		now: ctx.now,
+	});
+
+	const descriptor: AutomationToggleDescriptor = {
+		actionId: ctx.actionId,
+		paused,
+		reason: ctx.reason,
+		cts: ctx.now.toISOString(),
+	};
+	return jsonData(
+		await commitMutation(deps.db, ctx, spec, [stateUpdate, eventInsert], descriptor),
+	);
 }

--- a/apps/labeler/test/console-api.test.ts
+++ b/apps/labeler/test/console-api.test.ts
@@ -637,13 +637,43 @@ describe("handleConsoleApi — system status", () => {
 			jetstreamConnected: boolean;
 			pendingAssessments: number;
 			deadLetterDepth: number;
+			automationPaused: boolean;
+			pausedReason: string | null;
+			pausedSince: string | null;
 		};
 		expect(status.labelerDid).toBe(LABELER_DID);
 		expect(status.jetstreamConnected).toBe(false);
 		// asmt_run (running) + asmt_pending (pending).
 		expect(status.pendingAssessments).toBe(2);
 		expect(status.deadLetterDepth).toBe(3);
+		// Ingestion runs by default: the seeded kill-switch reads unpaused.
+		expect(status.automationPaused).toBe(false);
+		expect(status.pausedReason).toBeNull();
+		expect(status.pausedSince).toBeNull();
 		expect(status).not.toHaveProperty("lastReconciliationAt");
+	});
+
+	it("reports the paused state, reason, and since when ingestion is paused", async () => {
+		await testEnv.DB.prepare(
+			`UPDATE automation_state
+			 SET paused = 1, paused_reason = 'incident-77', updated_at = '2026-07-13T12:00:00.000Z'
+			 WHERE id = 1`,
+		).run();
+		try {
+			const res = await handleConsoleApi(req("/admin/api/status", { token: reviewerToken }), deps());
+			const status = (await body(res)).data as {
+				automationPaused: boolean;
+				pausedReason: string | null;
+				pausedSince: string | null;
+			};
+			expect(status.automationPaused).toBe(true);
+			expect(status.pausedReason).toBe("incident-77");
+			expect(status.pausedSince).toBe("2026-07-13T12:00:00.000Z");
+		} finally {
+			await testEnv.DB.prepare(
+				`UPDATE automation_state SET paused = 0, paused_reason = NULL WHERE id = 1`,
+			).run();
+		}
 	});
 });
 

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@emdash-cms/registry-moderation";
 import { applyD1Migrations, env } from "cloudflare:test";
 import { generateKeyPair, SignJWT } from "jose";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import type { AccessKeyResolver } from "../src/access-auth.js";
 import { computeRunKey, initialTriggerId } from "../src/assessment-lifecycle.js";
@@ -21,7 +21,14 @@ import {
 	type ConsoleMutationDeps,
 	type IssuedLabelDescriptor,
 } from "../src/console-mutation-api.js";
+import {
+	processDiscoveryMessage,
+	type DiscoveryConsumerDeps,
+	type MessageController,
+} from "../src/discovery-consumer.js";
+import type { DiscoveryJob } from "../src/env.js";
 import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
+import type { DidDocumentResolverLike } from "../src/record-verification.js";
 import { issueAutomatedAssessmentLabel, issueManualLabel } from "../src/service.js";
 
 const TEAM_DOMAIN = "https://example-team.cloudflareaccess.com";
@@ -1290,5 +1297,283 @@ describe("console mutation: emergency §10 automation interaction", () => {
 
 		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
 		expect(winners.get("!takedown")?.active).toBe(true);
+	});
+});
+
+// ─── W9.6: admin-only automation kill-switch (pause/resume) ──────────────────
+
+function automation(
+	path: string,
+	token: string | null = adminToken,
+	body: Record<string, unknown> = {},
+): Request {
+	return post(path, { reason: "incident response", idempotencyKey: nextKey(), ...body }, { token });
+}
+
+async function automationRow(): Promise<{ paused: number; reason: string | null } | null> {
+	return testEnv.DB.prepare(
+		`SELECT paused, paused_reason AS reason FROM automation_state WHERE id = 1`,
+	).first<{ paused: number; reason: string | null }>();
+}
+
+async function resetAutomation(): Promise<void> {
+	await testEnv.DB.prepare(
+		`UPDATE automation_state SET paused = 0, paused_reason = NULL WHERE id = 1`,
+	).run();
+}
+
+interface AutomationToggleDescriptor {
+	actionId: string;
+	paused: boolean;
+	reason: string;
+	cts: string;
+}
+
+describe("console mutation: automation pause/resume (admin)", () => {
+	afterEach(resetAutomation);
+
+	it("pause flips the switch and emits one automation-paused event + audit row", async () => {
+		const response = await handleConsoleMutation(
+			automation("/admin/api/automation/pause"),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<AutomationToggleDescriptor>(response);
+		expect(descriptor).toMatchObject({ paused: true, reason: "incident response" });
+
+		const row = await automationRow();
+		expect(row?.paused).toBe(1);
+		expect(row?.reason).toBe("incident response");
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operator_actions WHERE id = ? AND action = 'pause-issuance'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operational_events
+				 WHERE action_id = ? AND event_type = 'automation-paused' AND severity = 'high'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+		// Pause issues no label and queues no delivery row.
+		expect(await outboxCount(descriptor.actionId)).toBe(0);
+
+		// T8: the event carries the operator reason only, with no subject or label.
+		const event = await testEnv.DB.prepare(
+			`SELECT payload_json, subject_uri, label_value FROM operational_events WHERE action_id = ?`,
+		)
+			.bind(descriptor.actionId)
+			.first<{ payload_json: string; subject_uri: string | null; label_value: string | null }>();
+		expect(event).toMatchObject({ subject_uri: null, label_value: null });
+		expect(JSON.parse(event!.payload_json)).toEqual({ reason: "incident response" });
+	});
+
+	it("resume flips the switch back and emits an automation-resumed event", async () => {
+		await handleConsoleMutation(automation("/admin/api/automation/pause"), mutationDeps());
+		expect((await automationRow())?.paused).toBe(1);
+
+		const response = await handleConsoleMutation(
+			automation("/admin/api/automation/resume"),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<AutomationToggleDescriptor>(response);
+		expect(descriptor.paused).toBe(false);
+
+		const row = await automationRow();
+		expect(row?.paused).toBe(0);
+		expect(row?.reason).toBeNull();
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operational_events
+				 WHERE action_id = ? AND event_type = 'automation-resumed' AND severity = 'info'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+	});
+});
+
+describe("console mutation: automation authorization (per-endpoint, pre-effect)", () => {
+	afterEach(resetAutomation);
+
+	it.each(["/admin/api/automation/pause", "/admin/api/automation/resume"])(
+		"rejects a reviewer with zero side effects: %s",
+		async (path) => {
+			const before = {
+				actions: await countRows(`SELECT COUNT(*) n FROM operator_actions`),
+				events: await countRows(`SELECT COUNT(*) n FROM operational_events`),
+				paused: (await automationRow())?.paused,
+			};
+			const response = await handleConsoleMutation(automation(path, reviewerToken), mutationDeps());
+			expect(response.status).toBe(403);
+			expect((await bodyError(response)).code).toBe("FORBIDDEN_ROLE");
+			expect(await countRows(`SELECT COUNT(*) n FROM operator_actions`)).toBe(before.actions);
+			expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(before.events);
+			expect((await automationRow())?.paused).toBe(before.paused);
+		},
+	);
+
+	it.each(["/admin/api/automation/pause", "/admin/api/automation/resume"])(
+		"accepts an admin (the 403 is the role, not a broken endpoint): %s",
+		async (path) => {
+			const response = await handleConsoleMutation(automation(path, adminToken), mutationDeps());
+			expect(response.status).toBe(200);
+		},
+	);
+
+	it("rejects an unauthenticated caller with zero side effects (401)", async () => {
+		const before = {
+			actions: await countRows(`SELECT COUNT(*) n FROM operator_actions`),
+			events: await countRows(`SELECT COUNT(*) n FROM operational_events`),
+			paused: (await automationRow())?.paused,
+		};
+		const response = await handleConsoleMutation(
+			automation("/admin/api/automation/pause", null),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(401);
+		expect(await countRows(`SELECT COUNT(*) n FROM operator_actions`)).toBe(before.actions);
+		expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(before.events);
+		expect((await automationRow())?.paused).toBe(before.paused);
+	});
+});
+
+describe("console mutation: automation replay and idempotency", () => {
+	afterEach(resetAutomation);
+
+	it("replays the stored result for the same key + reason, toggling once", async () => {
+		const key = nextKey();
+		const request = () =>
+			post(
+				"/admin/api/automation/pause",
+				{ reason: "same reason", idempotencyKey: key },
+				{ token: adminToken },
+			);
+		const first = await handleConsoleMutation(request(), mutationDeps());
+		const firstBody = await first.text();
+		const second = await handleConsoleMutation(request(), mutationDeps());
+		expect(second.status).toBe(200);
+		expect(await second.text()).toBe(firstBody);
+
+		const descriptor = (JSON.parse(firstBody) as { data: AutomationToggleDescriptor }).data;
+		expect(await eventCount(descriptor.actionId)).toBe(1);
+		expect((await automationRow())?.paused).toBe(1);
+	});
+
+	it("409s a same-key request whose reason differs, with no second event", async () => {
+		const key = nextKey();
+		const first = await handleConsoleMutation(
+			post(
+				"/admin/api/automation/pause",
+				{ reason: "first reason", idempotencyKey: key },
+				{ token: adminToken },
+			),
+			mutationDeps(),
+		);
+		expect(first.status).toBe(200);
+		const eventsBefore = await countRows(`SELECT COUNT(*) n FROM operational_events`);
+
+		const second = await handleConsoleMutation(
+			post(
+				"/admin/api/automation/pause",
+				{ reason: "different reason", idempotencyKey: key },
+				{ token: adminToken },
+			),
+			mutationDeps(),
+		);
+		expect(second.status).toBe(409);
+		expect((await bodyError(second)).code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+		expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(eventsBefore);
+	});
+
+	it("a second distinct pause while already paused is a harmless success", async () => {
+		const first = await bodyData<AutomationToggleDescriptor>(
+			await handleConsoleMutation(automation("/admin/api/automation/pause"), mutationDeps()),
+		);
+		const secondResponse = await handleConsoleMutation(
+			automation("/admin/api/automation/pause"),
+			mutationDeps(),
+		);
+		expect(secondResponse.status).toBe(200);
+		const second = await bodyData<AutomationToggleDescriptor>(secondResponse);
+		expect(second.paused).toBe(true);
+		expect(second.actionId).not.toBe(first.actionId);
+
+		// Still paused; each distinct action is independently audited and emits its
+		// own event.
+		expect((await automationRow())?.paused).toBe(1);
+		expect(await eventCount(first.actionId)).toBe(1);
+		expect(await eventCount(second.actionId)).toBe(1);
+	});
+});
+
+class KillSwitchMessage implements MessageController {
+	acked = 0;
+	retried = 0;
+	ack() {
+		this.acked += 1;
+	}
+	retry() {
+		this.retried += 1;
+	}
+}
+
+class KillSwitchStubResolver implements DidDocumentResolverLike {
+	resolve(): never {
+		throw new Error("resolver should not be called — verify is injected");
+	}
+}
+
+describe("console mutation: pause endpoint drives the discovery consumer gate (end-to-end)", () => {
+	afterEach(resetAutomation);
+
+	it("retries ingestion while paused, processes after resume", async () => {
+		const rkeyName = "kill-switch-e2e";
+		const uri = releaseUri(rkeyName);
+		const job: DiscoveryJob = {
+			did: PUBLISHER_DID,
+			collection: "com.emdashcms.experimental.package.release",
+			operation: "create",
+			cid: CID,
+			rkey: rkeyName,
+		};
+		const consumerDeps: DiscoveryConsumerDeps = {
+			db: testEnv.DB,
+			config: CONFIG,
+			signer: await testSigner(),
+			didDocumentResolver: new KillSwitchStubResolver(),
+			verify: () =>
+				Promise.resolve({
+					cid: CID,
+					record: { $type: job.collection, package: rkeyName, version: "1.0.0" },
+					carBytes: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+				}),
+		};
+
+		const paused = await handleConsoleMutation(
+			automation("/admin/api/automation/pause"),
+			mutationDeps(),
+		);
+		expect(paused.status).toBe(200);
+
+		const pausedMsg = new KillSwitchMessage();
+		await processDiscoveryMessage(job, pausedMsg, consumerDeps);
+		expect(pausedMsg.retried).toBe(1);
+		expect(pausedMsg.acked).toBe(0);
+		expect(await countRows(`SELECT COUNT(*) n FROM subjects WHERE uri = ?`, uri)).toBe(0);
+
+		const resumed = await handleConsoleMutation(
+			automation("/admin/api/automation/resume"),
+			mutationDeps(),
+		);
+		expect(resumed.status).toBe(200);
+
+		const resumedMsg = new KillSwitchMessage();
+		await processDiscoveryMessage(job, resumedMsg, consumerDeps);
+		expect(resumedMsg.acked).toBe(1);
+		expect(resumedMsg.retried).toBe(0);
+		expect(await countRows(`SELECT COUNT(*) n FROM subjects WHERE uri = ?`, uri)).toBe(1);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

W9.6 PR-2 — the **admin-only pause/resume of automated issuance**, the operator surface for the global ingestion kill-switch. PR-0 (#2024) built the mechanism (the `automation_state` singleton, the fail-closed `isAutomationPaused` read, and the discovery-consumer enforcement); this PR wires the endpoints, status read, and console control that drive it.

- **Two endpoints through the mutation guard:** `POST /admin/api/automation/pause` and `/resume`, both `requiredRole: "admin"`. The effect flips `automation_state.paused` (`buildAutomationPauseUpdate`) and emits an **ungated** operational event — `automation-paused` (severity `high`) or `automation-resumed` (`info`) — committed with the audit row in one `commitMutation` batch. No label is issued, so there's no phantom-label risk and `assertIssuancePersisted` doesn't apply. A `reason` is required (it folds into the idempotency fingerprint); no confirmation ceremony — pause/resume is reversible and low-blast-radius, unlike a takedown.
- **The kill-switch stays ingestion-only and fail-closed** (ratified): enforcement lives in the discovery consumer, never the signing layer, so manual/admin issuance — including an emergency `!takedown` — stays available while automation is paused. `resume` clears `paused_reason` to NULL. No auto-resume timer; resume is an explicit audited action.
- **Status read** now reports `automationPaused`, `pausedReason`, and `pausedSince` (a direct singleton read added to the existing status `Promise.all`), degrading in the safe direction on error like its siblings.
- **Console:** an admin-gated pause/resume control on the dashboard showing Active/Paused with a reason input, danger token when paused, RTL-safe logical Tailwind, plain English (unlocalized). Admin visibility is cosmetic via `/whoami`; the server is authoritative.

**End-to-end proof:** the payoff test drives the *real* `processDiscoveryMessage` on the same DB — hit the pause endpoint, and the consumer retries an ingestion create (no subject created); resume, and it processes to a subject + pending run. This proves the operator endpoint actually drives the gate PR-0 built, not a stubbed flag.

`OperatorActionType` already reserved `pause-issuance` / `resume-issuance`; `operational-events.ts` already reserved the event types. Nothing frozen was touched.

**Adversarially reviewed** by an independent Opus pass targeting authz-before-effect, the end-to-end gate drive, fail-closed preservation, singleton integrity under concurrent pause/resume, and a body-injection surface (`paused` derives from the route, never the wire — POSTing `{paused:false}` to `/pause` still pauses): **no blockers**, no test fixes needed. Two informational notes, neither worth a guard: a *missing* singleton row (a broken-migration state) makes the status card read "Active" while the consumer still fails closed and retries everything (cosmetic, safe direction); and `pausedSince` reflects the most recent pause under the event-per-action model.

Stacked on the integration branch (W9.5 + PR-0 + PR-1 merged). Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — the labeler console is deliberately not localized (decision 2026-07-13). Changeset n/a — `apps/labeler` is a private, unpublished Worker app.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Opus 4.8 (design, implementation, adversarial review, coordination)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker **520 pass** (28 files; new pause/resume happy-path, per-endpoint reviewer-403/unauth-401 zero-side-effect, replay/409/re-pause, and the end-to-end consumer-gate proof), console **29 pass** (new `AutomationControl` test)
- Typecheck (both projects) clean; `console:build` succeeds; lint: 0 diagnostics in `apps/labeler`

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-pause-resume-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-pause-resume`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
