### PR TITLE
feat(labeler): email adapter, issuance triggers, and retry sweep (W10.5 slice 2)

### DIFF
--- a/apps/labeler/src/assessment-workflow.ts
+++ b/apps/labeler/src/assessment-workflow.ts
@@ -33,8 +33,9 @@ import {
 	stubStages,
 	type OrchestratorStages,
 } from "./assessment-orchestrator.js";
-import { getAssessment } from "./assessment-store.js";
+import { getAssessment, type Assessment } from "./assessment-store.js";
 import { getLabelerIdentityConfig } from "./config.js";
+import { createNotifyDeps, notifyAssessmentOutcome } from "./notification-triggers.js";
 import { MODERATION_POLICY } from "./policy.js";
 import { createRuntimeSigner, getRuntimeSigningSecret } from "./signing-runtime.js";
 
@@ -71,7 +72,12 @@ export async function executeAssessmentInstance(
 	// attempt already finalized (its batch committed but the step result was
 	// lost) — return that state. A `pending` or crash-left `running` row falls
 	// through to `runAssessment`, which drives (or resumes) it to finalization.
-	if (TERMINAL_STATES.has(existing.state)) return existing.state;
+	// The notify runs on the resume path too (dedup makes it idempotent), so a
+	// crash between the label commit and the notify still delivers.
+	if (TERMINAL_STATES.has(existing.state)) {
+		await notifyOutcome(env, existing);
+		return existing.state;
+	}
 
 	const config = await getLabelerIdentityConfig(env);
 	const versioned = await createRuntimeSigner(config, getRuntimeSigningSecret(env));
@@ -83,7 +89,27 @@ export async function executeAssessmentInstance(
 		stages: buildStages(),
 	});
 	const finalized = await orchestrator.runAssessment(assessmentId);
+	await notifyOutcome(env, finalized);
 	return finalized.state;
+}
+
+/**
+ * Fire the automated block/warning publisher notice, best-effort. Reaching a
+ * `blocked`/`warned` terminal state means finalization's CAS committed the
+ * labels, so this is a true post-commit side effect; it never affects the run.
+ * `notifyAssessmentOutcome` swallows its own send errors and dedups on the
+ * assessment id, so a Workflow-step retry re-drives it harmlessly.
+ */
+async function notifyOutcome(env: Env, assessment: Assessment): Promise<void> {
+	if (assessment.state !== "blocked" && assessment.state !== "warned") return;
+	try {
+		await notifyAssessmentOutcome(await createNotifyDeps(env), assessment);
+	} catch (error) {
+		console.error("[notifications] assessment notify failed", {
+			assessmentId: assessment.id,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
 }
 
 /**

--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -46,6 +46,13 @@ import {
 	type OperatorActionType,
 } from "./mutation-guard.js";
 import {
+	notifyEmergencyTakedown,
+	notifyOperatorLabel,
+	notifyOverride,
+	notifyOverrideRetract,
+	type NotifyDeps,
+} from "./notification-triggers.js";
+import {
 	buildOperationalEventInsert,
 	buildOutboxInsert,
 	newOperationalEventId,
@@ -138,6 +145,11 @@ export interface ConsoleMutationDeps {
 	 * cannot join the D1 batch, so it runs in the deferred tail; the discovery
 	 * consumer's `runKey` dedup absorbs a duplicate re-drive. */
 	sendDiscoveryJob: (job: DiscoveryJob) => Promise<void>;
+	/** Publisher-notification deps (plan W10.5). When present, a label-affecting
+	 * operator action fires a post-commit publisher notice in the deferred tail
+	 * (never blocking or failing the label). Omitted in tests that don't exercise
+	 * notifications. */
+	notify?: NotifyDeps;
 }
 
 /**
@@ -244,6 +256,7 @@ async function runLabelMutation(
 	const outcome = await guardMutation(request, spec, guardDeps);
 	if (outcome.outcome === "replay") {
 		await assertIssuancePersisted(deps.db, [outcome.actionId]);
+		deferLabelNotify(deps, storedDescriptor<IssuedLabelDescriptor>(outcome.result));
 		return jsonData(outcome.result);
 	}
 
@@ -284,6 +297,7 @@ async function runLabelMutation(
 	const returned = await commitMutation(deps.db, ctx, spec, statements, descriptor);
 	await assertIssuancePersisted(deps.db, [returned.actionId]);
 	deps.defer(deps.afterCommit(ctx.actionId));
+	deferLabelNotify(deps, returned);
 	return jsonData(returned);
 }
 
@@ -541,6 +555,41 @@ function deferPublishAll(deps: ConsoleMutationDeps, issuanceKeys: readonly strin
 	deps.defer(Promise.all(issuanceKeys.map((key) => deps.afterCommit(key))));
 }
 
+// ─── W10.5: post-commit publisher notifications (deferred, never blocking) ────
+// Each fires only once the authoritative batch has committed. The trigger
+// swallows its own errors and dedups on the operator action id, so a replay
+// re-drives it harmlessly and a notification failure never touches the label.
+
+function deferLabelNotify(deps: ConsoleMutationDeps, d: IssuedLabelDescriptor): void {
+	if (!deps.notify) return;
+	deps.defer(
+		notifyOperatorLabel(deps.notify, {
+			actionId: d.actionId,
+			uri: d.uri,
+			...(d.cid !== null ? { cid: d.cid } : {}),
+			val: d.val,
+			neg: d.neg,
+		}),
+	);
+}
+
+function deferOverrideNotify(deps: ConsoleMutationDeps, d: OverrideDescriptor): void {
+	if (!deps.notify) return;
+	deps.defer(notifyOverride(deps.notify, { actionId: d.actionId, uri: d.uri, cid: d.cid }));
+}
+
+function deferOverrideRetractNotify(deps: ConsoleMutationDeps, d: OverrideRetractDescriptor): void {
+	if (!deps.notify) return;
+	deps.defer(notifyOverrideRetract(deps.notify, { actionId: d.actionId, uri: d.uri, cid: d.cid }));
+}
+
+function deferTakedownNotify(deps: ConsoleMutationDeps, d: EmergencyDescriptor): void {
+	if (!deps.notify) return;
+	deps.defer(
+		notifyEmergencyTakedown(deps.notify, { actionId: d.actionId, uri: d.uri, neg: d.neg }),
+	);
+}
+
 /**
  * `POST /admin/api/assessments/:id/rerun` — mints the immutable operator trigger
  * (`operator:<actionId>`), creates a fresh run for the assessment's exact URI+CID
@@ -681,6 +730,7 @@ async function runOverride(
 		const keys = overrideIssuanceKeys(stored.actionId, stored.negated, stored.issued);
 		await assertIssuancePersisted(deps.db, keys);
 		deferPublishAll(deps, keys);
+		deferOverrideNotify(deps, stored);
 		return jsonData(stored);
 	}
 
@@ -733,6 +783,7 @@ async function runOverride(
 	const committedKeys = overrideIssuanceKeys(returned.actionId, returned.negated, returned.issued);
 	await assertIssuancePersisted(deps.db, committedKeys);
 	deferPublishAll(deps, committedKeys);
+	deferOverrideNotify(deps, returned);
 	return jsonData(returned);
 }
 
@@ -761,6 +812,7 @@ async function runOverrideRetract(
 		const keys = stored.negated.map((val) => overridePieceKey(stored.actionId, val, true));
 		await assertIssuancePersisted(deps.db, keys);
 		deferPublishAll(deps, keys);
+		deferOverrideRetractNotify(deps, stored);
 		return jsonData(stored);
 	}
 
@@ -810,6 +862,7 @@ async function runOverrideRetract(
 	);
 	await assertIssuancePersisted(deps.db, committedKeys);
 	deferPublishAll(deps, committedKeys);
+	deferOverrideRetractNotify(deps, returned);
 	return jsonData(returned);
 }
 
@@ -922,6 +975,7 @@ async function runEmergencyAction(
 	if (outcome.outcome === "replay") {
 		const stored = storedDescriptor<EmergencyDescriptor>(outcome.result);
 		await assertIssuancePersisted(deps.db, [stored.actionId]);
+		if (action === "takedown") deferTakedownNotify(deps, stored);
 		return jsonData(stored);
 	}
 
@@ -988,6 +1042,7 @@ async function runEmergencyAction(
 	);
 	await assertIssuancePersisted(deps.db, [returned.actionId]);
 	deps.defer(deps.afterCommit(returned.actionId));
+	if (action === "takedown") deferTakedownNotify(deps, returned);
 	return jsonData(returned);
 }
 

--- a/apps/labeler/src/constants.ts
+++ b/apps/labeler/src/constants.ts
@@ -23,3 +23,20 @@ export const WANTED_COLLECTIONS = [NSID.packageRelease] as const;
 export const CONFIRM_RATE_LIMIT_VERSION = 1;
 export const CONFIRM_DID_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const CONFIRM_DID_MAX_DISTINCT_RECIPIENTS = 10;
+
+/**
+ * Delivery retry-sweep tunables (plan W10.5 slice 2). Versioned as a set: bump
+ * together if the retry posture is retuned. The 5-minute cron is the natural
+ * backoff interval — each pass re-drives every `failed` row (and every crashed
+ * `pending` row older than {@link NOTIFICATION_STUCK_PENDING_MS}) once, capped at
+ * {@link NOTIFICATION_MAX_SEND_ATTEMPTS} attempts before a row is abandoned to
+ * `undeliverable` (which clears plaintext and, for a confirmation, reopens the
+ * lifetime cap so the channel is not silently foreclosed). Terminal rows older
+ * than {@link NOTIFICATION_RETENTION_MS} are pruned; a `sent` confirmation row is
+ * kept (it holds the lifetime cap and carries no plaintext).
+ */
+export const NOTIFICATION_SWEEP_VERSION = 1;
+export const NOTIFICATION_MAX_SEND_ATTEMPTS = 5;
+export const NOTIFICATION_STUCK_PENDING_MS = 15 * 60 * 1000;
+export const NOTIFICATION_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+export const NOTIFICATION_SWEEP_BATCH = 200;

--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -11,6 +11,8 @@ import { LABELER_DISCOVERY_DO_NAME } from "./discovery-do.js";
 import type { DiscoveryJob } from "./env.js";
 import { didDocumentResponse, policyDocumentResponse } from "./identity.js";
 import { handleNotificationRequest, isNotificationPath } from "./notification-endpoints.js";
+import { runNotificationSweep } from "./notification-sweep.js";
+import { createNotifyDeps } from "./notification-triggers.js";
 import { queryLabels } from "./query-labels.js";
 import { reconcileAssessments } from "./reconciliation.js";
 import { createRuntimeSigner, getRuntimeSigningSecret } from "./signing-runtime.js";
@@ -107,6 +109,21 @@ export default {
 				});
 			}),
 		);
