### PR TITLE
fix(ui): move Comments/CommentForm to emdash/ui/comments subpath (#2039)

### DIFF
--- a/.changeset/comments-ui-subpath.md
+++ b/.changeset/comments-ui-subpath.md
@@ -1,0 +1,7 @@
+---
+"emdash": minor
+---
+
+Moves the `Comments` and `CommentForm` components from `emdash/ui` to a dedicated `emdash/ui/comments` entry point so their CSS is no longer loaded on pages that don't render comments. Previously, importing anything from `emdash/ui` (such as `PortableText`) pulled the comment styles into a shared, render-blocking stylesheet on every page.
+
+Migration: update comment imports from `import { Comments, CommentForm } from "emdash/ui"` to `import { Comments, CommentForm } from "emdash/ui/comments"`.

--- a/.changeset/comments-ui-subpath.md
+++ b/.changeset/comments-ui-subpath.md
@@ -2,6 +2,4 @@
 "emdash": minor
 ---
 
-Moves the `Comments` and `CommentForm` components from `emdash/ui` to a dedicated `emdash/ui/comments` entry point so their CSS is no longer loaded on pages that don't render comments. Previously, importing anything from `emdash/ui` (such as `PortableText`) pulled the comment styles into a shared, render-blocking stylesheet on every page.
-
-Migration: update comment imports from `import { Comments, CommentForm } from "emdash/ui"` to `import { Comments, CommentForm } from "emdash/ui/comments"`.
+Adds `emdash/ui/comments` for `Comments` and `CommentForm` so their CSS only loads on pages that import them. Importing from `emdash/ui` still works but is deprecated and will be removed in 1.0 — prefer `import { Comments, CommentForm } from "emdash/ui/comments"`.

--- a/demos/cloudflare/src/pages/posts/[slug].astro
+++ b/demos/cloudflare/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/demos/playground/src/pages/posts/[slug].astro
+++ b/demos/playground/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/demos/postgres/src/pages/posts/[slug].astro
+++ b/demos/postgres/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/demos/preview/src/pages/posts/[slug].astro
+++ b/demos/preview/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/demos/simple/src/pages/posts/[slug].astro
+++ b/demos/simple/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/e2e/fixture-cloudflare/src/pages/posts/[slug].astro
+++ b/e2e/fixture-cloudflare/src/pages/posts/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getEmDashEntry } from "emdash";
-import { PortableText, Comments, CommentForm } from "emdash/ui";
+import { PortableText } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 
 const { slug } = Astro.params;
 if (!slug) return Astro.redirect("/404");

--- a/e2e/fixture/src/pages/posts/[slug].astro
+++ b/e2e/fixture/src/pages/posts/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getEmDashEntry } from "emdash";
-import { PortableText, Comments, CommentForm } from "emdash/ui";
+import { PortableText } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 
 const { slug } = Astro.params;
 if (!slug) return Astro.redirect("/404");

--- a/fixtures/perf-site/src/pages/posts/[slug].astro
+++ b/fixtures/perf-site/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/infra/blog-demo/src/pages/posts/[slug].astro
+++ b/infra/blog-demo/src/pages/posts/[slug].astro
@@ -11,10 +11,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/infra/cache-demo/src/pages/posts/[slug].astro
+++ b/infra/cache-demo/src/pages/posts/[slug].astro
@@ -11,10 +11,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/infra/do-demo/src/pages/posts/[slug].astro
+++ b/infra/do-demo/src/pages/posts/[slug].astro
@@ -11,10 +11,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/infra/do-solo-demo/src/pages/posts/[slug].astro
+++ b/infra/do-solo-demo/src/pages/posts/[slug].astro
@@ -11,10 +11,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
       "default": "./dist/astro/middleware/redirect.mjs"
     },
     "./ui": "./src/ui.ts",
