### PR TITLE
test(labeler): component a11y, keyboard, and RTL coverage for the operator console

### DIFF
--- a/apps/labeler/console/src/routes/NotFound.tsx
+++ b/apps/labeler/console/src/routes/NotFound.tsx
@@ -15,6 +15,6 @@ function NotFoundPage() {
 
 export const notFoundRoute = createRoute({
 	getParentRoute: () => shellRoute,
-	path: "*",
+	path: "$",
 	component: NotFoundPage,
 });

--- a/apps/labeler/console/src/test/axe.test.tsx
+++ b/apps/labeler/console/src/test/axe.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+
+import { apiClient } from "../api/client.js";
+import { AssessmentActionDialog } from "../components/AssessmentActionDialog.js";
+import { AutomationControl } from "../components/AutomationControl.js";
+import { DeadLetterActions } from "../components/DeadLetterActions.js";
+import { EmergencyActionDialog } from "../components/EmergencyActionDialog.js";
+import { LabelActionDialog } from "../components/LabelActionDialog.js";
+import { OverrideDialog } from "../components/OverrideDialog.js";
+import { ASSESSMENT_GAMMA, SUBJECT_ALPHA } from "../fixtures/index.js";
+import { RELEASE_ISSUABLE_LABELS } from "../labels.js";
+import { ADMIN_IDENTITY, renderRoute, renderWithClient } from "./harness.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+beforeEach(() => {
+	vi.spyOn(apiClient, "whoami").mockResolvedValue(ADMIN_IDENTITY);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+const RELEASE_URI = "at://did:plc:x/com.emdashcms.experimental.package.release/rk1";
+
+/** Kumo dialogs portal a Base UI focus-guard sentinel (role="button", no name)
+ * into the body around the panel; scoping axe to the panel scans the console's
+ * own dialog markup and not that framework artifact. */
+async function expectDialogClean(role: "dialog" | "alertdialog") {
+	const panel = await screen.findByRole(role);
+	expect(await axe(panel)).toHaveNoViolations();
+}
+
+describe("axe: routes", () => {
+	it("Dashboard", async () => {
+		const { container } = renderRoute("/");
+		await screen.findByRole("heading", { name: "Dashboard", level: 1 });
+		await screen.findByRole("button", { name: "Pause ingestion" });
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("AssessmentList", async () => {
+		const { container } = renderRoute("/assessments");
+		await screen.findByRole("heading", { name: "Assessments", level: 1 });
+		await screen.findByRole("table");
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("AssessmentDetail", async () => {
+		const { container } = renderRoute(`/assessments/${ASSESSMENT_GAMMA.id}`);
+		await screen.findByRole("heading", { name: "Assessment", level: 1 });
+		await screen.findByRole("button", { name: "Rerun" });
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("SubjectHistory", async () => {
+		const { container } = renderRoute(`/subjects/${encodeURIComponent(SUBJECT_ALPHA.uri)}`);
+		await screen.findByRole("heading", { name: "Subject history", level: 1 });
+		await screen.findByRole("heading", { name: "Emergency actions", level: 2 });
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("AuditLog", async () => {
+		const { container } = renderRoute("/audit");
+		await screen.findByRole("heading", { name: "Audit log", level: 1 });
+		await screen.findByText("Audit log not yet available");
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("DeadLetterQueue", async () => {
+		const { container } = renderRoute("/dead-letters");
+		await screen.findByRole("heading", { name: "Dead-letter queue", level: 1 });
+		await screen.findByRole("button", { name: "Retry" });
+		expect(await axe(container)).toHaveNoViolations();
+	});
+});
+
+describe("axe: dialogs", () => {
+	it("EmergencyActionDialog", async () => {
+		renderWithClient(
+			<EmergencyActionDialog
+				open
+				onOpenChange={() => {}}
+				kind="takedown"
+				mode="issue"
+				subjectUri={RELEASE_URI}
+				subjectConfirmationExpected="rk1"
+				invalidateKeys={[]}
+			/>,
+		);
+		await expectDialogClean("alertdialog");
+	});
+
+	it("OverrideDialog", async () => {
+		renderWithClient(
+			<OverrideDialog
+				open
+				onOpenChange={() => {}}
+				assessmentId="asmt_1"
+				subjectUri={RELEASE_URI}
+				subjectCid="bafyfixture"
+				blocks={["security-yanked"]}
+				invalidateKeys={[]}
+			/>,
+		);
+		await expectDialogClean("alertdialog");
+	});
+
+	it("AssessmentActionDialog", async () => {
+		renderWithClient(
+			<AssessmentActionDialog
+				open
+				onOpenChange={() => {}}
+				mode="rerun"
+				assessmentId="asmt_1"
+				subjectUri={RELEASE_URI}
+				subjectCid="bafyfixture"
+				invalidateKeys={[]}
+			/>,
+		);
+		await expectDialogClean("alertdialog");
+	});
+
+	it("LabelActionDialog", async () => {
+		renderWithClient(
+			<LabelActionDialog
+				open
+				onOpenChange={() => {}}
+				mode="issue"
+				subjectUri={RELEASE_URI}
+				subjectCid="bafyfixture"
+				issuable={RELEASE_ISSUABLE_LABELS}
+				invalidateKeys={[]}
+			/>,
+		);
+		await expectDialogClean("dialog");
+	});
+
+	it("AutomationControl pause dialog", async () => {
+		renderWithClient(<AutomationControl paused={false} pausedReason={null} isAdmin />);
+		fireEvent.click(screen.getByRole("button", { name: "Pause ingestion" }));
+		await expectDialogClean("alertdialog");
+	});
+
+	it("DeadLetterActions retry dialog", async () => {
+		renderWithClient(<DeadLetterActions deadLetterId={3} />);
+		fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+		const panel = await screen.findByRole("alertdialog");
+		await within(panel).findByText("Retry dead letter");
+		expect(await axe(panel)).toHaveNoViolations();
+	});
+});

--- a/apps/labeler/console/src/test/axe.test.tsx
+++ b/apps/labeler/console/src/test/axe.test.tsx
@@ -78,6 +78,12 @@ describe("axe: routes", () => {
 		await screen.findByRole("button", { name: "Retry" });
 		expect(await axe(container)).toHaveNoViolations();
 	});
+
+	it("NotFound", async () => {
+		const { container } = renderRoute("/no-such-page");
+		await screen.findByRole("heading", { name: "Not found", level: 1 });
+		expect(await axe(container)).toHaveNoViolations();
+	});
 });
 
 describe("axe: dialogs", () => {

--- a/apps/labeler/console/src/test/harness.tsx
+++ b/apps/labeler/console/src/test/harness.tsx
@@ -1,0 +1,70 @@
+import { DirectionProvider } from "@cloudflare/kumo/primitives";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { render, type RenderResult } from "@testing-library/react";
+import type { ReactElement } from "react";
+
+import type { WhoamiIdentity } from "../api/types.js";
+import { assessmentDetailRoute } from "../routes/AssessmentDetail.js";
+import { assessmentListRoute } from "../routes/AssessmentList.js";
+import { auditLogRoute } from "../routes/AuditLog.js";
+import { dashboardRoute } from "../routes/Dashboard.js";
+import { deadLetterQueueRoute } from "../routes/DeadLetterQueue.js";
+import { notFoundRoute } from "../routes/NotFound.js";
+import { rootRoute, shellRoute } from "../routes/root.js";
+import { subjectHistoryRoute } from "../routes/SubjectHistory.js";
+
+const routeTree = rootRoute.addChildren([
+	shellRoute.addChildren([
+		dashboardRoute,
+		assessmentListRoute,
+		assessmentDetailRoute,
+		subjectHistoryRoute,
+		auditLogRoute,
+		deadLetterQueueRoute,
+		notFoundRoute,
+	]),
+]);
+
+export const ADMIN_IDENTITY: WhoamiIdentity = {
+	kind: "human",
+	principal: "admin@example.com",
+	sub: "dev-admin",
+	roles: ["admin"],
+};
+
+export const REVIEWER_IDENTITY: WhoamiIdentity = {
+	kind: "human",
+	principal: "reviewer@example.com",
+	sub: "dev-reviewer",
+	roles: ["reviewer"],
+};
+
+function newClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+export function renderRoute(path: string): RenderResult {
+	const queryClient = newClient();
+	const router = createRouter({
+		routeTree,
+		context: { queryClient },
+		basepath: "/admin",
+		history: createMemoryHistory({ initialEntries: [`/admin${path}`] }),
+	});
+	return render(
+		<DirectionProvider direction="ltr">
+			<QueryClientProvider client={queryClient}>
+				<RouterProvider router={router} />
+			</QueryClientProvider>
+		</DirectionProvider>,
+	);
+}
+
+export function renderWithClient(ui: ReactElement): RenderResult {
+	return render(
+		<DirectionProvider direction="ltr">
+			<QueryClientProvider client={newClient()}>{ui}</QueryClientProvider>
+		</DirectionProvider>,
+	);
+}

--- a/apps/labeler/console/src/test/keyboard.test.tsx
+++ b/apps/labeler/console/src/test/keyboard.test.tsx
@@ -1,0 +1,179 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState, type ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { AssessmentActionDialog } from "../components/AssessmentActionDialog.js";
+import { AutomationControl } from "../components/AutomationControl.js";
+import { DeadLetterActions } from "../components/DeadLetterActions.js";
+import { EmergencyActionDialog } from "../components/EmergencyActionDialog.js";
+import { LabelActionDialog } from "../components/LabelActionDialog.js";
+import { OverrideDialog } from "../components/OverrideDialog.js";
+import { RELEASE_ISSUABLE_LABELS } from "../labels.js";
+import { renderWithClient } from "./harness.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+const RELEASE_URI = "at://did:plc:x/com.emdashcms.experimental.package.release/rk1";
+
+interface DialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+/** Renders a real trigger button alongside a controlled dialog so the tests can
+ * exercise the full open -> trap -> Escape -> restore cycle Kumo's Dialog owns. */
+function renderTriggered(build: (props: DialogProps) => ReactElement) {
+	const onOpenChange = vi.fn();
+	function Wrapper() {
+		const [open, setOpen] = useState(false);
+		return (
+			<>
+				<button type="button" onClick={() => setOpen(true)}>
+					Open dialog
+				</button>
+				{build({
+					open,
+					onOpenChange: (next) => {
+						onOpenChange(next);
+						setOpen(next);
+					},
+				})}
+			</>
+		);
+	}
+	renderWithClient(<Wrapper />);
+	return { onOpenChange };
+}
+
+const CASES: {
+	name: string;
+	role: "dialog" | "alertdialog";
+	build: (props: DialogProps) => ReactElement;
+}[] = [
+	{
+		name: "EmergencyActionDialog",
+		role: "alertdialog",
+		build: (props) => (
+			<EmergencyActionDialog
+				{...props}
+				kind="takedown"
+				mode="issue"
+				subjectUri={RELEASE_URI}
+				subjectConfirmationExpected="rk1"
+				invalidateKeys={[]}
+			/>
+		),
+	},
+	{
+		name: "OverrideDialog",
+		role: "alertdialog",
+		build: (props) => (
+			<OverrideDialog
+				{...props}
+				assessmentId="asmt_1"
+				subjectUri={RELEASE_URI}
+				subjectCid="bafyfixture"
+				blocks={["security-yanked"]}
+				invalidateKeys={[]}
+			/>
+		),
+	},
+	{
+		name: "AssessmentActionDialog",
+		role: "alertdialog",
+		build: (props) => (
+			<AssessmentActionDialog
+				{...props}
+				mode="rerun"
+				assessmentId="asmt_1"
+				subjectUri={RELEASE_URI}
+				subjectCid="bafyfixture"
+				invalidateKeys={[]}
+			/>
+		),
+	},
+	{
+		name: "LabelActionDialog",
+		role: "dialog",
+		build: (props) => (
+			<LabelActionDialog
+				{...props}
+				mode="issue"
+				subjectUri={RELEASE_URI}
+				subjectCid="bafyfixture"
+				issuable={RELEASE_ISSUABLE_LABELS}
+				invalidateKeys={[]}
+			/>
+		),
+	},
+];
+
+describe("keyboard: dialog focus management", () => {
+	it.each(CASES)(
+		"$name moves focus in on open and Escape closes it, restoring focus",
+		async ({ role, build }) => {
+			const user = userEvent.setup();
+			const { onOpenChange } = renderTriggered(build);
+
+			const trigger = screen.getByRole("button", { name: "Open dialog" });
+			await user.click(trigger);
+
+			const dialog = await screen.findByRole(role);
+			await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+
+			await user.keyboard("{Escape}");
+			await waitFor(() => expect(screen.queryByRole(role)).toBeNull());
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+			await waitFor(() => expect(document.activeElement).toBe(trigger));
+		},
+	);
+});
+
+describe("keyboard: self-contained action controls", () => {
+	it("AutomationControl restores focus to its trigger after Escape", async () => {
+		const user = userEvent.setup();
+		renderWithClient(<AutomationControl paused={false} pausedReason={null} isAdmin />);
+
+		const trigger = screen.getByRole("button", { name: "Pause ingestion" });
+		await user.click(trigger);
+		const dialog = await screen.findByRole("alertdialog");
+		await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+
+		await user.keyboard("{Escape}");
+		await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+		await waitFor(() => expect(document.activeElement).toBe(trigger));
+	});
+
+	it("DeadLetterActions runs its primary action from the keyboard", async () => {
+		const user = userEvent.setup();
+		const retry = vi
+			.spyOn(apiClient, "retryDeadLetter")
+			.mockResolvedValue({ actionId: "oact_1", deadLetterId: 3, status: "retried", cts: "" });
+		renderWithClient(<DeadLetterActions deadLetterId={3} />);
+
+		const trigger = screen.getByRole("button", { name: "Retry" });
+		await user.click(trigger);
+		await screen.findByRole("alertdialog");
+
+		await user.type(
+			screen.getByPlaceholderText("Why this event is being re-driven"),
+			"PDS recovered",
+		);
+		const submit = screen.getByRole("button", { name: "Confirm retry" });
+		submit.focus();
+		await user.keyboard("{Enter}");
+
+		await waitFor(() =>
+			expect(retry).toHaveBeenCalledWith(3, expect.objectContaining({ reason: "PDS recovered" })),
+		);
+	});
+});

--- a/apps/labeler/console/src/test/routing.test.tsx
+++ b/apps/labeler/console/src/test/routing.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderRoute } from "./harness.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+describe("console routing", () => {
+	it("renders the NotFound page for an unknown path", async () => {
+		renderRoute("/no-such-page");
+		expect(await screen.findByRole("heading", { name: "Not found", level: 1 })).toBeTruthy();
+	});
+});

--- a/apps/labeler/console/src/test/rtl-safety.test.ts
+++ b/apps/labeler/console/src/test/rtl-safety.test.ts
@@ -1,0 +1,61 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SRC_ROOT = dirname(import.meta.dirname);
+
+/** Tailwind classes that hard-code a physical side. RTL-safe layout uses the
+ * logical equivalents (ms/me, ps/pe, start/end, border-s/e, rounded-s/e,
+ * float-start/end, text-start/end). */
+const PHYSICAL = [
+	/^-?(ml|mr|pl|pr)-/,
+	/^-?(left|right)-/,
+	/^(text-left|text-right)$/,
+	/^border-(l|r)(-|$)/,
+	/^rounded-(l|r)(-|$)/,
+	/^(float-left|float-right)$/,
+];
+
+const CLASS_VALUE = /className=(?:"([^"]*)"|\{`([^`]*)`\})/g;
+
+function sourceFiles(dir: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const path = `${dir}/${entry.name}`;
+		if (entry.isDirectory()) {
+			if (entry.name === "test") continue;
+			files.push(...sourceFiles(path));
+		} else if (/\.tsx?$/.test(entry.name) && !entry.name.includes(".test.")) {
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+function physicalClasses(source: string): string[] {
+	const hits: string[] = [];
+	for (const match of source.matchAll(CLASS_VALUE)) {
+		const value = match[1] ?? match[2] ?? "";
+		for (const token of value.split(/\s+/)) {
+			const base = (token.split(":").at(-1) ?? token).replace(/["'`]/g, "");
+			if (PHYSICAL.some((re) => re.test(base))) hits.push(token);
+		}
+	}
+	return hits;
+}
+
+describe("RTL safety: console source uses logical Tailwind classes", () => {
+	const files = sourceFiles(SRC_ROOT);
+
+	it("scans a non-trivial set of source files", () => {
+		expect(files.length).toBeGreaterThan(10);
+	});
+
+	it.each(files.map((file) => [file.slice(SRC_ROOT.length), file] as const))(
+		"%s has no physical-direction classes",
+		(_label, file) => {
+			expect(physicalClasses(readFileSync(file, "utf8"))).toEqual([]);
+		},
+	);
+});

--- a/apps/labeler/console/src/test/visibility.test.tsx
+++ b/apps/labeler/console/src/test/visibility.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { SUBJECT_ALPHA } from "../fixtures/index.js";
+import { ADMIN_IDENTITY, renderRoute, REVIEWER_IDENTITY } from "./harness.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function asRole(identity: typeof ADMIN_IDENTITY) {
+	vi.spyOn(apiClient, "whoami").mockResolvedValue(identity);
+}
+
+describe("cosmetic admin gating (server stays authoritative)", () => {
+	describe("SubjectHistory emergency actions", () => {
+		const path = `/subjects/${encodeURIComponent(SUBJECT_ALPHA.uri)}`;
+
+		it("renders for an admin", async () => {
+			asRole(ADMIN_IDENTITY);
+			renderRoute(path);
+			await screen.findByRole("heading", { name: "Subject history", level: 1 });
+			expect(await screen.findByRole("heading", { name: "Emergency actions" })).toBeTruthy();
+			expect(screen.getByRole("button", { name: "Take down record" })).toBeTruthy();
+		});
+
+		it("is hidden from a reviewer", async () => {
+			asRole(REVIEWER_IDENTITY);
+			renderRoute(path);
+			await screen.findByRole("heading", { name: "Subject history", level: 1 });
+			await screen.findByRole("button", { name: "Issue record label" });
+			expect(screen.queryByRole("heading", { name: "Emergency actions" })).toBeNull();
+			expect(screen.queryByRole("button", { name: "Take down record" })).toBeNull();
+		});
+	});
+
+	describe("Dashboard automation control", () => {
+		it("shows the pause toggle to an admin", async () => {
+			asRole(ADMIN_IDENTITY);
+			renderRoute("/");
+			await screen.findByRole("heading", { name: "Dashboard", level: 1 });
+			expect(await screen.findByRole("button", { name: "Pause ingestion" })).toBeTruthy();
+		});
+
+		it("hides the pause toggle from a reviewer", async () => {
+			asRole(REVIEWER_IDENTITY);
+			renderRoute("/");
+			await screen.findByRole("heading", { name: "Dashboard", level: 1 });
+			await screen.findByText("Active");
+			expect(screen.queryByRole("button", { name: "Pause ingestion" })).toBeNull();
+		});
+	});
+
+	describe("DeadLetterQueue actions", () => {
+		it("renders retry/quarantine for an admin", async () => {
+			asRole(ADMIN_IDENTITY);
+			renderRoute("/dead-letters");
+			await screen.findByRole("heading", { name: "Dead-letter queue", level: 1 });
+			expect(await screen.findByRole("button", { name: "Retry" })).toBeTruthy();
+			expect(screen.getByRole("button", { name: "Quarantine" })).toBeTruthy();
+		});
+
+		it("hides them from a reviewer", async () => {
+			asRole(REVIEWER_IDENTITY);
+			renderRoute("/dead-letters");
+			await screen.findByRole("heading", { name: "Dead-letter queue", level: 1 });
+			await screen.findByRole("table");
+			expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+			expect(screen.queryByRole("button", { name: "Quarantine" })).toBeNull();
+		});
+	});
+});

--- a/apps/labeler/console/tsconfig.json
+++ b/apps/labeler/console/tsconfig.json
@@ -6,5 +6,5 @@
 		"types": ["vite/client"],
 		"noEmit": true
 	},
-	"include": ["src/**/*", "vite.config.ts", "vitest.config.ts"]
+	"include": ["src/**/*", "vite.config.ts", "vitest.config.ts", "vitest.setup.ts"]
 }

--- a/apps/labeler/console/vitest.config.ts
+++ b/apps/labeler/console/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
 		globals: true,
 		environment: "jsdom",
 		include: ["src/**/*.test.{ts,tsx}"],
+		setupFiles: ["./vitest.setup.ts"],
 	},
 });

--- a/apps/labeler/console/vitest.setup.ts
+++ b/apps/labeler/console/vitest.setup.ts
@@ -1,0 +1,36 @@
+import { expect, vi } from "vitest";
+import type { AxeMatchers } from "vitest-axe";
+import * as matchers from "vitest-axe/matchers";
+
+expect.extend(matchers);
+
+declare module "vitest" {
+	// eslint-disable-next-line typescript/no-explicit-any -- match vitest's own Assertion<T = any>.
+	interface Assertion<T = any> extends AxeMatchers {}
+	interface AsymmetricMatchersContaining extends AxeMatchers {}
+}
+
+if (!window.matchMedia) {
+	window.matchMedia = (query: string): MediaQueryList => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(() => false),
+	});
+}
+
+if (!globalThis.ResizeObserver) {
+	globalThis.ResizeObserver = class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	};
+}
+
+if (!Element.prototype.getAnimations) {
+	Element.prototype.getAnimations = () => [];
+}

--- a/apps/labeler/package.json
+++ b/apps/labeler/package.json
@@ -43,6 +43,7 @@
 		"@tanstack/react-query": "catalog:",
 		"@tanstack/react-router": "catalog:",
 		"@testing-library/react": "^16.3.0",
+		"@testing-library/user-event": "^14.6.1",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
@@ -54,6 +55,7 @@
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:",
+		"vitest-axe": "^0.1.0",
 		"wrangler": "catalog:"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
@@ -517,6 +520,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))
       wrangler:
         specifier: 'catalog:'
         version: 4.110.0(@cloudflare/workers-types@5.20260712.1)
