### PR TITLE
feat(labeler): publisher contact resolution via aggregator binding (W10.4 slice A)

### DIFF
--- a/.changeset/aggregator-get-publisher.md
+++ b/.changeset/aggregator-get-publisher.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-lexicons": minor
+---
+
+Adds an aggregator `getPublisher` query and `publisherView` definition, returning a publisher's signed profile (display name, description, and identity-level contact channels) by DID alongside any hydrated labels — the publisher counterpart to the existing `getPackage` read.

--- a/apps/aggregator/src/routes/xrpc/getPublisher.ts
+++ b/apps/aggregator/src/routes/xrpc/getPublisher.ts
@@ -1,0 +1,62 @@
+/**
+ * `com.emdashcms.experimental.aggregator.getPublisher` — single publisher
+ * profile by DID. Returns the lexicon's `publisherView` envelope (decoded
+ * record + cid + indexedAt + empty labels unless hydrated).
+ *
+ * Throws `XRPCError("NotFound")` when no row matches. Publisher deletes
+ * hard-delete the `publishers` row, so a NotFound covers both the
+ * never-indexed and the deleted cases — clients treat them equivalently.
+ */
+
+import { json, XRPCError } from "@atcute/xrpc-server";
+import { type AggregatorDefs, type AggregatorGetPublisher } from "@emdash-cms/registry-lexicons";
+
+import { parseSignatureMetadataCid } from "../../utils.js";
+import { hydrateLabels, isRedacted } from "./label-enforcement.js";
+import { getRequestLabelerPolicy } from "./request-policy.js";
+import { type PublisherRow, publisherColumns, publisherUri, publisherView } from "./views.js";
+
+export async function getPublisher(
+	env: Env,
+	params: AggregatorGetPublisher.$params,
+	request: Request,
+): Promise<Response> {
+	// `first-primary` for the same reason as getPackage: a label written by
+	// the labeler between two reads should be reflected on the next read.
+	const session = env.DB.withSession("first-primary");
+	const row = await session
+		.prepare(`SELECT ${publisherColumns()} FROM publishers WHERE did = ?`)
+		.bind(params.did)
+		.first<PublisherRow>();
+	if (!row) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No publisher indexed under ${params.did}.`,
+		});
+	}
+
+	const { accepted } = getRequestLabelerPolicy(request);
+	const uri = publisherUri(row);
+	const labelsByUri = await hydrateLabels(
+		session,
+		accepted,
+		[
+			{ uri, currentCid: parseSignatureMetadataCid(row.signature_metadata) ?? undefined },
+			{ uri: row.did },
+		],
+		Date.now(),
+	);
+	const labels = [...(labelsByUri.get(uri) ?? []), ...(labelsByUri.get(row.did) ?? [])];
+	if (isRedacted(labels, accepted)) {
+		// Indistinguishable from absence — that is what redaction means.
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No publisher indexed under ${params.did}.`,
+		});
+	}
+
+	const view: AggregatorDefs.PublisherView = publisherView(row, labels);
+	return json(view);
+}

--- a/apps/aggregator/src/routes/xrpc/router.ts
+++ b/apps/aggregator/src/routes/xrpc/router.ts
@@ -25,6 +25,7 @@ import { XRPCError, XRPCRouter } from "@atcute/xrpc-server";
 import {
 	AggregatorGetLatestRelease,
 	AggregatorGetPackage,
+	AggregatorGetPublisher,
 	AggregatorListReleases,
 	AggregatorResolvePackage,
 	AggregatorSearchPackages,
@@ -32,6 +33,7 @@ import {
 
 import { getLatestRelease } from "./getLatestRelease.js";
 import { getPackage } from "./getPackage.js";
+import { getPublisher } from "./getPublisher.js";
 import { listReleases } from "./listReleases.js";
 import { resolveRequestLabelerPolicy } from "./request-policy.js";
 import { resolvePackage } from "./resolvePackage.js";
@@ -170,6 +172,9 @@ function createRouter(env: Env): XRPCRouter {
 	});
 	router.addQuery(AggregatorResolvePackage.mainSchema, {
 		handler: ({ params, request }) => resolvePackage(env, params, request),
+	});
+	router.addQuery(AggregatorGetPublisher.mainSchema, {
+		handler: ({ params, request }) => getPublisher(env, params, request),
 	});
 	return router;
 }

--- a/apps/aggregator/src/routes/xrpc/views.ts
+++ b/apps/aggregator/src/routes/xrpc/views.ts
@@ -43,6 +43,19 @@ export interface PackageRow {
 	indexed_at: string | null;
 }
 
