### PR TITLE
docs(labeler): operator guide, ATProto reference, and keygen script

### DIFF
--- a/apps/labeler/README.md
+++ b/apps/labeler/README.md
@@ -1,0 +1,83 @@
+# @emdash-cms/labeler
+
+An ATProto labeler service for the emdash plugin registry, deployed as a single Cloudflare Worker. It ingests package-registry records from the ATProto firehose, runs automated moderation assessments on package releases, and emits signed ATProto labels describing each release's eligibility (passed, blocked, warned, pending, error). Consumers such as the emdash aggregator subscribe to those labels and decide what to surface and serve. A React operator console under `/admin` lets human reviewers and admins inspect assessments and act on them.
+
+## How it fits together
+
+```
+registry records ──▶ Jetstream firehose ──▶ discovery queue ──▶ automated assessment
+                                                                        │
+                                                                        ▼
+consumers ◀── subscribeLabels / queryLabels ◀── signed labels ◀── label store
+```
+
+The Worker consumes the registry's records from the ATProto firehose (Jetstream), enqueues discovered packages and releases, and runs an assessment pipeline over each release. Assessments produce signed labels. Consumers resolve the labeler's DID, discover its endpoint, subscribe to the label stream, verify each label's signature against the public key published in the DID document, and apply the resulting eligibility decisions.
+
+The concepts behind all of this (DIDs, `did:web`, the DID document, labels, signing, and the XRPC surface) are explained in [docs/atproto.md](docs/atproto.md). The label vocabulary and how labels overlay into an eligibility state are in [docs/moderation-model.md](docs/moderation-model.md). Running the operator console day to day is covered in [docs/operating.md](docs/operating.md).
+
+## Local development
+
+Scripts are run through pnpm, filtered to this package:
+
+```bash
+pnpm --filter @emdash-cms/labeler dev           # Worker + console dev server (vite dev)
+pnpm --filter @emdash-cms/labeler console:dev    # console SPA on its own vite config
+pnpm --filter @emdash-cms/labeler test           # Worker + console test suites
+pnpm --filter @emdash-cms/labeler typecheck      # tsgo over Worker and console
+pnpm --filter @emdash-cms/labeler db:migrate:local  # apply D1 migrations to the local database
+```
+
+The console is not localized (plain English) and there is no dev auth bypass, so operator flows are exercised through real Cloudflare Access in a deployed environment.
+
+## Deploying
+
+The Worker validates on boot that its signing keypair matches the public key published in its DID document, so a copy error fails the deploy rather than shipping a labeler whose signatures cannot be verified. Work through the checklist in order.
+
+1. **Create a Cloudflare Access application** covering `/admin/*` on the labeler's domain, with two Access groups (one for admins, one for reviewers) mapped to your identity provider. This produces the application's **AUD tag**.
+
+2. **Set the operator Access config.** Put the AUD tag, your team domain, and the group names into `OPERATOR_ACCESS_CONFIG` in `wrangler.jsonc` (it ships with a `REPLACE_WITH_ACCESS_APP_AUD_TAG` placeholder):
+
+   ```jsonc
+   "OPERATOR_ACCESS_CONFIG": "{\"teamDomain\":\"https://your-team.cloudflareaccess.com\",\"audience\":\"<AUD tag>\",\"admins\":[\"emdash-labeler-admins\"],\"reviewers\":[\"emdash-labeler-reviewers\"]}"
+   ```
+
+3. **Generate the signing keypair** and install it. The keygen script prints both values in the exact formats the Worker expects; nothing is written to disk.
+
+   ```bash
+   pnpm --filter @emdash-cms/labeler keygen
+   echo -n '<private key>' | wrangler secret put LABEL_SIGNING_PRIVATE_KEY
+   # then set LABEL_SIGNING_PUBLIC_KEY in wrangler.jsonc to the printed public key
+   ```
+
+   Bump `LABEL_SIGNING_KEY_VERSION` if you are rotating an existing key.
+
+4. **Run migrations** against the remote D1 database:
+
+   ```bash
+   pnpm --filter @emdash-cms/labeler db:migrate
+   ```
+
+5. **Deploy.** This builds the console and the Worker, then publishes:
+
+   ```bash
+   pnpm --filter @emdash-cms/labeler deploy
+   ```
+
+## Configuration reference
+
+| Key                         | Kind   | Description                                                                        |
+| --------------------------- | ------ | --------------------------------------------------------------------------------- |
+| `LABELER_DID`               | var    | The labeler's DID, `did:web:labels.emdashcms.com`.                                 |
+| `LABELER_SERVICE_URL`       | var    | Service endpoint published in the DID document, `https://labels.emdashcms.com`.    |
+| `LABEL_SIGNING_PUBLIC_KEY`  | var    | P-256 public key as a Multikey; published in the DID document's `#atproto_label` method for signature verification. |
+| `LABEL_SIGNING_PRIVATE_KEY` | secret | P-256 private key (unpadded base64url of the raw 32-byte scalar) used to sign labels server-side. |
+| `LABEL_SIGNING_KEY_VERSION` | var    | Signing key version (`v1`); bump when rotating.                                    |
+| `OPERATOR_ACCESS_CONFIG`    | var    | JSON: `teamDomain`, `audience` (Access AUD tag), and `admins` / `reviewers` group names. |
+
+The private key is declared as a required secret in `wrangler.jsonc`, so `wrangler deploy` refuses to publish if it has not been set on the target Worker.
+
+## Documents
+
+- [docs/atproto.md](docs/atproto.md) — ATProto foundations: DIDs, `did:web`, the DID document, labels, signing, and the XRPC surface.
+- [docs/operating.md](docs/operating.md) — operator console guide: sign-in, roles, and the review and emergency workflows.
+- [docs/moderation-model.md](docs/moderation-model.md) — label vocabulary and how labels evaluate into an eligibility state.

