### PR TITLE
fix(setup): allow admin recovery when setup_complete is set but no users exist

### DIFF
--- a/.changeset/setup-admin-recovery.md
+++ b/.changeset/setup-admin-recovery.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes admin-account recovery when `emdash:setup_complete` is set but the users table is empty (a wiped or sanitised database copied between environments). `/api/setup/status` already resumes the wizard at the admin step for this state, but the admin-step routes rejected it with `SETUP_COMPLETE`, leaving no UI path to an admin account. Both routes now reject on the flag only when a user also exists; the fully-set-up and admin-exists rejections are unchanged.

--- a/packages/core/src/astro/routes/api/setup/admin-verify.ts
+++ b/packages/core/src/astro/routes/api/setup/admin-verify.ts
@@ -33,18 +33,22 @@ export const POST: APIRoute = async ({ cookies, request, locals }) => {
 		// Check if setup is already complete
 		const options = new OptionsRepository(emdash.db);
 		const setupComplete = await options.get("emdash:setup_complete");
-
-		if (setupComplete === true || setupComplete === "true") {
-			return apiError("SETUP_COMPLETE", "Setup already complete", 400);
-		}
+		const isComplete = setupComplete === true || setupComplete === "true";
 
 		// Check if any users exist
 		const adapter = createKyselyAdapter(emdash.db);
 		const userCount = await adapter.countUsers();
 
 		if (userCount > 0) {
+			if (isComplete) {
+				return apiError("SETUP_COMPLETE", "Setup already complete", 400);
+			}
 			return apiError("ADMIN_EXISTS", "Admin user already exists", 400);
 		}
+
+		// `setup_complete` with ZERO users is a recoverable half-state —
+		// see the matching guard in ./admin.ts. The verify step must
+		// accept it too, or the wizard dies between its two calls.
 
 		// Get setup state
 		const setupState = await options.get<{

--- a/packages/core/src/astro/routes/api/setup/admin.ts
+++ b/packages/core/src/astro/routes/api/setup/admin.ts
@@ -32,18 +32,25 @@ export const POST: APIRoute = async ({ cookies, request, locals }) => {
 		// Check if setup is already complete
 		const options = new OptionsRepository(emdash.db);
 		const setupComplete = await options.get("emdash:setup_complete");
-
-		if (setupComplete === true || setupComplete === "true") {
-			return apiError("SETUP_COMPLETE", "Setup already complete", 400);
-		}
+		const isComplete = setupComplete === true || setupComplete === "true";
 
 		// Check if any users exist
 		const adapter = createKyselyAdapter(emdash.db);
 		const userCount = await adapter.countUsers();
 
 		if (userCount > 0) {
+			if (isComplete) {
+				return apiError("SETUP_COMPLETE", "Setup already complete", 400);
+			}
 			return apiError("ADMIN_EXISTS", "Admin user already exists", 400);
 		}
+
+		// `setup_complete` with ZERO users is a recoverable half-state (a
+		// wiped/sanitised users table — e.g. a DB copied between
+		// environments). /api/setup/status already resumes the wizard at
+		// the admin step for exactly this state, so admin creation must be
+		// allowed here too — rejecting on the stale flag alone leaves the
+		// instance with no UI path to an admin account.
 
 		// Parse request body
 		const body = await parseBody(request, setupAdminBody);

--- a/packages/core/tests/integration/astro/setup-admin-recovery.test.ts
+++ b/packages/core/tests/integration/astro/setup-admin-recovery.test.ts
@@ -1,0 +1,199 @@
+/**
+ * `emdash:setup_complete` with an EMPTY users table is a recoverable
+ * half-state: it appears when a completed instance's users are wiped or
+ * a sanitised DB copy is shipped to a new environment (the documented
+ * promote-a-QA'd-DB flow). GET /api/setup/status deliberately resumes
+ * the wizard at the "admin" step for this state — but the admin-step
+ * routes used to reject it on the stale flag alone (SETUP_COMPLETE,
+ * 400), leaving the instance with NO UI path to an admin account.
+ *
+ * These tests pin the recovery path end to end: with the flag set and
+ * zero users, POST /setup/admin must proceed (and /setup/admin/verify
+ * must get past the same guard), while the normal fully-set-up state
+ * keeps rejecting exactly as before.
+ */
+
+import type { APIContext, AstroCookies } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST as postAdminVerify } from "../../../src/astro/routes/api/setup/admin-verify.js";
+import { POST as postAdmin } from "../../../src/astro/routes/api/setup/admin.js";
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+interface CookieRecord {
+	value: string;
+	options: Record<string, unknown>;
+}
+
+/** Minimal in-memory AstroCookies stub (same shape as the nonce tests). */
+function createCookieJar(initial: Record<string, string> = {}): {
+	jar: Map<string, CookieRecord>;
+	cookies: AstroCookies;
+} {
+	const jar = new Map<string, CookieRecord>();
+	for (const [name, value] of Object.entries(initial)) {
+		jar.set(name, { value, options: {} });
+	}
+
+	const cookies = {
+		get(name: string) {
+			const record = jar.get(name);
+			if (!record) return undefined;
+			return { value: record.value };
+		},
+		set(name: string, value: string, options: Record<string, unknown> = {}) {
+			jar.set(name, { value, options });
+		},
+		delete(name: string) {
+			jar.delete(name);
+		},
+		has(name: string) {
+			return jar.has(name);
+		},
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- minimal stub
+	} as unknown as AstroCookies;
+
+	return { jar, cookies };
+}
+
+function buildRequest(path: string, body: unknown): Request {
+	return new Request(`http://localhost${path}`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function buildContext(db: Kysely<Database>, request: Request, cookies: AstroCookies): APIContext {
+	return {
+		params: {},
+		url: new URL(request.url),
+		request,
+		cookies,
+		locals: {
+			emdash: {
+				db,
+				config: {},
+				storage: undefined,
+			},
+		},
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- minimal stub
+	} as unknown as APIContext;
+}
+
+const adminBody = { email: "recovered@admin.example", name: "Recovered Admin" };
+
+async function insertUser(db: Kysely<Database>): Promise<void> {
+	await db
+		.insertInto("users")
+		.values({
+			id: "existing1",
+			email: "existing@admin.example",
+			name: "Existing Admin",
+			role: 50,
+			email_verified: 1,
+		})
+		.execute();
+}
+
+describe("POST /setup/admin — recovery when setup_complete but no users exist", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("allows starting admin registration when setup_complete is true but users is empty", async () => {
+		const options = new OptionsRepository(db);
+		await options.set("emdash:setup_complete", true);
+
+		const { cookies } = createCookieJar();
+		const res = await postAdmin(
+			buildContext(db, buildRequest("/_emdash/api/setup/admin", adminBody), cookies),
+		);
+
+		// Pre-fix this returned 400 SETUP_COMPLETE — the state
+		// /api/setup/status resumes at "admin" was unreachable.
+		expect(res.status).toBe(200);
+	});
+
+	it('accepts the string "true" flag variant the same way', async () => {
+		const options = new OptionsRepository(db);
+		await options.set("emdash:setup_complete", "true");
+
+		const { cookies } = createCookieJar();
+		const res = await postAdmin(
+			buildContext(db, buildRequest("/_emdash/api/setup/admin", adminBody), cookies),
+		);
+
+		expect(res.status).toBe(200);
+	});
+
+	it("lets /setup/admin/verify past the setup-complete guard in the same state", async () => {
+		const options = new OptionsRepository(db);
+		await options.set("emdash:setup_complete", true);
+
+		// Start the admin step for real so state + nonce cookie exist.
+		const { cookies } = createCookieJar();
+		const adminRes = await postAdmin(
+			buildContext(db, buildRequest("/_emdash/api/setup/admin", adminBody), cookies),
+		);
+		expect(adminRes.status).toBe(200);
+
+		// A bogus credential: verification fails at the WebAuthn step,
+		// but only AFTER the setup-complete/users gate. Assert the gate,
+		// not the passkey result (same technique as the nonce tests).
+		const verifyRes = await postAdminVerify(
+			buildContext(
+				db,
+				buildRequest("/_emdash/api/setup/admin/verify", {
+					credential: {
+						id: "AA",
+						rawId: "AA",
+						type: "public-key",
+						response: { clientDataJSON: "AA", attestationObject: "AA" },
+					},
+				}),
+				cookies,
+			),
+		);
+
+		const body = (await verifyRes.json()) as { error?: { code?: string } };
+		expect(body.error?.code).not.toBe("SETUP_COMPLETE");
+	});
+
+	it("still rejects with SETUP_COMPLETE when setup is complete AND a user exists", async () => {
+		const options = new OptionsRepository(db);
+		await options.set("emdash:setup_complete", true);
+		await insertUser(db);
+
+		const { cookies } = createCookieJar();
+		const res = await postAdmin(
+			buildContext(db, buildRequest("/_emdash/api/setup/admin", adminBody), cookies),
+		);
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error?: { code?: string } };
+		expect(body.error?.code).toBe("SETUP_COMPLETE");
+	});
+
+	it("still rejects with ADMIN_EXISTS when a user exists without the complete flag", async () => {
+		await insertUser(db);
+
+		const { cookies } = createCookieJar();
+		const res = await postAdmin(
+			buildContext(db, buildRequest("/_emdash/api/setup/admin", adminBody), cookies),
+		);
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error?: { code?: string } };
+		expect(body.error?.code).toBe("ADMIN_EXISTS");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an unrecoverable setup lockout. `GET /api/setup/status` deliberately resumes the wizard at the **admin** step when `emdash:setup_complete` is `true` but the `users` table is empty (`status.ts`: "If setup_complete but no users, jump to admin step") — a state that appears when a completed instance's users are wiped or a sanitised DB copy is shipped to a new environment. But `POST /api/setup/admin` and `POST /api/setup/admin/verify` rejected that state on the flag alone (`SETUP_COMPLETE`, 400), so the step status advertises was unreachable: the wizard UI shows the account form, the POST 400s, and the instance has **no UI path to an admin account** (recovery required a manual `DELETE FROM options` on the DB — hit in production while promoting a sanitised QA database to a fresh prod environment on 2026-07-15).

Both routes now reject `SETUP_COMPLETE` only when a user **also** exists. `ADMIN_EXISTS` (users present without the flag) is unchanged, and the empty-users fall-through lets the wizard re-create the admin — `admin-verify` re-sets `setup_complete` on success, exactly as before.

State matrix (only the third row changes):

| `setup_complete` | users | before | after |
|---|---|---|---|
| true | >0 | 400 `SETUP_COMPLETE` | 400 `SETUP_COMPLETE` |
| false | >0 | 400 `ADMIN_EXISTS` | 400 `ADMIN_EXISTS` |
| true | 0 | 400 `SETUP_COMPLETE` (dead end) | **allowed — recovery** |
| false | 0 | allowed | allowed |

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`packages/core` via tsgo after a workspace build)
- [x] `pnpm lint` passes (oxlint `--type-aware --deny-warnings` on the changed files)
- [x] `pnpm test` passes (or targeted tests for my change) — `tests/integration/astro/` suite; the one failure on my machine (`media-confirm-placeholder`) is environmental (sharp's native binding doesn't build locally) and fails identically without this diff
- [x] `pnpm format` has been run (oxfmt over the changed directories — no churn)
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no UI strings)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash`: patch)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

New test file `packages/core/tests/integration/astro/setup-admin-recovery.test.ts` (mirrors the `setup-admin-nonce` harness — real in-memory SQLite, no mocking). **Reproduction proof:** with the route changes stashed (unpatched code), 3 of the 5 tests fail — the two recovery-allowed cases (`true` and `"true"` flag variants) and the verify-gate case; the two regression-pin cases (SETUP_COMPLETE with users, ADMIN_EXISTS without flag) pass, as expected since those behaviors are unchanged. With the fix: 5/5.

```
unpatched:  Tests  3 failed | 2 passed (5)
patched:    Tests  5 passed (5)
```