+
+		// Publisher-notification retry sweep (plan W10.5): re-drive failed /
+		// crash-stuck sends, abandon the exhausted, prune terminal rows. Isolated in
+		// its own branch so a sweep failure never disturbs the passes above.
+		ctx.waitUntil(
+			(async () => {
+				try {
+					await runNotificationSweep(await createNotifyDeps(env));
+				} catch (err) {
+					console.error("[labeler] notification sweep failed", {
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
+			})(),
+		);
 	},
 };
 
@@ -155,6 +172,7 @@ async function handleConsoleApiRequest(
 			sendDiscoveryJob: async (job) => {
 				await env.DISCOVERY_QUEUE.send(job);
 			},
+			notify: await createNotifyDeps(env),
 		});
 	}
 	return handleConsoleApi(request, {

--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -12,7 +12,7 @@ import type { DiscoveryJob } from "./env.js";
 import { didDocumentResponse, policyDocumentResponse } from "./identity.js";
 import { handleNotificationRequest, isNotificationPath } from "./notification-endpoints.js";
 import { runNotificationSweep } from "./notification-sweep.js";
-import { createNotifyDeps } from "./notification-triggers.js";
+import { createNotifyDeps, type NotifyDeps } from "./notification-triggers.js";
 import { queryLabels } from "./query-labels.js";
 import { reconcileAssessments } from "./reconciliation.js";
 import { createRuntimeSigner, getRuntimeSigningSecret } from "./signing-runtime.js";
@@ -142,6 +142,21 @@ function getOperatorAccessConfig(env: Env): AccessAuthConfig {
 	return parsed;
 }
 
+/** Build notify deps for the console mutation path without ever throwing: a
+ * failure (e.g. a missing hash pepper) degrades notifications to `undefined` so
+ * the label mutation still commits. Notifications are a post-commit side effect
+ * and must never block a label action. */
+export async function safeCreateNotifyDeps(env: Env): Promise<NotifyDeps | undefined> {
+	try {
+		return await createNotifyDeps(env);
+	} catch (err) {
+		console.error("[notifications] notify deps unavailable; skipping notifications", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return undefined;
+	}
+}
+
 async function handleConsoleApiRequest(
 	env: Env,
 	request: Request,
@@ -172,7 +187,7 @@ async function handleConsoleApiRequest(
 			sendDiscoveryJob: async (job) => {
 				await env.DISCOVERY_QUEUE.send(job);
 			},
-			notify: await createNotifyDeps(env),
+			notify: await safeCreateNotifyDeps(env),
 		});
 	}
 	return handleConsoleApi(request, {

--- a/apps/labeler/src/notification-contacts.ts
+++ b/apps/labeler/src/notification-contacts.ts
@@ -247,6 +247,32 @@ export async function confirmContact(
 }
 
 /**
+ * Flip an `unconfirmed` contact straight to `confirmed` without a token — the
+ * verified-publisher path (W10.5 slice 2). A publisher carrying an in-force
+ * verification claim skips double opt-in, so a substantive notice may go out
+ * directly; this records that skip as an explicit confirm-state write distinct
+ * from token confirmation (no token was ever issued or matched). Guarded on
+ * `confirm_state = 'unconfirmed'` so it never reopens a `declined` contact — a
+ * publisher who said "not me" stays declined regardless of verification. Returns
+ * whether a row was updated.
+ */
+export async function confirmContactVerified(
+	db: D1Database,
+	recipientHashValue: string,
+	nowIso: string,
+): Promise<boolean> {
+	const result = await db
+		.prepare(
+			`UPDATE notification_contacts
+			 SET confirm_state = 'confirmed', confirm_token_hash = NULL, confirmed_at = ?
+			 WHERE recipient_hash = ? AND confirm_state = 'unconfirmed'`,
+		)
+		.bind(nowIso, recipientHashValue)
+		.run();
+	return result.meta.changes > 0;
+}
+
+/**
  * Decline the pending confirmation, clearing any outstanding token. Only touches
  * an `unconfirmed` contact — a confirmed opt-in is never revoked here (that goes
  * through {@link suppress}), so an unsubscribe-path bug can't downgrade it.

--- a/apps/labeler/src/notification-email.ts
+++ b/apps/labeler/src/notification-email.ts
@@ -1,0 +1,241 @@
+/**
+ * Cloudflare Email Sending adapter for the publisher-notification subsystem
+ * (spec §18/§19, plan W10.5 slice 2). Implements the injected
+ * {@link NotificationSender} the gated send core (`notification-send.ts`) drives,
+ * turning a {@link ConfirmationPayload} / {@link NoticePayload} into a real
+ * message through the `send_email` binding.
+ *
+ * Transport: the structured `env.EMAIL.send({ to, from, subject, html, text,
+ * headers, replyTo })` API (no raw MIME) — multipart html+text is assembled by
+ * the platform. Arbitrary external recipients are permitted because the binding
+ * is declared without a destination restriction (`{"send_email":[{"name":
+ * "EMAIL"}]}`), which requires the sending domain to be onboarded for Email
+ * Sending. `from` is a var (`NOTIFICATION_FROM_ADDRESS`) on the onboarded domain,
+ * never hardcoded.
+ *
+ * Every message carries `List-Unsubscribe` + `List-Unsubscribe-Post` (Gmail/Yahoo
+ * bulk-sender one-click unsubscribe) pointed at the recipient's capability link.
+ *
+ * SECURITY: `send()` throws typed errors carrying a `.code`. The returned
+ * {@link SendResult} error string is the CODE ONLY — never the provider message,
+ * which could echo the recipient address, nor the payload (confirm URL / token /
+ * body). That string is persisted verbatim in `notifications.last_error`, so
+ * leaking a capability or PII into it would leak to the database. The account
+ * hard-bounce/complaint suppression (`E_RECIPIENT_SUPPRESSED`) maps to a
+ * `suppress: 'bounce'` discriminant so the orchestration layer records our own
+ * suppression and retires the row `undeliverable` — it is never retried.
+ */
+
+import type {
+	ConfirmationPayload,
+	NoticePayload,
+	NotificationSender,
+	SendResult,
+} from "./notification-send.js";
+
+/** Cloudflare account-level hard-bounce / complaint suppression — terminal, must
+ * never be retried, and mapped to our own suppression ledger. */
+const RECIPIENT_SUPPRESSED = "E_RECIPIENT_SUPPRESSED";
+
+/** Codes we recognise for logging clarity; any other code is passed through as
+ * a retryable failure. All are transient/quota except the terminal one above. */
+const KNOWN_CODES: ReadonlySet<string> = new Set([
+	RECIPIENT_SUPPRESSED,
+	"E_RATE_LIMIT_EXCEEDED",
+	"E_DAILY_LIMIT_EXCEEDED",
+	"E_DELIVERY_FAILED",
+	"E_INTERNAL_SERVER_ERROR",
+]);
+
+export interface EmailSenderConfig {
+	/** The `from` address on the onboarded sending domain. */
+	fromAddress: string;
+	/** Optional display name shown alongside `fromAddress`. */
+	fromName?: string;
+	/** Optional `Reply-To` (the monitored reconsideration inbox), so publisher
+	 * replies route to a human rather than bouncing off the send-only domain. */
+	replyTo?: string;
+}
+
+export class CloudflareEmailSender implements NotificationSender {
+	readonly #email: SendEmail;
+	readonly #config: EmailSenderConfig;
+
+	constructor(email: SendEmail, config: EmailSenderConfig) {
+		this.#email = email;
+		this.#config = config;
+	}
+
+	async sendConfirmation(payload: ConfirmationPayload): Promise<SendResult> {
+		const content = confirmationContent(payload);
+		return this.#deliver(payload.to, payload.unsubscribeUrl, content);
+	}
+
+	async sendNotice(payload: NoticePayload): Promise<SendResult> {
+		const content = noticeContent(payload);
+		return this.#deliver(payload.to, payload.unsubscribeUrl, content);
+	}
+
+	async #deliver(
+		to: string,
+		unsubscribeUrl: string,
+		content: { subject: string; html: string; text: string },
+	): Promise<SendResult> {
+		try {
+			const result = await this.#email.send({
+				to,
+				from:
+					this.#config.fromName !== undefined
+						? { name: this.#config.fromName, email: this.#config.fromAddress }
+						: this.#config.fromAddress,
+				...(this.#config.replyTo !== undefined ? { replyTo: this.#config.replyTo } : {}),
+				subject: content.subject,
+				html: content.html,
+				text: content.text,
+				headers: {
+					"List-Unsubscribe": `<${unsubscribeUrl}>`,
+					"List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+				},
+			});
+			return { ok: true, providerId: result.messageId };
+		} catch (error) {
+			return mapSendError(error);
+		}
+	}
+}
+
+/** Map a thrown send error to a {@link SendResult}. Only the provider CODE is
+ * surfaced — never the message (which can echo the recipient) or the payload. */
+function mapSendError(error: unknown): SendResult {
+	const code = readErrorCode(error);
+	if (code === RECIPIENT_SUPPRESSED) {
+		return { ok: false, error: RECIPIENT_SUPPRESSED, suppress: "bounce" };
+	}
+	if (code !== undefined && KNOWN_CODES.has(code)) return { ok: false, error: code };
+	return { ok: false, error: code ?? "E_SEND_FAILED" };
+}
+
+function readErrorCode(error: unknown): string | undefined {
+	if (typeof error === "object" && error !== null && "code" in error) {
+		const { code } = error;
+		if (typeof code === "string") return code;
+	}
+	return undefined;
+}
+
+interface RenderedEmail {
+	subject: string;
+	html: string;
+	text: string;
+}
+
+/**
+ * Content-neutral double-opt-in confirmation (spec §18): it asks the recipient
+ * to confirm they should receive package-security notices, and carries NO
+ * assessment specifics — a third party named in hostile metadata must learn
+ * nothing about any subject from this mail.
+ */
+function confirmationContent(payload: ConfirmationPayload): RenderedEmail {
+	const subject = "Confirm emdash plugin security notices";
+	const lines = [
+		"The emdash plugin labeler sends security notices to the contact addresses published for plugins and publishers.",
+		"This address was listed as a contact. To receive those notices, confirm below. If you do nothing, you will not be emailed again.",
+		`Confirm: ${payload.confirmUrl}`,
+		`Not you, or don't want these? ${payload.notMeUrl}`,
+		`Unsubscribe: ${payload.unsubscribeUrl}`,
+	];
+	const text = lines.join("\n\n") + "\n";
+	const html = wrapHtml(
+		subject,
+		[
+			paragraph(
+				"The emdash plugin labeler sends security notices to the contact addresses published for plugins and publishers.",
+			),
+			paragraph(
+				"This address was listed as a contact. To receive those notices, confirm below. If you do nothing, you will not be emailed again.",
+			),
+			action("Confirm notifications", payload.confirmUrl),
+			paragraph(
+				`Not you, or don't want these? <a href="${escapeAttr(payload.notMeUrl)}">Report this address</a> &middot; <a href="${escapeAttr(payload.unsubscribeUrl)}">Unsubscribe</a>`,
+				true,
+			),
+		].join("\n"),
+	);
+	return { subject, html, text };
+}
+
+/**
+ * Substantive notice (spec §18/§19). Carries only the public-safe fields the
+ * {@link NoticePayload} allows — subject, label effect, public summary, and the
+ * public assessment + reconsideration URLs. NO private evidence or findings; the
+ * payload type is the enforcement.
+ */
+function noticeContent(payload: NoticePayload): RenderedEmail {
+	const subject = payload.subject;
+	const lines = [
+		payload.publicSummary,
+		`Effect: ${payload.effect}`,
+		`Public assessment: ${payload.assessmentUrl}`,
+		`Request reconsideration: ${payload.reconsiderationUrl}`,
+		`Unsubscribe: ${payload.unsubscribeUrl}`,
+	];
+	const text = lines.join("\n\n") + "\n";
+	const html = wrapHtml(
+		subject,
+		[
+			paragraph(escapeHtml(payload.publicSummary)),
+			paragraph(`<strong>Effect:</strong> ${escapeHtml(payload.effect)}`, true),
+			action("View the public assessment", payload.assessmentUrl),
+			paragraph(
+				`If you believe this is mistaken, <a href="${escapeAttr(payload.reconsiderationUrl)}">request reconsideration</a>.`,
+				true,
+			),
+			paragraph(
+				`<a href="${escapeAttr(payload.unsubscribeUrl)}">Unsubscribe from these notices</a>`,
+				true,
+			),
+		].join("\n"),
+	);
+	return { subject, html, text };
+}
+
+function wrapHtml(title: string, body: string): string {
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+</head>
+<body>
+<main>
+${body}
+</main>
+</body>
+</html>
+`;
+}
+
+/** A paragraph. `trusted` skips escaping when the caller has already escaped the
+ * interpolated values and is supplying its own markup (links, `<strong>`). */
+function paragraph(content: string, trusted = false): string {
+	return `<p>${trusted ? content : escapeHtml(content)}</p>`;
+}
+
+function action(label: string, url: string): string {
+	return `<p><a href="${escapeAttr(url)}">${escapeHtml(label)}</a></p>`;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+/** Attribute-context escape for a URL placed in `href="..."`. */
+function escapeAttr(value: string): string {
+	return escapeHtml(value);
+}

--- a/apps/labeler/src/notification-send.ts
+++ b/apps/labeler/src/notification-send.ts
@@ -44,6 +44,7 @@ import { ulid } from "ulidx";
 import type { AggregatorClient } from "./aggregator-client.js";
 import { CONFIRM_DID_MAX_DISTINCT_RECIPIENTS, CONFIRM_DID_WINDOW_MS } from "./constants.js";
 import {
+	confirmContactVerified,
 	ensureContact,
 	generateConfirmToken,
 	getContactState,
@@ -51,6 +52,8 @@ import {
 	isSuppressed,
 	recipientHash,
 	recordConfirmSent,
+	suppress,
+	type SuppressionReason,
 } from "./notification-contacts.js";
 import type { ContactTarget } from "./publisher-contact.js";
 import { resolvePublisherContact } from "./publisher-contact.js";
@@ -84,7 +87,25 @@ export interface NotificationRequest {
 	notice: NoticeContent;
 }
 
-export type SendResult = { ok: true; providerId?: string } | { ok: false; error: string };
+/**
+ * A send attempt's result. A transport failure is `{ ok: false }`, not a throw,
+ * so the caller records `failed` and lets the retry sweep pick it up.
+ *
+ * `suppress` is the terminal-bounce discriminant: a provider hard-bounce /
+ * complaint suppression (Cloudflare's `E_RECIPIENT_SUPPRESSED`) that the
+ * orchestration layer maps to our own {@link SuppressionReason} — the row is
+ * retired `undeliverable` (never retried) and the address is added to the
+ * suppression ledger, so our do-not-contact set learns what the provider knows.
+ *
+ * SECURITY (slice-2 contract): `error` is persisted verbatim in
+ * `notifications.last_error` and NEVER cleared. An implementation MUST NOT put
+ * the `confirmUrl`, raw confirm token, or email body into it — that would leak a
+ * single-use capability / PII to the database. Return the provider's status code
+ * only, never the payload it was given.
+ */
+export type SendResult =
+	| { ok: true; providerId?: string }
+	| { ok: false; error: string; suppress?: SuppressionReason };
 
 export interface ConfirmationPayload {
 	to: string;
@@ -124,6 +145,17 @@ export interface SendContext {
 	 * `LABELER_SERVICE_URL` var), e.g. `https://labels.emdashcms.com`. The
 	 * confirm/unsubscribe/not-me links are built against it. */
 	origin: string;
+	/**
+	 * When true, an `unconfirmed` contact for a VERIFIED publisher is upgraded to
+	 * `confirmed` in place (a token-less confirm) and receives the substantive
+	 * notice directly, skipping double opt-in (plan W10.5 slice 2). The caller
+	 * computes this from the publisher's in-force verification claims and MUST fail
+	 * closed — an unreadable verification state leaves it unset, so the address
+	 * falls back to the confirmation-mail path. Suppressed / declined contacts are
+	 * short-circuited before this flag is consulted, so verification never revives
+	 * a do-not-contact address.
+	 */
+	verifiedPublisher?: boolean;
 	now?: () => Date;
 }
 
@@ -132,10 +164,12 @@ export type SendOutcome =
 	| { status: "notice_failed"; recipientHash: string; error: string }
 	| { status: "confirmation_sent"; recipientHash: string; providerId?: string }
 	| { status: "confirmation_failed"; recipientHash: string; error: string }
+	| { status: "provider_suppressed"; recipientHash: string }
 	| { status: "rate_limited"; recipientHash: string; scope: "did" }
 	| { status: "suppressed"; recipientHash: string }
 	| { status: "declined"; recipientHash: string }
 	| { status: "already_mailed"; recipientHash: string }
+	| { status: "already_notified"; recipientHash: string }
 	| { status: "skipped"; recipientHash: string; reason: "contact_state_changed" }
 	| { status: "no_contact" };
 
@@ -192,6 +226,18 @@ export async function sendNotification(
 		return sendSubstantiveNotice(ctx, request, hash, resolution.email, nowDate);
 	}
 
+	// Verified-publisher skip: an in-force verification claim upgrades the
+	// unconfirmed contact to confirmed in place and delivers the substantive
+	// notice directly. The upgrade is guarded on `unconfirmed`, so a decline that
+	// raced the state read leaves it false and we fall back to double opt-in.
+	if (ctx.verifiedPublisher === true) {
+		const upgraded = await confirmContactVerified(ctx.db, hash, nowIso);
+		if (upgraded) {
+			logSend(request.target.did, "verified_skip", hash);
+			return sendSubstantiveNotice(ctx, request, hash, resolution.email, nowDate);
+		}
+	}
+
 	return sendConfirmationMail(ctx, request, hash, resolution.email, {
 		date: nowDate,
 		ms: nowMs,
@@ -208,9 +254,20 @@ async function sendSubstantiveNotice(
 	const id = newNotificationId();
 	const claimed = await claimSend(ctx.db, id, request.source, "notice", hash, email, now);
 	if (!claimed) {
-		await recordUndeliverable(ctx.db, request.source, "notice", hash, "suppressed", now);
-		logSend(request.target.did, "suppressed", hash);
-		return { status: "suppressed", recipientHash: hash };
+		// The notice claim guards on suppression AND per-source dedup (see
+		// claimSend). A suppression that landed before the claim is recorded as an
+		// undeliverable audit row; otherwise a non-undeliverable notice row already
+		// exists for this source — a concurrent duplicate of the same action — so
+		// nothing is written and no second mail goes out (the hard "one notice per
+		// action" invariant, closed atomically rather than by the trigger's
+		// check-then-act dedup).
+		if (await isSuppressed(ctx.db, hash)) {
+			await recordUndeliverable(ctx.db, request.source, "notice", hash, "suppressed", now);
+			logSend(request.target.did, "suppressed", hash);
+			return { status: "suppressed", recipientHash: hash };
+		}
+		logSend(request.target.did, "already_notified", hash);
+		return { status: "already_notified", recipientHash: hash };
 	}
 
 	const result = await ctx.sender.sendNotice({
@@ -218,6 +275,11 @@ async function sendSubstantiveNotice(
 		to: email,
 		unsubscribeUrl: buildActionUrl(ctx.origin, "unsubscribe", hash),
 	});
+	if (!result.ok && result.suppress !== undefined) {
+		await markProviderSuppressed(ctx.db, id, hash, result.suppress, now);
+		logSend(request.target.did, "provider_suppressed", hash);
+		return { status: "provider_suppressed", recipientHash: hash };
+	}
 	await finalizeSend(ctx.db, id, result, now);
 	if (result.ok) {
 		logSend(request.target.did, "notice_sent", hash);
@@ -302,6 +364,14 @@ async function sendConfirmationMail(
 		unsubscribeUrl: buildActionUrl(ctx.origin, "unsubscribe", hash),
 		notMeUrl: buildActionUrl(ctx.origin, "not-me", hash),
 	});
+	if (!result.ok && result.suppress !== undefined) {
+		// A provider hard-bounce on the confirmation mail retires the row
+		// `undeliverable` (which reopens the lifetime cap) and records the
+		// suppression, so the address is never re-mailed.
+		await markProviderSuppressed(ctx.db, id, hash, result.suppress, now.date);
+		logSend(request.target.did, "provider_suppressed", hash);
+		return { status: "provider_suppressed", recipientHash: hash };
+	}
 	await finalizeSend(ctx.db, id, result, now.date);
 	if (result.ok) {
 		logSend(request.target.did, "confirmation_sent", hash);
@@ -362,9 +432,22 @@ async function claimSend(
 		return result.meta.changes > 0;
 	}
 
+	// A `notice` claim adds a per-source dedup guard in the same INSERT...SELECT:
+	// it inserts only if NO non-`undeliverable` notice row already exists for this
+	// (source_type, source_id). One triggering action therefore mails at most one
+	// substantive notice even under concurrent duplicate triggers (an original and
+	// a racing replay), of which exactly one claims. An `undeliverable` prior (a
+	// suppressed-at-claim that never mailed) is excluded so it can't foreclose a
+	// later legitimate notice for the same source.
 	const result = await db
-		.prepare(`INSERT INTO notifications ${columns} ${row} ${notSuppressed}`)
-		.bind(...binds)
+		.prepare(
+			`INSERT INTO notifications ${columns} ${row} ${notSuppressed}
+			 AND NOT EXISTS (
+				SELECT 1 FROM notifications
+				WHERE source_type = ? AND source_id = ? AND kind = 'notice' AND state != 'undeliverable'
+			 )`,
+		)
+		.bind(...binds, source.type, source.id)
 		.run();
 	return result.meta.changes > 0;
 }
@@ -447,6 +530,33 @@ async function markRowUndeliverable(db: D1Database, id: string, reason: string):
 		.run();
 }
 
+/**
+ * Retire a claimed pending row after the provider reported the recipient is
+ * hard-suppressed (Cloudflare `E_RECIPIENT_SUPPRESSED`): the row goes
+ * `undeliverable` with plaintext cleared and is never retried, and the address is
+ * added to our suppression ledger so every future send short-circuits. For a
+ * confirmation row the undeliverable transition reopens the lifetime cap, but the
+ * fresh suppression row bars any re-mail — the address is off the list for good.
+ * `last_error` carries only the reason code, never the email payload.
+ */
+async function markProviderSuppressed(
+	db: D1Database,
+	id: string,
+	hash: string,
+	reason: SuppressionReason,
+	now: Date,
+): Promise<void> {
+	await db
+		.prepare(
+			`UPDATE notifications
+			 SET state = 'undeliverable', plaintext_email = NULL, last_error = ?, attempts = attempts + 1
+			 WHERE id = ? AND state = 'pending'`,
+		)
+		.bind(`provider_suppressed:${reason}`, id)
+		.run();
+	await suppress(db, hash, reason, now.toISOString(), now.getTime());
+}
+
 /** Distinct recipients this DID has sent confirmation mail to since `sinceMs` —
  * the per-DID rate-limit read (counts victims, not repeats). */
 async function countDistinctConfirmRecipients(
@@ -479,7 +589,7 @@ async function recordConfirmLedgerEntry(
 		.run();
 }
 
-function buildActionUrl(
+export function buildActionUrl(
 	origin: string,
 	action: "confirm" | "unsubscribe" | "not-me",
 	hash: string,

--- a/apps/labeler/src/notification-send.ts
+++ b/apps/labeler/src/notification-send.ts
@@ -546,6 +546,12 @@ async function markProviderSuppressed(
 	reason: SuppressionReason,
 	now: Date,
 ): Promise<void> {
+	// Suppress FIRST, THEN retire the row (which reopens a confirmation's lifetime
+	// cap). Before the suppression write the row is still a non-`undeliverable`
+	// confirmation prior, so a concurrent live claim is blocked by the lifetime
+	// guard; after it, by the suppression guard — closing the window where both
+	// cap-open and suppression-absent would admit a second mail.
+	await suppress(db, hash, reason, now.toISOString(), now.getTime());
 	await db
 		.prepare(
 			`UPDATE notifications
@@ -554,7 +560,6 @@ async function markProviderSuppressed(
 		)
 		.bind(`provider_suppressed:${reason}`, id)
 		.run();
-	await suppress(db, hash, reason, now.toISOString(), now.getTime());
 }
 
 /** Distinct recipients this DID has sent confirmation mail to since `sinceMs` —

--- a/apps/labeler/src/notification-sweep.ts
+++ b/apps/labeler/src/notification-sweep.ts
@@ -33,6 +33,7 @@ import {
 import {
 	generateConfirmToken,
 	hashConfirmToken,
+	isSuppressed,
 	recordConfirmSent,
 	suppress,
 	type SuppressionReason,
@@ -128,6 +129,16 @@ async function sweepRow(
 	// audit rows never enter the candidate set; this guards a corrupt row.)
 	if (row.plaintext_email === null || row.recipient_hash === null) {
 		if (await abandonRow(deps.db, row.id, "no_plaintext")) stats.abandoned++;
+		return;
+	}
+
+	// Suppression re-check — the live send gates every claim on it, but a
+	// suppression can land AFTER a row fails (e.g. a confirmed publisher whose
+	// notice failed transiently then clicks Unsubscribe). Abandon (not just skip):
+	// a suppressed `failed` row would otherwise linger as a candidate forever, since
+	// retention only deletes terminal rows. Covers notice AND confirmation uniformly.
+	if (await isSuppressed(deps.db, row.recipient_hash)) {
+		if (await abandonRow(deps.db, row.id, "suppressed")) stats.abandoned++;
 		return;
 	}
 
@@ -261,6 +272,13 @@ async function markSuppressed(
 	reason: SuppressionReason,
 	now: Date,
 ): Promise<void> {
+	// Suppress FIRST, THEN retire the row. Flipping the row to `undeliverable`
+	// reopens the confirmation lifetime cap; recording the suppression before that
+	// flip means a concurrent live claim is blocked by the lifetime guard until the
+	// suppression is durable and by the suppression guard after — no window where a
+	// second mail slips through. A crash between the two is covered by the sweep's
+	// own isSuppressed→abandon check.
+	await suppress(db, hash, reason, now.toISOString(), now.getTime());
 	await db
 		.prepare(
 			`UPDATE notifications
@@ -269,7 +287,6 @@ async function markSuppressed(
 		)
 		.bind(`provider_suppressed:${reason}`, id)
 		.run();
-	await suppress(db, hash, reason, now.toISOString(), now.getTime());
 }
 
 /**

--- a/apps/labeler/src/notification-sweep.ts
+++ b/apps/labeler/src/notification-sweep.ts
@@ -1,0 +1,306 @@
+/**
+ * Publisher-notification retry sweep (spec §18, plan W10.5 slice 2). A cron
+ * branch that keeps the delivery table live: it re-drives failed and
+ * crash-stuck sends, abandons the exhausted ones, and prunes terminal rows.
+ *
+ * The 5-minute cron is the backoff interval — each pass re-drives every `failed`
+ * row and every `pending` row older than {@link NOTIFICATION_STUCK_PENDING_MS}
+ * (crashed in-flight, contract c) exactly once, bumping `attempts` at the claim.
+ * A row that has reached {@link NOTIFICATION_MAX_SEND_ATTEMPTS} is abandoned to
+ * `undeliverable` with plaintext cleared. For a CONFIRMATION row abandonment
+ * REOPENS the lifetime cap (the claim excludes `undeliverable` priors), so a
+ * crashed or exhausted confirmation never silently forecloses the channel — the
+ * slice-1 contract (c) this sweep exists to honor.
+ *
+ * Re-render, not re-store (plaintext minimization): a confirmation retry mints a
+ * FRESH token (only the hash was ever stored — contract b) and rebuilds its
+ * links; a notice retry re-derives its public content from the source row
+ * (`resolveNoticeForSource`). The recipient address is read from the row's
+ * `plaintext_email`, the only place it lives.
+ *
+ * Every step is best-effort and self-contained: an error on one row is logged
+ * and the sweep continues, and a sweep failure never disturbs the other cron
+ * branches (the caller wraps it in its own `waitUntil`+catch).
+ */
+
+import {
+	CONFIRM_DID_WINDOW_MS,
+	NOTIFICATION_MAX_SEND_ATTEMPTS,
+	NOTIFICATION_RETENTION_MS,
+	NOTIFICATION_STUCK_PENDING_MS,
+	NOTIFICATION_SWEEP_BATCH,
+} from "./constants.js";
+import {
+	generateConfirmToken,
+	hashConfirmToken,
+	recordConfirmSent,
+	suppress,
+	type SuppressionReason,
+} from "./notification-contacts.js";
+import { buildActionUrl, type SendResult } from "./notification-send.js";
+import { resolveNoticeForSource, type NotifyDeps } from "./notification-triggers.js";
+
+interface SweepRow {
+	id: string;
+	kind: "confirmation" | "notice";
+	source_type: string;
+	source_id: string;
+	recipient_hash: string | null;
+	plaintext_email: string | null;
+	attempts: number;
+	state: string;
+}
+
+export interface SweepStats {
+	scanned: number;
+	sent: number;
+	failed: number;
+	abandoned: number;
+	suppressed: number;
+	skipped: number;
+	cleaned: number;
+	prunedLedger: number;
+}
+
+/**
+ * One sweep pass. Re-drives retryable rows, abandons exhausted ones, then prunes
+ * terminal rows and stale confirm-ledger entries.
+ */
+export async function runNotificationSweep(deps: NotifyDeps): Promise<SweepStats> {
+	const now = deps.now ?? (() => new Date());
+	const nowMs = now().getTime();
+	const stats: SweepStats = {
+		scanned: 0,
+		sent: 0,
+		failed: 0,
+		abandoned: 0,
+		suppressed: 0,
+		skipped: 0,
+		cleaned: 0,
+		prunedLedger: 0,
+	};
+
+	const stuckBefore = nowMs - NOTIFICATION_STUCK_PENDING_MS;
+	const candidates = await deps.db
+		.prepare(
+			`SELECT id, kind, source_type, source_id, recipient_hash, plaintext_email, attempts, state
+			 FROM notifications
+			 WHERE state = 'failed' OR (state = 'pending' AND created_at_epoch_ms < ?)
+			 ORDER BY created_at_epoch_ms
+			 LIMIT ?`,
+		)
+		.bind(stuckBefore, NOTIFICATION_SWEEP_BATCH)
+		.all<SweepRow>();
+
+	for (const row of candidates.results ?? []) {
+		stats.scanned++;
+		try {
+			await sweepRow(deps, row, now(), stats);
+		} catch (error) {
+			console.error("[notifications] sweep row failed", {
+				id: row.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	stats.cleaned = await cleanupTerminalRows(deps.db, nowMs - NOTIFICATION_RETENTION_MS);
+	stats.prunedLedger = await pruneConfirmLedger(deps.db, nowMs - CONFIRM_DID_WINDOW_MS);
+
+	console.log("[notifications]", { action: "sweep", ...stats });
+	return stats;
+}
+
+async function sweepRow(
+	deps: NotifyDeps,
+	row: SweepRow,
+	now: Date,
+	stats: SweepStats,
+): Promise<void> {
+	// Exhausted: abandon before any further send. For a confirmation this reopens
+	// the lifetime cap; plaintext is cleared either way.
+	if (row.attempts >= NOTIFICATION_MAX_SEND_ATTEMPTS) {
+		if (await abandonRow(deps.db, row.id, "max_attempts")) stats.abandoned++;
+		return;
+	}
+
+	// A row with no address/hash can never send — treat as terminal. (Undeliverable
+	// audit rows never enter the candidate set; this guards a corrupt row.)
+	if (row.plaintext_email === null || row.recipient_hash === null) {
+		if (await abandonRow(deps.db, row.id, "no_plaintext")) stats.abandoned++;
+		return;
+	}
+
+	// Exclusive claim: bump attempts under a CAS on the observed count, so two
+	// concurrent sweeps never re-drive the same row twice. The winner flips the
+	// row to `pending`; a stuck-pending row stays pending but its attempts advance.
+	const claimed = await claimRetry(deps.db, row.id, row.attempts);
+	if (!claimed) {
+		stats.skipped++;
+		return;
+	}
+
+	const to = row.plaintext_email;
+	const hash = row.recipient_hash;
+
+	let result: SendResult;
+	if (row.kind === "confirmation") {
+		// Fresh token every retry — only the hash was ever stored (contract b), and
+		// a reused token would be unrecoverable. Stamped on the still-unconfirmed
+		// contact; if it has since confirmed/declined, the confirmation is moot.
+		const token = generateConfirmToken();
+		const tokenHash = await hashConfirmToken(token);
+		const recorded = await recordConfirmSent(deps.db, hash, tokenHash, now.getTime());
+		if (!recorded) {
+			if (await finishAbandon(deps.db, row.id, "contact_state_changed")) stats.abandoned++;
+			return;
+		}
+		result = await deps.sender.sendConfirmation({
+			to,
+			confirmUrl: buildActionUrl(deps.serviceUrl, "confirm", hash, token),
+			unsubscribeUrl: buildActionUrl(deps.serviceUrl, "unsubscribe", hash),
+			notMeUrl: buildActionUrl(deps.serviceUrl, "not-me", hash),
+		});
+	} else {
+		const notice = await resolveNoticeForSource(deps, row.source_type, row.source_id);
+		if (!notice) {
+			if (await finishAbandon(deps.db, row.id, "source_unavailable")) stats.abandoned++;
+			return;
+		}
+		result = await deps.sender.sendNotice({
+			...notice,
+			to,
+			unsubscribeUrl: buildActionUrl(deps.serviceUrl, "unsubscribe", hash),
+		});
+	}
+
+	await finalizeRetry(deps.db, row.id, hash, result, now, stats);
+}
+
+/** Finalize a re-driven row. Attempts were already bumped at the claim, so a
+ * failure does NOT bump again. Success clears plaintext; provider suppression
+ * retires the row and records our own suppression (never retried). */
+async function finalizeRetry(
+	db: D1Database,
+	id: string,
+	hash: string,
+	result: SendResult,
+	now: Date,
+	stats: SweepStats,
+): Promise<void> {
+	if (result.ok) {
+		await db
+			.prepare(
+				`UPDATE notifications
+				 SET state = 'sent', provider_id = ?, sent_at = ?, plaintext_email = NULL, last_error = NULL
+				 WHERE id = ? AND state = 'pending'`,
+			)
+			.bind(result.providerId ?? null, now.toISOString(), id)
+			.run();
+		stats.sent++;
+		return;
+	}
+	if (result.suppress !== undefined) {
+		await markSuppressed(db, id, hash, result.suppress, now);
+		stats.suppressed++;
+		return;
+	}
+	await db
+		.prepare(
+			`UPDATE notifications SET state = 'failed', last_error = ? WHERE id = ? AND state = 'pending'`,
+		)
+		.bind(truncate(result.error), id)
+		.run();
+	stats.failed++;
+}
+
+/** CAS claim: only the sweep that observed `attempts` wins, flipping the row to
+ * `pending` and advancing the counter. */
+async function claimRetry(db: D1Database, id: string, attempts: number): Promise<boolean> {
+	const result = await db
+		.prepare(
+			`UPDATE notifications SET state = 'pending', attempts = attempts + 1
+			 WHERE id = ? AND attempts = ? AND state IN ('failed', 'pending')`,
+		)
+		.bind(id, attempts)
+		.run();
+	return result.meta.changes > 0;
+}
+
+/** Retire a not-yet-claimed row (exhausted / corrupt) to `undeliverable`, guarded
+ * on it still being retryable so a concurrent claim wins cleanly. */
+async function abandonRow(db: D1Database, id: string, reason: string): Promise<boolean> {
+	const result = await db
+		.prepare(
+			`UPDATE notifications
+			 SET state = 'undeliverable', plaintext_email = NULL, last_error = ?
+			 WHERE id = ? AND state IN ('failed', 'pending')`,
+		)
+		.bind(reason, id)
+		.run();
+	return result.meta.changes > 0;
+}
+
+/** Retire an already-claimed (`pending`) row to `undeliverable`. */
+async function finishAbandon(db: D1Database, id: string, reason: string): Promise<boolean> {
+	const result = await db
+		.prepare(
+			`UPDATE notifications
+			 SET state = 'undeliverable', plaintext_email = NULL, last_error = ?
+			 WHERE id = ? AND state = 'pending'`,
+		)
+		.bind(reason, id)
+		.run();
+	return result.meta.changes > 0;
+}
+
+async function markSuppressed(
+	db: D1Database,
+	id: string,
+	hash: string,
+	reason: SuppressionReason,
+	now: Date,
+): Promise<void> {
+	await db
+		.prepare(
+			`UPDATE notifications
+			 SET state = 'undeliverable', plaintext_email = NULL, last_error = ?
+			 WHERE id = ? AND state = 'pending'`,
+		)
+		.bind(`provider_suppressed:${reason}`, id)
+		.run();
+	await suppress(db, hash, reason, now.toISOString(), now.getTime());
+}
+
+/**
+ * Delete terminal rows older than retention: every `undeliverable` row and every
+ * SENT NOTICE. A `sent` CONFIRMATION row is KEPT — it holds the lifetime cap and
+ * carries no plaintext (cleared on send), so retaining it costs nothing and
+ * prevents an address being re-mailed a confirmation after 30 days.
+ */
+async function cleanupTerminalRows(db: D1Database, cutoffMs: number): Promise<number> {
+	const result = await db
+		.prepare(
+			`DELETE FROM notifications
+			 WHERE created_at_epoch_ms < ?
+			   AND (state = 'undeliverable' OR (state = 'sent' AND kind = 'notice'))`,
+		)
+		.bind(cutoffMs)
+		.run();
+	return result.meta.changes ?? 0;
+}
+
+/** Prune confirm-ledger rows below the per-DID rolling window — they can no
+ * longer affect the distinct-recipient count. */
+async function pruneConfirmLedger(db: D1Database, cutoffMs: number): Promise<number> {
+	const result = await db
+		.prepare(`DELETE FROM notification_confirm_ledger WHERE sent_at_epoch_ms < ?`)
+		.bind(cutoffMs)
+		.run();
+	return result.meta.changes ?? 0;
+}
+
+const LAST_ERROR_MAX = 500;
+function truncate(error: string): string {
+	return error.length > LAST_ERROR_MAX ? error.slice(0, LAST_ERROR_MAX) : error;
+}

--- a/apps/labeler/src/notification-triggers.ts
+++ b/apps/labeler/src/notification-triggers.ts
@@ -1,0 +1,478 @@
+/**
+ * Publisher-notification triggers (spec §18/§19, plan W10.5 slice 2). The glue
+ * between a committed label action and the gated send core
+ * (`notification-send.ts`): each of the five ratified events — automated block,
+ * automated warning, reviewer override, reviewer/override retraction, and
+ * emergency takedown — builds a {@link NotificationRequest} and drives it through
+ * {@link sendNotification}.
+ *
+ * These are POST-COMMIT side effects. A notification NEVER rolls back or fails a
+ * label action: callers invoke them from the deferred (`waitUntil`) tail after
+ * the authoritative batch has committed, and every entry point here swallows and
+ * logs its own errors. Delivery retries live independently in the cron sweep.
+ *
+ * Two guards wrap every send:
+ *   - Per-source dedup: a source (`source_type`, `source_id`) already carrying a
+ *     `notifications` row is skipped, so a Workflow-step retry or a mutation
+ *     replay does not re-notify. `sendNotification`'s notice claim closes the
+ *     residual concurrent race atomically.
+ *   - Verified-publisher skip: a publisher with an in-force verification claim
+ *     bypasses double opt-in (the notice goes out directly). The verification read
+ *     fails CLOSED — any error leaves the publisher on the normal confirmation
+ *     path, never looser.
+ *
+ * All notice copy is public-safe: subject line, label effect, the assessment's
+ * public summary, and the public assessment + reconsideration URLs. No findings,
+ * evidence, or private detail — the {@link NoticeContent} shape is the enforcement.
+ */
+
+import { NSID } from "@emdash-cms/registry-lexicons";
+
+import moderationPolicy from "../fixtures/moderation-policy.json";
+import { AggregatorClient } from "./aggregator-client.js";
+import { getAssessment, type Assessment } from "./assessment-store.js";
+import { getNotificationHashPepper } from "./notification-contacts.js";
+import { CloudflareEmailSender } from "./notification-email.js";
+import type {
+	NoticeContent,
+	NotificationRequest,
+	NotificationSender,
+	NotificationSource,
+	SendContext,
+} from "./notification-send.js";
+import { sendNotification } from "./notification-send.js";
+import { getOperatorActionById } from "./operator-actions.js";
+import { getLabelDefinition } from "./policy.js";
+import type { ContactTarget } from "./publisher-contact.js";
+
+/**
+ * Everything a trigger needs to resolve, gate, and send a notification. Built
+ * from the Worker `env` in production (real {@link CloudflareEmailSender} +
+ * {@link AggregatorClient}); tests inject a fake sender and aggregator.
+ */
+export interface NotifyDeps {
+	db: D1Database;
+	aggregator: AggregatorClient;
+	sender: NotificationSender;
+	pepper: string;
+	/** Public origin of the labeler service (`LABELER_SERVICE_URL`) — the base for
+	 * the confirm/unsubscribe landing links AND the public assessment URL. */
+	serviceUrl: string;
+	/** The monitored reconsideration URL from the moderation policy. */
+	reconsiderationUrl: string;
+	now?: () => Date;
+}
+
+/**
+ * Build the production {@link NotifyDeps} from the Worker env: the real Cloudflare
+ * Email Sending adapter over the `EMAIL` binding, the aggregator client over the
+ * `AGGREGATOR` service binding, and the peppered recipient hash. The reconsideration
+ * URL and reply-to inbox come from the ratified moderation-policy fixture.
+ */
+export async function createNotifyDeps(env: Env): Promise<NotifyDeps> {
+	const pepper = await getNotificationHashPepper(env).get();
+	return {
+		db: env.DB,
+		aggregator: new AggregatorClient(env.AGGREGATOR),
+		sender: new CloudflareEmailSender(env.EMAIL, {
+			fromAddress: env.NOTIFICATION_FROM_ADDRESS,
+			fromName: "emdash plugin labeler",
+			replyTo: moderationPolicy.contact.reconsiderationEmail,
+		}),
+		pepper,
+		serviceUrl: env.LABELER_SERVICE_URL,
+		reconsiderationUrl: moderationPolicy.contact.reconsiderationUrl,
+	};
+}
+
+interface OperatorLabelInput {
+	actionId: string;
+	uri: string;
+	cid?: string;
+	val: string;
+	neg: boolean;
+}
+
+/** The public-safe URLs every notice carries — satisfied structurally by
+ * {@link NotifyDeps}, so a content builder takes either. */
+interface NoticeUrls {
+	serviceUrl: string;
+	reconsiderationUrl: string;
+}
+
+// ── Pure notice-content builders ────────────────────────────────────────────
+// Shared by the live triggers AND the sweep's re-render-from-source. Keeping them
+// pure and shared guarantees a retried send renders byte-identical copy to the
+// original — nothing about the notice is persisted, so both paths derive it from
+// the same source fields.
+
+/** Automated block/warning notice for a finalized run — null for any other
+ * outcome (so the sweep abandons a notice whose run is no longer blocked/warned). */
+function assessmentNoticeContent(urls: NoticeUrls, assessment: Assessment): NoticeContent | null {
+	if (assessment.state !== "blocked" && assessment.state !== "warned") return null;
+	const blocked = assessment.state === "blocked";
+	return {
+		subject: blocked
+			? "Your plugin release was blocked by the emdash labeler"
+			: "Your plugin release was flagged by the emdash labeler",
+		publicSummary:
+			assessment.publicSummary && assessment.publicSummary.length > 0
+				? assessment.publicSummary
+				: blocked
+					? "A security assessment blocked this release."
+					: "A security assessment flagged this release with a warning.",
+		effect: blocked
+			? "The release is blocked and hidden from install surfaces pending reconsideration."
+			: "The release is flagged with a warning.",
+		assessmentUrl: assessmentUrl(urls.serviceUrl, assessment.uri, assessment.cid),
+		reconsiderationUrl: urls.reconsiderationUrl,
+	};
+}
+
+function operatorLabelNoticeContent(
+	urls: NoticeUrls,
+	input: { uri: string; cid?: string; val: string; neg: boolean },
+): NoticeContent {
+	const shared = {
+		assessmentUrl: assessmentUrl(urls.serviceUrl, input.uri, input.cid),
+		reconsiderationUrl: urls.reconsiderationUrl,
+	};
+	return input.neg
+		? {
+				subject: "A label on your plugin was retracted",
+				publicSummary: `The "${input.val}" label was retracted from this subject.`,
+				effect: "The label no longer applies.",
+				...shared,
+			}
+		: {
+				subject: "A label was applied to your plugin",
+				publicSummary: `The "${input.val}" label was applied to this subject.`,
+				effect: getLabelDefinition(input.val)?.officialEffect ?? "",
+				...shared,
+			};
+}
+
+function overrideNoticeContent(
+	urls: NoticeUrls,
+	input: { uri: string; cid?: string },
+): NoticeContent {
+	return {
+		subject: "Your plugin release was unblocked",
+		publicSummary: "A reviewer overrode the automated block for this release.",
+		effect: "The release is no longer blocked.",
+		assessmentUrl: assessmentUrl(urls.serviceUrl, input.uri, input.cid),
+		reconsiderationUrl: urls.reconsiderationUrl,
+	};
+}
+
+function overrideRetractNoticeContent(
+	urls: NoticeUrls,
+	input: { uri: string; cid?: string },
+): NoticeContent {
+	return {
+		subject: "An override on your plugin release was retracted",
+		publicSummary: "The reviewer override for this release was retracted.",
+		effect: "The automated block applies again.",
+		assessmentUrl: assessmentUrl(urls.serviceUrl, input.uri, input.cid),
+		reconsiderationUrl: urls.reconsiderationUrl,
+	};
+}
+
+function emergencyNoticeContent(
+	urls: NoticeUrls,
+	input: { uri: string; neg: boolean },
+): NoticeContent {
+	const shared = {
+		assessmentUrl: assessmentUrl(urls.serviceUrl, input.uri),
+		reconsiderationUrl: urls.reconsiderationUrl,
+	};
+	return input.neg
+		? {
+				subject: "The takedown on your plugin was lifted",
+				publicSummary: "An emergency takedown affecting this subject was retracted.",
+				effect: "The takedown no longer applies.",
+				...shared,
+			}
+		: {
+				subject: "Your plugin was taken down by the emdash labeler",
+				publicSummary: "An operator issued an emergency takedown affecting this subject.",
+				effect: getLabelDefinition("!takedown")?.officialEffect ?? "The subject is taken down.",
+				...shared,
+			};
+}
+
+// ── Live trigger entry points ───────────────────────────────────────────────
+
+/** Automated block/warning notice from a finalized assessment run. Source is the
+ * assessment id: a Workflow-step retry of the same run dedups on it, and repeated
+ * discovery of the same release dedups onto the same run (same runKey). */
+export async function notifyAssessmentOutcome(
+	deps: NotifyDeps,
+	assessment: Assessment,
+): Promise<void> {
+	const notice = assessmentNoticeContent(deps, assessment);
+	if (!notice) return;
+	const target = contactTargetFromUri(assessment.uri);
+	if (!target) return;
+	await runTrigger(deps, { type: "issuance", id: assessment.id }, target, notice);
+}
+
+/** Reviewer label issue / retract (console `labels/issue` + `labels/retract`). */
+export async function notifyOperatorLabel(
+	deps: NotifyDeps,
+	input: OperatorLabelInput,
+): Promise<void> {
+	const target = contactTargetFromUri(input.uri);
+	if (!target) return;
+	await runTrigger(
+		deps,
+		{ type: "operator", id: input.actionId },
+		target,
+		operatorLabelNoticeContent(deps, input),
+	);
+}
+
+/** Reviewer false-positive override (console `assessments/:id/override`). */
+export async function notifyOverride(
+	deps: NotifyDeps,
+	input: { actionId: string; uri: string; cid: string },
+): Promise<void> {
+	const target = contactTargetFromUri(input.uri);
+	if (!target) return;
+	await runTrigger(
+		deps,
+		{ type: "operator", id: input.actionId },
+		target,
+		overrideNoticeContent(deps, input),
+	);
+}
+
+/** Retraction of a reviewer override (console `assessments/:id/override-retract`). */
+export async function notifyOverrideRetract(
+	deps: NotifyDeps,
+	input: { actionId: string; uri: string; cid: string },
+): Promise<void> {
+	const target = contactTargetFromUri(input.uri);
+	if (!target) return;
+	await runTrigger(
+		deps,
+		{ type: "operator", id: input.actionId },
+		target,
+		overrideRetractNoticeContent(deps, input),
+	);
+}
+
+/** Emergency takedown or its retraction (console `emergency/takedown[-retract]`).
+ * The subject may be redacted; the aggregator read is unfiltered (blank
+ * accept-labelers), so contact resolution still works. */
+export async function notifyEmergencyTakedown(
+	deps: NotifyDeps,
+	input: { actionId: string; uri: string; neg: boolean },
+): Promise<void> {
+	const target = contactTargetFromUri(input.uri);
+	if (!target) return;
+	await runTrigger(
+		deps,
+		{ type: "operator", id: input.actionId },
+		target,
+		emergencyNoticeContent(deps, input),
+	);
+}
+
+/**
+ * Rebuild a NOTICE's public content from its source row, for the retry sweep.
+ * Nothing about the notice is persisted (plaintext minimization), so a retry
+ * re-derives it from the assessment (`issuance`) or operator action (`operator`)
+ * exactly as the live trigger did. Returns null when the source is gone or no
+ * longer warrants a notice (e.g. a run that is no longer blocked/warned, or an
+ * operator action whose type does not notify) — the sweep then abandons the row.
+ */
+export async function resolveNoticeForSource(
+	deps: NotifyDeps,
+	sourceType: string,
+	sourceId: string,
+): Promise<NoticeContent | null> {
+	if (sourceType === "issuance") {
+		const assessment = await loadAssessmentSafe(deps.db, sourceId);
+		return assessment ? assessmentNoticeContent(deps, assessment) : null;
+	}
+	const action = await getOperatorActionById(deps.db, sourceId);
+	if (!action || action.subjectUri === null) return null;
+	const uri = action.subjectUri;
+	const cid = action.subjectCid ?? undefined;
+	switch (action.action) {
+		case "label-issue":
+			return operatorLabelNoticeContent(deps, {
+				uri,
+				cid,
+				val: action.labelValue ?? "",
+				neg: false,
+			});
+		case "label-retract":
+			return operatorLabelNoticeContent(deps, {
+				uri,
+				cid,
+				val: action.labelValue ?? "",
+				neg: true,
+			});
+		case "unblock-override":
+			return overrideNoticeContent(deps, { uri, cid });
+		case "override-retract":
+			return overrideRetractNoticeContent(deps, { uri, cid });
+		case "takedown":
+			return emergencyNoticeContent(deps, { uri, neg: operatorActionNeg(action.metadataJson) });
+		default:
+			return null;
+	}
+}
+
+/** `getAssessment` throws on a malformed id; a stored `source_id` is always
+ * well-formed, but a defensive null keeps the sweep from crashing on a bad row. */
+async function loadAssessmentSafe(db: D1Database, id: string): Promise<Assessment | null> {
+	try {
+		return await getAssessment(db, id);
+	} catch {
+		return null;
+	}
+}
+
+/** The `neg` flag an emergency action stored in its metadata (issue vs retract). */
+function operatorActionNeg(metadataJson: string): boolean {
+	try {
+		const parsed: unknown = JSON.parse(metadataJson);
+		return (
+			typeof parsed === "object" && parsed !== null && (parsed as { neg?: unknown }).neg === true
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Dedup, resolve verification (fail-closed), send, swallow+log. Shared by every
+ * trigger so the dedup and verified-skip policy is applied uniformly and a
+ * notification failure can never escape into the label path.
+ */
+async function runTrigger(
+	deps: NotifyDeps,
+	source: NotificationSource,
+	target: ContactTarget,
+	notice: NoticeContent,
+): Promise<void> {
+	const now = deps.now ?? (() => new Date());
+	try {
+		if (await sourceAlreadyProcessed(deps.db, source)) {
+			logTrigger(source, target.did, "deduped");
+			return;
+		}
+		const verifiedPublisher = await isVerifiedPublisher(deps.aggregator, target.did, now());
+		const ctx: SendContext = {
+			db: deps.db,
+			aggregator: deps.aggregator,
+			pepper: deps.pepper,
+			sender: deps.sender,
+			origin: deps.serviceUrl,
+			verifiedPublisher,
+			now,
+		};
+		const request: NotificationRequest = { source, target, notice };
+		const outcome = await sendNotification(ctx, request);
+		logTrigger(source, target.did, outcome.status);
+	} catch (error) {
+		console.error("[notifications] trigger failed", {
+			sourceType: source.type,
+			sourceId: source.id,
+			did: target.did,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+/** Whether any `notifications` row already exists for this source — the primary
+ * dedup, so a retried Workflow step or a replayed operator mutation does not
+ * re-notify. */
+async function sourceAlreadyProcessed(
+	db: D1Database,
+	source: NotificationSource,
+): Promise<boolean> {
+	const row = await db
+		.prepare(`SELECT 1 FROM notifications WHERE source_type = ? AND source_id = ? LIMIT 1`)
+		.bind(source.type, source.id)
+		.first<{ 1: number }>();
+	return row !== null;
+}
+
+/**
+ * Whether the publisher holds an IN-FORCE verification claim — reuses the
+ * history-context notion of "in force" (a claim whose `expiresAt` is absent or in
+ * the future). FAILS CLOSED: a `null` view (redacted / unverified), an empty
+ * claim set, or ANY read error returns `false`, so the address stays on the
+ * stricter double-opt-in path.
+ */
+export async function isVerifiedPublisher(
+	aggregator: Pick<AggregatorClient, "getPublisherVerification">,
+	did: string,
+	now: Date,
+): Promise<boolean> {
+	try {
+		const state = await aggregator.getPublisherVerification(did);
+		if (!state || state.verifications.length === 0) return false;
+		return state.verifications.some((claim) => isInForce(claim.expiresAt, now));
+	} catch (error) {
+		console.error("[notifications] verification read failed, using double opt-in", {
+			did,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return false;
+	}
+}
+
+/** A claim is in force when it has no expiry or its expiry is still in the future
+ * (mirrors `history-context`'s `isExpired`). */
+function isInForce(expiresAt: string | undefined, now: Date): boolean {
+	if (expiresAt === undefined) return true;
+	const expiry = Date.parse(expiresAt);
+	if (Number.isNaN(expiry)) return true;
+	return expiry > now.getTime();
+}
+
+/** Public assessment URL for a subject — the `getCurrentAssessment` XRPC view,
+ * which resolves the subject's current assessment (the run this notice concerns).
+ * `cid` narrows it to the exact release when known. */
+function assessmentUrl(serviceUrl: string, uri: string, cid?: string): string {
+	const url = new URL(`/xrpc/${NSID.labelerGetCurrentAssessment}`, serviceUrl);
+	url.searchParams.set("uri", uri);
+	if (cid !== undefined && cid.length > 0) url.searchParams.set("cid", cid);
+	return url.toString();
+}
+
+/**
+ * The `{ did, slug }` a notice's contact resolution needs, parsed from the
+ * subject URI. A record URI (`at://did/collection/rkey`) yields the DID and the
+ * rkey as the slug — for a package record the rkey IS the package slug (tier-1/2
+ * resolve); for a release the rkey misses the package tiers and resolution falls
+ * through to the DID-keyed publisher-profile contact (tier 3), which is the
+ * reliable channel. A bare DID subject (publisher-level action) resolves by DID
+ * alone. Anything unparseable returns null and the notice is skipped.
+ */
+export function contactTargetFromUri(uri: string): ContactTarget | null {
+	if (uri.startsWith("at://")) {
+		const [did, , rkey] = uri.slice("at://".length).split("/");
+		if (did === undefined || did.length === 0) return null;
+		return { did, slug: rkey ?? "" };
+	}
+	if (uri.startsWith("did:")) {
+		return { did: uri, slug: uri.split(":").at(-1) ?? uri };
+	}
+	return null;
+}
+
+function logTrigger(source: NotificationSource, did: string, outcome: string): void {
+	console.log("[notifications]", {
+		action: "trigger",
+		sourceType: source.type,
+		sourceId: source.id,
+		did,
+		outcome,
+	});
+}

--- a/apps/labeler/src/notification-triggers.ts
+++ b/apps/labeler/src/notification-triggers.ts
@@ -326,13 +326,18 @@ export async function resolveNoticeForSource(
 	}
 }
 
-/** `getAssessment` throws on a malformed id; a stored `source_id` is always
- * well-formed, but a defensive null keeps the sweep from crashing on a bad row. */
+/** `getAssessment` throws `TypeError` only for a malformed id — which a stored
+ * `source_id` never is — so that maps to "no notice" (null). Any OTHER error is a
+ * transient read failure: it must PROPAGATE, not abandon the row, so the sweep
+ * leaves the claimed row `pending` to self-heal on a later pass (matching the
+ * operator path's unwrapped read). Swallowing it would permanently drop a
+ * legitimate block/warning notice on a single flaky D1 read. */
 async function loadAssessmentSafe(db: D1Database, id: string): Promise<Assessment | null> {
 	try {
 		return await getAssessment(db, id);
-	} catch {
-		return null;
+	} catch (error) {
+		if (error instanceof TypeError) return null;
+		throw error;
 	}
 }
 

--- a/apps/labeler/src/operator-actions.ts
+++ b/apps/labeler/src/operator-actions.ts
@@ -135,6 +135,25 @@ export async function getOperatorActionByKey(
 	return row ? rowToStoredOperatorAction(row) : null;
 }
 
+/** Read one audit row by its `operator_actions.id` primary key — the
+ * notification subsystem's polymorphic `source_id` for an operator-triggered
+ * notice, re-read by the retry sweep to rebuild the notice from source. */
+export async function getOperatorActionById(
+	db: D1Database,
+	id: string,
+): Promise<StoredOperatorAction | null> {
+	const row = await db
+		.prepare(
+			`SELECT id, actor_type, actor_id, actor_email, actor_common_name, role, action,
+			 subject_uri, subject_cid, label_value, reason, idempotency_key,
+			 request_fingerprint, result_json, metadata_json, created_at, created_at_epoch_ms
+			 FROM operator_actions WHERE id = ?`,
+		)
+		.bind(id)
+		.first<OperatorActionRow>();
+	return row ? rowToStoredOperatorAction(row) : null;
+}
+
 /**
  * Audit-log page, newest first, exclusive keyset on `(created_at_epoch_ms, id)`
  * over `idx_operator_actions_created`. `keyset.createdAt` is the ISO timestamp

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -27,6 +27,7 @@ import {
 	type MessageController,
 } from "../src/discovery-consumer.js";
 import type { DiscoveryJob } from "../src/env.js";
+import { safeCreateNotifyDeps } from "../src/index.js";
 import { OPERATOR_REQUEST_HEADER } from "../src/mutation-guard.js";
 import type { DidDocumentResolverLike } from "../src/record-verification.js";
 import { issueAutomatedAssessmentLabel, issueManualLabel } from "../src/service.js";
@@ -2135,5 +2136,55 @@ describe("console mutation: dead-letter replay and idempotency", () => {
 		);
 		expect(second.status).toBe(409);
 		expect((await bodyError(second)).code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+	});
+});
+
+describe("console mutation: notify-deps failure never blocks the label", () => {
+	it("returns undefined (never throws) when the hash pepper is unconfigured", async () => {
+		await expect(safeCreateNotifyDeps({} as unknown as Env)).resolves.toBeUndefined();
+	});
+
+	it("returns undefined (never throws) when the pepper binding rejects", async () => {
+		const brokenEnv = {
+			NOTIFICATION_HASH_PEPPER: {
+				get: async () => {
+					throw new Error("secret store unavailable");
+				},
+			},
+		} as unknown as Env;
+		await expect(safeCreateNotifyDeps(brokenEnv)).resolves.toBeUndefined();
+	});
+
+	it("commits the label even when notify-deps construction failed (notify undefined)", async () => {
+		const uri = await seedReleaseSubject("notify-deps-down");
+		const notify = await safeCreateNotifyDeps({} as unknown as Env);
+		expect(notify).toBeUndefined();
+
+		const key = nextKey();
+		const response = await handleConsoleMutation(
+			post("/admin/api/labels/issue", {
+				uri,
+				val: "security-yanked",
+				confirmation: "notify-deps-down",
+				reason: "notify deps unavailable must not block issuance",
+				idempotencyKey: key,
+			}),
+			mutationDeps({ notify }),
+		);
+
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<IssuedLabelDescriptor>(response);
+		expect(descriptor).toMatchObject({ val: "security-yanked", uri, effect: "block" });
+
+		const persisted = await testEnv.DB.prepare(
+			`SELECT l.val, l.neg FROM issued_labels l
+			 JOIN issuance_actions a ON a.id = l.action_id
+			 WHERE a.idempotency_key = ?`,
+		)
+			.bind(descriptor.actionId)
+			.first<{ val: string; neg: number }>();
+		expect(persisted).toEqual({ val: "security-yanked", neg: 0 });
+
+		expect(await countRows(`SELECT COUNT(*) AS n FROM notifications`)).toBe(0);
 	});
 });

--- a/apps/labeler/test/notification-email.test.ts
+++ b/apps/labeler/test/notification-email.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import { CloudflareEmailSender } from "../src/notification-email.js";
+import type { ConfirmationPayload, NoticePayload } from "../src/notification-send.js";
+
+/** A fake `SendEmail` binding that records the composed message and either
+ * resolves with a messageId or throws a coded error. */
+function fakeEmail(behavior: { messageId: string } | { throw: unknown }): {
+	binding: SendEmail;
+	calls: EmailMessageBuilder[];
+} {
+	const calls: EmailMessageBuilder[] = [];
+	const binding = {
+		send: async (message: EmailMessage | EmailMessageBuilder) => {
+			calls.push(message as EmailMessageBuilder);
+			if ("throw" in behavior) throw behavior.throw;
+			return { messageId: behavior.messageId };
+		},
+	} as unknown as SendEmail;
+	return { binding, calls };
+}
+
+const CONFIG = {
+	fromAddress: "notifications@emdashcms.com",
+	fromName: "labeler",
+	replyTo: "recon@x",
+};
+
+const confirmation: ConfirmationPayload = {
+	to: "dev@example.test",
+	confirmUrl: "https://labels.example/notifications/confirm?c=abc&t=SECRETTOKEN",
+	unsubscribeUrl: "https://labels.example/notifications/unsubscribe?c=abc",
+	notMeUrl: "https://labels.example/notifications/not-me?c=abc",
+};
+
+const notice: NoticePayload = {
+	to: "dev@example.test",
+	subject: "Your plugin release was blocked",
+	publicSummary: "A security assessment blocked this release.",
+	assessmentUrl: "https://labels.example/xrpc/getCurrentAssessment?uri=at://x",
+	effect: "The release is blocked.",
+	reconsiderationUrl: "https://labels.example/reconsider",
+	unsubscribeUrl: "https://labels.example/notifications/unsubscribe?c=abc",
+};
+
+describe("CloudflareEmailSender success", () => {
+	it("sends a notice with html+text bodies and returns the provider messageId", async () => {
+		const email = fakeEmail({ messageId: "msg-1" });
+		const sender = new CloudflareEmailSender(email.binding, CONFIG);
+
+		const result = await sender.sendNotice(notice);
+
+		expect(result).toEqual({ ok: true, providerId: "msg-1" });
+		expect(email.calls).toHaveLength(1);
+		const sent = email.calls[0]!;
+		expect(sent.to).toBe("dev@example.test");
+		expect(sent.from).toEqual({ name: "labeler", email: "notifications@emdashcms.com" });
+		expect(sent.replyTo).toBe("recon@x");
+		expect(sent.subject).toBe("Your plugin release was blocked");
+		expect(sent.html).toContain("A security assessment blocked this release.");
+		expect(sent.text).toContain("A security assessment blocked this release.");
+		expect(sent.html?.length).toBeGreaterThan(0);
+		expect(sent.text?.length).toBeGreaterThan(0);
+	});
+
+	it("sets List-Unsubscribe + one-click headers on every send", async () => {
+		const email = fakeEmail({ messageId: "m" });
+		const sender = new CloudflareEmailSender(email.binding, CONFIG);
+
+		await sender.sendConfirmation(confirmation);
+
+		const headers = email.calls[0]!.headers ?? {};
+		expect(headers["List-Unsubscribe"]).toBe(
+			"<https://labels.example/notifications/unsubscribe?c=abc>",
+		);
+		expect(headers["List-Unsubscribe-Post"]).toBe("List-Unsubscribe=One-Click");
+	});
+
+	it("sends a content-neutral confirmation (no assessment specifics) returning the messageId", async () => {
+		const email = fakeEmail({ messageId: "c-1" });
+		const sender = new CloudflareEmailSender(email.binding, CONFIG);
+
+		const result = await sender.sendConfirmation(confirmation);
+
+		expect(result).toEqual({ ok: true, providerId: "c-1" });
+		const sent = email.calls[0]!;
+		// Carries the confirm/opt-out links, but nothing about any assessment.
+		expect(sent.text).toContain(confirmation.confirmUrl);
+		expect(sent.text).not.toContain("blocked");
+		expect(sent.html).not.toContain("blocked");
+	});
+});
+
+describe("CloudflareEmailSender error mapping", () => {
+	it("maps E_RECIPIENT_SUPPRESSED to a bounce-suppression discriminant", async () => {
+		const email = fakeEmail({ throw: { code: "E_RECIPIENT_SUPPRESSED" } });
+		const sender = new CloudflareEmailSender(email.binding, CONFIG);
+
+		const result = await sender.sendNotice(notice);
+
+		expect(result).toEqual({ ok: false, error: "E_RECIPIENT_SUPPRESSED", suppress: "bounce" });
+	});
+
+	it.each([
+		"E_RATE_LIMIT_EXCEEDED",
+		"E_DAILY_LIMIT_EXCEEDED",
+		"E_DELIVERY_FAILED",
+		"E_INTERNAL_SERVER_ERROR",
+	])("maps %s to a retryable failure with no suppression", async (code) => {
+		const email = fakeEmail({ throw: { code } });
+		const sender = new CloudflareEmailSender(email.binding, CONFIG);
+
+		const result = await sender.sendNotice(notice);
+
+		expect(result).toEqual({ ok: false, error: code });
+	});
+
+	it("maps an unknown/absent code to a generic failure", async () => {
+		const email = fakeEmail({ throw: new Error("boom") });
+		const sender = new CloudflareEmailSender(email.binding, CONFIG);
+
+		expect(await sender.sendNotice(notice)).toEqual({ ok: false, error: "E_SEND_FAILED" });
+	});
+
+	it("NEVER leaks the payload (confirm URL / token) into the error string", async () => {
+		// A provider error whose message echoes the recipient + confirm token — the
+		// adapter must surface only the code, never this message.
+		const email = fakeEmail({
+			throw: {
+				code: "E_DELIVERY_FAILED",
+				message: `failed to deliver to ${confirmation.confirmUrl}`,
+			},
+		});
+		const sender = new CloudflareEmailSender(email.binding, CONFIG);
+
+		const result = await sender.sendConfirmation(confirmation);
+
+		expect(result).toEqual({ ok: false, error: "E_DELIVERY_FAILED" });
+		if (!result.ok) {
+			expect(result.error).not.toContain("SECRETTOKEN");
+			expect(result.error).not.toContain("confirm");
+		}
+	});
+});

--- a/apps/labeler/test/notification-sweep.test.ts
+++ b/apps/labeler/test/notification-sweep.test.ts
@@ -1,0 +1,398 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { AggregatorClient } from "../src/aggregator-client.js";
+import {
+	NOTIFICATION_MAX_SEND_ATTEMPTS,
+	NOTIFICATION_RETENTION_MS,
+	NOTIFICATION_STUCK_PENDING_MS,
+} from "../src/constants.js";
+import {
+	ensureContact,
+	hashConfirmToken,
+	recipientHash,
+	recordConfirmSent,
+} from "../src/notification-contacts.js";
+import type { ConfirmationPayload, NoticePayload, SendResult } from "../src/notification-send.js";
+import { runNotificationSweep } from "../src/notification-sweep.js";
+import type { NotifyDeps } from "../src/notification-triggers.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+const db = () => testEnv.DB;
+
+const PEPPER = "sweep-pepper";
+const SERVICE = "https://labels.example";
+const RELEASE_URI = "at://did:plc:x/com.emdashcms.experimental.package.release/rel1";
+const NOW = new Date(10_000_000_000);
+
+let counter = 0;
+const uniq = (p: string) => `${p}-${++counter}`;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+function dummyAggregator(): AggregatorClient {
+	return new AggregatorClient({
+		fetch: async () => new Response("nope", { status: 404 }),
+	} as unknown as Fetcher);
+}
+
+interface RecordingSender {
+	confirmations: ConfirmationPayload[];
+	notices: NoticePayload[];
+	sendConfirmation(p: ConfirmationPayload): Promise<SendResult>;
+	sendNotice(p: NoticePayload): Promise<SendResult>;
+}
+function recordingSender(result: SendResult = { ok: true, providerId: "swept" }): RecordingSender {
+	const confirmations: ConfirmationPayload[] = [];
+	const notices: NoticePayload[] = [];
+	return {
+		confirmations,
+		notices,
+		sendConfirmation: async (p) => (confirmations.push(p), result),
+		sendNotice: async (p) => (notices.push(p), result),
+	};
+}
+
+function deps(sender: RecordingSender): NotifyDeps {
+	return {
+		db: db(),
+		aggregator: dummyAggregator(),
+		sender,
+		pepper: PEPPER,
+		serviceUrl: SERVICE,
+		reconsiderationUrl: "https://recon.example",
+		now: () => NOW,
+	};
+}
+
+interface InsertRow {
+	kind: "confirmation" | "notice";
+	sourceType?: string;
+	sourceId: string;
+	recipientHash?: string | null;
+	plaintext?: string | null;
+	state: string;
+	attempts: number;
+	createdMs?: number;
+}
+async function insertNotification(row: InsertRow): Promise<string> {
+	const id = uniq("ntf");
+	await db()
+		.prepare(
+			`INSERT INTO notifications
+			 (id, source_type, source_id, kind, channel, recipient_hash, state, attempts,
+			  plaintext_email, created_at, created_at_epoch_ms)
+			 VALUES (?, ?, ?, ?, 'email', ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			id,
+			row.sourceType ?? "operator",
+			row.sourceId,
+			row.kind,
+			row.recipientHash ?? null,
+			row.state,
+			row.attempts,
+			row.plaintext ?? null,
+			new Date(row.createdMs ?? NOW.getTime()).toISOString(),
+			row.createdMs ?? NOW.getTime(),
+		)
+		.run();
+	return id;
+}
+
+async function insertOperatorAction(id: string, val: string): Promise<void> {
+	await db()
+		.prepare(
+			`INSERT INTO operator_actions
+			 (id, actor_type, actor_id, role, action, subject_uri, subject_cid, label_value,
+			  reason, idempotency_key, request_fingerprint, metadata_json, created_at, created_at_epoch_ms)
+			 VALUES (?, 'human', 'op', 'reviewer', 'label-issue', ?, 'bafycid', ?, 'r', ?, 'fp', '{}', ?, ?)`,
+		)
+		.bind(id, RELEASE_URI, val, uniq("idem"), NOW.toISOString(), NOW.getTime())
+		.run();
+}
+
+async function rowState(
+	id: string,
+): Promise<{ state: string; attempts: number; plaintext: string | null; provider: string | null }> {
+	const r = await db()
+		.prepare(
+			`SELECT state, attempts, plaintext_email AS plaintext, provider_id AS provider FROM notifications WHERE id = ?`,
+		)
+		.bind(id)
+		.first<{
+			state: string;
+			attempts: number;
+			plaintext: string | null;
+			provider: string | null;
+		}>();
+	return r!;
+}
+
+describe("failed notice retry", () => {
+	it("re-renders from source and marks it sent", async () => {
+		const sourceId = uniq("oact");
+		await insertOperatorAction(sourceId, "security-yanked");
+		const email = uniq("n") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		const id = await insertNotification({
+			kind: "notice",
+			sourceId,
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 1,
+		});
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.notices).toHaveLength(1);
+		expect(sender.notices[0]?.to).toBe(email);
+		const row = await rowState(id);
+		expect(row).toMatchObject({ state: "sent", plaintext: null, provider: "swept" });
+	});
+
+	it("abandons a notice whose source has vanished", async () => {
+		const email = uniq("gone") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		const id = await insertNotification({
+			kind: "notice",
+			sourceId: uniq("missing"),
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 1,
+		});
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.notices).toHaveLength(0);
+		expect((await rowState(id)).state).toBe("undeliverable");
+	});
+});
+
+describe("failed confirmation retry", () => {
+	it("mints a FRESH token, stamps its hash, and sends", async () => {
+		const email = uniq("c") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		await ensureContact(db(), hash, NOW.toISOString());
+		const oldHash = await hashConfirmToken("old-token");
+		await recordConfirmSent(db(), hash, oldHash, 1_000);
+		const id = await insertNotification({
+			kind: "confirmation",
+			sourceId: uniq("src"),
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 2,
+		});
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.confirmations).toHaveLength(1);
+		const url = new URL(sender.confirmations[0]!.confirmUrl);
+		const newToken = url.searchParams.get("t") ?? "";
+		const stored = await db()
+			.prepare(`SELECT confirm_token_hash FROM notification_contacts WHERE recipient_hash = ?`)
+			.bind(hash)
+			.first<{ confirm_token_hash: string }>();
+		expect(stored?.confirm_token_hash).toBe(await hashConfirmToken(newToken));
+		expect(stored?.confirm_token_hash).not.toBe(oldHash);
+		expect((await rowState(id)).state).toBe("sent");
+	});
+
+	it("abandons (undeliverable) when the contact is no longer unconfirmed", async () => {
+		const email = uniq("cdone") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		// No unconfirmed contact row exists → recordConfirmSent no-ops → abandon.
+		const id = await insertNotification({
+			kind: "confirmation",
+			sourceId: uniq("src"),
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 1,
+		});
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.confirmations).toHaveLength(0);
+		expect((await rowState(id)).state).toBe("undeliverable");
+	});
+});
+
+describe("attempts cap", () => {
+	it("abandons an exhausted confirmation to undeliverable, clears plaintext, and reopens the lifetime cap", async () => {
+		const email = uniq("cap") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		await ensureContact(db(), hash, NOW.toISOString());
+		const id = await insertNotification({
+			kind: "confirmation",
+			sourceId: uniq("src"),
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: NOTIFICATION_MAX_SEND_ATTEMPTS,
+		});
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.confirmations).toHaveLength(0);
+		const row = await rowState(id);
+		expect(row).toMatchObject({ state: "undeliverable", plaintext: null });
+		// Cap reopened: no non-undeliverable confirmation row blocks a fresh send.
+		const blocking = await db()
+			.prepare(
+				`SELECT COUNT(*) AS n FROM notifications WHERE recipient_hash = ? AND kind = 'confirmation' AND state != 'undeliverable'`,
+			)
+			.bind(hash)
+			.first<{ n: number }>();
+		expect(blocking?.n).toBe(0);
+	});
+});
+
+describe("stuck pending", () => {
+	it("re-drives a crash-stuck pending row", async () => {
+		const sourceId = uniq("oact");
+		await insertOperatorAction(sourceId, "security-yanked");
+		const email = uniq("stuck") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		const id = await insertNotification({
+			kind: "notice",
+			sourceId,
+			recipientHash: hash,
+			plaintext: email,
+			state: "pending",
+			attempts: 0,
+			createdMs: NOW.getTime() - NOTIFICATION_STUCK_PENDING_MS - 1,
+		});
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.notices).toHaveLength(1);
+		expect((await rowState(id)).state).toBe("sent");
+	});
+
+	it("leaves a FRESH pending row alone", async () => {
+		const email = uniq("fresh") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		const id = await insertNotification({
+			kind: "notice",
+			sourceId: uniq("oact"),
+			recipientHash: hash,
+			plaintext: email,
+			state: "pending",
+			attempts: 0,
+			createdMs: NOW.getTime(),
+		});
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.notices).toHaveLength(0);
+		expect((await rowState(id)).state).toBe("pending");
+	});
+});
+
+describe("provider suppression during a retry", () => {
+	it("retires the row and records the suppression", async () => {
+		const email = uniq("bnc") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		await ensureContact(db(), hash, NOW.toISOString());
+		await recordConfirmSent(db(), hash, await hashConfirmToken("t"), 1_000);
+		const id = await insertNotification({
+			kind: "confirmation",
+			sourceId: uniq("src"),
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 1,
+		});
+		const sender = recordingSender({
+			ok: false,
+			error: "E_RECIPIENT_SUPPRESSED",
+			suppress: "bounce",
+		});
+
+		await runNotificationSweep(deps(sender));
+
+		expect((await rowState(id)).state).toBe("undeliverable");
+		const supp = await db()
+			.prepare(`SELECT reason FROM notification_suppressions WHERE recipient_hash = ?`)
+			.bind(hash)
+			.first<{ reason: string }>();
+		expect(supp?.reason).toBe("bounce");
+	});
+});
+
+describe("retention cleanup + ledger prune", () => {
+	it("deletes old undeliverable and sent-notice rows but KEEPS sent confirmations", async () => {
+		const old = NOW.getTime() - NOTIFICATION_RETENTION_MS - 1;
+		const undel = await insertNotification({
+			kind: "notice",
+			sourceId: uniq("s"),
+			recipientHash: "h1",
+			state: "undeliverable",
+			attempts: 0,
+			createdMs: old,
+		});
+		const sentNotice = await insertNotification({
+			kind: "notice",
+			sourceId: uniq("s"),
+			recipientHash: "h2",
+			state: "sent",
+			attempts: 0,
+			createdMs: old,
+		});
+		const sentConfirm = await insertNotification({
+			kind: "confirmation",
+			sourceId: uniq("s"),
+			recipientHash: "h3",
+			state: "sent",
+			attempts: 0,
+			createdMs: old,
+		});
+
+		await runNotificationSweep(deps(recordingSender()));
+
+		expect(await exists(undel)).toBe(false);
+		expect(await exists(sentNotice)).toBe(false);
+		expect(await exists(sentConfirm)).toBe(true);
+	});
+
+	it("prunes confirm-ledger rows below the rolling window", async () => {
+		const oldMs = NOW.getTime() - 48 * 60 * 60 * 1000;
+		await db()
+			.prepare(
+				`INSERT INTO notification_confirm_ledger (id, publisher_did, recipient_hash, sent_at_epoch_ms) VALUES (?, ?, ?, ?)`,
+			)
+			.bind(uniq("ncl"), "did:plc:old", "hh", oldMs)
+			.run();
+
+		await runNotificationSweep(deps(recordingSender()));
+
+		const remaining = await db()
+			.prepare(
+				`SELECT COUNT(*) AS n FROM notification_confirm_ledger WHERE publisher_did = 'did:plc:old'`,
+			)
+			.first<{ n: number }>();
+		expect(remaining?.n).toBe(0);
+	});
+});
+
+async function exists(id: string): Promise<boolean> {
+	const r = await db().prepare(`SELECT 1 FROM notifications WHERE id = ?`).bind(id).first();
+	return r !== null;
+}

--- a/apps/labeler/test/notification-sweep.test.ts
+++ b/apps/labeler/test/notification-sweep.test.ts
@@ -1,4 +1,5 @@
 import { applyD1Migrations, env } from "cloudflare:test";
+import { ulid } from "ulidx";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { AggregatorClient } from "../src/aggregator-client.js";
@@ -12,6 +13,7 @@ import {
 	hashConfirmToken,
 	recipientHash,
 	recordConfirmSent,
+	suppress,
 } from "../src/notification-contacts.js";
 import type { ConfirmationPayload, NoticePayload, SendResult } from "../src/notification-send.js";
 import { runNotificationSweep } from "../src/notification-sweep.js";
@@ -391,6 +393,110 @@ describe("retention cleanup + ledger prune", () => {
 		expect(remaining?.n).toBe(0);
 	});
 });
+
+describe("suppression re-check (F1)", () => {
+	it("abandons and does NOT mail a failed NOTICE whose address was suppressed after it failed", async () => {
+		const sourceId = uniq("oact");
+		await insertOperatorAction(sourceId, "security-yanked");
+		const email = uniq("supp") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		const id = await insertNotification({
+			kind: "notice",
+			sourceId,
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 1,
+		});
+		// The suppression lands after the row failed (e.g. an Unsubscribe click).
+		await suppress(db(), hash, "unsubscribe", NOW.toISOString(), NOW.getTime());
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.notices).toHaveLength(0);
+		expect(await rowState(id)).toMatchObject({ state: "undeliverable", plaintext: null });
+	});
+
+	it("abandons a suppressed failed CONFIRMATION without minting a token", async () => {
+		const email = uniq("csupp") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		await ensureContact(db(), hash, NOW.toISOString());
+		await recordConfirmSent(db(), hash, await hashConfirmToken("t"), 1_000);
+		const id = await insertNotification({
+			kind: "confirmation",
+			sourceId: uniq("src"),
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 1,
+		});
+		await suppress(db(), hash, "not_me", NOW.toISOString(), NOW.getTime());
+		const sender = recordingSender();
+
+		await runNotificationSweep(deps(sender));
+
+		expect(sender.confirmations).toHaveLength(0);
+		expect((await rowState(id)).state).toBe("undeliverable");
+	});
+});
+
+describe("transient source read (F3)", () => {
+	it("keeps a notice row pending (self-heals) when the assessment read fails transiently — never abandons it", async () => {
+		const email = uniq("f3") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		const sourceId = `asmt_${ulid()}`; // valid id shape → getAssessment reaches the (throwing) query
+		const id = await insertNotification({
+			kind: "notice",
+			sourceType: "issuance",
+			sourceId,
+			recipientHash: hash,
+			plaintext: email,
+			state: "failed",
+			attempts: 1,
+		});
+		const sender = recordingSender();
+		const throwingDeps: NotifyDeps = { ...deps(sender), db: dbThrowingOnAssessments(db()) };
+
+		await runNotificationSweep(throwingDeps);
+
+		expect(sender.notices).toHaveLength(0);
+		// Claimed (→pending, attempts bumped) but NOT abandoned: the next sweep re-drives it.
+		const row = await rowState(id);
+		expect(row.state).toBe("pending");
+		expect(row.attempts).toBe(2);
+	});
+});
+
+/** Wrap a D1Database so the `getAssessment` read (`FROM assessments`) throws a
+ * transient (non-TypeError) error; every other statement delegates. */
+function dbThrowingOnAssessments(real: D1Database): D1Database {
+	const wrapStmt = (stmt: D1PreparedStatement): D1PreparedStatement =>
+		new Proxy(stmt, {
+			get(target, prop, receiver) {
+				if (prop === "bind")
+					return (...args: unknown[]) =>
+						wrapStmt((target.bind as (...a: unknown[]) => D1PreparedStatement)(...args));
+				if (prop === "first")
+					return async () => {
+						throw new Error("transient D1 read");
+					};
+				const v = Reflect.get(target, prop, receiver);
+				return typeof v === "function" ? v.bind(target) : v;
+			},
+		});
+	return new Proxy(real, {
+		get(target, prop, receiver) {
+			if (prop === "prepare")
+				return (query: string) => {
+					const stmt = target.prepare(query);
+					return query.includes("FROM assessments") ? wrapStmt(stmt) : stmt;
+				};
+			const v = Reflect.get(target, prop, receiver);
+			return typeof v === "function" ? v.bind(target) : v;
+		},
+	});
+}
 
 async function exists(id: string): Promise<boolean> {
 	const r = await db().prepare(`SELECT 1 FROM notifications WHERE id = ?`).bind(id).first();

--- a/apps/labeler/test/notification-triggers.test.ts
+++ b/apps/labeler/test/notification-triggers.test.ts
@@ -1,0 +1,381 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { AggregatorClient } from "../src/aggregator-client.js";
+import type { Assessment } from "../src/assessment-store.js";
+import {
+	confirmContact,
+	ensureContact,
+	hashConfirmToken,
+	recipientHash,
+	recordConfirmSent,
+	suppress,
+} from "../src/notification-contacts.js";
+import type { ConfirmationPayload, NoticePayload, SendResult } from "../src/notification-send.js";
+import {
+	notifyAssessmentOutcome,
+	notifyEmergencyTakedown,
+	notifyOperatorLabel,
+	notifyOverride,
+	notifyOverrideRetract,
+	type NotifyDeps,
+} from "../src/notification-triggers.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+const db = () => testEnv.DB;
+
+const PEPPER = "trig-pepper";
+const SERVICE = "https://labels.example";
+const RECON = "https://recon.example/reconsider";
+const DID = "did:plc:x";
+const RELEASE_URI = `at://${DID}/com.emdashcms.experimental.package.release/rel1`;
+
+let counter = 0;
+const uniq = (p: string) => `${p}-${++counter}`;
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+interface AggregatorOpts {
+	email?: string;
+	verifications?: unknown[];
+	verifyStatus?: number;
+}
+
+function aggregatorFor(opts: AggregatorOpts): AggregatorClient {
+	const fetcher = {
+		fetch: async (url: string) => {
+			if (url.includes("getPublisherVerification")) {
+				if (opts.verifyStatus !== undefined && opts.verifyStatus !== 200)
+					return new Response("err", { status: opts.verifyStatus });
+				return Response.json({ did: DID, verifications: opts.verifications ?? [], labels: [] });
+			}
+			if (url.includes("getPublisher") && opts.email !== undefined) {
+				return Response.json({
+					did: DID,
+					profile: { contact: [{ kind: "security", email: opts.email }] },
+				});
+			}
+			return new Response(JSON.stringify({ error: "NotFound" }), {
+				status: 404,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	} as unknown as Fetcher;
+	return new AggregatorClient(fetcher);
+}
+
+interface RecordingSender {
+	confirmations: ConfirmationPayload[];
+	notices: NoticePayload[];
+	sendConfirmation(p: ConfirmationPayload): Promise<SendResult>;
+	sendNotice(p: NoticePayload): Promise<SendResult>;
+}
+
+function recordingSender(result: SendResult = { ok: true, providerId: "p" }): RecordingSender {
+	const confirmations: ConfirmationPayload[] = [];
+	const notices: NoticePayload[] = [];
+	return {
+		confirmations,
+		notices,
+		sendConfirmation: async (p) => {
+			confirmations.push(p);
+			return result;
+		},
+		sendNotice: async (p) => {
+			notices.push(p);
+			return result;
+		},
+	};
+}
+
+function throwingSender(): RecordingSender {
+	return {
+		confirmations: [],
+		notices: [],
+		sendConfirmation: async () => {
+			throw new Error("transport exploded");
+		},
+		sendNotice: async () => {
+			throw new Error("transport exploded");
+		},
+	};
+}
+
+function deps(aggregator: AggregatorClient, sender: RecordingSender): NotifyDeps {
+	return {
+		db: db(),
+		aggregator,
+		sender,
+		pepper: PEPPER,
+		serviceUrl: SERVICE,
+		reconsiderationUrl: RECON,
+	};
+}
+
+function assessmentRow(overrides: Partial<Assessment>): Assessment {
+	return {
+		id: uniq("asmt"),
+		uri: RELEASE_URI,
+		cid: "bafycid",
+		state: "blocked",
+		publicSummary: "A finding was reported.",
+		...overrides,
+	} as unknown as Assessment;
+}
+
+async function seedConfirmed(email: string): Promise<string> {
+	const hash = await recipientHash(PEPPER, email);
+	await ensureContact(db(), hash, "2026-07-16T00:00:00.000Z");
+	const th = await hashConfirmToken("seed");
+	await recordConfirmSent(db(), hash, th, 1_000);
+	await confirmContact(db(), hash, th, "2026-07-16T00:00:01.000Z");
+	return hash;
+}
+
+async function notificationRows(sourceId: string): Promise<{ kind: string; state: string }[]> {
+	const r = await db()
+		.prepare(`SELECT kind, state FROM notifications WHERE source_id = ?`)
+		.bind(sourceId)
+		.all<{ kind: string; state: string }>();
+	return r.results ?? [];
+}
+
+const IN_FORCE = [
+	{ issuer: "did:plc:issuer", handle: "x.test", createdAt: "2026-01-01T00:00:00.000Z" },
+];
+const EXPIRED = [
+	{
+		issuer: "did:plc:issuer",
+		handle: "x.test",
+		createdAt: "2020-01-01T00:00:00.000Z",
+		expiresAt: "2021-01-01T00:00:00.000Z",
+	},
+];
+
+describe("the five events each notify a confirmed publisher", () => {
+	it("automated block → notice from source 'issuance'", async () => {
+		const email = uniq("blk") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "blocked" });
+
+		await notifyAssessmentOutcome(deps(aggregatorFor({ email }), sender), a);
+
+		expect(sender.notices).toHaveLength(1);
+		expect(sender.notices[0]).toMatchObject({
+			to: email,
+			subject: expect.stringContaining("blocked"),
+		});
+		expect(await notificationRows(a.id)).toEqual([{ kind: "notice", state: "sent" }]);
+	});
+
+	it("automated warning → notice", async () => {
+		const email = uniq("warn") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "warned" });
+
+		await notifyAssessmentOutcome(deps(aggregatorFor({ email }), sender), a);
+
+		expect(sender.notices).toHaveLength(1);
+		expect(sender.notices[0]?.effect).toContain("warning");
+	});
+
+	it("passed outcome does NOT notify", async () => {
+		const email = uniq("pass") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "passed" });
+
+		await notifyAssessmentOutcome(deps(aggregatorFor({ email }), sender), a);
+
+		expect(sender.notices).toHaveLength(0);
+		expect(await notificationRows(a.id)).toHaveLength(0);
+	});
+
+	it("operator label issue → notice from source 'operator'", async () => {
+		const email = uniq("lbl") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const actionId = uniq("oact");
+
+		await notifyOperatorLabel(deps(aggregatorFor({ email }), sender), {
+			actionId,
+			uri: RELEASE_URI,
+			cid: "bafycid",
+			val: "security-yanked",
+			neg: false,
+		});
+
+		expect(sender.notices).toHaveLength(1);
+		expect(await notificationRows(actionId)).toEqual([{ kind: "notice", state: "sent" }]);
+	});
+
+	it("operator override → notice", async () => {
+		const email = uniq("ovr") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const actionId = uniq("oact");
+
+		await notifyOverride(deps(aggregatorFor({ email }), sender), {
+			actionId,
+			uri: RELEASE_URI,
+			cid: "bafycid",
+		});
+
+		expect(sender.notices).toHaveLength(1);
+		expect(sender.notices[0]?.subject).toContain("unblocked");
+	});
+
+	it("operator override-retract → notice", async () => {
+		const email = uniq("ovrr") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const actionId = uniq("oact");
+
+		await notifyOverrideRetract(deps(aggregatorFor({ email }), sender), {
+			actionId,
+			uri: RELEASE_URI,
+			cid: "bafycid",
+		});
+
+		expect(sender.notices).toHaveLength(1);
+	});
+
+	it("emergency takedown → notice", async () => {
+		const email = uniq("td") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const actionId = uniq("oact");
+
+		await notifyEmergencyTakedown(deps(aggregatorFor({ email }), sender), {
+			actionId,
+			uri: RELEASE_URI,
+			neg: false,
+		});
+
+		expect(sender.notices).toHaveLength(1);
+		expect(sender.notices[0]?.subject).toContain("taken down");
+	});
+});
+
+describe("dedup", () => {
+	it("an unchanged re-run for the same source does not re-notify", async () => {
+		const email = uniq("dedup") + "@x.test";
+		await seedConfirmed(email);
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "blocked" });
+		const d = deps(aggregatorFor({ email }), sender);
+
+		await notifyAssessmentOutcome(d, a);
+		await notifyAssessmentOutcome(d, a);
+
+		expect(sender.notices).toHaveLength(1);
+		expect(await notificationRows(a.id)).toHaveLength(1);
+	});
+});
+
+describe("verified-publisher skip", () => {
+	it("an in-force verification claim delivers the notice without a confirmation mail", async () => {
+		const email = uniq("vok") + "@x.test";
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "blocked" });
+
+		// The contact is UNCONFIRMED; verification upgrades it in place.
+		await notifyAssessmentOutcome(
+			deps(aggregatorFor({ email, verifications: IN_FORCE }), sender),
+			a,
+		);
+
+		expect(sender.notices).toHaveLength(1);
+		expect(sender.confirmations).toHaveLength(0);
+		const hash = await recipientHash(PEPPER, email);
+		const contact = await db()
+			.prepare(`SELECT confirm_state FROM notification_contacts WHERE recipient_hash = ?`)
+			.bind(hash)
+			.first<{ confirm_state: string }>();
+		expect(contact?.confirm_state).toBe("confirmed");
+	});
+
+	it("an EXPIRED claim falls back to double opt-in", async () => {
+		const email = uniq("vexp") + "@x.test";
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "blocked" });
+
+		await notifyAssessmentOutcome(
+			deps(aggregatorFor({ email, verifications: EXPIRED }), sender),
+			a,
+		);
+
+		expect(sender.notices).toHaveLength(0);
+		expect(sender.confirmations).toHaveLength(1);
+	});
+
+	it("a verification read failure fails closed to double opt-in", async () => {
+		const email = uniq("vfail") + "@x.test";
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "blocked" });
+
+		await notifyAssessmentOutcome(deps(aggregatorFor({ email, verifyStatus: 500 }), sender), a);
+
+		expect(sender.notices).toHaveLength(0);
+		expect(sender.confirmations).toHaveLength(1);
+	});
+
+	it("a suppressed address gets NOTHING even when the publisher is verified", async () => {
+		const email = uniq("vsupp") + "@x.test";
+		const hash = await recipientHash(PEPPER, email);
+		await suppress(db(), hash, "not_me", "2026-07-16T00:00:00.000Z", 1_000);
+		const sender = recordingSender();
+		const a = assessmentRow({ state: "blocked" });
+
+		await notifyAssessmentOutcome(
+			deps(aggregatorFor({ email, verifications: IN_FORCE }), sender),
+			a,
+		);
+
+		expect(sender.notices).toHaveLength(0);
+		expect(sender.confirmations).toHaveLength(0);
+	});
+});
+
+describe("provider hard-bounce", () => {
+	it("E_RECIPIENT_SUPPRESSED marks the row undeliverable and suppresses the address", async () => {
+		const email = uniq("bounce") + "@x.test";
+		await seedConfirmed(email);
+		const hash = await recipientHash(PEPPER, email);
+		const sender = recordingSender({
+			ok: false,
+			error: "E_RECIPIENT_SUPPRESSED",
+			suppress: "bounce",
+		});
+		const a = assessmentRow({ state: "blocked" });
+
+		await notifyAssessmentOutcome(deps(aggregatorFor({ email }), sender), a);
+
+		expect(await notificationRows(a.id)).toEqual([{ kind: "notice", state: "undeliverable" }]);
+		const supp = await db()
+			.prepare(`SELECT reason FROM notification_suppressions WHERE recipient_hash = ?`)
+			.bind(hash)
+			.first<{ reason: string }>();
+		expect(supp?.reason).toBe("bounce");
+	});
+});
+
+describe("failure isolation", () => {
+	it("a sender that THROWS never propagates out of the trigger (the label is safe)", async () => {
+		const email = uniq("throw") + "@x.test";
+		await seedConfirmed(email);
+		const a = assessmentRow({ state: "blocked" });
+
+		await expect(
+			notifyAssessmentOutcome(deps(aggregatorFor({ email }), throwingSender()), a),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/labeler/vitest.config.ts
+++ b/apps/labeler/vitest.config.ts
@@ -22,6 +22,13 @@ export default defineConfig({
 	},
 	plugins: [
 		cloudflareTest({
+			// Use miniflare's LOCAL binding simulation, never a remote proxy to real
+			// Cloudflare. The unrestricted `send_email` binding (arbitrary recipients)
+			// would otherwise force a remote proxy session — real credentials, real
+			// mail. Locally, the EMAIL binding is simulated; adapter tests inject a
+			// fake `SendEmail` regardless (src/notification-email.ts takes the binding
+			// as a constructor arg), so no test depends on the local email behaviour.
+			remoteBindings: false,
 			wrangler: { configPath: "./wrangler.jsonc" },
 			miniflare: {
 				bindings: {

--- a/apps/labeler/worker-configuration.d.ts
+++ b/apps/labeler/worker-configuration.d.ts
@@ -6,9 +6,11 @@ interface __BaseEnv_Env {
 	DB: D1Database;
 	DISCOVERY_QUEUE: Queue;
 	AI: Ai;
+	EMAIL: SendEmail;
 	ASSETS: Fetcher;
 	LABELER_DID: "did:web:labels.emdashcms.com";
 	LABELER_SERVICE_URL: "https://labels.emdashcms.com";
+	NOTIFICATION_FROM_ADDRESS: "notifications@emdashcms.com";
 	LABEL_SIGNING_KEY_VERSION: "v1";
 	LABEL_SIGNING_PUBLIC_KEY: "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ";
 	JETSTREAM_URL: "wss://jetstream2.us-east.bsky.network/subscribe";
@@ -32,7 +34,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "LABELER_DID" | "LABELER_SERVICE_URL" | "LABEL_SIGNING_KEY_VERSION" | "LABEL_SIGNING_PUBLIC_KEY" | "JETSTREAM_URL" | "OPERATOR_ACCESS_CONFIG" | "LABEL_SIGNING_PRIVATE_KEY" | "NOTIFICATION_HASH_PEPPER">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "LABELER_DID" | "LABELER_SERVICE_URL" | "NOTIFICATION_FROM_ADDRESS" | "LABEL_SIGNING_KEY_VERSION" | "LABEL_SIGNING_PUBLIC_KEY" | "JETSTREAM_URL" | "OPERATOR_ACCESS_CONFIG" | "LABEL_SIGNING_PRIVATE_KEY" | "NOTIFICATION_HASH_PEPPER">> {}
 }
 
 // Begin runtime types

--- a/apps/labeler/wrangler.jsonc
+++ b/apps/labeler/wrangler.jsonc
@@ -43,6 +43,12 @@
 	"ai": {
 		"binding": "AI",
 	},
+	// Cloudflare Email Sending for publisher notifications (plan W10.5). The
+	// unrestricted binding form (no destination_address) permits arbitrary
+	// external recipients, which requires the emdashcms.com sending domain to be
+	// onboarded for Email Sending (`wrangler email sending enable`, operator
+	// prereq). Consumed via src/notification-email.ts.
+	"send_email": [{ "name": "EMAIL" }],
 	// Read-only service binding to the aggregator Worker's XRPC surface
 	// (fetch-over-binding; the aggregator is HTTP/XRPC-only, no RPC entrypoint).
 	// Consumed via src/aggregator-client.ts.
@@ -111,6 +117,9 @@
 	"vars": {
 		"LABELER_DID": "did:web:labels.emdashcms.com",
 		"LABELER_SERVICE_URL": "https://labels.emdashcms.com",
+		// From-address for publisher notifications, on the onboarded Email Sending
+		// domain (plan W10.5). Consumed via src/notification-email.ts.
+		"NOTIFICATION_FROM_ADDRESS": "notifications@emdashcms.com",
 		"LABEL_SIGNING_KEY_VERSION": "v1",
 		"LABEL_SIGNING_PUBLIC_KEY": "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ",
 		"JETSTREAM_URL": "wss://jetstream2.us-east.bsky.network/subscribe",


### PR DESCRIPTION
## What does this PR do?

Implements **W10.5 slice 2** of the labeler publisher-notification subsystem, on top of slice 1's gated send-core (#2076): the Cloudflare Email Sending adapter, the five issuance/operator triggers, verified-publisher skip, and the cron retry sweep. This is the layer that turns a committed label action into a real email to the publisher's resolved contact.

- **`CloudflareEmailSender`** (`notification-email.ts`) implements the injected `NotificationSender` over the unrestricted `send_email` binding (arbitrary external recipients). Structured `env.EMAIL.send()` with `html`+`text` bodies, `List-Unsubscribe` + one-click headers on every message, from-address from a var. Thrown coded errors map to a `SendResult` **code only** (never the provider message or the payload — it is persisted verbatim in `last_error`); `E_RECIPIENT_SUPPRESSED` carries a `suppress: 'bounce'` discriminant that the orchestration layer turns into our own suppression + a never-retried `undeliverable` row.
- **Triggers** (`notification-triggers.ts`) fire post-commit from the deferred (`waitUntil`) tail at the five ratified events — automated block/warning (assessment workflow), reviewer label issue/retract, override, override-retract, and emergency takedown (console mutations). A notification failure never rolls back or fails a label: every entry point swallows and logs. Per-source dedup plus an atomic per-source guard on the notice claim give "one notice per action" even under a replay race.
- **Verified-publisher skip**: a publisher with an in-force verification claim (reusing history-context's expiry logic over the W8.4 aggregator read) bypasses double opt-in via a token-less confirm. The verification read **fails closed** — any error routes to the normal confirmation-mail path — and suppressed/declined addresses get nothing regardless.
- **Cron sweep** (`notification-sweep.ts`), a third `waitUntil` branch in `scheduled()`: re-drives `failed` and crash-stuck `pending` rows under a CAS claim, abandons the exhausted to `undeliverable` (which clears plaintext and reopens a confirmation's lifetime cap so the channel is never silently foreclosed), re-checks suppression before every send, mints a fresh token for confirmation retries, re-renders notice content from source, and prunes terminal rows / stale ledger entries (keeping cap-holding sent confirmations).

Satisfies the three recorded slice-2 contracts: (a) the adapter never puts the confirm URL/token into its returned error; (b) a failed confirmation retry regenerates the token (only the hash was stored); (c) the sweep re-drives stuck `pending` and exhausted `failed` confirmation rows, flipping abandonment to `undeliverable` so the lifetime cap re-opens rather than a dead row locking the channel out.

**Operator go-live prereq (not blocking merge):** one-time Email Sending onboarding of the `emdashcms.com` sending domain (`wrangler email sending enable`, auto-managed SPF/DKIM/DMARC), plus a review of the `NOTIFICATION_FROM_ADDRESS` var and the `NOTIFICATION_HASH_PEPPER` secret, before any real delivery. Until then the subsystem is inert (no cron sends without an onboarded domain).

Design is governed by the ratified plan `.opencode/plans/plugin-registry-labelling-service/implementation-plan.md` § W10.5; targets the integration branch `feat/plugin-registry-labelling-service`, not `main`.

## Type of change

- [x] Feature (ratified in the W10.5 plan; targets the labeler integration branch, not `main`)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all three labeler tsconfigs)
- [x] `pnpm lint` passes — no new diagnostics in touched files (the sole `apps/labeler/src/dead-letters.ts` warning predates this PR, from W9.6 #2028)
- [x] `pnpm test` passes (full labeler suite: 745 passed, 40 files)
- [x] `pnpm format` has been run (oxfmt, touched files)
- [x] I have added/updated tests for my changes (adapter, triggers, sweep — 37 new tests)
- [ ] User-visible strings in the admin UI are wrapped for translation — **n/a**: no admin UI, no user-facing admin strings (email bodies are transactional, not localized in this slice)
- [ ] I have added a changeset — **n/a**: `apps/labeler` is an unpublished application
- [ ] New features link to an approved Discussion — **n/a**: governed by the ratified W10.5 plan doc; targets the labeler integration branch, not `main`

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8**

## Screenshots / test output

```
Test Files  40 passed (40)
     Tests  745 passed (745)
```

New coverage: adapter (success/`providerId`, per-code mapping, `E_RECIPIENT_SUPPRESSED` → suppression discriminant, `List-Unsubscribe` headers, no-payload-in-error), triggers (each of the five events, per-source dedup, verified-skip in-force/expired/read-failure/suppressed, throw isolation), sweep (retry→sent, fresh-token stamp, cap exhaustion + reopen, stuck-pending re-drive, suppression re-check → no mail, provider suppression, transient-read self-heal, 30-day cleanup, ledger prune).

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-notification-email-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-notification-email`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
