### PR TITLE
feat(labeler): admin dead-letter retry and quarantine controls (W9.6 PR-3)

### DIFF
--- a/apps/labeler/console/src/api/client.test.ts
+++ b/apps/labeler/console/src/api/client.test.ts
@@ -40,6 +40,14 @@ describe("fixture client", () => {
 		expect(history?.subject.uri).toBe(assessment!.uri);
 		expect(history?.assessments.some((a) => a.id === assessment!.id)).toBe(true);
 	});
+
+	it("lists dead letters newest-first with a new (actionable) row", async () => {
+		const page = await apiClient.listDeadLetters();
+		expect(page.items.length).toBeGreaterThan(0);
+		const ids = page.items.map((d) => d.id);
+		expect(ids).toEqual(ids.toSorted((a, b) => b - a));
+		expect(page.items.some((d) => d.status === "new")).toBe(true);
+	});
 });
 
 describe("fetch client label actions", () => {
@@ -208,6 +216,51 @@ describe("fetch client label actions", () => {
 		expect(url).toContain("/admin/api/labels/override-effect-preview?");
 		expect(url).toContain("negate=malware");
 		expect(url).toContain("negate=impersonation");
+	});
+
+	it("POSTs a dead-letter retry to the retry route with the threaded key", async () => {
+		stubFetch(() =>
+			Response.json({ data: { actionId: "oact_1", deadLetterId: 42, status: "retried" } }),
+		);
+		const result = await fetchClient.retryDeadLetter(42, {
+			reason: "re-drive",
+			idempotencyKey: input.idempotencyKey,
+		});
+		expect(result).toMatchObject({ deadLetterId: 42, status: "retried" });
+		const call = calls[0]!;
+		expect(call.url).toBe("/admin/api/dead-letters/42/retry");
+		expect(call.init.method).toBe("POST");
+		const headers = new Headers(call.init.headers);
+		expect(headers.get("X-EmDash-Request")).toBe("1");
+		expect(headers.get("Content-Type")).toBe("application/json");
+		expect(JSON.parse(call.init.body as string)).toMatchObject({
+			reason: "re-drive",
+			idempotencyKey: input.idempotencyKey,
+		});
+	});
+
+	it("POSTs a dead-letter quarantine to the quarantine route", async () => {
+		stubFetch(() =>
+			Response.json({ data: { actionId: "oact_1", deadLetterId: 42, status: "quarantined" } }),
+		);
+		await fetchClient.quarantineDeadLetter(42, {
+			reason: "reviewed",
+			idempotencyKey: input.idempotencyKey,
+		});
+		expect(calls[0]!.url).toBe("/admin/api/dead-letters/42/quarantine");
+		expect(calls[0]!.init.method).toBe("POST");
+	});
+
+	it("surfaces the server 409 already-resolved message on a dead-letter retry", async () => {
+		stubFetch(() =>
+			Response.json(
+				{ error: { code: "DEAD_LETTER_RESOLVED", message: "Dead letter is already resolved" } },
+				{ status: 409 },
+			),
+		);
+		await expect(
+			fetchClient.retryDeadLetter(42, { reason: "x", idempotencyKey: input.idempotencyKey }),
+		).rejects.toThrow("Dead letter is already resolved");
 	});
 
 	it("surfaces a 409 idempotency conflict message", async () => {

--- a/apps/labeler/console/src/api/client.ts
+++ b/apps/labeler/console/src/api/client.ts
@@ -1,5 +1,6 @@
 import {
 	FIXTURE_ASSESSMENTS,
+	FIXTURE_DEAD_LETTERS,
 	FIXTURE_FINDINGS_BY_ASSESSMENT,
 	FIXTURE_LABELS_BY_ASSESSMENT,
 	FIXTURE_OPERATOR_ACTIONS,
@@ -11,6 +12,9 @@ import type {
 	AssessmentRun,
 	AutomationToggleInput,
 	AutomationToggleResult,
+	DeadLetter,
+	DeadLetterActionInput,
+	DeadLetterActionResult,
 	EffectPreview,
 	EffectPreviewParams,
 	EmergencyActionInput,
@@ -20,6 +24,7 @@ import type {
 	LabelActionInput,
 	ListAssessmentsParams,
 	ListAuditLogParams,
+	ListDeadLettersParams,
 	OperatorAction,
 	OverrideActionInput,
 	OverrideEffectPreviewParams,
@@ -48,6 +53,7 @@ export interface LabelerConsoleClient {
 	getSubjectHistory(uri: string): Promise<SubjectHistoryView | null>;
 	getSubjectLabels(uri: string, cid?: string): Promise<SubjectLabel[]>;
 	listAuditLog(params?: ListAuditLogParams): Promise<Page<OperatorAction>>;
+	listDeadLetters(params?: ListDeadLettersParams): Promise<Page<DeadLetter>>;
 	getSystemStatus(): Promise<SystemStatusSnapshot>;
 	whoami(): Promise<WhoamiIdentity>;
 	previewEffect(params: EffectPreviewParams): Promise<EffectPreview>;
@@ -64,6 +70,8 @@ export interface LabelerConsoleClient {
 	): Promise<IssuedLabelDescriptor>;
 	pauseAutomation(input: AutomationToggleInput): Promise<AutomationToggleResult>;
 	resumeAutomation(input: AutomationToggleInput): Promise<AutomationToggleResult>;
+	retryDeadLetter(id: number, input: DeadLetterActionInput): Promise<DeadLetterActionResult>;
+	quarantineDeadLetter(id: number, input: DeadLetterActionInput): Promise<DeadLetterActionResult>;
 }
 
 /** The admin-only emergency endpoints, keyed by action and direction. */
@@ -167,6 +175,13 @@ export function createFetchClient(): LabelerConsoleClient {
 			const response = await consoleApiFetch(`/audit-log?${search.toString()}`);
 			return parseJson(response, "Failed to load audit log");
 		},
+		async listDeadLetters(params = {}) {
+			const search = new URLSearchParams();
+			if (params.cursor) search.set("cursor", params.cursor);
+			if (params.limit) search.set("limit", String(params.limit));
+			const response = await consoleApiFetch(`/dead-letters?${search.toString()}`);
+			return parseJson(response, "Failed to load dead letters");
+		},
 		async getSystemStatus() {
 			const response = await consoleApiFetch("/status");
 			return parseJson(response, "Failed to load system status");
@@ -230,6 +245,20 @@ export function createFetchClient(): LabelerConsoleClient {
 		async resumeAutomation(input) {
 			return postAction("/automation/resume", input, "Failed to resume automation");
 		},
+		async retryDeadLetter(id, input) {
+			return postAction(
+				`/dead-letters/${encodeURIComponent(id)}/retry`,
+				input,
+				"Failed to retry dead letter",
+			);
+		},
+		async quarantineDeadLetter(id, input) {
+			return postAction(
+				`/dead-letters/${encodeURIComponent(id)}/quarantine`,
+				input,
+				"Failed to quarantine dead letter",
+			);
+		},
 	};
 }
 
@@ -261,6 +290,9 @@ export function createFixtureClient(): LabelerConsoleClient {
 		},
 		async listAuditLog() {
 			return { items: [...FIXTURE_OPERATOR_ACTIONS] };
+		},
+		async listDeadLetters() {
+			return { items: [...FIXTURE_DEAD_LETTERS] };
 		},
 		async getSystemStatus() {
 			return FIXTURE_SYSTEM_STATUS;
@@ -360,6 +392,22 @@ export function createFixtureClient(): LabelerConsoleClient {
 				actionId: "oact_fixture",
 				paused: false,
 				reason: input.reason,
+				cts: new Date().toISOString(),
+			};
+		},
+		async retryDeadLetter(id) {
+			return {
+				actionId: "oact_fixture",
+				deadLetterId: id,
+				status: "retried",
+				cts: new Date().toISOString(),
+			};
+		},
+		async quarantineDeadLetter(id) {
+			return {
+				actionId: "oact_fixture",
+				deadLetterId: id,
+				status: "quarantined",
 				cts: new Date().toISOString(),
 			};
 		},

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -335,6 +335,41 @@ export interface AutomationToggleResult {
 	cts: string;
 }
 
+export type DeadLetterStatus = "new" | "retried" | "quarantined";
+
+/** A `dead_letters` row from `GET /admin/api/dead-letters` — a discovery event
+ * that failed verification. The raw payload is never sent; the console shows the
+ * failure reason and resolution state. `new` letters are actionable (admin-only
+ * retry / quarantine); `retried` / `quarantined` are terminal. */
+export interface DeadLetter {
+	id: number;
+	did: string;
+	collection: string;
+	rkey: string;
+	reason: string;
+	detail: string | null;
+	status: DeadLetterStatus;
+	receivedAt: string;
+	resolvedAt: string | null;
+	resolvedByActionId: string | null;
+}
+
+/** Body for the admin-only dead-letter endpoints (`POST /admin/api/dead-letters/:id/*`).
+ * A required reason and a client-minted idempotency key reused across retries so
+ * a network retry replays rather than re-drives twice. */
+export interface DeadLetterActionInput {
+	reason: string;
+	idempotencyKey: string;
+}
+
+/** Idempotent retry / quarantine result — the dead letter's post-action status. */
+export interface DeadLetterActionResult {
+	actionId: string;
+	deadLetterId: number;
+	status: Exclude<DeadLetterStatus, "new">;
+	cts: string;
+}
+
 export interface ListAssessmentsParams {
 	state?: PublicAssessmentState;
 	cursor?: string;
@@ -342,6 +377,11 @@ export interface ListAssessmentsParams {
 }
 
 export interface ListAuditLogParams {
+	cursor?: string;
+	limit?: number;
+}
+
+export interface ListDeadLettersParams {
 	cursor?: string;
 	limit?: number;
 }

--- a/apps/labeler/console/src/components/DeadLetterActions.test.tsx
+++ b/apps/labeler/console/src/components/DeadLetterActions.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { DeadLetterActions } from "./DeadLetterActions.js";
+
+vi.mock("../api/client.js", () => ({
+	apiClient: { retryDeadLetter: vi.fn(), quarantineDeadLetter: vi.fn() },
+}));
+
+const retryDeadLetter = vi.mocked(apiClient.retryDeadLetter);
+const quarantineDeadLetter = vi.mocked(apiClient.quarantineDeadLetter);
+
+function renderActions(id = 7) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	render(
+		<QueryClientProvider client={client}>
+			<DeadLetterActions deadLetterId={id} />
+		</QueryClientProvider>,
+	);
+}
+
+afterEach(() => {
+	retryDeadLetter.mockReset();
+	quarantineDeadLetter.mockReset();
+});
+
+describe("DeadLetterActions", () => {
+	it("retries through the required-reason dialog, threading id and reason", async () => {
+		retryDeadLetter.mockResolvedValue({
+			actionId: "oact_1",
+			deadLetterId: 7,
+			status: "retried",
+			cts: "2026-07-13T00:00:00.000Z",
+		});
+		renderActions(7);
+
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		const submit = screen.getByRole("button", { name: "Confirm retry" }) as HTMLButtonElement;
+		expect(submit.disabled).toBe(true);
+
+		fireEvent.change(screen.getByPlaceholderText("Why this event is being re-driven"), {
+			target: { value: "transient PDS outage cleared" },
+		});
+		expect(submit.disabled).toBe(false);
+		fireEvent.click(submit);
+
+		await waitFor(() => {
+			expect(retryDeadLetter).toHaveBeenCalledWith(
+				7,
+				expect.objectContaining({ reason: "transient PDS outage cleared" }),
+			);
+		});
+		expect(quarantineDeadLetter).not.toHaveBeenCalled();
+	});
+
+	it("quarantines through the required-reason dialog", async () => {
+		quarantineDeadLetter.mockResolvedValue({
+			actionId: "oact_2",
+			deadLetterId: 7,
+			status: "quarantined",
+			cts: "2026-07-13T00:00:00.000Z",
+		});
+		renderActions(7);
+
+		fireEvent.click(screen.getByRole("button", { name: "Quarantine" }));
+		fireEvent.change(screen.getByPlaceholderText("Why this event is being quarantined"), {
+			target: { value: "not a real release" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Confirm quarantine" }));
+
+		await waitFor(() => {
+			expect(quarantineDeadLetter).toHaveBeenCalledWith(
+				7,
+				expect.objectContaining({ reason: "not a real release" }),
+			);
+		});
+		expect(retryDeadLetter).not.toHaveBeenCalled();
+	});
+});

--- a/apps/labeler/console/src/components/DeadLetterActions.tsx
+++ b/apps/labeler/console/src/components/DeadLetterActions.tsx
@@ -1,0 +1,134 @@
+import { Button, Dialog, InputArea } from "@cloudflare/kumo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+
+type Action = "retry" | "quarantine";
+
+interface DialogCopy {
+	title: string;
+	description: string;
+	verb: string;
+	placeholder: string;
+	variant: "primary" | "destructive";
+}
+
+const DIALOG_COPY: Record<Action, DialogCopy> = {
+	retry: {
+		title: "Retry dead letter",
+		description:
+			"Re-enqueues the failed discovery event. The consumer re-fetches and re-verifies the record; a duplicate re-drive converges on a single assessment.",
+		verb: "Confirm retry",
+		placeholder: "Why this event is being re-driven",
+		variant: "primary",
+	},
+	quarantine: {
+		title: "Quarantine dead letter",
+		description:
+			"Marks the failed event reviewed and permanently excluded from retry. It leaves the dead-letter backlog and is not re-driven.",
+		verb: "Confirm quarantine",
+		placeholder: "Why this event is being quarantined",
+		variant: "destructive",
+	},
+};
+
+interface DeadLetterActionsProps {
+	deadLetterId: number;
+}
+
+/**
+ * The admin-only retry / quarantine controls for one `new` dead letter (design
+ * §6). Each action runs behind a required-reason dialog; the idempotency key is
+ * minted per dialog open and reused across retries so a network retry replays
+ * rather than re-drives twice. The server (`guardMutation` admin gate) is the
+ * enforcement boundary — the route only renders this for an admin.
+ */
+export function DeadLetterActions({ deadLetterId }: DeadLetterActionsProps) {
+	const queryClient = useQueryClient();
+	const [action, setAction] = useState<Action | null>(null);
+	const [reason, setReason] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (action === null) return;
+		setIdempotencyKey(ulid());
+		setReason("");
+	}, [action]);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			action === "quarantine"
+				? apiClient.quarantineDeadLetter(deadLetterId, { reason, idempotencyKey })
+				: apiClient.retryDeadLetter(deadLetterId, { reason, idempotencyKey }),
+		onSuccess: async () => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: ["dead-letters"] }),
+				queryClient.invalidateQueries({ queryKey: ["system-status"] }),
+			]);
+			setAction(null);
+		},
+	});
+
+	const copy = action ? DIALOG_COPY[action] : null;
+	const canSubmit = reason.trim().length > 0 && !mutation.isPending;
+
+	return (
+		<div className="flex justify-end gap-2">
+			<Button variant="secondary" onClick={() => setAction("retry")}>
+				Retry
+			</Button>
+			<Button variant="destructive" onClick={() => setAction("quarantine")}>
+				Quarantine
+			</Button>
+
+			<Dialog.Root
+				open={action !== null}
+				onOpenChange={(open) => {
+					if (!open) setAction(null);
+				}}
+				role="alertdialog"
+			>
+				<Dialog className="flex flex-col gap-4 p-6" size="base">
+					{copy && (
+						<>
+							<Dialog.Title className="text-lg font-semibold">{copy.title}</Dialog.Title>
+							<Dialog.Description className="text-sm text-kumo-subtle">
+								{copy.description}
+							</Dialog.Description>
+
+							<InputArea
+								label="Reason"
+								value={reason}
+								onValueChange={setReason}
+								placeholder={copy.placeholder}
+							/>
+
+							{mutation.isError && (
+								<p className="text-sm text-kumo-danger">
+									{mutation.error instanceof Error ? mutation.error.message : "Action failed"}
+								</p>
+							)}
+
+							<div className="flex justify-end gap-2">
+								<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+									Cancel
+								</Dialog.Close>
+								<Button
+									variant={copy.variant}
+									disabled={!canSubmit}
+									onClick={() => {
+										mutation.mutate();
+									}}
+								>
+									{mutation.isPending ? "Submitting…" : copy.verb}
+								</Button>
+							</div>
+						</>
+					)}
+				</Dialog>
+			</Dialog.Root>
+		</div>
+	);
+}

--- a/apps/labeler/console/src/components/Sidebar.tsx
+++ b/apps/labeler/console/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Sidebar as KumoSidebar, useSidebar } from "@cloudflare/kumo";
-import { ClockCounterClockwise, ShieldCheck, SquaresFour } from "@phosphor-icons/react";
+import { ClockCounterClockwise, Envelope, ShieldCheck, SquaresFour } from "@phosphor-icons/react";
 import { useLocation } from "@tanstack/react-router";
 import * as React from "react";
 