@@ -7063,6 +7069,12 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tiptap/core@3.20.0':
     resolution: {integrity: sha512-aC9aROgia/SpJqhsXFiX9TsligL8d+oeoI8W3u00WI45s0VfsqjgeKQLDLF7Tu7hC+7F02teC84SAHuup003VQ==}
     peerDependencies:
@@ -9078,6 +9090,10 @@ packages:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -9457,6 +9473,9 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
@@ -9742,6 +9761,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   miniflare@4.20260301.1:
     resolution: {integrity: sha512-fqkHx0QMKswRH9uqQQQOU/RoaS3Wjckxy3CUX3YGJr0ZIMu7ObvI+NovdYi6RIsSPthNtq+3TPmRNxjeRiasog==}
@@ -10619,6 +10642,10 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -11023,6 +11050,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -11781,6 +11812,11 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest-browser-react@2.2.0:
     resolution: {integrity: sha512-oY3KM6305kwJMa6nHo92vVtkOsih7mjEf12dLKuphaF+9ywWPEc+qanIBd394SZ6m5LadVEaG6dicvvizOzmjA==}
@@ -16878,6 +16914,10 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tiptap/core@3.20.0(@tiptap/pm@3.20.0)':
     dependencies:
       '@tiptap/pm': 3.20.0
