### PR TITLE
feat(labeler): verification-state history input via aggregator read (W8.4 slice 3)

### DIFF
--- a/.changeset/aggregator-publisher-verification-read.md
+++ b/.changeset/aggregator-publisher-verification-read.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-lexicons": minor
+---
+
+Adds the `com.emdashcms.experimental.aggregator.getPublisherVerification` query and its `publisherVerificationView` / `verificationClaimView` definitions: read the verification claims an aggregator has indexed for a publisher DID.

--- a/apps/aggregator/src/routes/xrpc/getPublisherVerification.ts
+++ b/apps/aggregator/src/routes/xrpc/getPublisherVerification.ts
@@ -4,11 +4,21 @@
  * `publisher_verifications` claims naming it as subject, as operator/display
  * context.
  *
- * An empty `verifications` array is a valid 200 (an unverified publisher).
- * NotFound is returned only when the DID is redacted by a labeler the request
- * accepts — same redaction rule as `getPackage` applies to a publisher DID
- * subject, so an internal caller opting out with a blank
- * `atproto-accept-labelers` header always gets the view.
+ * Redaction runs at two scopes, because a claim is authored by its ISSUER's
+ * repo, not the subject's:
+ *   - the subject DID gates the whole view (redacted → NotFound), the same rule
+ *     `getPackage` applies to a publisher subject;
+ *   - each claim's issuer DID gates only that claim (redacted issuer → the claim
+ *     is dropped from `verifications`), so one taken-down issuer can't hide a
+ *     publisher's other, still-valid claims.
+ * An internal caller opting out with a blank `atproto-accept-labelers` header
+ * has an empty accepted set, so nothing is redacted — it reads every claim,
+ * including redacted-issuer ones, and weighs trust itself.
+ *
+ * An empty `verifications` array is a valid 200 (an unverified publisher, or one
+ * whose every claim's issuer is redacted for this caller) — a NON-redacted
+ * subject is never a 404, so 404 (redacted subject) is distinguishable from an
+ * empty result, unlike `getPackage` where absence is also a 404.
  *
  * The companion input in plan W8.4 slice 3 — recent handle/profile *changes* —
  * has no read here because the aggregator does not ingest a history of them:
@@ -57,10 +67,17 @@ export async function getPublisherVerification(
 	const rows = result.results ?? [];
 
 	const { accepted } = getRequestLabelerPolicy(request);
-	const labelsByUri = await hydrateLabels(session, accepted, [{ uri: params.did }], Date.now());
-	const labels = labelsByUri.get(params.did) ?? [];
-	if (isRedacted(labels, accepted)) {
-		// Indistinguishable from absence — that is what redaction means.
+	// One batched hydration for the subject DID plus every distinct issuer DID
+	// in the result. `hydrateLabels` chunks its `uri IN (...)` at 50, so this
+	// stays a single query unless a publisher has 50+ distinct issuers.
+	const issuerDids = [...new Set(rows.map((row) => row.issuer_did))];
+	const subjects = [params.did, ...issuerDids].map((uri) => ({ uri }));
+	const labelsByUri = await hydrateLabels(session, accepted, subjects, Date.now());
+
+	const subjectLabels = labelsByUri.get(params.did) ?? [];
+	if (isRedacted(subjectLabels, accepted)) {
+		// A redacted publisher DID hides the whole view — the caller can't tell it
+		// apart from an empty result, which is the point of redaction.
 		throw new XRPCError({
 			status: 404,
 			error: "NotFound",
@@ -68,10 +85,14 @@ export async function getPublisherVerification(
 		});
 	}
 
+	const visibleRows = rows.filter(
+		(row) => !isRedacted(labelsByUri.get(row.issuer_did) ?? [], accepted),
+	);
+
 	const view: AggregatorDefs.PublisherVerificationView = publisherVerificationView(
 		params.did,
-		rows,
-		labels,
+		visibleRows,
+		subjectLabels,
 	);
 	return json(view);
 }

--- a/apps/aggregator/src/routes/xrpc/getPublisherVerification.ts
+++ b/apps/aggregator/src/routes/xrpc/getPublisherVerification.ts
@@ -1,0 +1,77 @@
+/**
+ * `com.emdashcms.experimental.aggregator.getPublisherVerification` — the
+ * verification state indexed for a publisher DID: the non-tombstoned
+ * `publisher_verifications` claims naming it as subject, as operator/display
+ * context.
+ *
+ * An empty `verifications` array is a valid 200 (an unverified publisher).
+ * NotFound is returned only when the DID is redacted by a labeler the request
+ * accepts — same redaction rule as `getPackage` applies to a publisher DID
+ * subject, so an internal caller opting out with a blank
+ * `atproto-accept-labelers` header always gets the view.
+ *
+ * The companion input in plan W8.4 slice 3 — recent handle/profile *changes* —
+ * has no read here because the aggregator does not ingest a history of them:
+ * `publishers` is upserted to current state only and handle changes arrive as
+ * atproto identity events the ingestor does not subscribe to
+ * (`jetstream-client.ts`). Exposing them is blocked on that ingestion work,
+ * not on a read path.
+ */
+
+import { json, XRPCError } from "@atcute/xrpc-server";
+import {
+	type AggregatorDefs,
+	type AggregatorGetPublisherVerification,
+} from "@emdash-cms/registry-lexicons";
+
+import { hydrateLabels, isRedacted } from "./label-enforcement.js";
+import { getRequestLabelerPolicy } from "./request-policy.js";
+import {
+	type PublisherVerificationRow,
+	publisherVerificationColumns,
+	publisherVerificationView,
+} from "./views.js";
+
+/** Upper bound on claims returned in one view. A publisher with more than this
+ * many verification claims is pathological; the view's lexicon `maxLength`
+ * matches. */
+const MAX_VERIFICATION_CLAIMS = 100;
+
+export async function getPublisherVerification(
+	env: Env,
+	params: AggregatorGetPublisherVerification.$params,
+	request: Request,
+): Promise<Response> {
+	// `first-primary` for read-after-write consistency with a takedown label
+	// that could land between two reads, mirroring `getPackage`.
+	const session = env.DB.withSession("first-primary");
+	const result = await session
+		.prepare(
+			`SELECT ${publisherVerificationColumns()} FROM publisher_verifications
+			 WHERE subject_did = ? AND tombstoned_at IS NULL
+			 ORDER BY created_at DESC, issuer_did ASC
+			 LIMIT ?`,
+		)
+		.bind(params.did, MAX_VERIFICATION_CLAIMS)
+		.all<PublisherVerificationRow>();
+	const rows = result.results ?? [];
+
+	const { accepted } = getRequestLabelerPolicy(request);
+	const labelsByUri = await hydrateLabels(session, accepted, [{ uri: params.did }], Date.now());
+	const labels = labelsByUri.get(params.did) ?? [];
+	if (isRedacted(labels, accepted)) {
+		// Indistinguishable from absence — that is what redaction means.
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No publisher indexed under ${params.did}.`,
+		});
+	}
+
+	const view: AggregatorDefs.PublisherVerificationView = publisherVerificationView(
+		params.did,
+		rows,
+		labels,
+	);
+	return json(view);
+}

--- a/apps/aggregator/src/routes/xrpc/router.ts
+++ b/apps/aggregator/src/routes/xrpc/router.ts
@@ -26,6 +26,7 @@ import {
 	AggregatorGetLatestRelease,
 	AggregatorGetPackage,
 	AggregatorGetPublisher,
+	AggregatorGetPublisherVerification,
 	AggregatorListReleases,
 	AggregatorResolvePackage,
 	AggregatorSearchPackages,
@@ -34,6 +35,7 @@ import {
 import { getLatestRelease } from "./getLatestRelease.js";
 import { getPackage } from "./getPackage.js";
 import { getPublisher } from "./getPublisher.js";
+import { getPublisherVerification } from "./getPublisherVerification.js";
 import { listReleases } from "./listReleases.js";
 import { resolveRequestLabelerPolicy } from "./request-policy.js";
 import { resolvePackage } from "./resolvePackage.js";
@@ -175,6 +177,9 @@ function createRouter(env: Env): XRPCRouter {
 	});
 	router.addQuery(AggregatorGetPublisher.mainSchema, {
 		handler: ({ params, request }) => getPublisher(env, params, request),
+	});
+	router.addQuery(AggregatorGetPublisherVerification.mainSchema, {
+		handler: ({ params, request }) => getPublisherVerification(env, params, request),
 	});
 	return router;
 }

--- a/apps/aggregator/src/routes/xrpc/views.ts
+++ b/apps/aggregator/src/routes/xrpc/views.ts
@@ -357,6 +357,77 @@ function synthesizePackageRelease(row: ReleaseRow): Record<string, unknown> {
 	return release;
 }
 
+/** Subset of columns from `publisher_verifications` we read for
+ * `verificationClaimView`. */
+export interface PublisherVerificationRow {
+	issuer_did: string;
+	subject_handle: string;
+	subject_display_name: string;
+	created_at: string;
+	expires_at: string | null;
+	indexed_at: string | null;
+	verified_at: string;
+}
+
+const PUBLISHER_VERIFICATION_VIEW_COLUMN_NAMES = [
+	"issuer_did",
+	"subject_handle",
+	"subject_display_name",
+	"created_at",
+	"expires_at",
+	"indexed_at",
+	"verified_at",
+] as const;
+
+/** SELECT-clause string for `PublisherVerificationRow`, optionally prefixed
+ * for JOINs. */
+export function publisherVerificationColumns(prefix = ""): string {
+	return PUBLISHER_VERIFICATION_VIEW_COLUMN_NAMES.map((c) => `${prefix}${c}`).join(", ");
+}
+
+/**
+ * Map the `publisher_verifications` rows naming `did` as subject to the
+ * lexicon's `publisherVerificationView`. `labels` are hydrated by the caller
+ * (the publisher DID subject) and passed in; an empty `rows` is a valid view
+ * (an unverified publisher), distinct from the caller throwing NotFound for a
+ * redacted DID.
+ */
+export function publisherVerificationView(
+	did: string,
+	rows: PublisherVerificationRow[],
+	labels: LabelView[] = [],
+): AggregatorDefs.PublisherVerificationView {
+	return {
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- `did` is the route param, validated as a DID by the lexicon
+		did: did as `did:${string}:${string}`,
+		verifications: rows.map(verificationClaimView),
+		labels: toLexiconVerificationLabels(capLabels(labels, did)),
+	};
+}
+
+function verificationClaimView(
+	row: PublisherVerificationRow,
+): AggregatorDefs.VerificationClaimView {
+	const claim: AggregatorDefs.VerificationClaimView = {
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- issuer_did is consumer-validated at ingest time
+		issuer: row.issuer_did as `did:${string}:${string}`,
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- subject_handle is consumer-validated at ingest time
+		handle: row.subject_handle as AggregatorDefs.VerificationClaimView["handle"],
+		displayName: row.subject_display_name,
+		createdAt: row.created_at,
+		indexedAt: row.indexed_at ?? row.verified_at,
+	};
+	if (row.expires_at !== null) claim.expiresAt = row.expires_at;
+	return claim;
+}
+
+function toLexiconVerificationLabels(
+	labels: LabelView[],
+): AggregatorDefs.PublisherVerificationView["labels"] {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion
+	return labels as AggregatorDefs.PublisherVerificationView["labels"];
+}
+
 function parseJsonArray(json: string): unknown[] {
 	try {
 		const parsed: unknown = JSON.parse(json);

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -250,6 +250,43 @@ async function seedLabelState(opts: {
 		.run();
 }
 
+interface SeedVerificationOpts {
+	issuerDid?: string;
+	rkey?: string;
+	subjectDid?: string;
+	handle?: string;
+	displayName?: string;
+	createdAt?: string;
+	expiresAt?: string | null;
+	indexedAt?: string;
+	tombstoned?: boolean;
+}
+
+async function seedVerification(opts: SeedVerificationOpts = {}): Promise<void> {
+	await testEnv.DB.prepare(
+		`INSERT INTO publisher_verifications
+		   (issuer_did, rkey, subject_did, subject_handle, subject_display_name,
+		    created_at, expires_at, record_blob, signature_metadata, verified_at,
+		    indexed_at, tombstoned_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			opts.issuerDid ?? DID_B,
+			opts.rkey ?? "3kaverifyrkey000",
+			opts.subjectDid ?? DID_A,
+			opts.handle ?? "publisher.example",
+			opts.displayName ?? "Publisher",
+			opts.createdAt ?? NOW.toISOString(),
+			opts.expiresAt === undefined ? null : opts.expiresAt,
+			new Uint8Array([0xc1, 0xc2, 0xc3]),
+			JSON.stringify({ cid: "bafyverif" }),
+			NOW.toISOString(),
+			opts.indexedAt ?? NOW.toISOString(),
+			opts.tombstoned ? NOW.toISOString() : null,
+		)
+		.run();
+}
+
 /** An expiry that is an hour in the past as an instant, rendered with a
  * +14:00 offset so its raw string compares lexically AFTER the current UTC
  * timestamp — the case that text comparison gets wrong. */
@@ -1106,5 +1143,110 @@ describe("XRPC dispatcher", () => {
 	it("returns 404 on unknown XRPC NSIDs", async () => {
 		const res = await SELF.fetch("https://test/xrpc/com.example.notARealEndpoint");
 		expect(res.status).toBe(404);
+	});
+});
+
+describe("getPublisherVerification", () => {
+	it("returns the verification claims naming a DID as subject, newest first", async () => {
+		await seedVerification({
+			issuerDid: DID_B,
+			rkey: "3kolder000000000",
+			createdAt: "2026-01-01T00:00:00.000Z",
+			handle: "pub.example",
+			displayName: "Pub",
+		});
+		await seedVerification({
+			issuerDid: DID_B,
+			rkey: "3knewer000000000",
+			createdAt: "2026-03-01T00:00:00.000Z",
+			handle: "pub.example",
+			displayName: "Pub",
+			expiresAt: "2027-01-01T00:00:00.000Z",
+		});
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			did: string;
+			labels: unknown[];
+			verifications: Array<Record<string, unknown>>;
+		};
+		expect(body.did).toBe(DID_A);
+		expect(body.labels).toEqual([]);
+		expect(body.verifications).toHaveLength(2);
+		// created_at DESC — the March claim comes first.
+		expect(body.verifications[0]).toMatchObject({
+			issuer: DID_B,
+			handle: "pub.example",
+			displayName: "Pub",
+			createdAt: "2026-03-01T00:00:00.000Z",
+			expiresAt: "2027-01-01T00:00:00.000Z",
+			indexedAt: NOW.toISOString(),
+		});
+		// The older claim has no expiry — expiresAt is omitted, not null.
+		expect(body.verifications[1]).not.toHaveProperty("expiresAt");
+	});
+
+	it("returns an empty verifications array for a DID with no claims (not a 404)", async () => {
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { did: string; verifications: unknown[] };
+		expect(body.verifications).toEqual([]);
+	});
+
+	it("excludes tombstoned claims", async () => {
+		await seedVerification({ rkey: "3klive0000000000" });
+		await seedVerification({ rkey: "3kdead0000000000", tombstoned: true });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+		);
+		const body = (await res.json()) as { verifications: unknown[] };
+		expect(body.verifications).toHaveLength(1);
+	});
+
+	it("returns 400 InvalidRequest when the did param is missing", async () => {
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}`);
+		expect(res.status).toBe(400);
+	});
+
+	it("sets Cache-Control: private, no-store on success", async () => {
+		await seedVerification();
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+		);
+		expect(res.headers.get("cache-control")).toBe("private, no-store");
+	});
+
+	it("404s (redacted) when a default-accepted source's !takedown covers the DID", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedVerification();
+		await seedLabelState({ uri: DID_A, val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+		);
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("NotFound");
+	});
+
+	it("serves the view unfiltered for a blank accept-labelers header despite an active takedown", async () => {
+		await seedLabeler(LABELER_DID, true);
+		await seedVerification();
+		await seedLabelState({ uri: DID_A, val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+			{ headers: { "atproto-accept-labelers": "" } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { verifications: unknown[]; labels: unknown[] };
+		expect(body.verifications).toHaveLength(1);
+		expect(body.labels).toEqual([]);
 	});
 });

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -1249,4 +1249,45 @@ describe("getPublisherVerification", () => {
 		expect(body.verifications).toHaveLength(1);
 		expect(body.labels).toEqual([]);
 	});
+
+	it("drops a claim whose issuer is redacted for a default-policy caller, keeping the others", async () => {
+		const redactedIssuer = "did:plc:issuertakedown00000000000";
+		const okIssuer = "did:plc:issuerok0000000000000000";
+		await seedLabeler(LABELER_DID, true);
+		await seedVerification({ issuerDid: redactedIssuer, rkey: "3kredacted000000" });
+		await seedVerification({ issuerDid: okIssuer, rkey: "3kok000000000000" });
+		// Takedown is on the ISSUER's DID, not the subject's.
+		await seedLabelState({ uri: redactedIssuer, val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { verifications: Array<{ issuer: string }> };
+		// The subject is not redacted, so the view is served; only the
+		// redacted-issuer claim is filtered out.
+		expect(body.verifications).toHaveLength(1);
+		expect(body.verifications[0]?.issuer).toBe(okIssuer);
+	});
+
+	it("keeps a redacted-issuer claim for a blank accept-labelers caller (internal unfiltered read)", async () => {
+		const redactedIssuer = "did:plc:issuertakedown00000000000";
+		const okIssuer = "did:plc:issuerok0000000000000000";
+		await seedLabeler(LABELER_DID, true);
+		await seedVerification({ issuerDid: redactedIssuer, rkey: "3kredacted000000" });
+		await seedVerification({ issuerDid: okIssuer, rkey: "3kok000000000000" });
+		await seedLabelState({ uri: redactedIssuer, val: "!takedown" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPublisherVerification}?did=${DID_A}`,
+			{ headers: { "atproto-accept-labelers": "" } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { verifications: Array<{ issuer: string }> };
+		// Empty accepted set → nothing redacted → the labeler sees both claims.
+		expect(body.verifications).toHaveLength(2);
+		expect(body.verifications.map((v) => v.issuer).toSorted()).toEqual(
+			[okIssuer, redactedIssuer].toSorted(),
+		);
+	});
 });

--- a/apps/labeler/src/aggregator-client.ts
+++ b/apps/labeler/src/aggregator-client.ts
@@ -33,7 +33,11 @@
  * may treat a throw as transient and retry the whole read.
  */
 
-import type { AggregatorDefs, AggregatorListReleases } from "@emdash-cms/registry-lexicons";
+import type {
+	AggregatorDefs,
+	AggregatorGetPublisherVerification,
+	AggregatorListReleases,
+} from "@emdash-cms/registry-lexicons";
 
 /**
  * XRPC endpoint host. Irrelevant to routing — a service binding dispatches by
@@ -58,6 +62,7 @@ const NSID = {
 	getPublisher: "com.emdashcms.experimental.aggregator.getPublisher",
 	getLatestRelease: "com.emdashcms.experimental.aggregator.getLatestRelease",
 	listReleases: "com.emdashcms.experimental.aggregator.listReleases",
+	getPublisherVerification: "com.emdashcms.experimental.aggregator.getPublisherVerification",
 } as const;
 
 /** Build an XRPC GET URL from a constant NSID and caller-supplied param
@@ -123,6 +128,22 @@ export class AggregatorClient {
 		if (cursor) params["cursor"] = cursor;
 		const url = buildUrl(NSID.listReleases, params);
 		return this.#query<AggregatorListReleases.$output>(NSID.listReleases, url);
+	}
+
+	/** Fetch the verification state indexed for a publisher `did` — the
+	 * non-tombstoned verification claims naming it as subject. Returns a view
+	 * with an empty `verifications` array for an unverified publisher; `null`
+	 * only when the DID is redacted by a labeler the aggregator's default
+	 * policy accepts (which the blank accept-labelers header opts out of, so an
+	 * indexed subject resolves to the view). */
+	async getPublisherVerification(
+		did: string,
+	): Promise<AggregatorGetPublisherVerification.$output | null> {
+		const url = buildUrl(NSID.getPublisherVerification, { did });
+		return this.#query<AggregatorGetPublisherVerification.$output>(
+			NSID.getPublisherVerification,
+			url,
+		);
 	}
 
 	/** One fetch, no retry. `NotFound` → `null`; any other non-2xx or a

--- a/apps/labeler/src/findings.ts
+++ b/apps/labeler/src/findings.ts
@@ -45,12 +45,14 @@ export type FindingSourceMetadata = ToolFindingMetadata | ModelFindingMetadata;
 export type HistoryFindingCategory =
 	| "publisher-history"
 	| "shared-artifact"
-	| "active-manual-label";
+	| "active-manual-label"
+	| "publisher-verification";
 
 export const HISTORY_FINDING_CATEGORIES: ReadonlySet<string> = new Set<HistoryFindingCategory>([
 	"publisher-history",
 	"shared-artifact",
 	"active-manual-label",
+	"publisher-verification",
 ]);
 
 export interface NormalizedFinding {

--- a/apps/labeler/src/history-context.ts
+++ b/apps/labeler/src/history-context.ts
@@ -1,8 +1,10 @@
 /**
- * Publisher-history context stage (plan W8.4, slice 1). Produces
+ * Publisher-history context stage (plan W8.4, slices 1 + 3). Produces
  * `source: "history"` normalized findings from the labeler's OWN D1 — prior
  * releases from the publishing DID, the same artifact checksum submitted under
- * other DIDs, and existing active manual labels on the subject.
+ * other DIDs, and existing active manual labels on the subject — plus, when a
+ * read-only aggregator binding is supplied, the publisher's verification state
+ * (slice 3).
  *
  * These findings are bounded, factual context an operator reads through the
  * assessment projection. They are structurally never turned into labels: the
@@ -11,11 +13,14 @@
  * dedicated `HISTORY_FINDING_CATEGORIES` set (`findings.ts`), disjoint from the
  * policy's label vocabulary.
  *
- * The two deferred inputs — recent handle/profile changes and verification
- * state — live only in the aggregator's D1, which the labeler has no binding to
- * reach; they are gated on a ratified read path (plan W8.4 D1) and not built
- * here.
+ * Slice 3's second deferred input — recent handle/profile *changes* — has no
+ * read here: the aggregator ingests only current profile state (`publishers` is
+ * upserted, keeping no prior values) and does not subscribe to the atproto
+ * identity events that carry handle changes, so a change history does not exist
+ * to expose. It is blocked on that ingestion work, not on a read path.
  */
+
+import type { AggregatorGetPublisherVerification } from "@emdash-cms/registry-lexicons";
 
 import {
 	getActiveLabelState,
@@ -34,6 +39,15 @@ const DEFAULT_SHARED_PUBLISHER_LIMIT = 20;
 /** How many URIs/DIDs to name in a finding's private detail. */
 const SAMPLE_SIZE = 5;
 
+/**
+ * Read-only aggregator surface `analyzeHistory` needs for slice 3. Narrowed to
+ * the one method so tests inject a plain object and the stage doesn't depend on
+ * the whole `AggregatorClient`. `AggregatorClient` satisfies it structurally.
+ */
+export interface PublisherVerificationReader {
+	getPublisherVerification(did: string): Promise<AggregatorGetPublisherVerification.$output | null>;
+}
+
 export interface HistoryContextOptions {
 	/** The labeler's own DID (`src`) — the stream whose active manual labels
 	 * count as context. */
@@ -41,6 +55,10 @@ export interface HistoryContextOptions {
 	priorReleaseLimit?: number;
 	sharedPublisherLimit?: number;
 	now?: Date;
+	/** Read-only aggregator binding for the publisher's verification state
+	 * (slice 3). When omitted, the verification input is skipped and only the
+	 * own-D1 findings are produced. */
+	aggregator?: PublisherVerificationReader;
 }
 
 /**
@@ -97,6 +115,23 @@ export async function analyzeHistory(
 			.map((winner) => winner.val);
 		if (activeManualLabels.length > 0) findings.push(activeManualLabelFinding(activeManualLabels));
 
+		// Slice-3 aggregator read. Its own try/catch so an aggregator failure
+		// skips only the verification context and never discards the own-D1
+		// findings already gathered above — a verification read that threw into
+		// the outer catch would return `[]` and lose the decision-adjacent
+		// context the operator relies on.
+		if (opts.aggregator && subject) {
+			try {
+				const state = await opts.aggregator.getPublisherVerification(subject.did);
+				const finding = verificationStateFinding(subject.did, state, opts.now ?? new Date());
+				if (finding) findings.push(finding);
+			} catch (err) {
+				console.error(
+					`[history-context] verification-state lookup failed, skipping verification context: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		}
+
 		return findings;
 	} catch (err) {
 		console.error(
@@ -149,6 +184,43 @@ function sharedArtifactFinding(checksum: string, dids: string[], limit: number):
 		evidenceRefs: [],
 		sourceMetadata: toolMetadata(),
 	};
+}
+
+function verificationStateFinding(
+	did: string,
+	state: AggregatorGetPublisherVerification.$output | null,
+	now: Date,
+): NormalizedFinding | null {
+	// `null` means the aggregator has no view (a redacted publisher DID under
+	// the default policy); an empty `verifications` array means an unverified
+	// publisher. Neither is a finding — the console assembles the neutral
+	// "unverified" display state at read time (plan W8.4 D5). Emit only when
+	// there is verification state to record, mirroring the own-D1 findings.
+	if (!state || state.verifications.length === 0) return null;
+
+	const claims = state.verifications;
+	const inForce = claims.filter((claim) => !isExpired(claim.expiresAt, now)).length;
+	const issuers = [...new Set(claims.map((claim) => claim.issuer))];
+	// Issuer identities and the subject's bound handle are indexed from public
+	// records, but the finding keeps them out of the public-facing title and
+	// summary and in privateDetail — consistent with the other history findings
+	// and with history being an operator-only projection.
+	return {
+		source: "history",
+		category: "publisher-verification",
+		severity: "info",
+		title: "Publisher verification context",
+		publicSummary: "Operator-only publisher-verification context is recorded for this subject.",
+		privateDetail: `Publisher ${did} has ${claims.length} indexed verification ${pluralize(claims.length, "claim")} (${inForce} currently in force) from ${issuers.length} ${pluralize(issuers.length, "issuer")}: ${issuers.slice(0, SAMPLE_SIZE).join(", ")}.`,
+		evidenceRefs: [],
+		sourceMetadata: toolMetadata(),
+	};
+}
+
+function isExpired(expiresAt: string | undefined, now: Date): boolean {
+	if (expiresAt === undefined) return false;
+	const expiry = Date.parse(expiresAt);
+	return !Number.isNaN(expiry) && expiry <= now.getTime();
 }
 
 function activeManualLabelFinding(vals: string[]): NormalizedFinding {

--- a/apps/labeler/test/aggregator-client.test.ts
+++ b/apps/labeler/test/aggregator-client.test.ts
@@ -72,6 +72,21 @@ const RELEASE_VIEW = {
 	labels: [],
 };
 
+const PUBLISHER_VERIFICATION_VIEW = {
+	did: "did:plc:abc123",
+	verifications: [
+		{
+			issuer: "did:plc:issuer0000000000000000000",
+			handle: "ada.example",
+			displayName: "Ada",
+			createdAt: "2026-03-01T00:00:00.000Z",
+			expiresAt: "2027-03-01T00:00:00.000Z",
+			indexedAt: "2026-03-01T00:00:00.000Z",
+		},
+	],
+	labels: [],
+};
+
 describe("AggregatorClient.getPackage", () => {
 	it("builds the getPackage URL with URL-encoded params and parses the view", async () => {
 		const { fetcher, urls } = mockFetcher(() => jsonResponse(PACKAGE_VIEW));
@@ -172,6 +187,39 @@ describe("AggregatorClient.listReleases", () => {
 	});
 });
 
+describe("AggregatorClient.getPublisherVerification", () => {
+	it("builds the getPublisherVerification URL and parses the view", async () => {
+		const { fetcher, urls } = mockFetcher(() => jsonResponse(PUBLISHER_VERIFICATION_VIEW));
+		const view = await new AggregatorClient(fetcher).getPublisherVerification("did:plc:abc123");
+
+		expect(urls).toEqual([
+			`${BASE}/com.emdashcms.experimental.aggregator.getPublisherVerification?did=did%3Aplc%3Aabc123`,
+		]);
+		expect(view).toEqual(PUBLISHER_VERIFICATION_VIEW);
+	});
+
+	it("returns null on a NotFound (404) error (redacted DID)", async () => {
+		const { fetcher } = mockFetcher(() => notFoundResponse());
+		const view = await new AggregatorClient(fetcher).getPublisherVerification("did:plc:redacted");
+		expect(view).toBeNull();
+	});
+
+	it("sends a blank atproto-accept-labelers header to opt out of default redaction", async () => {
+		const { fetcher, inits } = mockFetcher(() => jsonResponse(PUBLISHER_VERIFICATION_VIEW));
+		await new AggregatorClient(fetcher).getPublisherVerification("did:plc:abc123");
+
+		const headers = new Headers(inits[0]?.headers);
+		expect(headers.get("atproto-accept-labelers")).toBe("");
+	});
+
+	it("throws on a 5xx response", async () => {
+		const { fetcher } = mockFetcher(() => new Response("upstream boom", { status: 500 }));
+		await expect(
+			new AggregatorClient(fetcher).getPublisherVerification("did:plc:abc123"),
+		).rejects.toThrow(/getPublisherVerification failed: 500/);
+	});
+});
+
 describe("AggregatorClient param encoding", () => {
 	it("percent-encodes reserved characters so they cannot alter the query", async () => {
 		const { fetcher, urls } = mockFetcher(() => jsonResponse(PACKAGE_VIEW));
@@ -194,5 +242,22 @@ describe("AGGREGATOR binding transport", () => {
 			headers: { "atproto-accept-labelers": "" },
 		});
 		expect(response.headers.get("x-test-accept-labelers")).toBe("empty");
+	});
+
+	// Drives the real binding through AggregatorClient (not an injected mock
+	// Fetcher): proves the getPublisherVerification method reaches the bound
+	// Worker, sends the blank accept-labelers header across the hop, and parses
+	// the view. The vitest AGGREGATOR stub serves the canned view.
+	it("reads publisher verification state through the real AGGREGATOR binding", async () => {
+		const view = await new AggregatorClient(env.AGGREGATOR).getPublisherVerification(
+			"did:plc:abc123",
+		);
+		expect(view).not.toBeNull();
+		expect(view?.did).toBe("did:plc:abc123");
+		expect(view?.verifications).toHaveLength(1);
+		expect(view?.verifications[0]).toMatchObject({
+			issuer: "did:plc:issuerstub00000000000000",
+			handle: "stub.example",
+		});
 	});
 });

--- a/apps/labeler/test/history-context.test.ts
+++ b/apps/labeler/test/history-context.test.ts
@@ -1,3 +1,4 @@
+import type { AggregatorGetPublisherVerification } from "@emdash-cms/registry-lexicons";
 import { createLabelSigner, type LabelSigner } from "@emdash-cms/registry-moderation";
 import { applyD1Migrations, env } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -8,7 +9,7 @@ import {
 	HISTORY_FINDING_CATEGORIES,
 	validateFindings,
 } from "../src/findings.js";
-import { analyzeHistory } from "../src/history-context.js";
+import { analyzeHistory, type PublisherVerificationReader } from "../src/history-context.js";
 import { MODERATION_POLICY } from "../src/policy.js";
 import { issueManualLabel } from "../src/service.js";
 import { initializeSigningState } from "../src/signing-rotation.js";
@@ -287,4 +288,96 @@ describe("analyzeHistory", () => {
 			}),
 		).resolves.toEqual([]);
 	});
+
+	it("reports the publisher's verification state read from the aggregator", async () => {
+		const did = "did:plc:verified0000000000000000";
+		const subject = await seedSubject(did, "verified");
+		const reader = readerReturning(
+			verificationView([
+				{ issuer: "did:plc:issuerA00000000000000000", handle: "pub.example" },
+				{ issuer: "did:plc:issuerB00000000000000000", handle: "pub.example" },
+			]),
+		);
+
+		const findings = await analyzeHistory(
+			testEnv.DB,
+			assessmentFor({ uri: subject.uri, cid: subject.cid }),
+			{ src: LABELER_DID, aggregator: reader },
+		);
+
+		const verification = findings.find((f) => f.category === "publisher-verification");
+		expect(verification).toBeDefined();
+		expect(verification!.source).toBe("history");
+		// Issuer identities are indexed from public records but stay out of the
+		// public-facing fields, consistent with the other history findings.
+		expect(verification!.title).not.toContain("did:plc:issuerA00000000000000000");
+		expect(verification!.publicSummary).not.toContain("did:plc:issuerA00000000000000000");
+		expect(verification!.privateDetail).toContain("did:plc:issuerA00000000000000000");
+		expect(verification!.privateDetail).toContain("2 issuers");
+
+		// The orchestrator validates every stage's output; the verification
+		// category must be admitted by the amended validator.
+		const validated = validateFindings(findings, {
+			allowedCategories: allowedFindingCategories(MODERATION_POLICY),
+			resolvableEvidenceIds: new Set(),
+		});
+		expect(validated.some((f) => f.category === "publisher-verification")).toBe(true);
+	});
+
+	it("omits a verification finding for an unverified publisher (no indexed claims)", async () => {
+		const did = "did:plc:unverified00000000000000";
+		const subject = await seedSubject(did, "unverified");
+		const reader = readerReturning(verificationView([]));
+
+		const findings = await analyzeHistory(
+			testEnv.DB,
+			assessmentFor({ uri: subject.uri, cid: subject.cid }),
+			{ src: LABELER_DID, aggregator: reader },
+		);
+
+		expect(findings.find((f) => f.category === "publisher-verification")).toBeUndefined();
+	});
+
+	it("preserves the own-D1 findings when the aggregator verification read fails", async () => {
+		const did = "did:plc:aggfail00000000000000000";
+		const current = await seedSubject(did, "aggfail-current");
+		await seedSubject(did, "aggfail-older");
+		const reader: PublisherVerificationReader = {
+			getPublisherVerification: () => Promise.reject(new Error("aggregator unreachable")),
+		};
+
+		const findings = await analyzeHistory(
+			testEnv.DB,
+			assessmentFor({ uri: current.uri, cid: current.cid }),
+			{ src: LABELER_DID, aggregator: reader },
+		);
+
+		// The own-D1 prior-releases finding survives; the failed aggregator read
+		// contributes nothing and never throws.
+		expect(findings.find((f) => f.category === "publisher-history")).toBeDefined();
+		expect(findings.find((f) => f.category === "publisher-verification")).toBeUndefined();
+	});
 });
+
+type VerificationView = AggregatorGetPublisherVerification.$output;
+
+function verificationView(
+	claims: Array<{ issuer: string; handle: string; expiresAt?: string }>,
+): VerificationView {
+	return {
+		did: "did:plc:viewsubject0000000000000",
+		verifications: claims.map((claim) => ({
+			issuer: claim.issuer,
+			handle: claim.handle,
+			displayName: "Publisher",
+			createdAt: "2026-03-01T00:00:00.000Z",
+			indexedAt: "2026-03-01T00:00:00.000Z",
+			...(claim.expiresAt !== undefined ? { expiresAt: claim.expiresAt } : {}),
+		})),
+		labels: [],
+	} as VerificationView;
+}
+
+function readerReturning(view: VerificationView | null): PublisherVerificationReader {
+	return { getPublisherVerification: () => Promise.resolve(view) };
+}

--- a/apps/labeler/vitest.config.ts
+++ b/apps/labeler/vitest.config.ts
@@ -39,11 +39,13 @@ export default defineConfig({
 				// through the real binding: the package view carries only url-only
 				// contacts (tiers 1-2 miss) and the publisher view carries a
 				// security-kind email (tier 3 hits), so one resolution walks the
-				// full tier chain across the binding hop. Any other path still fails
-				// loud (501) and echoes the inbound atproto-accept-labelers header
-				// as a marker, so a binding-transport test can prove the client's
-				// blank value survives the hop (a dropped empty header reads
-				// `absent`, not `empty`).
+				// full tier chain across the binding hop. It also serves a canned
+				// getPublisherVerification view so a consumer-wiring test can drive
+				// AggregatorClient over the real binding end-to-end (W8.4 slice 3).
+				// Any other path still fails loud (501) and echoes the inbound
+				// atproto-accept-labelers header as a marker, so a binding-transport
+				// test can prove the client's blank value survives the hop (a
+				// dropped empty header reads `absent`, not `empty`).
 				serviceBindings: {
 					AGGREGATOR: (request) => {
 						const path = new URL(request.url).pathname;
@@ -85,6 +87,29 @@ export default defineConfig({
 						}
 						const raw = request.headers.get("atproto-accept-labelers");
 						const marker = raw === null ? "absent" : raw === "" ? "empty" : `value:${raw}`;
+						const url = new URL(request.url);
+						if (
+							url.pathname ===
+							"/xrpc/com.emdashcms.experimental.aggregator.getPublisherVerification"
+						) {
+							const did = url.searchParams.get("did") ?? "did:plc:unknown";
+							return Response.json(
+								{
+									did,
+									verifications: [
+										{
+											issuer: "did:plc:issuerstub00000000000000",
+											handle: "stub.example",
+											displayName: "Stub Publisher",
+											createdAt: "2026-03-01T00:00:00.000Z",
+											indexedAt: "2026-03-01T00:00:00.000Z",
+										},
+									],
+									labels: [],
+								},
+								{ headers: { "x-test-accept-labelers": marker } },
+							);
+						}
 						return new Response("AGGREGATOR is stubbed in tests", {
 							status: 501,
 							headers: { "x-test-accept-labelers": marker },

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/defs.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/defs.json
@@ -206,7 +206,7 @@
 		},
 		"publisherVerificationView": {
 			"type": "object",
-			"description": "An aggregator's view of the verification state indexed for a publisher DID: the non-tombstoned verification claims naming it as subject. Returns an empty `verifications` array for a DID with no indexed claims (an unverified publisher) — distinct from NotFound, which means the DID is redacted by a labeler the request accepts.",
+			"description": "An aggregator's view of the verification state indexed for a publisher DID: the non-tombstoned verification claims naming it as subject. Claims are returned regardless of expiry — the caller evaluates in-force state from each claim's `expiresAt`. An empty `verifications` array means the DID has no indexed claims (an unverified publisher), or every claim's issuer is redacted for this caller — distinct from NotFound, which means the subject DID itself is redacted.",
 			"required": ["did", "verifications"],
 			"properties": {
 				"did": {

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/defs.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/defs.json
@@ -165,6 +165,74 @@
 					}
 				}
 			}
+		},
+		"verificationClaimView": {
+			"type": "object",
+			"description": "One verification claim the aggregator has indexed for a subject: an issuer DID vouching for the subject as a trusted publisher, bound to the subject's handle and publisher-profile displayName at issuance. Whether the claim is currently in force (handle and displayName still match, and it has not expired) is a read-time concern; this view reports the facts as indexed.",
+			"required": ["issuer", "handle", "displayName", "createdAt", "indexedAt"],
+			"properties": {
+				"issuer": {
+					"type": "string",
+					"format": "did",
+					"description": "DID of the repo that issued the verification."
+				},
+				"handle": {
+					"type": "string",
+					"format": "handle",
+					"description": "Subject handle bound at issuance."
+				},
+				"displayName": {
+					"type": "string",
+					"description": "Subject publisher-profile displayName bound at issuance.",
+					"maxLength": 1024,
+					"maxGraphemes": 100
+				},
+				"createdAt": {
+					"type": "string",
+					"format": "datetime",
+					"description": "When the verification was issued."
+				},
+				"expiresAt": {
+					"type": "string",
+					"format": "datetime",
+					"description": "Optional expiry. Absent means no automatic expiry."
+				},
+				"indexedAt": {
+					"type": "string",
+					"format": "datetime",
+					"description": "When the aggregator first indexed this verification."
+				}
+			}
+		},
+		"publisherVerificationView": {
+			"type": "object",
+			"description": "An aggregator's view of the verification state indexed for a publisher DID: the non-tombstoned verification claims naming it as subject. Returns an empty `verifications` array for a DID with no indexed claims (an unverified publisher) — distinct from NotFound, which means the DID is redacted by a labeler the request accepts.",
+			"required": ["did", "verifications"],
+			"properties": {
+				"did": {
+					"type": "string",
+					"format": "did",
+					"description": "Subject publisher DID the verification state is for."
+				},
+				"verifications": {
+					"type": "array",
+					"description": "Non-tombstoned verification claims naming this DID as subject, newest issuance first.",
+					"maxLength": 100,
+					"items": {
+						"type": "ref",
+						"ref": "com.emdashcms.experimental.aggregator.defs#verificationClaimView"
+					}
+				},
+				"labels": {
+					"type": "array",
+					"description": "Hydrated labels applying to this publisher DID, per the labelers the request asked for via the atproto-accept-labelers header.",
+					"maxLength": 64,
+					"items": {
+						"type": "ref",
+						"ref": "com.atproto.label.defs#label"
+					}
+				}
+			}
 		}
 	}
 }

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPublisherVerification.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPublisherVerification.json
@@ -1,0 +1,35 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.aggregator.getPublisherVerification",
+	"description": "Get the verification state indexed for a publisher DID. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"description": "Returns the non-tombstoned verification claims naming `did` as subject, as operator/display context. Returns an empty `verifications` array when the DID has no indexed claims. Returns NotFound only when the DID is redacted by a labeler the request accepts (the atproto-accept-labelers negotiation applies, same as the other read endpoints); a request that opts out of redaction with a blank header always gets the view.",
+			"parameters": {
+				"type": "params",
+				"required": ["did"],
+				"properties": {
+					"did": {
+						"type": "string",
+						"format": "did",
+						"description": "Subject publisher DID."
+					}
+				}
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "ref",
+					"ref": "com.emdashcms.experimental.aggregator.defs#publisherVerificationView"
+				}
+			},
+			"errors": [
+				{
+					"name": "NotFound",
+					"description": "The publisher DID is redacted by a labeler the request accepts. Indistinguishable from absence by design."
+				}
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPublisherVerification.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPublisherVerification.json
@@ -5,7 +5,7 @@
 	"defs": {
 		"main": {
 			"type": "query",
-			"description": "Returns the non-tombstoned verification claims naming `did` as subject, as operator/display context. Returns an empty `verifications` array when the DID has no indexed claims. Returns NotFound only when the DID is redacted by a labeler the request accepts (the atproto-accept-labelers negotiation applies, same as the other read endpoints); a request that opts out of redaction with a blank header always gets the view.",
+			"description": "Returns the non-tombstoned verification claims naming `did` as subject, as operator/display context. Claims are returned regardless of expiry — each carries `expiresAt` for the caller to evaluate in-force state. Returns an empty `verifications` array when the DID has no indexed claims. Redaction (the atproto-accept-labelers negotiation, same as the other read endpoints) applies at two scopes: a redacted subject DID returns NotFound; a claim whose issuer DID is redacted is dropped from `verifications`, since a claim is authored by its issuer, not the subject. A request that opts out with a blank header always gets the full view.",
 			"parameters": {
 				"type": "params",
 				"required": ["did"],
@@ -27,7 +27,7 @@
 			"errors": [
 				{
 					"name": "NotFound",
-					"description": "The publisher DID is redacted by a labeler the request accepts. Indistinguishable from absence by design."
+					"description": "The subject publisher DID is redacted by a labeler the request accepts. An unknown or unverified DID is NOT a 404 — it returns 200 with an empty `verifications` array — so this status is distinguishable from absence."
 				}
 			]
 		}

--- a/packages/registry-lexicons/src/generated/index.ts
+++ b/packages/registry-lexicons/src/generated/index.ts
@@ -2,6 +2,7 @@ export * as ComEmdashcmsExperimentalAggregatorDefs from "./types/com/emdashcms/e
 export * as ComEmdashcmsExperimentalAggregatorGetLatestRelease from "./types/com/emdashcms/experimental/aggregator/getLatestRelease.js";
 export * as ComEmdashcmsExperimentalAggregatorGetPackage from "./types/com/emdashcms/experimental/aggregator/getPackage.js";
 export * as ComEmdashcmsExperimentalAggregatorGetPublisher from "./types/com/emdashcms/experimental/aggregator/getPublisher.js";
+export * as ComEmdashcmsExperimentalAggregatorGetPublisherVerification from "./types/com/emdashcms/experimental/aggregator/getPublisherVerification.js";
 export * as ComEmdashcmsExperimentalAggregatorListReleases from "./types/com/emdashcms/experimental/aggregator/listReleases.js";
 export * as ComEmdashcmsExperimentalAggregatorResolvePackage from "./types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as ComEmdashcmsExperimentalAggregatorSearchPackages from "./types/com/emdashcms/experimental/aggregator/searchPackages.js";

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/defs.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/defs.ts
@@ -62,6 +62,39 @@ const _packageViewSchema = /*#__PURE__*/ v.object({
 	 */
 	uri: /*#__PURE__*/ v.resourceUriString(),
 });
+const _publisherVerificationViewSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.aggregator.defs#publisherVerificationView",
+		),
+	),
+	/**
+	 * Subject publisher DID the verification state is for.
+	 */
+	did: /*#__PURE__*/ v.didString(),
+	/**
+	 * Hydrated labels applying to this publisher DID, per the labelers the request asked for via the atproto-accept-labelers header.
+	 * @maxLength 64
+	 */
+	get labels() {
+		return /*#__PURE__*/ v.optional(
+			/*#__PURE__*/ v.constrain(
+				/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
+				[/*#__PURE__*/ v.arrayLength(0, 64)],
+			),
+		);
+	},
+	/**
+	 * Non-tombstoned verification claims naming this DID as subject, newest issuance first.
+	 * @maxLength 100
+	 */
+	get verifications() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(verificationClaimViewSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 100)],
+		);
+	},
+});
 const _publisherViewSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
 		/*#__PURE__*/ v.literal(
@@ -174,21 +207,72 @@ const _releaseViewSchema = /*#__PURE__*/ v.object({
 		/*#__PURE__*/ v.stringLength(1, 64),
 	]),
 });
