### PR TITLE
fix(admin): preserve EmDash footer product attribution

### DIFF
--- a/.changeset/fix-admin-footer-attribution.md
+++ b/.changeset/fix-admin-footer-attribution.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the admin sidebar footer so it always identifies EmDash CMS and its running version instead of replacing the product name with the configured site brand.

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -105,6 +105,15 @@ interface NavItem {
 }
 
 /**
+ * Product attribution shown in the admin footer. The configured site name
+ * belongs in the header brand; it must not replace the CMS product identity.
+ */
+export function formatAdminFooter(version?: string, commit?: string): string {
+	const label = `EmDash CMS v${version || "0.0.0"}`;
+	return commit ? `${label} (${commit})` : label;
+}
+
+/**
  * Navigation item rendered with Kumo's native Sidebar.MenuButton. Kumo's
  * LinkProvider maps the href to TanStack Router for client-side navigation.
  */
@@ -401,8 +410,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 						data-testid="admin-version"
 						className="w-40 overflow-hidden truncate ps-2 text-[11px] text-kumo-subtle"
 					>
-						{manifest.admin?.siteName || "EmDash CMS"} v{manifest.version || "0.0.0"}
-						{manifest.commit && ` (${manifest.commit})`}
+						{formatAdminFooter(manifest.version, manifest.commit)}
 					</p>
 				</div>
 			</KumoSidebar.Footer>

--- a/packages/admin/tests/components/Sidebar.test.tsx
+++ b/packages/admin/tests/components/Sidebar.test.tsx
@@ -36,6 +36,7 @@ import { describe, it, expect } from "vitest";
 import {
 	BYLINE_SCHEMA_NAV_ITEM,
 	filterNavItemsByRole,
+	formatAdminFooter,
 	resolveNavIcon,
 	resolvePluginPageLabel,
 	toPhosphorIconName,
@@ -49,6 +50,16 @@ const ROLE_CONTRIBUTOR = 20;
 const ROLE_AUTHOR = 30;
 const ROLE_EDITOR = 40;
 const ROLE_ADMIN = 50;
+
+describe("formatAdminFooter", () => {
+	it("keeps EmDash product attribution independent from site branding", () => {
+		expect(formatAdminFooter("0.29.0", "baf4d839")).toBe("EmDash CMS v0.29.0 (baf4d839)");
+	});
+
+	it("keeps a deterministic fallback when build metadata is unavailable", () => {
+		expect(formatAdminFooter()).toBe("EmDash CMS v0.0.0");
+	});
+});
 
 describe("BYLINE_SCHEMA_NAV_ITEM invariants", () => {
 	it("points to the /byline-schema route", () => {


### PR DESCRIPTION
## What does this PR do?

Keeps the admin sidebar footer tied to the EmDash product identity instead of replacing it with a site's configured white-label name.

The configured site name still belongs in the admin header. The footer now deterministically renders `EmDash CMS v<version> (<commit>)`, with a stable version fallback when build metadata is unavailable.

Root cause: the footer reused `manifest.admin.siteName`, which is site branding rather than CMS product attribution.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable (bug fix)

## Screenshots / test output

- `@emdash-cms/admin` typecheck (`tsgo --noEmit`): passed
- Targeted Oxlint on the changed TypeScript files: 0 warnings, 0 errors
- Oxfmt check on the changed TypeScript files: passed
- `git diff --check`: passed
- Added two focused `formatAdminFooter` regression tests. The local browser runner could not execute them because this isolated worktree has stale Vitest 4.1.5 dependencies while the current lockfile expects `@vitest/browser` 4.1.9; the draft PR CI will run from a clean install.

The diff contains no site-specific branding or private plugin code.