@@ -19694,6 +19734,8 @@ snapshots:
 
   import-without-cache@0.2.5: {}
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -20053,6 +20095,8 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+
+  lodash-es@4.18.1: {}
 
   lodash.startcase@4.4.0: {}
 
@@ -20616,6 +20660,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   miniflare@4.20260301.1:
     dependencies:
@@ -21611,6 +21657,11 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -22238,6 +22289,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -22816,6 +22871,16 @@ snapshots:
   vitefu@1.1.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
+  vitest-axe@0.1.0(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.12.1
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   vitest-browser-react@2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5):
     dependencies:


### PR DESCRIPTION
## What does this PR do?

Adds component-level accessibility and layout-regression tests for the labeler operator console (W9.7), plus the one production fix the coverage surfaced (the NotFound route). Otherwise: tests, a vitest setup file, and two devDependencies.

Coverage added (console suite 35 → 98 tests):

- **axe (jsdom)** — `toHaveNoViolations` on every route container (Dashboard, AssessmentList, AssessmentDetail, SubjectHistory, AuditLog, DeadLetterQueue) and every dialog panel (emergency action, override, assessment action, label action, automation control, dead-letter actions). Dialog checks are scoped to the `role=dialog/alertdialog` panel rather than `document.body`, because Base UI portals a focus-guard sentinel as a sibling of the panel that is Kumo/Base UI internal markup, not console markup.
- **keyboard/focus (user-event)** — all six dialogs: opening moves focus into the panel; Escape closes, fires `onOpenChange(false)`, and restores focus to the trigger. Dead-letter actions are shown operable end-to-end from the keyboard.
- **RTL safety** — a source scan asserting every non-test `.ts`/`.tsx` under `console/src` uses logical Tailwind classes, never physical-direction ones (`ml`/`mr`, `left`/`right`, `text-left`/`text-right`, `border-l`/`r`, `rounded-l`/`r`, `float-left`/`right`). This is implemented as a source scan rather than a rendered-DOM walk deliberately: a DOM walk conflates console classes with Kumo's framework-owned physical classes (Base UI emits `left-1/2`, `border-r`, `text-left` that we do not control), so it would either false-positive or need an allowlist that also masks our own misuse. The source scan tests exactly the code we own, with zero false positives. Console source is clean.
- **Cosmetic admin gating** — reviewer sessions do not render admin-only controls (emergency actions, pause toggle, dead-letter retry/quarantine); admin sessions do. Each negative assertion first waits for a role-appropriate element to render, so it can't false-pass on an unrendered page. The server remains authoritative regardless of what the UI shows.