@@ -42,6 +42,7 @@ export function SidebarNav() {
 	const items: NavItem[] = [
 		{ to: "/", label: "Dashboard", icon: SquaresFour },
 		{ to: "/assessments", label: "Assessments", icon: ShieldCheck },
+		{ to: "/dead-letters", label: "Dead letters", icon: Envelope },
 		{ to: "/audit", label: "Audit log", icon: ClockCounterClockwise },
 	];
 

--- a/apps/labeler/console/src/fixtures/dead-letters.ts
+++ b/apps/labeler/console/src/fixtures/dead-letters.ts
@@ -1,0 +1,42 @@
+import type { DeadLetter } from "../api/types.js";
+
+/** Sample `dead_letters` rows for offline UI work and tests — a new (actionable)
+ * letter, a retried one, and a quarantined one, newest first. */
+export const FIXTURE_DEAD_LETTERS: DeadLetter[] = [
+	{
+		id: 3,
+		did: "did:plc:publisher000000000000000003",
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: "rk-new",
+		reason: "INVALID_PROOF",
+		detail: "MST proof did not verify",
+		status: "new",
+		receivedAt: "2026-07-13 09:15:00",
+		resolvedAt: null,
+		resolvedByActionId: null,
+	},
+	{
+		id: 2,
+		did: "did:plc:publisher000000000000000002",
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: "rk-retried",
+		reason: "PDS_HTTP_ERROR",
+		detail: "502 from PDS",
+		status: "retried",
+		receivedAt: "2026-07-13 08:40:00",
+		resolvedAt: "2026-07-13 09:00:00",
+		resolvedByActionId: "oact_fixture_retry",
+	},
+	{
+		id: 1,
+		did: "did:plc:publisher000000000000000001",
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: "rk-quarantined",
+		reason: "RECORD_NOT_FOUND",
+		detail: null,
+		status: "quarantined",
+		receivedAt: "2026-07-13 08:00:00",
+		resolvedAt: "2026-07-13 08:20:00",
+		resolvedByActionId: "oact_fixture_quarantine",
+	},
+];

--- a/apps/labeler/console/src/fixtures/index.ts
+++ b/apps/labeler/console/src/fixtures/index.ts
@@ -14,6 +14,7 @@ export {
 	FINDING_GAMMA_OBFUSCATED_CODE,
 	FIXTURE_FINDINGS_BY_ASSESSMENT,
 } from "./findings.js";
+export { FIXTURE_DEAD_LETTERS } from "./dead-letters.js";
 export { FIXTURE_LABELS_BY_ASSESSMENT } from "./labels.js";
 export { FIXTURE_OPERATOR_ACTIONS } from "./operator-actions.js";
 export { FIXTURE_SUBJECT_HISTORY } from "./subject-history.js";

--- a/apps/labeler/console/src/router.tsx
+++ b/apps/labeler/console/src/router.tsx
@@ -5,6 +5,7 @@ import { assessmentDetailRoute } from "./routes/AssessmentDetail.js";
 import { assessmentListRoute } from "./routes/AssessmentList.js";
 import { auditLogRoute } from "./routes/AuditLog.js";
 import { dashboardRoute } from "./routes/Dashboard.js";
+import { deadLetterQueueRoute } from "./routes/DeadLetterQueue.js";
 import { notFoundRoute } from "./routes/NotFound.js";
 import { rootRoute, shellRoute } from "./routes/root.js";
 import { subjectHistoryRoute } from "./routes/SubjectHistory.js";
@@ -15,6 +16,7 @@ const shellRoutes = shellRoute.addChildren([
 	assessmentDetailRoute,
 	subjectHistoryRoute,
 	auditLogRoute,
+	deadLetterQueueRoute,
 	notFoundRoute,
 ]);
 

--- a/apps/labeler/console/src/routes/DeadLetterQueue.tsx
+++ b/apps/labeler/console/src/routes/DeadLetterQueue.tsx
@@ -1,0 +1,107 @@
+import { Badge, LayerCard, Loader, Table } from "@cloudflare/kumo";
+import { useQuery } from "@tanstack/react-query";
+import { createRoute } from "@tanstack/react-router";
+
+import { apiClient } from "../api/client.js";
+import type { DeadLetterStatus } from "../api/types.js";
+import { DeadLetterActions } from "../components/DeadLetterActions.js";
+import { QueryError } from "../components/QueryError.js";
+import { shellRoute } from "./root.js";
+
+type BadgeVariant = "neutral" | "info" | "success" | "warning" | "error";
+
+const STATUS_VARIANT: Record<DeadLetterStatus, BadgeVariant> = {
+	new: "warning",
+	retried: "info",
+	quarantined: "neutral",
+};
+
+const STATUS_LABEL: Record<DeadLetterStatus, string> = {
+	new: "New",
+	retried: "Retried",
+	quarantined: "Quarantined",
+};
+
+function DeadLetterQueue() {
+	const { data, isLoading, isError, error } = useQuery({
+		queryKey: ["dead-letters"],
+		queryFn: () => apiClient.listDeadLetters(),
+	});
+	const { data: whoami } = useQuery({ queryKey: ["whoami"], queryFn: () => apiClient.whoami() });
+	const isAdmin = whoami?.roles.includes("admin") ?? false;
+
+	return (
+		<div className="flex flex-col gap-4">
+			<h1 className="text-xl font-semibold">Dead-letter queue</h1>
+			<p className="text-sm text-kumo-subtle">
+				Discovery events that failed verification. Retry re-drives an event through the consumer;
+				quarantine marks it reviewed and excludes it from retry.
+			</p>
+
+			{isError ? (
+				<QueryError title="Failed to load dead letters" error={error} />
+			) : (
+				<LayerCard className="p-0">
+					{isLoading || !data ? (
+						<div className="flex items-center justify-center py-16">
+							<Loader />
+						</div>
+					) : data.items.length === 0 ? (
+						<div className="p-8 text-center text-sm text-kumo-subtle">No dead letters.</div>
+					) : (
+						<Table>
+							<Table.Header>
+								<Table.Row>
+									<Table.Head>Subject</Table.Head>
+									<Table.Head>Reason</Table.Head>
+									<Table.Head>Status</Table.Head>
+									<Table.Head>Received</Table.Head>
+									<Table.Head>Actions</Table.Head>
+								</Table.Row>
+							</Table.Header>
+							<Table.Body>
+								{data.items.map((letter) => (
+									<Table.Row key={letter.id}>
+										<Table.Cell>
+											<span
+												className="font-mono"
+												title={`at://${letter.did}/${letter.collection}/${letter.rkey}`}
+											>
+												{letter.rkey}
+											</span>
+										</Table.Cell>
+										<Table.Cell>
+											<span className="font-medium">{letter.reason}</span>
+											{letter.detail && (
+												<span className="block text-sm text-kumo-subtle">{letter.detail}</span>
+											)}
+										</Table.Cell>
+										<Table.Cell>
+											<Badge variant={STATUS_VARIANT[letter.status]} appearance="dot">
+												{STATUS_LABEL[letter.status]}
+											</Badge>
+										</Table.Cell>
+										<Table.Cell>{new Date(letter.receivedAt).toLocaleString()}</Table.Cell>
+										<Table.Cell>
+											{isAdmin && letter.status === "new" ? (
+												<DeadLetterActions deadLetterId={letter.id} />
+											) : (
+												<span className="text-sm text-kumo-subtle">—</span>
+											)}
+										</Table.Cell>
+									</Table.Row>
+								))}
+							</Table.Body>
+						</Table>
+					)}
+				</LayerCard>
+			)}
+		</div>
+	);
+}
+
+export const deadLetterQueueRoute = createRoute({
+	getParentRoute: () => shellRoute,
+	path: "/dead-letters",
+	component: DeadLetterQueue,
+});

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -35,6 +35,7 @@ import {
 } from "./assessment-store.js";
 import {
 	serializeAssessmentRun,
+	serializeDeadLetter,
 	serializeIssuedLabel,
 	serializeOperatorActionView,
 	serializeOperatorFinding,
@@ -42,6 +43,7 @@ import {
 	serializeSubjectRecord,
 	type Page,
 } from "./console-serialize.js";
+import { getDeadLettersPage } from "./dead-letters.js";
 import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
 import { computeEffectPreview, computeOverrideEffectPreview } from "./label-effect-preview.js";
 import { MutationGuardError } from "./mutation-guard.js";
@@ -122,6 +124,8 @@ function matchRoute(
 			return () => handleGetSubjectLabels(request, url, deps, uri);
 	} else if (segments[0] === "audit-log" && segments.length === 1) {
 		return () => handleListAuditLog(request, url, deps);
+	} else if (segments[0] === "dead-letters" && segments.length === 1) {
+		return () => handleListDeadLetters(request, url, deps);
 	} else if (segments[0] === "status" && segments.length === 1) {
 		return () => handleGetStatus(request, deps);
 	} else if (segments[0] === "whoami" && segments.length === 1) {
@@ -319,6 +323,45 @@ async function handleListAuditLog(
 	return jsonData(body);
 }
 
+/**
+ * Lists `dead_letters` newest-first for the operator console (design §6). All
+ * statuses are listed so the operator sees resolved history; the retry /
+ * quarantine actions are admin-only and gated separately. Keyset pagination is
+ * on the numeric autoincrement `id` (a total order); the opaque cursor still
+ * carries `received_at` for the shared cursor's shape/validation.
+ */
+async function handleListDeadLetters(
+	request: Request,
+	url: URL,
+	deps: ConsoleApiDeps,
+): Promise<Response> {
+	requireGet(request);
+	const limit = parseLimit(url.searchParams);
+	const filterHash = await computeFilterHash({});
+	const keyset = decodeReadCursor(url.searchParams.get("cursor"), filterHash);
+	const keysetId = keyset === null ? null : parseCursorId(keyset.id);
+
+	const rows = await getDeadLettersPage(deps.db, keysetId, limit);
+	const hasMore = rows.length > limit;
+	const page = hasMore ? rows.slice(0, limit) : rows;
+	const last = page.at(-1);
+	const body: Page<ReturnType<typeof serializeDeadLetter>> = {
+		items: page.map(serializeDeadLetter),
+		...(hasMore && last
+			? {
+					nextCursor: encodeCursor({ createdAt: last.receivedAt, id: String(last.id) }, filterHash),
+				}
+			: {}),
+	};
+	return jsonData(body);
+}
+
+function parseCursorId(raw: string): number {
+	const id = Number(raw);
+	if (!Number.isSafeInteger(id) || id <= 0) throw new ReadGuardError("INVALID_CURSOR");
+	return id;
+}
+
 async function handleGetStatus(request: Request, deps: ConsoleApiDeps): Promise<Response> {
 	requireGet(request);
 	const [pendingAssessments, deadLetterDepth, automation, jetstreamConnected] = await Promise.all([
@@ -432,9 +475,12 @@ function parseNeg(raw: string | null): boolean {
 
 /** Dead-letter backlog — the observable stand-in for discovery-queue depth,
  * which the Queues API does not expose to the consumer Worker (spec §11.1's
- * `/admin/system` "queue/DLQ health"). */
+ * `/admin/system` "queue/DLQ health"). Counts only `status = 'new'`: a retried
+ * or quarantined letter has been actioned and no longer represents backlog. */
 async function countDeadLetters(db: D1Database): Promise<number> {
-	const row = await db.prepare(`SELECT COUNT(*) AS n FROM dead_letters`).first<{ n: number }>();
+	const row = await db
+		.prepare(`SELECT COUNT(*) AS n FROM dead_letters WHERE status = 'new'`)
+		.first<{ n: number }>();
 	return row?.n ?? 0;
 }
 

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -30,11 +30,19 @@ import {
 import { buildAutomationPauseUpdate } from "./automation-state.js";
 import type { LabelerIdentityConfig } from "./config.js";
 import {
+	buildDeadLetterResolveUpdate,
+	getDeadLetter,
+	readDeadLetterJob,
+	type DeadLetterStatus,
+} from "./dead-letters.js";
+import type { DiscoveryJob } from "./env.js";
+import {
 	commitMutation,
 	guardMutation,
 	MutationGuardError,
 	type MutationGuardDeps,
 	type MutationSpec,
+	type OperatorActionType,
 } from "./mutation-guard.js";
 import {
 	buildOperationalEventInsert,
@@ -68,6 +76,7 @@ const RERUN_PROMPT_HASH = "unassigned";
 const RERUN_SCANNER_SET_VERSION = "unassigned";
 
 const ADMIN_API_PREFIX = /^\/admin\/api\/?/;
+const POSITIVE_INTEGER = /^[1-9]\d*$/;
 
 /** Override-coupled labels: the atomic unblock action (W9.5) is the only path
  * that issues these, so the standalone issue/retract endpoints reject them. */
@@ -124,6 +133,10 @@ export interface ConsoleMutationDeps {
 	afterCommit: (actionId: string) => Promise<void>;
 	/** Schedules `afterCommit` without blocking the response (workerd `waitUntil`). */
 	defer: (work: Promise<unknown>) => void;
+	/** Re-enqueues a dead letter's discovery job on retry (design §6). A queue op
+	 * cannot join the D1 batch, so it runs in the deferred tail; the discovery
+	 * consumer's `runKey` dedup absorbs a duplicate re-drive. */
+	sendDiscoveryJob: (job: DiscoveryJob) => Promise<void>;
 }
 
 /**
@@ -173,12 +186,19 @@ export async function handleConsoleMutation(
 			if (segments[1] === "pause") return await runAutomationToggle(request, deps, true);
 			if (segments[1] === "resume") return await runAutomationToggle(request, deps, false);
 		}
+		if (segments[0] === "dead-letters" && segments.length === 3 && segments[1] !== undefined) {
+			const id = segments[1];
+			if (segments[2] === "retry") return await runDeadLetterAction(request, deps, id, "retried");
+			if (segments[2] === "quarantine")
+				return await runDeadLetterAction(request, deps, id, "quarantined");
+		}
 		throw new ReadGuardError("NOT_FOUND");
 	} catch (error) {
 		if (
 			error instanceof MutationGuardError ||
 			error instanceof ReadGuardError ||
-			error instanceof LabelMutationError
+			error instanceof LabelMutationError ||
+			error instanceof DeadLetterResolvedError
 		)
 			return error.toResponse();
 		// A submitted override negation set that isn't exactly the live automated
@@ -1049,7 +1069,166 @@ async function runAutomationToggle(
 		reason: ctx.reason,
 		cts: ctx.now.toISOString(),
 	};
-	return jsonData(
-		await commitMutation(deps.db, ctx, spec, [stateUpdate, eventInsert], descriptor),
+	return jsonData(await commitMutation(deps.db, ctx, spec, [stateUpdate, eventInsert], descriptor));
+}
+
+// ─── W9.6: admin-only dead-letter retry / quarantine controls ────────────────
+
+type DeadLetterResolution = Exclude<DeadLetterStatus, "new">;
+
+const DEAD_LETTER_ACTION: Record<DeadLetterResolution, OperatorActionType> = {
+	retried: "dlq-retry",
+	quarantined: "dlq-quarantine",
+};
+
+const DEAD_LETTER_EVENT_TYPE: Record<DeadLetterResolution, OperationalEventType> = {
+	retried: "dead-letter-retried",
+	quarantined: "dead-letter-quarantined",
+};
+
+/** A dead letter that is no longer actionable (already retried or quarantined).
+ * Static message; a 409 rather than a spurious success so a second resolve does
+ * not double-enqueue (T6). */
+class DeadLetterResolvedError extends Error {
+	override readonly name = "DeadLetterResolvedError";
+	readonly code = "DEAD_LETTER_RESOLVED";
+	readonly status = 409;
+
+	constructor() {
+		super("Dead letter is already resolved");
+	}
+
+	toResponse(): Response {
+		return Response.json(
+			{ error: { code: this.code, message: this.message } },
+			{ status: this.status },
+		);
+	}
+}
+
+/** The id from the path, folded into the parsed body so it joins the request
+ * fingerprint — a replayed key must target the same dead letter. */
+interface DeadLetterActionBody {
+	deadLetterId: number;
+}
+
+/** The idempotent resolve result. */
+interface DeadLetterActionDescriptor {
+	actionId: string;
+	deadLetterId: number;
+	status: DeadLetterResolution;
+	cts: string;
+}
+
+/**
+ * `POST /admin/api/dead-letters/:id/{retry,quarantine}` — the admin-only
+ * operational controls (design §6). Neither issues a label: the effect is a
+ * `status` UPDATE guarded by `status = 'new'` plus an ungated `info` operational
+ * event, both committed in one atomic `commitMutation` batch with the audit row.
+ * Retry additionally re-enqueues the dead letter's discovery job in the deferred
+ * tail. A row that is absent (404) or already resolved (409) is rejected before
+ * any commit, so a late request commits nothing and enqueues nothing (T6).
+ */
+async function runDeadLetterAction(
+	request: Request,
+	deps: ConsoleMutationDeps,
+	rawId: string,
+	status: DeadLetterResolution,
+): Promise<Response> {
+	const spec: MutationSpec<DeadLetterActionBody> = {
+		action: DEAD_LETTER_ACTION[status],
+		requiredRole: "admin",
+		parseBody: () => ({ deadLetterId: parseDeadLetterId(rawId) }),
+		auditFields: () => ({}),
+	};
+
+	const outcome = await guardMutation(request, spec, guardDepsOf(deps));
+	if (outcome.outcome === "replay")
+		return jsonData(storedDescriptor<DeadLetterActionDescriptor>(outcome.result));
+
+	const { ctx } = outcome;
+	const id = ctx.body.deadLetterId;
+	const letter = await getDeadLetter(deps.db, id);
+	if (!letter) throw new ReadGuardError("NOT_FOUND");
+	if (letter.status !== "new") throw new DeadLetterResolvedError();
+
+	const subjectUri = `at://${letter.did}/${letter.collection}/${letter.rkey}`;
+	const update = buildDeadLetterResolveUpdate(deps.db, {
+		id,
+		status,
+		actionId: ctx.actionId,
+		now: ctx.now,
+	});
+	const eventInsert = buildOperationalEventInsert(deps.db, {
+		id: newOperationalEventId(),
+		eventType: DEAD_LETTER_EVENT_TYPE[status],
+		severity: "info",
+		actionId: ctx.actionId,
+		subjectUri,
+		payload: { reason: ctx.reason },
+		now: ctx.now,
+	});
+
+	const descriptor: DeadLetterActionDescriptor = {
+		actionId: ctx.actionId,
+		deadLetterId: id,
+		status,
+		cts: ctx.now.toISOString(),
+	};
+	const commitSpec: MutationSpec<DeadLetterActionBody> = {
+		...spec,
+		auditFields: () => ({ subjectUri, metadata: { deadLetterId: id, status } }),
+	};
+	const returned = await commitMutation(
+		deps.db,
+		ctx,
+		commitSpec,
+		[update, eventInsert],
+		descriptor,
 	);
+
+	if (status === "retried") deferDeadLetterReenqueue(deps, id, ctx.actionId);
+	return jsonData(returned);
+}
+
+/**
+ * Re-enqueues a retried dead letter's discovery job off the response path, but
+ * only when this action won the `status = 'new'` race: a concurrent retry that
+ * committed its audit row yet matched zero rows in the UPDATE reads back a
+ * `resolved_by_action_id` that is not ours and skips, so the job enqueues once
+ * even under a double retry. The consumer's `runKey` dedup is the backstop; a
+ * lost enqueue is recoverable by re-driving `status = 'retried'` rows.
+ */
+function deferDeadLetterReenqueue(deps: ConsoleMutationDeps, id: number, actionId: string): void {
+	deps.defer(
+		(async () => {
+			try {
+				const letter = await getDeadLetter(deps.db, id);
+				if (!letter || letter.resolvedByActionId !== actionId) return;
+				const job = await readDeadLetterJob(deps.db, id);
+				if (!job) {
+					// The row flipped to 'retried' but its payload didn't decode to a
+					// valid job (e.g. a row written before the full-job payload shape),
+					// so nothing re-drives it and a fresh retry is barred by status.
+					console.error("[console-mutation] dead-letter payload undecodable, re-enqueue skipped", {
+						id,
+					});
+					return;
+				}
+				await deps.sendDiscoveryJob(job);
+			} catch (error) {
+				console.error("[console-mutation] dead-letter re-enqueue failed", error);
+			}
+		})(),
+	);
+}
+
+/** A non-numeric or non-positive path segment names no dead letter — a 404,
+ * matching the absent-row case. Runs after the guard's role gate, so a non-admin
+ * is rejected before this. */
+function parseDeadLetterId(raw: string): number {
+	if (!POSITIVE_INTEGER.test(raw)) throw new ReadGuardError("NOT_FOUND");
+	const id = Number(raw);
+	if (!Number.isSafeInteger(id)) throw new ReadGuardError("NOT_FOUND");
+	return id;
 }

--- a/apps/labeler/src/console-serialize.ts
+++ b/apps/labeler/src/console-serialize.ts
@@ -25,6 +25,7 @@ import type {
 	ListedAssessment,
 	Subject,
 } from "./assessment-store.js";
+import type { StoredDeadLetter } from "./dead-letters.js";
 import type { FindingSeverity } from "./evidence.js";
 import type { FindingSource } from "./findings.js";
 import type { StoredOperatorAction } from "./operator-actions.js";
@@ -125,6 +126,22 @@ export interface SystemStatusSnapshot {
 	deadLetterDepth: number;
 }
 
+/** A `dead_letters` row for the operator console. The raw `payload` (unverified
+ * Jetstream bytes) is deliberately excluded — the console displays the failure
+ * reason and resolution state, never the untrusted record. */
+export interface DeadLetter {
+	id: number;
+	did: string;
+	collection: string;
+	rkey: string;
+	reason: string;
+	detail: string | null;
+	status: string;
+	receivedAt: string;
+	resolvedAt: string | null;
+	resolvedByActionId: string | null;
+}
+
 export interface Page<T> {
 	items: T[];
 	nextCursor?: string;
@@ -222,5 +239,20 @@ export function serializeOperatorActionView(action: StoredOperatorAction): Opera
 		labelValue: action.labelValue,
 		reason: action.reason,
 		createdAt: action.createdAt,
+	};
+}
+
+export function serializeDeadLetter(row: StoredDeadLetter): DeadLetter {
+	return {
+		id: row.id,
+		did: row.did,
+		collection: row.collection,
+		rkey: row.rkey,
+		reason: row.reason,
+		detail: row.detail,
+		status: row.status,
+		receivedAt: row.receivedAt,
+		resolvedAt: row.resolvedAt,
+		resolvedByActionId: row.resolvedByActionId,
 	};
 }

--- a/apps/labeler/src/dead-letters.ts
+++ b/apps/labeler/src/dead-letters.ts
@@ -1,0 +1,155 @@
+/**
+ * Dead-letter operational controls (plan W9.6, design §6). The read side of the
+ * `dead_letters` table for the console and the effect statement the admin-only
+ * retry / quarantine mutations commit. `writeDeadLetter` (discovery-consumer.ts)
+ * is the only writer of new rows; those rows land with `status = 'new'` and are
+ * resolved here to `retried` or `quarantined`.
+ */
+
+import type { DiscoveryJob } from "./env.js";
+
+export type DeadLetterStatus = "new" | "retried" | "quarantined";
+
+export interface StoredDeadLetter {
+	id: number;
+	did: string;
+	collection: string;
+	rkey: string;
+	reason: string;
+	detail: string | null;
+	status: string;
+	receivedAt: string;
+	resolvedAt: string | null;
+	resolvedByActionId: string | null;
+}
+
+interface DeadLetterRow {
+	id: number;
+	did: string;
+	collection: string;
+	rkey: string;
+	reason: string;
+	detail: string | null;
+	status: string;
+	received_at: string;
+	resolved_at: string | null;
+	resolved_by_action_id: string | null;
+}
+
+const READ_COLUMNS = `id, did, collection, rkey, reason, detail, status,
+	 received_at, resolved_at, resolved_by_action_id`;
+
+/**
+ * Dead-letter page, newest first. `id` is a monotonic autoincrement, so keyset
+ * pagination on `id DESC` alone is a total order — no timestamp tiebreaker (the
+ * `received_at` string has no epoch sibling and can collide). Fetches `limit + 1`
+ * so the caller detects a next page without a trailing COUNT.
+ */
+export async function getDeadLettersPage(
+	db: D1Database,
+	keysetId: number | null,
+	limit: number,
+): Promise<StoredDeadLetter[]> {
+	const bindings: number[] = [];
+	let where = "";
+	if (keysetId !== null) {
+		where = `WHERE id < ?`;
+		bindings.push(keysetId);
+	}
+	bindings.push(limit + 1);
+	const rows = await db
+		.prepare(`SELECT ${READ_COLUMNS} FROM dead_letters ${where} ORDER BY id DESC LIMIT ?`)
+		.bind(...bindings)
+		.all<DeadLetterRow>();
+	return (rows.results ?? []).map(rowToStored);
+}
+
+/** One dead letter by id, or null when absent. Carries the status the retry /
+ * quarantine handlers gate on and the `resolved_by_action_id` they read back
+ * post-commit to tell the winner of a concurrent resolve from the loser. */
+export async function getDeadLetter(db: D1Database, id: number): Promise<StoredDeadLetter | null> {
+	const row = await db
+		.prepare(`SELECT ${READ_COLUMNS} FROM dead_letters WHERE id = ?`)
+		.bind(id)
+		.first<DeadLetterRow>();
+	return row ? rowToStored(row) : null;
+}
+
+/**
+ * Effect statement for a retry / quarantine resolve. The `status = 'new'`
+ * predicate makes a second concurrent resolve a zero-row UPDATE (T6): the row
+ * flips exactly once and `resolved_by_action_id` records the winner, so a loser
+ * that also committed can be detected post-commit and skip its re-enqueue.
+ * Batched with the operator_actions row + the operational event by `commitMutation`.
+ */
+export function buildDeadLetterResolveUpdate(
+	db: D1Database,
+	input: { id: number; status: Exclude<DeadLetterStatus, "new">; actionId: string; now: Date },
+): D1PreparedStatement {
+	return db
+		.prepare(
+			`UPDATE dead_letters
+			 SET status = ?, resolved_at = ?, resolved_by_action_id = ?
+			 WHERE id = ? AND status = 'new'`,
+		)
+		.bind(input.status, input.now.toISOString(), input.actionId, input.id);
+}
+
+/**
+ * Reconstructs the discovery job stored in `dead_letters.payload` for a re-drive.
+ * `writeDeadLetter` persists the full {@link DiscoveryJob} as JSON, so the retry
+ * re-enqueues an identical job — the discovery consumer re-fetches and verifies
+ * (uri, cid) from the PDS, and its `runKey` dedup absorbs a duplicate re-drive.
+ * Returns null when the payload is missing or not a well-formed job.
+ */
+export async function readDeadLetterJob(db: D1Database, id: number): Promise<DiscoveryJob | null> {
+	const row = await db
+		.prepare(`SELECT payload FROM dead_letters WHERE id = ?`)
+		.bind(id)
+		.first<{ payload: ArrayBuffer | Uint8Array | number[] | null }>();
+	if (!row || row.payload === null) return null;
+	return decodeDiscoveryJob(row.payload);
+}
+
+function decodeDiscoveryJob(payload: ArrayBuffer | Uint8Array | number[]): DiscoveryJob | null {
+	const bytes =
+		payload instanceof Uint8Array
+			? payload
+			: payload instanceof ArrayBuffer
+				? new Uint8Array(payload)
+				: Uint8Array.from(payload);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(new TextDecoder().decode(bytes));
+	} catch {
+		return null;
+	}
+	return isDiscoveryJob(parsed) ? parsed : null;
+}
+
+function isDiscoveryJob(value: unknown): value is DiscoveryJob {
+	if (typeof value !== "object" || value === null) return false;
+	const job = value as Record<string, unknown>;
+	return (
+		typeof job.did === "string" &&
+		typeof job.collection === "string" &&
+		typeof job.rkey === "string" &&
+		typeof job.cid === "string" &&
+		(job.operation === "create" || job.operation === "update" || job.operation === "delete")
+	);
+}
+
+function rowToStored(row: DeadLetterRow): StoredDeadLetter {
+	return {
+		id: row.id,
+		did: row.did,
+		collection: row.collection,
+		rkey: row.rkey,
+		reason: row.reason,
+		detail: row.detail,
+		status: row.status,
+		receivedAt: row.received_at,
+		resolvedAt: row.resolved_at,
+		resolvedByActionId: row.resolved_by_action_id,
+	};
+}

--- a/apps/labeler/src/discovery-consumer.ts
+++ b/apps/labeler/src/discovery-consumer.ts
@@ -536,7 +536,10 @@ async function writeDeadLetter(
 	detail: string | null,
 	now: Date,
 ): Promise<void> {
-	const payload = JSON.stringify(job.jetstreamRecord ?? { operation: job.operation, cid: job.cid });
+	// Persist the whole discovery job (identity + operation + cid + the unverified
+	// Jetstream record) so an operator retry can re-enqueue an identical job for a
+	// re-drive (design §6); the record alone would lose the cid a re-verify needs.
+	const payload = JSON.stringify(job);
 	const payloadBytes = new TextEncoder().encode(payload);
 	await db
 		.prepare(

--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -145,6 +145,9 @@ async function handleConsoleApiRequest(
 			now: () => new Date(),
 			afterCommit: (actionId) => publishAfterCommit(env, actionId),
 			defer: (work) => ctx.waitUntil(work),
+			sendDiscoveryJob: async (job) => {
+				await env.DISCOVERY_QUEUE.send(job);
+			},
 		});
 	}
 	return handleConsoleApi(request, {

--- a/apps/labeler/test/console-api.test.ts
+++ b/apps/labeler/test/console-api.test.ts
@@ -660,7 +660,10 @@ describe("handleConsoleApi — system status", () => {
 			 WHERE id = 1`,
 		).run();
 		try {
-			const res = await handleConsoleApi(req("/admin/api/status", { token: reviewerToken }), deps());
+			const res = await handleConsoleApi(
+				req("/admin/api/status", { token: reviewerToken }),
+				deps(),
+			);
 			const status = (await body(res)).data as {
 				automationPaused: boolean;
 				pausedReason: string | null;
@@ -674,6 +677,73 @@ describe("handleConsoleApi — system status", () => {
 				`UPDATE automation_state SET paused = 0, paused_reason = NULL WHERE id = 1`,
 			).run();
 		}
+	});
+});
+
+async function insertResolvedDeadLetter(status: "retried" | "quarantined"): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO dead_letters (did, collection, rkey, reason, payload, received_at, status, resolved_at)
+		 VALUES (?, 'col', ?, 'verify-failed', ?, datetime('now'), ?, datetime('now'))`,
+	)
+		.bind(`did:plc:resolved${status}`, `rk-${status}`, new Uint8Array([0]), status)
+		.run();
+}
+
+describe("handleConsoleApi — dead letters", () => {
+	it("lists dead letters newest-first for a reviewer", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/dead-letters", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+		const page = (await body(res)).data as { items: { id: number; status: string }[] };
+		expect(page.items.length).toBeGreaterThan(0);
+		const ids = page.items.map((d) => d.id);
+		expect(ids).toEqual(ids.toSorted((a, b) => b - a));
+	});
+
+	it("round-trips the cursor across pages, newest-first", async () => {
+		const first = await handleConsoleApi(
+			req("/admin/api/dead-letters?limit=1", { token: reviewerToken }),
+			deps(),
+		);
+		const page1 = (await body(first)).data as { items: { id: number }[]; nextCursor?: string };
+		expect(page1.items).toHaveLength(1);
+		expect(page1.nextCursor).toBeDefined();
+		const second = await handleConsoleApi(
+			req(`/admin/api/dead-letters?limit=1&cursor=${encodeURIComponent(page1.nextCursor!)}`, {
+				token: reviewerToken,
+			}),
+			deps(),
+		);
+		const page2 = (await body(second)).data as { items: { id: number }[] };
+		expect(page2.items).toHaveLength(1);
+		expect(page2.items[0]!.id).toBeLessThan(page1.items[0]!.id);
+	});
+
+	it("rejects an identity with no role (403) and an unauthenticated caller (401)", async () => {
+		expect(
+			(await handleConsoleApi(req("/admin/api/dead-letters", { token: noRoleToken }), deps()))
+				.status,
+		).toBe(403);
+		expect((await handleConsoleApi(req("/admin/api/dead-letters"), deps())).status).toBe(401);
+	});
+
+	it("400s a malformed cursor", async () => {
+		const res = await handleConsoleApi(
+			req("/admin/api/dead-letters?cursor=not-a-cursor", { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("counts only new dead letters in the health figure", async () => {
+		await insertResolvedDeadLetter("retried");
+		await insertResolvedDeadLetter("quarantined");
+		const res = await handleConsoleApi(req("/admin/api/status", { token: reviewerToken }), deps());
+		const status = (await body(res)).data as { deadLetterDepth: number };
+		// The three seeded rows are 'new'; the retried + quarantined rows are excluded.
+		expect(status.deadLetterDepth).toBe(3);
 	});
 });
 

--- a/apps/labeler/test/console-assessment-mutations.test.ts
+++ b/apps/labeler/test/console-assessment-mutations.test.ts
@@ -108,6 +108,7 @@ function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): ConsoleMuta
 		defer: (work) => {
 			void work;
 		},
+		sendDiscoveryJob: async () => {},
 		...overrides,
 	};
 }

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -125,6 +125,7 @@ function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): ConsoleMuta
 		defer: (work) => {
 			void work;
 		},
+		sendDiscoveryJob: async () => {},
 		...overrides,
 	};
 }
@@ -1575,5 +1576,337 @@ describe("console mutation: pause endpoint drives the discovery consumer gate (e
 		expect(resumedMsg.acked).toBe(1);
 		expect(resumedMsg.retried).toBe(0);
 		expect(await countRows(`SELECT COUNT(*) n FROM subjects WHERE uri = ?`, uri)).toBe(1);
+	});
+});
+
+// ─── W9.6: admin-only dead-letter retry / quarantine controls ────────────────
+
+interface DeadLetterActionDescriptor {
+	actionId: string;
+	deadLetterId: number;
+	status: string;
+	cts: string;
+}
+
+let dlSeq = 0;
+
+async function seedDeadLetter(
+	overrides: { status?: string; job?: Partial<DiscoveryJob> } = {},
+): Promise<{ id: number; job: DiscoveryJob }> {
+	dlSeq += 1;
+	const rkey = `dl-${dlSeq.toString().padStart(4, "0")}`;
+	const job: DiscoveryJob = {
+		did: PUBLISHER_DID,
+		collection: "com.emdashcms.experimental.package.release",
+		rkey,
+		operation: "create",
+		cid: CID,
+		jetstreamRecord: { $type: "com.emdashcms.experimental.package.release", package: rkey },
+		...overrides.job,
+	};
+	const payload = new TextEncoder().encode(JSON.stringify(job));
+	const result = await testEnv.DB.prepare(
+		`INSERT INTO dead_letters (did, collection, rkey, reason, detail, payload, received_at, status)
+		 VALUES (?, ?, ?, 'verify-failed', 'detail', ?, datetime('now'), ?)`,
+	)
+		.bind(job.did, job.collection, job.rkey, payload, overrides.status ?? "new")
+		.run();
+	return { id: Number(result.meta.last_row_id), job };
+}
+
+async function deadLetterRow(
+	id: number,
+): Promise<{
+	status: string;
+	resolved_at: string | null;
+	resolved_by_action_id: string | null;
+} | null> {
+	return testEnv.DB.prepare(
+		`SELECT status, resolved_at, resolved_by_action_id FROM dead_letters WHERE id = ?`,
+	)
+		.bind(id)
+		.first();
+}
+
+function deadLetterReq(
+	path: string,
+	token: string | null = adminToken,
+	body: Record<string, unknown> = {},
+): Request {
+	return post(path, { reason: "re-drive", idempotencyKey: nextKey(), ...body }, { token });
+}
+
+/** Captures the deferred re-enqueue tail so a test can settle it and observe the
+ * queue sends. `defer` collects the work rather than dropping it (the default
+ * `mutationDeps` swallows deferred work). */
+function captureReenqueue(): {
+	deps: ConsoleMutationDeps;
+	sent: DiscoveryJob[];
+	settle: () => Promise<unknown>;
+} {
+	const sent: DiscoveryJob[] = [];
+	const deferred: Promise<unknown>[] = [];
+	const deps = mutationDeps({
+		sendDiscoveryJob: async (job) => {
+			sent.push(job);
+		},
+		defer: (work) => {
+			deferred.push(work);
+		},
+	});
+	return { deps, sent, settle: () => Promise.all(deferred.splice(0)) };
+}
+
+describe("console mutation: dead-letter retry (admin)", () => {
+	it("flips new→retried, emits one info event + audit row, enqueues one job", async () => {
+		const { id, job } = await seedDeadLetter();
+		const { deps, sent, settle } = captureReenqueue();
+		const response = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/${id}/retry`),
+			deps,
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<DeadLetterActionDescriptor>(response);
+		expect(descriptor).toMatchObject({ deadLetterId: id, status: "retried" });
+
+		const row = await deadLetterRow(id);
+		expect(row?.status).toBe("retried");
+		expect(row?.resolved_at).not.toBeNull();
+		expect(row?.resolved_by_action_id).toBe(descriptor.actionId);
+
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operator_actions WHERE id = ? AND action = 'dlq-retry'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operational_events
+				 WHERE action_id = ? AND event_type = 'dead-letter-retried' AND severity = 'info'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+		// No label issued, so no delivery outbox row.
+		expect(await outboxCount(descriptor.actionId)).toBe(0);
+
+		await settle();
+		expect(sent).toHaveLength(1);
+		expect(sent[0]).toMatchObject({
+			did: job.did,
+			collection: job.collection,
+			rkey: job.rkey,
+			cid: job.cid,
+			operation: "create",
+		});
+	});
+});
+
+describe("console mutation: dead-letter quarantine (admin)", () => {
+	it("flips new→quarantined, emits one info event, enqueues nothing", async () => {
+		const { id } = await seedDeadLetter();
+		const { deps, sent, settle } = captureReenqueue();
+		const response = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/${id}/quarantine`),
+			deps,
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<DeadLetterActionDescriptor>(response);
+		expect(descriptor).toMatchObject({ deadLetterId: id, status: "quarantined" });
+
+		const row = await deadLetterRow(id);
+		expect(row?.status).toBe("quarantined");
+		expect(row?.resolved_by_action_id).toBe(descriptor.actionId);
+		expect(
+			await countRows(
+				`SELECT COUNT(*) n FROM operational_events
+				 WHERE action_id = ? AND event_type = 'dead-letter-quarantined' AND severity = 'info'`,
+				descriptor.actionId,
+			),
+		).toBe(1);
+
+		await settle();
+		expect(sent).toHaveLength(0);
+	});
+});
+
+describe("console mutation: dead-letter authorization (per-endpoint, pre-effect)", () => {
+	it.each(["retry", "quarantine"])(
+		"rejects a reviewer with zero side effects: %s",
+		async (verb) => {
+			const { id } = await seedDeadLetter();
+			const before = {
+				actions: await countRows(`SELECT COUNT(*) n FROM operator_actions`),
+				events: await countRows(`SELECT COUNT(*) n FROM operational_events`),
+			};
+			const { deps, sent, settle } = captureReenqueue();
+			const response = await handleConsoleMutation(
+				deadLetterReq(`/admin/api/dead-letters/${id}/${verb}`, reviewerToken),
+				deps,
+			);
+			expect(response.status).toBe(403);
+			expect((await bodyError(response)).code).toBe("FORBIDDEN_ROLE");
+			expect(await countRows(`SELECT COUNT(*) n FROM operator_actions`)).toBe(before.actions);
+			expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(before.events);
+			expect((await deadLetterRow(id))?.status).toBe("new");
+			await settle();
+			expect(sent).toHaveLength(0);
+		},
+	);
+
+	it.each(["retry", "quarantine"])(
+		"accepts an admin (the 403 is the role, not a broken endpoint): %s",
+		async (verb) => {
+			const { id } = await seedDeadLetter();
+			const response = await handleConsoleMutation(
+				deadLetterReq(`/admin/api/dead-letters/${id}/${verb}`, adminToken),
+				mutationDeps(),
+			);
+			expect(response.status).toBe(200);
+		},
+	);
+
+	it("rejects an unauthenticated caller with zero side effects (401)", async () => {
+		const { id } = await seedDeadLetter();
+		const before = {
+			actions: await countRows(`SELECT COUNT(*) n FROM operator_actions`),
+			events: await countRows(`SELECT COUNT(*) n FROM operational_events`),
+		};
+		const { deps, sent, settle } = captureReenqueue();
+		const response = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/${id}/retry`, null),
+			deps,
+		);
+		expect(response.status).toBe(401);
+		expect(await countRows(`SELECT COUNT(*) n FROM operator_actions`)).toBe(before.actions);
+		expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(before.events);
+		expect((await deadLetterRow(id))?.status).toBe("new");
+		await settle();
+		expect(sent).toHaveLength(0);
+	});
+});
+
+describe("console mutation: dead-letter double-processing (T6)", () => {
+	it("404s a retry on an absent dead letter", async () => {
+		const response = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/99999999/retry`),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(404);
+	});
+
+	it("404s a malformed dead-letter id", async () => {
+		const response = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/not-an-id/retry`),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(404);
+	});
+
+	it("409s a second retry on an already-resolved letter with no second enqueue", async () => {
+		const { id } = await seedDeadLetter();
+		const { deps, sent, settle } = captureReenqueue();
+		const first = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/${id}/retry`),
+			deps,
+		);
+		expect(first.status).toBe(200);
+		await settle();
+		expect(sent).toHaveLength(1);
+
+		const actionsBefore = await countRows(`SELECT COUNT(*) n FROM operator_actions`);
+		const eventsBefore = await countRows(`SELECT COUNT(*) n FROM operational_events`);
+		const second = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/${id}/retry`),
+			deps,
+		);
+		expect(second.status).toBe(409);
+		expect((await bodyError(second)).code).toBe("DEAD_LETTER_RESOLVED");
+		expect(await countRows(`SELECT COUNT(*) n FROM operator_actions`)).toBe(actionsBefore);
+		expect(await countRows(`SELECT COUNT(*) n FROM operational_events`)).toBe(eventsBefore);
+		await settle();
+		expect(sent).toHaveLength(1);
+	});
+
+	it("409s a quarantine after a retry, and a retry after a quarantine", async () => {
+		const a = await seedDeadLetter();
+		expect(
+			(
+				await handleConsoleMutation(
+					deadLetterReq(`/admin/api/dead-letters/${a.id}/retry`),
+					mutationDeps(),
+				)
+			).status,
+		).toBe(200);
+		const quarantineAfterRetry = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/${a.id}/quarantine`),
+			mutationDeps(),
+		);
+		expect(quarantineAfterRetry.status).toBe(409);
+
+		const b = await seedDeadLetter();
+		expect(
+			(
+				await handleConsoleMutation(
+					deadLetterReq(`/admin/api/dead-letters/${b.id}/quarantine`),
+					mutationDeps(),
+				)
+			).status,
+		).toBe(200);
+		const retryAfterQuarantine = await handleConsoleMutation(
+			deadLetterReq(`/admin/api/dead-letters/${b.id}/retry`),
+			mutationDeps(),
+		);
+		expect(retryAfterQuarantine.status).toBe(409);
+	});
+});
+
+describe("console mutation: dead-letter replay and idempotency", () => {
+	it("replays the stored result for the same key, enqueuing exactly once", async () => {
+		const { id } = await seedDeadLetter();
+		const key = nextKey();
+		const { deps, sent, settle } = captureReenqueue();
+		const request = () =>
+			post(
+				`/admin/api/dead-letters/${id}/retry`,
+				{ reason: "re-drive", idempotencyKey: key },
+				{ token: adminToken },
+			);
+		const first = await handleConsoleMutation(request(), deps);
+		const firstBody = await first.text();
+		await settle();
+		const second = await handleConsoleMutation(request(), deps);
+		expect(second.status).toBe(200);
+		expect(await second.text()).toBe(firstBody);
+		await settle();
+		// The replay returns the stored descriptor without re-running the effect.
+		expect(sent).toHaveLength(1);
+		const actionId = (JSON.parse(firstBody) as { data: DeadLetterActionDescriptor }).data.actionId;
+		expect(await eventCount(actionId)).toBe(1);
+	});
+
+	it("409s a same-key request targeting a different dead letter", async () => {
+		const a = await seedDeadLetter();
+		const b = await seedDeadLetter();
+		const key = nextKey();
+		const first = await handleConsoleMutation(
+			post(
+				`/admin/api/dead-letters/${a.id}/retry`,
+				{ reason: "re-drive", idempotencyKey: key },
+				{ token: adminToken },
+			),
+			mutationDeps(),
+		);
+		expect(first.status).toBe(200);
+		const second = await handleConsoleMutation(
+			post(
+				`/admin/api/dead-letters/${b.id}/retry`,
+				{ reason: "re-drive", idempotencyKey: key },
+				{ token: adminToken },
+			),
+			mutationDeps(),
+		);
+		expect(second.status).toBe(409);
+		expect((await bodyError(second)).code).toBe("IDEMPOTENCY_KEY_CONFLICT");
 	});
 });


