### PR TITLE
fix(core): avoid optional dialect export warnings

### DIFF
--- a/.changeset/quiet-dialects-build.md
+++ b/.changeset/quiet-dialects-build.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes production build warnings when database adapters do not provide the optional cold-start query coalescing dialect.

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -262,6 +262,7 @@ export function d1(config: D1Config): DatabaseDescriptor {
 		config,
 		type: "sqlite",
 		supportsRequestScope: true,
+		supportsCoalescing: true,
 	};
 }
 
@@ -370,6 +371,7 @@ export function durableObjects(config: DurableObjectsConfig): DatabaseDescriptor
 		config,
 		type: "sqlite",
 		supportsRequestScope: true,
+		supportsCoalescing: true,
 	};
 }
 

--- a/packages/cloudflare/tests/do-config.test.ts
+++ b/packages/cloudflare/tests/do-config.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from "vitest";
 
-import { previewDatabase, playgroundDatabase } from "../src/index.js";
+import { d1, durableObjects, previewDatabase, playgroundDatabase } from "../src/index.js";
+
+describe("d1()", () => {
+	it("opts into request-scoped and coalescing dialects", () => {
+		const result = d1({ binding: "DB" });
+		expect(result.supportsRequestScope).toBe(true);
+		expect(result.supportsCoalescing).toBe(true);
+	});
+});
+
+describe("durableObjects()", () => {
+	it("opts into request-scoped and coalescing dialects", () => {
+		const result = durableObjects({ binding: "DB_DO" });
+		expect(result.supportsRequestScope).toBe(true);
+		expect(result.supportsCoalescing).toBe(true);
+	});
+});
 
 describe("previewDatabase()", () => {
 	it("returns a sqlite DatabaseDescriptor with the DO entrypoint", () => {

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -84,13 +84,18 @@ export function generateConfigModule(serializableConfig: Record<string, unknown>
  * the generator re-exports it so middleware can ask for a per-request Kysely
  * (used for D1 Sessions API, bookmark cookies, read-replica routing). Other
  * adapters get a stub that returns null.
+ *
+ * Adapters independently opt into the cold-start coalescing dialect. Keeping
+ * this capability explicit prevents bundlers from probing exports that do not
+ * exist on SQLite, libSQL, PostgreSQL, or other adapters.
  */
 export function generateDialectModule(opts: {
 	entrypoint?: string;
 	type?: string;
 	supportsRequestScope: boolean;
+	supportsCoalescing: boolean;
 }): string {
-	const { entrypoint, supportsRequestScope } = opts;
+	const { entrypoint, supportsRequestScope, supportsCoalescing } = opts;
 	if (!entrypoint) {
 		return [
 			`export const createDialect = undefined;`,
@@ -101,16 +106,16 @@ export function generateDialectModule(opts: {
 	}
 	const type = opts.type ?? "sqlite";
 
-	// Namespace access (not a named re-export) so backends that don't export
-	// createCoalescingDialect yield `undefined` rather than a build error.
-	const coalescingReExport = `import * as _dialectModule from "${entrypoint}";
-export const createCoalescingDialect = _dialectModule.createCoalescingDialect;`;
+	const coalescingExport = supportsCoalescing
+		? `import { createCoalescingDialect as _createCoalescingDialect } from "${entrypoint}";
+export const createCoalescingDialect = _createCoalescingDialect;`
+		: `export const createCoalescingDialect = undefined;`;
 
 	if (supportsRequestScope) {
 		return `
 import { createDialect as _createDialect } from "${entrypoint}";
 export { createRequestScopedDb } from "${entrypoint}";
-${coalescingReExport}
+${coalescingExport}
 export const createDialect = _createDialect;
 export const dialectType = ${JSON.stringify(type)};
 `;
@@ -118,7 +123,7 @@ export const dialectType = ${JSON.stringify(type)};
 
 	return `
 import { createDialect as _createDialect } from "${entrypoint}";
-${coalescingReExport}
+${coalescingExport}
 export const createDialect = _createDialect;
 export const dialectType = ${JSON.stringify(type)};
 export const createRequestScopedDb = (_opts) => null;

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -239,6 +239,7 @@ export function createVirtualModulesPlugin(
 					entrypoint: resolvedConfig.database?.entrypoint,
 					type: resolvedConfig.database?.type,
 					supportsRequestScope: resolvedConfig.database?.supportsRequestScope ?? false,
+					supportsCoalescing: resolvedConfig.database?.supportsCoalescing ?? false,
 				});
 			}
 			// Generate a module that statically imports the configured storage

--- a/packages/core/src/db/adapters.ts
+++ b/packages/core/src/db/adapters.ts
@@ -48,6 +48,15 @@ export interface DatabaseDescriptor {
 	 * the middleware takes its default (singleton) path.
 	 */
 	supportsRequestScope?: boolean;
+	/**
+	 * When true, the adapter's runtime entrypoint MUST export a named
+	 * `createCoalescingDialect` function. The runtime uses this fresh dialect
+	 * only for its cold-start read batch.
+	 *
+	 * When false or absent, the virtual module exports `undefined` without
+	 * inspecting an optional entrypoint export.
+	 */
+	supportsCoalescing?: boolean;
 }
 
 export interface SqliteConfig {

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -37,7 +37,10 @@ describe("generateConfigModule", () => {
 
 describe("generateDialectModule", () => {
 	it("emits undefined createDialect and null stub when no entrypoint is configured", () => {
-		const out = generateDialectModule({ supportsRequestScope: false });
+		const out = generateDialectModule({
+			supportsRequestScope: false,
+			supportsCoalescing: false,
+		});
 		expect(out).toContain("export const createDialect = undefined");
 		expect(out).toContain("export const createRequestScopedDb = (_opts) => null");
 	});
@@ -47,9 +50,12 @@ describe("generateDialectModule", () => {
 			entrypoint: "some-adapter/dialect",
 			type: "sqlite",
 			supportsRequestScope: false,
+			supportsCoalescing: false,
 		});
 		expect(out).toContain(`import { createDialect as _createDialect } from "some-adapter/dialect"`);
 		expect(out).toContain("export const createRequestScopedDb = (_opts) => null");
+		expect(out).toContain("export const createCoalescingDialect = undefined");
+		expect(out).not.toContain("_dialectModule.createCoalescingDialect");
 		expect(out).not.toContain(`export { createRequestScopedDb } from`);
 	});
 
@@ -58,8 +64,13 @@ describe("generateDialectModule", () => {
 			entrypoint: "@emdash-cms/cloudflare/db/d1",
 			type: "sqlite",
 			supportsRequestScope: true,
+			supportsCoalescing: true,
 		});
 		expect(out).toContain(`export { createRequestScopedDb } from "@emdash-cms/cloudflare/db/d1"`);
+		expect(out).toContain(
+			`import { createCoalescingDialect as _createCoalescingDialect } from "@emdash-cms/cloudflare/db/d1"`,
+		);
+		expect(out).toContain("export const createCoalescingDialect = _createCoalescingDialect");
 		expect(out).not.toContain("= () => null");
 		expect(out).not.toContain("= (_opts) => null");
 	});
@@ -69,6 +80,7 @@ describe("generateDialectModule", () => {
 			entrypoint: "emdash/db/postgres",
 			type: "postgres",
 			supportsRequestScope: false,
+			supportsCoalescing: false,
 		});
 		expect(out).toContain(`export const dialectType = "postgres"`);
 	});


### PR DESCRIPTION
## What does this PR do?

Makes cold-start query coalescing an explicit database-adapter capability.

The cold-start batching change in #1617 reads `createCoalescingDialect` through a namespace import. Bundlers can still statically inspect that property access and warn when the configured SQLite, libSQL, PostgreSQL, or third-party adapter does not export it.

This change adds an optional `supportsCoalescing` descriptor flag, enables it for the Cloudflare D1 and Durable Objects adapters that provide the export, and emits `undefined` for every other adapter without probing a missing export. The runtime fallback behavior is unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] Affected-package typechecks pass
- [ ] `pnpm lint` passes (changed files pass; the full run currently reports an unrelated existing diagnostic in `packages/registry-verification/src/records.ts:276`)
- [x] Targeted tests pass
- [x] Formatting checks pass
- [x] Tests cover both capability-enabled and fallback module generation
- [x] No user-visible strings were added
- [x] A changeset is included
- [x] New features link to an approved Discussion: N/A, this is a bug fix

## Test output

- Core virtual-module tests: 15 passed
- Cloudflare descriptor tests: 4 passed
- `emdash` typecheck: passed
- `@emdash-cms/cloudflare` typecheck: passed
- Both affected package builds: passed
- Publint for both affected packages: passed
- Type-aware oxlint on changed files: passed
- Oxfmt and Prettier checks on changed files: passed
