### PR TITLE
i18n(admin): localize built-in widget palette labels

### DIFF
--- a/.changeset/localize-widget-palette.md
+++ b/.changeset/localize-widget-palette.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Localizes the built-in widget UI in the admin. The core widget labels, descriptions, editor component-select options, and prop-field labels/options (Recent Posts, Categories, Tags, Search, Archives — including fields like "Placeholder text", "Show post count", "Group by") now follow the selected admin language instead of always showing English. Plugin-registered widgets fall back to their server-provided strings.

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -105,6 +105,66 @@ const BUILTIN_WIDGETS: Array<{
 	},
 ];
 
+/**
+ * Localized labels/descriptions for built-in core widget components. The server
+ * (packages/core/src/widgets/components.ts) ships these in English as stable
+ * data; the admin maps them to translated strings client-side, the same way
+ * error codes are localized. Plugin-provided components fall back to their
+ * server-provided strings.
+ */
+interface CoreWidgetMeta {
+	label: MessageDescriptor;
+	description: MessageDescriptor;
+	/** Prop-field labels keyed by prop key; `options` localizes select choices by option value. */
+	props?: Record<string, { label: MessageDescriptor; options?: Record<string, MessageDescriptor> }>;
+}
+
+const CORE_WIDGET_META: Record<string, CoreWidgetMeta> = {
+	"core:recent-posts": {
+		label: msg`Recent Posts`,
+		description: msg`Display a list of recent posts`,
+		props: {
+			count: { label: msg`Number of posts` },
+			showThumbnails: { label: msg`Show thumbnails` },
+			showDate: { label: msg`Show date` },
+		},
+	},
+	"core:categories": {
+		label: msg`Categories`,
+		description: msg`Display category list`,
+		props: {
+			showCount: { label: msg`Show post count` },
+			hierarchical: { label: msg`Show hierarchy` },
+		},
+	},
+	"core:tags": {
+		label: msg`Tags`,
+		description: msg`Display tag cloud`,
+		props: {
+			showCount: { label: msg`Show count` },
+			limit: { label: msg`Maximum tags` },
+		},
+	},
+	"core:search": {
+		label: msg`Search`,
+		description: msg`Search form`,
+		props: {
+			placeholder: { label: msg`Placeholder text` },
+		},
+	},
+	"core:archives": {
+		label: msg`Archives`,
+		description: msg`Monthly/yearly archives`,
+		props: {
+			type: {
+				label: msg`Group by`,
+				options: { monthly: msg`Monthly`, yearly: msg`Yearly` },
+			},
+			limit: { label: msg`Limit` },
+		},
+	},
+};
+
 export function Widgets() {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
@@ -410,19 +470,24 @@ export function Widgets() {
 										widgetInput={{ ...item.input, title: t(item.label) }}
 									/>
 								))}
-								{components.map((comp) => (
-									<DraggablePaletteItem
-										key={`palette-comp-${comp.id}`}
-										id={`palette-comp-${comp.id}`}
-										label={comp.label}
-										description={comp.description}
-										widgetInput={{
-											type: "component",
-											title: comp.label,
-											componentId: comp.id,
-										}}
-									/>
-								))}
+								{components.map((comp) => {
+									const meta = CORE_WIDGET_META[comp.id];
+									const label = meta ? t(meta.label) : comp.label;
+									const description = meta ? t(meta.description) : comp.description;
+									return (
+										<DraggablePaletteItem
+											key={`palette-comp-${comp.id}`}
+											id={`palette-comp-${comp.id}`}
+											label={label}
+											description={description}
+											widgetInput={{
+												type: "component",
+												title: label,
+												componentId: comp.id,
+											}}
+										/>
+									);
+								})}
 							</div>
 						</div>
 					</div>
@@ -864,20 +929,29 @@ function WidgetEditor({
 								}
 							}
 						}}
-						items={Object.fromEntries(components.map((c) => [c.id, c.label]))}
+						items={Object.fromEntries(
+							components.map((c) => {
+								const meta = CORE_WIDGET_META[c.id];
+								return [c.id, meta ? t(meta.label) : c.label];
+							}),
+						)}
 					>
 						<Select.Option value="">{t`Select a component...`}</Select.Option>