--- a/apps/labeler/README.md
+++ b/apps/labeler/README.md
@@ -31,7 +31,7 @@ The console is not localized (plain English) and there is no dev auth bypass, so
 
 ## Deploying
 
-The Worker validates on boot that its signing keypair matches the public key published in its DID document, so a copy error fails the deploy rather than shipping a labeler whose signatures cannot be verified. Work through the checklist in order.
+The Worker checks that its signing keypair matches the public key published in its DID document the first time it signs a label — not at deploy time. `wrangler deploy` only enforces that the `LABEL_SIGNING_PRIVATE_KEY` secret exists, so a mismatched pair deploys cleanly and then fails on the first signing operation. After setting or rotating the key, exercise a signing path (a console mutation, an assessment, or a `queryLabels` re-sign) to confirm the pair is consistent. Work through the checklist in order.
 
 1. **Create a Cloudflare Access application** covering `/admin/*` on the labeler's domain, with two Access groups (one for admins, one for reviewers) mapped to your identity provider. This produces the application's **AUD tag**.
 

--- a/apps/labeler/docs/atproto.md
+++ b/apps/labeler/docs/atproto.md
@@ -1,0 +1,118 @@
+# ATProto foundations
+
+This document explains the ATProto concepts the labeler is built on, and the concrete choices this service makes. Read it if you are consuming the labeler's labels, verifying its signatures, or working on the service itself. For the label vocabulary see [moderation-model.md](moderation-model.md); for the operator console see [operating.md](operating.md).
+
+## Decentralized identity and DIDs
+
+ATProto identifies every account and service by a **DID** (Decentralized Identifier): a stable, method-scoped string that does not change even when the underlying host, handle, or key rotates. A DID resolves to a **DID document**, a JSON object describing how to interact with that identity. Two parts of the document matter here:
+
+- **Verification methods** — public keys bound to the identity. Anything the identity signs can be verified against these keys.
+- **Services** — named endpoints. A client that knows a DID can resolve it, read the service list, and find where to talk to it.
+
+The DID string encodes a **method** that says how to resolve it. Two methods are relevant to a labeler:
+
+- **`did:plc`** — the common ATProto method. The identifier is an opaque string (`did:plc:abc123…`) hosted by the PLC directory, a separate service that stores and serves the DID document. Rotating keys or moving hosts means updating the record in the directory.
+- **`did:web`** — the identifier *is* a domain. `did:web:labels.emdashcms.com` resolves by fetching `https://labels.emdashcms.com/.well-known/did.json`. No external directory is involved; whoever controls the domain controls the document.
+
+### Why this labeler uses `did:web`
+
+A labeler already owns and operates a domain and an HTTP server. `did:web` lets it be its own source of truth: the Worker serves its own DID document at `/.well-known/did.json`, so there is no registration step, no external directory to keep in sync, and no third party in the resolution path. The tradeoff — that identity is tied to continued control of the domain — is acceptable for an infrastructure service whose whole purpose is to serve that domain.
+
+## This labeler's identity
+
+The labeler's DID is `did:web:labels.emdashcms.com` (config var `LABELER_DID`), and its service URL is `https://labels.emdashcms.com` (`LABELER_SERVICE_URL`). Resolving the DID means fetching `https://labels.emdashcms.com/.well-known/did.json` — which the Worker serves itself, with content type `application/did+ld+json`.
+
+The document (built by `serviceDidDocument` in `src/identity.ts`) has this shape:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1"
+  ],
+  "id": "did:web:labels.emdashcms.com",
+  "verificationMethod": [
+    {
+      "id": "did:web:labels.emdashcms.com#atproto_label",
+      "type": "Multikey",
+      "controller": "did:web:labels.emdashcms.com",
+      "publicKeyMultibase": "zDnae..."
+    }
+  ],
+  "service": [
+    {
+      "id": "did:web:labels.emdashcms.com#atproto_labeler",
+      "type": "AtprotoLabeler",
+      "serviceEndpoint": "https://labels.emdashcms.com"
+    }
+  ]
+}
+```
+
+Two entries carry the whole contract:
+
+- **`#atproto_label`** — a single `Multikey` verification method holding the P-256 public key (`publicKeyMultibase`, from `LABEL_SIGNING_PUBLIC_KEY`). Consumers use this key to verify the signature on every label the service emits. This is the anchor of trust: a label is only as trustworthy as the DID document that publishes the key it was signed with.
+- **`#atproto_labeler`** — a single service entry of type `AtprotoLabeler` whose `serviceEndpoint` is the labeler's base URL. This is how an ATProto client, given only the DID, discovers where to query and subscribe.
+
+## Labels
+
+A **label** in ATProto is a small, signed assertion that attaches a value (a short string like `malware` or `assessment-passed`) to a subject. The subject is either a whole repository (identified by a DID) or a specific record (identified by its AT-URI, optionally pinned to a content hash, the **CID**). Labels can be self-authored (an account labeling its own content) or third-party: a **labeler** is a service that publishes labels about subjects it does not own. Clients choose which labelers they trust and subscribe to them; a label from an untrusted labeler carries no weight.
+
+This service labels three kinds of subject:
+
+- **Publisher** — a DID. The identity that publishes packages.
+- **Package** — a record URI (the package profile record).
+- **Release** — a specific release, identified by its record URI *and* CID, so a label applies to one exact version's bytes.
+
+The **`cidRule`** on each label encodes which of these it can target:
+
+- `required` — the label must pin a CID, so it targets one specific release version.
+- `forbidden` — the label must not pin a CID, so it applies URI-wide (a whole package or publisher).
+- `optional` — either form is valid.
+
+Release-eligibility labels are `required` (they are about one version's bytes); publisher and package actions are `forbidden` (they apply to everything under that subject). The full rules per label are in [moderation-model.md](moderation-model.md).
+
+## Signing
+
+Labels are cryptographically signed so a consumer can trust their provenance without trusting the transport. The signing key is a **P-256** (ECDSA / ES256) keypair:
+
+- The **public key** lives in the DID document's `#atproto_label` method, as a canonical P-256 Multikey (`LABEL_SIGNING_PUBLIC_KEY`). Anyone resolving the DID can read it.
+- The **private key** stays on the server as a secret (`LABEL_SIGNING_PRIVATE_KEY`, the unpadded base64url of the raw 32-byte scalar). It signs every label the service emits and is never exposed.
+
+A consumer verifies a label by resolving the labeler's DID, reading the public key from `#atproto_label`, and checking the label's signature against it. The Worker validates on boot that the configured private key derives the public key published in the document — a mismatch throws and fails the deploy, so the service cannot ship in a state where its own signatures would fail to verify.
+
+Key rotation is tracked by `LABEL_SIGNING_KEY_VERSION` (currently `v1`). Generate a fresh keypair with `pnpm --filter @emdash-cms/labeler keygen`, install the new secret and public key, and bump the version.
+
+## XRPC surface
+
+ATProto's HTTP-RPC convention is **XRPC**: each method is a namespaced identifier (an NSID like `com.atproto.label.queryLabels`) called at `/xrpc/<nsid>`. The labeler exposes:
+
+| Path                                            | Purpose                                                                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `/xrpc/com.atproto.label.queryLabels`           | Query the current labels for a set of subjects (a point-in-time read).                       |
+| `/xrpc/com.atproto.label.subscribeLabels`       | The streaming label firehose. A WebSocket subscription consumers follow to receive labels as they are issued; accepts a numeric `cursor` to resume. |
+| `/xrpc/com.atproto.moderation.createReport`     | **Rejected.** This labeler does not accept user moderation reports; the endpoint returns a `NotSupported` error. |
+| `/xrpc/com.emdashcms.experimental.labeler.*`    | The experimental assessment API (`getAssessment`, `getCurrentAssessment`, `listAssessments`, `getPolicy`). |
+
+Alongside the XRPC methods, two documents are served under `/.well-known`:
+
+| Path                                          | Purpose                                                          |
+| --------------------------------------------- | --------------------------------------------------------------- |
+| `/.well-known/did.json`                       | The DID document (above).                                       |
+| `/.well-known/emdash-labeler-policy.json`     | The moderation policy document (label vocabulary and rules), cached for 300s. |
+
+## Jetstream and ingestion
+
+The labeler does not wait for anyone to submit content. It consumes the registry's records directly from the ATProto firehose via **Jetstream** (a JSON-streaming view of the network's commit stream), which is how it discovers new packages and releases to assess. Discovered work is enqueued and processed by the assessment pipeline, which is what ultimately produces the labels.
+
+## How it fits the wider network
+
+A consumer — the emdash aggregator, or any client that trusts this labeler — puts the pieces together like this:
+
+1. Resolve `did:web:labels.emdashcms.com` by fetching `/.well-known/did.json`.
+2. Read the `#atproto_labeler` service entry to find the endpoint.
+3. Subscribe to labels via `subscribeLabels` (or query current state with `queryLabels`).
+4. Verify each label's signature against the P-256 key in `#atproto_label`.
+5. Overlay the verified labels into an eligibility decision (see [moderation-model.md](moderation-model.md)) and act on it — showing, gating, or withholding the release.
+
+The trust chain is end to end: control of the domain backs the DID, the DID publishes the key, the key signs the labels, and the labels drive the decision.

