### PR TITLE
fix(admin): improve portable text editor controls

### DIFF
--- a/.changeset/refine-portable-text-editor.md
+++ b/.changeset/refine-portable-text-editor.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Improves portable text editing with a centered writing column, a responsive single-row toolbar, direct block insertion controls, and an unclipped link popover.
+Improves portable text editing with a centered writing column, a responsive toolbar, clearer empty-state guidance, direct block insertion controls, and floating controls that avoid clipping and toolbar overlap.

--- a/.changeset/refine-portable-text-editor.md
+++ b/.changeset/refine-portable-text-editor.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Improves portable text editing with a centered writing column, a responsive single-row toolbar, direct block insertion controls, and an unclipped link popover.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1174,7 +1174,7 @@ function FieldRenderer({
 					<PortableTextEditor
 						value={Array.isArray(value) ? value : []}
 						onChange={handleChange}
-						placeholder={t`Enter ${label.toLowerCase()}...`}
+						placeholder={t`Type / for commands`}
 						aria-labelledby={labelId}
 						pluginBlocks={pluginBlocks}
 						onEditorReady={onEditorReady}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1174,7 +1174,7 @@ function FieldRenderer({
 					<PortableTextEditor
 						value={Array.isArray(value) ? value : []}
 						onChange={handleChange}
-						placeholder={t`Type / for commands`}
+						placeholder={t`Start writing, or type '/' for commands`}
 						aria-labelledby={labelId}
 						pluginBlocks={pluginBlocks}
 						onEditorReady={onEditorReady}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1332,6 +1332,12 @@ function SlashCommandMenu({
 	}, [onClose, state.isOpen]);
 
 	if (!state.isOpen) return null;
+	const selectedItem = state.items[state.selectedIndex];
+	const selectedItemTitle = selectedItem
+		? typeof selectedItem.title === "string"
+			? selectedItem.title
+			: t(selectedItem.title)
+		: "";
 
 	return createPortal(
 		<div
@@ -1345,6 +1351,11 @@ function SlashCommandMenu({
 				hasMouseMovedRef.current = true;
 			}}
 		>
+			{selectedItem && (
+				<span className="sr-only" role="status">
+					{t`Selected ${selectedItemTitle}`}
+				</span>
+			)}
 			{state.items.length === 0 ? (
 				<p className="text-sm text-kumo-subtle px-3 py-2">{t`No results`}</p>
 			) : (
@@ -1353,6 +1364,7 @@ function SlashCommandMenu({
 						key={item.id}
 						type="button"
 						data-index={index}
+						aria-current={index === state.selectedIndex ? "true" : undefined}
 						className={cn(
 							"flex items-center gap-3 w-full px-3 py-2 text-sm rounded text-start",
 							index === state.selectedIndex
@@ -3000,11 +3012,12 @@ function EditorBubbleMenu({
 					<Input
 						ref={inputRef}
 						type="url"
-						placeholder="https://..."
+						placeholder={t`https://...`}
 						value={linkUrl}
 						onChange={(e) => setLinkUrl(e.target.value)}
 						onKeyDown={handleKeyDown}
 						className="h-8 w-48 text-sm"
+						aria-label={t`URL`}
 					/>
 					<Button
 						type="button"
@@ -3561,7 +3574,7 @@ function EditorToolbar({
 								<Input
 									ref={linkInputRef}
 									type="url"
-									placeholder="https://..."
+									placeholder={t`https://...`}
 									value={linkUrl}
 									onChange={(e) => setLinkUrl(e.target.value)}
 									onKeyDown={handleLinkKeyDown}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -11,7 +11,7 @@
  * - Floating menu on empty lines
  */
 
-import { Button, Dialog, Input, Select, Switch } from "@cloudflare/kumo";
+import { Button, Dialog, Input, Popover, Select, Switch } from "@cloudflare/kumo";
 import {
 	DndContext,
 	KeyboardSensor,
@@ -1126,6 +1126,8 @@ interface SlashMenuState {
 	selectedIndex: number;
 	clientRect: (() => DOMRect | null) | null;
 	range: Range | null;
+	trigger: "slash" | "gutter";
+	gutterBlockPos: number | null;
 }
 
 /**
@@ -1161,6 +1163,8 @@ function createSlashCommandsExtension(options: {
 									selectedIndex: 0,
 									clientRect: props.clientRect ?? null,
 									range: props.range,
+									trigger: "slash",
+									gutterBlockPos: null,
 								});
 							},
 							onUpdate: (props) => {
@@ -1170,6 +1174,8 @@ function createSlashCommandsExtension(options: {
 									selectedIndex: 0,
 									clientRect: props.clientRect ?? null,
 									range: props.range,
+									trigger: "slash",
+									gutterBlockPos: null,
 								}));
 							},
 							onKeyDown: (props) => {
@@ -1226,7 +1232,7 @@ function createSlashCommandsExtension(options: {
 function SlashCommandMenu({
 	state,
 	onCommand,
-	onClose: _onClose,
+	onClose,
 	setSelectedIndex,
 }: {
 	state: SlashMenuState;
@@ -1281,6 +1287,19 @@ function SlashCommandMenu({
 			hasMouseMovedRef.current = false;
 		}
 	}, [state.isOpen]);
+
+	React.useEffect(() => {
+		if (!state.isOpen) return;
+
+		const handlePointerDown = (event: PointerEvent) => {
+			const target = event.target as Node | null;
+			if (target && containerRef.current?.contains(target)) return;
+			onClose();
+		};
+
+		document.addEventListener("pointerdown", handlePointerDown, true);
+		return () => document.removeEventListener("pointerdown", handlePointerDown, true);
+	}, [onClose, state.isOpen]);
 
 	if (!state.isOpen) return null;
 
@@ -2096,7 +2115,7 @@ export interface PortableTextEditorProps {
 export function PortableTextEditor({
 	value,
 	onChange,
-	placeholder = "Start writing...",
+	placeholder,
 	className,
 	editable = true,
 	"aria-labelledby": ariaLabelledby,
@@ -2109,6 +2128,8 @@ export function PortableTextEditor({
 	onBlockSidebarClose,
 }: PortableTextEditorProps) {
 	const { t } = useLingui();
+	const placeholderRef = React.useRef(placeholder ?? t`Type / for commands`);
+	placeholderRef.current = placeholder ?? t`Type / for commands`;
 
 	// Use a ref for onChange to avoid recreating the editor when the callback changes
 	const onChangeRef = React.useRef(onChange);
@@ -2148,6 +2169,8 @@ export function PortableTextEditor({
 		selectedIndex: 0,
 		clientRect: null,
 		range: null,
+		trigger: "slash",
+		gutterBlockPos: null,
 	});
 
 	// Ref to access current state synchronously in keyboard handlers.
@@ -2302,12 +2325,7 @@ export function PortableTextEditor({
 			TableCell,
 			Placeholder.configure({
 				includeChildren: true,
-				placeholder: ({ node }) => {
-					if (node.type.name === "paragraph") {
-						return placeholder;
-					}
-					return placeholder;
-				},
+				placeholder: () => placeholderRef.current,
 			}),
 			TextAlign.configure({
 				types: ["heading", "paragraph"],
@@ -2334,7 +2352,7 @@ export function PortableTextEditor({
 		() => ({
 			attributes: {
 				class:
-					"prose prose-sm sm:prose-base dark:prose-invert max-w-none focus:outline-none min-h-[200px] p-4",
+					"prose prose-sm sm:prose-base dark:prose-invert w-full max-w-[calc(75ch+8rem)] mx-auto focus:outline-none min-h-[200px] p-4 ps-14 pe-14 sm:ps-16 sm:pe-16",
 				dir: "auto",
 			},
 		}),
@@ -2358,6 +2376,113 @@ export function PortableTextEditor({
 			}
 		},
 	});
+
+	const openBlockInsertMenuAt = React.useCallback(
+		(insertPos: number) => {
+			if (!editor) return;
+
+			const selectionPos = insertPos + 1;
+			const inserted = editor
+				.chain()
+				.focus()
+				.insertContentAt(insertPos, { type: "paragraph" })
+				.setTextSelection(selectionPos)
+				.run();
+			if (!inserted) return;
+
+			setSlashMenuState({
+				isOpen: true,
+				items: filterCommandsRef.current(""),
+				selectedIndex: 0,
+				clientRect: () => {
+					if (editor.isDestroyed) return null;
+					const coords = editor.view.coordsAtPos(selectionPos);
+					const DOMRectCtor = editor.view.dom.ownerDocument.defaultView?.DOMRect;
+					if (!DOMRectCtor) return null;
+					return new DOMRectCtor(
+						coords.left,
+						coords.top,
+						coords.right - coords.left,
+						coords.bottom - coords.top,
+					);
+				},
+				range: { from: selectionPos, to: selectionPos },
+				trigger: "gutter",
+				gutterBlockPos: insertPos,
+			});
+		},
+		[editor, setSlashMenuState],
+	);
+
+	const closeSlashMenu = React.useCallback(() => {
+		const state = slashMenuStateRef.current;
+		if (editor && state.trigger === "gutter" && state.gutterBlockPos !== null) {
+			const node = editor.state.doc.nodeAt(state.gutterBlockPos);
+			if (node?.type.name === "paragraph" && node.content.size === 0) {
+				editor
+					.chain()
+					.deleteRange({
+						from: state.gutterBlockPos,
+						to: state.gutterBlockPos + node.nodeSize,
+					})
+					.run();
+			}
+		}
+		setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
+	}, [editor, setSlashMenuState]);
+
+	React.useEffect(() => {
+		if (!editor || !slashMenuState.isOpen || slashMenuState.trigger !== "gutter") return;
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			const state = slashMenuStateRef.current;
+			if (!state.isOpen || state.trigger !== "gutter") return;
+
+			if (event.key === "Escape") {
+				event.preventDefault();
+				closeSlashMenu();
+				return;
+			}
+
+			if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+				if (state.items.length === 0) return;
+				event.preventDefault();
+				const delta = event.key === "ArrowUp" ? -1 : 1;
+				setSlashMenuState((prev) => ({
+					...prev,
+					selectedIndex: (prev.selectedIndex + delta + prev.items.length) % prev.items.length,
+				}));
+				return;
+			}
+
+			if (event.key === "Enter") {
+				const item = state.items[state.selectedIndex];
+				if (!item || !state.range) return;
+				event.preventDefault();
+				item.command({ editor, range: state.range });
+				setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
+				return;
+			}
+
+			if (event.key.length === 1 || event.key === "Backspace" || event.key === "Delete") {
+				setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
+			}
+		};
+
+		const editorElement = editor.view.dom;
+		editorElement.addEventListener("keydown", handleKeyDown);
+		return () => editorElement.removeEventListener("keydown", handleKeyDown);
+	}, [closeSlashMenu, editor, setSlashMenuState, slashMenuState.isOpen, slashMenuState.trigger]);
+
+	const handleTouchInsertBlock = React.useCallback(() => {
+		if (!editor) return;
+		const { $from } = editor.state.selection;
+		const topLevelPos = $from.depth > 0 ? $from.before(1) : $from.pos;
+		const topLevelNode = editor.state.doc.nodeAt(topLevelPos);
+		openBlockInsertMenuAt(
+			topLevelNode ? topLevelPos + topLevelNode.nodeSize : editor.state.doc.content.size,
+		);
+	}, [editor, openBlockInsertMenuAt]);
 
 	// Notify when editor is ready, and on unmount so consumers can clear the
 	// reference before TipTap destroys the instance (e.g. when keying by item.id
@@ -2507,12 +2632,13 @@ export function PortableTextEditor({
 	// Handle slash menu command execution
 	const handleSlashCommand = React.useCallback(
 		(item: SlashCommandItem) => {
-			if (editor && slashMenuState.range) {
-				item.command({ editor, range: slashMenuState.range });
-				setSlashMenuState((prev) => ({ ...prev, isOpen: false }));
+			const state = slashMenuStateRef.current;
+			if (editor && state.range) {
+				item.command({ editor, range: state.range });
+				setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
 			}
 		},
-		[editor, slashMenuState.range],
+		[editor, setSlashMenuState],
 	);
 
 	// Handle section selection - insert section content at cursor
@@ -2551,13 +2677,18 @@ export function PortableTextEditor({
 			aria-labelledby={ariaLabelledby}
 		>
 			{!minimal && (
-				<EditorToolbar editor={editor} focusMode={focusMode} onFocusModeChange={setFocusMode} />
+				<EditorToolbar
+					editor={editor}
+					focusMode={focusMode}
+					onFocusModeChange={setFocusMode}
+					onInsertBlock={handleTouchInsertBlock}
+				/>
 			)}
 			<EditorBubbleMenu editor={editor} />
 			<TableBubbleMenu editor={editor} />
 			<div className="relative overflow-visible">
 				<EditorContent editor={editor} />
-				{editable && <DragHandleWrapper editor={editor} />}
+				{editable && <DragHandleWrapper editor={editor} onInsertBlock={openBlockInsertMenuAt} />}
 			</div>
 			{!minimal && <EditorFooter editor={editor} />}
 
@@ -2565,7 +2696,7 @@ export function PortableTextEditor({
 			<SlashCommandMenu
 				state={slashMenuState}
 				onCommand={handleSlashCommand}
-				onClose={() => setSlashMenuState((prev) => ({ ...prev, isOpen: false }))}
+				onClose={closeSlashMenu}
 				setSelectedIndex={(index) =>
 					setSlashMenuState((prev) => ({ ...prev, selectedIndex: index }))
 				}
@@ -2864,10 +2995,12 @@ function EditorToolbar({
 	editor,
 	focusMode,
 	onFocusModeChange,
+	onInsertBlock,
 }: {
 	editor: Editor;
 	focusMode: FocusMode;
 	onFocusModeChange: (mode: FocusMode) => void;
+	onInsertBlock: () => void;
 }) {
 	const { t } = useLingui();
 	const [mediaPickerOpen, setMediaPickerOpen] = React.useState(false);
@@ -2963,9 +3096,9 @@ function EditorToolbar({
 
 		const buttons = [
 			...toolbar.querySelectorAll<HTMLButtonElement>(
-				'button:not([disabled]), [role="button"]:not([disabled])',
+				'button:not([disabled]):not([data-touch-block-insert]), [role="button"]:not([disabled]):not([data-touch-block-insert])',
 			),
-		];
+		].filter((button) => button.getClientRects().length > 0);
 		const currentIndex = buttons.findIndex((btn) => btn === document.activeElement);
 		if (currentIndex === -1) return;
 
@@ -3001,11 +3134,24 @@ function EditorToolbar({
 			ref={toolbarRef}
 			role="toolbar"
 			aria-label={t`Text formatting`}
-			className="sticky -top-6 z-10 border-b bg-kumo-tint p-1 flex flex-wrap gap-0.5"
+			className="sticky -top-6 z-10 border-b bg-kumo-tint p-1 flex flex-nowrap gap-0.5 overflow-x-auto"
 			onKeyDown={handleKeyDown}
 		>
 			{/* Text formatting */}
 			<ToolbarGroup>
+				<Button
+					type="button"
+					variant="ghost"
+					shape="square"
+					className="hidden h-8 w-8 flex-none pointer-coarse:flex"
+					onMouseDown={(event) => event.preventDefault()}
+					onClick={onInsertBlock}
+					aria-label={t`Insert block below`}
+					tabIndex={-1}
+					data-touch-block-insert
+				>
+					<Plus className="h-4 w-4" aria-hidden="true" />
+				</Button>
 				<ToolbarButton
 					onClick={() => editor.chain().focus().toggleBold().run()}
 					active={editorState.isBold}
@@ -3145,63 +3291,79 @@ function EditorToolbar({
 			{/* Insert */}
 			<ToolbarGroup>
 				{/* Link with popover */}
-				<div className="relative">
-					<ToolbarButton
-						onClick={() => setShowLinkPopover(!showLinkPopover)}
-						active={editorState.isLink}
-						title={t`Insert Link`}
-					>
-						<LinkIcon className="h-4 w-4" aria-hidden="true" />
-					</ToolbarButton>
-					{showLinkPopover && (
-						<div className="absolute top-full start-0 mt-1 z-50 rounded-md border bg-kumo-overlay p-3 shadow-lg">
-							<div className="flex flex-col gap-2">
-								<label className="text-xs font-medium text-kumo-subtle">{t`URL`}</label>
-								<div className="flex items-center gap-1">
-									<Input
-										ref={linkInputRef}
-										type="url"
-										placeholder="https://..."
-										value={linkUrl}
-										onChange={(e) => setLinkUrl(e.target.value)}
-										onKeyDown={handleLinkKeyDown}
-										className="h-8 w-52 text-sm"
-									/>
-								</div>
-								<div className="flex justify-between">
-									<Button
-										type="button"
-										variant="ghost"
-										size="sm"
-										onClick={() => {
-											setShowLinkPopover(false);
-											setLinkUrl("");
-										}}
-									>
-										{t`Cancel`}
-									</Button>
-									<div className="flex gap-1">
-										{editorState.isLink && (
-											<Button
-												type="button"
-												variant="ghost"
-												size="sm"
-												className="text-kumo-danger"
-												onClick={handleRemoveLink}
-												icon={<LinkBreak />}
-											>
-												{t`Remove`}
-											</Button>
-										)}
-										<Button type="button" variant="primary" size="sm" onClick={handleSetLink}>
-											{t`Apply`}
+				<Popover
+					open={showLinkPopover}
+					onOpenChange={(open) => {
+						setShowLinkPopover(open);
+						if (!open) setLinkUrl("");
+					}}
+				>
+					<Popover.Trigger
+						render={
+							<Button
+								type="button"
+								variant="ghost"
+								shape="square"
+								className={cn(
+									"h-8 w-8 flex-none",
+									editorState.isLink && "bg-kumo-tint text-kumo-default",
+								)}
+								onMouseDown={(event) => event.preventDefault()}
+								aria-label={t`Insert Link`}
+								aria-pressed={editorState.isLink}
+							>
+								<LinkIcon className="h-4 w-4" aria-hidden="true" />
+							</Button>
+						}
+					/>
+					<Popover.Content side="bottom" align="start" className="w-auto p-3">
+						<div className="flex flex-col gap-2">
+							<label className="text-xs font-medium text-kumo-subtle">{t`URL`}</label>
+							<div className="flex items-center gap-1">
+								<Input
+									ref={linkInputRef}
+									type="url"
+									placeholder="https://..."
+									value={linkUrl}
+									onChange={(e) => setLinkUrl(e.target.value)}
+									onKeyDown={handleLinkKeyDown}
+									className="h-8 w-52 text-sm"
+									aria-label={t`URL`}
+								/>
+							</div>
+							<div className="flex justify-between">
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									onClick={() => {
+										setShowLinkPopover(false);
+										setLinkUrl("");
+									}}
+								>
+									{t`Cancel`}
+								</Button>
+								<div className="flex gap-1">
+									{editorState.isLink && (
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											className="text-kumo-danger"
+											onClick={handleRemoveLink}
+											icon={<LinkBreak />}
+										>
+											{t`Remove`}
 										</Button>
-									</div>
+									)}
+									<Button type="button" variant="primary" size="sm" onClick={handleSetLink}>
+										{t`Apply`}
+									</Button>
 								</div>
 							</div>
 						</div>
-					)}
-				</div>
+					</Popover.Content>
+				</Popover>
 				<ToolbarButton onClick={() => setMediaPickerOpen(true)} title={t`Insert Image`}>
 					<ImageIcon className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
@@ -3257,7 +3419,6 @@ function EditorToolbar({
 					<Eye className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
 			</ToolbarGroup>
-
 			{/* Media Picker Modal */}
 			<MediaPickerModal
 				open={mediaPickerOpen}
@@ -3271,11 +3432,11 @@ function EditorToolbar({
 }
 
 function ToolbarGroup({ children }: { children: React.ReactNode }) {
-	return <div className="flex gap-0.5">{children}</div>;
+	return <div className="flex flex-none gap-0.5">{children}</div>;
 }
 
 function ToolbarSeparator() {
-	return <div className="w-px bg-kumo-line mx-1" />;
+	return <div className="w-px bg-kumo-line mx-1 flex-none" />;
 }
 
 interface ToolbarButtonProps {
@@ -3292,7 +3453,7 @@ function ToolbarButton({ onClick, active, disabled, title, children }: ToolbarBu
 			type="button"
 			variant="ghost"
 			shape="square"
-			className={cn("h-8 w-8", active && "bg-kumo-tint text-kumo-default")}
+			className={cn("h-8 w-8 flex-none", active && "bg-kumo-tint text-kumo-default")}
 			onMouseDown={(e) => e.preventDefault()}
 			onClick={onClick}
 			disabled={disabled}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -11,7 +11,7 @@
  * - Floating menu on empty lines
  */
 
-import { Button, Dialog, Input, Popover, Select, Switch } from "@cloudflare/kumo";
+import { Button, Dialog, Input, Popover, Select, Switch, Toolbar, Tooltip } from "@cloudflare/kumo";
 import {
 	DndContext,
 	KeyboardSensor,
@@ -80,10 +80,12 @@ import { TableHeader } from "@tiptap/extension-table-header";
 import { TableRow } from "@tiptap/extension-table-row";
 import TextAlign from "@tiptap/extension-text-align";
 import Typography from "@tiptap/extension-typography";
+import { AllSelection, TextSelection } from "@tiptap/pm/state";
+import { CellSelection } from "@tiptap/pm/tables";
 import { useEditor, EditorContent, useEditorState, type Editor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
-import Suggestion from "@tiptap/suggestion";
+import Suggestion, { exitSuggestion } from "@tiptap/suggestion";
 import * as React from "react";
 import { createPortal } from "react-dom";
 
@@ -106,6 +108,14 @@ import {
 } from "./editor/PluginBlockNode";
 import { MediaPickerModal } from "./MediaPickerModal";
 import { SectionPickerModal } from "./SectionPickerModal";
+
+const INLINE_BUBBLE_MENU_KEY = "emdashInlineBubbleMenu";
+const TABLE_BUBBLE_MENU_KEY = "emdashTableBubbleMenu";
+
+type BubbleMenuCollisionOptions = () => {
+	rootBoundary: { x: number; y: number; width: number; height: number };
+	padding: number;
+};
 
 // Import converters from inline module since we can't import from emdash package
 // These will be duplicated here until we set up proper package exports
@@ -1131,6 +1141,7 @@ interface SlashMenuState {
 	range: Range | null;
 	trigger: "slash" | "gutter";
 	gutterBlockPos: number | null;
+	dismissedSlashFrom: number | null;
 }
 
 /**
@@ -1145,6 +1156,14 @@ function createSlashCommandsExtension(options: {
 
 	return Extension.create({
 		name: "slashCommands",
+		onTransaction() {
+			const state = getState();
+			if (state.dismissedSlashFrom === null) return;
+			const to = Math.min(state.dismissedSlashFrom + 1, this.editor.state.doc.content.size);
+			if (this.editor.state.doc.textBetween(state.dismissedSlashFrom, to) !== "/") {
+				onStateChange((prev) => ({ ...prev, dismissedSlashFrom: null }));
+			}
+		},
 
 		addProseMirrorPlugins() {
 			return [
@@ -1157,6 +1176,7 @@ function createSlashCommandsExtension(options: {
 						item.command({ editor, range });
 					},
 					items: ({ query }) => filterCommands(query),
+					allow: ({ range }) => getState().dismissedSlashFrom !== range.from,
 					render: () => {
 						return {
 							onStart: (props) => {
@@ -1168,6 +1188,7 @@ function createSlashCommandsExtension(options: {
 									range: props.range,
 									trigger: "slash",
 									gutterBlockPos: null,
+									dismissedSlashFrom: null,
 								});
 							},
 							onUpdate: (props) => {
@@ -1179,11 +1200,17 @@ function createSlashCommandsExtension(options: {
 									range: props.range,
 									trigger: "slash",
 									gutterBlockPos: null,
+									dismissedSlashFrom: null,
 								}));
 							},
 							onKeyDown: (props) => {
 								if (props.event.key === "Escape") {
-									onStateChange((prev) => ({ ...prev, isOpen: false }));
+									onStateChange((prev) => ({
+										...prev,
+										isOpen: false,
+										dismissedSlashFrom: props.range.from,
+									}));
+									exitSuggestion(props.view);
 									return true;
 								}
 
@@ -2134,6 +2161,27 @@ export function PortableTextEditor({
 	const placeholderRef = React.useRef(placeholder ?? t`Start writing, or type '/' for commands`);
 	placeholderRef.current = placeholder ?? t`Start writing, or type '/' for commands`;
 	const toolbarRef = React.useRef<HTMLDivElement>(null);
+	const floatingRootRef = React.useRef<HTMLDivElement>(null);
+	const appendBubbleMenu = React.useCallback(() => floatingRootRef.current!, []);
+	const getBubbleMenuCollisionOptions = React.useCallback(() => {
+		const viewport = window.visualViewport;
+		const viewportTop = viewport?.offsetTop ?? 0;
+		const viewportLeft = viewport?.offsetLeft ?? 0;
+		const viewportWidth = viewport?.width ?? window.innerWidth;
+		const viewportBottom = viewportTop + (viewport?.height ?? window.innerHeight);
+		const toolbarBottom = toolbarRef.current?.getBoundingClientRect().bottom ?? viewportTop;
+		const safeTop = Math.min(viewportBottom, Math.max(viewportTop, toolbarBottom));
+
+		return {
+			rootBoundary: {
+				x: viewportLeft,
+				y: safeTop,
+				width: viewportWidth,
+				height: Math.max(0, viewportBottom - safeTop),
+			},
+			padding: 8,
+		};
+	}, []);
 
 	// Use a ref for onChange to avoid recreating the editor when the callback changes
 	const onChangeRef = React.useRef(onChange);
@@ -2176,6 +2224,7 @@ export function PortableTextEditor({
 		range: null,
 		trigger: "slash",
 		gutterBlockPos: null,
+		dismissedSlashFrom: null,
 	});
 
 	// Ref to access current state synchronously in keyboard handlers.
@@ -2388,9 +2437,15 @@ export function PortableTextEditor({
 	const openBlockInsertMenuAt = React.useCallback(
 		(insertPos: number) => {
 			if (!editor) return;
+			const state = slashMenuStateRef.current;
+			const activeSlashFrom = state.trigger === "slash" && state.isOpen ? state.range?.from : null;
+			if (activeSlashFrom != null) {
+				setSlashMenuState((prev) => ({ ...prev, dismissedSlashFrom: activeSlashFrom }));
+			}
+			exitSuggestion(editor.view);
 			editor.commands.focus();
 
-			setSlashMenuState({
+			setSlashMenuState((prev) => ({
 				isOpen: true,
 				items: filterCommandsRef.current(""),
 				selectedIndex: 0,
@@ -2409,14 +2464,25 @@ export function PortableTextEditor({
 				range: { from: insertPos, to: insertPos },
 				trigger: "gutter",
 				gutterBlockPos: insertPos,
-			});
+				dismissedSlashFrom: prev.dismissedSlashFrom,
+			}));
 		},
 		[editor, setSlashMenuState],
 	);
 
 	const closeSlashMenu = React.useCallback(() => {
-		setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
-	}, [setSlashMenuState]);
+		const state = slashMenuStateRef.current;
+		setSlashMenuState((prev) => ({
+			...prev,
+			isOpen: false,
+			gutterBlockPos: null,
+			dismissedSlashFrom:
+				state.trigger === "slash" ? (state.range?.from ?? null) : prev.dismissedSlashFrom,
+		}));
+		if (editor && state.trigger === "slash") {
+			exitSuggestion(editor.view);
+		}
+	}, [editor, setSlashMenuState]);
 
 	const executeSlashCommand = React.useCallback(
 		(item: SlashCommandItem, state: SlashMenuState) => {
@@ -2545,6 +2611,27 @@ export function PortableTextEditor({
 		}
 		return undefined;
 	}, [editor, onEditorReady]);
+
+	React.useEffect(() => {
+		const viewport = window.visualViewport;
+		if (!editor || !viewport) return;
+
+		const updateBubbleMenuPositions = () => {
+			if (editor.isDestroyed) return;
+			editor.view.dispatch(
+				editor.state.tr
+					.setMeta(INLINE_BUBBLE_MENU_KEY, "updatePosition")
+					.setMeta(TABLE_BUBBLE_MENU_KEY, "updatePosition"),
+			);
+		};
+
+		viewport.addEventListener("resize", updateBubbleMenuPositions);
+		viewport.addEventListener("scroll", updateBubbleMenuPositions);
+		return () => {
+			viewport.removeEventListener("resize", updateBubbleMenuPositions);
+			viewport.removeEventListener("scroll", updateBubbleMenuPositions);
+		};
+	}, [editor]);
 
 	// Register plugin blocks into editor storage so the node view can look up metadata
 	React.useEffect(() => {
@@ -2727,76 +2814,87 @@ export function PortableTextEditor({
 	}
 
 	return (
-		<div
-			className={cn(
-				"border rounded-lg overflow-clip",
-				minimal && "border-0 rounded-none -mx-4",
-				focusMode === "spotlight" && "spotlight-mode",
-				className,
-			)}
-			aria-labelledby={ariaLabelledby}
-		>
-			{!minimal && (
-				<EditorToolbar
-					toolbarRef={toolbarRef}
-					editor={editor}
-					focusMode={focusMode}
-					onFocusModeChange={setFocusMode}
-					onInsertBlock={handleTouchInsertBlock}
+		<div ref={floatingRootRef} className="relative" data-emdash-editor-floating-root>
+			<EditorBubbleMenu
+				editor={editor}
+				appendTo={appendBubbleMenu}
+				getCollisionOptions={getBubbleMenuCollisionOptions}
+			/>
+			<TableBubbleMenu
+				editor={editor}
+				appendTo={appendBubbleMenu}
+				getCollisionOptions={getBubbleMenuCollisionOptions}
+			/>
+			<div
+				className={cn(
+					"border rounded-lg overflow-clip",
+					minimal && "border-0 rounded-none -mx-4",
+					focusMode === "spotlight" && "spotlight-mode",
+					className,
+				)}
+				aria-labelledby={ariaLabelledby}
+				data-emdash-editor-surface
+			>
+				{!minimal && (
+					<EditorToolbar
+						toolbarRef={toolbarRef}
+						editor={editor}
+						focusMode={focusMode}
+						onFocusModeChange={setFocusMode}
+						onInsertBlock={handleTouchInsertBlock}
+					/>
+				)}
+				<div className="relative overflow-visible">
+					<EditorContent editor={editor} />
+					{editable && <DragHandleWrapper editor={editor} onInsertBlock={openBlockInsertMenuAt} />}
+				</div>
+				{!minimal && <EditorFooter editor={editor} />}
+
+				{/* Slash command menu */}
+				<SlashCommandMenu
+					state={slashMenuState}
+					onCommand={handleSlashCommand}
+					onClose={closeSlashMenu}
+					setSelectedIndex={(index) =>
+						setSlashMenuState((prev) => ({ ...prev, selectedIndex: index }))
+					}
 				/>
-			)}
-			<EditorBubbleMenu editor={editor} toolbarRef={toolbarRef} />
-			<TableBubbleMenu editor={editor} />
-			<div className="relative overflow-visible">
-				<EditorContent editor={editor} />
-				{editable && <DragHandleWrapper editor={editor} onInsertBlock={openBlockInsertMenuAt} />}
+
+				{/* Media picker for image insertion */}
+				<MediaPickerModal
+					open={mediaPickerOpen}
+					onOpenChange={(open) => {
+						setMediaPickerOpen(open);
+						if (!open) pendingBlockInsertPosRef.current = null;
+					}}
+					onSelect={handleImageSelect}
+					mimeTypeFilter="image/"
+					title={t`Select Image`}
+				/>
+
+				{/* Plugin block insertion/editing modal */}
+				<PluginBlockModal
+					block={pluginBlockModal}
+					initialValues={pluginBlockInitialValues}
+					onClose={() => {
+						pendingBlockInsertPosRef.current = null;
+						setPluginBlockModal(null);
+						setPluginBlockInitialValues(undefined);
+						editingBlockPosRef.current = null;
+					}}
+					onInsert={handlePluginBlockInsert}
+				/>
+
+				{/* Section picker modal */}
+				<SectionPickerModal
+					open={sectionPickerOpen}
+					onOpenChange={(open) => {
+						setSectionPickerOpen(open);
+						if (!open) pendingBlockInsertPosRef.current = null;
+					}}
+					onSelect={handleSectionSelect}
+				/>
 			</div>
-			{!minimal && <EditorFooter editor={editor} />}
-
-			{/* Slash command menu */}
-			<SlashCommandMenu
-				state={slashMenuState}
-				onCommand={handleSlashCommand}
-				onClose={closeSlashMenu}
-				setSelectedIndex={(index) =>
-					setSlashMenuState((prev) => ({ ...prev, selectedIndex: index }))
-				}
-			/>
-
-			{/* Media picker for image insertion */}
-			<MediaPickerModal
-				open={mediaPickerOpen}
-				onOpenChange={(open) => {
-					setMediaPickerOpen(open);
-					if (!open) pendingBlockInsertPosRef.current = null;
-				}}
-				onSelect={handleImageSelect}
-				mimeTypeFilter="image/"
-				title={t`Select Image`}
-			/>
-
-			{/* Plugin block insertion/editing modal */}
-			<PluginBlockModal
-				block={pluginBlockModal}
-				initialValues={pluginBlockInitialValues}
-				onClose={() => {
-					pendingBlockInsertPosRef.current = null;
-					setPluginBlockModal(null);
-					setPluginBlockInitialValues(undefined);
-					editingBlockPosRef.current = null;
-				}}
-				onInsert={handlePluginBlockInsert}
-			/>
-
-			{/* Section picker modal */}
-			<SectionPickerModal
-				open={sectionPickerOpen}
-				onOpenChange={(open) => {
-					setSectionPickerOpen(open);
-					if (!open) pendingBlockInsertPosRef.current = null;
-				}}
-				onSelect={handleSectionSelect}
-			/>
 		</div>
 	);
 }
@@ -2807,36 +2905,28 @@ export function PortableTextEditor({
  */
 function EditorBubbleMenu({
 	editor,
-	toolbarRef,
+	appendTo,
+	getCollisionOptions,
 }: {
 	editor: Editor;
-	toolbarRef: React.RefObject<HTMLDivElement | null>;
+	appendTo: () => HTMLElement;
+	getCollisionOptions: BubbleMenuCollisionOptions;
 }) {
 	const [showLinkInput, setShowLinkInput] = React.useState(false);
 	const [linkUrl, setLinkUrl] = React.useState("");
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const { t } = useLingui();
-	// The adjacent sticky toolbar is not a clipping ancestor, so Floating UI cannot detect it.
-	const getCollisionOptions = () => {
-		const viewport = window.visualViewport;
-		const viewportTop = viewport?.offsetTop ?? 0;
-		const viewportLeft = viewport?.offsetLeft ?? 0;
-		const viewportWidth = viewport?.width ?? window.innerWidth;
-		const viewportBottom = viewportTop + (viewport?.height ?? window.innerHeight);
-		const toolbarBottom = toolbarRef.current?.getBoundingClientRect().bottom ?? viewportTop;
-		const safeTop = Math.min(viewportBottom, Math.max(viewportTop, toolbarBottom));
-
-		return {
-			rootBoundary: {
-				x: viewportLeft,
-				y: safeTop,
-				width: viewportWidth,
-				height: Math.max(0, viewportBottom - safeTop),
-			},
-			padding: 8,
-		};
-	};
-
+	const activeMarks = useEditorState({
+		editor,
+		selector: ({ editor: activeEditor }) => ({
+			bold: activeEditor.isActive("bold"),
+			italic: activeEditor.isActive("italic"),
+			underline: activeEditor.isActive("underline"),
+			strike: activeEditor.isActive("strike"),
+			code: activeEditor.isActive("code"),
+			link: activeEditor.isActive("link"),
+		}),
+	});
 	// When bubble menu opens with link input, populate the URL
 	React.useEffect(() => {
 		if (showLinkInput) {
@@ -2877,12 +2967,32 @@ function EditorBubbleMenu({
 	return (
 		<BubbleMenu
 			editor={editor}
+			pluginKey={INLINE_BUBBLE_MENU_KEY}
+			appendTo={appendTo}
 			options={{
+				strategy: "absolute",
 				placement: "top",
 				offset: 8,
 				flip: getCollisionOptions,
 				shift: getCollisionOptions,
+				size: () => ({
+					...getCollisionOptions(),
+					apply: ({ availableWidth, elements }) => {
+						elements.floating.style.maxWidth = `${Math.max(0, availableWidth)}px`;
+						elements.floating.style.overflowX = "auto";
+					},
+				}),
 			}}
+			shouldShow={({ editor: activeEditor, element, state, view }) => {
+				const { selection } = state;
+				return (
+					activeEditor.isEditable &&
+					(selection instanceof TextSelection || selection instanceof AllSelection) &&
+					!selection.empty &&
+					(view.hasFocus() || element.contains(document.activeElement))
+				);
+			}}
+			data-emdash-inline-bubble-menu
 			className="z-[100] flex items-center gap-0.5 rounded-lg border bg-kumo-base p-1 shadow-lg"
 		>
 			{showLinkInput ? (
@@ -2907,7 +3017,7 @@ function EditorBubbleMenu({
 					>
 						<ArrowSquareOut className="h-4 w-4" />
 					</Button>
-					{editor.isActive("link") && (
+					{activeMarks.link && (
 						<Button
 							type="button"
 							variant="ghost"
@@ -2925,35 +3035,35 @@ function EditorBubbleMenu({
 				<>
 					<BubbleButton
 						onClick={() => editor.chain().focus().toggleBold().run()}
-						active={editor.isActive("bold")}
+						active={activeMarks.bold}
 						title={t`Bold`}
 					>
 						<TextB className="h-4 w-4" />
 					</BubbleButton>
 					<BubbleButton
 						onClick={() => editor.chain().focus().toggleItalic().run()}
-						active={editor.isActive("italic")}
+						active={activeMarks.italic}
 						title={t`Italic`}
 					>
 						<TextItalic className="h-4 w-4" />
 					</BubbleButton>
 					<BubbleButton
 						onClick={() => editor.chain().focus().toggleUnderline().run()}
-						active={editor.isActive("underline")}
+						active={activeMarks.underline}
 						title={t`Underline`}
 					>
 						<TextUnderline className="h-4 w-4" />
 					</BubbleButton>
 					<BubbleButton
 						onClick={() => editor.chain().focus().toggleStrike().run()}
-						active={editor.isActive("strike")}
+						active={activeMarks.strike}
 						title={t`Strikethrough`}
 					>
 						<TextStrikethrough className="h-4 w-4" />
 					</BubbleButton>
 					<BubbleButton
 						onClick={() => editor.chain().focus().toggleCode().run()}
-						active={editor.isActive("code")}
+						active={activeMarks.code}
 						title={t`Code`}
 					>
 						<Code className="h-4 w-4" />
@@ -2961,8 +3071,8 @@ function EditorBubbleMenu({
 					<div className="w-px h-6 bg-kumo-line mx-1" />
 					<BubbleButton
 						onClick={() => setShowLinkInput(true)}
-						active={editor.isActive("link")}
-						title={editor.isActive("link") ? t`Edit link` : t`Add link`}
+						active={activeMarks.link}
+						title={activeMarks.link ? t`Edit link` : t`Add link`}
 					>
 						<LinkIcon className="h-4 w-4" />
 					</BubbleButton>
@@ -2976,80 +3086,160 @@ function EditorBubbleMenu({
  * Table Bubble Menu - appears when cursor is in a table.
  * Shows table editing options: add/remove rows/columns, toggle header, delete table.
  */
-function TableBubbleMenu({ editor }: { editor: Editor }) {
+function TableBubbleMenu({
+	editor,
+	appendTo,
+	getCollisionOptions,
+}: {
+	editor: Editor;
+	appendTo: () => HTMLElement;
+	getCollisionOptions: BubbleMenuCollisionOptions;
+}) {
 	const { t } = useLingui();
-
-	if (!editor.isActive("table")) {
-		return null;
-	}
+	const [toolbarGeneration, setToolbarGeneration] = React.useState(0);
+	const isHeaderRow = useEditorState({
+		editor,
+		selector: ({ editor: activeEditor }) => activeEditor.isActive("tableHeader"),
+	});
 
 	return (
 		<BubbleMenu
 			editor={editor}
+			pluginKey={TABLE_BUBBLE_MENU_KEY}
+			appendTo={appendTo}
 			options={{
+				strategy: "absolute",
 				placement: "top",
 				offset: 8,
+				flip: getCollisionOptions,
+				shift: getCollisionOptions,
+				onShow: () => setToolbarGeneration((generation) => generation + 1),
+				size: () => ({
+					...getCollisionOptions(),
+					apply: ({ availableWidth, elements }) => {
+						elements.floating.style.maxWidth = `${Math.max(0, availableWidth)}px`;
+						elements.floating.style.overflowX = "auto";
+					},
+				}),
 			}}
-			shouldShow={({ editor: activeEditor }) => activeEditor.isActive("table")}
-			className="z-[100] flex items-center gap-0.5 rounded-lg border bg-kumo-base p-1 shadow-lg"
+			shouldShow={({ editor: activeEditor, element, state, view }) => {
+				const hasEditorFocus = view.hasFocus() || element.contains(document.activeElement);
+				return (
+					activeEditor.isEditable &&
+					hasEditorFocus &&
+					activeEditor.isActive("table") &&
+					(state.selection.empty || state.selection instanceof CellSelection)
+				);
+			}}
+			data-emdash-table-bubble-menu
+			className="z-[100]"
 		>
-			<BubbleButton
-				onClick={() => editor.chain().focus().addColumnBefore().run()}
-				title={t`Add column before`}
+			<Toolbar
+				key={toolbarGeneration}
+				size="sm"
+				loopFocus
+				aria-label={t`Table controls`}
+				className="gap-0.5 bg-kumo-base p-1 shadow-lg"
 			>
-				<Columns className="h-4 w-4" />
-				<Plus className="absolute -left-0.5 h-2 w-2" />
-			</BubbleButton>
-			<BubbleButton
-				onClick={() => editor.chain().focus().addColumnAfter().run()}
-				title={t`Add column after`}
-			>
-				<Columns className="h-4 w-4" />
-				<Plus className="absolute -right-0.5 h-2 w-2" />
-			</BubbleButton>
-			<BubbleButton
-				onClick={() => editor.chain().focus().deleteColumn().run()}
-				title={t`Delete column`}
-			>
-				<Columns className="h-4 w-4 text-kumo-danger" />
-			</BubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().addColumnBefore().run()}
+					title={t`Add column before`}
+				>
+					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
+						<Columns className="size-4" />
+						<Plus className="absolute -start-0.5 top-1/2 size-2 -translate-y-1/2" />
+					</span>
+				</TableBubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().addColumnAfter().run()}
+					title={t`Add column after`}
+				>
+					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
+						<Columns className="size-4" />
+						<Plus className="absolute -end-0.5 top-1/2 size-2 -translate-y-1/2" />
+					</span>
+				</TableBubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().deleteColumn().run()}
+					title={t`Delete column`}
+				>
+					<Columns className="size-4 text-kumo-danger" aria-hidden="true" />
+				</TableBubbleButton>
 
-			<div className="mx-1 h-6 w-px bg-kumo-line" />
+				<div className="mx-1 h-6 w-px bg-kumo-line" aria-hidden="true" />
 
-			<BubbleButton
-				onClick={() => editor.chain().focus().addRowBefore().run()}
-				title={t`Add row before`}
-			>
-				<Rows className="h-4 w-4" />
-				<Plus className="absolute -top-0.5 h-2 w-2" />
-			</BubbleButton>
-			<BubbleButton
-				onClick={() => editor.chain().focus().addRowAfter().run()}
-				title={t`Add row after`}
-			>
-				<Rows className="h-4 w-4" />
-				<Plus className="absolute -bottom-0.5 h-2 w-2" />
-			</BubbleButton>
-			<BubbleButton onClick={() => editor.chain().focus().deleteRow().run()} title={t`Delete row`}>
-				<Rows className="h-4 w-4 text-kumo-danger" />
-			</BubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().addRowBefore().run()}
+					title={t`Add row before`}
+				>
+					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
+						<Rows className="size-4" />
+						<Plus className="absolute -top-0.5 start-1/2 size-2 -translate-x-1/2 rtl:translate-x-1/2" />
+					</span>
+				</TableBubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().addRowAfter().run()}
+					title={t`Add row after`}
+				>
+					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
+						<Rows className="size-4" />
+						<Plus className="absolute -bottom-0.5 start-1/2 size-2 -translate-x-1/2 rtl:translate-x-1/2" />
+					</span>
+				</TableBubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().deleteRow().run()}
+					title={t`Delete row`}
+				>
+					<Rows className="size-4 text-kumo-danger" aria-hidden="true" />
+				</TableBubbleButton>
 
-			<div className="mx-1 h-6 w-px bg-kumo-line" />
+				<div className="mx-1 h-6 w-px bg-kumo-line" aria-hidden="true" />
 
-			<BubbleButton
-				onClick={() => editor.chain().focus().toggleHeaderRow().run()}
-				active={editor.isActive("tableHeader")}
-				title={t`Toggle header row`}
-			>
-				<TableIcon className="h-4 w-4" />
-			</BubbleButton>
-			<BubbleButton
-				onClick={() => editor.chain().focus().deleteTable().run()}
-				title={t`Delete table`}
-			>
-				<Trash className="h-4 w-4 text-kumo-danger" />
-			</BubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().toggleHeaderRow().run()}
+					active={isHeaderRow}
+					title={t`Toggle header row`}
+				>
+					<TableIcon className="size-4" aria-hidden="true" />
+				</TableBubbleButton>
+				<TableBubbleButton
+					onClick={() => editor.chain().focus().deleteTable().run()}
+					title={t`Delete table`}
+				>
+					<Trash className="size-4 text-kumo-danger" aria-hidden="true" />
+				</TableBubbleButton>
+			</Toolbar>
 		</BubbleMenu>
+	);
+}
+
+function TableBubbleButton({
+	onClick,
+	active,
+	title,
+	children,
+}: {
+	onClick: () => void;
+	active?: boolean;
+	title: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<Toolbar.Button
+			type="button"
+			shape="square"
+			className={cn(
+				"h-8 w-8 flex-none rounded-lg! border-0!",
+				active && "bg-kumo-tint text-kumo-default",
+			)}
+			onClick={onClick}
+			aria-label={title}
+			aria-pressed={active}
+		>
+			<Tooltip content={title} render={<span className="contents" tabIndex={-1} />}>
+				{children}
+			</Tooltip>
+		</Toolbar.Button>
 	);
 }
 
@@ -3073,6 +3263,7 @@ function BubbleButton({
 			onClick={onClick}
 			title={title}
 			aria-label={title}
+			aria-pressed={Boolean(active)}
 		>
 			{children}
 		</Button>
@@ -3168,7 +3359,7 @@ function EditorToolbar({
 
 		const buttons = [
 			...toolbar.querySelectorAll<HTMLButtonElement>(
-				'button:not([disabled]):not([data-touch-block-insert]), [role="button"]:not([disabled]):not([data-touch-block-insert])',
+				'button:not([disabled]), [role="button"]:not([disabled])',
 			),
 		].filter((button) => button.getClientRects().length > 0);
 		const currentIndex = buttons.findIndex((btn) => btn === document.activeElement);
@@ -3225,7 +3416,6 @@ function EditorToolbar({
 					onMouseDown={(event) => event.preventDefault()}
 					onClick={onInsertBlock}
 					aria-label={t`Insert block after current block`}
-					tabIndex={-1}
 					data-touch-block-insert
 				>
 					<Plus className="h-4 w-4" aria-hidden="true" />

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -3099,7 +3099,6 @@ function EditorToolbar({
 	onInsertBlock: () => void;
 }) {
 	const { t } = useLingui();
-	const [mediaPickerOpen, setMediaPickerOpen] = React.useState(false);
 	const [showLinkPopover, setShowLinkPopover] = React.useState(false);
 	const [linkUrl, setLinkUrl] = React.useState("");
 	const linkInputRef = React.useRef<HTMLInputElement>(null);
@@ -3162,25 +3161,6 @@ function EditorToolbar({
 		}
 	};
 
-	const handleImageSelect = React.useCallback(
-		(item: MediaItem) => {
-			editor
-				.chain()
-				.focus()
-				.setImage({
-					src: item.url,
-					alt: item.alt || item.filename,
-					mediaId: item.id,
-					width: item.width,
-					height: item.height,
-					blurhash: item.blurhash,
-					dominantColor: item.dominantColor,
-				})
-				.run();
-		},
-		[editor],
-	);
-
 	// Keyboard navigation for toolbar (WAI-ARIA toolbar pattern)
 	const handleKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
 		const toolbar = toolbarRef.current;
@@ -3231,7 +3211,8 @@ function EditorToolbar({
 			ref={toolbarRef}
 			role="toolbar"
 			aria-label={t`Text formatting`}
-			className="sticky -top-6 z-10 border-b bg-kumo-tint p-1 flex flex-nowrap gap-0.5 overflow-x-auto"
+			className="sticky -top-6 z-10 flex flex-nowrap gap-0.5 overflow-x-auto border-b bg-kumo-tint p-1"
+			style={{ justifyContent: "safe center" }}
 			onKeyDown={handleKeyDown}
 		>
 			{/* Text formatting */}
@@ -3325,15 +3306,6 @@ function EditorToolbar({
 				>
 					<CodeBlock className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
-				<ToolbarButton
-					onClick={() =>
-						editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run()
-					}
-					active={editor.isActive("table")}
-					title={t`Insert Table`}
-				>
-					<TableIcon className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
 			</ToolbarGroup>
 
 			<ToolbarSeparator />
@@ -3365,9 +3337,8 @@ function EditorToolbar({
 
 			<ToolbarSeparator />
 
-			{/* Insert */}
+			{/* Link */}
 			<ToolbarGroup>
-				{/* Link with popover */}
 				<Popover
 					open={showLinkPopover}
 					onOpenChange={(open) => {
@@ -3441,27 +3412,6 @@ function EditorToolbar({
 						</div>
 					</Popover.Content>
 				</Popover>
-				<ToolbarButton onClick={() => setMediaPickerOpen(true)} title={t`Insert Image`}>
-					<ImageIcon className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
-				<ToolbarButton
-					onClick={() =>
-						editor
-							.chain()
-							.focus()
-							.insertContent({ type: "htmlBlock", attrs: { html: "" } })
-							.run()
-					}
-					title={t`Insert HTML`}
-				>
-					<BracketsAngle className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
-				<ToolbarButton
-					onClick={() => editor.chain().focus().setHorizontalRule().run()}
-					title={t`Insert Horizontal Rule`}
-				>
-					<Minus className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
 			</ToolbarGroup>
 
 			<ToolbarSeparator aria-hidden="true" />
@@ -3496,14 +3446,6 @@ function EditorToolbar({
 					<Eye className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
 			</ToolbarGroup>
-			{/* Media Picker Modal */}
-			<MediaPickerModal
-				open={mediaPickerOpen}
-				onOpenChange={setMediaPickerOpen}
-				onSelect={handleImageSelect}
-				mimeTypeFilter="image/"
-				title={t`Select Image`}
-			/>
 		</div>
 	);
 }

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -993,6 +993,8 @@ interface SlashCommandItem {
 	description: MessageDescriptor | string;
 	icon: Icon | React.ComponentType<{ className?: string }>;
 	command: (props: { editor: Editor; range: Range }) => void;
+	/** Delay document insertion until a modal-backed command returns a selection. */
+	deferInsertion?: boolean;
 	aliases?: string[];
 	/**
 	 * Display category. Built-in commands use `msg`-tagged descriptors;
@@ -2162,6 +2164,7 @@ export function PortableTextEditor({
 
 	// Section picker state (for inserting sections)
 	const [sectionPickerOpen, setSectionPickerOpen] = React.useState(false);
+	const pendingBlockInsertPosRef = React.useRef<number | null>(null);
 
 	// Slash commands state
 	const [slashMenuState, setSlashMenuStateRaw] = React.useState<SlashMenuState>({
@@ -2216,6 +2219,7 @@ export function PortableTextEditor({
 			icon: ImageIcon,
 			aliases: ["img", "photo", "picture", "url"],
 			category: msg`Media`,
+			deferInsertion: true,
 			command: ({ editor, range }) => {
 				editor.chain().focus().deleteRange(range).run();
 				setMediaPickerOpen(true);
@@ -2230,6 +2234,7 @@ export function PortableTextEditor({
 			icon: Stack,
 			aliases: ["pattern", "block", "template"],
 			category: msg`Content`,
+			deferInsertion: true,
 			command: ({ editor, range }) => {
 				editor.chain().focus().deleteRange(range).run();
 				setSectionPickerOpen(true);
@@ -2246,6 +2251,7 @@ export function PortableTextEditor({
 				icon: resolveIcon(block.icon),
 				aliases: [block.type],
 				category: block.category ?? msg`Embeds`,
+				deferInsertion: true,
 				command: ({ editor, range }) => {
 					editor.chain().focus().deleteRange(range).run();
 					setPluginBlockModal(block);
@@ -2381,15 +2387,7 @@ export function PortableTextEditor({
 	const openBlockInsertMenuAt = React.useCallback(
 		(insertPos: number) => {
 			if (!editor) return;
-
-			const selectionPos = insertPos + 1;
-			const inserted = editor
-				.chain()
-				.focus()
-				.insertContentAt(insertPos, { type: "paragraph" })
-				.setTextSelection(selectionPos)
-				.run();
-			if (!inserted) return;
+			editor.commands.focus();
 
 			setSlashMenuState({
 				isOpen: true,
@@ -2397,7 +2395,7 @@ export function PortableTextEditor({
 				selectedIndex: 0,
 				clientRect: () => {
 					if (editor.isDestroyed) return null;
-					const coords = editor.view.coordsAtPos(selectionPos);
+					const coords = editor.view.coordsAtPos(insertPos);
 					const DOMRectCtor = editor.view.dom.ownerDocument.defaultView?.DOMRect;
 					if (!DOMRectCtor) return null;
 					return new DOMRectCtor(
@@ -2407,7 +2405,7 @@ export function PortableTextEditor({
 						coords.bottom - coords.top,
 					);
 				},
-				range: { from: selectionPos, to: selectionPos },
+				range: { from: insertPos, to: insertPos },
 				trigger: "gutter",
 				gutterBlockPos: insertPos,
 			});
@@ -2416,21 +2414,40 @@ export function PortableTextEditor({
 	);
 
 	const closeSlashMenu = React.useCallback(() => {
-		const state = slashMenuStateRef.current;
-		if (editor && state.trigger === "gutter" && state.gutterBlockPos !== null) {
-			const node = editor.state.doc.nodeAt(state.gutterBlockPos);
-			if (node?.type.name === "paragraph" && node.content.size === 0) {
-				editor
-					.chain()
-					.deleteRange({
-						from: state.gutterBlockPos,
-						to: state.gutterBlockPos + node.nodeSize,
-					})
-					.run();
-			}
-		}
 		setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
-	}, [editor, setSlashMenuState]);
+	}, [setSlashMenuState]);
+
+	const executeSlashCommand = React.useCallback(
+		(item: SlashCommandItem, state: SlashMenuState) => {
+			if (!editor || !state.range) return;
+
+			let range = state.range;
+			if (state.trigger === "gutter") {
+				const insertPos = state.gutterBlockPos;
+				if (insertPos === null) return;
+
+				if (item.deferInsertion) {
+					pendingBlockInsertPosRef.current = insertPos;
+					const selectionPos = editor.state.selection.from;
+					range = { from: selectionPos, to: selectionPos };
+				} else {
+					const selectionPos = insertPos + 1;
+					const inserted = editor
+						.chain()
+						.focus()
+						.insertContentAt(insertPos, { type: "paragraph" })
+						.setTextSelection(selectionPos)
+						.run();
+					if (!inserted) return;
+					range = { from: selectionPos, to: selectionPos };
+				}
+			}
+
+			item.command({ editor, range });
+			setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
+		},
+		[editor, setSlashMenuState],
+	);
 
 	React.useEffect(() => {
 		if (!editor || !slashMenuState.isOpen || slashMenuState.trigger !== "gutter") return;
@@ -2460,20 +2477,50 @@ export function PortableTextEditor({
 				const item = state.items[state.selectedIndex];
 				if (!item || !state.range) return;
 				event.preventDefault();
-				item.command({ editor, range: state.range });
+				executeSlashCommand(item, state);
+				return;
+			}
+
+			if (
+				event.key.length === 1 &&
+				!event.ctrlKey &&
+				!event.metaKey &&
+				!event.altKey &&
+				!event.isComposing &&
+				state.gutterBlockPos !== null
+			) {
+				event.preventDefault();
+				const selectionPos = state.gutterBlockPos + event.key.length + 1;
+				editor
+					.chain()
+					.focus()
+					.insertContentAt(state.gutterBlockPos, {
+						type: "paragraph",
+						content: [{ type: "text", text: event.key }],
+					})
+					.setTextSelection(selectionPos)
+					.run();
 				setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
 				return;
 			}
 
-			if (event.key.length === 1 || event.key === "Backspace" || event.key === "Delete") {
-				setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
+			if (event.key === "Backspace" || event.key === "Delete") {
+				event.preventDefault();
+				closeSlashMenu();
 			}
 		};
 
 		const editorElement = editor.view.dom;
-		editorElement.addEventListener("keydown", handleKeyDown);
-		return () => editorElement.removeEventListener("keydown", handleKeyDown);
-	}, [closeSlashMenu, editor, setSlashMenuState, slashMenuState.isOpen, slashMenuState.trigger]);
+		editorElement.addEventListener("keydown", handleKeyDown, true);
+		return () => editorElement.removeEventListener("keydown", handleKeyDown, true);
+	}, [
+		closeSlashMenu,
+		editor,
+		executeSlashCommand,
+		setSlashMenuState,
+		slashMenuState.isOpen,
+		slashMenuState.trigger,
+	]);
 
 	const handleTouchInsertBlock = React.useCallback(() => {
 		if (!editor) return;
@@ -2559,21 +2606,25 @@ export function PortableTextEditor({
 			if (editor) {
 				// For external providers, src is only used for admin preview
 				// The frontend Image component uses provider + mediaId to generate proper URLs
-				editor
-					.chain()
-					.focus()
-					.setImage({
-						src: item.url,
-						alt: item.alt || item.filename,
-						mediaId: item.id,
-						provider: item.provider || "local",
-						width: item.width,
-						height: item.height,
-						blurhash: item.blurhash,
-						dominantColor: item.dominantColor,
-					})
-					.run();
+				const attrs = {
+					src: item.url,
+					alt: item.alt || item.filename,
+					mediaId: item.id,
+					provider: item.provider || "local",
+					width: item.width,
+					height: item.height,
+					blurhash: item.blurhash,
+					dominantColor: item.dominantColor,
+				};
+				const insertPos = pendingBlockInsertPosRef.current;
+				const chain = editor.chain().focus();
+				if (insertPos === null) {
+					chain.setImage(attrs).run();
+				} else {
+					chain.insertContentAt(insertPos, { type: "image", attrs }).run();
+				}
 			}
+			pendingBlockInsertPosRef.current = null;
 			setMediaPickerOpen(false);
 		},
 		[editor],
@@ -2609,20 +2660,24 @@ export function PortableTextEditor({
 					.run();
 			} else {
 				// Inserting a new block
-				editor
-					.chain()
-					.focus()
-					.insertContent({
-						type: "pluginBlock",
-						attrs: {
-							blockType: pluginBlockModal.type,
-							id: typeof id === "string" ? id : "",
-							data,
-						},
-					})
-					.run();
+				const content = {
+					type: "pluginBlock",
+					attrs: {
+						blockType: pluginBlockModal.type,
+						id: typeof id === "string" ? id : "",
+						data,
+					},
+				};
+				const insertPos = pendingBlockInsertPosRef.current;
+				const chain = editor.chain().focus();
+				if (insertPos === null) {
+					chain.insertContent(content).run();
+				} else {
+					chain.insertContentAt(insertPos, content).run();
+				}
 			}
 
+			pendingBlockInsertPosRef.current = null;
 			setPluginBlockModal(null);
 			setPluginBlockInitialValues(undefined);
 			editingBlockPosRef.current = null;
@@ -2634,12 +2689,9 @@ export function PortableTextEditor({
 	const handleSlashCommand = React.useCallback(
 		(item: SlashCommandItem) => {
 			const state = slashMenuStateRef.current;
-			if (editor && state.range) {
-				item.command({ editor, range: state.range });
-				setSlashMenuState((prev) => ({ ...prev, isOpen: false, gutterBlockPos: null }));
-			}
+			executeSlashCommand(item, state);
 		},
-		[editor, setSlashMenuState],
+		[executeSlashCommand],
 	);
 
 	// Handle section selection - insert section content at cursor
@@ -2653,8 +2705,14 @@ export function PortableTextEditor({
 				: [];
 			const { content: prosemirrorContent } = portableTextToProsemirror(ptContent);
 
-			// Insert the content at current cursor position
-			editor.chain().focus().insertContent(prosemirrorContent).run();
+			const insertPos = pendingBlockInsertPosRef.current;
+			const chain = editor.chain().focus();
+			if (insertPos === null) {
+				chain.insertContent(prosemirrorContent).run();
+			} else {
+				chain.insertContentAt(insertPos, prosemirrorContent).run();
+			}
+			pendingBlockInsertPosRef.current = null;
 		},
 		[editor],
 	);
@@ -2706,7 +2764,10 @@ export function PortableTextEditor({
 			{/* Media picker for image insertion */}
 			<MediaPickerModal
 				open={mediaPickerOpen}
-				onOpenChange={setMediaPickerOpen}
+				onOpenChange={(open) => {
+					setMediaPickerOpen(open);
+					if (!open) pendingBlockInsertPosRef.current = null;
+				}}
 				onSelect={handleImageSelect}
 				mimeTypeFilter="image/"
 				title={t`Select Image`}
@@ -2717,6 +2778,7 @@ export function PortableTextEditor({
 				block={pluginBlockModal}
 				initialValues={pluginBlockInitialValues}
 				onClose={() => {
+					pendingBlockInsertPosRef.current = null;
 					setPluginBlockModal(null);
 					setPluginBlockInitialValues(undefined);
 					editingBlockPosRef.current = null;
@@ -2727,7 +2789,10 @@ export function PortableTextEditor({
 			{/* Section picker modal */}
 			<SectionPickerModal
 				open={sectionPickerOpen}
-				onOpenChange={setSectionPickerOpen}
+				onOpenChange={(open) => {
+					setSectionPickerOpen(open);
+					if (!open) pendingBlockInsertPosRef.current = null;
+				}}
 				onSelect={handleSectionSelect}
 			/>
 		</div>
@@ -3099,15 +3164,20 @@ function EditorToolbar({
 		].filter((button) => button.getClientRects().length > 0);
 		const currentIndex = buttons.findIndex((btn) => btn === document.activeElement);
 		if (currentIndex === -1) return;
+		const isRtl = getComputedStyle(toolbar).direction === "rtl";
 
 		let nextIndex: number | null = null;
 
 		switch (e.key) {
 			case "ArrowRight":
+				nextIndex = (currentIndex + (isRtl ? -1 : 1) + buttons.length) % buttons.length;
+				break;
+			case "ArrowLeft":
+				nextIndex = (currentIndex + (isRtl ? 1 : -1) + buttons.length) % buttons.length;
+				break;
 			case "ArrowDown":
 				nextIndex = (currentIndex + 1) % buttons.length;
 				break;
-			case "ArrowLeft":
 			case "ArrowUp":
 				nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
 				break;

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -11,7 +11,7 @@
  * - Floating menu on empty lines
  */
 
-import { Button, Dialog, Input, Popover, Select, Switch, Toolbar, Tooltip } from "@cloudflare/kumo";
+import { Button, Dialog, Input, Popover, Select, Switch } from "@cloudflare/kumo";
 import {
 	DndContext,
 	KeyboardSensor,
@@ -64,7 +64,11 @@ import {
 	Plus,
 	Trash,
 	Rows,
+	RowsPlusBottom,
+	RowsPlusTop,
 	Columns,
+	ColumnsPlusLeft,
+	ColumnsPlusRight,
 	DotsSixVertical,
 	CaretDown,
 	type Icon,
@@ -3109,7 +3113,6 @@ function TableBubbleMenu({
 	getCollisionOptions: BubbleMenuCollisionOptions;
 }) {
 	const { t } = useLingui();
-	const [toolbarGeneration, setToolbarGeneration] = React.useState(0);
 	const isHeaderRow = useEditorState({
 		editor,
 		selector: ({ editor: activeEditor }) => activeEditor.isActive("tableHeader"),
@@ -3126,7 +3129,6 @@ function TableBubbleMenu({
 				offset: 8,
 				flip: getCollisionOptions,
 				shift: getCollisionOptions,
-				onShow: () => setToolbarGeneration((generation) => generation + 1),
 				size: () => ({
 					...getCollisionOptions(),
 					apply: ({ availableWidth, elements }) => {
@@ -3145,114 +3147,63 @@ function TableBubbleMenu({
 				);
 			}}
 			data-emdash-table-bubble-menu
-			className="z-[100]"
+			role="group"
+			aria-label={t`Table controls`}
+			className="z-[100] flex items-center gap-0.5 rounded-lg border bg-kumo-base p-1 shadow-lg"
 		>
-			<Toolbar
-				key={toolbarGeneration}
-				size="sm"
-				loopFocus
-				aria-label={t`Table controls`}
-				className="gap-0.5 bg-kumo-base p-1 shadow-lg"
+			<BubbleButton
+				onClick={() => editor.chain().focus().addColumnBefore().run()}
+				title={t`Add column before`}
 			>
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().addColumnBefore().run()}
-					title={t`Add column before`}
-				>
-					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
-						<Columns className="size-4" />
-						<Plus className="absolute -start-0.5 top-1/2 size-2 -translate-y-1/2" />
-					</span>
-				</TableBubbleButton>
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().addColumnAfter().run()}
-					title={t`Add column after`}
-				>
-					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
-						<Columns className="size-4" />
-						<Plus className="absolute -end-0.5 top-1/2 size-2 -translate-y-1/2" />
-					</span>
-				</TableBubbleButton>
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().deleteColumn().run()}
-					title={t`Delete column`}
-				>
-					<Columns className="size-4 text-kumo-danger" aria-hidden="true" />
-				</TableBubbleButton>
+				<ColumnsPlusLeft className="h-4 w-4 rtl:-scale-x-100" aria-hidden="true" />
+			</BubbleButton>
+			<BubbleButton
+				onClick={() => editor.chain().focus().addColumnAfter().run()}
+				title={t`Add column after`}
+			>
+				<ColumnsPlusRight className="h-4 w-4 rtl:-scale-x-100" aria-hidden="true" />
+			</BubbleButton>
+			<BubbleButton
+				onClick={() => editor.chain().focus().deleteColumn().run()}
+				title={t`Delete column`}
+			>
+				<Columns className="h-4 w-4 text-kumo-danger" aria-hidden="true" />
+			</BubbleButton>
 
-				<div className="mx-1 h-6 w-px bg-kumo-line" aria-hidden="true" />
+			<div className="mx-1 h-6 w-px bg-kumo-line" aria-hidden="true" />
 
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().addRowBefore().run()}
-					title={t`Add row before`}
-				>
-					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
-						<Rows className="size-4" />
-						<Plus className="absolute -top-0.5 start-1/2 size-2 -translate-x-1/2 rtl:translate-x-1/2" />
-					</span>
-				</TableBubbleButton>
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().addRowAfter().run()}
-					title={t`Add row after`}
-				>
-					<span className="relative size-4" aria-hidden="true" data-emdash-composite-icon>
-						<Rows className="size-4" />
-						<Plus className="absolute -bottom-0.5 start-1/2 size-2 -translate-x-1/2 rtl:translate-x-1/2" />
-					</span>
-				</TableBubbleButton>
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().deleteRow().run()}
-					title={t`Delete row`}
-				>
-					<Rows className="size-4 text-kumo-danger" aria-hidden="true" />
-				</TableBubbleButton>
+			<BubbleButton
+				onClick={() => editor.chain().focus().addRowBefore().run()}
+				title={t`Add row before`}
+			>
+				<RowsPlusTop className="h-4 w-4" aria-hidden="true" />
+			</BubbleButton>
+			<BubbleButton
+				onClick={() => editor.chain().focus().addRowAfter().run()}
+				title={t`Add row after`}
+			>
+				<RowsPlusBottom className="h-4 w-4" aria-hidden="true" />
+			</BubbleButton>
+			<BubbleButton onClick={() => editor.chain().focus().deleteRow().run()} title={t`Delete row`}>
+				<Rows className="h-4 w-4 text-kumo-danger" aria-hidden="true" />
+			</BubbleButton>
 
-				<div className="mx-1 h-6 w-px bg-kumo-line" aria-hidden="true" />
+			<div className="mx-1 h-6 w-px bg-kumo-line" aria-hidden="true" />
 
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().toggleHeaderRow().run()}
-					active={isHeaderRow}
-					title={t`Toggle header row`}
-				>
-					<TableIcon className="size-4" aria-hidden="true" />
-				</TableBubbleButton>
-				<TableBubbleButton
-					onClick={() => editor.chain().focus().deleteTable().run()}
-					title={t`Delete table`}
-				>
-					<Trash className="size-4 text-kumo-danger" aria-hidden="true" />
-				</TableBubbleButton>
-			</Toolbar>
+			<BubbleButton
+				onClick={() => editor.chain().focus().toggleHeaderRow().run()}
+				active={isHeaderRow}
+				title={t`Toggle header row`}
+			>
+				<TableIcon className="h-4 w-4" aria-hidden="true" />
+			</BubbleButton>
+			<BubbleButton
+				onClick={() => editor.chain().focus().deleteTable().run()}
+				title={t`Delete table`}
+			>
+				<Trash className="h-4 w-4 text-kumo-danger" aria-hidden="true" />
+			</BubbleButton>
 		</BubbleMenu>
-	);
-}
-
-function TableBubbleButton({
-	onClick,
-	active,
-	title,
-	children,
-}: {
-	onClick: () => void;
-	active?: boolean;
-	title: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<Toolbar.Button
-			type="button"
-			shape="square"
-			className={cn(
-				"h-8 w-8 flex-none rounded-lg! border-0!",
-				active && "bg-kumo-tint text-kumo-default",
-			)}
-			onClick={onClick}
-			aria-label={title}
-			aria-pressed={active}
-		>
-			<Tooltip content={title} render={<span className="contents" tabIndex={-1} />}>
-				{children}
-			</Tooltip>
-		</Toolbar.Button>
 	);
 }
 
@@ -3276,7 +3227,7 @@ function BubbleButton({
 			onClick={onClick}
 			title={title}
 			aria-label={title}
-			aria-pressed={Boolean(active)}
+			aria-pressed={active === undefined ? undefined : active}
 		>
 			{children}
 		</Button>

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Dialog, Input, Popover, Select, Switch } from "@cloudflare/kumo";
+import { Popover as PopoverPrimitive } from "@cloudflare/kumo/primitives/popover";
 import {
 	DndContext,
 	KeyboardSensor,
@@ -30,7 +31,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Element } from "@emdash-cms/blocks";
-import { useFloating, offset, flip, shift, autoUpdate } from "@floating-ui/react";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
@@ -91,7 +91,6 @@ import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
 import Suggestion, { exitSuggestion } from "@tiptap/suggestion";
 import * as React from "react";
-import { createPortal } from "react-dom";
 
 import type { MediaItem } from "../lib/api";
 import type { Section } from "../lib/api";
@@ -1208,14 +1207,14 @@ function createSlashCommandsExtension(options: {
 								}));
 							},
 							onKeyDown: (props) => {
-								if (props.event.key === "Escape") {
+								if (props.event.key === "Escape" || props.event.key === "Tab") {
 									onStateChange((prev) => ({
 										...prev,
 										isOpen: false,
 										dismissedSlashFrom: props.range.from,
 									}));
 									exitSuggestion(props.view);
-									return true;
+									return props.event.key === "Escape";
 								}
 
 								if (props.event.key === "ArrowUp") {
@@ -1260,9 +1259,7 @@ function createSlashCommandsExtension(options: {
 	});
 }
 
-/**
- * Slash command menu component using Floating UI
- */
+/** Slash command menu anchored to the TipTap caret. */
 function SlashCommandMenu({
 	state,
 	onCommand,
@@ -1276,23 +1273,13 @@ function SlashCommandMenu({
 }) {
 	const { t } = useLingui();
 	const containerRef = React.useRef<HTMLDivElement>(null);
-
-	const { refs, floatingStyles } = useFloating({
-		open: state.isOpen,
-		placement: "bottom-start",
-		middleware: [offset(8), flip(), shift({ padding: 8 })],
-		whileElementsMounted: autoUpdate,
-	});
-
-	// Sync virtual reference from TipTap's clientRect
-	React.useEffect(() => {
-		if (state.clientRect) {
-			const clientRectFn = state.clientRect;
-			refs.setReference({
-				getBoundingClientRect: () => clientRectFn() ?? new DOMRect(),
-			});
-		}
-	}, [state.clientRect, refs]);
+	const popupRef = React.useRef<HTMLDivElement>(null);
+	const virtualAnchor = React.useMemo(
+		() => ({
+			getBoundingClientRect: () => state.clientRect?.() ?? new DOMRect(),
+		}),
+		[state.clientRect],
+	);
 
 	// Scroll selected item into view
 	React.useEffect(() => {
@@ -1327,7 +1314,7 @@ function SlashCommandMenu({
 
 		const handlePointerDown = (event: PointerEvent) => {
 			const target = event.target as Node | null;
-			if (target && containerRef.current?.contains(target)) return;
+			if (target && popupRef.current?.contains(target)) return;
 			onClose();
 		};
 
@@ -1335,7 +1322,6 @@ function SlashCommandMenu({
 		return () => document.removeEventListener("pointerdown", handlePointerDown, true);
 	}, [onClose, state.isOpen]);
 
-	if (!state.isOpen) return null;
 	const selectedItem = state.items[state.selectedIndex];
 	const selectedItemTitle = selectedItem
 		? typeof selectedItem.title === "string"
@@ -1343,62 +1329,100 @@ function SlashCommandMenu({
 			: t(selectedItem.title)
 		: "";
 
-	return createPortal(
-		<div
-			ref={(node) => {
-				containerRef.current = node;
-				refs.setFloating(node);
-			}}
-			style={floatingStyles}
-			className="z-[100] rounded-lg border bg-kumo-overlay p-1 shadow-lg min-w-[220px] max-h-[300px] overflow-y-auto"
-			onPointerMove={() => {
-				hasMouseMovedRef.current = true;
+	return (
+		<PopoverPrimitive.Root
+			open={state.isOpen}
+			modal={false}
+			onOpenChange={(open) => {
+				if (!open && state.isOpen) onClose();
 			}}
 		>
-			{selectedItem && (
-				<span className="sr-only" role="status">
-					{t`Selected ${selectedItemTitle}`}
-				</span>
-			)}
-			{state.items.length === 0 ? (
-				<p className="text-sm text-kumo-subtle px-3 py-2">{t`No results`}</p>
-			) : (
-				state.items.map((item, index) => (
-					<button
-						key={item.id}
-						type="button"
-						data-index={index}
-						aria-current={index === state.selectedIndex ? "true" : undefined}
+			<PopoverPrimitive.Portal>
+				{/* TipTap owns focus, so Base UI's portal guards must stay out of the Tab order. */}
+				<PopoverPrimitive.Positioner
+					anchor={virtualAnchor}
+					side="bottom"
+					align="start"
+					sideOffset={8}
+					positionMethod="fixed"
+					collisionPadding={8}
+					collisionAvoidance={{ side: "flip", align: "shift", fallbackAxisSide: "none" }}
+					className="slash-command-menu-positioner z-[100]"
+				>
+					<PopoverPrimitive.Popup
+						ref={popupRef}
+						initialFocus={false}
+						finalFocus={false}
+						aria-label={t`Insert block`}
+						data-slash-command-menu
 						className={cn(
-							"flex items-center gap-3 w-full px-3 py-2 text-sm rounded text-start",
-							index === state.selectedIndex
-								? "bg-kumo-interact text-kumo-default"
-								: "hover:bg-kumo-interact",
+							"min-w-[220px] overflow-hidden rounded-lg bg-kumo-base text-sm text-kumo-default",
+							"shadow-lg shadow-kumo-tip-shadow outline outline-kumo-fill",
+							"origin-(--transform-origin) transition-[transform,scale,opacity] duration-150 ease-out",
+							"data-starting-style:scale-90 data-starting-style:opacity-0",
+							"data-ending-style:scale-90 data-ending-style:opacity-0 data-instant:duration-0",
+							"motion-reduce:transition-none",
 						)}
-						onClick={() => onCommand(item)}
-						onMouseEnter={() => {
-							// Only react if the user has actually moved the
-							// mouse since the menu opened -- not when items
-							// appear under a stationary pointer.
-							if (hasMouseMovedRef.current) {
-								setSelectedIndex(index);
-							}
+						onPointerMove={() => {
+							hasMouseMovedRef.current = true;
 						}}
 					>
-						<item.icon className="h-4 w-4 text-kumo-subtle flex-shrink-0" />
-						<div className="flex flex-col">
-							<span className="font-medium">
-								{typeof item.title === "string" ? item.title : t(item.title)}
+						{selectedItem && (
+							<span className="sr-only" role="status">
+								{t`Selected ${selectedItemTitle}`}
 							</span>
-							<span className="text-xs text-kumo-subtle">
-								{typeof item.description === "string" ? item.description : t(item.description)}
-							</span>
+						)}
+						<div
+							ref={containerRef}
+							data-slash-menu-scroll-viewport
+							className="max-h-[300px] overflow-y-auto overscroll-contain scroll-py-1 p-1"
+						>
+							{state.items.length === 0 ? (
+								<p className="px-3 py-2 text-sm text-kumo-subtle">{t`No results`}</p>
+							) : (
+								state.items.map((item, index) => (
+									<button
+										key={item.id}
+										type="button"
+										tabIndex={-1}
+										data-index={index}
+										aria-current={index === state.selectedIndex ? "true" : undefined}
+										className={cn(
+											"flex w-full items-center gap-3 rounded px-3 py-2 text-start text-sm",
+											index === state.selectedIndex
+												? "bg-kumo-interact text-kumo-default"
+												: "hover:bg-kumo-interact",
+										)}
+										onPointerDown={(event) => event.preventDefault()}
+										onClick={() => onCommand(item)}
+										onMouseEnter={() => {
+											// Only react if the user has actually moved the
+											// mouse since the menu opened -- not when items
+											// appear under a stationary pointer.
+											if (hasMouseMovedRef.current) {
+												setSelectedIndex(index);
+											}
+										}}
+									>
+										<item.icon className="h-4 w-4 flex-shrink-0 text-kumo-subtle" />
+										<div className="flex flex-col">
+											<span className="font-medium">
+												{typeof item.title === "string" ? item.title : t(item.title)}
+											</span>
+											<span className="text-xs text-kumo-subtle">
+												{typeof item.description === "string"
+													? item.description
+													: t(item.description)}
+											</span>
+										</div>
+									</button>
+								))
+							)}
 						</div>
-					</button>
-				))
-			)}
-		</div>,
-		document.body,
+					</PopoverPrimitive.Popup>
+				</PopoverPrimitive.Positioner>
+			</PopoverPrimitive.Portal>
+		</PopoverPrimitive.Root>
 	);
 }
 
@@ -2538,6 +2562,11 @@ export function PortableTextEditor({
 		const handleKeyDown = (event: KeyboardEvent) => {
 			const state = slashMenuStateRef.current;
 			if (!state.isOpen || state.trigger !== "gutter") return;
+
+			if (event.key === "Tab") {
+				closeSlashMenu();
+				return;
+			}
 
 			if (event.key === "Escape") {
 				event.preventDefault();

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2131,8 +2131,9 @@ export function PortableTextEditor({
 	onBlockSidebarClose,
 }: PortableTextEditorProps) {
 	const { t } = useLingui();
-	const placeholderRef = React.useRef(placeholder ?? t`Type / for commands`);
-	placeholderRef.current = placeholder ?? t`Type / for commands`;
+	const placeholderRef = React.useRef(placeholder ?? t`Start writing, or type '/' for commands`);
+	placeholderRef.current = placeholder ?? t`Start writing, or type '/' for commands`;
+	const toolbarRef = React.useRef<HTMLDivElement>(null);
 
 	// Use a ref for onChange to avoid recreating the editor when the callback changes
 	const onChangeRef = React.useRef(onChange);
@@ -2737,13 +2738,14 @@ export function PortableTextEditor({
 		>
 			{!minimal && (
 				<EditorToolbar
+					toolbarRef={toolbarRef}
 					editor={editor}
 					focusMode={focusMode}
 					onFocusModeChange={setFocusMode}
 					onInsertBlock={handleTouchInsertBlock}
 				/>
 			)}
-			<EditorBubbleMenu editor={editor} />
+			<EditorBubbleMenu editor={editor} toolbarRef={toolbarRef} />
 			<TableBubbleMenu editor={editor} />
 			<div className="relative overflow-visible">
 				<EditorContent editor={editor} />
@@ -2803,11 +2805,37 @@ export function PortableTextEditor({
  * Bubble Menu - appears when text is selected
  * Shows inline formatting options and link editing
  */
-function EditorBubbleMenu({ editor }: { editor: Editor }) {
+function EditorBubbleMenu({
+	editor,
+	toolbarRef,
+}: {
+	editor: Editor;
+	toolbarRef: React.RefObject<HTMLDivElement | null>;
+}) {
 	const [showLinkInput, setShowLinkInput] = React.useState(false);
 	const [linkUrl, setLinkUrl] = React.useState("");
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const { t } = useLingui();
+	// The adjacent sticky toolbar is not a clipping ancestor, so Floating UI cannot detect it.
+	const getCollisionOptions = () => {
+		const viewport = window.visualViewport;
+		const viewportTop = viewport?.offsetTop ?? 0;
+		const viewportLeft = viewport?.offsetLeft ?? 0;
+		const viewportWidth = viewport?.width ?? window.innerWidth;
+		const viewportBottom = viewportTop + (viewport?.height ?? window.innerHeight);
+		const toolbarBottom = toolbarRef.current?.getBoundingClientRect().bottom ?? viewportTop;
+		const safeTop = Math.min(viewportBottom, Math.max(viewportTop, toolbarBottom));
+
+		return {
+			rootBoundary: {
+				x: viewportLeft,
+				y: safeTop,
+				width: viewportWidth,
+				height: Math.max(0, viewportBottom - safeTop),
+			},
+			padding: 8,
+		};
+	};
 
 	// When bubble menu opens with link input, populate the URL
 	React.useEffect(() => {
@@ -2852,8 +2880,8 @@ function EditorBubbleMenu({ editor }: { editor: Editor }) {
 			options={{
 				placement: "top",
 				offset: 8,
-				flip: true,
-				shift: true,
+				flip: getCollisionOptions,
+				shift: getCollisionOptions,
 			}}
 			className="z-[100] flex items-center gap-0.5 rounded-lg border bg-kumo-base p-1 shadow-lg"
 		>
@@ -3058,11 +3086,13 @@ function BubbleButton({
  * Arrow keys move focus between buttons, Home/End jump to first/last.
  */
 function EditorToolbar({
+	toolbarRef,
 	editor,
 	focusMode,
 	onFocusModeChange,
 	onInsertBlock,
 }: {
+	toolbarRef: React.RefObject<HTMLDivElement | null>;
 	editor: Editor;
 	focusMode: FocusMode;
 	onFocusModeChange: (mode: FocusMode) => void;
@@ -3072,7 +3102,6 @@ function EditorToolbar({
 	const [mediaPickerOpen, setMediaPickerOpen] = React.useState(false);
 	const [showLinkPopover, setShowLinkPopover] = React.useState(false);
 	const [linkUrl, setLinkUrl] = React.useState("");
-	const toolbarRef = React.useRef<HTMLDivElement>(null);
 	const linkInputRef = React.useRef<HTMLInputElement>(null);
 
 	// Subscribe to editor state changes for reactive button states
@@ -3214,7 +3243,7 @@ function EditorToolbar({
 					className="hidden h-8 w-8 flex-none pointer-coarse:flex"
 					onMouseDown={(event) => event.preventDefault()}
 					onClick={onInsertBlock}
-					aria-label={t`Insert block below`}
+					aria-label={t`Insert block after current block`}
 					tabIndex={-1}
 					data-touch-block-insert
 				>

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -94,6 +94,7 @@ import { CaretNext } from "./ArrowIcons.js";
 import { BlockKitMediaPickerField } from "./BlockKitMediaPickerField";
 import { CodeBlockExtension } from "./editor/CodeBlockNode";
 import { DragHandleWrapper } from "./editor/DragHandleWrapper";
+import { HeadingDropdownMenu } from "./editor/HeadingDropdownMenu";
 import { HtmlBlockExtension } from "./editor/HtmlBlockNode";
 import { ImageExtension } from "./editor/ImageNode";
 import { MarkdownLinkExtension } from "./editor/MarkdownLinkExtension";
@@ -3018,9 +3019,6 @@ function EditorToolbar({
 			isUnderline: ctx.editor.isActive("underline"),
 			isStrike: ctx.editor.isActive("strike"),
 			isCode: ctx.editor.isActive("code"),
-			isHeading1: ctx.editor.isActive("heading", { level: 1 }),
-			isHeading2: ctx.editor.isActive("heading", { level: 2 }),
-			isHeading3: ctx.editor.isActive("heading", { level: 3 }),
 			isBulletList: ctx.editor.isActive("bulletList"),
 			isOrderedList: ctx.editor.isActive("orderedList"),
 			isBlockquote: ctx.editor.isActive("blockquote"),
@@ -3193,27 +3191,7 @@ function EditorToolbar({
 
 			{/* Headings */}
 			<ToolbarGroup>
-				<ToolbarButton
-					onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-					active={editorState.isHeading1}
-					title={t`Heading 1`}
-				>
-					<TextHOne className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
-				<ToolbarButton
-					onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-					active={editorState.isHeading2}
-					title={t`Heading 2`}
-				>
-					<TextHTwo className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
-				<ToolbarButton
-					onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-					active={editorState.isHeading3}
-					title={t`Heading 3`}
-				>
-					<TextHThree className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
+				<HeadingDropdownMenu editor={editor} levels={[1, 2, 3]} />
 			</ToolbarGroup>
 
 			<ToolbarSeparator />

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1372,8 +1372,8 @@ function SlashCommandMenu({
 						className={cn(
 							"flex items-center gap-3 w-full px-3 py-2 text-sm rounded text-start",
 							index === state.selectedIndex
-								? "bg-kumo-tint text-kumo-default"
-								: "hover:bg-kumo-tint/50",
+								? "bg-kumo-interact text-kumo-default"
+								: "hover:bg-kumo-interact",
 						)}
 						onClick={() => onCommand(item)}
 						onMouseEnter={() => {

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -169,12 +169,13 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 					>
 						<Plus className="h-4 w-4" aria-hidden="true" />
 					</Button>
-					<button
+					<Button
 						ref={handleRef}
 						type="button"
+						variant="ghost"
+						shape="square"
 						className={cn(
-							"flex items-center justify-center",
-							"w-6 h-6 rounded select-none",
+							"h-6 w-6 flex-none rounded select-none",
 							"text-kumo-subtle/50 hover:text-kumo-subtle",
 							"hover:bg-kumo-tint/80 cursor-grab active:cursor-grabbing",
 							"transition-colors duration-100",
@@ -184,8 +185,8 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 						data-block-handle
 						aria-label={t`Block actions - drag to reorder, click for menu`}
 					>
-						<DotsSixVertical className="h-4 w-4" />
-					</button>
+						<DotsSixVertical className="h-4 w-4" aria-hidden="true" />
+					</Button>
 				</div>
 			</DragHandle>
 

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -17,6 +17,7 @@ import type { Node as PMNode } from "@tiptap/pm/model";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
+import { getLocaleDir } from "../../locales/config.js";
 import { BlockMenu } from "./BlockMenu";
 
 interface DragHandleWrapperProps {
@@ -29,17 +30,6 @@ interface HoveredNode {
 	pos: number;
 }
 
-// Extend Editor commands type to include DragHandle commands
-declare module "@tiptap/core" {
-	interface Commands<ReturnType> {
-		dragHandle: {
-			lockDragHandle: () => ReturnType;
-			unlockDragHandle: () => ReturnType;
-			toggleDragHandle: () => ReturnType;
-		};
-	}
-}
-
 export function _getDragHandlePlacement(direction: "ltr" | "rtl") {
 	return direction === "rtl" ? ("right-start" as const) : ("left-start" as const);
 }
@@ -48,15 +38,40 @@ export function _getDragHandlePlacement(direction: "ltr" | "rtl") {
  * DragHandleWrapper - Official TipTap drag handle with BlockMenu integration
  */
 export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperProps) {
-	const { t } = useLingui();
-	const direction =
-		editor.view.dom.ownerDocument.defaultView?.getComputedStyle(editor.view.dom).direction === "rtl"
-			? "rtl"
-			: "ltr";
+	const { i18n, t } = useLingui();
+	const direction = getLocaleDir(i18n.locale);
 	const [hoveredNode, setHoveredNode] = React.useState<HoveredNode | null>(null);
 	const [menuOpen, setMenuOpen] = React.useState(false);
 	const [menuAnchor, setMenuAnchor] = React.useState<HTMLElement | null>(null);
 	const handleRef = React.useRef<HTMLButtonElement>(null);
+	const insertPressLockedRef = React.useRef(false);
+
+	const disableDrag = React.useCallback(
+		(e: React.PointerEvent<HTMLButtonElement>) => {
+			e.stopPropagation();
+			if (!insertPressLockedRef.current) {
+				insertPressLockedRef.current = true;
+				editor.commands.setMeta("lockDragHandle", true);
+			}
+		},
+		[editor],
+	);
+
+	const restoreDrag = React.useCallback(() => {
+		if (insertPressLockedRef.current) {
+			insertPressLockedRef.current = false;
+			editor.commands.setMeta("lockDragHandle", menuOpen);
+		}
+	}, [editor, menuOpen]);
+
+	React.useEffect(() => {
+		window.addEventListener("pointerup", restoreDrag, true);
+		window.addEventListener("pointercancel", restoreDrag, true);
+		return () => {
+			window.removeEventListener("pointerup", restoreDrag, true);
+			window.removeEventListener("pointercancel", restoreDrag, true);
+		};
+	}, [restoreDrag]);
 
 	// Handle click on drag handle to open menu
 	const handleClick = React.useCallback(
@@ -74,7 +89,7 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 			setMenuOpen(true);
 
 			// Lock the drag handle so it stays visible while menu is open
-			editor.commands.lockDragHandle();
+			editor.commands.setMeta("lockDragHandle", true);
 		},
 		[editor, hoveredNode],
 	);
@@ -94,7 +109,7 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 	const handleCloseMenu = React.useCallback(() => {
 		setMenuOpen(false);
 		setMenuAnchor(null);
-		editor.commands.unlockDragHandle();
+		editor.commands.setMeta("lockDragHandle", false);
 	}, [editor]);
 
 	// Handle node change from drag handle
@@ -130,13 +145,16 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 				onNodeChange={handleNodeChange}
 				computePositionConfig={computePositionConfig}
 			>
-				<div className="flex translate-y-0.5 items-center gap-0">
+				<div className="flex translate-y-0.5 items-center gap-0 rtl:flex-row-reverse">
 					<Button
 						type="button"
 						variant="ghost"
 						shape="square"
 						className="h-6 w-6 text-kumo-subtle/50 hover:text-kumo-subtle"
-						onPointerDown={(e) => e.stopPropagation()}
+						onPointerDown={disableDrag}
+						onPointerUp={restoreDrag}
+						onPointerCancel={restoreDrag}
+						onBlur={restoreDrag}
 						onMouseDown={(e) => {
 							e.preventDefault();
 							e.stopPropagation();

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -9,6 +9,7 @@
  */
 
 import { Button } from "@cloudflare/kumo";
+import { offset } from "@floating-ui/react";
 import { useLingui } from "@lingui/react/macro";
 import { DotsSixVertical, Plus } from "@phosphor-icons/react";
 import type { Editor } from "@tiptap/core";
@@ -134,6 +135,7 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 		() => ({
 			placement: _getDragHandlePlacement(direction),
 			strategy: "absolute" as const,
+			middleware: [offset(4)],
 		}),
 		[direction],
 	);

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -8,8 +8,9 @@
  * - Block menu integration for transforms, duplicate, delete
  */
 
+import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { DotsSixVertical } from "@phosphor-icons/react";
+import { DotsSixVertical, Plus } from "@phosphor-icons/react";
 import type { Editor } from "@tiptap/core";
 import { DragHandle } from "@tiptap/extension-drag-handle-react";
 import type { Node as PMNode } from "@tiptap/pm/model";
@@ -20,6 +21,7 @@ import { BlockMenu } from "./BlockMenu";
 
 interface DragHandleWrapperProps {
 	editor: Editor;
+	onInsertBlock: (insertPos: number) => void;
 }
 
 interface HoveredNode {
@@ -38,11 +40,19 @@ declare module "@tiptap/core" {
 	}
 }
 
+export function _getDragHandlePlacement(direction: "ltr" | "rtl") {
+	return direction === "rtl" ? ("right-start" as const) : ("left-start" as const);
+}
+
 /**
  * DragHandleWrapper - Official TipTap drag handle with BlockMenu integration
  */
-export function DragHandleWrapper({ editor }: DragHandleWrapperProps) {
+export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperProps) {
 	const { t } = useLingui();
+	const direction =
+		editor.view.dom.ownerDocument.defaultView?.getComputedStyle(editor.view.dom).direction === "rtl"
+			? "rtl"
+			: "ltr";
 	const [hoveredNode, setHoveredNode] = React.useState<HoveredNode | null>(null);
 	const [menuOpen, setMenuOpen] = React.useState(false);
 	const [menuAnchor, setMenuAnchor] = React.useState<HTMLElement | null>(null);
@@ -67,6 +77,17 @@ export function DragHandleWrapper({ editor }: DragHandleWrapperProps) {
 			editor.commands.lockDragHandle();
 		},
 		[editor, hoveredNode],
+	);
+
+	const handleInsertClick = React.useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			if (!hoveredNode) return;
+
+			onInsertBlock(hoveredNode.pos + hoveredNode.node.nodeSize);
+		},
+		[hoveredNode, onInsertBlock],
 	);
 
 	// Close the menu
@@ -96,10 +117,10 @@ export function DragHandleWrapper({ editor }: DragHandleWrapperProps) {
 	// tears down the Suggestion plugin view (calling onExit → setState → loop).
 	const computePositionConfig = React.useMemo(
 		() => ({
-			placement: "left-start" as const,
+			placement: _getDragHandlePlacement(direction),
 			strategy: "absolute" as const,
 		}),
-		[],
+		[direction],
 	);
 
 	return (
@@ -109,23 +130,45 @@ export function DragHandleWrapper({ editor }: DragHandleWrapperProps) {
 				onNodeChange={handleNodeChange}
 				computePositionConfig={computePositionConfig}
 			>
-				<button
-					ref={handleRef}
-					type="button"
-					className={cn(
-						"flex items-center justify-center",
-						"w-6 h-6 rounded select-none",
-						"text-kumo-subtle/50 hover:text-kumo-subtle",
-						"hover:bg-kumo-tint/80 cursor-grab active:cursor-grabbing",
-						"transition-colors duration-100",
-						menuOpen && "text-kumo-subtle bg-kumo-tint",
-					)}
-					onClick={handleClick}
-					data-block-handle
-					aria-label={t`Block actions - drag to reorder, click for menu`}
-				>
-					<DotsSixVertical className="h-4 w-4" />
-				</button>
+				<div className="flex translate-y-0.5 items-center gap-0">
+					<Button
+						type="button"
+						variant="ghost"
+						shape="square"
+						className="h-6 w-6 text-kumo-subtle/50 hover:text-kumo-subtle"
+						onPointerDown={(e) => e.stopPropagation()}
+						onMouseDown={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+						}}
+						onDragStart={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+						}}
+						draggable={false}
+						onClick={handleInsertClick}
+						aria-label={t`Insert block below`}
+					>
+						<Plus className="h-4 w-4" aria-hidden="true" />
+					</Button>
+					<button
+						ref={handleRef}
+						type="button"
+						className={cn(
+							"flex items-center justify-center",
+							"w-6 h-6 rounded select-none",
+							"text-kumo-subtle/50 hover:text-kumo-subtle",
+							"hover:bg-kumo-tint/80 cursor-grab active:cursor-grabbing",
+							"transition-colors duration-100",
+							menuOpen && "text-kumo-subtle bg-kumo-tint",
+						)}
+						onClick={handleClick}
+						data-block-handle
+						aria-label={t`Block actions - drag to reorder, click for menu`}
+					>
+						<DotsSixVertical className="h-4 w-4" />
+					</button>
+				</div>
 			</DragHandle>
 
 			{/* Block menu */}

--- a/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
+++ b/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
@@ -1,0 +1,170 @@
+import { Button, DropdownMenu } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import {
+	CaretDown,
+	TextH,
+	TextHFive,
+	TextHFour,
+	TextHOne,
+	TextHSix,
+	TextHThree,
+	TextHTwo,
+	type Icon,
+} from "@phosphor-icons/react";
+import type { Editor } from "@tiptap/core";
+import { useEditorState } from "@tiptap/react";
+import * as React from "react";
+
+import { cn } from "../../lib/utils.js";
+
+/**
+ * TipTap's heading-dropdown-menu API adapted to EmDash's Kumo primitives.
+ * Source pattern: `npx @tiptap/cli add heading-dropdown-menu`.
+ */
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+const DEFAULT_LEVELS: readonly HeadingLevel[] = [1, 2, 3, 4, 5, 6];
+
+const HEADING_ICONS: Record<HeadingLevel, Icon> = {
+	1: TextHOne,
+	2: TextHTwo,
+	3: TextHThree,
+	4: TextHFour,
+	5: TextHFive,
+	6: TextHSix,
+};
+
+export function getActiveHeadingLevel(
+	editor: Editor | null,
+	levels: readonly HeadingLevel[] = DEFAULT_LEVELS,
+): HeadingLevel | undefined {
+	if (!editor || !editor.isEditable) return undefined;
+	return levels.find((level) => editor.isActive("heading", { level }));
+}
+
+function canToggleHeading(editor: Editor | null, levels: readonly HeadingLevel[]): boolean {
+	if (!editor || !editor.isEditable || !editor.schema.nodes.heading) return false;
+	return levels.some(
+		(level) => editor.can().setNode("heading", { level }) || editor.can().clearNodes(),
+	);
+}
+
+function toggleHeading(editor: Editor | null, level: HeadingLevel): boolean {
+	if (!editor || !canToggleHeading(editor, [level])) return false;
+	return editor.chain().focus().toggleHeading({ level }).run();
+}
+
+export interface UseHeadingDropdownMenuConfig {
+	editor?: Editor | null;
+	levels?: readonly HeadingLevel[];
+	hideWhenUnavailable?: boolean;
+}
+
+export function useHeadingDropdownMenu(config: UseHeadingDropdownMenuConfig = {}) {
+	const { editor = null, levels = DEFAULT_LEVELS, hideWhenUnavailable = false } = config;
+
+	const state = useEditorState({
+		editor,
+		selector: ({ editor: currentEditor }) => {
+			const activeLevel = getActiveHeadingLevel(currentEditor, levels);
+			const canToggle = canToggleHeading(currentEditor, levels);
+			return {
+				activeLevel,
+				isActive: activeLevel !== undefined,
+				canToggle,
+				isVisible: !hideWhenUnavailable || canToggle,
+			};
+		},
+	});
+
+	const activeLevel = state?.activeLevel;
+
+	return {
+		isVisible: state?.isVisible ?? !hideWhenUnavailable,
+		activeLevel,
+		isActive: state?.isActive ?? false,
+		canToggle: state?.canToggle ?? false,
+		levels,
+		Icon: activeLevel ? HEADING_ICONS[activeLevel] : TextH,
+	};
+}
+
+export interface HeadingDropdownMenuProps extends UseHeadingDropdownMenuConfig {
+	className?: string;
+	onOpenChange?: (isOpen: boolean) => void;
+}
+
+export const HeadingDropdownMenu = React.forwardRef<HTMLButtonElement, HeadingDropdownMenuProps>(
+	function HeadingDropdownMenu(
+		{
+			editor = null,
+			levels = DEFAULT_LEVELS,
+			hideWhenUnavailable = false,
+			className,
+			onOpenChange,
+		},
+		ref,
+	) {
+		const { t } = useLingui();
+		const [open, setOpen] = React.useState(false);
+		const { isVisible, activeLevel, isActive, canToggle, Icon } = useHeadingDropdownMenu({
+			editor,
+			levels,
+			hideWhenUnavailable,
+		});
+
+		const handleOpenChange = React.useCallback(
+			(nextOpen: boolean) => {
+				if (nextOpen && !canToggle) return;
+				setOpen(nextOpen);
+				onOpenChange?.(nextOpen);
+			},
+			[canToggle, onOpenChange],
+		);
+
+		if (!isVisible) return null;
+
+		return (
+			<DropdownMenu open={open} onOpenChange={handleOpenChange}>
+				<DropdownMenu.Trigger
+					render={
+						<Button
+							ref={ref}
+							type="button"
+							variant="ghost"
+							className={cn(
+								"h-8 min-w-11 flex-none gap-0.5 px-2",
+								isActive && "bg-kumo-tint text-kumo-default",
+								className,
+							)}
+							disabled={!canToggle}
+							onMouseDown={(event) => event.preventDefault()}
+							aria-label={t`Headings`}
+							aria-pressed={isActive}
+						>
+							<Icon className="h-4 w-4" aria-hidden="true" />
+							<CaretDown className="h-3 w-3" aria-hidden="true" />
+						</Button>
+					}
+				/>
+				<DropdownMenu.Content align="start" className="min-w-44">
+					{levels.map((level) => {
+						const HeadingIcon = HEADING_ICONS[level];
+						return (
+						<DropdownMenu.Item
+							key={level}
+							icon={HeadingIcon}
+							selected={activeLevel === level}
+							data-emdash-heading-item
+							onClick={() => toggleHeading(editor, level)}
+							>
+								{t`Heading ${level}`}
+							</DropdownMenu.Item>
+						);
+					})}
+				</DropdownMenu.Content>
+			</DropdownMenu>
+		);
+	},
+);

--- a/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
+++ b/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
@@ -141,7 +141,8 @@ export const HeadingDropdownMenu = React.forwardRef<HTMLButtonElement, HeadingDr
 							disabled={!canToggle}
 							onMouseDown={(event) => event.preventDefault()}
 							aria-label={t`Headings`}
-							aria-pressed={isActive}
+							aria-haspopup="menu"
+							aria-expanded={open}
 						>
 							<Icon className="h-4 w-4" aria-hidden="true" />
 							<CaretDown className="h-3 w-3" aria-hidden="true" />
@@ -152,12 +153,12 @@ export const HeadingDropdownMenu = React.forwardRef<HTMLButtonElement, HeadingDr
 					{levels.map((level) => {
 						const HeadingIcon = HEADING_ICONS[level];
 						return (
-						<DropdownMenu.Item
-							key={level}
-							icon={HeadingIcon}
-							selected={activeLevel === level}
-							data-emdash-heading-item
-							onClick={() => toggleHeading(editor, level)}
+							<DropdownMenu.Item
+								key={level}
+								icon={HeadingIcon}
+								selected={activeLevel === level}
+								data-emdash-heading-item
+								onClick={() => toggleHeading(editor, level)}
 							>
 								{t`Heading ${level}`}
 							</DropdownMenu.Item>

--- a/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
+++ b/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
@@ -1,4 +1,6 @@
 import { Button, DropdownMenu } from "@cloudflare/kumo";
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	CaretDown,
@@ -25,6 +27,15 @@ import { cn } from "../../lib/utils.js";
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
 const DEFAULT_LEVELS: readonly HeadingLevel[] = [1, 2, 3, 4, 5, 6];
+
+const HEADING_LABELS: Record<HeadingLevel, MessageDescriptor> = {
+	1: msg`Heading 1`,
+	2: msg`Heading 2`,
+	3: msg`Heading 3`,
+	4: msg`Heading 4`,
+	5: msg`Heading 5`,
+	6: msg`Heading 6`,
+};
 
 const HEADING_ICONS: Record<HeadingLevel, Icon> = {
 	1: TextHOne,
@@ -160,7 +171,7 @@ export const HeadingDropdownMenu = React.forwardRef<HTMLButtonElement, HeadingDr
 								data-emdash-heading-item
 								onClick={() => toggleHeading(editor, level)}
 							>
-								{t`Heading ${level}`}
+								{t(HEADING_LABELS[level])}
 							</DropdownMenu.Item>
 						);
 					})}

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -224,11 +224,6 @@ body {
 	transition: opacity 0.2s ease;
 }
 
-/* Add left padding to accommodate block handles */
-.ProseMirror {
-	padding-left: 2.5rem;
-}
-
 /* Block dragging styles */
 .ProseMirror .dragging {
 	opacity: 0.5;

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -110,6 +110,11 @@ body {
 	color: var(--text-color-kumo-default);
 }
 
+/* Keep heading choices visibly distinct from the dropdown surface. */
+[data-emdash-heading-item][data-highlighted] {
+	background-color: var(--color-kumo-interact) !important;
+}
+
 /* Transitions.dev — Text states swap */
 :root {
 	--text-swap-dur: 150ms;

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -319,6 +319,11 @@ body {
 	cursor: col-resize;
 }
 
+/* TipTap owns slash-menu focus, so Base UI's portal guards must not enter the Tab order. */
+.slash-command-menu-positioner > [data-base-ui-focus-guard] {
+	display: none;
+}
+
 /**
  * Prevent dialogs from overflowing the viewport on small screens.
  * Kumo's size variants set min-width (e.g. min-w-[32rem] for "lg")

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -215,6 +215,16 @@ describe("ContentEditor", () => {
 		portableTextProps.current = null;
 	});
 
+	it("uses a task-oriented placeholder for portable text fields", async () => {
+		await renderEditor({
+			isNew: false,
+			item: makeItem(),
+			fields: { content: { kind: "portableText", label: "Content" } },
+		});
+
+		expect(portableTextProps.current?.placeholder).toBe("Type / for commands");
+	});
+
 	describe("block panel + mobile sheet sync", () => {
 		const ptFields: Record<string, FieldDescriptor> = {
 			content: { kind: "portableText", label: "Content" },

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -222,7 +222,7 @@ describe("ContentEditor", () => {
 			fields: { content: { kind: "portableText", label: "Content" } },
 		});
 
-		expect(portableTextProps.current?.placeholder).toBe("Type / for commands");
+		expect(portableTextProps.current?.placeholder).toBe("Start writing, or type '/' for commands");
 	});
 
 	describe("block panel + mobile sheet sync", () => {

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -1,0 +1,32 @@
+import type { Editor } from "@tiptap/core";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DragHandleWrapper } from "../../src/components/editor/DragHandleWrapper";
+import { render } from "../utils/render";
+
+vi.mock("@tiptap/extension-drag-handle-react", () => ({
+	DragHandle: ({ children }: { children: React.ReactNode }) => (
+		<div draggable="true">{children}</div>
+	),
+}));
+
+vi.mock("../../src/components/editor/BlockMenu", () => ({
+	BlockMenu: () => null,
+}));
+
+describe("DragHandleWrapper interactions", () => {
+	it("prevents the insert button from starting a native block drag", async () => {
+		const editorElement = document.createElement("div");
+		const editor = {
+			view: { dom: editorElement },
+		} as unknown as Editor;
+		const screen = await render(<DragHandleWrapper editor={editor} onInsertBlock={vi.fn()} />);
+		const insertButton = screen.getByRole("button", { name: "Insert block below" }).element();
+		const mouseDown = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+
+		insertButton.dispatchEvent(mouseDown);
+
+		expect(mouseDown.defaultPrevented).toBe(true);
+	});
+});

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import type { Editor } from "@tiptap/core";
 import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -6,8 +7,16 @@ import { DragHandleWrapper } from "../../src/components/editor/DragHandleWrapper
 import { render } from "../utils/render";
 
 vi.mock("@tiptap/extension-drag-handle-react", () => ({
-	DragHandle: ({ children }: { children: React.ReactNode }) => (
-		<div draggable="true">{children}</div>
+	DragHandle: ({
+		children,
+		computePositionConfig,
+	}: {
+		children: React.ReactNode;
+		computePositionConfig: { placement: string };
+	}) => (
+		<div className="drag-handle" draggable="true" data-placement={computePositionConfig.placement}>
+			{children}
+		</div>
 	),
 }));
 
@@ -16,17 +25,59 @@ vi.mock("../../src/components/editor/BlockMenu", () => ({
 }));
 
 describe("DragHandleWrapper interactions", () => {
-	it("prevents the insert button from starting a native block drag", async () => {
+	it("disables native block dragging while pressing the insert button", async () => {
 		const editorElement = document.createElement("div");
+		const setMeta = vi.fn((_key: string, locked: boolean) => {
+			const dragHandle = document.querySelector<HTMLElement>(".drag-handle");
+			if (dragHandle) dragHandle.draggable = !locked;
+			return true;
+		});
 		const editor = {
 			view: { dom: editorElement },
+			commands: { setMeta },
 		} as unknown as Editor;
 		const screen = await render(<DragHandleWrapper editor={editor} onInsertBlock={vi.fn()} />);
 		const insertButton = screen.getByRole("button", { name: "Insert block below" }).element();
-		const mouseDown = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+		const dragHandle = insertButton.closest<HTMLElement>(".drag-handle");
+		expect(dragHandle).not.toBe(insertButton);
+		expect(dragHandle?.draggable).toBe(true);
 
-		insertButton.dispatchEvent(mouseDown);
+		insertButton.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+		expect(setMeta).toHaveBeenLastCalledWith("lockDragHandle", true);
+		expect(dragHandle?.draggable).toBe(false);
 
-		expect(mouseDown.defaultPrevented).toBe(true);
+		window.dispatchEvent(new PointerEvent("pointerup"));
+		expect(setMeta).toHaveBeenLastCalledWith("lockDragHandle", false);
+		expect(dragHandle?.draggable).toBe(true);
+	});
+
+	it("places and orders controls from the admin UI direction", async () => {
+		const previousLocale = i18n.locale;
+		i18n.load("ar", {});
+		i18n.load("en", {});
+		i18n.activate("en");
+		const editorElement = document.createElement("div");
+		editorElement.dir = "ltr";
+		const editor = {
+			view: { dom: editorElement },
+		} as unknown as Editor;
+
+		try {
+			const screen = await render(<DragHandleWrapper editor={editor} onInsertBlock={vi.fn()} />);
+			const insertButton = screen.getByRole("button", { name: "Insert block below" }).element();
+			expect(insertButton.closest("[data-placement]")?.getAttribute("data-placement")).toBe(
+				"left-start",
+			);
+
+			i18n.activate("ar");
+			await vi.waitFor(() => {
+				expect(insertButton.closest("[data-placement]")?.getAttribute("data-placement")).toBe(
+					"right-start",
+				);
+			});
+			expect(insertButton.parentElement?.className).toContain("rtl:flex-row-reverse");
+		} finally {
+			i18n.activate(previousLocale);
+		}
 	});
 });

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -14,16 +14,16 @@ vi.mock("@tiptap/extension-drag-handle-react", () => ({
 		children: React.ReactNode;
 		computePositionConfig: {
 			placement: string;
-			middleware?: Array<{ name: string; options?: unknown[] }>;
+			middleware?: Array<{ name: string; options?: [number?] }>;
 		};
 	}) => (
 		<div
 			className="drag-handle"
 			draggable="true"
 			data-placement={computePositionConfig.placement}
-			data-offset={String(
-				computePositionConfig.middleware?.find(({ name }) => name === "offset")?.options?.[0] ?? "",
-			)}
+			data-offset={
+				computePositionConfig.middleware?.find(({ name }) => name === "offset")?.options?.[0] ?? ""
+			}
 		>
 			{children}
 		</div>

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -12,9 +12,19 @@ vi.mock("@tiptap/extension-drag-handle-react", () => ({
 		computePositionConfig,
 	}: {
 		children: React.ReactNode;
-		computePositionConfig: { placement: string };
+		computePositionConfig: {
+			placement: string;
+			middleware?: Array<{ name: string; options?: unknown[] }>;
+		};
 	}) => (
-		<div className="drag-handle" draggable="true" data-placement={computePositionConfig.placement}>
+		<div
+			className="drag-handle"
+			draggable="true"
+			data-placement={computePositionConfig.placement}
+			data-offset={String(
+				computePositionConfig.middleware?.find(({ name }) => name === "offset")?.options?.[0] ?? "",
+			)}
+		>
 			{children}
 		</div>
 	),
@@ -86,6 +96,7 @@ describe("DragHandleWrapper interactions", () => {
 			expect(insertButton.closest("[data-placement]")?.getAttribute("data-placement")).toBe(
 				"left-start",
 			);
+			expect(insertButton.closest("[data-offset]")?.getAttribute("data-offset")).toBe("4");
 
 			i18n.activate("ar");
 			await vi.waitFor(() => {

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -25,6 +25,24 @@ vi.mock("../../src/components/editor/BlockMenu", () => ({
 }));
 
 describe("DragHandleWrapper interactions", () => {
+	it("uses Kumo buttons for both drag-handle controls", async () => {
+		const editor = {
+			view: { dom: document.createElement("div") },
+		} as unknown as Editor;
+		const screen = await render(<DragHandleWrapper editor={editor} onInsertBlock={vi.fn()} />);
+
+		await expect
+			.element(screen.getByRole("button", { name: "Insert block below" }))
+			.toHaveAttribute("data-kumo-component", "Button");
+		await expect
+			.element(
+				screen.getByRole("button", {
+					name: "Block actions - drag to reorder, click for menu",
+				}),
+			)
+			.toHaveAttribute("data-kumo-component", "Button");
+	});
+
 	it("disables native block dragging while pressing the insert button", async () => {
 		const editorElement = document.createElement("div");
 		const setMeta = vi.fn((_key: string, locked: boolean) => {

--- a/packages/admin/tests/editor/DragHandleWrapper.test.ts
+++ b/packages/admin/tests/editor/DragHandleWrapper.test.ts
@@ -1,10 +1,46 @@
+import { Editor } from "@tiptap/core";
+import { DragHandlePlugin, normalizeNestedOptions } from "@tiptap/extension-drag-handle";
+import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
 
 import { _getDragHandlePlacement } from "../../src/components/editor/DragHandleWrapper";
 
 describe("DragHandleWrapper", () => {
-	it("places controls at the content's logical start edge", () => {
+	it("places controls at the admin UI's logical start edge", () => {
 		expect(_getDragHandlePlacement("ltr")).toBe("left-start");
 		expect(_getDragHandlePlacement("rtl")).toBe("right-start");
+	});
+
+	it("locks the real drag plugin through core transaction metadata", () => {
+		const host = document.createElement("div");
+		const editorElement = document.createElement("div");
+		const dragElement = document.createElement("div");
+		host.append(editorElement);
+		document.body.append(host);
+		const editor = new Editor({
+			element: editorElement,
+			extensions: [StarterKit],
+			content: "<p>Test</p>",
+		});
+		const dragPlugin = DragHandlePlugin({
+			editor,
+			element: dragElement,
+			nestedOptions: normalizeNestedOptions(false),
+		});
+
+		try {
+			editor.registerPlugin(dragPlugin.plugin);
+			expect(dragElement.draggable).toBe(true);
+
+			editor.commands.setMeta("lockDragHandle", true);
+			expect(dragElement.draggable).toBe(false);
+
+			editor.commands.setMeta("lockDragHandle", false);
+			expect(dragElement.draggable).toBe(true);
+		} finally {
+			dragPlugin.unbind();
+			editor.destroy();
+			host.remove();
+		}
 	});
 });

--- a/packages/admin/tests/editor/DragHandleWrapper.test.ts
+++ b/packages/admin/tests/editor/DragHandleWrapper.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { _getDragHandlePlacement } from "../../src/components/editor/DragHandleWrapper";
+
+describe("DragHandleWrapper", () => {
+	it("places controls at the content's logical start edge", () => {
+		expect(_getDragHandlePlacement("ltr")).toBe("left-start");
+		expect(_getDragHandlePlacement("rtl")).toBe("right-start");
+	});
+});

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -682,13 +682,14 @@ describe("Toolbar", () => {
 		await expect.element(screen.getByRole("button", { name: "Align Right" })).toBeInTheDocument();
 	});
 
-	it("has insert buttons", async () => {
+	it("keeps insertion-only actions out of the formatting toolbar", async () => {
 		const screen = await renderWithToolbar();
+		const toolbar = screen.getByRole("toolbar").element();
 		await expect.element(screen.getByRole("button", { name: "Insert Link" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Insert Image" })).toBeInTheDocument();
-		await expect
-			.element(screen.getByRole("button", { name: "Insert Horizontal Rule" }))
-			.toBeInTheDocument();
+		expect(toolbar.querySelector('[aria-label="Insert Table"]')).toBeNull();
+		expect(toolbar.querySelector('[aria-label="Insert Image"]')).toBeNull();
+		expect(toolbar.querySelector('[aria-label="Insert HTML"]')).toBeNull();
+		expect(toolbar.querySelector('[aria-label="Insert Horizontal Rule"]')).toBeNull();
 	});
 
 	it("has history buttons (initially disabled)", async () => {

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -450,6 +450,25 @@ describe("Portable Text ↔ ProseMirror conversion", () => {
 		expect(textContent.trim()).toBe("");
 	});
 
+	it("teaches slash commands in the default placeholder", async () => {
+		await render(<PortableTextEditor value={[]} />);
+		const pm = await waitForEditor();
+		const placeholder = pm.querySelector("[data-placeholder]");
+		expect(placeholder?.getAttribute("data-placeholder")).toBe("Type / for commands");
+	});
+
+	it("centers the writing column with responsive space for block controls", async () => {
+		await render(<PortableTextEditor value={[textBlock("Gutter spacing")]} />);
+		const pm = await waitForEditor();
+		expect(pm.className).toContain("w-full");
+		expect(pm.className).toContain("max-w-[calc(75ch+8rem)]");
+		expect(pm.className).toContain("mx-auto");
+		expect(pm.className).toContain("ps-14");
+		expect(pm.className).toContain("pe-14");
+		expect(pm.className).toContain("sm:ps-16");
+		expect(pm.className).toContain("sm:pe-16");
+	});
+
 	it("renders bold+italic text with multiple marks", async () => {
 		await render(
 			<PortableTextEditor value={[textBlock("Bold italic", { marks: ["strong", "em"] })]} />,

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -450,11 +450,13 @@ describe("Portable Text ↔ ProseMirror conversion", () => {
 		expect(textContent.trim()).toBe("");
 	});
 
-	it("teaches slash commands in the default placeholder", async () => {
+	it("teaches writing and slash commands in the default placeholder", async () => {
 		await render(<PortableTextEditor value={[]} />);
 		const pm = await waitForEditor();
 		const placeholder = pm.querySelector("[data-placeholder]");
-		expect(placeholder?.getAttribute("data-placeholder")).toBe("Type / for commands");
+		expect(placeholder?.getAttribute("data-placeholder")).toBe(
+			"Start writing, or type '/' for commands",
+		);
 	});
 
 	it("centers the writing column with responsive space for block controls", async () => {
@@ -652,11 +654,13 @@ describe("Toolbar", () => {
 		await expect.element(screen.getByRole("button", { name: "Inline Code" })).toBeInTheDocument();
 	});
 
-	it("has heading buttons", async () => {
+	it("has a heading menu", async () => {
 		const screen = await renderWithToolbar();
-		await expect.element(screen.getByRole("button", { name: "Heading 1" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Heading 2" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Heading 3" })).toBeInTheDocument();
+		const trigger = screen.getByRole("button", { name: "Headings" });
+		await trigger.click();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 1" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 2" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 3" })).toBeInTheDocument();
 	});
 
 	it("has list buttons", async () => {
@@ -740,19 +744,19 @@ describe("Toolbar", () => {
 		);
 	});
 
-	it("toggles Heading 1 aria-pressed when clicked", async () => {
+	it("changes the current block to Heading 1 from the heading menu", async () => {
 		const screen = await renderWithToolbar();
 		const pm = document.querySelector(".ProseMirror") as HTMLElement;
 		await focusEditor(pm);
 
-		const h1Btn = screen.getByRole("button", { name: "Heading 1" });
-		await expect.element(h1Btn).toHaveAttribute("aria-pressed", "false");
-
-		await h1Btn.click();
+		const trigger = screen.getByRole("button", { name: "Headings" });
+		await trigger.click();
+		await screen.getByRole("menuitem", { name: "Heading 1" }).click();
 
 		await vi.waitFor(
-			async () => {
-				await expect.element(h1Btn).toHaveAttribute("aria-pressed", "true");
+			() => {
+				expect(pm.querySelector("h1")).toBeTruthy();
+				expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
 			},
 			{ timeout: 2000 },
 		);

--- a/packages/admin/tests/editor/bubble-menu.test.tsx
+++ b/packages/admin/tests/editor/bubble-menu.test.tsx
@@ -212,7 +212,7 @@ async function waitForTableToolbar(): Promise<HTMLElement> {
 	let toolbar: HTMLElement | null = null;
 	await vi.waitFor(
 		() => {
-			toolbar = document.querySelector('[role="toolbar"][aria-label="Table controls"]');
+			toolbar = document.querySelector('[role="group"][aria-label="Table controls"]');
 			expect(toolbar).toBeTruthy();
 		},
 		{ timeout: 3000 },
@@ -427,22 +427,19 @@ describe("Bubble Menu", () => {
 		expect(getBubbleMenu()).toBeNull();
 	});
 
-	it("uses one keyboard-navigable Kumo toolbar with accessible table toggle state", async () => {
+	it("exposes accessible table actions and toggle state", async () => {
 		const { screen, editor, pm } = await renderEditor({ value: tableValue });
 		await focusTableCell(editor, pm);
 		await waitForTableToolbar();
 
 		const addBefore = screen.getByRole("button", { name: "Add column before" });
-		const addAfter = screen.getByRole("button", { name: "Add column after" });
 		const headerToggle = screen.getByRole("button", { name: "Toggle header row" });
+		await expect.element(addBefore).toBeVisible();
+		expect(addBefore.element().hasAttribute("aria-pressed")).toBe(false);
 		await expect.element(headerToggle).toHaveAttribute("aria-pressed", "true");
-
-		addBefore.element().focus();
-		await userEvent.keyboard("{ArrowRight}");
-		await vi.waitFor(() => expect(document.activeElement).toBe(addAfter.element()));
 	});
 
-	it("anchors each decorative table badge to an RTL-safe icon wrapper", async () => {
+	it("uses purpose-built icons for table insertion actions", async () => {
 		const { screen, editor, pm } = await renderEditor({ value: tableValue });
 		await focusTableCell(editor, pm);
 		await waitForTableToolbar();
@@ -454,29 +451,15 @@ describe("Bubble Menu", () => {
 			"Add row after",
 		]) {
 			const button = screen.getByRole("button", { name }).element();
-			const icon = button.querySelector<HTMLElement>("[data-emdash-composite-icon]");
-			expect(icon).toBeTruthy();
-			expect(icon?.className).toContain("relative");
-			expect(icon?.className).toContain("size-4");
-			expect(icon?.getAttribute("aria-hidden")).toBe("true");
-			const buttonRect = button.getBoundingClientRect();
-			const badgeRect = icon!.querySelectorAll("svg")[1]!.getBoundingClientRect();
-			expect(badgeRect.left).toBeGreaterThanOrEqual(buttonRect.left);
-			expect(badgeRect.right).toBeLessThanOrEqual(buttonRect.right);
-			expect(badgeRect.top).toBeGreaterThanOrEqual(buttonRect.top);
-			expect(badgeRect.bottom).toBeLessThanOrEqual(buttonRect.bottom);
+			expect(button.querySelectorAll("svg")).toHaveLength(1);
+			expect(button.querySelector(".absolute")).toBeNull();
 		}
 
-		const beforeBadge = screen
+		const beforeIcon = screen
 			.getByRole("button", { name: "Add column before" })
 			.element()
-			.querySelectorAll("svg")[1];
-		const afterBadge = screen
-			.getByRole("button", { name: "Add column after" })
-			.element()
-			.querySelectorAll("svg")[1];
-		expect(beforeBadge?.getAttribute("class")).toContain("-start-0.5");
-		expect(afterBadge?.getAttribute("class")).toContain("-end-0.5");
+			.querySelector("svg");
+		expect(beforeIcon?.getAttribute("class")).toContain("rtl:-scale-x-100");
 	});
 
 	it("shows formatting buttons: Bold, Italic, Underline, Strikethrough, Code", async () => {

--- a/packages/admin/tests/editor/bubble-menu.test.tsx
+++ b/packages/admin/tests/editor/bubble-menu.test.tsx
@@ -9,6 +9,7 @@
  * when there's a text selection in the editor.
  */
 
+import { CellSelection } from "@tiptap/pm/tables";
 import type { Editor } from "@tiptap/react";
 import { userEvent } from "@vitest/browser/context";
 import { describe, it, expect, vi } from "vitest";
@@ -104,6 +105,50 @@ const defaultValue = [
 	},
 ];
 
+const tableValue = [
+	{
+		_type: "table" as const,
+		_key: "table-1",
+		hasHeaderRow: true,
+		rows: [
+			{
+				_type: "tableRow" as const,
+				_key: "row-1",
+				cells: [
+					{
+						_type: "tableCell" as const,
+						_key: "cell-1",
+						content: [{ _type: "span" as const, _key: "table-span-1", text: "Header" }],
+						isHeader: true,
+					},
+					{
+						_type: "tableCell" as const,
+						_key: "cell-2",
+						content: [{ _type: "span" as const, _key: "table-span-2", text: "Other" }],
+						isHeader: true,
+					},
+				],
+			},
+			{
+				_type: "tableRow" as const,
+				_key: "row-2",
+				cells: [
+					{
+						_type: "tableCell" as const,
+						_key: "cell-3",
+						content: [{ _type: "span" as const, _key: "table-span-3", text: "Body" }],
+					},
+					{
+						_type: "tableCell" as const,
+						_key: "cell-4",
+						content: [{ _type: "span" as const, _key: "table-span-4", text: "Cell" }],
+					},
+				],
+			},
+		],
+	},
+];
+
 async function renderEditor(props: Partial<PortableTextEditorProps> = {}, scrollContainerTop = 0) {
 	let editorInstance: Editor | null = null;
 
@@ -143,6 +188,36 @@ async function focusAndSelectAll(editor: Editor, pm: HTMLElement) {
 	await vi.waitFor(() => expect(document.activeElement).toBe(pm), { timeout: 1000 });
 	editor.commands.focus();
 	editor.commands.selectAll();
+}
+
+function getTextPosition(editor: Editor, text: string): number {
+	let textPosition = 0;
+	editor.state.doc.descendants((node, position) => {
+		if (node.isText && node.text === text) {
+			textPosition = position;
+			return false;
+		}
+		return undefined;
+	});
+	return textPosition;
+}
+
+async function focusTableCell(editor: Editor, pm: HTMLElement, text = "Header") {
+	pm.focus();
+	editor.chain().focus().setTextSelection(getTextPosition(editor, text)).run();
+	await vi.waitFor(() => expect(editor.isActive("table")).toBe(true));
+}
+
+async function waitForTableToolbar(): Promise<HTMLElement> {
+	let toolbar: HTMLElement | null = null;
+	await vi.waitFor(
+		() => {
+			toolbar = document.querySelector('[role="toolbar"][aria-label="Table controls"]');
+			expect(toolbar).toBeTruthy();
+		},
+		{ timeout: 3000 },
+	);
+	return toolbar!;
 }
 
 /**
@@ -192,6 +267,30 @@ function getBubbleButton(menu: HTMLElement, label: string): HTMLButtonElement | 
 // =============================================================================
 
 describe("Bubble Menu", () => {
+	it("registers stable, independent plugins for both bubble menus", async () => {
+		const { editor, pm } = await renderEditor({ value: [...tableValue, ...defaultValue] });
+		const expectBubbleMenuPlugins = () => {
+			const pluginKeys = editor.state.plugins.map((plugin) => plugin.key);
+			expect(pluginKeys.filter((key) => key.startsWith("emdashInlineBubbleMenu"))).toHaveLength(1);
+			expect(pluginKeys.filter((key) => key.startsWith("emdashTableBubbleMenu"))).toHaveLength(1);
+		};
+
+		await vi.waitFor(expectBubbleMenuPlugins);
+		await focusTableCell(editor, pm);
+		await waitForTableToolbar();
+		expectBubbleMenuPlugins();
+
+		editor.chain().focus().setTextSelection(getTextPosition(editor, "Hello world")).run();
+		await vi.waitFor(() => {
+			expect(document.querySelector('[aria-label="Table controls"]')).toBeNull();
+		});
+		expectBubbleMenuPlugins();
+
+		await focusTableCell(editor, pm);
+		await waitForTableToolbar();
+		expectBubbleMenuPlugins();
+	});
+
 	it("appears when text is selected", async () => {
 		const { editor, pm } = await renderEditor();
 		await focusAndSelectAll(editor, pm);
@@ -254,6 +353,132 @@ describe("Bubble Menu", () => {
 		});
 	});
 
+	it("keeps table controls mounted, unclipped, and below obstructing sticky chrome", async () => {
+		const { screen, editor, pm } = await renderEditor({ value: tableValue });
+		await focusTableCell(editor, pm);
+
+		const tableToolbar = await waitForTableToolbar();
+		const floatingRoot = screen.container.querySelector("[data-emdash-editor-floating-root]");
+		const clippedSurface = screen.container.querySelector("[data-emdash-editor-surface]");
+		expect(floatingRoot).toBeTruthy();
+		expect(floatingRoot?.contains(tableToolbar)).toBe(true);
+		expect(clippedSurface?.contains(tableToolbar)).toBe(false);
+
+		await vi.waitFor(() => {
+			const selection = window.getSelection();
+			expect(selection?.rangeCount).toBe(1);
+			const selectionRect = selection!.getRangeAt(0).getBoundingClientRect();
+			const menuRect = tableToolbar.getBoundingClientRect();
+			const formattingToolbar = document.querySelector<HTMLElement>(
+				'[role="toolbar"][aria-label="Text formatting"]',
+			);
+			expect(menuRect.top).toBeGreaterThanOrEqual(selectionRect.bottom);
+			expect(menuRect.top).toBeGreaterThanOrEqual(
+				formattingToolbar!.getBoundingClientRect().bottom,
+			);
+		});
+	});
+
+	it("shows only inline formatting for a non-empty text selection inside a table", async () => {
+		const { editor, pm } = await renderEditor({ value: tableValue });
+		pm.focus();
+		const textPosition = getTextPosition(editor, "Body");
+		editor
+			.chain()
+			.focus()
+			.setTextSelection({ from: textPosition, to: textPosition + 4 })
+			.run();
+
+		await waitForBubbleMenu();
+		await vi.waitFor(() => {
+			expect(document.querySelector('[aria-label="Table controls"]')).toBeNull();
+		});
+	});
+
+	it("shows only table controls for a cell selection", async () => {
+		const { editor, pm } = await renderEditor({ value: tableValue });
+		pm.focus();
+		const cellPositions: number[] = [];
+		editor.state.doc.descendants((node, position) => {
+			if (node.type.name === "tableHeader" || node.type.name === "tableCell") {
+				cellPositions.push(position);
+			}
+		});
+		editor.view.dispatch(
+			editor.state.tr.setSelection(
+				CellSelection.create(editor.state.doc, cellPositions[0]!, cellPositions[3]!),
+			),
+		);
+		expect(editor.state.selection).toBeInstanceOf(CellSelection);
+
+		await waitForTableToolbar();
+		await vi.waitFor(() => expect(getBubbleMenu()).toBeNull());
+	});
+
+	it("hides inline formatting controls when the editor becomes read-only", async () => {
+		const { editor, pm } = await renderEditor();
+		editor.setEditable(false);
+		pm.tabIndex = 0;
+		pm.focus();
+		editor.commands.selectAll();
+		await new Promise((resolve) => setTimeout(resolve, 350));
+
+		expect(document.activeElement).toBe(pm);
+		expect(getBubbleMenu()).toBeNull();
+	});
+
+	it("uses one keyboard-navigable Kumo toolbar with accessible table toggle state", async () => {
+		const { screen, editor, pm } = await renderEditor({ value: tableValue });
+		await focusTableCell(editor, pm);
+		await waitForTableToolbar();
+
+		const addBefore = screen.getByRole("button", { name: "Add column before" });
+		const addAfter = screen.getByRole("button", { name: "Add column after" });
+		const headerToggle = screen.getByRole("button", { name: "Toggle header row" });
+		await expect.element(headerToggle).toHaveAttribute("aria-pressed", "true");
+
+		addBefore.element().focus();
+		await userEvent.keyboard("{ArrowRight}");
+		await vi.waitFor(() => expect(document.activeElement).toBe(addAfter.element()));
+	});
+
+	it("anchors each decorative table badge to an RTL-safe icon wrapper", async () => {
+		const { screen, editor, pm } = await renderEditor({ value: tableValue });
+		await focusTableCell(editor, pm);
+		await waitForTableToolbar();
+
+		for (const name of [
+			"Add column before",
+			"Add column after",
+			"Add row before",
+			"Add row after",
+		]) {
+			const button = screen.getByRole("button", { name }).element();
+			const icon = button.querySelector<HTMLElement>("[data-emdash-composite-icon]");
+			expect(icon).toBeTruthy();
+			expect(icon?.className).toContain("relative");
+			expect(icon?.className).toContain("size-4");
+			expect(icon?.getAttribute("aria-hidden")).toBe("true");
+			const buttonRect = button.getBoundingClientRect();
+			const badgeRect = icon!.querySelectorAll("svg")[1]!.getBoundingClientRect();
+			expect(badgeRect.left).toBeGreaterThanOrEqual(buttonRect.left);
+			expect(badgeRect.right).toBeLessThanOrEqual(buttonRect.right);
+			expect(badgeRect.top).toBeGreaterThanOrEqual(buttonRect.top);
+			expect(badgeRect.bottom).toBeLessThanOrEqual(buttonRect.bottom);
+		}
+
+		const beforeBadge = screen
+			.getByRole("button", { name: "Add column before" })
+			.element()
+			.querySelectorAll("svg")[1];
+		const afterBadge = screen
+			.getByRole("button", { name: "Add column after" })
+			.element()
+			.querySelectorAll("svg")[1];
+		expect(beforeBadge?.getAttribute("class")).toContain("-start-0.5");
+		expect(afterBadge?.getAttribute("class")).toContain("-end-0.5");
+	});
+
 	it("shows formatting buttons: Bold, Italic, Underline, Strikethrough, Code", async () => {
 		const { editor, pm } = await renderEditor();
 		await focusAndSelectAll(editor, pm);
@@ -281,11 +506,13 @@ describe("Bubble Menu", () => {
 
 		const menu = await waitForBubbleMenu();
 		const boldBtn = getBubbleButton(menu, "Bold")!;
+		expect(boldBtn.getAttribute("aria-pressed")).toBe("false");
 
 		boldBtn.click();
 
 		await vi.waitFor(() => {
 			expect(editor.isActive("bold")).toBe(true);
+			expect(boldBtn.getAttribute("aria-pressed")).toBe("true");
 		});
 
 		// Verify the text is wrapped in <strong>

--- a/packages/admin/tests/editor/bubble-menu.test.tsx
+++ b/packages/admin/tests/editor/bubble-menu.test.tsx
@@ -104,17 +104,25 @@ const defaultValue = [
 	},
 ];
 
-async function renderEditor(props: Partial<PortableTextEditorProps> = {}) {
+async function renderEditor(props: Partial<PortableTextEditorProps> = {}, scrollContainerTop = 0) {
 	let editorInstance: Editor | null = null;
 
 	const screen = await render(
-		<PortableTextEditor
-			value={defaultValue}
-			onEditorReady={(editor) => {
-				editorInstance = editor;
+		<div
+			style={{
+				marginTop: scrollContainerTop,
+				maxHeight: scrollContainerTop ? 500 : undefined,
+				overflowY: scrollContainerTop ? "auto" : undefined,
 			}}
-			{...props}
-		/>,
+		>
+			<PortableTextEditor
+				value={defaultValue}
+				onEditorReady={(editor) => {
+					editorInstance = editor;
+				}}
+				{...props}
+			/>
+		</div>,
 	);
 
 	await vi.waitFor(
@@ -190,6 +198,60 @@ describe("Bubble Menu", () => {
 
 		const menu = await waitForBubbleMenu();
 		expect(menu).toBeTruthy();
+	});
+
+	it("flips below a top-line selection when the sticky toolbar blocks the preferred position", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusAndSelectAll(editor, pm);
+
+		const menu = await waitForBubbleMenu();
+		const toolbar = document.querySelector<HTMLElement>(
+			'[role="toolbar"][aria-label="Text formatting"]',
+		);
+		expect(toolbar).toBeTruthy();
+
+		await vi.waitFor(() => {
+			const selection = window.getSelection();
+			expect(selection?.rangeCount).toBe(1);
+			const selectionRect = selection!.getRangeAt(0).getBoundingClientRect();
+			const menuRect = menu.getBoundingClientRect();
+			expect(menuRect.top).toBeGreaterThanOrEqual(selectionRect.bottom);
+			expect(menuRect.top).toBeGreaterThanOrEqual(toolbar!.getBoundingClientRect().bottom);
+		});
+	});
+
+	it("stays above the selection when there is room below the sticky toolbar", async () => {
+		const value = ["First line", "Second line", "Third line"].map((text, index) => ({
+			_type: "block" as const,
+			_key: String(index),
+			style: "normal" as const,
+			children: [{ _type: "span" as const, _key: `span-${index}`, text }],
+		}));
+		const { editor, pm } = await renderEditor({ value }, 58);
+		pm.focus();
+
+		let textPosition = 0;
+		editor.state.doc.descendants((node, position) => {
+			if (node.isText && node.text === "Third line") {
+				textPosition = position;
+				return false;
+			}
+			return undefined;
+		});
+		editor
+			.chain()
+			.focus()
+			.setTextSelection({ from: textPosition, to: textPosition + 10 })
+			.run();
+
+		const menu = await waitForBubbleMenu();
+		await vi.waitFor(() => {
+			const selection = window.getSelection();
+			expect(selection?.rangeCount).toBe(1);
+			const selectionRect = selection!.getRangeAt(0).getBoundingClientRect();
+			const menuRect = menu.getBoundingClientRect();
+			expect(menuRect.bottom).toBeLessThanOrEqual(selectionRect.top);
+		});
 	});
 
 	it("shows formatting buttons: Bold, Italic, Underline, Strikethrough, Code", async () => {

--- a/packages/admin/tests/editor/bubble-menu.test.tsx
+++ b/packages/admin/tests/editor/bubble-menu.test.tsx
@@ -601,6 +601,7 @@ describe("Bubble Menu", () => {
 		// Should have a URL input with placeholder
 		const input = menu.querySelector('input[type="url"]');
 		expect(input).toBeTruthy();
+		expect(input?.getAttribute("aria-label")).toBe("URL");
 	});
 
 	it("applies link URL when Apply button is clicked", async () => {

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -220,12 +220,10 @@ function getSlashMenuItems(menu: HTMLElement): HTMLButtonElement[] {
 
 /**
  * Check if an item is the selected/highlighted item.
- * Selected items use "bg-kumo-tint text-kumo-default" (space-separated).
- * Non-selected items use "hover:bg-kumo-tint/50".
+ * Selected items use the semantic interaction surface.
  */
 function isItemSelected(el: HTMLElement): boolean {
-	// Split className by spaces and check for exact "bg-kumo-tint" token
-	return el.className.split(WHITESPACE_SPLIT_REGEX).includes("bg-kumo-tint");
+	return el.className.split(WHITESPACE_SPLIT_REGEX).includes("bg-kumo-interact");
 }
 
 function isSlashSuggestionActive(editor: Editor): boolean {
@@ -489,6 +487,18 @@ describe("Slash Command Menu", () => {
 			},
 			{ timeout: 3000 },
 		);
+	});
+
+	it("uses the interaction surface for selected items", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+
+		const menu = await waitForSlashMenu();
+		const selectedItem = getSlashMenuItems(menu)[0]!;
+		const classes = selectedItem.className.split(WHITESPACE_SPLIT_REGEX);
+		expect(classes).toContain("bg-kumo-interact");
+		expect(classes).not.toContain("bg-kumo-tint");
 	});
 
 	it("moves selection down with ArrowDown", async () => {

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -484,6 +484,8 @@ describe("Slash Command Menu", () => {
 				const menu = getSlashMenu()!;
 				const items = getSlashMenuItems(menu);
 				expect(isItemSelected(items[0]!)).toBe(true);
+				expect(items[0]?.getAttribute("aria-current")).toBe("true");
+				expect(menu.querySelector('[role="status"]')?.textContent).toBe("Selected Heading 1");
 			},
 			{ timeout: 3000 },
 		);
@@ -502,6 +504,9 @@ describe("Slash Command Menu", () => {
 			const items = getSlashMenuItems(menu);
 			expect(isItemSelected(items[1]!)).toBe(true);
 			expect(isItemSelected(items[0]!)).toBe(false);
+			expect(items[1]?.getAttribute("aria-current")).toBe("true");
+			expect(items[0]?.hasAttribute("aria-current")).toBe(false);
+			expect(menu.querySelector('[role="status"]')?.textContent).toBe("Selected Heading 2");
 		});
 	});
 

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -181,13 +181,7 @@ async function focusEditor(pm: HTMLElement) {
 
 /** Get the slash menu portal element from document.body */
 function getSlashMenu(): HTMLElement | null {
-	const portals = document.querySelectorAll("body > div");
-	for (const el of portals) {
-		if (el.querySelector("[data-index]") || el.textContent?.includes("No results")) {
-			return el as HTMLElement;
-		}
-	}
-	return null;
+	return document.querySelector<HTMLElement>("[data-slash-command-menu]");
 }
 
 /** Wait for the slash menu to appear */
@@ -237,6 +231,77 @@ function isSlashSuggestionActive(editor: Editor): boolean {
 // =============================================================================
 
 describe("Slash Command Menu", () => {
+	it("keeps focus in the editor when the menu opens", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+
+		const menu = await waitForSlashMenu();
+		expect(document.activeElement).toBe(pm);
+
+		const focusGuards = menu.parentElement?.querySelectorAll("[data-base-ui-focus-guard]");
+		expect(focusGuards).toHaveLength(2);
+		expect(menu.parentElement?.classList.contains("slash-command-menu-positioner")).toBe(true);
+	});
+
+	it("uses a contained scroll viewport inside the menu shell", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+
+		const menu = await waitForSlashMenu();
+		const scrollViewport = menu.querySelector<HTMLElement>("[data-slash-menu-scroll-viewport]");
+
+		expect(scrollViewport).toBeTruthy();
+		expect(scrollViewport).not.toBe(menu);
+		expect(scrollViewport!.className.split(WHITESPACE_SPLIT_REGEX)).toEqual(
+			expect.arrayContaining(["overflow-y-auto", "overscroll-contain"]),
+		);
+		expect(menu.className.split(WHITESPACE_SPLIT_REGEX)).not.toContain("overflow-y-auto");
+	});
+
+	it("closes on Tab and lets focus leave the editor", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+		await waitForSlashMenu();
+		const nextFocusable = screen.getByRole("button", { name: "Test gutter insert" }).element();
+
+		await userEvent.keyboard("{Tab}");
+
+		await waitForSlashMenuClosed();
+		expect(document.activeElement).toBe(nextFocusable);
+		expect(editor.getText()).toBe("/");
+		expect(isSlashSuggestionActive(editor)).toBe(false);
+	});
+
+	it("closes on Shift+Tab and lets focus leave the editor", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+		await waitForSlashMenu();
+
+		await userEvent.keyboard("{Shift>}{Tab}{/Shift}");
+
+		await waitForSlashMenuClosed();
+		expect(document.activeElement).not.toBe(pm);
+		expect(editor.getText()).toBe("/");
+		expect(isSlashSuggestionActive(editor)).toBe(false);
+	});
+
+	it("closes a gutter-triggered menu on Tab without inserting content", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		const before = editor.getJSON();
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		await waitForSlashMenu();
+		await userEvent.keyboard("{Tab}");
+
+		await waitForSlashMenuClosed();
+		expect(editor.getJSON()).toEqual(before);
+	});
+
 	it("opens from the gutter and cancels without inserting a slash", async () => {
 		const { screen, editor, pm } = await renderEditor();
 		await focusEditor(pm);

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -10,6 +10,7 @@
  */
 
 import type { Editor } from "@tiptap/react";
+import { SuggestionPluginKey } from "@tiptap/suggestion";
 import { userEvent } from "@vitest/browser/context";
 import { describe, it, expect, vi } from "vitest";
 
@@ -227,6 +228,12 @@ function isItemSelected(el: HTMLElement): boolean {
 	return el.className.split(WHITESPACE_SPLIT_REGEX).includes("bg-kumo-tint");
 }
 
+function isSlashSuggestionActive(editor: Editor): boolean {
+	return Boolean(
+		(SuggestionPluginKey.getState(editor.state) as { active?: boolean } | undefined)?.active,
+	);
+}
+
 // =============================================================================
 // Slash Command Menu
 // =============================================================================
@@ -258,6 +265,49 @@ describe("Slash Command Menu", () => {
 
 		await waitForSlashMenuClosed();
 		expect(editor.getText()).toBe(before);
+	});
+
+	it("exits the slash suggestion plugin when clicking outside the menu", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+		await waitForSlashMenu();
+		expect(isSlashSuggestionActive(editor)).toBe(true);
+
+		pm.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+
+		await waitForSlashMenuClosed();
+		expect(isSlashSuggestionActive(editor)).toBe(false);
+	});
+
+	it("keeps slash suggestion dismissed when opening the gutter menu", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+		await waitForSlashMenu();
+
+		const gutterButton = screen.getByRole("button", { name: "Test gutter insert" }).element();
+		gutterButton.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+		gutterButton.click();
+		await waitForSlashMenu();
+		editor.view.dispatch(editor.state.tr.setMeta("test", true));
+
+		expect(isSlashSuggestionActive(editor)).toBe(false);
+		expect(getSlashMenu()).toBeTruthy();
+	});
+
+	it("records slash dismissal when opening the gutter menu from the keyboard", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+		await waitForSlashMenu();
+
+		screen.getByRole("button", { name: "Test gutter insert" }).element().click();
+		await waitForSlashMenu();
+		editor.view.dispatch(editor.state.tr.setMeta("test", true));
+
+		expect(isSlashSuggestionActive(editor)).toBe(false);
+		expect(getSlashMenu()).toBeTruthy();
 	});
 
 	it("does not leave a staging paragraph when a gutter command opens a modal", async () => {
@@ -519,6 +569,7 @@ describe("Slash Command Menu", () => {
 
 		// Should still be a paragraph
 		expect(pm.querySelector("h1")).toBeNull();
+		expect(isSlashSuggestionActive(editor)).toBe(false);
 	});
 
 	it("executes command when clicking an item", async () => {

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -30,7 +30,17 @@ vi.mock("../../src/components/SectionPickerModal", () => ({
 }));
 
 vi.mock("../../src/components/editor/DragHandleWrapper", () => ({
-	DragHandleWrapper: () => null,
+	DragHandleWrapper: ({
+		editor,
+		onInsertBlock,
+	}: {
+		editor: Editor;
+		onInsertBlock?: (insertPos: number) => void;
+	}) => (
+		<button type="button" onClick={() => onInsertBlock?.(editor.state.doc.content.size)}>
+			Test gutter insert
+		</button>
+	),
 }));
 
 vi.mock("../../src/components/editor/ImageNode", async () => {
@@ -194,6 +204,33 @@ function isItemSelected(el: HTMLElement): boolean {
 // =============================================================================
 
 describe("Slash Command Menu", () => {
+	it("opens from the gutter and cancels without inserting a slash", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		const before = editor.getText();
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		await waitForSlashMenu();
+		expect(editor.getText()).not.toContain("/");
+
+		await userEvent.keyboard("{Escape}");
+		await waitForSlashMenuClosed();
+		expect(editor.getText()).toBe(before);
+	});
+
+	it("discards an untouched gutter block when clicking outside the menu", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		const before = editor.getText();
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		await waitForSlashMenu();
+		pm.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+
+		await waitForSlashMenuClosed();
+		expect(editor.getText()).toBe(before);
+	});
+
 	it("opens when typing / at the start of an empty line", async () => {
 		const { editor, pm } = await renderEditor();
 		await focusEditor(pm);

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -26,7 +26,35 @@ vi.mock("../../src/components/MediaPickerModal", () => ({
 }));
 
 vi.mock("../../src/components/SectionPickerModal", () => ({
-	SectionPickerModal: () => null,
+	SectionPickerModal: ({
+		open,
+		onOpenChange,
+		onSelect,
+	}: {
+		open: boolean;
+		onOpenChange: (open: boolean) => void;
+		onSelect: (section: { content: unknown[] }) => void;
+	}) =>
+		open ? (
+			<button
+				type="button"
+				onClick={() => {
+					onSelect({
+						content: [
+							{
+								_type: "block",
+								_key: "section-block",
+								style: "normal",
+								children: [{ _type: "span", _key: "section-span", text: "Inserted section" }],
+							},
+						],
+					});
+					onOpenChange(false);
+				}}
+			>
+				Select test section
+			</button>
+		) : null,
 }));
 
 vi.mock("../../src/components/editor/DragHandleWrapper", () => ({
@@ -207,15 +235,16 @@ describe("Slash Command Menu", () => {
 	it("opens from the gutter and cancels without inserting a slash", async () => {
 		const { screen, editor, pm } = await renderEditor();
 		await focusEditor(pm);
-		const before = editor.getText();
+		const before = editor.getJSON();
 
 		await screen.getByRole("button", { name: "Test gutter insert" }).click();
 		await waitForSlashMenu();
 		expect(editor.getText()).not.toContain("/");
+		expect(editor.getJSON()).toEqual(before);
 
 		await userEvent.keyboard("{Escape}");
 		await waitForSlashMenuClosed();
-		expect(editor.getText()).toBe(before);
+		expect(editor.getJSON()).toEqual(before);
 	});
 
 	it("discards an untouched gutter block when clicking outside the menu", async () => {
@@ -229,6 +258,80 @@ describe("Slash Command Menu", () => {
 
 		await waitForSlashMenuClosed();
 		expect(editor.getText()).toBe(before);
+	});
+
+	it("does not leave a staging paragraph when a gutter command opens a modal", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		const before = editor.getJSON();
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		const menu = await waitForSlashMenu();
+		const imageCommand = getSlashMenuItems(menu).find((item) =>
+			item.textContent?.includes("Image"),
+		);
+		expect(imageCommand).toBeTruthy();
+
+		imageCommand?.click();
+		await waitForSlashMenuClosed();
+		expect(editor.getJSON()).toEqual(before);
+	});
+
+	it("materializes a new block when a direct gutter command is selected", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		const menu = await waitForSlashMenu();
+		getSlashMenuItems(menu)[0]?.click();
+		await waitForSlashMenuClosed();
+
+		const content = editor.getJSON().content;
+		expect(content?.[1]?.type).toBe("heading");
+		expect(content?.[1]?.attrs?.level).toBe(1);
+	});
+
+	it("inserts modal-backed gutter content at the requested block position", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		const menu = await waitForSlashMenu();
+		const sectionCommand = getSlashMenuItems(menu).find((item) =>
+			item.textContent?.includes("Section"),
+		);
+		sectionCommand?.click();
+		await screen.getByRole("button", { name: "Select test section" }).click();
+
+		const content = editor.getJSON().content;
+		expect(content).toHaveLength(2);
+		expect(content?.[1]?.content?.[0]?.text).toBe("Inserted section");
+	});
+
+	it("materializes a new gutter paragraph when the user starts typing", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		await waitForSlashMenu();
+		await userEvent.keyboard("A");
+
+		await waitForSlashMenuClosed();
+		const content = editor.getJSON().content;
+		expect(content).toHaveLength(2);
+		expect(content?.[1]?.content?.[0]?.text).toBe("A");
+	});
+
+	it("does not materialize a gutter paragraph for modifier shortcuts", async () => {
+		const { screen, editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		const before = editor.getJSON();
+
+		await screen.getByRole("button", { name: "Test gutter insert" }).click();
+		await waitForSlashMenu();
+		await userEvent.keyboard("{Control>}b{/Control}");
+
+		expect(editor.getJSON()).toEqual(before);
 	});
 
 	it("opens when typing / at the start of an empty line", async () => {

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -362,7 +362,9 @@ describe("Slash Command Menu", () => {
 		expect(titles).toContain("Numbered List");
 		expect(titles).toContain("Quote");
 		expect(titles).toContain("Code Block");
+		expect(titles).toContain("HTML");
 		expect(titles).toContain("Divider");
+		expect(titles).toContain("Table");
 	});
 
 	it("shows descriptions for each command", async () => {
@@ -576,6 +578,27 @@ describe("Slash Command Menu", () => {
 
 		await vi.waitFor(() => {
 			expect(pm.querySelector("hr")).toBeTruthy();
+		});
+	});
+
+	it("inserts an HTML block via slash command", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusEditor(pm);
+		editor.commands.insertContent("/");
+
+		const menu = await waitForSlashMenu();
+		const htmlBtn = getSlashMenuItems(menu).find(
+			(btn) => btn.querySelector(".font-medium")?.textContent === "HTML",
+		);
+		expect(htmlBtn).toBeTruthy();
+		htmlBtn!.click();
+
+		await waitForSlashMenuClosed();
+
+		await vi.waitFor(() => {
+			const htmlBlock = editor.getJSON().content?.find((node) => node.type === "htmlBlock");
+			expect(htmlBlock).toBeDefined();
+			expect((htmlBlock as { attrs?: { html?: string } }).attrs?.html).toBe("");
 		});
 	});
 

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -158,6 +158,14 @@ describe("Toolbar Presence and Structure", () => {
 		await expect.element(toolbar).toHaveAttribute("aria-label", "Text formatting");
 	});
 
+	it("centers controls when they fit and preserves horizontal overflow", async () => {
+		const { screen } = await renderEditor();
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+
+		expect(toolbar.className).toContain("overflow-x-auto");
+		expect(getComputedStyle(toolbar).justifyContent).toBe("safe center");
+	});
+
 	it("has all formatting buttons", async () => {
 		const { screen } = await renderEditor();
 		await expect.element(screen.getByRole("button", { name: "Bold" })).toBeVisible();
@@ -210,14 +218,14 @@ describe("Toolbar Presence and Structure", () => {
 		await expect.element(screen.getByRole("button", { name: "Align Right" })).toBeVisible();
 	});
 
-	it("has all insert buttons", async () => {
+	it("keeps insertion-only actions in the block menu", async () => {
 		const { screen } = await renderEditor();
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
 		await expect.element(screen.getByRole("button", { name: "Insert Link" })).toBeVisible();
-		await expect.element(screen.getByRole("button", { name: "Insert Image" })).toBeVisible();
-		await expect.element(screen.getByRole("button", { name: "Insert HTML" })).toBeVisible();
-		await expect
-			.element(screen.getByRole("button", { name: "Insert Horizontal Rule" }))
-			.toBeVisible();
+		expect(toolbar.querySelector('[aria-label="Insert Table"]')).toBeNull();
+		expect(toolbar.querySelector('[aria-label="Insert Image"]')).toBeNull();
+		expect(toolbar.querySelector('[aria-label="Insert HTML"]')).toBeNull();
+		expect(toolbar.querySelector('[aria-label="Insert Horizontal Rule"]')).toBeNull();
 	});
 
 	it("renders the link editor outside the horizontally scrolling toolbar", async () => {
@@ -600,26 +608,7 @@ describe("Undo/Redo", () => {
 });
 
 // =============================================================================
-// 5. HTML Block Insertion
-// =============================================================================
-
-describe("HTML Block Insertion", () => {
-	it("clicking Insert HTML inserts an empty HTML block", async () => {
-		const { screen, editor } = await renderEditor();
-		editor.commands.focus("end");
-
-		getToolbarButton(screen, "Insert HTML").element().click();
-
-		await vi.waitFor(() => {
-			const htmlBlock = editor.getJSON().content?.find((node) => node.type === "htmlBlock");
-			expect(htmlBlock).toBeDefined();
-			expect((htmlBlock as { attrs?: { html?: string } }).attrs?.html).toBe("");
-		});
-	});
-});
-
-// =============================================================================
-// 6. Link Insertion (Toolbar Popover)
+// 5. Link Insertion (Toolbar Popover)
 // =============================================================================
 
 describe("Link Insertion", () => {

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -239,6 +239,7 @@ describe("Toolbar Presence and Structure", () => {
 
 		expect(touchInsert).toBeTruthy();
 		expect(touchInsert?.className).toContain("pointer-coarse:flex");
+		expect(touchInsert?.getAttribute("aria-label")).toBe("Insert block after current block");
 		touchInsert?.click();
 		await vi.waitFor(() => {
 			expect(document.querySelector("body > div [data-index]")).toBeTruthy();

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -169,16 +169,19 @@ describe("Toolbar Presence and Structure", () => {
 
 	it("collapses the supported heading levels into one menu", async () => {
 		const { screen } = await renderEditor();
-		await expect.element(getToolbarButton(screen, "Headings")).toBeVisible();
+		const trigger = getToolbarButton(screen, "Headings");
+		await expect.element(trigger).toBeVisible();
+		await expect.element(trigger).toHaveAttribute("aria-haspopup", "menu");
 
-		getToolbarButton(screen, "Headings").element().click();
+		trigger.element().click();
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 1" })).toBeVisible();
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 2" })).toBeVisible();
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 3" })).toBeVisible();
 		expect(
-			screen.getByRole("menuitem", { name: "Heading 1" }).element().hasAttribute(
-				"data-emdash-heading-item",
-			),
+			screen
+				.getByRole("menuitem", { name: "Heading 1" })
+				.element()
+				.hasAttribute("data-emdash-heading-item"),
 		).toBe(true);
 
 		const headingLabels = Array.from(
@@ -330,22 +333,23 @@ describe("Formatting Button Toggle States", () => {
 		});
 	});
 
-	it("Heading 1: click toggles aria-pressed to true and changes to h1", async () => {
+	it("Heading 1: click changes to h1 without exposing toggle semantics", async () => {
 		const { screen, editor } = await renderEditor();
 		// Focus editor and place cursor (block commands need cursor in a paragraph)
 		editor.commands.focus();
 
 		const { trigger, item } = await getHeadingMenuItem(screen, "Heading 1");
-		await expect.element(trigger).toHaveAttribute("aria-pressed", "false");
+		expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
+		await expect.element(trigger).toHaveAttribute("aria-expanded", "true");
 		item.element().click();
 
 		await vi.waitFor(() => {
-			expect(trigger.element().getAttribute("aria-pressed")).toBe("true");
+			expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
 			expect(editor.isActive("heading", { level: 1 })).toBe(true);
 		});
 	});
 
-	it("Heading 2: click toggles aria-pressed to true", async () => {
+	it("Heading 2: click changes to h2", async () => {
 		const { screen, editor } = await renderEditor();
 		editor.commands.focus();
 
@@ -353,12 +357,12 @@ describe("Formatting Button Toggle States", () => {
 		item.element().click();
 
 		await vi.waitFor(() => {
-			expect(trigger.element().getAttribute("aria-pressed")).toBe("true");
+			expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
 			expect(editor.isActive("heading", { level: 2 })).toBe(true);
 		});
 	});
 
-	it("Heading 3: click toggles aria-pressed to true", async () => {
+	it("Heading 3: click changes to h3", async () => {
 		const { screen, editor } = await renderEditor();
 		editor.commands.focus();
 
@@ -366,7 +370,7 @@ describe("Formatting Button Toggle States", () => {
 		item.element().click();
 
 		await vi.waitFor(() => {
-			expect(trigger.element().getAttribute("aria-pressed")).toBe("true");
+			expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
 			expect(editor.isActive("heading", { level: 3 })).toBe(true);
 		});
 	});
@@ -818,6 +822,21 @@ describe("WAI-ARIA Keyboard Navigation", () => {
 
 		// Press ArrowLeft
 		await userEvent.keyboard("{ArrowLeft}");
+
+		await vi.waitFor(() => {
+			expect(document.activeElement).toBe(bold.element());
+		});
+	});
+
+	it("inverts horizontal arrow navigation in RTL", async () => {
+		const { screen } = await renderEditor();
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+		const bold = screen.getByRole("button", { name: "Bold" });
+		const italic = screen.getByRole("button", { name: "Italic" });
+		toolbar.style.direction = "rtl";
+		italic.element().focus();
+
+		await userEvent.keyboard("{ArrowRight}");
 
 		await vi.waitFor(() => {
 			expect(document.activeElement).toBe(bold.element());

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -136,6 +136,17 @@ function getToolbarButton(screen: Awaited<ReturnType<typeof render>>, name: stri
 	return screen.getByRole("toolbar", { name: "Text formatting" }).getByRole("button", { name });
 }
 
+async function getHeadingMenuItem(
+	screen: Awaited<ReturnType<typeof render>>,
+	name: "Heading 1" | "Heading 2" | "Heading 3",
+) {
+	const trigger = getToolbarButton(screen, "Headings");
+	trigger.element().click();
+	const item = screen.getByRole("menuitem", { name });
+	await expect.element(item).toBeVisible();
+	return { trigger, item };
+}
+
 // =============================================================================
 // 1. Toolbar Presence and Structure
 // =============================================================================
@@ -156,11 +167,25 @@ describe("Toolbar Presence and Structure", () => {
 		await expect.element(screen.getByRole("button", { name: "Inline Code" })).toBeVisible();
 	});
 
-	it("has all heading buttons", async () => {
+	it("collapses the supported heading levels into one menu", async () => {
 		const { screen } = await renderEditor();
-		await expect.element(screen.getByRole("button", { name: "Heading 1" })).toBeVisible();
-		await expect.element(screen.getByRole("button", { name: "Heading 2" })).toBeVisible();
-		await expect.element(screen.getByRole("button", { name: "Heading 3" })).toBeVisible();
+		await expect.element(getToolbarButton(screen, "Headings")).toBeVisible();
+
+		getToolbarButton(screen, "Headings").element().click();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 1" })).toBeVisible();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 2" })).toBeVisible();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 3" })).toBeVisible();
+		expect(
+			screen.getByRole("menuitem", { name: "Heading 1" }).element().hasAttribute(
+				"data-emdash-heading-item",
+			),
+		).toBe(true);
+
+		const headingLabels = Array.from(
+			document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+			(item) => item.textContent?.trim(),
+		);
+		expect(headingLabels).not.toContain("Heading 4");
 	});
 
 	it("has all list buttons", async () => {
@@ -310,12 +335,12 @@ describe("Formatting Button Toggle States", () => {
 		// Focus editor and place cursor (block commands need cursor in a paragraph)
 		editor.commands.focus();
 
-		const btn = screen.getByRole("button", { name: "Heading 1" });
-		await expect.element(btn).toHaveAttribute("aria-pressed", "false");
-		btn.element().click();
+		const { trigger, item } = await getHeadingMenuItem(screen, "Heading 1");
+		await expect.element(trigger).toHaveAttribute("aria-pressed", "false");
+		item.element().click();
 
 		await vi.waitFor(() => {
-			expect(btn.element().getAttribute("aria-pressed")).toBe("true");
+			expect(trigger.element().getAttribute("aria-pressed")).toBe("true");
 			expect(editor.isActive("heading", { level: 1 })).toBe(true);
 		});
 	});
@@ -324,11 +349,12 @@ describe("Formatting Button Toggle States", () => {
 		const { screen, editor } = await renderEditor();
 		editor.commands.focus();
 
-		const btn = screen.getByRole("button", { name: "Heading 2" });
-		btn.element().click();
+		const { trigger, item } = await getHeadingMenuItem(screen, "Heading 2");
+		item.element().click();
 
 		await vi.waitFor(() => {
-			expect(btn.element().getAttribute("aria-pressed")).toBe("true");
+			expect(trigger.element().getAttribute("aria-pressed")).toBe("true");
+			expect(editor.isActive("heading", { level: 2 })).toBe(true);
 		});
 	});
 
@@ -336,11 +362,12 @@ describe("Formatting Button Toggle States", () => {
 		const { screen, editor } = await renderEditor();
 		editor.commands.focus();
 
-		const btn = screen.getByRole("button", { name: "Heading 3" });
-		btn.element().click();
+		const { trigger, item } = await getHeadingMenuItem(screen, "Heading 3");
+		item.element().click();
 
 		await vi.waitFor(() => {
-			expect(btn.element().getAttribute("aria-pressed")).toBe("true");
+			expect(trigger.element().getAttribute("aria-pressed")).toBe("true");
+			expect(editor.isActive("heading", { level: 3 })).toBe(true);
 		});
 	});
 

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -192,6 +192,31 @@ describe("Toolbar Presence and Structure", () => {
 			.toBeVisible();
 	});
 
+	it("renders the link editor outside the horizontally scrolling toolbar", async () => {
+		const { screen } = await renderEditor();
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+		screen.getByRole("button", { name: "Insert Link" }).element().click();
+
+		await vi.waitFor(() => {
+			const input = document.querySelector<HTMLInputElement>('input[placeholder="https://..."]');
+			expect(input).toBeTruthy();
+			expect(toolbar.contains(input)).toBe(false);
+		});
+	});
+
+	it("provides an independent block inserter for coarse pointers", async () => {
+		const { screen } = await renderEditor();
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+		const touchInsert = toolbar.querySelector<HTMLButtonElement>("[data-touch-block-insert]");
+
+		expect(touchInsert).toBeTruthy();
+		expect(touchInsert?.className).toContain("pointer-coarse:flex");
+		touchInsert?.click();
+		await vi.waitFor(() => {
+			expect(document.querySelector("body > div [data-index]")).toBeTruthy();
+		});
+	});
+
 	it("has history buttons", async () => {
 		const { screen } = await renderEditor();
 		await expect.element(screen.getByRole("button", { name: "Undo" })).toBeVisible();
@@ -574,7 +599,7 @@ describe("Link Insertion", () => {
 		linkBtn.element().click();
 
 		await vi.waitFor(() => {
-			const input = screen.container.querySelector('input[type="url"]');
+			const input = document.querySelector('input[type="url"]');
 			expect(input).toBeTruthy();
 		});
 	});
@@ -598,10 +623,10 @@ describe("Link Insertion", () => {
 		screen.getByRole("button", { name: "Insert Link" }).element().click();
 
 		await vi.waitFor(() => {
-			expect(screen.container.querySelector('input[type="url"]')).toBeTruthy();
+			expect(document.querySelector('input[type="url"]')).toBeTruthy();
 		});
 
-		const input = screen.container.querySelector('input[type="url"]') as HTMLInputElement;
+		const input = document.querySelector('input[type="url"]') as HTMLInputElement;
 		// Focus input and type URL
 		input.focus();
 		// Use native input value setter to trigger React's onChange
@@ -627,13 +652,13 @@ describe("Link Insertion", () => {
 		screen.getByRole("button", { name: "Insert Link" }).element().click();
 
 		await vi.waitFor(() => {
-			expect(screen.container.querySelector('input[type="url"]')).toBeTruthy();
+			expect(document.querySelector('input[type="url"]')).toBeTruthy();
 		});
 
 		screen.getByRole("button", { name: "Cancel" }).element().click();
 
 		await vi.waitFor(() => {
-			expect(screen.container.querySelector('input[type="url"]')).toBeNull();
+			expect(document.querySelector('input[type="url"]')).toBeNull();
 		});
 	});
 

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -248,10 +248,24 @@ describe("Toolbar Presence and Structure", () => {
 		expect(touchInsert).toBeTruthy();
 		expect(touchInsert?.className).toContain("pointer-coarse:flex");
 		expect(touchInsert?.getAttribute("aria-label")).toBe("Insert block after current block");
+		expect(touchInsert?.tabIndex).toBe(0);
 		touchInsert?.click();
 		await vi.waitFor(() => {
 			expect(document.querySelector("body > div [data-index]")).toBeTruthy();
 		});
+	});
+
+	it("includes the coarse-pointer inserter in toolbar arrow navigation when visible", async () => {
+		const { screen } = await renderEditor();
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+		const touchInsert = toolbar.querySelector<HTMLButtonElement>("[data-touch-block-insert]")!;
+		const bold = screen.getByRole("button", { name: "Bold" });
+		touchInsert.style.display = "flex";
+		bold.element().focus();
+
+		await userEvent.keyboard("{ArrowLeft}");
+
+		await vi.waitFor(() => expect(document.activeElement).toBe(touchInsert));
 	});
 
 	it("has history buttons", async () => {
@@ -835,8 +849,10 @@ describe("WAI-ARIA Keyboard Navigation", () => {
 
 	it("Home moves focus to first button", async () => {
 		const { screen } = await renderEditor();
-
-		const bold = screen.getByRole("button", { name: "Bold" });
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+		const firstButton = [...toolbar.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => !button.disabled && button.getClientRects().length > 0,
+		)!;
 		const alignCenter = screen.getByRole("button", { name: "Align Center" });
 
 		// Focus a button in the middle
@@ -846,7 +862,7 @@ describe("WAI-ARIA Keyboard Navigation", () => {
 		await userEvent.keyboard("{Home}");
 
 		await vi.waitFor(() => {
-			expect(document.activeElement).toBe(bold.element());
+			expect(document.activeElement).toBe(firstButton);
 		});
 	});
 
@@ -870,9 +886,11 @@ describe("WAI-ARIA Keyboard Navigation", () => {
 
 	it("ArrowRight wraps from last to first button", async () => {
 		const { screen } = await renderEditor();
-
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
 		const spotlightBtn = screen.getByRole("button", { name: "Spotlight Mode" });
-		const bold = screen.getByRole("button", { name: "Bold" });
+		const firstButton = [...toolbar.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => !button.disabled && button.getClientRects().length > 0,
+		)!;
 
 		// Focus the last button
 		spotlightBtn.element().focus();
@@ -881,17 +899,19 @@ describe("WAI-ARIA Keyboard Navigation", () => {
 		await userEvent.keyboard("{ArrowRight}");
 
 		await vi.waitFor(() => {
-			expect(document.activeElement).toBe(bold.element());
+			expect(document.activeElement).toBe(firstButton);
 		});
 	});
 
 	it("ArrowLeft wraps from first to last button", async () => {
 		const { screen } = await renderEditor();
-
-		const bold = screen.getByRole("button", { name: "Bold" });
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+		const firstButton = [...toolbar.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => !button.disabled && button.getClientRects().length > 0,
+		)!;
 
 		// Focus the first button
-		bold.element().focus();
+		firstButton.focus();
 
 		// Press ArrowLeft - should wrap to last
 		await userEvent.keyboard("{ArrowLeft}");

--- a/packages/admin/vitest.config.ts
+++ b/packages/admin/vitest.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
 	plugins: [
 		react({
 			babel: {
-				plugins: ["@lingui/babel-plugin-lingui-macro"],
+				plugins: [
+					// Match the admin package build so production-fallback tests keep source messages.
+					["@lingui/babel-plugin-lingui-macro", { stripMessageField: false }],
+				],
 			},
 		}),
 	],


### PR DESCRIPTION
## What does this PR do?

Makes the portable text editor easier and more reliable to use:

- Centers the writing area and simplifies the responsive toolbar.
- Adds clearer block insertion controls and a compact heading menu.
- Prevents inline and table controls from clipping, overlapping the sticky toolbar, or appearing together.
- Keeps slash commands and gutter insertion predictable across mouse, touch, and keyboard input.

This also improves keyboard navigation, screen-reader state, narrow-screen behavior, and RTL icon placement.

Related issue: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this PR fixes existing editor behavior.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode (GPT-5.6 Sol), reviewed with Grok 4.5 Thinking High

## Screenshots / test output

No screenshots included.

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @emdash-cms/admin test --run` — 1,131 tests passed
- Focused editor suites — 111 tests passed

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-tiptap-editor-refinements-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/tiptap-editor-refinements`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