### PR DESCRIPTION
## What does this PR do?

W9.6 PR-3 — the **admin-only dead-letter retry / quarantine controls**, the final piece of W9.6. PR-0 added the `dead_letters` status columns (`status` default `'new'`, `resolved_at`, `resolved_by_action_id`); this PR wires the operator controls over them.

- **Retry** (`POST /admin/api/dead-letters/:id/retry`, admin-only): flips a `new` letter to `retried`, records the resolving action, and emits an `info` `dead-letter-retried` operational event — all in one `commitMutation` batch with the audit row. A **deferred tail** then re-enqueues the letter's discovery job (off the response path); the consumer's `runKey` dedup makes a double-drive converge, so a lost enqueue is recoverable by re-driving `retried` rows (the reconciliation sweep is out of scope, as the design notes).
- **Quarantine** (`.../quarantine`, admin-only): a terminal "reviewed, won't retry" flip to `quarantined` with a `dead-letter-quarantined` event; no re-enqueue.
- **At-most-once (T6):** both actions guard on `status = 'new'` — an already-resolved letter is a 409 `DEAD_LETTER_RESOLVED` rejected *before* any commit, so a late or repeated request commits and enqueues nothing. Under a concurrent race the `WHERE status='new'` UPDATE flips exactly once and the deferred tail re-reads `resolved_by_action_id`, so only the winner enqueues. Replay (same key) returns the stored descriptor without re-deferring.
- **Health count:** `countDeadLetters` now filters `WHERE status = 'new'`, so retried/quarantined letters leave the `/admin/api/status` dead-letter depth.
- **Read:** a reviewer-gated, newest-first paginated list route (`id DESC` keyset, `{items, nextCursor}`); the *actions* are admin-only. The console gains a dead-letter queue view with admin-gated retry/quarantine buttons.