--- a/apps/labeler/docs/atproto.md
+++ b/apps/labeler/docs/atproto.md
@@ -79,7 +79,7 @@ Labels are cryptographically signed so a consumer can trust their provenance wit
 - The **public key** lives in the DID document's `#atproto_label` method, as a canonical P-256 Multikey (`LABEL_SIGNING_PUBLIC_KEY`). Anyone resolving the DID can read it.
 - The **private key** stays on the server as a secret (`LABEL_SIGNING_PRIVATE_KEY`, the unpadded base64url of the raw 32-byte scalar). It signs every label the service emits and is never exposed.
 
-A consumer verifies a label by resolving the labeler's DID, reading the public key from `#atproto_label`, and checking the label's signature against it. The Worker validates on boot that the configured private key derives the public key published in the document — a mismatch throws and fails the deploy, so the service cannot ship in a state where its own signatures would fail to verify.
+A consumer verifies a label by resolving the labeler's DID, reading the public key from `#atproto_label`, and checking the label's signature against it. The Worker checks that the configured private key derives the public key published in the document when it constructs its signer — which happens lazily, on the first signing operation, not at boot or deploy. A mismatched pair therefore deploys cleanly and fails the first time the Worker tries to sign (a discovery assessment, a `queryLabels` re-sign, or a console mutation), rather than being caught up front.
 
 Key rotation is tracked by `LABEL_SIGNING_KEY_VERSION` (currently `v1`). Generate a fresh keypair with `pnpm --filter @emdash-cms/labeler keygen`, install the new secret and public key, and bump the version.
 