-						{components.map((c) => (
-							<Select.Option key={c.id} value={c.id}>
-								{c.label}
-							</Select.Option>
-						))}
+						{components.map((c) => {
+							const meta = CORE_WIDGET_META[c.id];
+							return (
+								<Select.Option key={c.id} value={c.id}>
+									{meta ? t(meta.label) : c.label}
+								</Select.Option>
+							);
+						})}
 					</Select>
 
 					{selectedComponent &&
 						Object.entries(selectedComponent.props).map(([key, def]) => (
 							<ComponentPropField
 								key={key}
+								componentId={selectedComponent.id}
 								propKey={key}
 								def={def}
 								value={componentProps[key] ?? def.default ?? ""}
@@ -898,20 +972,32 @@ function WidgetEditor({
 
 /** Renders a single prop field for a component widget based on PropDef type */
 function ComponentPropField({
+	componentId,
+	propKey,
 	def,
 	value,
 	onChange,
 }: {
+	componentId: string;
 	propKey: string;
 	def: WidgetComponent["props"][string];
 	value: unknown;
 	onChange: (value: unknown) => void;
 }) {
+	const { t } = useLingui();
+	// Localize built-in core widget prop labels/options; fall back to the
+	// server-provided string for plugin-registered components.
+	const propMeta = CORE_WIDGET_META[componentId]?.props?.[propKey];
+	const label = propMeta ? t(propMeta.label) : def.label;
+	const optionLabel = (optValue: string, fallback: string) => {
+		const descriptor = propMeta?.options?.[optValue];
+		return descriptor ? t(descriptor) : fallback;
+	};
 	switch (def.type) {
 		case "string":
 			return (
 				<Input
-					label={def.label}
+					label={label}
 					value={typeof value === "string" ? value : ""}
 					onChange={(e) => onChange(e.target.value)}
 				/>
@@ -919,29 +1005,29 @@ function ComponentPropField({
 		case "number":
 			return (
 				<Input
-					label={def.label}
+					label={label}
 					type="number"
 					value={typeof value === "number" ? value : ""}
 					onChange={(e) => onChange(Number(e.target.value))}
 				/>
 			);
 		case "boolean":
-			return <Switch label={def.label} checked={Boolean(value)} onCheckedChange={onChange} />;
+			return <Switch label={label} checked={Boolean(value)} onCheckedChange={onChange} />;
 		case "select": {
 			const items: Record<string, string> = {};
 			for (const opt of def.options ?? []) {
-				items[opt.value] = opt.label;
+				items[opt.value] = optionLabel(opt.value, opt.label);
 			}
 			return (
 				<Select
-					label={def.label}
+					label={label}
 					value={typeof value === "string" ? value : ""}
 					onValueChange={(v) => onChange(v ?? "")}
 					items={items}
 				>
 					{def.options?.map((opt) => (
 						<Select.Option key={opt.value} value={opt.value}>
-							{opt.label}
+							{optionLabel(opt.value, opt.label)}
 						</Select.Option>
 					))}
 				</Select>
@@ -950,7 +1036,7 @@ function ComponentPropField({
 		default:
 			return (
 				<Input
-					label={def.label}
+					label={label}
 					value={typeof value === "string" ? value : ""}
 					onChange={(e) => onChange(e.target.value)}
 				/>


### PR DESCRIPTION
## What does this PR do?

Localizes the built-in **widget UI** in the admin. The core widget components (`core:recent-posts`, `core:categories`, `core:tags`, `core:search`, `core:archives`) ship hardcoded English `label`/`description`/prop labels from the server (`packages/core/src/widgets/components.ts`), and the admin rendered them **raw** in three places — the palette, the widget-editor component `<Select>`, and the prop-field labels/options — bypassing Lingui.

This maps the core widget IDs to `msg` descriptors (`CORE_WIDGET_META`) covering labels, descriptions, prop labels, and select-option labels, rendered with `t()`, **falling back to the server-provided string** for plugin-registered components.

Code-only: no `messages.po` changes. The new source strings are picked up by the merge-time `locale:extract`; the Dutch translations are tracked as a follow-up on #2035 (the Dutch locale PR) to be added once these strings land.

Follows the "server stays English, admin maps to localized strings client-side" pattern (same as error codes).

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes — n/a: UI string-wiring change with no test surface; verified by building the admin and confirming the palette, editor select, and prop fields render localized labels (with the `nl` catalog loaded locally).
- [ ] I have added/updated tests — n/a (see above)
- [x] User-visible strings are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n). No `messages.po` in this PR — extraction runs on merge.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (1M context), via Claude Code

## Screenshots / test output

Verified locally against `demos/simple` with the admin locale set to Nederlands: the palette, the widget-editor component select, and the prop fields (e.g. *Placeholdertekst*, *Aantal berichten tonen*, *Hiërarchie tonen*, *Groeperen op* → *Maandelijks*/*Jaarlijks*) render in Dutch instead of English.

> Note: existing seeded widget **instances** and widget-**area** labels remain English because those are database/seed values, not catalog strings — tracked separately for a demo reseed on #2035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