+const _verificationClaimViewSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.aggregator.defs#verificationClaimView",
+		),
+	),
+	/**
+	 * When the verification was issued.
+	 */
+	createdAt: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * Subject publisher-profile displayName bound at issuance.
+	 * @maxLength 1024
+	 * @maxGraphemes 100
+	 */
+	displayName: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(0, 1024),
+		/*#__PURE__*/ v.stringGraphemes(0, 100),
+	]),
+	/**
+	 * Optional expiry. Absent means no automatic expiry.
+	 */
+	expiresAt: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.datetimeString()),
+	/**
+	 * Subject handle bound at issuance.
+	 */
+	handle: /*#__PURE__*/ v.handleString(),
+	/**
+	 * When the aggregator first indexed this verification.
+	 */
+	indexedAt: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * DID of the repo that issued the verification.
+	 */
+	issuer: /*#__PURE__*/ v.didString(),
+});
 
 type packageView$schematype = typeof _packageViewSchema;
+type publisherVerificationView$schematype =
+	typeof _publisherVerificationViewSchema;
 type publisherView$schematype = typeof _publisherViewSchema;
 type releaseView$schematype = typeof _releaseViewSchema;
+type verificationClaimView$schematype = typeof _verificationClaimViewSchema;
 
 export interface packageViewSchema extends packageView$schematype {}