--- a/apps/labeler/docs/moderation-model.md
+++ b/apps/labeler/docs/moderation-model.md
@@ -1,0 +1,69 @@
+# Moderation model
+
+This is the reference for the labeler's label vocabulary and how active labels evaluate into an eligibility decision. It is what a `queryLabels` consumer needs to act on the labels correctly, and what an operator needs to understand which action produces which effect. For the console workflows that issue these labels, see [operating.md](operating.md); for the ATProto label and subject concepts, see [atproto.md](atproto.md).
+
+## Structure
+
+Labels are grouped into categories. Each label carries:
+
+- an **effect** — `pass`, `block`, `warn`, `pending`, `error`, or `redact`;
+- a **subject scope** — release, package, or publisher;
+- a **`cidRule`** — `required` (targets one exact release CID), `forbidden` (URI-wide, whole record or publisher), or `optional` (either); and
+- **issuance modes** — who may issue it: `automated`, `reviewer`, or `admin`.
+
+The policy document is served publicly at `/.well-known/emdash-labeler-policy.json`. The current `policyVersion` is `2026-07-10.experimental.3`.
+
+## Vocabulary
+
+| Label                        | Category        | Effect  | Subject → cidRule                                             | Who issues            |
+| ---------------------------- | --------------- | ------- | ------------------------------------------------------------ | --------------------- |
+| `assessment-passed`          | eligibility     | pass    | release → required                                           | automated, reviewer   |
+| `assessment-overridden`      | eligibility     | pass    | release → required                                           | reviewer              |
+| `assessment-pending`         | eligibility     | pending | release → required                                           | automated             |
+| `assessment-error`           | eligibility     | error   | release → required                                           | automated             |
+| `malware`                    | automated-block | block   | release → required                                           | automated, reviewer   |
+| `data-exfiltration`          | automated-block | block   | release → required                                           | automated, reviewer   |
+| `credential-harvesting`      | automated-block | block   | release → required                                           | automated, reviewer   |
+| `supply-chain-compromise`    | automated-block | block   | release → required                                           | automated, reviewer   |
+| `critical-vulnerability`     | automated-block | block   | release → required                                           | automated, reviewer   |
+| `artifact-integrity-failure` | automated-block | block   | release → required                                           | automated, reviewer   |
+| `invalid-bundle`             | automated-block | block   | release → required                                           | automated, reviewer   |
+| `undeclared-access`          | automated-block | block   | release → required                                           | automated, reviewer   |
+| `impersonation`              | automated-block | block   | release → required                                           | automated, reviewer   |
+| `suspicious-code`            | warning         | warn    | release → required                                           | automated, reviewer   |
+| `obfuscated-code`            | warning         | warn    | release → required                                           | automated, reviewer   |
+| `privacy-risk`               | warning         | warn    | release → required                                           | automated, reviewer   |
+| `misleading-metadata`        | warning         | warn    | release → required                                           | automated, reviewer   |
+| `low-quality`                | warning         | warn    | release → required                                           | automated, reviewer   |
+| `broken-release`             | warning         | warn    | release → required                                           | automated, reviewer   |
+| `!takedown`                  | manual-system   | redact  | release / package / publisher → forbidden                    | admin                 |
+| `security-yanked`            | manual-system   | block   | release → forbidden                                          | reviewer              |
+| `publisher-compromised`      | manual-system   | block   | publisher → forbidden                                        | admin                 |
+| `package-disputed`           | manual-system   | warn    | package → optional                                           | reviewer              |
+
+Notes:
+
+- The **eligibility** labels are automation-issued, except the override pair (`assessment-overridden`, and the reviewer half of `assessment-passed`), which is reviewer-only. `assessment-pending` gates a release until it resolves; `assessment-error` marks a pipeline failure after bounded retries.
+- The **automated-block** and **warning** labels each carry *both* `automated` and `reviewer` issuance modes, so a reviewer may also apply any of them by hand — always CID-bound to one release.
+- **`!takedown`** is the strongest action: it redacts the subject, and applies to a release, package, or publisher.
+
+## Eligibility evaluation
+
+A consumer overlays a release's active labels into one overall state: **eligible**, **pending**, **error**, or **blocked** (plus redaction). This is what `queryLabels` consumers act on. The rules:
+
+- Any active **block** (automated or manual) makes the release **blocked**.
+- An active **pending** makes it **pending**.
+- An active **error** surfaces as **error**.
+- The **pass + override** pair suppresses the current automated blocks *and* future ones for that release — override permanence — so a re-assessment cannot silently re-block an overridden release.
+- **Warnings never block.** A release can be eligible and still carry warning labels; they are advisory.
+- A **`!takedown`** redacts the subject regardless of its other labels.
+
+The policy's precedence order (highest first) is: manual block, label-state collision, assessment error, assessment pending, automated block, missing assessment pass, then eligible.
+
+## The §10 rule
+
+Automation can never negate a human decision. Any manually issued label — a takedown, an override, a reviewer label — is **human-retract-only**. Re-assessment and the automated pipeline cannot pull a human's label; only an operator can. This is why an override is permanent in effect: once a reviewer has passed a release, automation is not allowed to re-block it.
+
+## No cascade
+
+A takedown (or block) on a publisher or package is a single URI-wide or DID-wide label that the evaluator honors for everything beneath it. It is **not** fanned out into per-release labels. One subject, one label; the evaluation walks up to the covering subject rather than expecting a copy on every release underneath.