+    "./ui/comments": "./src/ui-comments.ts",
     "./ui/search": "./src/components/LiveSearch.astro",
     "./cli": {
       "types": "./dist/cli/index.d.mts",

--- a/packages/core/src/components/CommentForm.astro
+++ b/packages/core/src/components/CommentForm.astro
@@ -11,7 +11,7 @@
  * @example
  * ```astro
  * ---
- * import { CommentForm } from "emdash/ui";
+ * import { CommentForm } from "emdash/ui/comments";
  * ---
  * <CommentForm collection="posts" contentId={post.id} />
  * ```

--- a/packages/core/src/components/Comments.astro
+++ b/packages/core/src/components/Comments.astro
@@ -8,7 +8,7 @@
  * @example
  * ```astro
  * ---
- * import { Comments } from "emdash/ui";
+ * import { Comments } from "emdash/ui/comments";
  * ---
  * <Comments collection="posts" contentId={post.id} threaded />
  * ```

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -22,8 +22,16 @@
 // Wrapper component with EmDash defaults
 export { default as PortableText } from "./PortableText.astro";
 
-// Comment components live in a separate `emdash/ui/comments` entry point so
-// their styles aren't pulled into every page that imports this barrel (#2039).
+/**
+ * @deprecated Import from `emdash/ui/comments` instead. Barrel re-exports pull
+ * comment CSS into every page that imports `emdash/ui` (#2039). Will be removed in 1.0.
+ */
+export { default as Comments } from "./Comments.astro";
+/**
+ * @deprecated Import from `emdash/ui/comments` instead. Barrel re-exports pull
+ * comment CSS into every page that imports `emdash/ui` (#2039). Will be removed in 1.0.
+ */
+export { default as CommentForm } from "./CommentForm.astro";
 
 // Widget components
 export { default as WidgetArea } from "./WidgetArea.astro";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -22,9 +22,8 @@
 // Wrapper component with EmDash defaults
 export { default as PortableText } from "./PortableText.astro";
 
-// Comment components
-export { default as Comments } from "./Comments.astro";
-export { default as CommentForm } from "./CommentForm.astro";
+// Comment components live in a separate `emdash/ui/comments` entry point so
+// their styles aren't pulled into every page that imports this barrel (#2039).
 
 // Widget components
 export { default as WidgetArea } from "./WidgetArea.astro";

--- a/packages/core/src/ui-comments.ts
+++ b/packages/core/src/ui-comments.ts
@@ -1,0 +1,19 @@
+/**
+ * EmDash comment components
+ *
+ * Kept out of the main `emdash/ui` barrel so their styles are only loaded on
+ * pages that actually render comments. Importing from `emdash/ui` pulls the
+ * whole barrel into Astro's CSS module graph, which put comment CSS on every
+ * page that used e.g. `PortableText` (#2039).
+ *
+ * ```astro
+ * ---
+ * import { Comments, CommentForm } from "emdash/ui/comments";
+ * ---
+ * <Comments collection="posts" contentId={post.data.id} threaded />
+ * <CommentForm collection="posts" contentId={post.data.id} />
+ * ```
+ */
+
+export { default as Comments } from "./components/Comments.astro";
+export { default as CommentForm } from "./components/CommentForm.astro";

--- a/packages/core/src/ui.ts
+++ b/packages/core/src/ui.ts
@@ -52,9 +52,6 @@ export {
 	// Shares the name with the `type Block` re-export above; the
 	// type and the component live in different namespaces.
 	Block,
-	// Comment components
-	Comments,
-	CommentForm,
 	// Widget components
 	WidgetArea,
 	// Components object for manual use

--- a/packages/core/src/ui.ts
+++ b/packages/core/src/ui.ts
@@ -75,3 +75,14 @@ export {
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "./components/index.js";
+
+/**
+ * @deprecated Import from `emdash/ui/comments` instead. Barrel re-exports pull
+ * comment CSS into every page that imports `emdash/ui` (#2039). Will be removed in 1.0.
+ */
+export { Comments } from "./components/index.js";
+/**
+ * @deprecated Import from `emdash/ui/comments` instead. Barrel re-exports pull
+ * comment CSS into every page that imports `emdash/ui` (#2039). Will be removed in 1.0.
+ */
+export { CommentForm } from "./components/index.js";

--- a/packages/core/tests/integration/fixture/src/pages/posts/[slug].astro
+++ b/packages/core/tests/integration/fixture/src/pages/posts/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getEmDashEntry } from "emdash";
-import { PortableText, Comments, CommentForm } from "emdash/ui";
+import { PortableText } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 
 const { slug } = Astro.params;
 if (!slug) return Astro.redirect("/404");

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,6 +17,7 @@
 		"src/components/**",
 		"src/preview/**",
 		"src/ui.ts",
+		"src/ui-comments.ts",
 		"src/auth/providers/*-admin.tsx"
 	]
 }