+export interface publisherVerificationViewSchema extends publisherVerificationView$schematype {}
 export interface publisherViewSchema extends publisherView$schematype {}
 export interface releaseViewSchema extends releaseView$schematype {}
+export interface verificationClaimViewSchema extends verificationClaimView$schematype {}
 
 export const packageViewSchema = _packageViewSchema as packageViewSchema;
+export const publisherVerificationViewSchema =
+	_publisherVerificationViewSchema as publisherVerificationViewSchema;
 export const publisherViewSchema = _publisherViewSchema as publisherViewSchema;
 export const releaseViewSchema = _releaseViewSchema as releaseViewSchema;
+export const verificationClaimViewSchema =
+	_verificationClaimViewSchema as verificationClaimViewSchema;
 
 export interface PackageView extends v.InferInput<typeof packageViewSchema> {}
+export interface PublisherVerificationView extends v.InferInput<
+	typeof publisherVerificationViewSchema
+> {}
 export interface PublisherView extends v.InferInput<
 	typeof publisherViewSchema
 > {}
 export interface ReleaseView extends v.InferInput<typeof releaseViewSchema> {}
+export interface VerificationClaimView extends v.InferInput<
+	typeof verificationClaimViewSchema
+> {}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getPublisherVerification.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getPublisherVerification.ts
@@ -1,0 +1,37 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalAggregatorDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.aggregator.getPublisherVerification",
+	{
+		params: /*#__PURE__*/ v.object({
+			/**
+			 * Subject publisher DID.
+			 */
+			did: /*#__PURE__*/ v.didString(),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalAggregatorDefs.publisherVerificationViewSchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.aggregator.getPublisherVerification": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/index.ts
+++ b/packages/registry-lexicons/src/index.ts
@@ -25,6 +25,7 @@ export * as AggregatorDefs from "./generated/types/com/emdashcms/experimental/ag
 export * as AggregatorGetLatestRelease from "./generated/types/com/emdashcms/experimental/aggregator/getLatestRelease.js";
 export * as AggregatorGetPackage from "./generated/types/com/emdashcms/experimental/aggregator/getPackage.js";
 export * as AggregatorGetPublisher from "./generated/types/com/emdashcms/experimental/aggregator/getPublisher.js";
+export * as AggregatorGetPublisherVerification from "./generated/types/com/emdashcms/experimental/aggregator/getPublisherVerification.js";
 export * as AggregatorListReleases from "./generated/types/com/emdashcms/experimental/aggregator/listReleases.js";
 export * as AggregatorResolvePackage from "./generated/types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as AggregatorSearchPackages from "./generated/types/com/emdashcms/experimental/aggregator/searchPackages.js";
@@ -59,6 +60,8 @@ export const NSID = {
 	aggregatorGetLatestRelease: "com.emdashcms.experimental.aggregator.getLatestRelease",
 	aggregatorGetPackage: "com.emdashcms.experimental.aggregator.getPackage",
 	aggregatorGetPublisher: "com.emdashcms.experimental.aggregator.getPublisher",
+	aggregatorGetPublisherVerification:
+		"com.emdashcms.experimental.aggregator.getPublisherVerification",
 	aggregatorListReleases: "com.emdashcms.experimental.aggregator.listReleases",
 	aggregatorResolvePackage: "com.emdashcms.experimental.aggregator.resolvePackage",
 	aggregatorSearchPackages: "com.emdashcms.experimental.aggregator.searchPackages",
@@ -110,6 +113,7 @@ export const QUERY_NSIDS = [
 	NSID.aggregatorGetLatestRelease,
 	NSID.aggregatorGetPackage,
 	NSID.aggregatorGetPublisher,
+	NSID.aggregatorGetPublisherVerification,
 	NSID.aggregatorListReleases,
 	NSID.aggregatorResolvePackage,
 	NSID.aggregatorSearchPackages,

--- a/packages/registry-lexicons/tests/types.test.ts
+++ b/packages/registry-lexicons/tests/types.test.ts
@@ -322,6 +322,7 @@ describe("NSID map", () => {
 			"com.emdashcms.experimental.aggregator.getLatestRelease",
 			"com.emdashcms.experimental.aggregator.getPackage",
 			"com.emdashcms.experimental.aggregator.getPublisher",
+			"com.emdashcms.experimental.aggregator.getPublisherVerification",
 			"com.emdashcms.experimental.aggregator.listReleases",
 			"com.emdashcms.experimental.aggregator.resolvePackage",
 			"com.emdashcms.experimental.aggregator.searchPackages",


### PR DESCRIPTION
## What does this PR do?

Implements **W8.4 slice 3** of the plugin-registry labelling service: the aggregator-sourced inputs to the labeler's publisher-history stage. Targets the integration branch `feat/plugin-registry-labelling-service`.

**Scope honesty — this delivers one of the two slice-3 inputs:**

- ✅ **Verification state (delivered).** A new read-only aggregator query `com.emdashcms.experimental.aggregator.getPublisherVerification` returns the non-tombstoned verification claims indexed for a publisher DID. The labeler consumes it through `AggregatorClient.getPublisherVerification` and `analyzeHistory`, emitting an operator-only `publisher-verification` history finding (specifics in `privateDetail` only). Like every `source: "history"` finding it can never become a label — the resolver drops it, and `validateFinding` holds it to the dedicated history category set.

- ⏳ **Recent handle/profile changes (documented seam, NOT built).** This input is **genuinely un-ingested**, not half-wired: the aggregator's `publishers` table is upsert-only (current state, no prior-values log), handle isn't stored except snapshotted inside a verification record at issuance, and the Jetstream ingestor does not subscribe to the atproto identity events that carry handle changes (`apps/aggregator/src/jetstream-client.ts`). Deriving "recent changes" therefore requires **new aggregator ingestion work (a W4-era gap)** — a follow-up ingestion ticket is needed before this second input can exist. It is left as a documented seam in `history-context.ts` and the route header; nothing speculative was built against non-existent tables.

**Best-effort + fail-safe:** history is operator-only context that never gates a run. The aggregator read sits in its own `try/catch` inside `analyzeHistory`, so a read failure skips only the verification context and never discards the decision-relevant own-D1 findings.

**Per-issuer redaction (review follow-up):** each verification claim is authored by its *issuer's* repo, so `getPublisherVerification` hydrates labels for the subject DID **and every distinct issuer DID** in one batched call — a redacted subject 404s the whole view, a redacted issuer drops only its own claim. The internal labeler read sends a blank `atproto-accept-labelers` header (empty accepted set), so it reads every claim unfiltered and weighs trust itself.

Ratified plan-doc decisions governing this slice live on the integration branch (`.opencode/plans/plugin-registry-labelling-service/implementation-plan.md`, W8.4, including the 2026-07-16 read-path ratification and the per-issuer-redaction decision recorded in `09e795d9`).

Closes # <!-- governed by the ratified W8.4 plan, no standalone issue -->

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (labeler, aggregator, registry-lexicons)
- [x] `pnpm lint` passes (type-aware lint shows the ~40 repo-wide baseline diagnostics only; none in the changed files)
- [x] `pnpm test` passes (labeler full 660, aggregator full 305, registry-lexicons 23)
- [x] `pnpm format` has been run (oxfmt on touched TS, prettier-clean on the lexicon JSON)
- [x] I have added/updated tests for my changes
- [ ] User-visible strings in the admin UI are wrapped for translation — **n/a**: no admin-UI strings (server routes + lexicon defs; server error messages are English-only per repo policy)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) — `@emdash-cms/registry-lexicons` minor (additive `getPublisherVerification` NSID + views)
- [ ] New features link to an approved Discussion — **n/a**: governed by the ratified W8.4 implementation-plan decisions on the integration branch, not a standalone Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8**

## Screenshots / test output

Targeted invariant tests (per-issuer redaction, the security-critical part of this PR):

```
✓ getPublisherVerification > drops a claim whose issuer is redacted for a default-policy caller, keeping the others
✓ getPublisherVerification > keeps a redacted-issuer claim for a blank accept-labelers caller (internal unfiltered read)
✓ history-context > preserves the own-D1 findings when the aggregator verification read fails
```

Suites: aggregator 305 pass (14 files), labeler 660 pass (33 files), registry-lexicons 23 pass. The workers test pool needs a Cloudflare account selected (`CLOUDFLARE_ACCOUNT_ID` for EmDash CMS) since two are available.

**Query cost:** per-issuer redaction adds no round-trip in the realistic case — it widens the existing single label-hydration query's `IN (...)` list (chunked at 50), so a request stays at 2 queries (verifications SELECT + one hydration) until a publisher has 50+ distinct issuers.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-history-aggregator-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-history-aggregator`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