The setup file registers the vitest-axe matcher (with a `declare module "vitest"` augmentation — the shipped `extend-expect` augments the legacy `Vi.Assertion` namespace that vitest 4 ignores) and the jsdom polyfills Kumo needs to render: `matchMedia`, `ResizeObserver`, and `Element.prototype.getAnimations`.

### Bug fixed by this coverage

- **NotFound route.** `console/src/routes/NotFound.tsx` declared `path: "*"`, but TanStack Router's splat segment is `$` — so `*` matched literally and unknown URLs fell through to the router's default `Not Found` instead of the console's styled NotFoundPage inside the shell. Fixed by switching to the splat token, with a reproducing routing test and an axe check on the now-reachable page.

### Known gap (out of scope, intentional)

- **Tab-cycle containment is not asserted.** jsdom has no real sequential-focus/`inert` model, so a "Tab N times, stays inside" assertion flaps. The parts jsdom can verify faithfully (focus-in on open, Escape-close, focus-restore) are covered; real trap containment needs Playwright, which is deferred with the rest of browser-e2e.

## Type of change

- [x] Bug fix
- [x] Tests

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes <!-- worker + console typecheck clean -->
- [x] `pnpm lint` passes <!-- no new diagnostics from changed files -->
- [x] `pnpm test` passes (or targeted tests for my change) <!-- console suite 98 passed; worker suite 546 unaffected. The NotFound fix is TDD: the routing test failed before the one-line route change, passes after -->
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable) <!-- this PR is the tests -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a — the labeler console is deliberately not localized; no strings changed -->
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- n/a — @emdash-cms/labeler is private (not published); test-only -->
- [ ] New features link to an approved Discussion <!-- n/a — test coverage, no new feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

```
Test Files  11 passed (11)
     Tests  98 passed (98)
```


<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-a11y-tests-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-a11y-tests`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

