### PR TITLE
feat(labeler): publisher-notification token endpoints (W10.4 slice C)

### DIFF
--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -10,6 +10,7 @@ import { drainDiscoveryDeadLetterBatch, processDiscoveryBatch } from "./discover
 import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
 import type { DiscoveryJob } from "./env.js";
 import { didDocumentResponse, policyDocumentResponse } from "./identity.js";
+import { handleNotificationRequest, isNotificationPath } from "./notification-endpoints.js";
 import { queryLabels } from "./query-labels.js";
 import { reconcileAssessments } from "./reconciliation.js";
 import { createRuntimeSigner, getRuntimeSigningSecret } from "./signing-runtime.js";
@@ -51,6 +52,11 @@ export default {
 			if (pathname === CREATE_REPORT_PATH) return rejectModerationReport(request);
 			return handleAssessmentXrpc(env, request, config);
 		}
+		// Public publisher-notification landing pages (confirm / unsubscribe /
+		// not-me). Mounted outside `/admin/*` so the Access edge policy and the
+		// operator guard never apply — the capability in the link is the sole
+		// authority (see notification-endpoints.ts).
+		if (isNotificationPath(pathname)) return handleNotificationRequest(env.DB, request);
 		// `/admin/api/*` is the Access-guarded operator read API; anything else
 		// under `/admin` is the console SPA, served (with SPA deep-link
 		// fallback) by the assets binding. The Access edge policy on `/admin/*`

--- a/apps/labeler/src/notification-contacts.ts
+++ b/apps/labeler/src/notification-contacts.ts
@@ -101,6 +101,19 @@ function getHmacKey(pepper: string): Promise<CryptoKey> {
 	return key;
 }
 