--- a/scripts/typecheck-public-source.mjs
+++ b/scripts/typecheck-public-source.mjs
@@ -38,6 +38,7 @@ const pkgPath = resolve(repoRoot, "packages/core/package.json");
  */
 const RUNTIME_COUPLED = new Set([
 	"./ui", // src/ui.ts -- re-exports Astro <Image>/<PortableText> components
+	"./ui/comments", // src/ui-comments.ts -- re-exports Astro <Comments>/<CommentForm>
 	"./auth/providers/github-admin", // .tsx -- admin React + @cloudflare/kumo
 	"./auth/providers/google-admin", // .tsx -- admin React + @cloudflare/kumo
 ]);

--- a/skills/building-emdash-site/SKILL.md
+++ b/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/skills/building-emdash-site/references/site-features.md
+++ b/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/blank/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/blank/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/blank/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/blank/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/blog-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/blog-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/blog-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/templates/blog/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/blog/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/blog/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/blog/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/blog/src/pages/posts/[slug].astro
+++ b/templates/blog/src/pages/posts/[slug].astro
@@ -10,10 +10,9 @@ import {
 import {
 	Image,
 	PortableText,
-	Comments,
-	CommentForm,
 	WidgetArea,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";

--- a/templates/marketing-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/marketing-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/marketing/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/marketing/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/marketing/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/marketing/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/portfolio/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/portfolio/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/portfolio/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/portfolio/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/starter-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/starter-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />

--- a/templates/starter/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/starter/.agents/skills/building-emdash-site/SKILL.md
@@ -102,13 +102,12 @@ import { getByline, getBylineBySlug } from "emdash";
 import {
 	PortableText,
 	Image,
-	Comments,
-	CommentForm,
 	WidgetArea,
 	EmDashHead,
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 import LiveSearch from "emdash/ui/search";
 
 // Page context (for plugin contributions)

--- a/templates/starter/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/starter/.agents/skills/building-emdash-site/references/site-features.md
@@ -288,7 +288,7 @@ Built-in comments system:
 
 ```astro
 ---
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
 ---
 <Comments collection="posts" contentId={post.data.id} threaded />
 <CommentForm collection="posts" contentId={post.data.id} />


### PR DESCRIPTION
## What does this PR do?

Adds a dedicated `emdash/ui/comments` entry point for `Comments` and `CommentForm`, so their CSS no longer bleeds onto pages that don't render comments — while keeping the barrel re-exports for backwards compatibility.

Astro's CSS scanner processes the **entire** barrel module when any export is imported. Because `Comments.astro` and `CommentForm.astro` were only available via `emdash/ui`'s barrel, a page that only did `import { PortableText } from "emdash/ui"` pulled their `<style>` blocks into a shared, render-blocking CSS chunk on **every** page. This mirrors the existing `emdash/ui/search` entry point.

**Non-breaking (per @ascorbic):** the barrel still re-exports `Comments`/`CommentForm` with `@deprecated` JSDoc pointing at `emdash/ui/comments`. Templates, demos, fixtures, and docs use the new subpath. Barrel re-exports drop in 1.0.

Closes #2039

### Reproduction / verification

Built `demos/simple` (`astro build`, SSR) before and after the change and grepped the emitted client CSS for `ec-comment` selectors (when demos import from the subpath):

| CSS file (loaded on…) | Before (barrel) | After (this PR) |
| --- | --- | --- |
| `Base.*.css` (shared layout — **every page**) | **1** ❌ | **0** ✅ |
| `index.*.css` (home) | 0 | 0 |
| `styles.*.css` (global) | 0 | 0 |
| `_slug_.*.css` (posts page that renders comments) | 1 | 1 |

### Migration (recommended)

```diff
-import { Comments, CommentForm } from "emdash/ui";
+import { Comments, CommentForm } from "emdash/ui/comments";
```

Existing `emdash/ui` imports continue to work until 1.0.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (packages, demos, templates)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (verified via a before/after production build CSS comparison — see above)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a (no admin UI strings changed)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 / grok-4.5 (opencode)

## Screenshots / test output

See the before/after CSS table above. Follow-ups from review:
- Restored barrel exports as `@deprecated` (non-breaking)
- Added `./ui/comments` to `RUNTIME_COUPLED` (fixes typecheck public-source guard)
- Ran `./scripts/sync-template-skills.sh` for embedded skill copies

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-2039-comments-ui-subpath-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/2039-comments-ui-subpath`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