**Ingestion-path change (worth a look):** `writeDeadLetter` now persists the full `DiscoveryJob` instead of the bare jetstream record. A create/update dead letter's record carries no CID, so the old payload couldn't be faithfully re-verified on retry — the retry feature needs the whole job. It's code-only within the existing BLOB column; the only reader is the new `readDeadLetterJob`, the job is all JSON-safe data (round-trips through both `JSON` and the queue's structured clone), and it's public ATProto data (nothing sensitive in the blob).

**Adversarially reviewed** by an independent Opus pass targeting the T6 races (sequential, concurrent, retry-vs-quarantine, replay), the payload deviation's round-trip, and authz: **no blockers** — the at-most-once-enqueue invariant holds under every constructed race. Two of its findings are addressed here: an **observability log** when a retry's payload doesn't decode (so a skipped re-enqueue isn't silent — matters only for any pre-PR staging row, since the labeler has never hit `main`), and a reverted oxfmt-only churn hunk. Its INFO on replay asymmetry (a lost enqueue is recoverable only by the unbuilt sweep, not by API replay) is a conscious, design-consistent choice.

### For the batched decision (non-blocking)

One adversary finding I've deliberately **not** changed, because it's the same audit/event-accuracy theme as two open questions on #2026 and #2027 and should be decided as one policy: **in a concurrent two-admin race on the same letter, the loser commits an audit row + an `info` operational event and returns a 200 asserting a status its zero-row UPDATE never applied.** The safety invariant fully holds (at-most-once enqueue; the consumer dedups regardless), and it takes two admins acting on one letter within the same moment — but the loser's response and its (info-severity, non-paging) event misrepresent reality. Tightening it means either gating the event on the UPDATE matching (a change to PR-0's frozen `operational-events.ts` gate) or a post-commit winner re-read → 409. I'll fold this into the incident-notification/audit-observability decisions to settle coherently rather than per-PR.

**W9.6 is feature-complete** with this PR: takedown + publisher-compromised + ceremony (PR-1), the operational-event/outbox subsystem (PR-0), pause/resume (PR-2), and DLQ retry/quarantine (PR-3).

Stacked on the integration branch (W9.5 + PR-0/1/2 merged). Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — the labeler console is deliberately not localized (decision 2026-07-13). Changeset n/a — `apps/labeler` is a private, unpublished Worker app.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Opus 4.8 (design, implementation, adversarial review, coordination)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker **538 pass** (28 files; new DLQ suite covers retry/quarantine happy paths, per-endpoint reviewer-403/unauth-401 zero-side-effect + reviewer-can-list, the T6 rejections, exactly-one-enqueue, `countDeadLetters` exclusion, replay, and pagination), console **35 pass** (new dead-letter view + actions)
- Typecheck (both projects) clean; `console:build` succeeds; lint: 0 diagnostics in `apps/labeler`

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM
