### PR TITLE
feat(labeler): publisher-history context in the console subject view (W8.4 slice 2)

### DIFF
--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -101,9 +101,33 @@ export interface SubjectRecord {
 	deletedAt: string | null;
 }
 
+/** An active, reviewer/admin-issued label on the subject, surfaced as neutral
+ * publisher-history context. `cid` is present only for a CID-bound label. */
+export interface PublisherHistoryLabel {
+	val: string;
+	cid?: string;
+}
+
+/**
+ * Neutral publisher-history context the server assembles at read-time in the
+ * subject-history endpoint (plan W8.4 D5): the publishing DID's prior releases
+ * and the subject's active manual labels, from the labeler's own D1. Operator-
+ * only; never part of any public serializer. `priorReleaseCount` is bounded by
+ * the server's read-time cap — `priorReleaseCapped` true means "at least this
+ * many". Optional so the UI degrades if a response omits it.
+ */
+export interface PublisherHistory {
+	did: string;
+	priorReleaseCount: number;
+	priorReleaseCapped: boolean;
+	priorReleaseSample: string[];
+	activeManualLabels: PublisherHistoryLabel[];
+}
+
 export interface SubjectHistoryView {
 	subject: SubjectRecord;
 	assessments: AssessmentRun[];
+	publisherHistory?: PublisherHistory;
 }
 
 /**

--- a/apps/labeler/console/src/fixtures/subject-history.ts
+++ b/apps/labeler/console/src/fixtures/subject-history.ts
@@ -1,6 +1,35 @@
-import type { SubjectHistoryView } from "../api/types.js";
+import type { PublisherHistory, SubjectHistoryView } from "../api/types.js";
 import { FIXTURE_ASSESSMENTS } from "./assessments.js";
-import { FIXTURE_SUBJECTS } from "./subjects.js";
+import { FIXTURE_SUBJECTS, SUBJECT_ALPHA } from "./subjects.js";
+
+/** Publisher-history context keyed by URI, mirroring the server's read-time
+ * assembly (`serializePublisherHistory`). Alpha carries prior releases and an
+ * active manual label; the rest default to an empty block. */
+const PUBLISHER_HISTORY_BY_URI: Readonly<Record<string, PublisherHistory>> = {
+	[SUBJECT_ALPHA.uri]: {
+		did: SUBJECT_ALPHA.did,
+		priorReleaseCount: 3,
+		priorReleaseCapped: false,
+		priorReleaseSample: [
+			"at://did:plc:z7x3g4k9m2q8w1r5t6y0u3i7/com.emdashcms.experimental.package.release/3lduzalpha0000",
+			"at://did:plc:z7x3g4k9m2q8w1r5t6y0u3i7/com.emdashcms.experimental.package.release/3lduzalphaprev1",
+			"at://did:plc:z7x3g4k9m2q8w1r5t6y0u3i7/com.emdashcms.experimental.package.release/3lduzalphaprev2",
+		],
+		activeManualLabels: [{ val: "disputed" }, { val: "security-yanked", cid: SUBJECT_ALPHA.cid }],
+	},
+};
+
+function publisherHistoryFor(uri: string, did: string): PublisherHistory {
+	return (
+		PUBLISHER_HISTORY_BY_URI[uri] ?? {
+			did,
+			priorReleaseCount: 0,
+			priorReleaseCapped: false,
+			priorReleaseSample: [],
+			activeManualLabels: [],
+		}
+	);
+}
 
 /** Subject history keyed by URI, matching `listNonTerminalAssessmentsForUri` +
  * `getAssessmentsPage`'s per-uri grouping, newest run first. */
@@ -11,6 +40,7 @@ export const FIXTURE_SUBJECT_HISTORY: Readonly<Record<string, SubjectHistoryView
 			{
 				subject,
 				assessments: FIXTURE_ASSESSMENTS.filter((a) => a.uri === subject.uri),
+				publisherHistory: publisherHistoryFor(subject.uri, subject.did),
 			},
 		]),
 	);

--- a/apps/labeler/console/src/routes/SubjectHistory.tsx
+++ b/apps/labeler/console/src/routes/SubjectHistory.tsx
@@ -1,10 +1,15 @@
-import { Button, LayerCard, Loader, Table } from "@cloudflare/kumo";
+import { Badge, Button, LayerCard, Loader, Table } from "@cloudflare/kumo";
 import { useQuery } from "@tanstack/react-query";
 import { createRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { apiClient } from "../api/client.js";
-import type { EmergencyActionKind, IssuableLabel, SubjectLabel } from "../api/types.js";
+import type {
+	EmergencyActionKind,
+	IssuableLabel,
+	PublisherHistory,
+	SubjectLabel,
+} from "../api/types.js";
 import { EmergencyActionDialog } from "../components/EmergencyActionDialog.js";
 import { LabelActionDialog } from "../components/LabelActionDialog.js";
 import { QueryError } from "../components/QueryError.js";
@@ -87,7 +92,7 @@ function SubjectHistory() {
 		return <div className="p-8 text-center text-sm text-kumo-subtle">Subject not found.</div>;
 	}
 
-	const { subject, assessments } = history;
+	const { subject, assessments, publisherHistory } = history;
 	const uriWideLabels = uriWideLabelsFor(subject.collection);
 	const publisherSegment = didFinalSegment(subject.did);
 	const recordTakenDown = isLabelActive(recordLabels, "!takedown");
@@ -120,6 +125,8 @@ function SubjectHistory() {
 					</Button>
 				)}
 			</div>
+
+			{publisherHistory && <PublisherHistoryCard history={publisherHistory} />}
 
 			{isAdmin && (
 				<LayerCard className="flex flex-col gap-3 border border-kumo-danger p-4">
@@ -240,6 +247,51 @@ function SubjectHistory() {
 				)}
 			</LayerCard>
 		</div>
+	);
+}
+
+/** Neutral read-time context (plan W8.4 D5): the publishing account's prior
+ * releases and the subject's active manual labels. Facts only — no findings, no
+ * action affordances. */
+function PublisherHistoryCard({ history }: { history: PublisherHistory }) {
+	const priorReleases = history.priorReleaseCapped
+		? `at least ${history.priorReleaseCount}`
+		: String(history.priorReleaseCount);
+	return (
+		<LayerCard className="flex flex-col gap-3 p-4">
+			<h2 className="text-lg font-semibold">Publisher history</h2>
+			<div className="flex flex-col gap-1">
+				<span className="text-sm text-kumo-subtle">Publishing account</span>
+				<span className="font-mono text-sm">{history.did}</span>
+			</div>
+			<div className="flex flex-col gap-1">
+				<span className="text-sm text-kumo-subtle">Prior releases from this publisher</span>
+				<span className="text-sm">{priorReleases}</span>
+				{history.priorReleaseSample.length > 0 && (
+					<ul className="flex flex-col gap-1">
+						{history.priorReleaseSample.map((uri) => (
+							<li key={uri} className="font-mono text-xs break-all">
+								{uri}
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+			<div className="flex flex-col gap-1">
+				<span className="text-sm text-kumo-subtle">Active manual labels</span>
+				{history.activeManualLabels.length > 0 ? (
+					<div className="flex flex-wrap gap-2">
+						{history.activeManualLabels.map((label) => (
+							<Badge key={`${label.val}:${label.cid ?? ""}`} variant="neutral">
+								{label.val}
+							</Badge>
+						))}
+					</div>
+				) : (
+					<span className="text-sm">None</span>
+				)}
+			</div>
+		</LayerCard>
 	);
 }
 

--- a/apps/labeler/console/src/test/subject-history.test.tsx
+++ b/apps/labeler/console/src/test/subject-history.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { SUBJECT_ALPHA } from "../fixtures/index.js";
+import { renderRoute, REVIEWER_IDENTITY } from "./harness.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+const path = `/subjects/${encodeURIComponent(SUBJECT_ALPHA.uri)}`;
+
+describe("SubjectHistory publisher-history section", () => {
+	it("renders prior releases and active manual labels from the fixture", async () => {
+		vi.spyOn(apiClient, "whoami").mockResolvedValue(REVIEWER_IDENTITY);
+		renderRoute(path);
+		await screen.findByRole("heading", { name: "Subject history", level: 1 });
+		expect(
+			await screen.findByRole("heading", { name: "Publisher history", level: 2 }),
+		).toBeTruthy();
+		expect(screen.getByText(SUBJECT_ALPHA.did)).toBeTruthy();
+		expect(screen.getByText("disputed")).toBeTruthy();
+		expect(screen.getByText(/3lduzalphaprev1/)).toBeTruthy();
+	});
+
+	it("omits the section when the response carries no publisher-history block", async () => {
+		vi.spyOn(apiClient, "whoami").mockResolvedValue(REVIEWER_IDENTITY);
+		vi.spyOn(apiClient, "getSubjectHistory").mockResolvedValue({
+			subject: SUBJECT_ALPHA,
+			assessments: [],
+		});
+		renderRoute(path);
+		await screen.findByRole("heading", { name: "Subject history", level: 1 });
+		expect(screen.queryByRole("heading", { name: "Publisher history" })).toBeNull();
+	});
+});

--- a/apps/labeler/src/console-api.ts
+++ b/apps/labeler/src/console-api.ts
@@ -29,6 +29,7 @@ import {
 	getAssessmentsPage,
 	getCurrentSubjectByUri,
 	getFindingsForAssessment,
+	getPriorReleaseUrisForDid,
 	isSuperseded,
 	type ListAssessmentsFilters,
 	type ListedAssessment,
@@ -39,6 +40,7 @@ import {
 	serializeIssuedLabel,
 	serializeOperatorActionView,
 	serializeOperatorFinding,
+	serializePublisherHistory,
 	serializeSubjectLabel,
 	serializeSubjectRecord,
 	type Page,
@@ -53,6 +55,10 @@ import { assertNegatableBlockSet, NegatableBlockSetError, parseSubjectKind } fro
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
+// Matches history-context.ts's DEFAULT_PRIOR_RELEASE_LIMIT / SAMPLE_SIZE so the
+// console's read-time count and sample agree with a run's history finding.
+const PRIOR_RELEASE_LIMIT = 20;
+const PRIOR_RELEASE_SAMPLE_SIZE = 5;
 const NON_NEGATIVE_INTEGER = /^\d+$/;
 const ADMIN_API_PREFIX = /^\/admin\/api\/?/;
 
@@ -255,10 +261,33 @@ async function handleGetSubjectHistory(
 	requireGet(request);
 	const subject = await getCurrentSubjectByUri(deps.db, uri);
 	if (!subject) throw new ReadGuardError("NOT_FOUND");
-	const assessments = await getAssessmentsForUri(deps.db, uri);
+	// Three independent reads keyed on the resolved subject — the assessment
+	// history plus the two neutral publisher-history inputs (plan W8.4 D5). No
+	// per-row fan-out: the label lookup reduces the whole (src, uri) stream once.
+	const [assessments, priorReleaseUris, labelWinners] = await Promise.all([
+		getAssessmentsForUri(deps.db, uri),
+		getPriorReleaseUrisForDid(deps.db, {
+			did: subject.did,
+			excludeUri: uri,
+			limit: PRIOR_RELEASE_LIMIT,
+		}),
+		getActiveLabelState(deps.db, {
+			src: deps.labelerDid,
+			uri,
+			cid: subject.cid,
+			now: new Date(),
+		}),
+	]);
 	return jsonData({
 		subject: serializeSubjectRecord(subject),
 		assessments: assessments.map(serializeAssessmentRun),
+		publisherHistory: serializePublisherHistory({
+			did: subject.did,
+			priorReleaseUris,
+			priorReleaseLimit: PRIOR_RELEASE_LIMIT,
+			priorReleaseSampleSize: PRIOR_RELEASE_SAMPLE_SIZE,
+			labelWinners: labelWinners.values(),
+		}),
 	});
 }
 

--- a/apps/labeler/src/console-serialize.ts
+++ b/apps/labeler/src/console-serialize.ts
@@ -99,9 +99,32 @@ export interface SubjectRecord {
 	deletedAt: string | null;
 }
 
+/** An active, reviewer/admin-issued label on the subject, surfaced as neutral
+ * publisher-history context. `cid` is present only for a CID-bound label. */
+export interface PublisherHistoryLabel {
+	val: string;
+	cid?: string;
+}
+
+/**
+ * Neutral publisher-history context assembled at console read-time from the
+ * labeler's own D1 (plan W8.4 D5): the publishing DID's prior releases and the
+ * subject's active manual labels. `priorReleaseCount` is bounded by the
+ * read-time cap — `priorReleaseCapped` true means "at least this many". Never
+ * part of any public serializer; served only on the reviewer-gated console API.
+ */
+export interface PublisherHistory {
+	did: string;
+	priorReleaseCount: number;
+	priorReleaseCapped: boolean;
+	priorReleaseSample: string[];
+	activeManualLabels: PublisherHistoryLabel[];
+}
+
 export interface SubjectHistoryView {
 	subject: SubjectRecord;
 	assessments: AssessmentRun[];
+	publisherHistory: PublisherHistory;
 }
 
 export interface OperatorActionView {
@@ -207,6 +230,37 @@ export function serializeSubjectLabel(winner: LabelStreamWinner): SubjectLabel {
 		cts: winner.cts,
 		exp: winner.exp,
 		sequence: winner.sequence,
+	};
+}
+
+/**
+ * Assembles the publisher-history block from the slice-1 queries
+ * (`getPriorReleaseUrisForDid`, `getActiveLabelState`). The prior-release count
+ * is the number of URIs returned under the cap; `capped` matches the pipeline
+ * stage's rule (`length >= limit`). Active manual labels are the non-automated,
+ * currently-active stream winners — the same `!automated && active` filter the
+ * history stage applies.
+ */
+export function serializePublisherHistory(input: {
+	did: string;
+	priorReleaseUris: readonly string[];
+	priorReleaseLimit: number;
+	priorReleaseSampleSize: number;
+	labelWinners: Iterable<LabelStreamWinner>;
+}): PublisherHistory {
+	const activeManualLabels: PublisherHistoryLabel[] = [];
+	for (const winner of input.labelWinners) {
+		if (winner.automated || !winner.active) continue;
+		activeManualLabels.push(
+			winner.cid === null ? { val: winner.val } : { val: winner.val, cid: winner.cid },
+		);
+	}
+	return {
+		did: input.did,
+		priorReleaseCount: input.priorReleaseUris.length,
+		priorReleaseCapped: input.priorReleaseUris.length >= input.priorReleaseLimit,
+		priorReleaseSample: input.priorReleaseUris.slice(0, input.priorReleaseSampleSize),
+		activeManualLabels,
 	};
 }
 

--- a/apps/labeler/test/console-api.test.ts
+++ b/apps/labeler/test/console-api.test.ts
@@ -29,6 +29,16 @@ const URI_S =
 const CID_S_OLD = "bafyreisssssssssssssssssssssssssssssssssssssssssssssssold";
 const CID_S_NEW = "bafyreisssssssssssssssssssssssssssssssssssssssssssssssnew";
 
+// Publisher-history fixture: one DID with three releases and, on the first, an
+// active manual label plus an automated label (which must not count as manual).
+const DID_HIST = "did:plc:hhhhhhhhhhhhhhhhhhhhhhhh";
+const URI_H1 = `at://${DID_HIST}/com.emdashcms.experimental.package.release/rkH1`;
+const CID_H1 = "bafyreihhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh1";
+const URI_H2 = `at://${DID_HIST}/com.emdashcms.experimental.package.release/rkH2`;
+const CID_H2 = "bafyreihhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh2";
+const URI_H3 = `at://${DID_HIST}/com.emdashcms.experimental.package.release/rkH3`;
+const CID_H3 = "bafyreihhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh3";
+
 // Assessment ids must satisfy assessment-lifecycle's ASSESSMENT_ID (ULID) regex,
 // which the detail route validates via getAssessment.
 const ASMT_PASS_A = "asmt_SQCP5CP1X1RBMM0V0TQP2WR9PD";
@@ -61,6 +71,7 @@ beforeAll(async () => {
 	noRoleToken = await mintToken({ email: "nobody@example.com" });
 
 	await seedSubjects();
+	await seedPublisherHistory();
 	await seedAssessments();
 	await seedFindings();
 	await seedLabels();
@@ -145,6 +156,72 @@ async function seedSubjects(): Promise<void> {
 		collection: "com.emdashcms.experimental.package.release",
 		rkey: "rkS",
 		now: new Date("2026-07-05T10:00:00.000Z"),
+	});
+}
+
+async function seedStreamLabel(input: {
+	actionId: number;
+	uri: string;
+	cid: string;
+	val: string;
+	type: string;
+	neg?: 0 | 1;
+	cts: string;
+}): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO issuance_actions (id, actor, type, reason, idempotency_key, created_at)
+		 VALUES (?, ?, ?, 'r', ?, ?)`,
+	)
+		.bind(input.actionId, LABELER_DID, input.type, `idem-hist-${input.actionId}`, input.cts)
+		.run();
+	await testEnv.DB.prepare(
+		`INSERT INTO issued_labels (action_id, ver, src, uri, cid, val, neg, cts, sig, signing_key_id)
+		 VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, 'v1')`,
+	)
+		.bind(
+			input.actionId,
+			LABELER_DID,
+			input.uri,
+			input.cid,
+			input.val,
+			input.neg ?? 0,
+			input.cts,
+			new Uint8Array([0]),
+		)
+		.run();
+}
+
+async function seedPublisherHistory(): Promise<void> {
+	const releases: [uri: string, cid: string, rkey: string, observedAt: string][] = [
+		[URI_H1, CID_H1, "rkH1", "2026-07-01T00:00:00.000Z"],
+		[URI_H2, CID_H2, "rkH2", "2026-07-02T00:00:00.000Z"],
+		[URI_H3, CID_H3, "rkH3", "2026-07-03T00:00:00.000Z"],
+	];
+	for (const [uri, cid, rkey, observedAt] of releases) {
+		await createSubject(testEnv.DB, {
+			uri,
+			cid,
+			did: DID_HIST,
+			collection: "com.emdashcms.experimental.package.release",
+			rkey,
+			now: new Date(observedAt),
+		});
+	}
+	await seedStreamLabel({
+		actionId: 3001,
+		uri: URI_H1,
+		cid: CID_H1,
+		val: "disputed",
+		type: "manual-label",
+		cts: "2026-07-04T00:00:00.000Z",
+	});
+	await seedStreamLabel({
+		actionId: 3002,
+		uri: URI_H1,
+		cid: CID_H1,
+		val: "assessment-passed",
+		type: "automated-assessment",
+		cts: "2026-07-04T01:00:00.000Z",
 	});
 }
 
@@ -553,6 +630,53 @@ describe("handleConsoleApi — subject history", () => {
 			deps(),
 		);
 		expect(res.status).toBe(404);
+	});
+
+	interface PublisherHistoryBody {
+		publisherHistory: {
+			did: string;
+			priorReleaseCount: number;
+			priorReleaseCapped: boolean;
+			priorReleaseSample: string[];
+			activeManualLabels: { val: string; cid?: string }[];
+		};
+	}
+
+	it("assembles publisher-history context: prior releases and active manual labels", async () => {
+		const res = await handleConsoleApi(
+			req(`/admin/api/subjects/${encodeURIComponent(URI_H1)}`, { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+		const view = (await body(res)).data as PublisherHistoryBody;
+		expect(view.publisherHistory.did).toBe(DID_HIST);
+		expect(view.publisherHistory.priorReleaseCount).toBe(2);
+		expect(view.publisherHistory.priorReleaseCapped).toBe(false);
+		expect(view.publisherHistory.priorReleaseSample).toEqual(
+			expect.arrayContaining([URI_H2, URI_H3]),
+		);
+		expect(view.publisherHistory.priorReleaseSample).not.toContain(URI_H1);
+		const vals = view.publisherHistory.activeManualLabels.map((label) => label.val);
+		expect(vals).toContain("disputed");
+		// An automated stream head is not a manual label.
+		expect(vals).not.toContain("assessment-passed");
+		const disputed = view.publisherHistory.activeManualLabels.find(
+			(label) => label.val === "disputed",
+		);
+		expect(disputed?.cid).toBe(CID_H1);
+	});
+
+	it("returns an empty publisher-history block for a subject with no history", async () => {
+		const res = await handleConsoleApi(
+			req(`/admin/api/subjects/${encodeURIComponent(URI_A)}`, { token: reviewerToken }),
+			deps(),
+		);
+		expect(res.status).toBe(200);
+		const view = (await body(res)).data as PublisherHistoryBody;
+		expect(view.publisherHistory.did).toBe("did:plc:aaaaaaaaaaaaaaaaaaaaaaaa");
+		expect(view.publisherHistory.priorReleaseCount).toBe(0);
+		expect(view.publisherHistory.priorReleaseSample).toEqual([]);
+		expect(view.publisherHistory.activeManualLabels).toEqual([]);
 	});
 });
 

--- a/apps/labeler/test/console-serialize.test.ts
+++ b/apps/labeler/test/console-serialize.test.ts
@@ -4,6 +4,7 @@ import type { AssessmentState } from "../src/assessment-lifecycle.js";
 import type {
 	AssessmentFinding,
 	AssessmentIssuedLabel,
+	LabelStreamWinner,
 	ListedAssessment,
 	Subject,
 } from "../src/assessment-store.js";
@@ -12,6 +13,7 @@ import {
 	serializeIssuedLabel,
 	serializeOperatorActionView,
 	serializeOperatorFinding,
+	serializePublisherHistory,
 	serializeSubjectRecord,
 } from "../src/console-serialize.js";
 import type { StoredOperatorAction } from "../src/operator-actions.js";
@@ -137,6 +139,57 @@ describe("serializeSubjectRecord", () => {
 			deletedAt: null,
 		};
 		expect(serializeSubjectRecord(subject)).toEqual(subject);
+	});
+});
+
+describe("serializePublisherHistory", () => {
+	function winner(over: Partial<LabelStreamWinner> & { val: string }): LabelStreamWinner {
+		return {
+			val: over.val,
+			cid: over.cid ?? null,
+			cts: "2026-07-12T00:00:00.000Z",
+			exp: over.exp ?? null,
+			sequence: over.sequence ?? 1,
+			neg: over.neg ?? false,
+			automated: over.automated ?? false,
+			active: over.active ?? true,
+		};
+	}
+
+	it("bounds the prior-release count and samples the URIs", () => {
+		const uris = Array.from({ length: 20 }, (_, i) => `at://did:plc:x/col/rk${i}`);
+		const view = serializePublisherHistory({
+			did: "did:plc:x",
+			priorReleaseUris: uris,
+			priorReleaseLimit: 20,
+			priorReleaseSampleSize: 5,
+			labelWinners: [],
+		});
+		expect(view.did).toBe("did:plc:x");
+		expect(view.priorReleaseCount).toBe(20);
+		expect(view.priorReleaseCapped).toBe(true);
+		expect(view.priorReleaseSample).toEqual(uris.slice(0, 5));
+	});
+
+	it("keeps only active, non-automated labels and omits a null cid", () => {
+		const view = serializePublisherHistory({
+			did: "did:plc:x",
+			priorReleaseUris: ["at://did:plc:x/col/rk0"],
+			priorReleaseLimit: 20,
+			priorReleaseSampleSize: 5,
+			labelWinners: [
+				winner({ val: "disputed" }),
+				winner({ val: "security-yanked", cid: "bafyreialpha" }),
+				winner({ val: "assessment-passed", automated: true }),
+				winner({ val: "retracted-manual", active: false }),
+			],
+		});
+		expect(view.priorReleaseCount).toBe(1);
+		expect(view.priorReleaseCapped).toBe(false);
+		expect(view.activeManualLabels).toEqual([
+			{ val: "disputed" },
+			{ val: "security-yanked", cid: "bafyreialpha" },
+		]);
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Implements **W8.4 slice 2** (publisher-history context, console surfacing) per the ratified D5 decision: neutral display facts are assembled at **console read-time** in the existing subject-history endpoint — no pipeline artifact, no persistence. Part of the plugin-registry labelling service (umbrella #1909, RFC #694); slice 1 (the pipeline stage) merged in #2033.

### API

`GET /admin/api/subjects/:uri/history` (existing reviewer-gated read) gains a `publisherHistory` block: the publishing `did`, a bounded `priorReleaseCount` with an explicit `priorReleaseCapped` flag ("at least N" semantics matching slice 1's cap), a ≤5-URI `priorReleaseSample`, and `activeManualLabels` (`!automated && active` winners for the current subject CID, `cid` omitted for URI-wide labels). Composed via the slice-1 store queries in one `Promise.all` with the assessment history — endpoint goes 2→4 queries with no per-row fan-out. Caps mirror `history-context.ts` values so the console's count agrees with a run's history finding.

### Console

A "Publisher history" card on the subject view: DID, prior-release count/sample, manual labels as badges ("None" when empty). Facts only — no findings, no action affordances. Kumo components, RTL-safe logical classes, plain English (console is deliberately not localized). Renders for any console viewer.

### Privacy boundary (verified)

Every console viewer is ≥reviewer via Cloudflare Access, and the subject-labels endpoint already serves this data to reviewers (`guardRead` minRole reviewer, per the W9.5 ratification) — `activeManualLabels` adds convenience, not exposure. No public serializer touched (verified: the diff contains no XRPC/public/evidence-path files). The reviewer console is explicitly permitted operator detail per spec §19.2; the operator-only constraint from the W8.4 plan record binds the *public* surface, which is unchanged.

### Out of scope

History-finding rendering (findings aren't persisted until the W7/W8 orchestrator wiring) and the two aggregator-sourced inputs (slice 3, gated on the ratified read-path decision).

## Type of change

- [x] Feature (tracked under umbrella #1909 / RFC #694)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes <!-- zero new diagnostics in touched files -->
- [x] `pnpm test` passes (or targeted tests for my change) <!-- 712: 573 workerd + 100 console + 39 calibration-node -->
- [x] `pnpm format` has been run <!-- touched files conform; 5 known pre-existing unformatted files left out of scope -->
- [x] I have added/updated tests for my changes (if applicable) <!-- +2 handler, +2 serializer, +2 console component; SubjectHistory axe test green over the new section -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a — labeler console is deliberately not localized; packages/admin untouched -->
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- n/a — @emdash-cms/labeler is private (not published) -->
- [ ] New features link to an approved Discussion <!-- n/a — ratified W-item of the RFC #694 workstream tracked by umbrella #1909 -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (implementation; orchestrated via Claude Code)

## Screenshots / test output

```
Tests: 573 workerd + 100 console + 39 calibration-node = 712 passed
```


<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-history-console-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-history-console`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

