### PR TITLE
feat(labeler): notification delivery table + CSPRNG token + gated send-core (W10.5 slice 1)

### DIFF
--- a/apps/labeler/migrations/0008_notifications.sql
+++ b/apps/labeler/migrations/0008_notifications.sql
@@ -48,7 +48,10 @@ CREATE TABLE notifications (
 	plaintext_email TEXT,
 	created_at TEXT NOT NULL,
 	created_at_epoch_ms INTEGER NOT NULL,
-	sent_at TEXT
+	sent_at TEXT,
+	-- Only a no-resolvable-contact `undeliverable` audit row may omit the hash;
+	-- every sendable row (pending/sent/failed) must carry one.
+	CHECK (state = 'undeliverable' OR recipient_hash IS NOT NULL)
 );
 
 CREATE INDEX idx_notifications_pending ON notifications(state, created_at_epoch_ms)

--- a/apps/labeler/migrations/0008_notifications.sql
+++ b/apps/labeler/migrations/0008_notifications.sql
@@ -1,0 +1,70 @@
+-- Publisher-facing notification delivery (spec §14.4/§18/§19, plan W10.5). This
+-- is the MUTABLE outbox the send path drives per recipient, distinct from both
+-- `notification_outbox` (0005 — the OPERATOR alert subsystem) and the
+-- `notification_contacts`/`notification_suppressions` double-opt-in ledger (0007,
+-- which this send path reads). Two tables land together:
+--
+--   * `notifications`              — one row per delivery attempt, keyed by ULID.
+--     A row is claimed `pending`, then flipped to `sent` (with `provider_id` and
+--     `sent_at` set, `plaintext_email` CLEARED to NULL) or `failed`/`undeliverable`
+--     (with `last_error`, `attempts` bumped). Mutable — a failed send is retried
+--     independently and NEVER rolls back a label, so no immutability trigger. The
+--     trigger is referenced polymorphically by (`source_type`, `source_id`): there
+--     is NO SQL FK because the source is one of two audit tables (`issuance_actions`
+--     for automated block/warning/retraction, `operator_actions` for override/
+--     emergency); the writer enforces referential integrity.
+--   * `notification_confirm_ledger` — per-DID confirmation-send ledger. Per-address
+--     rate limiting lives on `notification_contacts.last_confirm_sent_at_epoch_ms`,
+--     but that does NOT cap a hostile publisher DID naming many DISTINCT victim
+--     addresses. This ledger records one row per confirmation mail so the send path
+--     can count DISTINCT recipients per DID in a rolling window before sending, and
+--     prune rows below the window. Keyed by ULID; no plaintext, hashes only.
+--
+-- `plaintext_email` is the ONLY plaintext in the subsystem (0007 stores hashes
+-- only): a delivery row must hold the address until the mail is handed to the
+-- provider, then clears it on success. Undelivered rows are swept after a
+-- versioned retention window (W10.5 slice 2 cron), so plaintext for a failed send
+-- does not linger indefinitely.
+--
+-- Timestamp columns queries order/compare on gain an integer `*_epoch_ms` sibling
+-- (RFC 3339 strings compare incorrectly across timezone offsets in SQL), matching
+-- 0003-0007. `created_at`/`sent_at` are RFC 3339 audit strings; `created_at_epoch_ms`
+-- is what the retention sweep orders on.
+
+CREATE TABLE notifications (
+	id TEXT PRIMARY KEY,
+	source_type TEXT NOT NULL CHECK (source_type IN ('issuance', 'operator')),
+	source_id TEXT NOT NULL,
+	kind TEXT NOT NULL CHECK (kind IN ('confirmation', 'notice')),
+	channel TEXT NOT NULL DEFAULT 'email',
+	-- NULL only on a no-resolvable-contact `undeliverable` audit row, where no
+	-- address (hence no hash) exists. Every row that was actually sendable carries
+	-- the HMAC-SHA256 recipient hash.
+	recipient_hash TEXT,
+	state TEXT NOT NULL CHECK (state IN ('pending', 'sent', 'failed', 'undeliverable')),
+	attempts INTEGER NOT NULL DEFAULT 0,
+	provider_id TEXT,
+	last_error TEXT,
+	plaintext_email TEXT,
+	created_at TEXT NOT NULL,
+	created_at_epoch_ms INTEGER NOT NULL,
+	sent_at TEXT
+);
+
+CREATE INDEX idx_notifications_pending ON notifications(state, created_at_epoch_ms)
+	WHERE state IN ('pending', 'failed');
+CREATE INDEX idx_notifications_created ON notifications(created_at_epoch_ms);
+CREATE INDEX idx_notifications_recipient ON notifications(recipient_hash);
+CREATE INDEX idx_notifications_source ON notifications(source_type, source_id);
+
+CREATE TABLE notification_confirm_ledger (
+	id TEXT PRIMARY KEY,
+	publisher_did TEXT NOT NULL,
+	recipient_hash TEXT NOT NULL,
+	sent_at_epoch_ms INTEGER NOT NULL
+);
+
+CREATE INDEX idx_notification_confirm_ledger_did
+	ON notification_confirm_ledger(publisher_did, sent_at_epoch_ms);
+CREATE INDEX idx_notification_confirm_ledger_sweep
+	ON notification_confirm_ledger(sent_at_epoch_ms);

--- a/apps/labeler/src/constants.ts
+++ b/apps/labeler/src/constants.ts
@@ -10,20 +10,16 @@ import { NSID } from "@emdash-cms/registry-lexicons";
 export const WANTED_COLLECTIONS = [NSID.packageRelease] as const;
 
 /**
- * Confirmation-send rate limits (plan W10.5). Versioned as a set: bump all three
- * together if the double-opt-in throttle is retuned. Two independent gates guard
- * the confirmation mail, the only send an unconfirmed (hence unverified) contact
- * can receive:
- *
- *   * per-ADDRESS — `CONFIRM_MIN_INTERVAL_MS` since the last confirmation to this
- *     recipient hash (`notification_contacts.last_confirm_sent_at_epoch_ms`). Caps
- *     how often one victim is re-mailed while they ignore the first message.
- *   * per-DID — at most `CONFIRM_DID_MAX_DISTINCT_RECIPIENTS` DISTINCT recipients
- *     in a `CONFIRM_DID_WINDOW_MS` rolling window per publisher DID
- *     (`notification_confirm_ledger`). Caps a hostile DID naming many distinct
- *     `victim@x` addresses — the amplification the per-address gate cannot see.
+ * Confirmation-send rate limits (plan W10.5). Versioned as a set: bump together
+ * if the double-opt-in throttle is retuned. The per-ADDRESS limit is a LIFETIME
+ * cap — a confirmation mail reaches an address at most once ever — enforced
+ * atomically by the confirmation delivery-row claim, so it needs no interval
+ * constant. The per-DID gate below is the remaining tunable: at most
+ * `CONFIRM_DID_MAX_DISTINCT_RECIPIENTS` DISTINCT recipients in a
+ * `CONFIRM_DID_WINDOW_MS` rolling window per publisher DID
+ * (`notification_confirm_ledger`), capping a hostile DID naming many distinct
+ * `victim@x` addresses — the amplification the per-address cap cannot see.
  */
 export const CONFIRM_RATE_LIMIT_VERSION = 1;
-export const CONFIRM_MIN_INTERVAL_MS = 24 * 60 * 60 * 1000;
 export const CONFIRM_DID_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const CONFIRM_DID_MAX_DISTINCT_RECIPIENTS = 10;

--- a/apps/labeler/src/constants.ts
+++ b/apps/labeler/src/constants.ts
@@ -8,3 +8,22 @@
 import { NSID } from "@emdash-cms/registry-lexicons";
 
 export const WANTED_COLLECTIONS = [NSID.packageRelease] as const;
+
+/**
+ * Confirmation-send rate limits (plan W10.5). Versioned as a set: bump all three
+ * together if the double-opt-in throttle is retuned. Two independent gates guard
+ * the confirmation mail, the only send an unconfirmed (hence unverified) contact
+ * can receive:
+ *
+ *   * per-ADDRESS — `CONFIRM_MIN_INTERVAL_MS` since the last confirmation to this
+ *     recipient hash (`notification_contacts.last_confirm_sent_at_epoch_ms`). Caps
+ *     how often one victim is re-mailed while they ignore the first message.
+ *   * per-DID — at most `CONFIRM_DID_MAX_DISTINCT_RECIPIENTS` DISTINCT recipients
+ *     in a `CONFIRM_DID_WINDOW_MS` rolling window per publisher DID
+ *     (`notification_confirm_ledger`). Caps a hostile DID naming many distinct
+ *     `victim@x` addresses — the amplification the per-address gate cannot see.
+ */
+export const CONFIRM_RATE_LIMIT_VERSION = 1;
+export const CONFIRM_MIN_INTERVAL_MS = 24 * 60 * 60 * 1000;
+export const CONFIRM_DID_WINDOW_MS = 24 * 60 * 60 * 1000;
+export const CONFIRM_DID_MAX_DISTINCT_RECIPIENTS = 10;

--- a/apps/labeler/src/notification-contacts.ts
+++ b/apps/labeler/src/notification-contacts.ts
@@ -122,6 +122,34 @@ export async function hashConfirmToken(token: string): Promise<string> {
 	return toHex(digest);
 }
 