--- a/apps/labeler/docs/operating.md
+++ b/apps/labeler/docs/operating.md
@@ -1,0 +1,87 @@
+# Operating the labeler console
+
+The operator console is a React SPA served under `/admin` on the labeler's domain. It lets reviewers and admins inspect automated assessments and act on them: issuing and retracting labels, overriding false positives, taking down abusive content, pausing automation, and clearing the dead-letter queue. This guide covers signing in, the two roles, and each workflow.
+
+For the label vocabulary the actions manipulate, see [moderation-model.md](moderation-model.md). For the identity and signing concepts underneath, see [atproto.md](atproto.md).
+
+## Signing in
+
+Authentication is **Cloudflare Access** — there is no separate password and no dev bypass. You authenticate at the Cloudflare edge against your identity provider; Access issues a signed JWT and injects it (as `Cf-Access-Jwt-Assertion`) on every request to `/admin/api/*`. The Worker verifies that JWT against Access's JWKS (RS256, checking issuer, audience, and expiry) on every request. The edge policy on `/admin/*` also redirects an unauthenticated browser before it ever reaches the Worker, so you will be sent through your IdP the first time you open the console.
+
+Your role comes from the Access group membership in the verified JWT, matched against the `admins` and `reviewers` group names in `OPERATOR_ACCESS_CONFIG`. `GET /admin/api/whoami` returns your roles; the console uses it only to show or hide admin controls. The server re-checks authorization on every mutation regardless of what the UI shows, so the button visibility is cosmetic — the server is always authoritative.
+
+## Roles
+
+There are two roles, **reviewer** and **admin**. An admin inherits every reviewer capability; there is no path the other way.
+
+| Capability                                                        | Reviewer | Admin |
+| ----------------------------------------------------------------- | :------: | :---: |
+| Read assessments, findings, labels, subject history, audit log, system status, dead-letter list, effect previews | ✓ | ✓ |
+| Issue and retract a reviewer label                                | ✓ | ✓ |
+| Re-run an assessment                                              | ✓ | ✓ |
+| False-positive override and override-retract                      | ✓ | ✓ |
+| Emergency takedown / takedown-retract                             |          | ✓ |
+| Publisher-compromised / retract                                   |          | ✓ |
+| Automation pause / resume                                         |          | ✓ |
+| Dead-letter retry / quarantine                                    |          | ✓ |
+
+A reviewer who calls an admin-only endpoint gets a `403`.
+
+Reviewers can read operator-only detail on findings (the `privateDetail` field), not just the public assessment.
+
+## Reviewing an assessment
+
+Open an assessment from the list to see its findings, the labels currently live on the subject, and the operator-only detail. From there a reviewer can attach a descriptive label to a subject with **issue** (`POST /admin/api/labels/issue`) and pull one back with **retract** (`POST /admin/api/labels/retract`), which negates a reviewer-issued label. Which labels a reviewer may issue, and against which subject and CID, is governed by the policy — see [moderation-model.md](moderation-model.md).
+
+## Re-running an assessment
+
+**Re-run** (`POST /admin/api/assessments/:id/rerun`) re-queues the assessment: it mints a fresh run and re-issues `assessment-pending` so the release is gated again until the new run resolves. Because a re-run changes the live state of a specific release, you confirm the action by typing the release **CID** — a deliberate check that you are acting on the version you think you are.
+
+## False-positive override
+
+When an automated block is wrong, **override** (`POST /admin/api/assessments/:id/override`) clears it. In one atomic action it negates *all* live automated blocks on the exact URI + CID and issues the reviewer pair `assessment-passed` + `assessment-overridden`. The negate-set you submit must equal the live automated-block set exactly; if automation has issued a block you did not include, the action is rejected rather than partially applied. Like a re-run, it requires CID confirmation.
+
+An override is permanent in effect: the pass pair suppresses the negated blocks *and* future automated blocks for that release, so re-assessment cannot silently re-block it. This is the §10 rule in action — automation may not overturn a human decision.
+
+**Override-retract** (`POST /admin/api/assessments/:id/override-retract`) pulls the override pair back. It does **not** restore the original blocks — those stay negated — so the release resolves to a "safe-blocked" state: blocked, but for a missing assessment pass rather than a live finding. To re-surface the real findings, retract the override and then re-run.
+
+## Emergency actions (admin)
+
+Emergency actions carry a two-field ceremony to prevent misfires. Every one requires you to type the **subject identifier** and an exact **intent phrase**; the action is rejected unless both match.
+
+- The subject identifier is the record `rkey` for a release or package subject, or the DID's final `:`-segment for a publisher.
+- The intent phrase is fixed per action.
+
+| Action                                                     | Endpoint                                        | Intent phrase       |
+| ---------------------------------------------------------- | ----------------------------------------------- | ------------------- |
+| Takedown (`!takedown` redaction on release/package/publisher) | `POST /admin/api/emergency/takedown`            | `CONFIRM TAKEDOWN`  |
+| Takedown retract                                           | `POST /admin/api/emergency/takedown-retract`    | `CONFIRM RETRACT`   |
+| Publisher-compromised                                      | `POST /admin/api/emergency/publisher-compromised` | `CONFIRM COMPROMISE` |
+| Publisher-compromised retract                              | `POST /admin/api/emergency/publisher-compromised-retract` | `CONFIRM RETRACT`   |
+
+A takedown of a publisher or package is a single URI-wide (or DID-wide) label the evaluator honors for everything beneath it — it is not fanned out into per-release labels. Retracting a takedown restores the state that was computed before it: the automated blocks that were live re-expose, because they were never negated and nothing is re-issued. A retract with no active label to pull returns `404 NO_ACTIVE_LABEL`.
+
+## The automation kill-switch (admin)
+
+**Pause** (`POST /admin/api/automation/pause`) and **resume** (`POST /admin/api/automation/resume`) are the global switch on automated ingestion. Pausing halts Jetstream ingestion only: the discovery consumer holds and retries paused events, so nothing is lost, and manual issuance and reruns stay fully available. A `reason` is required; there is no confirmation ceremony. The switch fails closed — if its state cannot be determined, automation does not run.
+
+## Dead-letter queue (admin)
+
+Discovery jobs that exhaust their retries land in the dead-letter list. Each letter can be:
+
+- **Retried** (`POST /admin/api/dead-letters/:id/retry`) — re-enqueues the discovery job (at-most-once).
+- **Quarantined** (`POST /admin/api/dead-letters/:id/quarantine`) — a terminal "will not retry" state.
+
+Both reject an already-resolved letter with `409`, so two operators acting on the same letter cannot double-resolve it.
+
+## Audit log
+
+Every console mutation writes an append-only audit row recording who acted (the Access `sub`), the action, the reason, and an idempotency key. The table is immutable — rows are never updated or deleted.
+
+Idempotency: replaying a request with the same key and an identical body returns the stored result (a safe retry). The same key with a *different* body is a `409` conflict, so a key cannot be reused to smuggle a different action through.
+
+The audit view you see in the console omits internal columns — idempotency key, request fingerprint, raw result, metadata, and epoch timestamps — and shows the human-facing record.
+
+## CSRF
+
+Every state-changing request also needs the header `X-EmDash-Request: 1`, plus same-origin and JSON content-type checks. The console sends this automatically; operators do nothing. It is noted here only so that anyone scripting against `/admin/api/*` directly knows it is required.

