### PR TITLE
fix(labeler): reject an emergency retract with no active label (W9.6 follow-up)

### DIFF
--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -24,6 +24,7 @@ import {
 import {
 	advanceAssessmentToPending,
 	buildAssessmentRunStatement,
+	getActiveLabelState,
 	getAssessment,
 	type Assessment,
 } from "./assessment-store.js";
@@ -198,7 +199,8 @@ export async function handleConsoleMutation(
 			error instanceof MutationGuardError ||
 			error instanceof ReadGuardError ||
 			error instanceof LabelMutationError ||
-			error instanceof DeadLetterResolvedError
+			error instanceof DeadLetterResolvedError ||
+			error instanceof NoActiveLabelError
 		)
 			return error.toResponse();
 		// A submitted override negation set that isn't exactly the live automated
@@ -853,6 +855,27 @@ interface EmergencyActionBody {
  * (`cid` is always null: every emergency label is URI-wide / DID-subject). */
 type EmergencyDescriptor = IssuedLabelDescriptor;
 
+/** A retract whose target positive label is not currently in effect (never
+ * issued, already negated, or expired) — there is nothing to retract. Static
+ * message; a 404 mirroring the absent-subject case so a no-op negation is never
+ * signed and no operational event fires for a takedown that was never live. */
+class NoActiveLabelError extends Error {
+	override readonly name = "NoActiveLabelError";
+	readonly code = "NO_ACTIVE_LABEL";
+	readonly status = 404;
+
+	constructor() {
+		super("No active label to retract");
+	}
+
+	toResponse(): Response {
+		return Response.json(
+			{ error: { code: this.code, message: this.message } },
+			{ status: this.status },
+		);
+	}
+}
+
 /**
  * `POST /admin/api/emergency/{takedown,publisher-compromised}` and their
  * `-retract` siblings — the admin-only crown-jewel actions (spec §11.3/§18.2,
@@ -901,6 +924,12 @@ async function runEmergencyAction(
 	}
 
 	const { ctx } = outcome;
+	// A retract only makes sense against a currently-in-effect positive label. A
+	// pure read after the role + ceremony gates and before any signing/commit: an
+	// absent, already-negated, or expired winner is rejected here, so no no-op
+	// negation is signed and no operational event or alert fires.
+	if (neg) await assertRetractableLabel(deps.db, deps.config.labelerDid, ctx.body.uri, val);
+
 	const signer = await deps.createSigner();
 	const issuance = await prepareManualLabelIssuance(
 		deps.db,
@@ -1003,6 +1032,24 @@ function assertEmergencyConfirmation(
  * PLC/web identifier), not a resolved handle. */
 function didFinalSegment(uri: string): string {
 	return uri.split(":").at(-1) ?? "";
+}
+
+/**
+ * Rejects a retract with no positive label to retract. Reads the same stream
+ * winner official clients see (`getActiveLabelState`); the label is retractable
+ * iff its winner exists and is `active` (non-negated, unexpired). Every emergency
+ * label is URI-wide, so `cid: ""` matches the CID-forbidden winner the same way
+ * the console's publisher subject-label read does.
+ */
+async function assertRetractableLabel(
+	db: D1Database,
+	src: string,
+	uri: string,
+	val: string,
+): Promise<void> {
+	const winners = await getActiveLabelState(db, { src, uri, cid: "" });
+	const winner = winners.get(val);
+	if (!winner || !winner.active) throw new NoActiveLabelError();
 }
 
 // ─── W9.6: admin-only automation kill-switch (pause/resume ingestion) ────────

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -832,6 +832,15 @@ async function outboxCount(actionId: string): Promise<number> {
 	);
 }
 
+async function globalCounts(): Promise<Record<string, number>> {
+	return {
+		actions: await countRows(`SELECT COUNT(*) n FROM operator_actions`),
+		labels: await countRows(`SELECT COUNT(*) n FROM issued_labels`),
+		events: await countRows(`SELECT COUNT(*) n FROM operational_events`),
+		outbox: await countRows(`SELECT COUNT(*) n FROM notification_outbox`),
+	};
+}
+
 function emergency(
 	path: string,
 	body: Record<string, unknown>,
@@ -1246,10 +1255,21 @@ describe("console mutation: emergency retract resting state", () => {
 	});
 
 	it("emits a high-severity operational event for a retract", async () => {
+		const uri = await seedReleaseSubject("emrg-retract-event");
+		const issued = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: "emrg-retract-event",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(issued.status).toBe(200);
+
 		const response = await handleConsoleMutation(
 			emergency("/admin/api/emergency/takedown-retract", {
-				uri: PUBLISHER_DID,
-				subjectConfirmation: PUBLISHER_SEGMENT,
+				uri,
+				subjectConfirmation: "emrg-retract-event",
 				intent: "CONFIRM RETRACT",
 			}),
 			mutationDeps(),
@@ -1262,6 +1282,211 @@ describe("console mutation: emergency retract resting state", () => {
 				descriptor.actionId,
 			),
 		).toBe(1);
+	});
+});
+
+describe("console mutation: emergency retract guard", () => {
+	const FRESH_DID = "did:plc:nocompromise00000000000000";
+	const FRESH_DID_SEGMENT = FRESH_DID.split(":").at(-1)!;
+
+	it("retracts an active takedown: negation lands, event emitted (200)", async () => {
+		const uri = await seedReleaseSubject("guard-active-td");
+		const issued = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: "guard-active-td",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(issued.status).toBe(200);
+
+		const retract = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: "guard-active-td",
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(retract.status).toBe(200);
+		const descriptor = await bodyData<IssuedLabelDescriptor>(retract);
+		expect(descriptor.neg).toBe(true);
+
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: CID });
+		expect(winners.get("!takedown")?.active).toBe(false);
+		expect(await eventCount(descriptor.actionId)).toBe(1);
+	});
+
+	it("retracts an active takedown on a package subject (200)", async () => {
+		const uri = profileUri("guard-active-td-pkg");
+		const issued = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: "guard-active-td-pkg",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(issued.status).toBe(200);
+
+		const retract = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: "guard-active-td-pkg",
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(retract.status).toBe(200);
+		expect((await bodyData<IssuedLabelDescriptor>(retract)).neg).toBe(true);
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: "" });
+		expect(winners.get("!takedown")?.active).toBe(false);
+	});
+
+	it("retracts an active takedown on a publisher subject (200)", async () => {
+		const uri = "did:plc:guardtdpublisher00000000000";
+		const issued = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: uri.split(":").at(-1)!,
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(issued.status).toBe(200);
+
+		const retract = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: uri.split(":").at(-1)!,
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(retract.status).toBe(200);
+		expect((await bodyData<IssuedLabelDescriptor>(retract)).neg).toBe(true);
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: "" });
+		expect(winners.get("!takedown")?.active).toBe(false);
+	});
+
+	it("retracts an active publisher-compromised on a publisher (200)", async () => {
+		const uri = "did:plc:guardpccompromised000000000";
+		const issued = await handleConsoleMutation(
+			emergency("/admin/api/emergency/publisher-compromised", {
+				uri,
+				subjectConfirmation: uri.split(":").at(-1)!,
+				intent: "CONFIRM COMPROMISE",
+			}),
+			mutationDeps(),
+		);
+		expect(issued.status).toBe(200);
+
+		const retract = await handleConsoleMutation(
+			emergency("/admin/api/emergency/publisher-compromised-retract", {
+				uri,
+				subjectConfirmation: uri.split(":").at(-1)!,
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(retract.status).toBe(200);
+		expect((await bodyData<IssuedLabelDescriptor>(retract)).neg).toBe(true);
+		const winners = await getActiveLabelState(testEnv.DB, { src: LABELER_DID, uri, cid: "" });
+		expect(winners.get("publisher-compromised")?.active).toBe(false);
+	});
+
+	it("rejects a takedown-retract with no active takedown (404, zero side effects)", async () => {
+		const uri = await seedReleaseSubject("guard-no-td");
+		const before = await globalCounts();
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: "guard-no-td",
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(404);
+		expect((await bodyError(response)).code).toBe("NO_ACTIVE_LABEL");
+		expect(await globalCounts()).toEqual(before);
+	});
+
+	it("rejects a publisher-compromised-retract with no active label (404, zero side effects)", async () => {
+		const before = await globalCounts();
+		const response = await handleConsoleMutation(
+			emergency("/admin/api/emergency/publisher-compromised-retract", {
+				uri: FRESH_DID,
+				subjectConfirmation: FRESH_DID_SEGMENT,
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(response.status).toBe(404);
+		expect((await bodyError(response)).code).toBe("NO_ACTIVE_LABEL");
+		expect(await globalCounts()).toEqual(before);
+	});
+
+	it("rejects retracting an already-retracted takedown (404, zero side effects)", async () => {
+		const uri = await seedReleaseSubject("guard-double-retract");
+		const issued = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown", {
+				uri,
+				subjectConfirmation: "guard-double-retract",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(issued.status).toBe(200);
+		const firstRetract = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: "guard-double-retract",
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(firstRetract.status).toBe(200);
+
+		const before = await globalCounts();
+		const secondRetract = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: "guard-double-retract",
+				intent: "CONFIRM RETRACT",
+			}),
+			mutationDeps(),
+		);
+		expect(secondRetract.status).toBe(404);
+		expect((await bodyError(secondRetract)).code).toBe("NO_ACTIVE_LABEL");
+		expect(await globalCounts()).toEqual(before);
+	});
+
+	it("keeps the role and ceremony rejections ahead of the retract guard", async () => {
+		const uri = await seedReleaseSubject("guard-order");
+		// Reviewer role gate (403) precedes the retract guard even with nothing active.
+		const roleDenied = await handleConsoleMutation(
+			emergency(
+				"/admin/api/emergency/takedown-retract",
+				{ uri, subjectConfirmation: "guard-order", intent: "CONFIRM RETRACT" },
+				reviewerToken,
+			),
+			mutationDeps(),
+		);
+		expect(roleDenied.status).toBe(403);
+		expect((await bodyError(roleDenied)).code).toBe("FORBIDDEN_ROLE");
+
+		// Admin with a wrong intent: the ceremony gate (400) precedes the retract guard.
+		const ceremonyDenied = await handleConsoleMutation(
+			emergency("/admin/api/emergency/takedown-retract", {
+				uri,
+				subjectConfirmation: "guard-order",
+				intent: "CONFIRM TAKEDOWN",
+			}),
+			mutationDeps(),
+		);
+		expect(ceremonyDenied.status).toBe(400);
+		expect((await bodyError(ceremonyDenied)).code).toBe("CONFIRMATION_MISMATCH");
 	});
 });
 
@@ -1614,9 +1839,7 @@ async function seedDeadLetter(
 	return { id: Number(result.meta.last_row_id), job };
 }
 
-async function deadLetterRow(
-	id: number,
-): Promise<{
+async function deadLetterRow(id: number): Promise<{
 	status: string;
 	resolved_at: string | null;
 	resolved_by_action_id: string | null;


### PR DESCRIPTION
## What does this PR do?

A small ratified hardening (2026-07-14) to the W9.6 **emergency-action retract** endpoints. Previously, retracting a `!takedown` or `publisher-compromised` label that **wasn't in effect** succeeded anyway — it signed a no-op `neg:true` label and emitted a high-severity operational event, returning 200 for a takedown that was never live. Now the retract endpoints pre-check that the target positive label is currently active and reject with **404 `NO_ACTIVE_LABEL`** if it isn't — so no no-op negation is signed and no spurious alert fires.

- `assertRetractableLabel` reads the same stream winner official clients see (`getActiveLabelState`) and rejects unless the winner for the target `val` exists and is `active` (non-negated, unexpired). The read passes `cid: ""` — every emergency label is `cidRule: forbidden` (URI-wide / DID, stored with `cid` NULL), so the URI-wide winner is always found regardless of subject kind.
- **Pure read, commits nothing on reject.** The check runs after `guardMutation`'s role gate (a reviewer still gets 403, never a 404 leaking label state) and after the typed-ceremony validation (a wrong confirmation still gets 400), but before `createSigner` / `prepareManualLabelIssuance` / `commitMutation`. An absent, already-negated, or expired label commits no `operator_actions`, `issued_labels`, `operational_events`, or `notification_outbox` row.

Handler-only change (`console-mutation-api.ts` + its test); the console isn't touched — a retract on a stale view surfaces a clean 404. Nothing frozen was touched.

This resolves one of four post-review decisions on the merged W9.6 (the other three — audit `action` shape, pause alerting, DLQ concurrent-loser accuracy — were ratified as leave-as-is; all four are recorded in the plan).

**Adversarially reviewed** by an independent Opus pass focused on the one dangerous failure mode — a false-positive rejection that would block a *legitimate* takedown undo. It proved, per subject kind, that `cid: ""` finds the active winner for release/package/publisher takedown and publisher-compromised (all store `cid` NULL), that the guard fires on both retract endpoints and can't be bypassed (replay only short-circuits an already-guarded action), and that ordering/zero-side-effects/no-info-leak all hold: **no blockers**. It closed the real coverage gap — the initial happy-path test only covered release/takedown, so it added the package/takedown, publisher/takedown, and publisher-compromised/DID issue→retract→200 round-trips, all folded in.

Stacked on the integration branch (all W9.6 merged). Targets `feat/plugin-registry-labelling-service`. Related to #1909 and RFC #694.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: RFC #694

i18n n/a — no admin UI; the labeler console isn't localized (decision 2026-07-13), and this PR touches no console strings. Changeset n/a — `apps/labeler` is a private, unpublished Worker app. Bug fix on unreleased W9.6 code, so no Discussion needed beyond the existing RFC #694.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code with Opus 4.8 (implementation, adversarial review, coordination)

## Screenshots / test output

- `pnpm --filter @emdash-cms/labeler test`: worker **546 pass** (28 files; the emergency-retract-guard suite covers the active-label happy path for all four label/subject combinations, the no-active-label 404 with four-count zero-side-effect assertions on both retract endpoints, the already-retracted double-retract edge, and the 403-before-guard / 400-before-guard ordering), console **35 pass**
- Typecheck (both projects) clean; lint: 0 diagnostics in `apps/labeler`

https://claude.ai/code/session_014rikrGMh25h1rJczUQyTMM

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-retract-guard-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-retract-guard`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