+/**
+ * Bytes of CSPRNG entropy per confirmation token — 32 (256 bits), comfortably
+ * above the 128-bit floor {@link hashConfirmToken}'s doc mandates. base64url of
+ * 32 bytes is 43 chars, within the confirm endpoint's `CONFIRM_TOKEN` bound.
+ */
+const CONFIRM_TOKEN_BYTES = 32;
+
+/**
+ * Fresh single-use confirmation token, base64url (no padding) of
+ * {@link CONFIRM_TOKEN_BYTES} CSPRNG bytes from `crypto.getRandomValues`.
+ *
+ * SECURITY — this token is the SOLE protection against a brute-force confirm of
+ * a contact whose recipient hash leaked: the confirm endpoint stores only the
+ * pepper-less SHA-256 digest and applies no rate limit (see
+ * {@link hashConfirmToken}). It MUST therefore be drawn from a CSPRNG with high
+ * entropy — never a ULID, `randomUUID`, or any monotonic/timestamped value. The
+ * raw token travels only in the confirm link; the caller persists its
+ * {@link hashConfirmToken} digest via `recordConfirmSent` and never the raw value.
+ */
+export function generateConfirmToken(): string {
+	const bytes = crypto.getRandomValues(new Uint8Array(CONFIRM_TOKEN_BYTES));
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
 export async function getContactState(
 	db: D1Database,
 	recipientHashValue: string,

--- a/apps/labeler/src/notification-contacts.ts
+++ b/apps/labeler/src/notification-contacts.ts
@@ -187,23 +187,37 @@ export async function ensureContact(
  * confirm must match and stamps the send time the rate gate reads. Only touches
  * an `unconfirmed` contact — a confirmed or declined row is never reopened even
  * if a caller skips {@link canSendConfirm}. Returns whether a row was updated.
+ *
+ * The UPDATE is the per-address rate gate's atomic compare-and-set, not just a
+ * write: it re-checks the interval in SQL (`last_confirm_sent IS NULL OR
+ * last_confirm_sent <= epochMs − minIntervalMs`), so two triggers racing for the
+ * same unconfirmed address off a stale {@link canSendConfirm} snapshot cannot
+ * both stamp — the second sees the first's write and gets `changes = 0`. The
+ * caller sends only when this returns true. `minIntervalMs` defaults to 0 (a
+ * monotonicity-only guard) for the slice-B/C seeding callers; the send path
+ * passes the real `CONFIRM_MIN_INTERVAL_MS`.
  */
 export async function recordConfirmSent(
 	db: D1Database,
 	recipientHashValue: string,
 	tokenHash: string,
 	epochMs: number,
+	minIntervalMs = 0,
 ): Promise<boolean> {
 	if (!Number.isFinite(epochMs)) {
 		throw new TypeError("recordConfirmSent requires a finite epochMs");
+	}
+	if (!Number.isFinite(minIntervalMs)) {
+		throw new TypeError("recordConfirmSent requires a finite minIntervalMs");
 	}
 	const result = await db
 		.prepare(
 			`UPDATE notification_contacts
 			 SET confirm_token_hash = ?, last_confirm_sent_at_epoch_ms = ?
-			 WHERE recipient_hash = ? AND confirm_state = 'unconfirmed'`,
+			 WHERE recipient_hash = ? AND confirm_state = 'unconfirmed'
+			   AND (last_confirm_sent_at_epoch_ms IS NULL OR last_confirm_sent_at_epoch_ms <= ?)`,
 		)
-		.bind(tokenHash, epochMs, recipientHashValue)
+		.bind(tokenHash, epochMs, recipientHashValue, epochMs - minIntervalMs)
 		.run();
 	return result.meta.changes > 0;
 }

--- a/apps/labeler/src/notification-contacts.ts
+++ b/apps/labeler/src/notification-contacts.ts
@@ -184,40 +184,30 @@ export async function ensureContact(
 
 /**
  * Record that a confirmation mail was sent: stores the token hash the eventual
- * confirm must match and stamps the send time the rate gate reads. Only touches
- * an `unconfirmed` contact — a confirmed or declined row is never reopened even
- * if a caller skips {@link canSendConfirm}. Returns whether a row was updated.
+ * confirm must match and stamps the send time. Only touches an `unconfirmed`
+ * contact — a confirmed or declined row is never reopened even if a caller skips
+ * {@link canSendConfirm}. Returns whether a row was updated.
  *
- * The UPDATE is the per-address rate gate's atomic compare-and-set, not just a
- * write: it re-checks the interval in SQL (`last_confirm_sent IS NULL OR
- * last_confirm_sent <= epochMs − minIntervalMs`), so two triggers racing for the
- * same unconfirmed address off a stale {@link canSendConfirm} snapshot cannot
- * both stamp — the second sees the first's write and gets `changes = 0`. The
- * caller sends only when this returns true. `minIntervalMs` defaults to 0 (a
- * monotonicity-only guard) for the slice-B/C seeding callers; the send path
- * passes the real `CONFIRM_MIN_INTERVAL_MS`.
+ * The lifetime "mail once ever" cap and the concurrency race are enforced
+ * upstream, atomically, by the confirmation delivery-row claim (W10.5), so this
+ * only needs to stamp the token on the still-unconfirmed contact.
  */
 export async function recordConfirmSent(
 	db: D1Database,
 	recipientHashValue: string,
 	tokenHash: string,
 	epochMs: number,
-	minIntervalMs = 0,
 ): Promise<boolean> {
 	if (!Number.isFinite(epochMs)) {
 		throw new TypeError("recordConfirmSent requires a finite epochMs");
-	}
-	if (!Number.isFinite(minIntervalMs)) {
-		throw new TypeError("recordConfirmSent requires a finite minIntervalMs");
 	}
 	const result = await db
 		.prepare(
 			`UPDATE notification_contacts
 			 SET confirm_token_hash = ?, last_confirm_sent_at_epoch_ms = ?
-			 WHERE recipient_hash = ? AND confirm_state = 'unconfirmed'
-			   AND (last_confirm_sent_at_epoch_ms IS NULL OR last_confirm_sent_at_epoch_ms <= ?)`,
+			 WHERE recipient_hash = ? AND confirm_state = 'unconfirmed'`,
 		)
-		.bind(tokenHash, epochMs, recipientHashValue, epochMs - minIntervalMs)
+		.bind(tokenHash, epochMs, recipientHashValue)
 		.run();
 	return result.meta.changes > 0;
 }

--- a/apps/labeler/src/notification-send.ts
+++ b/apps/labeler/src/notification-send.ts
@@ -19,16 +19,19 @@
  *   4. Confirm-state gate, NEVER `seeded:true`:
  *        * `confirmed`   → substantive NOTICE.
  *        * `unconfirmed` → double opt-in: a content-neutral CONFIRMATION mail,
- *          and only if BOTH the per-address and per-DID confirmation rate limits
- *          pass. Never a substantive notice.
+ *          sent to an address at most ONCE EVER (lifetime cap) and subject to the
+ *          per-DID cap. Never a substantive notice.
  *        * `declined`    → nothing (handled in step 3).
  *
- * Atomicity: the send is CLAIMED by inserting the pending `notifications` row
+ * Atomicity: every send is CLAIMED by inserting the pending `notifications` row
  * guarded by `WHERE NOT EXISTS (suppression)`, so a suppression committed before
- * the claim blocks the send even under a race with the step-3 read. A suppression
- * landing in the sub-millisecond window between the claim and the external send
- * is the accepted double-opt-in tradeoff — at most one content-neutral
- * confirmation mail.
+ * the claim blocks the send even under a race with the step-3 read. The
+ * confirmation claim adds a second guard in the same statement — no prior
+ * non-`undeliverable` confirmation row for the hash — which enforces both the
+ * lifetime "mail once ever" cap and the concurrency race (of two racing sends
+ * exactly one inserts). A suppression landing in the sub-millisecond window
+ * between the claim and the external send is the accepted double-opt-in tradeoff:
+ * at most one content-neutral confirmation mail, ever.
  *
  * PII: `plaintext_email` lives only on the delivery row and is cleared to NULL on
  * a successful send. Nothing here logs plaintext — logs carry the (public)
@@ -39,14 +42,8 @@
 import { ulid } from "ulidx";
 
 import type { AggregatorClient } from "./aggregator-client.js";
+import { CONFIRM_DID_MAX_DISTINCT_RECIPIENTS, CONFIRM_DID_WINDOW_MS } from "./constants.js";
 import {
-	CONFIRM_DID_MAX_DISTINCT_RECIPIENTS,
-	CONFIRM_DID_WINDOW_MS,
-	CONFIRM_MIN_INTERVAL_MS,
-} from "./constants.js";
-import type { ContactState } from "./notification-contacts.js";
-import {
-	canSendConfirm,
 	ensureContact,
 	generateConfirmToken,
 	getContactState,
@@ -135,9 +132,10 @@ export type SendOutcome =
 	| { status: "notice_failed"; recipientHash: string; error: string }
 	| { status: "confirmation_sent"; recipientHash: string; providerId?: string }
 	| { status: "confirmation_failed"; recipientHash: string; error: string }
-	| { status: "rate_limited"; recipientHash: string; scope: "address" | "did" }
+	| { status: "rate_limited"; recipientHash: string; scope: "did" }
 	| { status: "suppressed"; recipientHash: string }
 	| { status: "declined"; recipientHash: string }
+	| { status: "already_mailed"; recipientHash: string }
 	| { status: "skipped"; recipientHash: string; reason: "contact_state_changed" }
 	| { status: "no_contact" };
 
@@ -192,7 +190,7 @@ export async function sendNotification(
 		return sendSubstantiveNotice(ctx, request, hash, resolution.email, nowDate);
 	}
 
-	return sendConfirmationMail(ctx, request, hash, resolution.email, state, {
+	return sendConfirmationMail(ctx, request, hash, resolution.email, {
 		date: nowDate,
 		ms: nowMs,
 	});
@@ -232,24 +230,17 @@ async function sendConfirmationMail(
 	request: NotificationRequest,
 	hash: string,
 	email: string,
-	state: ContactState,
 	now: { date: Date; ms: number },
 ): Promise<SendOutcome> {
-	if (!canSendConfirm(state, now.ms, CONFIRM_MIN_INTERVAL_MS)) {
-		logSend(request.target.did, "rate_limited:address", hash);
-		return { status: "rate_limited", recipientHash: hash, scope: "address" };
-	}
-
-	// Per-DID gate, then the ledger write, adjacently. The count→insert pair is a
-	// non-atomic check-then-act: concurrent confirmations to DISTINCT victims for
-	// one DID can overshoot the cap (each victim still receives at most one mail —
-	// it admits a few extra distinct victims, it does not bomb anyone). Keeping the
-	// two statements adjacent narrows that window; exact enforcement needs a
-	// serialized claim (a Durable Object) and is deferred to slice 2. The gate
-	// returns before any write so a sustained DID email-bomb costs no rows; the
-	// ledger is written before the claim/send, so a later suppressed-claim or
-	// lost-CAS attempt still counts — a conservative over-count, never an
-	// under-count.
+	// Per-DID best-effort gate. The count→claim→ledger sequence is a non-atomic
+	// check-then-act: concurrent confirmations to DISTINCT victims for one DID can
+	// overshoot the cap (each victim still receives at most one mail — the lifetime
+	// cap guarantees that — so it admits a few extra distinct victims, it never
+	// bombs anyone). Exact enforcement needs a serialized claim (a Durable Object)
+	// and is deferred to slice 2. The gate returns before any write, so a sustained
+	// DID email-bomb costs no rows; the ledger is written only after a successful
+	// claim (an actual first-ever mail), so a repeat trigger for an already-mailed
+	// address writes nothing and cannot bloat the ledger or falsely trip the cap.
 	const sinceMs = now.ms - CONFIRM_DID_WINDOW_MS;
 	const distinctRecipients = await countDistinctConfirmRecipients(
 		ctx.db,
@@ -260,8 +251,9 @@ async function sendConfirmationMail(
 		logSend(request.target.did, "rate_limited:did", hash);
 		return { status: "rate_limited", recipientHash: hash, scope: "did" };
 	}
-	await recordConfirmLedgerEntry(ctx.db, request.target.did, hash, now.ms);
 
+	// Atomic claim: suppression + lifetime "mail once ever" cap + concurrency, all
+	// in one INSERT...SELECT (see claimSend). A false means one of those fired.
 	const id = newNotificationId();
 	const claimed = await claimSend(
 		ctx.db,
@@ -273,21 +265,26 @@ async function sendConfirmationMail(
 		now.date,
 	);
 	if (!claimed) {
-		await recordUndeliverable(ctx.db, request.source, "confirmation", hash, "suppressed", now.date);
-		logSend(request.target.did, "suppressed", hash);
-		return { status: "suppressed", recipientHash: hash };
+		// Suppression is pre-checked upstream, so a false here is almost always the
+		// lifetime cap. The cheap re-check only distinguishes a suppression that
+		// landed in the pre-check→claim window — an audit nicety, not correctness.
+		if (await isSuppressed(ctx.db, hash)) {
+			logSend(request.target.did, "suppressed", hash);
+			return { status: "suppressed", recipientHash: hash };
+		}
+		logSend(request.target.did, "already_mailed", hash);
+		return { status: "already_mailed", recipientHash: hash };
 	}
+
+	await recordConfirmLedgerEntry(ctx.db, request.target.did, hash, now.ms);
 
 	const token = generateConfirmToken();
 	const tokenHash = await hashConfirmToken(token);
-	const recorded = await recordConfirmSent(
-		ctx.db,
-		hash,
-		tokenHash,
-		now.ms,
-		CONFIRM_MIN_INTERVAL_MS,
-	);
+	const recorded = await recordConfirmSent(ctx.db, hash, tokenHash, now.ms);
 	if (!recorded) {
+		// The claim already enforced the lifetime cap and concurrency; a false here
+		// is only the contact leaving `unconfirmed` between the state read and this
+		// stamp. Retire the claimed row rather than mail a dead-token confirmation.
 		await markRowUndeliverable(ctx.db, id, "contact_state_changed", now.date);
 		logSend(request.target.did, "skipped:contact_state_changed", hash);
 		return { status: "skipped", recipientHash: hash, reason: "contact_state_changed" };
@@ -309,10 +306,16 @@ async function sendConfirmationMail(
 }
 
 /**
- * Claim a send by inserting the pending delivery row. Guarded by `WHERE NOT
- * EXISTS (suppression)` so the claim and the suppression re-check are one atomic
- * statement: a suppression committed before the claim blocks it. Returns whether
- * the row was inserted (false ⇒ suppressed at claim time).
+ * Claim a send by inserting the pending delivery row, guarded atomically. The
+ * suppression guard (`WHERE NOT EXISTS (suppression)`) is on both kinds: a
+ * suppression committed before the claim blocks it. A `confirmation` claim adds a
+ * second guard enforcing the LIFETIME cap and the concurrency race in the same
+ * INSERT...SELECT — it inserts only if NO prior non-`undeliverable` confirmation
+ * row exists for this recipient hash, so an address is mailed a confirmation at
+ * most once ever, and of two racing sends exactly one inserts (the second's
+ * subquery sees the first's `pending` row). An `undeliverable` prior (a race
+ * loser or a suppressed-at-claim that never mailed) is excluded, so it can never
+ * block a later legitimate confirmation. Returns whether the row was inserted.
  */
 async function claimSend(
 	db: D1Database,
@@ -323,15 +326,39 @@ async function claimSend(
 	email: string,
 	now: Date,
 ): Promise<boolean> {
+	const columns = `(id, source_type, source_id, kind, channel, recipient_hash, state, attempts,
+			 plaintext_email, created_at, created_at_epoch_ms)`;
+	const row = `SELECT ?, ?, ?, ?, 'email', ?, 'pending', 0, ?, ?, ?`;
+	const notSuppressed = `WHERE NOT EXISTS (SELECT 1 FROM notification_suppressions WHERE recipient_hash = ?)`;
+	const binds: (string | number)[] = [
+		id,
+		source.type,
+		source.id,
+		kind,
+		hash,
+		email,
+		now.toISOString(),
+		now.getTime(),
+		hash,
+	];
+
+	if (kind === "confirmation") {
+		const result = await db
+			.prepare(
+				`INSERT INTO notifications ${columns} ${row} ${notSuppressed}
+				 AND NOT EXISTS (
+					SELECT 1 FROM notifications
+					WHERE recipient_hash = ? AND kind = 'confirmation' AND state != 'undeliverable'
+				 )`,
+			)
+			.bind(...binds, hash)
+			.run();
+		return result.meta.changes > 0;
+	}
+
 	const result = await db
-		.prepare(
-			`INSERT INTO notifications
-				(id, source_type, source_id, kind, channel, recipient_hash, state, attempts,
-				 plaintext_email, created_at, created_at_epoch_ms)
-			 SELECT ?, ?, ?, ?, 'email', ?, 'pending', 0, ?, ?, ?
-			 WHERE NOT EXISTS (SELECT 1 FROM notification_suppressions WHERE recipient_hash = ?)`,
-		)
-		.bind(id, source.type, source.id, kind, hash, email, now.toISOString(), now.getTime(), hash)
+		.prepare(`INSERT INTO notifications ${columns} ${row} ${notSuppressed}`)
+		.bind(...binds)
 		.run();
 	return result.meta.changes > 0;
 }

--- a/apps/labeler/src/notification-send.ts
+++ b/apps/labeler/src/notification-send.ts
@@ -1,0 +1,456 @@
+/**
+ * Gated send-orchestration core for publisher notifications (spec §18/§19, plan
+ * W10.5 slice 1). This is the security surface of the subsystem: it decides,
+ * per triggering action, whether an address may be mailed and what it may
+ * receive, then records the delivery attempt in the `notifications` table
+ * (migration 0008). The actual email adapter is injected as a
+ * {@link NotificationSender}; slice 2 supplies the real Cloudflare Email Sending
+ * implementation and wires the triggers.
+ *
+ * The gate, in order:
+ *   1. Fresh contact resolve via {@link resolvePublisherContact} (no caching —
+ *      a notice must resolve against the publisher's current metadata). No
+ *      resolvable contact is an expected terminal state: an `undeliverable`
+ *      audit row, no send.
+ *   2. `recipientHash` under the pepper.
+ *   3. Suppression / decline short-circuit: a suppressed address or a contact
+ *      that said "not me" (`declined`) receives NOTHING — an `undeliverable`
+ *      audit row, no send.
+ *   4. Confirm-state gate, NEVER `seeded:true`:
+ *        * `confirmed`   → substantive NOTICE.
+ *        * `unconfirmed` → double opt-in: a content-neutral CONFIRMATION mail,
+ *          and only if BOTH the per-address and per-DID confirmation rate limits
+ *          pass. Never a substantive notice.
+ *        * `declined`    → nothing (handled in step 3).
+ *
+ * Atomicity: the send is CLAIMED by inserting the pending `notifications` row
+ * guarded by `WHERE NOT EXISTS (suppression)`, so a suppression committed before
+ * the claim blocks the send even under a race with the step-3 read. A suppression
+ * landing in the sub-millisecond window between the claim and the external send
+ * is the accepted double-opt-in tradeoff — at most one content-neutral
+ * confirmation mail.
+ *
+ * PII: `plaintext_email` lives only on the delivery row and is cleared to NULL on
+ * a successful send. Nothing here logs plaintext — logs carry the (public)
+ * publisher DID and at most an 8-char recipient-hash prefix, matching slice C's
+ * `logOutcome`. The confirm token is never logged.
+ */
+
+import { ulid } from "ulidx";
+
+import type { AggregatorClient } from "./aggregator-client.js";
+import {
+	CONFIRM_DID_MAX_DISTINCT_RECIPIENTS,
+	CONFIRM_DID_WINDOW_MS,
+	CONFIRM_MIN_INTERVAL_MS,
+} from "./constants.js";
+import type { ContactState } from "./notification-contacts.js";
+import {
+	canSendConfirm,
+	ensureContact,
+	generateConfirmToken,
+	getContactState,
+	hashConfirmToken,
+	isSuppressed,
+	recipientHash,
+	recordConfirmSent,
+} from "./notification-contacts.js";
+import type { ContactTarget } from "./publisher-contact.js";
+import { resolvePublisherContact } from "./publisher-contact.js";
+
+/** Which audit table the triggering action lives in. No SQL FK (SQLite can't
+ * FK-to-one-of-two); the writer here is the only producer of these rows. */
+export type NotificationSourceType = "issuance" | "operator";
+
+export interface NotificationSource {
+	type: NotificationSourceType;
+	id: string;
+}
+
+/**
+ * The public-safe body of a substantive notice (spec §18/§19). Carries only what
+ * a publisher may see: the label effect, a public summary, and the URLs of the
+ * public assessment and reconsideration channel. NO private evidence, findings,
+ * or exploit detail — the type is the enforcement.
+ */
+export interface NoticeContent {
+	subject: string;
+	publicSummary: string;
+	assessmentUrl: string;
+	effect: string;
+	reconsiderationUrl: string;
+}
+
+export interface NotificationRequest {
+	source: NotificationSource;
+	target: ContactTarget;
+	notice: NoticeContent;
+}
+
+export type SendResult = { ok: true; providerId?: string } | { ok: false; error: string };
+
+export interface ConfirmationPayload {
+	to: string;
+	confirmUrl: string;
+	unsubscribeUrl: string;
+	notMeUrl: string;
+}
+
+export interface NoticePayload extends NoticeContent {
+	to: string;
+	unsubscribeUrl: string;
+}
+
+/**
+ * The injected email adapter. Slice 1 tests supply a fake that records calls;
+ * slice 2 supplies the Cloudflare Email Sending implementation. Each method
+ * returns a discriminated result — a transport failure is `{ ok: false }`, not a
+ * throw, so the caller records `failed` and lets the retry sweep pick it up.
+ */
+export interface NotificationSender {
+	sendConfirmation(payload: ConfirmationPayload): Promise<SendResult>;
+	sendNotice(payload: NoticePayload): Promise<SendResult>;
+}
+
+export interface SendContext {
+	db: D1Database;
+	aggregator: AggregatorClient;
+	pepper: string;
+	sender: NotificationSender;
+	/** Public origin of the notification landing endpoints (the
+	 * `LABELER_SERVICE_URL` var), e.g. `https://labels.emdashcms.com`. The
+	 * confirm/unsubscribe/not-me links are built against it. */
+	origin: string;
+	now?: () => Date;
+}
+
+export type SendOutcome =
+	| { status: "notice_sent"; recipientHash: string; providerId?: string }
+	| { status: "notice_failed"; recipientHash: string; error: string }
+	| { status: "confirmation_sent"; recipientHash: string; providerId?: string }
+	| { status: "confirmation_failed"; recipientHash: string; error: string }
+	| { status: "rate_limited"; recipientHash: string; scope: "address" | "did" }
+	| { status: "suppressed"; recipientHash: string }
+	| { status: "declined"; recipientHash: string }
+	| { status: "skipped"; recipientHash: string; reason: "contact_state_changed" }
+	| { status: "no_contact" };
+
+type NotificationKind = "confirmation" | "notice";
+
+const LAST_ERROR_MAX = 500;
+
+/**
+ * Resolve, gate, and send one notification. The entry point slice-2 triggers
+ * call. Returns a terminal {@link SendOutcome}; it never throws for an expected
+ * non-delivery (no contact, suppressed, declined, rate-limited) — only an
+ * aggregator/transport read failure in {@link resolvePublisherContact}
+ * propagates, so the caller can retry the whole send.
+ */
+export async function sendNotification(
+	ctx: SendContext,
+	request: NotificationRequest,
+): Promise<SendOutcome> {
+	const now = ctx.now ?? (() => new Date());
+	const resolution = await resolvePublisherContact(ctx.aggregator, request.target);
+	if ("none" in resolution) {
+		await recordUndeliverable(ctx.db, request.source, "notice", null, resolution.none, now());
+		logSend(request.target.did, "no_contact", undefined);
+		return { status: "no_contact" };
+	}
+
+	const hash = await recipientHash(ctx.pepper, resolution.email);
+	const nowDate = now();
+	const nowIso = nowDate.toISOString();
+	const nowMs = nowDate.getTime();
+
+	await ensureContact(ctx.db, hash, nowIso);
+	const state = await getContactState(ctx.db, hash);
+
+	if (await isSuppressed(ctx.db, hash)) {
+		await recordUndeliverable(ctx.db, request.source, "notice", hash, "suppressed", nowDate);
+		logSend(request.target.did, "suppressed", hash);
+		return { status: "suppressed", recipientHash: hash };
+	}
+
+	if (state === null || state.confirmState === "declined") {
+		if (state?.confirmState === "declined") {
+			await recordUndeliverable(ctx.db, request.source, "notice", hash, "declined", nowDate);
+			logSend(request.target.did, "declined", hash);
+			return { status: "declined", recipientHash: hash };
+		}
+		logSend(request.target.did, "skipped:no_state", hash);
+		return { status: "skipped", recipientHash: hash, reason: "contact_state_changed" };
+	}
+
+	if (state.confirmState === "confirmed") {
+		return sendSubstantiveNotice(ctx, request, hash, resolution.email, nowDate);
+	}
+
+	return sendConfirmationMail(ctx, request, hash, resolution.email, state, {
+		date: nowDate,
+		ms: nowMs,
+	});
+}
+
+async function sendSubstantiveNotice(
+	ctx: SendContext,
+	request: NotificationRequest,
+	hash: string,
+	email: string,
+	now: Date,
+): Promise<SendOutcome> {
+	const id = newNotificationId();
+	const claimed = await claimSend(ctx.db, id, request.source, "notice", hash, email, now);
+	if (!claimed) {
+		await recordUndeliverable(ctx.db, request.source, "notice", hash, "suppressed", now);
+		logSend(request.target.did, "suppressed", hash);
+		return { status: "suppressed", recipientHash: hash };
+	}
+
+	const result = await ctx.sender.sendNotice({
+		...request.notice,
+		to: email,
+		unsubscribeUrl: buildActionUrl(ctx.origin, "unsubscribe", hash),
+	});
+	await finalizeSend(ctx.db, id, result, now);
+	if (result.ok) {
+		logSend(request.target.did, "notice_sent", hash);
+		return { status: "notice_sent", recipientHash: hash, providerId: result.providerId };
+	}
+	logSend(request.target.did, "notice_failed", hash);
+	return { status: "notice_failed", recipientHash: hash, error: result.error };
+}
+
+async function sendConfirmationMail(
+	ctx: SendContext,
+	request: NotificationRequest,
+	hash: string,
+	email: string,
+	state: ContactState,
+	now: { date: Date; ms: number },
+): Promise<SendOutcome> {
+	if (!canSendConfirm(state, now.ms, CONFIRM_MIN_INTERVAL_MS)) {
+		logSend(request.target.did, "rate_limited:address", hash);
+		return { status: "rate_limited", recipientHash: hash, scope: "address" };
+	}
+
+	const sinceMs = now.ms - CONFIRM_DID_WINDOW_MS;
+	const distinctRecipients = await countDistinctConfirmRecipients(
+		ctx.db,
+		request.target.did,
+		sinceMs,
+	);
+	if (distinctRecipients >= CONFIRM_DID_MAX_DISTINCT_RECIPIENTS) {
+		logSend(request.target.did, "rate_limited:did", hash);
+		return { status: "rate_limited", recipientHash: hash, scope: "did" };
+	}
+
+	const id = newNotificationId();
+	const claimed = await claimSend(
+		ctx.db,
+		id,
+		request.source,
+		"confirmation",
+		hash,
+		email,
+		now.date,
+	);
+	if (!claimed) {
+		await recordUndeliverable(ctx.db, request.source, "confirmation", hash, "suppressed", now.date);
+		logSend(request.target.did, "suppressed", hash);
+		return { status: "suppressed", recipientHash: hash };
+	}
+
+	const token = generateConfirmToken();
+	const tokenHash = await hashConfirmToken(token);
+	const recorded = await recordConfirmSent(ctx.db, hash, tokenHash, now.ms);
+	if (!recorded) {
+		await markRowUndeliverable(ctx.db, id, "contact_state_changed", now.date);
+		logSend(request.target.did, "skipped:contact_state_changed", hash);
+		return { status: "skipped", recipientHash: hash, reason: "contact_state_changed" };
+	}
+
+	await recordConfirmLedgerEntry(ctx.db, request.target.did, hash, now.ms);
+
+	const result = await ctx.sender.sendConfirmation({
+		to: email,
+		confirmUrl: buildActionUrl(ctx.origin, "confirm", hash, token),
+		unsubscribeUrl: buildActionUrl(ctx.origin, "unsubscribe", hash),
+		notMeUrl: buildActionUrl(ctx.origin, "not-me", hash),
+	});
+	await finalizeSend(ctx.db, id, result, now.date);
+	if (result.ok) {
+		logSend(request.target.did, "confirmation_sent", hash);
+		return { status: "confirmation_sent", recipientHash: hash, providerId: result.providerId };
+	}
+	logSend(request.target.did, "confirmation_failed", hash);
+	return { status: "confirmation_failed", recipientHash: hash, error: result.error };
+}
+
+/**
+ * Claim a send by inserting the pending delivery row. Guarded by `WHERE NOT
+ * EXISTS (suppression)` so the claim and the suppression re-check are one atomic
+ * statement: a suppression committed before the claim blocks it. Returns whether
+ * the row was inserted (false ⇒ suppressed at claim time).
+ */
+async function claimSend(
+	db: D1Database,
+	id: string,
+	source: NotificationSource,
+	kind: NotificationKind,
+	hash: string,
+	email: string,
+	now: Date,
+): Promise<boolean> {
+	const result = await db
+		.prepare(
+			`INSERT INTO notifications
+				(id, source_type, source_id, kind, channel, recipient_hash, state, attempts,
+				 plaintext_email, created_at, created_at_epoch_ms)
+			 SELECT ?, ?, ?, ?, 'email', ?, 'pending', 0, ?, ?, ?
+			 WHERE NOT EXISTS (SELECT 1 FROM notification_suppressions WHERE recipient_hash = ?)`,
+		)
+		.bind(id, source.type, source.id, kind, hash, email, now.toISOString(), now.getTime(), hash)
+		.run();
+	return result.meta.changes > 0;
+}
+
+/** Flip a claimed row to its terminal state. On success: `sent`, `provider_id`
+ * and `sent_at` set, `plaintext_email` CLEARED. On failure: `failed`,
+ * `last_error` recorded, `attempts` bumped, plaintext retained for the retry. */
+async function finalizeSend(
+	db: D1Database,
+	id: string,
+	result: SendResult,
+	now: Date,
+): Promise<void> {
+	if (result.ok) {
+		await db
+			.prepare(
+				`UPDATE notifications
+				 SET state = 'sent', provider_id = ?, sent_at = ?, plaintext_email = NULL, last_error = NULL
+				 WHERE id = ?`,
+			)
+			.bind(result.providerId ?? null, now.toISOString(), id)
+			.run();
+		return;
+	}
+	await db
+		.prepare(
+			`UPDATE notifications
+			 SET state = 'failed', last_error = ?, attempts = attempts + 1
+			 WHERE id = ?`,
+		)
+		.bind(truncateError(result.error), id)
+		.run();
+}
+
+/** Insert a terminal `undeliverable` audit row for a send that was never
+ * attempted (no contact, suppressed, declined). Holds no plaintext — nothing
+ * will be sent. `recipient_hash` is NULL only for the no-contact case. */
+async function recordUndeliverable(
+	db: D1Database,
+	source: NotificationSource,
+	kind: NotificationKind,
+	hash: string | null,
+	reason: string,
+	now: Date,
+): Promise<void> {
+	await db
+		.prepare(
+			`INSERT INTO notifications
+				(id, source_type, source_id, kind, channel, recipient_hash, state, attempts,
+				 last_error, created_at, created_at_epoch_ms)
+			 VALUES (?, ?, ?, ?, 'email', ?, 'undeliverable', 0, ?, ?, ?)`,
+		)
+		.bind(
+			newNotificationId(),
+			source.type,
+			source.id,
+			kind,
+			hash,
+			reason,
+			now.toISOString(),
+			now.getTime(),
+		)
+		.run();
+}
+
+/** Flip an already-claimed pending row to `undeliverable`, clearing plaintext.
+ * Used when the contact left `unconfirmed` in the race after the claim. */
+async function markRowUndeliverable(
+	db: D1Database,
+	id: string,
+	reason: string,
+	now: Date,
+): Promise<void> {
+	await db
+		.prepare(
+			`UPDATE notifications
+			 SET state = 'undeliverable', last_error = ?, plaintext_email = NULL, sent_at = ?
+			 WHERE id = ?`,
+		)
+		.bind(reason, now.toISOString(), id)
+		.run();
+}
+
+/** Distinct recipients this DID has sent confirmation mail to since `sinceMs` —
+ * the per-DID rate-limit read (counts victims, not repeats). */
+async function countDistinctConfirmRecipients(
+	db: D1Database,
+	did: string,
+	sinceMs: number,
+): Promise<number> {
+	const row = await db
+		.prepare(
+			`SELECT COUNT(DISTINCT recipient_hash) AS n FROM notification_confirm_ledger
+			 WHERE publisher_did = ? AND sent_at_epoch_ms >= ?`,
+		)
+		.bind(did, sinceMs)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+async function recordConfirmLedgerEntry(
+	db: D1Database,
+	did: string,
+	hash: string,
+	epochMs: number,
+): Promise<void> {
+	await db
+		.prepare(
+			`INSERT INTO notification_confirm_ledger (id, publisher_did, recipient_hash, sent_at_epoch_ms)
+			 VALUES (?, ?, ?, ?)`,
+		)
+		.bind(`ncl_${ulid()}`, did, hash, epochMs)
+		.run();
+}
+
+function buildActionUrl(
+	origin: string,
+	action: "confirm" | "unsubscribe" | "not-me",
+	hash: string,
+	token?: string,
+): string {
+	const url = new URL(`/notifications/${action}`, origin);
+	url.searchParams.set("c", hash);
+	if (token !== undefined) url.searchParams.set("t", token);
+	return url.toString();
+}
+
+function newNotificationId(): string {
+	return `ntf_${ulid()}`;
+}
+
+function truncateError(error: string): string {
+	return error.length > LAST_ERROR_MAX ? error.slice(0, LAST_ERROR_MAX) : error;
+}
+
+function logSend(did: string, outcome: string, hash: string | undefined): void {
+	console.log("[notifications]", {
+		action: "send",
+		outcome,
+		did,
+		hashPrefix: hash?.slice(0, 8),
+	});
+}

--- a/apps/labeler/src/notification-send.ts
+++ b/apps/labeler/src/notification-send.ts
@@ -106,6 +106,12 @@ export interface NoticePayload extends NoticeContent {
  * slice 2 supplies the Cloudflare Email Sending implementation. Each method
  * returns a discriminated result — a transport failure is `{ ok: false }`, not a
  * throw, so the caller records `failed` and lets the retry sweep pick it up.
+ *
+ * SECURITY (slice-2 contract): the `error` string is persisted verbatim in
+ * `notifications.last_error` and is NEVER cleared. An implementation MUST NOT put
+ * the `confirmUrl` or the raw confirm token into it — that would leak the
+ * single-use capability to the database. Return the provider's status/message
+ * only, never the payload it was given.
  */
 export interface NotificationSender {
 	sendConfirmation(payload: ConfirmationPayload): Promise<SendResult>;
@@ -234,6 +240,16 @@ async function sendConfirmationMail(
 		return { status: "rate_limited", recipientHash: hash, scope: "address" };
 	}
 
+	// Per-DID gate, then the ledger write, adjacently. The count→insert pair is a
+	// non-atomic check-then-act: concurrent confirmations to DISTINCT victims for
+	// one DID can overshoot the cap (each victim still receives at most one mail —
+	// it admits a few extra distinct victims, it does not bomb anyone). Keeping the
+	// two statements adjacent narrows that window; exact enforcement needs a
+	// serialized claim (a Durable Object) and is deferred to slice 2. The gate
+	// returns before any write so a sustained DID email-bomb costs no rows; the
+	// ledger is written before the claim/send, so a later suppressed-claim or
+	// lost-CAS attempt still counts — a conservative over-count, never an
+	// under-count.
 	const sinceMs = now.ms - CONFIRM_DID_WINDOW_MS;
 	const distinctRecipients = await countDistinctConfirmRecipients(
 		ctx.db,
@@ -244,6 +260,7 @@ async function sendConfirmationMail(
 		logSend(request.target.did, "rate_limited:did", hash);
 		return { status: "rate_limited", recipientHash: hash, scope: "did" };
 	}
+	await recordConfirmLedgerEntry(ctx.db, request.target.did, hash, now.ms);
 
 	const id = newNotificationId();
 	const claimed = await claimSend(
@@ -263,14 +280,18 @@ async function sendConfirmationMail(
 
 	const token = generateConfirmToken();
 	const tokenHash = await hashConfirmToken(token);
-	const recorded = await recordConfirmSent(ctx.db, hash, tokenHash, now.ms);
+	const recorded = await recordConfirmSent(
+		ctx.db,
+		hash,
+		tokenHash,
+		now.ms,
+		CONFIRM_MIN_INTERVAL_MS,
+	);
 	if (!recorded) {
 		await markRowUndeliverable(ctx.db, id, "contact_state_changed", now.date);
 		logSend(request.target.did, "skipped:contact_state_changed", hash);
 		return { status: "skipped", recipientHash: hash, reason: "contact_state_changed" };
 	}
-
-	await recordConfirmLedgerEntry(ctx.db, request.target.did, hash, now.ms);
 
 	const result = await ctx.sender.sendConfirmation({
 		to: email,
@@ -317,7 +338,10 @@ async function claimSend(
 
 /** Flip a claimed row to its terminal state. On success: `sent`, `provider_id`
  * and `sent_at` set, `plaintext_email` CLEARED. On failure: `failed`,
- * `last_error` recorded, `attempts` bumped, plaintext retained for the retry. */
+ * `last_error` recorded, `attempts` bumped, plaintext retained for the retry.
+ * The `AND state = 'pending'` guard makes this a one-shot transition — it can
+ * never overwrite an already-terminal row (belt-and-braces against a
+ * double-finalize). */
 async function finalizeSend(
 	db: D1Database,
 	id: string,
@@ -329,7 +353,7 @@ async function finalizeSend(
 			.prepare(
 				`UPDATE notifications
 				 SET state = 'sent', provider_id = ?, sent_at = ?, plaintext_email = NULL, last_error = NULL
-				 WHERE id = ?`,
+				 WHERE id = ? AND state = 'pending'`,
 			)
 			.bind(result.providerId ?? null, now.toISOString(), id)
 			.run();
@@ -339,7 +363,7 @@ async function finalizeSend(
 		.prepare(
 			`UPDATE notifications
 			 SET state = 'failed', last_error = ?, attempts = attempts + 1
-			 WHERE id = ?`,
+			 WHERE id = ? AND state = 'pending'`,
 		)
 		.bind(truncateError(result.error), id)
 		.run();
@@ -388,7 +412,7 @@ async function markRowUndeliverable(
 		.prepare(
 			`UPDATE notifications
 			 SET state = 'undeliverable', last_error = ?, plaintext_email = NULL, sent_at = ?
-			 WHERE id = ?`,
+			 WHERE id = ? AND state = 'pending'`,
 		)
 		.bind(reason, now.toISOString(), id)
 		.run();

--- a/apps/labeler/src/notification-send.ts
+++ b/apps/labeler/src/notification-send.ts
@@ -167,14 +167,16 @@ export async function sendNotification(
 	const nowIso = nowDate.toISOString();
 	const nowMs = nowDate.getTime();
 
-	await ensureContact(ctx.db, hash, nowIso);
-	const state = await getContactState(ctx.db, hash);
-
+	// Suppression is checked BEFORE ensureContact (matching seedPublisherContact),
+	// so a suppressed address is never seeded with an unconfirmed contact row.
 	if (await isSuppressed(ctx.db, hash)) {
 		await recordUndeliverable(ctx.db, request.source, "notice", hash, "suppressed", nowDate);
 		logSend(request.target.did, "suppressed", hash);
 		return { status: "suppressed", recipientHash: hash };
 	}
+
+	await ensureContact(ctx.db, hash, nowIso);
+	const state = await getContactState(ctx.db, hash);
 
 	if (state === null || state.confirmState === "declined") {
 		if (state?.confirmState === "declined") {
@@ -238,9 +240,10 @@ async function sendConfirmationMail(
 	// cap guarantees that — so it admits a few extra distinct victims, it never
 	// bombs anyone). Exact enforcement needs a serialized claim (a Durable Object)
 	// and is deferred to slice 2. The gate returns before any write, so a sustained
-	// DID email-bomb costs no rows; the ledger is written only after a successful
-	// claim (an actual first-ever mail), so a repeat trigger for an already-mailed
-	// address writes nothing and cannot bloat the ledger or falsely trip the cap.
+	// DID email-bomb costs no rows; the ledger is written only once the token is
+	// stamped and the mail is about to go out, so neither an already-mailed repeat
+	// (blocked at the claim) nor a contact_state_changed abort (blocked at the
+	// stamp) leaves a ledger row eating a distinct-recipient slot.
 	const sinceMs = now.ms - CONFIRM_DID_WINDOW_MS;
 	const distinctRecipients = await countDistinctConfirmRecipients(
 		ctx.db,
@@ -276,8 +279,6 @@ async function sendConfirmationMail(
 		return { status: "already_mailed", recipientHash: hash };
 	}
 
-	await recordConfirmLedgerEntry(ctx.db, request.target.did, hash, now.ms);
-
 	const token = generateConfirmToken();
 	const tokenHash = await hashConfirmToken(token);
 	const recorded = await recordConfirmSent(ctx.db, hash, tokenHash, now.ms);
@@ -285,10 +286,15 @@ async function sendConfirmationMail(
 		// The claim already enforced the lifetime cap and concurrency; a false here
 		// is only the contact leaving `unconfirmed` between the state read and this
 		// stamp. Retire the claimed row rather than mail a dead-token confirmation.
-		await markRowUndeliverable(ctx.db, id, "contact_state_changed", now.date);
+		// No ledger row was written, so the aborted mail consumes no per-DID budget.
+		await markRowUndeliverable(ctx.db, id, "contact_state_changed");
 		logSend(request.target.did, "skipped:contact_state_changed", hash);
 		return { status: "skipped", recipientHash: hash, reason: "contact_state_changed" };
 	}
+
+	// Ledger only now — after a stamped token, before the send. A failed SEND still
+	// consumes budget (the conservative fail-safe), but an abort above does not.
+	await recordConfirmLedgerEntry(ctx.db, request.target.did, hash, now.ms);
 
 	const result = await ctx.sender.sendConfirmation({
 		to: email,
@@ -428,20 +434,16 @@ async function recordUndeliverable(
 }
 
 /** Flip an already-claimed pending row to `undeliverable`, clearing plaintext.
- * Used when the contact left `unconfirmed` in the race after the claim. */
-async function markRowUndeliverable(
-	db: D1Database,
-	id: string,
-	reason: string,
-	now: Date,
-): Promise<void> {
+ * Used when the contact left `unconfirmed` in the race after the claim. Leaves
+ * `sent_at` NULL — the mail was never handed to a provider. */
+async function markRowUndeliverable(db: D1Database, id: string, reason: string): Promise<void> {
 	await db
 		.prepare(
 			`UPDATE notifications
-			 SET state = 'undeliverable', last_error = ?, plaintext_email = NULL, sent_at = ?
+			 SET state = 'undeliverable', last_error = ?, plaintext_email = NULL
 			 WHERE id = ? AND state = 'pending'`,
 		)
-		.bind(reason, now.toISOString(), id)
+		.bind(reason, id)
 		.run();
 }
 

--- a/apps/labeler/test/notification-contacts.test.ts
+++ b/apps/labeler/test/notification-contacts.test.ts
@@ -7,7 +7,9 @@ import {
 	type ContactState,
 	declineContact,
 	ensureContact,
+	generateConfirmToken,
 	getContactState,
+	hashConfirmToken,
 	isSuppressed,
 	recipientHash,
 	recordConfirmSent,
@@ -306,6 +308,32 @@ describe("canSendConfirm", () => {
 		expect(canSendConfirm({ ...unconfirmed(null), confirmState: "declined" }, 10_000, 1_000)).toBe(
 			false,
 		);
+	});
+});
+
+describe("generateConfirmToken", () => {
+	it("emits base64url with at least 128 bits of entropy", () => {
+		const token = generateConfirmToken();
+		expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+		// base64url has no padding; >=22 chars is >=128 bits, and this token is 32 bytes.
+		expect(token.length).toBeGreaterThanOrEqual(22);
+		expect(token).not.toContain("=");
+	});
+
+	it("is unique across draws (CSPRNG, not monotonic)", () => {
+		const tokens = new Set(Array.from({ length: 500 }, () => generateConfirmToken()));
+		expect(tokens.size).toBe(500);
+	});
+
+	it("survives the confirm round-trip: the send-path hash confirms against the endpoint re-hash", async () => {
+		const hash = await freshHash();
+		const token = generateConfirmToken();
+		await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+		// Send path stores SHA-256(token); the raw token travels in the link.
+		await recordConfirmSent(db(), hash, await hashConfirmToken(token), 1_000);
+		// Confirm endpoint re-hashes the raw token from the link before comparing.
+		const presentedHash = await hashConfirmToken(token);
+		expect(await confirmContact(db(), hash, presentedHash, "2026-07-16T02:00:00.000Z")).toBe(true);
 	});
 });
 

--- a/apps/labeler/test/notification-send.test.ts
+++ b/apps/labeler/test/notification-send.test.ts
@@ -1,0 +1,443 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { AggregatorClient } from "../src/aggregator-client.js";
+import { CONFIRM_DID_MAX_DISTINCT_RECIPIENTS, CONFIRM_MIN_INTERVAL_MS } from "../src/constants.js";
+import {
+	confirmContact,
+	declineContact,
+	ensureContact,
+	hashConfirmToken,
+	recipientHash,
+	recordConfirmSent,
+	suppress,
+} from "../src/notification-contacts.js";
+import type {
+	ConfirmationPayload,
+	NoticePayload,
+	NotificationRequest,
+	NotificationSender,
+	SendContext,
+	SendResult,
+} from "../src/notification-send.js";
+import { sendNotification } from "../src/notification-send.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+const db = () => testEnv.DB;
+
+const PEPPER = "send-pepper";
+const ORIGIN = "https://labels.example";
+
+let counter = 0;
+function uniq(prefix: string): string {
+	counter++;
+	return `${prefix}-${counter}`;
+}
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+/** An AggregatorClient whose publisher-profile read carries `email` as a
+ * security-kind tier-3 contact (package reads 404, so tiers 1-2 miss). A null
+ * `email` makes both reads 404 — the no-resolvable-contact case. */
+function aggregatorFor(email: string | null): AggregatorClient {
+	const notFound = () =>
+		new Response(JSON.stringify({ error: "NotFound" }), {
+			status: 404,
+			headers: { "content-type": "application/json" },
+		});
+	const fetcher = {
+		// AggregatorClient always calls fetch with a string URL (see aggregator-client.ts).
+		fetch: async (url: string) => {
+			if (url.includes("getPublisher") && !url.includes("getPublisherVerification") && email) {
+				return Response.json({
+					did: "did:plc:stub",
+					profile: { contact: [{ kind: "security", email }] },
+				});
+			}
+			return notFound();
+		},
+	} as unknown as Fetcher;
+	return new AggregatorClient(fetcher);
+}
+
+interface RecordingSender extends NotificationSender {
+	confirmations: ConfirmationPayload[];
+	notices: NoticePayload[];
+}
+
+function recordingSender(result: SendResult = { ok: true, providerId: "prov-1" }): RecordingSender {
+	const confirmations: ConfirmationPayload[] = [];
+	const notices: NoticePayload[] = [];
+	return {
+		confirmations,
+		notices,
+		sendConfirmation: async (payload) => {
+			confirmations.push(payload);
+			return result;
+		},
+		sendNotice: async (payload) => {
+			notices.push(payload);
+			return result;
+		},
+	};
+}
+
+function context(email: string | null, sender: RecordingSender, now?: () => Date): SendContext {
+	return {
+		db: db(),
+		aggregator: aggregatorFor(email),
+		pepper: PEPPER,
+		sender,
+		origin: ORIGIN,
+		now,
+	};
+}
+
+function request(did: string, sourceId: string): NotificationRequest {
+	return {
+		source: { type: "issuance", id: sourceId },
+		target: { did, slug: "pkg" },
+		notice: {
+			subject: "Your package was blocked",
+			publicSummary: "public summary",
+			assessmentUrl: "https://labels.example/a/1",
+			effect: "blocked",
+			reconsiderationUrl: "https://labels.example/reconsider",
+		},
+	};
+}
+
+interface NotificationRow {
+	id: string;
+	kind: string;
+	state: string;
+	recipient_hash: string | null;
+	attempts: number;
+	provider_id: string | null;
+	last_error: string | null;
+	plaintext_email: string | null;
+	sent_at: string | null;
+}
+
+async function rowsForSource(sourceId: string): Promise<NotificationRow[]> {
+	const result = await db()
+		.prepare(`SELECT * FROM notifications WHERE source_id = ? ORDER BY created_at_epoch_ms`)
+		.bind(sourceId)
+		.all<NotificationRow>();
+	return result.results ?? [];
+}
+
+async function ledgerCount(did: string): Promise<number> {
+	const row = await db()
+		.prepare(`SELECT COUNT(*) AS n FROM notification_confirm_ledger WHERE publisher_did = ?`)
+		.bind(did)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+async function storedTokenHash(hash: string): Promise<string | null> {
+	const row = await db()
+		.prepare(`SELECT confirm_token_hash FROM notification_contacts WHERE recipient_hash = ?`)
+		.bind(hash)
+		.first<{ confirm_token_hash: string | null }>();
+	return row?.confirm_token_hash ?? null;
+}
+
+async function seedConfirmed(hash: string): Promise<void> {
+	await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+	const tokenHash = await hashConfirmToken("seed-token");
+	await recordConfirmSent(db(), hash, tokenHash, 1_000);
+	await confirmContact(db(), hash, tokenHash, "2026-07-16T00:00:01.000Z");
+}
+
+describe("confirmed contact", () => {
+	it("sends a substantive notice, marks it sent, and clears plaintext", async () => {
+		const email = uniq("confirmed") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		await seedConfirmed(hash);
+		const sender = recordingSender({ ok: true, providerId: "prov-notice" });
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(email, sender), request("did:plc:a", sourceId));
+
+		expect(outcome).toEqual({
+			status: "notice_sent",
+			recipientHash: hash,
+			providerId: "prov-notice",
+		});
+		expect(sender.notices).toHaveLength(1);
+		expect(sender.confirmations).toHaveLength(0);
+		expect(sender.notices[0]).toMatchObject({
+			to: email,
+			subject: "Your package was blocked",
+			effect: "blocked",
+			assessmentUrl: "https://labels.example/a/1",
+			reconsiderationUrl: "https://labels.example/reconsider",
+		});
+		expect(sender.notices[0]?.unsubscribeUrl).toBe(
+			`https://labels.example/notifications/unsubscribe?c=${hash}`,
+		);
+
+		const rows = await rowsForSource(sourceId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			kind: "notice",
+			state: "sent",
+			recipient_hash: hash,
+			provider_id: "prov-notice",
+			plaintext_email: null,
+			attempts: 0,
+		});
+		expect(rows[0]?.sent_at).not.toBeNull();
+	});
+
+	it("records failed with attempts bumped and plaintext retained on a send failure", async () => {
+		const email = uniq("confirmedfail") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		await seedConfirmed(hash);
+		const sender = recordingSender({ ok: false, error: "smtp down" });
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(email, sender), request("did:plc:a", sourceId));
+
+		expect(outcome).toEqual({ status: "notice_failed", recipientHash: hash, error: "smtp down" });
+		const rows = await rowsForSource(sourceId);
+		expect(rows[0]).toMatchObject({
+			kind: "notice",
+			state: "failed",
+			last_error: "smtp down",
+			attempts: 1,
+			plaintext_email: email,
+		});
+	});
+
+	it("sends nothing to a confirmed but suppressed contact", async () => {
+		const email = uniq("confsupp") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		await seedConfirmed(hash);
+		await suppress(db(), hash, "bounce", "2026-07-16T00:00:00.000Z", 1_000);
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(email, sender), request("did:plc:a", sourceId));
+
+		expect(outcome).toEqual({ status: "suppressed", recipientHash: hash });
+		expect(sender.notices).toHaveLength(0);
+		const rows = await rowsForSource(sourceId);
+		expect(rows[0]).toMatchObject({ state: "undeliverable", last_error: "suppressed" });
+	});
+});
+
+describe("unconfirmed contact — double opt-in", () => {
+	it("sends a confirmation mail, persisting only the token hash", async () => {
+		const email = uniq("unconf") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		const did = uniq("did:plc");
+		const sender = recordingSender({ ok: true, providerId: "prov-confirm" });
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(email, sender), request(did, sourceId));
+
+		expect(outcome).toEqual({
+			status: "confirmation_sent",
+			recipientHash: hash,
+			providerId: "prov-confirm",
+		});
+		expect(sender.confirmations).toHaveLength(1);
+		expect(sender.notices).toHaveLength(0);
+
+		const confirmUrl = new URL(sender.confirmations[0]!.confirmUrl);
+		expect(confirmUrl.origin + confirmUrl.pathname).toBe(
+			"https://labels.example/notifications/confirm",
+		);
+		expect(confirmUrl.searchParams.get("c")).toBe(hash);
+		const rawToken = confirmUrl.searchParams.get("t") ?? "";
+
+		// CSPRNG base64url, >=128 bits (>=22 chars); matches the confirm endpoint's token grammar.
+		expect(rawToken).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(rawToken.length).toBeGreaterThanOrEqual(22);
+
+		// The stored hash is SHA-256(rawToken); the raw token is nowhere in the DB.
+		expect(await storedTokenHash(hash)).toBe(await hashConfirmToken(rawToken));
+		const rows = await rowsForSource(sourceId);
+		expect(rows[0]).toMatchObject({
+			kind: "confirmation",
+			state: "sent",
+			recipient_hash: hash,
+			provider_id: "prov-confirm",
+			plaintext_email: null,
+		});
+		for (const row of rows) {
+			expect(row.plaintext_email).not.toBe(rawToken);
+			expect(row.last_error).not.toBe(rawToken);
+		}
+		expect(sender.confirmations[0]).toMatchObject({
+			to: email,
+			unsubscribeUrl: `https://labels.example/notifications/unsubscribe?c=${hash}`,
+			notMeUrl: `https://labels.example/notifications/not-me?c=${hash}`,
+		});
+		expect(await ledgerCount(did)).toBe(1);
+	});
+
+	it("records confirmation failure with plaintext retained (token still recorded)", async () => {
+		const email = uniq("unconffail") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		const sender = recordingSender({ ok: false, error: "provider 500" });
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(email, sender), request(uniq("did"), sourceId));
+
+		expect(outcome).toEqual({
+			status: "confirmation_failed",
+			recipientHash: hash,
+			error: "provider 500",
+		});
+		const rows = await rowsForSource(sourceId);
+		expect(rows[0]).toMatchObject({
+			kind: "confirmation",
+			state: "failed",
+			last_error: "provider 500",
+			attempts: 1,
+			plaintext_email: email,
+		});
+		expect(await storedTokenHash(hash)).not.toBeNull();
+	});
+
+	it("rate-limits per address: no second confirmation within the interval", async () => {
+		const email = uniq("addr") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		const sentAtMs = 2_000_000;
+		await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+		await recordConfirmSent(db(), hash, await hashConfirmToken("prev"), sentAtMs);
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+		const now = () => new Date(sentAtMs + CONFIRM_MIN_INTERVAL_MS - 1);
+
+		const outcome = await sendNotification(
+			context(email, sender, now),
+			request(uniq("did"), sourceId),
+		);
+
+		expect(outcome).toEqual({ status: "rate_limited", recipientHash: hash, scope: "address" });
+		expect(sender.confirmations).toHaveLength(0);
+		expect(await rowsForSource(sourceId)).toHaveLength(0);
+	});
+
+	it("rate-limits per DID once the distinct-recipient cap is reached", async () => {
+		const did = uniq("did:plc:bulk");
+		const nowMs = 5_000_000;
+		for (let i = 0; i < CONFIRM_DID_MAX_DISTINCT_RECIPIENTS; i++) {
+			await db()
+				.prepare(
+					`INSERT INTO notification_confirm_ledger (id, publisher_did, recipient_hash, sent_at_epoch_ms)
+					 VALUES (?, ?, ?, ?)`,
+				)
+				.bind(`ncl_bulk_${i}`, did, `victimhash${i}`, nowMs)
+				.run();
+		}
+		const email = uniq("victim") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(
+			context(email, sender, () => new Date(nowMs)),
+			request(did, sourceId),
+		);
+
+		expect(outcome).toEqual({ status: "rate_limited", recipientHash: hash, scope: "did" });
+		expect(sender.confirmations).toHaveLength(0);
+		expect(await rowsForSource(sourceId)).toHaveLength(0);
+	});
+
+	it("allows a confirmation when the DID is just below the cap", async () => {
+		const did = uniq("did:plc:justunder");
+		const nowMs = 6_000_000;
+		for (let i = 0; i < CONFIRM_DID_MAX_DISTINCT_RECIPIENTS - 1; i++) {
+			await db()
+				.prepare(
+					`INSERT INTO notification_confirm_ledger (id, publisher_did, recipient_hash, sent_at_epoch_ms)
+					 VALUES (?, ?, ?, ?)`,
+				)
+				.bind(`ncl_under_${i}`, did, `underhash${i}`, nowMs)
+				.run();
+		}
+		const email = uniq("under") + "@example.test";
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(
+			context(email, sender, () => new Date(nowMs)),
+			request(did, sourceId),
+		);
+
+		expect(outcome.status).toBe("confirmation_sent");
+		expect(sender.confirmations).toHaveLength(1);
+		expect(await ledgerCount(did)).toBe(CONFIRM_DID_MAX_DISTINCT_RECIPIENTS);
+	});
+});
+
+describe("declined / suppressed / no-contact", () => {
+	it("sends nothing to a declined contact (never gates on seeded:true)", async () => {
+		const email = uniq("declined") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+		await declineContact(db(), hash);
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(email, sender), request("did:plc:a", sourceId));
+
+		expect(outcome).toEqual({ status: "declined", recipientHash: hash });
+		expect(sender.confirmations).toHaveLength(0);
+		expect(sender.notices).toHaveLength(0);
+		const rows = await rowsForSource(sourceId);
+		expect(rows[0]).toMatchObject({
+			kind: "notice",
+			state: "undeliverable",
+			last_error: "declined",
+			recipient_hash: hash,
+			plaintext_email: null,
+		});
+	});
+
+	it("sends nothing to a suppressed contact and records undeliverable", async () => {
+		const email = uniq("suppressed") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		await suppress(db(), hash, "unsubscribe", "2026-07-16T00:00:00.000Z", 1_000);
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(email, sender), request("did:plc:a", sourceId));
+
+		expect(outcome).toEqual({ status: "suppressed", recipientHash: hash });
+		expect(sender.confirmations).toHaveLength(0);
+		const rows = await rowsForSource(sourceId);
+		expect(rows[0]).toMatchObject({ state: "undeliverable", last_error: "suppressed" });
+	});
+
+	it("records an undeliverable row with a null recipient hash when no contact resolves", async () => {
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+
+		const outcome = await sendNotification(context(null, sender), request("did:plc:a", sourceId));
+
+		expect(outcome).toEqual({ status: "no_contact" });
+		expect(sender.confirmations).toHaveLength(0);
+		expect(sender.notices).toHaveLength(0);
+		const rows = await rowsForSource(sourceId);
+		expect(rows[0]).toMatchObject({
+			kind: "notice",
+			state: "undeliverable",
+			recipient_hash: null,
+			last_error: "no_email_contact",
+		});
+	});
+});

--- a/apps/labeler/test/notification-send.test.ts
+++ b/apps/labeler/test/notification-send.test.ts
@@ -382,6 +382,26 @@ describe("unconfirmed contact — double opt-in", () => {
 		expect(sender.confirmations).toHaveLength(1);
 		expect(await ledgerCount(did)).toBe(CONFIRM_DID_MAX_DISTINCT_RECIPIENTS);
 	});
+
+	it("mails a racing unconfirmed victim exactly once (recordConfirmSent CAS closes the double-mail race)", async () => {
+		const email = uniq("race") + "@example.test";
+		const sender = recordingSender({ ok: true, providerId: "p" });
+		// One shared context + request, dispatched twice concurrently: both reads see
+		// the fresh unconfirmed contact and pass canSendConfirm off the same snapshot.
+		// Only the interval CAS in recordConfirmSent can stop the second mail.
+		const ctx = context(email, sender, () => new Date(9_000_000));
+		const sourceId = uniq("src");
+		const req = request(uniq("did:plc:race"), sourceId);
+
+		const outcomes = await Promise.all([sendNotification(ctx, req), sendNotification(ctx, req)]);
+
+		expect(outcomes.map((o) => o.status).toSorted()).toEqual(["confirmation_sent", "skipped"]);
+		expect(sender.confirmations).toHaveLength(1);
+
+		const rows = await rowsForSource(sourceId);
+		expect(rows).toHaveLength(2);
+		expect(rows.map((r) => r.state).toSorted()).toEqual(["sent", "undeliverable"]);
+	});
 });
 
 describe("declined / suppressed / no-contact", () => {

--- a/apps/labeler/test/notification-send.test.ts
+++ b/apps/labeler/test/notification-send.test.ts
@@ -100,6 +100,52 @@ function context(email: string | null, sender: RecordingSender, now?: () => Date
 	};
 }
 
+/**
+ * Wraps a D1Database so that `flip` runs exactly once, during the per-DID
+ * distinct-recipient count — which the send path runs AFTER reading the contact
+ * state but BEFORE stamping the token. That is the deterministic seam for the
+ * contact_state_changed abort: a fake sender / aggregator fires too early or too
+ * late, so a mid-query DB side effect is the only way to flip the contact at that
+ * exact point. Only `prepare` and the count statement's `first` are intercepted;
+ * everything else delegates to the real database.
+ */
+function dbFlippingContactDuringCount(real: D1Database, flip: () => Promise<void>): D1Database {
+	let fired = false;
+	const wrapStatement = (stmt: D1PreparedStatement, isTarget: boolean): D1PreparedStatement =>
+		new Proxy(stmt, {
+			get(target, prop, receiver) {
+				if (prop === "bind") {
+					return (...args: unknown[]) =>
+						wrapStatement(
+							(target.bind as (...a: unknown[]) => D1PreparedStatement)(...args),
+							isTarget,
+						);
+				}
+				if (prop === "first" && isTarget) {
+					return async (...args: unknown[]) => {
+						if (!fired) {
+							fired = true;
+							await flip();
+						}
+						return (target.first as (...a: unknown[]) => unknown)(...args);
+					};
+				}
+				const value = Reflect.get(target, prop, receiver);
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		});
+	return new Proxy(real, {
+		get(target, prop, receiver) {
+			if (prop === "prepare") {
+				return (query: string) =>
+					wrapStatement(target.prepare(query), query.includes("COUNT(DISTINCT recipient_hash)"));
+			}
+			const value = Reflect.get(target, prop, receiver);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}
+
 function request(did: string, sourceId: string): NotificationRequest {
 	return {
 		source: { type: "issuance", id: sourceId },
@@ -460,6 +506,47 @@ describe("unconfirmed contact — double opt-in", () => {
 		const rows = await rowsForSource(sourceId);
 		expect(rows).toHaveLength(1);
 		expect(rows[0]?.state).toBe("sent");
+	});
+
+	it("aborts with no ledger row when the contact leaves unconfirmed mid-send", async () => {
+		const email = uniq("midflip") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		const did = uniq("did:plc:midflip");
+		const sender = recordingSender();
+		const sourceId = uniq("src");
+
+		// Flip the contact to declined during the per-DID count — after the state read,
+		// before the token stamp — so recordConfirmSent aborts the send.
+		const ctx: SendContext = {
+			db: dbFlippingContactDuringCount(db(), async () => {
+				await declineContact(db(), hash);
+			}),
+			aggregator: aggregatorFor(email),
+			pepper: PEPPER,
+			sender,
+			origin: ORIGIN,
+			now: () => new Date(4_000_000),
+		};
+
+		const outcome = await sendNotification(ctx, request(did, sourceId));
+
+		expect(outcome).toEqual({
+			status: "skipped",
+			recipientHash: hash,
+			reason: "contact_state_changed",
+		});
+		expect(sender.confirmations).toHaveLength(0);
+		// The aborted mail consumed no per-DID budget...
+		expect(await ledgerCount(did)).toBe(0);
+		// ...and the claimed row is retired undeliverable, with sent_at left NULL.
+		const rows = await rowsForSource(sourceId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			kind: "confirmation",
+			state: "undeliverable",
+			last_error: "contact_state_changed",
+		});
+		expect(rows[0]?.sent_at).toBeNull();
 	});
 });
 

--- a/apps/labeler/test/notification-send.test.ts
+++ b/apps/labeler/test/notification-send.test.ts
@@ -2,7 +2,7 @@ import { applyD1Migrations, env } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { AggregatorClient } from "../src/aggregator-client.js";
-import { CONFIRM_DID_MAX_DISTINCT_RECIPIENTS, CONFIRM_MIN_INTERVAL_MS } from "../src/constants.js";
+import { CONFIRM_DID_MAX_DISTINCT_RECIPIENTS } from "../src/constants.js";
 import {
 	confirmContact,
 	declineContact,
@@ -310,24 +310,79 @@ describe("unconfirmed contact — double opt-in", () => {
 		expect(await storedTokenHash(hash)).not.toBeNull();
 	});
 
-	it("rate-limits per address: no second confirmation within the interval", async () => {
-		const email = uniq("addr") + "@example.test";
+	it("mails an address a confirmation at most once ever (lifetime cap)", async () => {
+		const email = uniq("lifetime") + "@example.test";
 		const hash = await recipientHash(PEPPER, email);
-		const sentAtMs = 2_000_000;
-		await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
-		await recordConfirmSent(db(), hash, await hashConfirmToken("prev"), sentAtMs);
-		const sender = recordingSender();
+		const did = uniq("did:plc:life");
+		const sender = recordingSender({ ok: true, providerId: "p1" });
+
+		const first = await sendNotification(
+			context(email, sender, () => new Date(1_000_000)),
+			request(did, uniq("src")),
+		);
+		expect(first.status).toBe("confirmation_sent");
+		expect(sender.confirmations).toHaveLength(1);
+
+		// Arbitrary time later, a fresh trigger for the still-unconfirmed contact
+		// mails nothing and creates no row.
+		const laterSourceId = uniq("src");
+		const second = await sendNotification(
+			context(email, sender, () => new Date(999_000_000)),
+			request(did, laterSourceId),
+		);
+		expect(second).toEqual({ status: "already_mailed", recipientHash: hash });
+		expect(sender.confirmations).toHaveLength(1);
+		expect(await rowsForSource(laterSourceId)).toHaveLength(0);
+	});
+
+	it("does not re-mail after a FAILED confirmation (the failed row still counts)", async () => {
+		const email = uniq("lifefail") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		const did = uniq("did:plc:lifefail");
+
+		const failSender = recordingSender({ ok: false, error: "boom" });
+		const first = await sendNotification(
+			context(email, failSender, () => new Date(1_000_000)),
+			request(did, uniq("src")),
+		);
+		expect(first.status).toBe("confirmation_failed");
+
+		const okSender = recordingSender({ ok: true, providerId: "p" });
+		const laterSourceId = uniq("src");
+		const second = await sendNotification(
+			context(email, okSender, () => new Date(2_000_000)),
+			request(did, laterSourceId),
+		);
+		expect(second).toEqual({ status: "already_mailed", recipientHash: hash });
+		expect(okSender.confirmations).toHaveLength(0);
+		expect(await rowsForSource(laterSourceId)).toHaveLength(0);
+	});
+
+	it("still mails when the only prior confirmation row is undeliverable", async () => {
+		const email = uniq("undelprior") + "@example.test";
+		const hash = await recipientHash(PEPPER, email);
+		const did = uniq("did:plc:undel");
+		// A prior undeliverable confirmation row (e.g. a race loser or a
+		// suppressed-at-claim that never actually mailed) must not block a later send.
+		await db()
+			.prepare(
+				`INSERT INTO notifications
+					(id, source_type, source_id, kind, channel, recipient_hash, state, attempts,
+					 created_at, created_at_epoch_ms)
+				 VALUES (?, 'issuance', ?, 'confirmation', 'email', ?, 'undeliverable', 0, ?, ?)`,
+			)
+			.bind(uniq("ntf_prior"), uniq("src"), hash, "2026-07-16T00:00:00.000Z", 1_000)
+			.run();
+		const sender = recordingSender({ ok: true, providerId: "p" });
 		const sourceId = uniq("src");
-		const now = () => new Date(sentAtMs + CONFIRM_MIN_INTERVAL_MS - 1);
 
 		const outcome = await sendNotification(
-			context(email, sender, now),
-			request(uniq("did"), sourceId),
+			context(email, sender, () => new Date(3_000_000)),
+			request(did, sourceId),
 		);
 
-		expect(outcome).toEqual({ status: "rate_limited", recipientHash: hash, scope: "address" });
-		expect(sender.confirmations).toHaveLength(0);
-		expect(await rowsForSource(sourceId)).toHaveLength(0);
+		expect(outcome.status).toBe("confirmation_sent");
+		expect(sender.confirmations).toHaveLength(1);
 	});
 
 	it("rate-limits per DID once the distinct-recipient cap is reached", async () => {
@@ -383,24 +438,28 @@ describe("unconfirmed contact — double opt-in", () => {
 		expect(await ledgerCount(did)).toBe(CONFIRM_DID_MAX_DISTINCT_RECIPIENTS);
 	});
 
-	it("mails a racing unconfirmed victim exactly once (recordConfirmSent CAS closes the double-mail race)", async () => {
+	it("mails a racing unconfirmed victim exactly once (atomic claim closes the double-mail race)", async () => {
 		const email = uniq("race") + "@example.test";
 		const sender = recordingSender({ ok: true, providerId: "p" });
-		// One shared context + request, dispatched twice concurrently: both reads see
-		// the fresh unconfirmed contact and pass canSendConfirm off the same snapshot.
-		// Only the interval CAS in recordConfirmSent can stop the second mail.
+		// One shared context + request dispatched twice concurrently: both reads see
+		// the fresh unconfirmed contact. Only the atomic confirmation claim stops the
+		// second mail — its lifetime-cap NOT EXISTS sees the first's pending row, so
+		// the loser inserts no row at all.
 		const ctx = context(email, sender, () => new Date(9_000_000));
 		const sourceId = uniq("src");
 		const req = request(uniq("did:plc:race"), sourceId);
 
 		const outcomes = await Promise.all([sendNotification(ctx, req), sendNotification(ctx, req)]);
 
-		expect(outcomes.map((o) => o.status).toSorted()).toEqual(["confirmation_sent", "skipped"]);
+		expect(outcomes.map((o) => o.status).toSorted()).toEqual([
+			"already_mailed",
+			"confirmation_sent",
+		]);
 		expect(sender.confirmations).toHaveLength(1);
 
 		const rows = await rowsForSource(sourceId);
-		expect(rows).toHaveLength(2);
-		expect(rows.map((r) => r.state).toSorted()).toEqual(["sent", "undeliverable"]);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.state).toBe("sent");
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

W10.5 **slice 1** of the publisher-notification subsystem: the security-critical send-orchestration core, plus its delivery table and CSPRNG confirm token. Builds on the merged W10.4 contact/confirm infrastructure (slices A/B/C).

What lands here:

- **Migration `0008_notifications.sql`** — the publisher-facing `notifications` delivery table (mutable outbox: polymorphic `issuance|operator` source with no cross-table FK, `confirmation|notice` kind, `pending|sent|failed|undeliverable` state, `attempts`/`provider_id`/`last_error`, and a nullable `plaintext_email` set on claim and cleared on successful send) plus a per-DID `notification_confirm_ledger` for distinct-recipient rate limiting. A `CHECK (state = 'undeliverable' OR recipient_hash IS NOT NULL)` keeps every sendable row hash-bearing.
- **CSPRNG confirm token** — `generateConfirmToken()` draws 256 bits from `crypto.getRandomValues`, base64url, single-use; only its SHA-256 digest is persisted (via the existing `recordConfirmSent`), the raw token travels only in the confirm link. This is the hard requirement from the W10.4 slice-C adversary pass (the pepper-less, rate-limit-free confirm endpoint rests entirely on token unguessability).
- **Gated send-core** — `sendNotification(ctx, request)` against an injected `NotificationSender` (the real Cloudflare Email Sending adapter is slice 2, exercised here with a fake). Fresh contact resolve → recipient hash → atomic suppression re-check → confirm-state gate (**never** `seeded:true`): `confirmed` → substantive notice; `unconfirmed` → a content-neutral confirmation mail subject to the caps; `declined`/suppressed/no-contact → `undeliverable`, no send.

**Lifetime-cap decision (ratified).** A confirmation mail reaches an address **at most once ever** — no re-nudge after any interval. This is enforced atomically inside the confirmation claim: one `INSERT ... SELECT ... WHERE NOT EXISTS (suppression) AND NOT EXISTS (prior non-undeliverable confirmation row for the hash)`. That single statement enforces all three of not-suppressed, the lifetime cap, and the concurrency race (of two racing sends exactly one inserts; the loser writes no row). An `undeliverable` prior never mailed, so it is deliberately excluded and cannot foreclose a later legitimate confirmation. A separate per-DID cap (distinct recipients in a rolling window) throttles a hostile DID naming many distinct `victim@x` addresses — the amplification the per-address cap cannot see.

**Out of scope (slice 2):** the real Cloudflare Email Sending adapter + templates, the five issuance-point triggers, verified-publisher confirmation-skip, and the cron retry/cleanup sweep. Three slice-2 contracts (source ref, verified-skip, and the sweep re-driving stuck `pending` rows / retiring terminally-abandoned rows) are recorded in `.opencode/plans/plugin-registry-labelling-service/implementation-plan.md` under W10.5.

Base is the integration branch `feat/plugin-registry-labelling-service`, not `main`.

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes — 0 diagnostics in the files this PR touches (the repo has pre-existing diagnostics in unrelated `registry-verification`/`calibration` files, untouched here)
- [x] `pnpm test` passes — full labeler suite green (707 tests, 37 files), including the new `notification-send`/`notification-contacts` coverage
- [x] `pnpm format` has been run (oxfmt, tabs)
- [x] I have added/updated tests for my changes
- [ ] User-visible strings wrapped for translation — **n/a**: no admin UI in this PR (labeler send-core + migration only)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) — **n/a**: the labeler app and its migrations are unpublished; no published package changed
- [ ] New features link to an approved Discussion — **n/a**: first-party workstream tracked and ratified in the W10.5 implementation plan (`.opencode/plans/plugin-registry-labelling-service/implementation-plan.md`), targeting the integration branch rather than `main`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8**

## Screenshots / test output

Full labeler suite: **707 passed (37 files)**. Gate-specific proofs for the anti-abuse core:

- **Concurrency:** `Promise.all([sendNotification, sendNotification])` for one unconfirmed address → the fake sender receives exactly **one** confirmation, exactly **one** `sent` row, the other call returns `already_mailed` with **no** row.
- **Lifetime cap:** after one **sent** confirmation, and separately after one **failed** confirmation, a later send (simulated far-future clock) mails nothing.
- **Undeliverable-prior-doesn't-block:** a hash whose only prior confirmation row is `undeliverable` is still mailed.
- **Negative proof:** with the lifetime `NOT EXISTS` guard temporarily removed, the concurrency and both lifetime tests fail (two mails / re-mails); the undeliverable-prior test still passes. Guard restored.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-notification-send-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-notification-send`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