--- a/apps/labeler/package.json
+++ b/apps/labeler/package.json
@@ -16,7 +16,8 @@
 		"console:dev": "vite dev --config console/vite.config.ts",
 		"console:build": "vite build --config console/vite.config.ts",
 		"console:typecheck": "tsgo --noEmit -p console/tsconfig.json",
-		"console:test": "vitest run --config console/vitest.config.ts"
+		"console:test": "vitest run --config console/vitest.config.ts",
+		"keygen": "node scripts/keygen.mjs"
 	},
 	"dependencies": {
 		"@atcute/cbor": "catalog:",
@@ -34,6 +35,7 @@
 	},
 	"devDependencies": {
 		"@atcute/cid": "catalog:",
+		"@atcute/multibase": "catalog:",
 		"@cloudflare/kumo": "catalog:",
 		"@cloudflare/vite-plugin": "catalog:",
 		"@cloudflare/vitest-pool-workers": "catalog:",

--- a/apps/labeler/scripts/keygen.mjs
+++ b/apps/labeler/scripts/keygen.mjs
@@ -1,5 +1,5 @@
 // Generates a P-256 signing keypair for the labeler in the exact formats the
-// Worker validates on boot: the private key as unpadded base64url of the raw
+// Worker validates: the private key as unpadded base64url of the raw
 // 32-byte scalar (LABEL_SIGNING_PRIVATE_KEY secret) and the public key as a
 // canonical P-256 Multikey (LABEL_SIGNING_PUBLIC_KEY var, published in the DID
 // document's #atproto_label verification method).
@@ -8,8 +8,9 @@
 //
 // The two values are printed to stdout; nothing is written to disk. Set the
 // private key with `wrangler secret put LABEL_SIGNING_PRIVATE_KEY` and paste the
-// public key into wrangler.jsonc. The Worker refuses to start if the pair is
-// inconsistent, so a copy error fails the deploy rather than shipping silently.
+// public key into wrangler.jsonc. The Worker verifies the pair the first time it
+// signs (not at deploy), so a mismatch surfaces as a failed signing operation
+// rather than at boot -- exercise a signing path after setting or rotating it.
 
 import { P256PrivateKeyExportable } from "@atcute/crypto";
 import { toBase64Url } from "@atcute/multibase";

--- a/apps/labeler/scripts/keygen.mjs
+++ b/apps/labeler/scripts/keygen.mjs
@@ -1,0 +1,37 @@
+// Generates a P-256 signing keypair for the labeler in the exact formats the
+// Worker validates on boot: the private key as unpadded base64url of the raw
+// 32-byte scalar (LABEL_SIGNING_PRIVATE_KEY secret) and the public key as a
+// canonical P-256 Multikey (LABEL_SIGNING_PUBLIC_KEY var, published in the DID
+// document's #atproto_label verification method).
+//
+// Run:  pnpm --filter @emdash-cms/labeler keygen
+//
+// The two values are printed to stdout; nothing is written to disk. Set the
+// private key with `wrangler secret put LABEL_SIGNING_PRIVATE_KEY` and paste the
+// public key into wrangler.jsonc. The Worker refuses to start if the pair is
+// inconsistent, so a copy error fails the deploy rather than shipping silently.
+
+import { P256PrivateKeyExportable } from "@atcute/crypto";
+import { toBase64Url } from "@atcute/multibase";
+
+const key = await P256PrivateKeyExportable.createKeypair();
+const privateKey = toBase64Url(await key.exportPrivateKey("raw"));
+const publicKey = await key.exportPublicKey("multikey");
+
+process.stdout.write(
+	[
+		"P-256 labeler signing keypair",
+		"",
+		"LABEL_SIGNING_PRIVATE_KEY (secret — never commit):",
+		`  ${privateKey}`,
+		"",
+		"LABEL_SIGNING_PUBLIC_KEY (wrangler.jsonc var):",
+		`  ${publicKey}`,
+		"",
+		"Next:",
+		"  1. echo -n '<private key>' | wrangler secret put LABEL_SIGNING_PRIVATE_KEY",
+		"  2. set LABEL_SIGNING_PUBLIC_KEY in wrangler.jsonc to the value above",
+		"  3. bump LABEL_SIGNING_KEY_VERSION if you are rotating an existing key",
+		"",
+	].join("\n"),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       '@atcute/cid':
         specifier: 'catalog:'
         version: 2.4.1
+      '@atcute/multibase':
+        specifier: 'catalog:'
+        version: 1.2.0
       '@cloudflare/kumo':
         specifier: 'catalog:'
         version: 2.6.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)


### PR DESCRIPTION
## What does this PR do?

Adds the labeler service's first documentation set, plus a `keygen` helper script.

Four Markdown files under `apps/labeler/`:

- **`README.md`** — overview, how the pieces fit together, local-dev scripts, a numbered deploy checklist (Access app + AUD tag → keypair → migrations → deploy), and a config reference table (vars vs secrets).
- **`docs/atproto.md`** — ATProto foundations for anyone consuming the labeler or working on it: decentralized identity and DIDs, `did:web` vs `did:plc` and why a labeler picks `did:web`, the actual DID-document shape served at `/.well-known/did.json`, the label and subject model, P-256 signing and boot-time key validation, the XRPC surface, Jetstream ingestion, and the end-to-end consumer trust chain.
- **`docs/operating.md`** — operator console guide: Cloudflare Access sign-in, the reviewer/admin capability split, and each workflow (review/issue/retract, rerun, false-positive override + override-retract, emergency ceremonies, the automation kill-switch, the dead-letter queue, and the audit log).
- **`docs/moderation-model.md`** — the full label vocabulary (all 23 labels with effect / subject / cidRule / issuer), the public policy URL and current `policyVersion`, eligibility evaluation and its precedence order, the §10 rule, and the no-cascade rule.

The **`keygen` script** (`apps/labeler/scripts/keygen.mjs`, wired as `pnpm --filter @emdash-cms/labeler keygen`) generates a P-256 signing keypair in the exact formats the Worker validates on boot: the private key as unpadded base64url of the raw 32-byte scalar (`LABEL_SIGNING_PRIVATE_KEY`) and the public key as a canonical P-256 Multikey (`LABEL_SIGNING_PUBLIC_KEY`). Verified: the private value round-trips to 32 bytes and reimporting it re-derives the same public Multikey. Adds `@atcute/multibase` as a devDependency (the script needs `toBase64Url`).

Every emdash-specific claim in the docs was checked against the merged source (`identity.ts`, `index.ts`, `xrpc-router.ts`, the eligibility evaluator in `registry-moderation`, `wrangler.jsonc`, and the policy fixture).

Closes #

## Type of change

- [x] Documentation
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes <!-- no TS surface changed; keygen is a plain .mjs, package.json adds a devDep + script -->
- [x] `pnpm lint` passes <!-- no new diagnostics from the changed files -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a — docs + a standalone script; no test-bearing source changed -->
- [x] `pnpm format` has been run <!-- markdown/.mjs are outside oxfmt's target set; package.json is not formatted by oxfmt -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a — documentation and a one-shot keygen script -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a — the labeler console is deliberately not localized; no admin-UI strings changed -->
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- n/a — @emdash-cms/labeler is private (not published) -->
- [ ] New features link to an approved Discussion <!-- n/a — documentation of existing behavior, no new feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (drafted), reviewed against source by Claude Opus 4.8

## Screenshots / test output

`pnpm --filter @emdash-cms/labeler keygen` prints the two values in the documented formats; the private key round-trips to 32 bytes and reimport re-derives the same public Multikey.


<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://docs-labeler-operator-guide-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `docs/labeler-operator-guide`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