+/**
+ * SHA-256 hex (64 chars) of a raw confirmation token — the stored
+ * `confirm_token_hash` form. The confirm endpoint hashes the token from the
+ * email link through this before {@link confirmContact}'s constant-time compare;
+ * the send path (W10.5) stores the same digest via {@link recordConfirmSent}, so
+ * the raw token never touches the database. WebCrypto only, so it runs unchanged
+ * on workerd.
+ */
+export async function hashConfirmToken(token: string): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", encoder.encode(token));
+	return toHex(digest);
+}
+
 export async function getContactState(
 	db: D1Database,
 	recipientHashValue: string,

--- a/apps/labeler/src/notification-contacts.ts
+++ b/apps/labeler/src/notification-contacts.ts
@@ -108,6 +108,14 @@ function getHmacKey(pepper: string): Promise<CryptoKey> {
  * the send path (W10.5) stores the same digest via {@link recordConfirmSent}, so
  * the raw token never touches the database. WebCrypto only, so it runs unchanged
  * on workerd.
+ *
+ * SECURITY — token entropy is a hard cross-slice dependency. This digest is
+ * pepper-less (plain SHA-256, so an offline dictionary of candidate tokens maps
+ * straight to stored hashes), and the confirm endpoint has no in-worker rate
+ * limit. Its safety therefore rests entirely on the token being unguessable:
+ * the W10.5 send path MUST draw the token from a CSPRNG with at least 128 bits
+ * of entropy. A weak or predictable token combined with a leaked recipient hash
+ * would be brute-forceable through the confirm endpoint.
  */
 export async function hashConfirmToken(token: string): Promise<string> {
 	const digest = await crypto.subtle.digest("SHA-256", encoder.encode(token));
@@ -222,6 +230,15 @@ export async function declineContact(db: D1Database, recipientHashValue: string)
 		.bind(recipientHashValue)
 		.run();
 	return result.meta.changes > 0;
+}
+
+/** Whether a contact row exists for the hash, without reading its columns. */
+export async function contactExists(db: D1Database, recipientHashValue: string): Promise<boolean> {
+	const row = await db
+		.prepare(`SELECT 1 FROM notification_contacts WHERE recipient_hash = ? LIMIT 1`)
+		.bind(recipientHashValue)
+		.first<{ 1: number }>();
+	return row !== null;
 }
 
 export async function isSuppressed(db: D1Database, recipientHashValue: string): Promise<boolean> {

--- a/apps/labeler/src/notification-endpoints.ts
+++ b/apps/labeler/src/notification-endpoints.ts
@@ -30,6 +30,7 @@
 
 import {
 	confirmContact,
+	contactExists,
 	declineContact,
 	hashConfirmToken,
 	isSuppressed,
@@ -132,6 +133,9 @@ async function readPostParams(
  * suppressed contact. A malformed recipient hash routes to an absent row and a
  * suppressed contact to a non-matching sentinel token, so the constant-time
  * compare always runs full-length regardless of validity or suppression.
+ *
+ * This endpoint has no rate limit and the token lookup is pepper-less, so its
+ * safety depends on the token's entropy — see {@link hashConfirmToken}.
  */
 async function performConfirm(
 	db: D1Database,
@@ -157,7 +161,14 @@ async function performConfirm(
  * Record a suppression (idempotent) and decline any pending confirmation, so a
  * suppressed address can never later confirm. A confirmed opt-in is not
  * downgraded — it keeps its state and gains a suppression row that the send path
- * honors. A malformed recipient hash is a neutral no-op (no junk row written).
+ * honors.
+ *
+ * The write is gated on an existing contact row: a legitimate recipient always
+ * has one (they were sent mail, which created it via `ensureContact`, and
+ * contacts are never swept), so gating costs them nothing while an attacker who
+ * fabricates a well-formed but unseen hash writes no orphan suppression row. A
+ * malformed or unknown hash is a neutral no-op; the response is byte-identical
+ * either way because the caller only ever sees {@link donePage}.
  */
 async function performSuppression(
 	db: D1Database,
@@ -167,6 +178,10 @@ async function performSuppression(
 ): Promise<void> {
 	if (!RECIPIENT_HASH.test(rawRecipientHash)) {
 		logOutcome(reason, rawRecipientHash, "ignored-malformed");
+		return;
+	}
+	if (!(await contactExists(db, rawRecipientHash))) {
+		logOutcome(reason, rawRecipientHash, "ignored-no-contact");
 		return;
 	}
 	await suppress(db, rawRecipientHash, reason, now.toISOString(), now.getTime());

--- a/apps/labeler/src/notification-endpoints.ts
+++ b/apps/labeler/src/notification-endpoints.ts
@@ -210,6 +210,8 @@ function htmlResponse(body: string, status = 200): Response {
 			"cache-control": "no-store",
 			"referrer-policy": "no-referrer",
 			"x-content-type-options": "nosniff",
+			"x-frame-options": "DENY",
+			"content-security-policy": "frame-ancestors 'none'",
 		},
 	});
 }

--- a/apps/labeler/src/notification-endpoints.ts
+++ b/apps/labeler/src/notification-endpoints.ts
@@ -1,0 +1,279 @@
+/**
+ * Public, token-authenticated landing endpoints for publisher-notification
+ * emails (spec §18/§19, plan W10.4 slice C). These back the links a recipient
+ * clicks — confirm, unsubscribe, and "not me" — and are mounted OUTSIDE
+ * `/admin/*` so neither the Cloudflare Access edge policy nor the in-Worker
+ * operator guard applies: the capability in the link is the sole authority.
+ *
+ * The recipient hash (an HMAC-SHA256 digest, never plaintext email) travels in
+ * the link and is the unforgeable capability — an attacker cannot compute a
+ * victim's hash without the pepper. The confirm link additionally carries a
+ * single-use random token whose SHA-256 digest the send path stored; the raw
+ * token never touches the database.
+ *
+ * Safety properties:
+ *   - GET renders a confirmation page with a POST form; only POST mutates. An
+ *     email scanner's or link-prefetcher's automated GET therefore never
+ *     confirms, unsubscribes, or suppresses. The token/hash live in hidden form
+ *     fields, so the mutating POST carries them in the body, not the URL.
+ *   - CSRF: a cross-site POST cannot supply a valid recipient hash (or confirm
+ *     token) for a victim, so possession of the capability is the CSRF defense;
+ *     a custom header (unsendable from a plain email-client form) is not used.
+ *   - Uniform responses: the page a caller sees never reveals whether the token
+ *     was valid, already consumed, or unknown, nor whether an address is on
+ *     file. The real outcome is logged server-side only, without the token.
+ *   - The confirm path always runs {@link confirmContact}'s constant-time
+ *     compare (fed a non-matching sentinel for a suppressed contact), so elapsed
+ *     time never reveals token validity, and a suppressed contact is never
+ *     confirmed.
+ */
+
+import {
+	confirmContact,
+	declineContact,
+	hashConfirmToken,
+	isSuppressed,
+	suppress,
+} from "./notification-contacts.js";
+
+type NotificationAction = "confirm" | "unsubscribe" | "not-me";
+
+const ACTION_PATHS: Record<string, NotificationAction> = {
+	"/notifications/confirm": "confirm",
+	"/notifications/unsubscribe": "unsubscribe",
+	"/notifications/not-me": "not-me",
+};
+
+/** A well-formed recipient hash: lowercase hex of an HMAC-SHA256 digest. */
+const RECIPIENT_HASH = /^[0-9a-f]{64}$/;
+
+/** URL-safe (base64url/hex) raw confirm token, length-bounded to cap hashing. */
+const CONFIRM_TOKEN = /^[A-Za-z0-9_-]{1,512}$/;
+
+/**
+ * A 64-hex value no real digest collides with (2^-256). Used both as a stand-in
+ * recipient hash when the supplied one is malformed — so the confirm path still
+ * runs its full constant-time compare against an absent row — and as the token
+ * hash fed to {@link confirmContact} for a suppressed contact, so the compare
+ * runs full-length yet can never flip the row.
+ */
+const UNMATCHABLE_HASH = "0".repeat(64);
+
+export function isNotificationPath(pathname: string): boolean {
+	return pathname in ACTION_PATHS;
+}
+
+export async function handleNotificationRequest(
+	db: D1Database,
+	request: Request,
+	now: () => Date = () => new Date(),
+): Promise<Response> {
+	const pathname = new URL(request.url).pathname;
+	const action = ACTION_PATHS[pathname];
+	if (!action) return htmlResponse(notFoundPage(), 404);
+
+	if (request.method === "GET") return htmlResponse(formPage(action, readParams(request, action)));
+	if (request.method !== "POST")
+		return new Response("method not allowed", {
+			status: 405,
+			headers: { allow: "GET, POST", "cache-control": "no-store" },
+		});
+
+	const params = await readPostParams(request, action);
+	switch (action) {
+		case "confirm":
+			await performConfirm(db, params.recipientHash, params.token, now());
+			break;
+		case "unsubscribe":
+			await performSuppression(db, params.recipientHash, "unsubscribe", now());
+			break;
+		case "not-me":
+			await performSuppression(db, params.recipientHash, "not_me", now());
+			break;
+	}
+	return htmlResponse(donePage(action));
+}
+
+interface RequestParams {
+	/** The raw recipient hash, unvalidated (echoed only after escaping). */
+	recipientHash: string;
+	/** The raw confirm token, unvalidated; empty for non-confirm actions. */
+	token: string;
+}
+
+function readParams(request: Request, action: NotificationAction): RequestParams {
+	const query = new URL(request.url).searchParams;
+	return {
+		recipientHash: query.get("c") ?? "",
+		token: action === "confirm" ? (query.get("t") ?? "") : "",
+	};
+}
+
+async function readPostParams(
+	request: Request,
+	action: NotificationAction,
+): Promise<RequestParams> {
+	let form: FormData;
+	try {
+		form = await request.formData();
+	} catch {
+		return { recipientHash: "", token: "" };
+	}
+	const recipientHash = form.get("c");
+	const token = form.get("t");
+	return {
+		recipientHash: typeof recipientHash === "string" ? recipientHash : "",
+		token: action === "confirm" && typeof token === "string" ? token : "",
+	};
+}
+
+/**
+ * Flip `unconfirmed -> confirmed` iff the token matches, and never for a
+ * suppressed contact. A malformed recipient hash routes to an absent row and a
+ * suppressed contact to a non-matching sentinel token, so the constant-time
+ * compare always runs full-length regardless of validity or suppression.
+ */
+async function performConfirm(
+	db: D1Database,
+	rawRecipientHash: string,
+	rawToken: string,
+	now: Date,
+): Promise<void> {
+	const recipientHash = RECIPIENT_HASH.test(rawRecipientHash) ? rawRecipientHash : UNMATCHABLE_HASH;
+	const tokenHash = CONFIRM_TOKEN.test(rawToken)
+		? await hashConfirmToken(rawToken)
+		: UNMATCHABLE_HASH;
+	const suppressed = await isSuppressed(db, recipientHash);
+	const effectiveTokenHash = suppressed ? UNMATCHABLE_HASH : tokenHash;
+	const confirmed = await confirmContact(db, recipientHash, effectiveTokenHash, now.toISOString());
+	logOutcome(
+		"confirm",
+		rawRecipientHash,
+		suppressed ? "suppressed" : confirmed ? "confirmed" : "no-op",
+	);
+}
+
+/**
+ * Record a suppression (idempotent) and decline any pending confirmation, so a
+ * suppressed address can never later confirm. A confirmed opt-in is not
+ * downgraded — it keeps its state and gains a suppression row that the send path
+ * honors. A malformed recipient hash is a neutral no-op (no junk row written).
+ */
+async function performSuppression(
+	db: D1Database,
+	rawRecipientHash: string,
+	reason: "unsubscribe" | "not_me",
+	now: Date,
+): Promise<void> {
+	if (!RECIPIENT_HASH.test(rawRecipientHash)) {
+		logOutcome(reason, rawRecipientHash, "ignored-malformed");
+		return;
+	}
+	await suppress(db, rawRecipientHash, reason, now.toISOString(), now.getTime());
+	await declineContact(db, rawRecipientHash);
+	logOutcome(reason, rawRecipientHash, "suppressed");
+}
+
+/**
+ * Log the real outcome for operability without leaking the capability: the raw
+ * token is never logged, and only an 8-char prefix of the recipient hash is
+ * recorded for correlation.
+ */
+function logOutcome(action: string, rawRecipientHash: string, outcome: string): void {
+	console.log("[notifications]", {
+		action,
+		outcome,
+		hashPrefix: rawRecipientHash.slice(0, 8),
+	});
+}
+
+function htmlResponse(body: string, status = 200): Response {
+	return new Response(body, {
+		status,
+		headers: {
+			"content-type": "text/html; charset=utf-8",
+			"cache-control": "no-store",
+			"referrer-policy": "no-referrer",
+			"x-content-type-options": "nosniff",
+		},
+	});
+}
+
+const ACTION_COPY: Record<NotificationAction, { title: string; prompt: string; button: string }> = {
+	confirm: {
+		title: "Confirm notifications",
+		prompt:
+			"Confirm that this address should receive publisher notifications from the emdash labeler.",
+		button: "Confirm",
+	},
+	unsubscribe: {
+		title: "Unsubscribe",
+		prompt: "Stop sending publisher notifications from the emdash labeler to this address.",
+		button: "Unsubscribe",
+	},
+	"not-me": {
+		title: "Not my address",
+		prompt: "Report that you did not expect this message and should not be contacted again.",
+		button: "Do not contact me",
+	},
+};
+
+const DONE_COPY: Record<NotificationAction, string> = {
+	confirm:
+		"If your confirmation link was valid, this address is now confirmed. You can close this page.",
+	unsubscribe:
+		"This address will no longer receive publisher notifications from the emdash labeler. You can close this page.",
+	"not-me":
+		"Thank you. This address will not be contacted again by the emdash labeler. You can close this page.",
+};
+
+function formPage(action: NotificationAction, params: RequestParams): string {
+	const copy = ACTION_COPY[action];
+	const hidden = [`<input type="hidden" name="c" value="${escapeHtml(params.recipientHash)}">`];
+	if (action === "confirm")
+		hidden.push(`<input type="hidden" name="t" value="${escapeHtml(params.token)}">`);
+	return page(
+		copy.title,
+		`<p>${escapeHtml(copy.prompt)}</p>
+		<form method="post" action="${escapeHtml(`/notifications/${action}`)}">
+			${hidden.join("\n\t\t\t")}
+			<button type="submit">${escapeHtml(copy.button)}</button>
+		</form>`,
+	);
+}
+
+function donePage(action: NotificationAction): string {
+	return page(ACTION_COPY[action].title, `<p>${escapeHtml(DONE_COPY[action])}</p>`);
+}
+
+function notFoundPage(): string {
+	return page("Not found", "<p>This link is not valid.</p>");
+}
+
+function page(title: string, body: string): string {
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>${escapeHtml(title)}</title>
+</head>
+<body>
+<main>
+<h1>${escapeHtml(title)}</h1>
+${body}
+</main>
+</body>
+</html>
+`;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}

--- a/apps/labeler/src/notification-endpoints.ts
+++ b/apps/labeler/src/notification-endpoints.ts
@@ -211,7 +211,8 @@ function htmlResponse(body: string, status = 200): Response {
 			"referrer-policy": "no-referrer",
 			"x-content-type-options": "nosniff",
 			"x-frame-options": "DENY",
-			"content-security-policy": "frame-ancestors 'none'",
+			"content-security-policy":
+				"default-src 'none'; script-src 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'",
 		},
 	});
 }

--- a/apps/labeler/test/notification-endpoints.test.ts
+++ b/apps/labeler/test/notification-endpoints.test.ts
@@ -75,7 +75,9 @@ describe("route mounting and Access bypass", () => {
 	it("denies framing so the state-changing form cannot be clickjacked", async () => {
 		const response = await get("/notifications/confirm?c=abc&t=xyz");
 		expect(response.headers.get("x-frame-options")).toBe("DENY");
-		expect(response.headers.get("content-security-policy")).toBe("frame-ancestors 'none'");
+		expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+		expect(response.headers.get("content-security-policy")).toContain("form-action 'self'");
+		expect(response.headers.get("content-security-policy")).toContain("default-src 'none'");
 	});
 
 	it("rejects non-GET/POST methods with an Allow header", async () => {

--- a/apps/labeler/test/notification-endpoints.test.ts
+++ b/apps/labeler/test/notification-endpoints.test.ts
@@ -209,12 +209,23 @@ describe("not-me", () => {
 		expect((await getContactState(db(), hash))?.confirmState).toBe("declined");
 	});
 
-	it("suppresses an address that has no contact row at all", async () => {
-		const hash = await freshHash();
-		const response = await post("/notifications/not-me", { c: hash });
-		expect(response.status).toBe(200);
-		expect(await isSuppressed(db(), hash)).toBe(true);
-		expect(await reasonFor(hash)).toBe("not_me");
+	it("writes no suppression for a well-formed hash with no contact row, yet returns the same done page", async () => {
+		// A recipient who legitimately received mail always has a contact row, so
+		// a well-formed hash with none is an attacker-fabricated value: it must
+		// write no orphan suppression row while staying response-uniform.
+		const seeded = await freshHash();
+		await ensureContact(db(), seeded, "2026-07-16T00:00:00.000Z");
+		const suppressed = await post("/notifications/not-me", { c: seeded });
+
+		const orphan = await freshHash();
+		const noop = await post("/notifications/not-me", { c: orphan });
+
+		expect(noop.status).toBe(200);
+		expect(await noop.text()).toBe(await suppressed.text());
+		expect(await isSuppressed(db(), orphan)).toBe(false);
+		expect(await reasonFor(orphan)).toBeUndefined();
+		// The seeded contact, which does exist, was suppressed.
+		expect(await isSuppressed(db(), seeded)).toBe(true);
 	});
 });
 

--- a/apps/labeler/test/notification-endpoints.test.ts
+++ b/apps/labeler/test/notification-endpoints.test.ts
@@ -72,6 +72,12 @@ describe("route mounting and Access bypass", () => {
 		expect(response.headers.get("referrer-policy")).toBe("no-referrer");
 	});
 
+	it("denies framing so the state-changing form cannot be clickjacked", async () => {
+		const response = await get("/notifications/confirm?c=abc&t=xyz");
+		expect(response.headers.get("x-frame-options")).toBe("DENY");
+		expect(response.headers.get("content-security-policy")).toBe("frame-ancestors 'none'");
+	});
+
 	it("rejects non-GET/POST methods with an Allow header", async () => {
 		const response = await get("/notifications/confirm", { method: "PUT" });
 		expect(response.status).toBe(405);

--- a/apps/labeler/test/notification-endpoints.test.ts
+++ b/apps/labeler/test/notification-endpoints.test.ts
@@ -1,0 +1,227 @@
+import { applyD1Migrations, env, SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+	ensureContact,
+	getContactState,
+	hashConfirmToken,
+	isSuppressed,
+	recipientHash,
+	recordConfirmSent,
+	suppress,
+} from "../src/notification-contacts.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+const db = () => testEnv.DB;
+
+const PEPPER = "test-notification-hash-pepper";
+let seq = 0;
+
+/** A distinct recipient hash per test, so rows never collide across cases. */
+async function freshHash(): Promise<string> {
+	seq++;
+	return recipientHash(PEPPER, `notify-${seq}@example.test`);
+}
+
+/** Seed an unconfirmed contact carrying a pending confirmation token. */
+async function seedPending(rawToken: string): Promise<string> {
+	const hash = await freshHash();
+	await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+	await recordConfirmSent(db(), hash, await hashConfirmToken(rawToken), 1_000);
+	return hash;
+}
+
+function get(path: string, init?: RequestInit): Promise<Response> {
+	return SELF.fetch(`https://labeler.test${path}`, init);
+}
+
+function post(path: string, fields: Record<string, string>): Promise<Response> {
+	return SELF.fetch(`https://labeler.test${path}`, {
+		method: "POST",
+		headers: { "content-type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams(fields).toString(),
+	});
+}
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+describe("route mounting and Access bypass", () => {
+	it("serves the confirm page without any Cloudflare Access assertion", async () => {
+		const response = await get("/notifications/confirm");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+	});
+
+	it("still guards /admin/api with Access (proving notifications are not behind it)", async () => {
+		const response = await get("/admin/api/assessments", {
+			headers: { "X-EmDash-Request": "1" },
+		});
+		expect(response.status).toBe(401);
+	});
+
+	it("sets no-store and no-referrer so the token does not leak downstream", async () => {
+		const response = await get("/notifications/confirm?c=abc&t=xyz");
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+	});
+
+	it("rejects non-GET/POST methods with an Allow header", async () => {
+		const response = await get("/notifications/confirm", { method: "PUT" });
+		expect(response.status).toBe(405);
+		expect(response.headers.get("allow")).toBe("GET, POST");
+	});
+});
+
+describe("GET does not mutate", () => {
+	it("confirm GET renders a form and leaves the contact unconfirmed", async () => {
+		const token = "confirm-token-get";
+		const hash = await seedPending(token);
+
+		const response = await get(`/notifications/confirm?c=${hash}&t=${encodeURIComponent(token)}`);
+		expect(response.status).toBe(200);
+		const body = await response.text();
+		expect(body).toContain('<form method="post"');
+		expect(body).toContain(`name="c" value="${hash}"`);
+
+		expect((await getContactState(db(), hash))?.confirmState).toBe("unconfirmed");
+	});
+
+	it("unsubscribe GET renders a form and records no suppression", async () => {
+		const hash = await freshHash();
+		await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+
+		const response = await get(`/notifications/unsubscribe?c=${hash}`);
+		expect(response.status).toBe(200);
+		expect(await isSuppressed(db(), hash)).toBe(false);
+	});
+
+	it("escapes caller-supplied values reflected into the form", async () => {
+		const response = await get(
+			`/notifications/confirm?c=${encodeURIComponent('"><script>alert(1)</script>')}`,
+		);
+		const body = await response.text();
+		expect(body).not.toContain("<script>alert(1)</script>");
+		expect(body).toContain("&lt;script&gt;");
+	});
+});
+
+describe("confirm", () => {
+	it("confirms an unconfirmed contact on a valid token", async () => {
+		const token = "confirm-token-valid";
+		const hash = await seedPending(token);
+
+		const response = await post("/notifications/confirm", { c: hash, t: token });
+		expect(response.status).toBe(200);
+
+		const state = await getContactState(db(), hash);
+		expect(state?.confirmState).toBe("confirmed");
+		expect(state?.confirmTokenHash).toBeNull();
+	});
+
+	it("is an idempotent no-op once already confirmed", async () => {
+		const token = "confirm-token-twice";
+		const hash = await seedPending(token);
+
+		const first = await post("/notifications/confirm", { c: hash, t: token });
+		const second = await post("/notifications/confirm", { c: hash, t: token });
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
+		expect(await first.text()).toBe(await second.text());
+		expect((await getContactState(db(), hash))?.confirmState).toBe("confirmed");
+	});
+
+	it("never confirms a suppressed contact even with a matching token", async () => {
+		const token = "confirm-token-suppressed";
+		const hash = await seedPending(token);
+		// A suppression that did not decline the contact (e.g. a hard bounce)
+		// leaves an unconfirmed row with a live token; the endpoint's suppression
+		// guard must still refuse the confirm.
+		await suppress(db(), hash, "bounce", "2026-07-16T00:00:00.000Z", 1_000);
+
+		const response = await post("/notifications/confirm", { c: hash, t: token });
+		expect(response.status).toBe(200);
+		expect((await getContactState(db(), hash))?.confirmState).toBe("unconfirmed");
+	});
+
+	it("returns the same neutral page for valid, wrong, and unknown tokens", async () => {
+		const token = "confirm-token-uniform";
+		const validHash = await seedPending(token);
+		const wrongHash = await seedPending(token);
+		const unknownHash = await freshHash();
+
+		const valid = await post("/notifications/confirm", { c: validHash, t: token });
+		const wrong = await post("/notifications/confirm", { c: wrongHash, t: "not-the-token" });
+		const unknown = await post("/notifications/confirm", { c: unknownHash, t: token });
+		const malformed = await post("/notifications/confirm", { c: "not-a-hash", t: token });
+
+		const validBody = await valid.text();
+		expect(await wrong.text()).toBe(validBody);
+		expect(await unknown.text()).toBe(validBody);
+		expect(await malformed.text()).toBe(validBody);
+		for (const response of [valid, wrong, unknown, malformed]) expect(response.status).toBe(200);
+
+		// The neutral page did not confirm the contacts that should not have been.
+		expect((await getContactState(db(), wrongHash))?.confirmState).toBe("unconfirmed");
+		expect(await getContactState(db(), unknownHash)).toBeNull();
+	});
+});
+
+describe("unsubscribe", () => {
+	it("records a suppression and is idempotent, keeping the first reason", async () => {
+		const hash = await freshHash();
+		await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+
+		const first = await post("/notifications/unsubscribe", { c: hash });
+		const second = await post("/notifications/unsubscribe", { c: hash });
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
+		expect(await isSuppressed(db(), hash)).toBe(true);
+		expect(await reasonFor(hash)).toBe("unsubscribe");
+		expect((await getContactState(db(), hash))?.confirmState).toBe("declined");
+	});
+
+	it("writes no row for a malformed recipient hash", async () => {
+		const response = await post("/notifications/unsubscribe", { c: "bogus" });
+		expect(response.status).toBe(200);
+		const count = await db()
+			.prepare("SELECT COUNT(*) AS n FROM notification_suppressions WHERE recipient_hash = ?")
+			.bind("bogus")
+			.first<{ n: number }>();
+		expect(count?.n).toBe(0);
+	});
+});
+
+describe("not-me", () => {
+	it("suppresses with the not_me reason and declines any pending confirmation", async () => {
+		const hash = await seedPending("pending-token");
+
+		const response = await post("/notifications/not-me", { c: hash });
+		expect(response.status).toBe(200);
+		expect(await isSuppressed(db(), hash)).toBe(true);
+		expect(await reasonFor(hash)).toBe("not_me");
+		expect((await getContactState(db(), hash))?.confirmState).toBe("declined");
+	});
+
+	it("suppresses an address that has no contact row at all", async () => {
+		const hash = await freshHash();
+		const response = await post("/notifications/not-me", { c: hash });
+		expect(response.status).toBe(200);
+		expect(await isSuppressed(db(), hash)).toBe(true);
+		expect(await reasonFor(hash)).toBe("not_me");
+	});
+});
+
+async function reasonFor(hash: string): Promise<string | undefined> {
+	const row = await db()
+		.prepare("SELECT reason FROM notification_suppressions WHERE recipient_hash = ?")
+		.bind(hash)
+		.first<{ reason: string }>();
+	return row?.reason;
+}


### PR DESCRIPTION
## What does this PR do?

Adds the three public, token-authorized landing endpoints that back publisher-notification email links (plan W10.4 slice C): `/notifications/confirm`, `/notifications/unsubscribe`, `/notifications/not-me`. They drive the double-opt-in and universal-suppression state transitions on the `notification_contacts` / `notification_suppressions` tables from slice B (#2068). No email sending (W10.5) and no contact resolution (slice A) here.

Mounted outside `/admin/*`, so neither the Cloudflare Access edge policy nor the operator guard applies — the capability in the link is the sole authority. The recipient hash (HMAC-SHA256 under the secret pepper) is unforgeable without the pepper; confirm additionally carries a single-use token whose SHA-256 the send path stores.

Security properties (an adversarial review pass verified all of these):
- **GET renders a form; only POST mutates** — an email scanner's or prefetcher's GET never confirms/suppresses.
- **Uniform, non-enumerating responses** — the page is byte-identical for valid / wrong-token / unknown / malformed input; the real outcome is logged server-side only (8-char hash prefix, never the token).
- **Timing-uniform confirm** — always runs slice B's constant-time compare (a sentinel token for a suppressed contact), so elapsed time never reveals token validity and a suppressed contact is never confirmed.
- **State guards** — confirm flips `unconfirmed → confirmed` only, never a suppressed contact; unsubscribe/not-me are idempotent hash-keyed suppressions.
- **CSRF via capability secrecy** — a cross-site POST can't supply a victim's recipient hash or token.
- **Suppression writes are gated on an existing contact row** — a legitimate recipient always has one (the mail that carried the link created it and contacts are never swept), so gating costs them nothing while an attacker fabricating a well-formed-but-unseen hash writes no orphan row. No usable enumeration oracle results (an attacker can't produce a hash matching a real contact without the pepper).

**Cross-slice dependency recorded (for W10.5):** the confirm-token lookup is a pepper-less `SHA-256(token)` with no in-worker rate limit, so its safety rests entirely on token entropy — the W10.5 send path MUST generate the token from a CSPRNG with ≥128 bits. Documented at `hashConfirmToken` and in the plan's W10.5 section.

Part of the plugin-registry labelling service (RFC #694, umbrella #1909). Targets the integration branch.

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))

Covered by the approved RFC #694 umbrella.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (zero diagnostics in changed files; pre-existing baseline unchanged)
- [x] `pnpm test` passes (notification-endpoints 15/15; full labeler suite green)
- [x] `pnpm format` has been run (touched paths)
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a; these are standalone public HTML landing pages, not admin UI (the labeler console is intentionally English-only per the W9.3 decision)
- [x] I have added a changeset (if this PR changes a published package) — n/a, `@emdash-cms/labeler` is unpublished (`private: true`)
- [x] New features link to an approved Discussion — RFC #694

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (implementation and adversarial review)

## Screenshots / test output

`vitest run test/notification-endpoints.test.ts` → 15/15: Access-bypass, GET-renders-form/POST-mutates, uniform-neutral-response equality, confirm state guards (unconfirmed-only, suppressed-never-confirmed, null-token), idempotent suppression, the gated no-orphan-row assertion (random hash writes nothing yet returns the identical done page), XSS-escaping, and 405 for other methods.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-notification-endpoints-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-notification-endpoints`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