+/** Subset of columns from `publishers` we read for `publisherView`. */
+export interface PublisherRow {
+	did: string;
+	display_name: string;
+	description: string | null;
+	url: string | null;
+	contact: string | null; // JSON array of { kind, url?, email? }
+	updated_at: string | null;
+	signature_metadata: string | null;
+	verified_at: string;
+	indexed_at: string | null;
+}
+
 /** Subset of columns from `releases` we read for `releaseView`. */
 export interface ReleaseRow {
 	did: string;
@@ -79,6 +92,19 @@ const PACKAGE_VIEW_COLUMN_NAMES = [
 	"indexed_at",
 ] as const;
 
+/** Column list backing `PublisherRow`. */
+const PUBLISHER_VIEW_COLUMN_NAMES = [
+	"did",
+	"display_name",
+	"description",
+	"url",
+	"contact",
+	"updated_at",
+	"signature_metadata",
+	"verified_at",
+	"indexed_at",
+] as const;
+
 /** Column list backing `ReleaseRow`. */
 const RELEASE_VIEW_COLUMN_NAMES = [
 	"did",
@@ -108,6 +134,11 @@ export function releaseColumns(prefix = ""): string {
 	return RELEASE_VIEW_COLUMN_NAMES.map((c) => `${prefix}${c}`).join(", ");
 }
 
+/** SELECT-clause string for `PublisherRow`, optionally prefixed for JOINs. */
+export function publisherColumns(prefix = ""): string {
+	return PUBLISHER_VIEW_COLUMN_NAMES.map((c) => `${prefix}${c}`).join(", ");
+}
+
 /** AT URI of a package's profile record — the `packageView.uri` and the
  * hydration subject handlers hydrate labels for before calling
  * `packageView`. Single source of truth so the two never drift. No return
@@ -123,6 +154,12 @@ export function packageUri(row: Pick<PackageRow, "did" | "slug">) {
  * subject handlers hydrate labels for before calling `releaseView`. */
 export function releaseUri(row: Pick<ReleaseRow, "did" | "rkey">) {
 	return `at://${row.did}/${NSID.packageRelease}/${row.rkey}` as const;
+}
+
+/** AT URI of a publisher's profile record — the `publisherView.uri` and a
+ * label-hydration subject. The rkey is always `self` (enforced at ingest). */
+export function publisherUri(row: Pick<PublisherRow, "did">) {
+	return `at://${row.did}/${NSID.publisherProfile}/self` as const;
 }
 
 /** Caps a combined labels array at the lexicon's maxLength. A view's
@@ -209,6 +246,50 @@ export function releaseView(row: ReleaseRow, labels: LabelView[] = []): Aggregat
 		indexedAt: row.indexed_at ?? row.verified_at,
 		labels: toLexiconLabels(capLabels(labels, uri)),
 	};
+}
+
+/**
+ * Map a `publishers` row to the lexicon's `publisherView`. The synthesized
+ * `profile` field reconstructs the publisher.profile record JSON from the
+ * normalised columns — same field values the publisher signed. For
+ * byte-identical bytes, clients call `sync.getRecord` and re-verify.
+ *
+ * `labels` are hydrated by the caller (profile URI + publisher DID subjects)
+ * and passed in; defaulting to `[]` covers the accepted-policy-empty case.
+ */
+export function publisherView(
+	row: PublisherRow,
+	labels: LabelView[] = [],
+): AggregatorDefs.PublisherView {
+	const uri = publisherUri(row);
+	const cid = parseSignatureMetadataCid(row.signature_metadata) ?? "";
+	return {
+		uri,
+		cid,
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- `did` is consumer-validated at write time
+		did: row.did as `did:${string}:${string}`,
+		profile: synthesizePublisherProfile(row),
+		indexedAt: row.indexed_at ?? row.verified_at,
+		labels: toLexiconLabels(capLabels(labels, uri)),
+	};
+}
+
+/** Reconstruct the `com.emdashcms.experimental.publisher.profile` record
+ * JSON from the row's columns. Optional fields are omitted (rather than
+ * emitted as null) so the JSON shape matches what a publisher would have
+ * written. Same passthrough-shape caveat as `synthesizePackageProfile`:
+ * typed as `Record<string, unknown>` because clients re-validate against
+ * the published lexicon. */
+function synthesizePublisherProfile(row: PublisherRow): Record<string, unknown> {
+	const profile: Record<string, unknown> = {
+		$type: NSID.publisherProfile,
+		displayName: row.display_name,
+	};
+	if (row.description !== null) profile["description"] = row.description;
+	if (row.url !== null) profile["url"] = row.url;
+	if (row.contact !== null) profile["contact"] = parseJsonArray(row.contact);
+	if (row.updated_at !== null) profile["updatedAt"] = row.updated_at;
+	return profile;
 }
 
 /** Reconstruct the `com.emdashcms.experimental.package.profile` record

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -155,6 +155,48 @@ function releaseUri(pkg: string, version: string, did: string = DID_A): string {
 	return `at://${did}/${NSID.packageRelease}/${pkg}:${version}`;
 }
 
+function publisherUri(did: string = DID_A): string {
+	return `at://${did}/${NSID.publisherProfile}/self`;
+}
+
+interface SeedPublisherOpts {
+	did?: string;
+	displayName?: string;
+	description?: string | null;
+	url?: string | null;
+	contact?: unknown[] | null;
+	updatedAt?: string | null;
+	cid?: string;
+	indexedAt?: string;
+	verifiedAt?: string;
+}
+
+async function seedPublisher(opts: SeedPublisherOpts = {}): Promise<void> {
+	const did = opts.did ?? DID_A;
+	const indexedAt = opts.indexedAt ?? NOW.toISOString();
+	await testEnv.DB.prepare(
+		`INSERT INTO publishers
+		   (did, display_name, description, url, contact, updated_at,
+		    record_blob, signature_metadata, verified_at, indexed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			did,
+			opts.displayName ?? "Demo Publisher",
+			opts.description ?? null,
+			opts.url ?? null,
+			opts.contact === null
+				? null
+				: JSON.stringify(opts.contact ?? [{ kind: "security", email: "sec@pub.test" }]),
+			opts.updatedAt ?? null,
+			new Uint8Array([0xb1, 0xb2, 0xb3]),
+			JSON.stringify({ cid: opts.cid ?? "bafypub" }),
+			opts.verifiedAt ?? NOW.toISOString(),
+			indexedAt,
+		)
+		.run();
+}
+
 /** Seeds a `labelers` row so a DID is "available" per W4.4's resolution:
  * `trusted = 1` rows feed the missing-header default set; any row (trusted
  * or not) makes a DID acceptable when explicitly requested. */
@@ -395,6 +437,94 @@ describe("getPackage", () => {
 		expect(label).not.toHaveProperty("sig");
 		expect(label).not.toHaveProperty("neg");
 		expect(label).not.toHaveProperty("ver");
+	});
+});
+
+describe("getPublisher", () => {
+	it("returns the publisherView envelope for an indexed publisher", async () => {
+		await seedPublisher({
+			displayName: "Acme Plugin Co.",
+			description: "We make plugins",
+			url: "https://acme.test",
+			contact: [{ kind: "security", email: "security@acme.test" }],
+			updatedAt: NOW.toISOString(),
+		});
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}?did=${DID_A}`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body).toMatchObject({
+			uri: publisherUri(),
+			cid: "bafypub",
+			did: DID_A,
+			indexedAt: NOW.toISOString(),
+			labels: [],
+		});
+		expect(body).not.toHaveProperty("slug");
+		const profile = body["profile"] as Record<string, unknown>;
+		expect(profile["$type"]).toBe(NSID.publisherProfile);
+		expect(profile["displayName"]).toBe("Acme Plugin Co.");
+		expect(profile["contact"]).toEqual([{ kind: "security", email: "security@acme.test" }]);
+	});
+
+	it("omits optional profile fields the publisher did not set", async () => {
+		await seedPublisher({
+			displayName: "Minimal",
+			description: null,
+			url: null,
+			contact: null,
+			updatedAt: null,
+		});
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}?did=${DID_A}`);
+		const body = (await res.json()) as { profile: Record<string, unknown> };
+		expect(body.profile).not.toHaveProperty("description");
+		expect(body.profile).not.toHaveProperty("url");
+		expect(body.profile).not.toHaveProperty("contact");
+		expect(body.profile).not.toHaveProperty("updatedAt");
+	});
+
+	it("returns 404 NotFound when no publisher is indexed", async () => {
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}?did=${DID_B}`);
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("NotFound");
+	});
+
+	it("returns 400 InvalidRequest when did is missing", async () => {
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}`);
+		expect(res.status).toBe(400);
+	});
+
+	it("sets Cache-Control: private, no-store on success", async () => {
+		await seedPublisher();
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}?did=${DID_A}`);
+		expect(res.headers.get("cache-control")).toBe("private, no-store");
+	});
+
+	it("404s (redacted) when a default-accepted source's !takedown is active on the publisher DID", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPublisher();
+		await seedLabelState({ uri: DID_A, val: "!takedown" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}?did=${DID_A}`);
+		expect(res.status).toBe(404);
+	});
+
+	it("hydrates labels on the publisher profile record URI", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPublisher();
+		await seedLabelState({ uri: publisherUri(), val: "unverified-publisher" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}?did=${DID_A}`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { labels: Array<{ src: string; uri: string; val: string }> };
+		expect(body.labels).toContainEqual(
+			expect.objectContaining({
+				src: LABELER_DID,
+				uri: publisherUri(),
+				val: "unverified-publisher",
+			}),
+		);
 	});
 });
 

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -510,6 +510,15 @@ describe("getPublisher", () => {
 		expect(res.status).toBe(404);
 	});
 
+	it("404s (redacted) when the !takedown is active on the profile record URI, not the DID", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedPublisher();
+		await seedLabelState({ uri: publisherUri(), val: "!takedown" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisher}?did=${DID_A}`);
+		expect(res.status).toBe(404);
+	});
+
 	it("hydrates labels on the publisher profile record URI", async () => {
 		await seedLabeler(LABELER_DID, true);
 		await seedPublisher();

--- a/apps/labeler/src/aggregator-client.ts
+++ b/apps/labeler/src/aggregator-client.ts
@@ -55,6 +55,7 @@ const ACCEPT_LABELERS_HEADER = "atproto-accept-labelers";
  * is therefore no path for caller data to alter the target host or path. */
 const NSID = {
 	getPackage: "com.emdashcms.experimental.aggregator.getPackage",
+	getPublisher: "com.emdashcms.experimental.aggregator.getPublisher",
 	getLatestRelease: "com.emdashcms.experimental.aggregator.getLatestRelease",
 	listReleases: "com.emdashcms.experimental.aggregator.listReleases",
 } as const;
@@ -94,6 +95,12 @@ export class AggregatorClient {
 	async getPackage(did: string, slug: string): Promise<AggregatorDefs.PackageView | null> {
 		const url = buildUrl(NSID.getPackage, { did, slug });
 		return this.#query<AggregatorDefs.PackageView>(NSID.getPackage, url);
+	}
+
+	/** Fetch the publisher profile view for `did`, or `null` if not indexed. */
+	async getPublisher(did: string): Promise<AggregatorDefs.PublisherView | null> {
+		const url = buildUrl(NSID.getPublisher, { did });
+		return this.#query<AggregatorDefs.PublisherView>(NSID.getPublisher, url);
 	}
 
 	/** Fetch the highest-precedence live release for `(did, pkg)`, or `null`

--- a/apps/labeler/src/publisher-contact.ts
+++ b/apps/labeler/src/publisher-contact.ts
@@ -1,0 +1,200 @@
+/**
+ * Publisher-contact resolution for the notification subsystem (spec §18,
+ * plan W10.4 slice A). Given a package subject, walks three contact tiers in
+ * priority order and returns the first entry carrying a non-empty EMAIL — the
+ * address a takedown/warning notice would be offered to. A url-only contact is
+ * skipped, not treated as resolved: this channel is email, and a URL cannot
+ * receive one.
+ *
+ * Tiers (spec order):
+ *   1. package `security[]`   — required per-package security contacts.
+ *   2. package `authors[]`    — author contact (email optional).
+ *   3. publisher `contact[]`  — identity-level channels, preferring `kind:
+ *                               security` over `general`/other within the tier.
+ *
+ * The reads go through the aggregator service binding ({@link AggregatorClient})
+ * with a fresh single fetch per tier and NO caching — a notice must resolve
+ * against the publisher's current metadata at send time. The aggregator read is
+ * deliberately unfiltered (blank accept-labelers, see the client's module doc):
+ * resolving a takedown contact must work even for a subject this labeler has
+ * itself redacted.
+ *
+ * "No resolvable contact" is an expected terminal outcome (`{ none: ... }`),
+ * not an error. Only a transport/aggregator failure throws, propagated from the
+ * client so the caller can retry the whole resolution.
+ *
+ * PII: the resolved email is returned in memory for the caller to hash
+ * immediately via {@link seedPublisherContact}. It is never persisted or logged
+ * here — logs carry the (public) publisher DID and at most an 8-char prefix of
+ * the recipient hash, matching slice C's `logOutcome`.
+ */
+
+import type { AggregatorClient } from "./aggregator-client.js";
+import { ensureContact, isSuppressed, recipientHash } from "./notification-contacts.js";
+
+/** The package subject a notice concerns. `did` is the publisher DID; it also
+ * keys the tier-3 publisher-profile read. */
+export interface ContactTarget {
+	did: string;
+	slug: string;
+}
+
+/** Which tier a resolved email came from — carried for observability and to
+ * let the caller shape tier-specific copy. */
+export type ContactTier = "package_security" | "package_author" | "publisher_profile";
+
+export interface ResolvedContact {
+	/** The address verbatim from the record; normalization happens at hashing
+	 * time in {@link recipientHash}, so this may carry surrounding whitespace. */
+	email: string;
+	tier: ContactTier;
+	/** Present only for `publisher_profile`: the contact channel `kind`
+	 * (`security` | `general` | other), when the record carried one. */
+	kind?: string;
+}
+
+/** The only expected non-resolution: every tier was walked and no entry
+ * carried a non-empty email (url-only entries don't count). */
+export type NoContactReason = "no_email_contact";
+
+export type ContactResolution = ResolvedContact | { none: NoContactReason };
+
+export async function resolvePublisherContact(
+	client: AggregatorClient,
+	target: ContactTarget,
+): Promise<ContactResolution> {
+	const pkg = await client.getPackage(target.did, target.slug);
+	if (pkg) {
+		const profile = asRecord(pkg.profile);
+		if (profile) {
+			const securityEmail = firstEmail(asArray(profile["security"]));
+			if (securityEmail !== null) {
+				return { email: securityEmail, tier: "package_security" };
+			}
+			const authorEmail = firstEmail(asArray(profile["authors"]));
+			if (authorEmail !== null) {
+				return { email: authorEmail, tier: "package_author" };
+			}
+		}
+	}
+
+	// Tier 3 is keyed by DID alone, so it is attempted even when the package
+	// read misses (e.g. the package was deleted between discovery and notice)
+	// — the publisher entity may still be reachable.
+	const publisher = await client.getPublisher(target.did);
+	if (publisher) {
+		const profile = asRecord(publisher.profile);
+		if (profile) {
+			const preferred = preferredPublisherEmail(asArray(profile["contact"]));
+			if (preferred !== null) {
+				return { email: preferred.email, tier: "publisher_profile", kind: preferred.kind };
+			}
+		}
+	}
+
+	return { none: "no_email_contact" };
+}
+
+export type SeedSkipReason = NoContactReason | "suppressed";
+
+export type SeedOutcome =
+	| { seeded: true; recipientHash: string; tier: ContactTier }
+	| { seeded: false; reason: SeedSkipReason };
+
+/**
+ * Resolve the publisher contact and seed the double-opt-in state row so slice
+ * C's confirm flow can proceed. On a resolved email: hash it under the pepper
+ * and {@link ensureContact} (insert-if-absent as `unconfirmed`). Sending the
+ * confirmation mail is W10.5 — this only seeds the contact and returns its
+ * recipient hash for the send path to use.
+ *
+ * Anti-abuse: a suppressed address is never seeded, so a victim who unsubscribed
+ * or reported "not me" stays off the list even if named again in fresh hostile
+ * metadata. `ensureContact` is insert-if-absent, so an already-confirmed or
+ * declined contact is never reset to `unconfirmed`; the per-address/per-DID
+ * rate limits and confirm-state machine (slices B/C) govern the rest.
+ *
+ * Never logs plaintext email — only the DID and a hash prefix.
+ */
+export async function seedPublisherContact(
+	client: AggregatorClient,
+	db: D1Database,
+	pepper: string,
+	target: ContactTarget,
+	nowIso: string,
+): Promise<SeedOutcome> {
+	const resolution = await resolvePublisherContact(client, target);
+	if ("none" in resolution) {
+		logResolve(target.did, resolution.none, undefined);
+		return { seeded: false, reason: resolution.none };
+	}
+
+	const hash = await recipientHash(pepper, resolution.email);
+	if (await isSuppressed(db, hash)) {
+		logResolve(target.did, "suppressed", hash);
+		return { seeded: false, reason: "suppressed" };
+	}
+
+	await ensureContact(db, hash, nowIso);
+	logResolve(target.did, `seeded:${resolution.tier}`, hash);
+	return { seeded: true, recipientHash: hash, tier: resolution.tier };
+}
+
+/** First entry with a non-empty `email`, or null. Skips url-only entries and
+ * anything that isn't a `{ email }`-shaped object. */
+function firstEmail(entries: readonly unknown[]): string | null {
+	for (const entry of entries) {
+		const email = readEmail(entry);
+		if (email !== null) return email;
+	}
+	return null;
+}
+
+/** Tier-3 selection: an entry with `kind: security` and an email wins outright;
+ * otherwise the first entry carrying any email (regardless of kind). */
+function preferredPublisherEmail(
+	entries: readonly unknown[],
+): { email: string; kind?: string } | null {
+	let fallback: { email: string; kind?: string } | null = null;
+	for (const entry of entries) {
+		const record = asRecord(entry);
+		if (record === null) continue;
+		const email = readEmail(record);
+		if (email === null) continue;
+		const kind = typeof record["kind"] === "string" ? record["kind"] : undefined;
+		if (kind === "security") return { email, kind };
+		if (fallback === null) fallback = kind === undefined ? { email } : { email, kind };
+	}
+	return fallback;
+}
+
+/** The `email` of a contact-shaped value, if present and non-empty after
+ * trimming; otherwise null. Returns the value verbatim (untrimmed). */
+function readEmail(entry: unknown): string | null {
+	const record = asRecord(entry);
+	if (record === null) return null;
+	const email = record["email"];
+	if (typeof email !== "string") return null;
+	return email.trim().length > 0 ? email : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return isRecord(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asArray(value: unknown): readonly unknown[] {
+	return Array.isArray(value) ? value : [];
+}
+
+function logResolve(did: string, outcome: string, recipientHashValue: string | undefined): void {
+	console.log("[notifications]", {
+		action: "resolve",
+		outcome,
+		did,
+		hashPrefix: recipientHashValue?.slice(0, 8),
+	});
+}

--- a/apps/labeler/test/publisher-contact.test.ts
+++ b/apps/labeler/test/publisher-contact.test.ts
@@ -1,0 +1,313 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { AggregatorClient } from "../src/aggregator-client.js";
+import {
+	getContactState,
+	hashConfirmToken,
+	recipientHash,
+	recordConfirmSent,
+	confirmContact,
+	suppress,
+} from "../src/notification-contacts.js";
+import {
+	type ContactTarget,
+	resolvePublisherContact,
+	seedPublisherContact,
+} from "../src/publisher-contact.js";
+
+interface TestEnv {
+	DB: D1Database;
+	AGGREGATOR: Fetcher;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+const db = () => testEnv.DB;
+
+const PEPPER = "pepper-contact";
+const TARGET: ContactTarget = { did: "did:plc:publisher", slug: "some-plugin" };
+
+/**
+ * A fake {@link AggregatorClient} whose `getPackage`/`getPublisher` return the
+ * supplied verbatim `profile` (wrapped in the view envelope the real methods
+ * return) or `null` for a not-indexed read. Records call counts so a test can
+ * prove the tier walk short-circuits and doesn't over-fetch.
+ */
+function makeClient(pkgProfile: unknown, pubProfile: unknown) {
+	const calls = { getPackage: 0, getPublisher: 0 };
+	const client = {
+		getPackage: () => {
+			calls.getPackage++;
+			return Promise.resolve(pkgProfile === null ? null : { profile: pkgProfile });
+		},
+		getPublisher: () => {
+			calls.getPublisher++;
+			return Promise.resolve(pubProfile === null ? null : { profile: pubProfile });
+		},
+	} as unknown as AggregatorClient;
+	return { client, calls };
+}
+
+const packageProfile = (opts: { security?: unknown[]; authors?: unknown[] }) => ({
+	$type: "com.emdashcms.experimental.package.profile",
+	type: "emdash-plugin",
+	license: "MIT",
+	security: opts.security ?? [],
+	authors: opts.authors ?? [],
+});
+
+const publisherProfile = (contact: unknown[]) => ({
+	$type: "com.emdashcms.experimental.publisher.profile",
+	displayName: "Acme",
+	contact,
+});
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+describe("resolvePublisherContact tier walk", () => {
+	it("tier 1: returns the first package security email", async () => {
+		const { client, calls } = makeClient(
+			packageProfile({
+				security: [{ email: "sec@pkg.test" }],
+				authors: [{ name: "A", email: "a@pkg.test" }],
+			}),
+			null,
+		);
+		const result = await resolvePublisherContact(client, TARGET);
+		expect(result).toEqual({ email: "sec@pkg.test", tier: "package_security" });
+		// A tier-1 hit must not read the publisher profile.
+		expect(calls.getPublisher).toBe(0);
+	});
+
+	it("tier 1 url-only falls through to a tier 2 author email", async () => {
+		const { client } = makeClient(
+			packageProfile({
+				security: [{ url: "https://pkg.test/security" }],
+				authors: [
+					{ name: "A", url: "https://a.test" },
+					{ name: "B", email: "b@pkg.test" },
+				],
+			}),
+			null,
+		);
+		const result = await resolvePublisherContact(client, TARGET);
+		expect(result).toEqual({ email: "b@pkg.test", tier: "package_author" });
+	});
+
+	it("all package contacts url-only falls through to tier 3 publisher contact", async () => {
+		const { client, calls } = makeClient(
+			packageProfile({
+				security: [{ url: "https://pkg.test/security" }],
+				authors: [{ name: "A", url: "https://a.test" }],
+			}),
+			publisherProfile([{ kind: "general", email: "hello@acme.test" }]),
+		);
+		const result = await resolvePublisherContact(client, TARGET);
+		expect(result).toEqual({
+			email: "hello@acme.test",
+			tier: "publisher_profile",
+			kind: "general",
+		});
+		expect(calls.getPublisher).toBe(1);
+	});
+
+	it("tier 3 prefers a kind:security channel over an earlier general one", async () => {
+		const { client } = makeClient(
+			packageProfile({
+				security: [{ url: "https://pkg.test/s" }],
+				authors: [{ name: "A", url: "https://a.test" }],
+			}),
+			publisherProfile([
+				{ kind: "general", email: "general@acme.test" },
+				{ kind: "security", email: "security@acme.test" },
+			]),
+		);
+		const result = await resolvePublisherContact(client, TARGET);
+		expect(result).toEqual({
+			email: "security@acme.test",
+			tier: "publisher_profile",
+			kind: "security",
+		});
+	});
+
+	it("tier 3 takes the first email when no security channel carries one", async () => {
+		const { client } = makeClient(
+			packageProfile({
+				security: [{ url: "https://pkg.test/s" }],
+				authors: [{ name: "A", url: "https://a.test" }],
+			}),
+			publisherProfile([
+				{ kind: "security", url: "https://acme.test/security" },
+				{ kind: "general", email: "general@acme.test" },
+			]),
+		);
+		const result = await resolvePublisherContact(client, TARGET);
+		expect(result).toEqual({
+			email: "general@acme.test",
+			tier: "publisher_profile",
+			kind: "general",
+		});
+	});
+
+	it("returns none when no tier carries an email", async () => {
+		const { client } = makeClient(
+			packageProfile({
+				security: [{ url: "https://pkg.test/s" }],
+				authors: [{ name: "A", url: "https://a.test" }],
+			}),
+			publisherProfile([{ kind: "general", url: "https://acme.test" }]),
+		);
+		const result = await resolvePublisherContact(client, TARGET);
+		expect(result).toEqual({ none: "no_email_contact" });
+	});
+
+	it("still resolves tier 3 when the package is not indexed", async () => {
+		const { client, calls } = makeClient(
+			null,
+			publisherProfile([{ kind: "security", email: "security@acme.test" }]),
+		);
+		const result = await resolvePublisherContact(client, TARGET);
+		expect(result).toEqual({
+			email: "security@acme.test",
+			tier: "publisher_profile",
+			kind: "security",
+		});
+		expect(calls.getPackage).toBe(1);
+		expect(calls.getPublisher).toBe(1);
+	});
+
+	it("returns none when neither package nor publisher is indexed", async () => {
+		const { client } = makeClient(null, null);
+		expect(await resolvePublisherContact(client, TARGET)).toEqual({ none: "no_email_contact" });
+	});
+
+	it("skips whitespace-only emails", async () => {
+		const { client } = makeClient(
+			packageProfile({
+				security: [{ email: "   " }],
+				authors: [{ name: "A", email: "real@pkg.test" }],
+			}),
+			null,
+		);
+		expect(await resolvePublisherContact(client, TARGET)).toEqual({
+			email: "real@pkg.test",
+			tier: "package_author",
+		});
+	});
+
+	it("propagates a transport failure rather than reporting no contact", async () => {
+		const client = {
+			getPackage: () => Promise.reject(new Error("binding unreachable")),
+			getPublisher: () => Promise.reject(new Error("binding unreachable")),
+		} as unknown as AggregatorClient;
+		await expect(resolvePublisherContact(client, TARGET)).rejects.toThrow("binding unreachable");
+	});
+});
+
+describe("seedPublisherContact", () => {
+	it("seeds an unconfirmed contact keyed by the recipient hash", async () => {
+		const email = "seed-me@pkg.test";
+		const { client } = makeClient(packageProfile({ security: [{ email }] }), null);
+		const outcome = await seedPublisherContact(
+			client,
+			db(),
+			PEPPER,
+			TARGET,
+			new Date().toISOString(),
+		);
+
+		const expectedHash = await recipientHash(PEPPER, email);
+		expect(outcome).toEqual({
+			seeded: true,
+			recipientHash: expectedHash,
+			tier: "package_security",
+		});
+		const state = await getContactState(db(), expectedHash);
+		expect(state?.confirmState).toBe("unconfirmed");
+	});
+
+	it("does not seed a suppressed address", async () => {
+		const email = "suppressed@pkg.test";
+		const hash = await recipientHash(PEPPER, email);
+		await suppress(db(), hash, "unsubscribe", new Date().toISOString(), Date.now());
+
+		const { client } = makeClient(packageProfile({ security: [{ email }] }), null);
+		const outcome = await seedPublisherContact(
+			client,
+			db(),
+			PEPPER,
+			TARGET,
+			new Date().toISOString(),
+		);
+
+		expect(outcome).toEqual({ seeded: false, reason: "suppressed" });
+		expect(await getContactState(db(), hash)).toBeNull();
+	});
+
+	it("does not reset an already-confirmed contact to unconfirmed", async () => {
+		const email = "confirmed@pkg.test";
+		const hash = await recipientHash(PEPPER, email);
+		const token = "raw-confirm-token";
+		const tokenHash = await hashConfirmToken(token);
+		const now = new Date().toISOString();
+		await seedPublisherContact(
+			makeClient(packageProfile({ security: [{ email }] }), null).client,
+			db(),
+			PEPPER,
+			TARGET,
+			now,
+		);
+		await recordConfirmSent(db(), hash, tokenHash, Date.now());
+		await confirmContact(db(), hash, tokenHash, now);
+		expect((await getContactState(db(), hash))?.confirmState).toBe("confirmed");
+
+		const { client } = makeClient(packageProfile({ security: [{ email }] }), null);
+		const outcome = await seedPublisherContact(
+			client,
+			db(),
+			PEPPER,
+			TARGET,
+			new Date().toISOString(),
+		);
+
+		expect(outcome).toEqual({ seeded: true, recipientHash: hash, tier: "package_security" });
+		expect((await getContactState(db(), hash))?.confirmState).toBe("confirmed");
+	});
+
+	it("reports no contact without touching the database", async () => {
+		const { client } = makeClient(
+			packageProfile({ security: [{ url: "https://pkg.test/s" }] }),
+			null,
+		);
+		const outcome = await seedPublisherContact(
+			client,
+			db(),
+			PEPPER,
+			TARGET,
+			new Date().toISOString(),
+		);
+		expect(outcome).toEqual({ seeded: false, reason: "no_email_contact" });
+	});
+});
+
+describe("resolvePublisherContact over the AGGREGATOR service binding", () => {
+	// Drives the resolver through the real binding and both new read methods:
+	// the stub's package view is url-only (tiers 1-2 miss) and its publisher
+	// view carries a security email (tier 3 hits), so one resolution proves the
+	// full walk survives the binding hop end to end.
+	it("walks package + publisher reads through the binding to a tier-3 email", async () => {
+		const client = new AggregatorClient(testEnv.AGGREGATOR);
+		const result = await resolvePublisherContact(client, {
+			did: "did:plc:stubpublisher",
+			slug: "stub-plugin",
+		});
+		expect(result).toEqual({
+			email: "security@stub.example",
+			tier: "publisher_profile",
+			kind: "security",
+		});
+	});
+});

--- a/apps/labeler/vitest.config.ts
+++ b/apps/labeler/vitest.config.ts
@@ -6,6 +6,13 @@ import { configDefaults, defineConfig } from "vitest/config";
 const migrationsPath = fileURLToPath(new URL("./migrations", import.meta.url));
 const migrations = await readD1Migrations(migrationsPath);
 
+function jsonView(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
 export default defineConfig({
 	// The console (console/vitest.config.ts) and calibration
 	// (calibration/unit.vitest.config.ts) run their own suites separately --
@@ -25,13 +32,57 @@ export default defineConfig({
 				// wrangler.jsonc declares an AGGREGATOR service binding to the
 				// aggregator Worker, which doesn't exist in the test runtime.
 				// Stub it so miniflare can start; most tests inject their own mock
-				// Fetcher rather than using this binding. The stub still fails loud
-				// (501) for an accidental call, and echoes the inbound
-				// atproto-accept-labelers header as a marker so a binding-transport
-				// test can prove the client's blank value survives the hop (a
-				// dropped empty header would read `absent`, not `empty`).
+				// Fetcher rather than using this binding.
+				//
+				// The stub serves realistic getPackage/getPublisher views so a
+				// consumer (the contact resolver) can be exercised end-to-end
+				// through the real binding: the package view carries only url-only
+				// contacts (tiers 1-2 miss) and the publisher view carries a
+				// security-kind email (tier 3 hits), so one resolution walks the
+				// full tier chain across the binding hop. Any other path still fails
+				// loud (501) and echoes the inbound atproto-accept-labelers header
+				// as a marker, so a binding-transport test can prove the client's
+				// blank value survives the hop (a dropped empty header reads
+				// `absent`, not `empty`).
 				serviceBindings: {
 					AGGREGATOR: (request) => {
+						const path = new URL(request.url).pathname;
+						if (path.endsWith("/com.emdashcms.experimental.aggregator.getPackage")) {
+							return jsonView({
+								uri: "at://did:plc:stubpublisher/com.emdashcms.experimental.package.profile/stub-plugin",
+								cid: "bafyreistubpackagecidvalue",
+								did: "did:plc:stubpublisher",
+								slug: "stub-plugin",
+								indexedAt: "2026-07-01T00:00:00.000Z",
+								labels: [],
+								profile: {
+									$type: "com.emdashcms.experimental.package.profile",
+									id: "at://did:plc:stubpublisher/com.emdashcms.experimental.package.profile/stub-plugin",
+									type: "emdash-plugin",
+									license: "MIT",
+									security: [{ url: "https://stub.example/security" }],
+									authors: [{ name: "Stub Author", url: "https://stub.example/author" }],
+									slug: "stub-plugin",
+								},
+							});
+						}
+						if (path.endsWith("/com.emdashcms.experimental.aggregator.getPublisher")) {
+							return jsonView({
+								uri: "at://did:plc:stubpublisher/com.emdashcms.experimental.publisher.profile/self",
+								cid: "bafyreistubpublishercidvalue",
+								did: "did:plc:stubpublisher",
+								indexedAt: "2026-07-01T00:00:00.000Z",
+								labels: [],
+								profile: {
+									$type: "com.emdashcms.experimental.publisher.profile",
+									displayName: "Stub Publisher",
+									contact: [
+										{ kind: "general", url: "https://stub.example/contact" },
+										{ kind: "security", email: "security@stub.example" },
+									],
+								},
+							});
+						}
 						const raw = request.headers.get("atproto-accept-labelers");
 						const marker = raw === null ? "absent" : raw === "" ? "empty" : `value:${raw}`;
 						return new Response("AGGREGATOR is stubbed in tests", {

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/defs.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/defs.json
@@ -59,6 +59,51 @@
 				}
 			}
 		},
+		"publisherView": {
+			"type": "object",
+			"description": "An aggregator's view of a publisher: the signed publisher.profile record verbatim (identity-level contact channels, display name), denormalised metadata for display, and any labels applied to the publisher DID by trusted labelers the aggregator hydrates.",
+			"required": ["uri", "cid", "did", "profile", "indexedAt"],
+			"properties": {
+				"uri": {
+					"type": "string",
+					"format": "at-uri",
+					"description": "AT URI of the publisher.profile record the aggregator indexed (rkey is always 'self'). Pins exactly which record version this view describes."
+				},
+				"cid": {
+					"type": "string",
+					"format": "cid",
+					"description": "CID of the profile record content the aggregator indexed. Lets clients confirm they're working with the same bytes the aggregator did."
+				},
+				"did": {
+					"type": "string",
+					"format": "did",
+					"description": "Publisher DID. Denormalised convenience; equivalent to the DID portion of `uri`."
+				},
+				"handle": {
+					"type": "string",
+					"format": "handle",
+					"description": "Publisher's current handle, if known. Best-effort: handles are mutable and may be stale at the moment of read."
+				},
+				"profile": {
+					"type": "unknown",
+					"description": "The signed publisher.profile record verbatim, passed through from the publisher's repo (carrying its $type, displayName, contact channels, etc.)."
+				},
+				"indexedAt": {
+					"type": "string",
+					"format": "datetime",
+					"description": "When the aggregator first indexed this publisher."
+				},
+				"labels": {
+					"type": "array",
+					"description": "Hydrated labels applying to this publisher DID, per the labelers the request asked for via the atproto-accept-labelers header.",
+					"maxLength": 64,
+					"items": {
+						"type": "ref",
+						"ref": "com.atproto.label.defs#label"
+					}
+				}
+			}
+		},
 		"releaseView": {
 			"type": "object",
 			"description": "An aggregator's view of a release: the signed record verbatim, the mirror URLs the aggregator is currently serving the primary artifact from, and any hydrated labels.",

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPublisher.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPublisher.json
@@ -1,0 +1,35 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.aggregator.getPublisher",
+	"description": "Get a single publisher profile by its DID. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"description": "Returns the aggregator's view of one publisher, including the signed publisher.profile record (identity-level contact channels, display name, description) and any hydrated labels. Returns NotFound if the aggregator has no profile indexed for this DID, or if the publisher has been tombstoned.",
+			"parameters": {
+				"type": "params",
+				"required": ["did"],
+				"properties": {
+					"did": {
+						"type": "string",
+						"format": "did",
+						"description": "Publisher DID."
+					}
+				}
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "ref",
+					"ref": "com.emdashcms.experimental.aggregator.defs#publisherView"
+				}
+			},
+			"errors": [
+				{
+					"name": "NotFound",
+					"description": "No publisher profile indexed under the given DID. Aggregators that hard-delete on publisher deletion (rather than soft-deleting) return NotFound for both the never-indexed and the deleted cases — clients should treat them equivalently."
+				}
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/src/generated/index.ts
+++ b/packages/registry-lexicons/src/generated/index.ts
@@ -1,6 +1,7 @@
 export * as ComEmdashcmsExperimentalAggregatorDefs from "./types/com/emdashcms/experimental/aggregator/defs.js";
 export * as ComEmdashcmsExperimentalAggregatorGetLatestRelease from "./types/com/emdashcms/experimental/aggregator/getLatestRelease.js";
 export * as ComEmdashcmsExperimentalAggregatorGetPackage from "./types/com/emdashcms/experimental/aggregator/getPackage.js";
+export * as ComEmdashcmsExperimentalAggregatorGetPublisher from "./types/com/emdashcms/experimental/aggregator/getPublisher.js";
 export * as ComEmdashcmsExperimentalAggregatorListReleases from "./types/com/emdashcms/experimental/aggregator/listReleases.js";
 export * as ComEmdashcmsExperimentalAggregatorResolvePackage from "./types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as ComEmdashcmsExperimentalAggregatorSearchPackages from "./types/com/emdashcms/experimental/aggregator/searchPackages.js";

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/defs.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/defs.ts
@@ -62,6 +62,49 @@ const _packageViewSchema = /*#__PURE__*/ v.object({
 	 */
 	uri: /*#__PURE__*/ v.resourceUriString(),
 });
+const _publisherViewSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.aggregator.defs#publisherView",
+		),
+	),
+	/**
+	 * CID of the profile record content the aggregator indexed. Lets clients confirm they're working with the same bytes the aggregator did.
+	 */
+	cid: /*#__PURE__*/ v.cidString(),
+	/**
+	 * Publisher DID. Denormalised convenience; equivalent to the DID portion of `uri`.
+	 */
+	did: /*#__PURE__*/ v.didString(),
+	/**
+	 * Publisher's current handle, if known. Best-effort: handles are mutable and may be stale at the moment of read.
+	 */
+	handle: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.handleString()),
+	/**
+	 * When the aggregator first indexed this publisher.
+	 */
+	indexedAt: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * Hydrated labels applying to this publisher DID, per the labelers the request asked for via the atproto-accept-labelers header.
+	 * @maxLength 64
+	 */
+	get labels() {
+		return /*#__PURE__*/ v.optional(
+			/*#__PURE__*/ v.constrain(
+				/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
+				[/*#__PURE__*/ v.arrayLength(0, 64)],
+			),
+		);
+	},
+	/**
+	 * The signed publisher.profile record verbatim, passed through from the publisher's repo (carrying its $type, displayName, contact channels, etc.).
+	 */
+	profile: /*#__PURE__*/ v.unknown(),
+	/**
+	 * AT URI of the publisher.profile record the aggregator indexed (rkey is always 'self'). Pins exactly which record version this view describes.
+	 */
+	uri: /*#__PURE__*/ v.resourceUriString(),
+});
 const _releaseViewSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
 		/*#__PURE__*/ v.literal(
@@ -133,13 +176,19 @@ const _releaseViewSchema = /*#__PURE__*/ v.object({
 });
 
 type packageView$schematype = typeof _packageViewSchema;
+type publisherView$schematype = typeof _publisherViewSchema;
 type releaseView$schematype = typeof _releaseViewSchema;
 
 export interface packageViewSchema extends packageView$schematype {}
+export interface publisherViewSchema extends publisherView$schematype {}
 export interface releaseViewSchema extends releaseView$schematype {}
 
 export const packageViewSchema = _packageViewSchema as packageViewSchema;
+export const publisherViewSchema = _publisherViewSchema as publisherViewSchema;
 export const releaseViewSchema = _releaseViewSchema as releaseViewSchema;
 
 export interface PackageView extends v.InferInput<typeof packageViewSchema> {}
+export interface PublisherView extends v.InferInput<
+	typeof publisherViewSchema
+> {}
 export interface ReleaseView extends v.InferInput<typeof releaseViewSchema> {}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getPublisher.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getPublisher.ts
@@ -1,0 +1,37 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalAggregatorDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.aggregator.getPublisher",
+	{
+		params: /*#__PURE__*/ v.object({
+			/**
+			 * Publisher DID.
+			 */
+			did: /*#__PURE__*/ v.didString(),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalAggregatorDefs.publisherViewSchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.aggregator.getPublisher": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/index.ts
+++ b/packages/registry-lexicons/src/index.ts
@@ -24,6 +24,7 @@
 export * as AggregatorDefs from "./generated/types/com/emdashcms/experimental/aggregator/defs.js";
 export * as AggregatorGetLatestRelease from "./generated/types/com/emdashcms/experimental/aggregator/getLatestRelease.js";
 export * as AggregatorGetPackage from "./generated/types/com/emdashcms/experimental/aggregator/getPackage.js";
+export * as AggregatorGetPublisher from "./generated/types/com/emdashcms/experimental/aggregator/getPublisher.js";
 export * as AggregatorListReleases from "./generated/types/com/emdashcms/experimental/aggregator/listReleases.js";
 export * as AggregatorResolvePackage from "./generated/types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as AggregatorSearchPackages from "./generated/types/com/emdashcms/experimental/aggregator/searchPackages.js";
@@ -57,6 +58,7 @@ export const NSID = {
 	aggregatorDefs: "com.emdashcms.experimental.aggregator.defs",
 	aggregatorGetLatestRelease: "com.emdashcms.experimental.aggregator.getLatestRelease",
 	aggregatorGetPackage: "com.emdashcms.experimental.aggregator.getPackage",
+	aggregatorGetPublisher: "com.emdashcms.experimental.aggregator.getPublisher",
 	aggregatorListReleases: "com.emdashcms.experimental.aggregator.listReleases",
 	aggregatorResolvePackage: "com.emdashcms.experimental.aggregator.resolvePackage",
 	aggregatorSearchPackages: "com.emdashcms.experimental.aggregator.searchPackages",
@@ -107,6 +109,7 @@ export const RECORD_NSIDS = [
 export const QUERY_NSIDS = [
 	NSID.aggregatorGetLatestRelease,
 	NSID.aggregatorGetPackage,
+	NSID.aggregatorGetPublisher,
 	NSID.aggregatorListReleases,
 	NSID.aggregatorResolvePackage,
 	NSID.aggregatorSearchPackages,

--- a/packages/registry-lexicons/tests/types.test.ts
+++ b/packages/registry-lexicons/tests/types.test.ts
@@ -321,6 +321,7 @@ describe("NSID map", () => {
 			"com.emdashcms.experimental.aggregator.defs",
 			"com.emdashcms.experimental.aggregator.getLatestRelease",
 			"com.emdashcms.experimental.aggregator.getPackage",
+			"com.emdashcms.experimental.aggregator.getPublisher",
 			"com.emdashcms.experimental.aggregator.listReleases",
 			"com.emdashcms.experimental.aggregator.resolvePackage",
 			"com.emdashcms.experimental.aggregator.searchPackages",


### PR DESCRIPTION
## What does this PR do?

Implements **W10.4 slice A — publisher contact resolution** for the labeler: given a package subject, resolve the email a takedown/warning notice would be offered to by walking three tiers in spec order and seeding the double-opt-in state row so slice C's confirm flow can proceed. Sending the mail is W10.5; this slice resolves and seeds only.

- **Resolver** (`apps/labeler/src/publisher-contact.ts`): walks package `security[]` → package `authors[]` → publisher profile `contact[]` (preferring `kind: security` within the tier), returning the first entry carrying a non-empty email. url-only contacts are skipped, not treated as resolved. Reads go through the aggregator service binding with a fresh single read per tier and no caching. "No resolvable contact" is an expected terminal outcome, not an error; only a transport failure throws.
- **Seeding seam** `seedPublisherContact`: hashes the resolved email via `recipientHash`, honors suppression (`isSuppressed`), then `ensureContact` (insert-if-absent). Never re-seeds a suppressed address or resets an already-confirmed contact. This is the unit W10.5's send path calls.
- **Tier-3 exposure:** the publisher profile `contact[]` was already indexed in the aggregator (`publishers.contact`) but not exposed by any read, so this adds a minimal read-only `getPublisher(did)` XRPC query + `publisherView` definition, mirroring `getPackage`'s label hydration and takedown redaction, plus a client method.

No notification trigger is wired yet (W10.5 owns it), so the resolver + seeding ship as a standalone, tested seam.

Part of the ratified plugin-registry labelling-service plan (W10.4). Targets the `feat/plugin-registry-labelling-service` integration branch, not `main`.

**Privacy note (informational, not a gate):** publisher/package contact emails are now also available as decoded JSON via `getPublisher`, a hair easier to scrape than the CBOR the aggregator already serves *unredacted* via `com.atproto.sync.getRecord`. This is no new disclosure — the `publisher.profile` is a signed public record already served verbatim by that endpoint, and `getPackage` exposes package `security[]` emails identically. In fact `getPublisher` is strictly *more* redaction-restrictive than `sync.getRecord`: it applies takedown enforcement (returns NotFound for a redacted publisher DID) where the raw record endpoint does not. The labeler's own reads send a blank `atproto-accept-labelers` header, so takedown-contact resolution still works on a redacted subject while public callers get normal redaction.

Plaintext email is held in memory only — hashed immediately, never persisted or logged (logs carry the public DID and an 8-char hash prefix).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (labeler, aggregator, registry-lexicons)
- [x] `pnpm lint` passes (0 diagnostics in changed files; ~40 pre-existing baseline unchanged)
- [x] `pnpm test` passes (labeler 667, aggregator 304, registry-lexicons 23)
- [x] `pnpm format` has been run (oxfmt on touched paths)
- [x] I have added/updated tests for my changes (tier walk, seeding, aggregator route, real-binding end-to-end)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI strings (server/worker + lexicon only)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`@emdash-cms/registry-lexicons` minor; labeler + aggregator are private)
- [ ] New features link to an approved Discussion — covered by the ratified W10.4 plan on the integration branch (maintainer-directed workstream)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

```
labeler:            34 files, 667 tests passed
aggregator:         14 files, 304 tests passed (incl. 8 getPublisher read-api tests)
registry-lexicons:   2 files,  23 tests passed
typecheck:          clean (labeler + aggregator + registry-lexicons)
lint:               0 diagnostics in changed files (40 baseline, unchanged)
oxfmt --check:      all touched files correctly formatted
```
