### PR TITLE
fix(head): avoid CSP warnings when disabled

### DIFF
--- a/.changeset/quiet-heads-rest.md
+++ b/.changeset/quiet-heads-rest.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Avoid production render warnings when Astro's built-in CSP is disabled while preserving JSON-LD script hashes when it is enabled.

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -381,6 +381,9 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 				if (astroVersion !== undefined) {
 					serializableConfig.astroVersion = astroVersion;
 				}
+				// EmDashHead must not access Astro.csp when the host has disabled
+				// Astro's built-in CSP runtime; Astro logs a warning for that access.
+				serializableConfig.astroCspEnabled = Boolean(astroConfig.security.csp);
 				// Extract i18n config from Astro config
 				// Astro locales can be strings OR { path, codes } objects — normalize to paths
 				if (astroConfig.i18n) {

--- a/packages/core/src/components/EmDashHead.astro
+++ b/packages/core/src/components/EmDashHead.astro
@@ -17,8 +17,9 @@
  * ```
  */
 import type { PublicPageContext, PageMetadataContribution } from "../plugins/types.js";
+import virtualConfig from "virtual:emdash/config";
 import {
-	createSha256CspHash,
+	registerJsonLdCspHashes,
 	resolvePageMetadata,
 	renderPageMetadata,
 	type ResolvedPageMetadata,
@@ -124,13 +125,7 @@ if (runtime) {
 	metadataHtml = renderPageMetadata(resolved, { includeJsonLd: false });
 }
 
-if (Astro.csp && jsonLdScripts.length > 0) {
-	await Promise.all(
-		jsonLdScripts.map(async ({ json }) => {
-			Astro.csp?.insertScriptHash(await createSha256CspHash(json));
-		}),
-	);
-}
+await registerJsonLdCspHashes(virtualConfig.astroCspEnabled === true, () => Astro.csp, jsonLdScripts);
 ---
 
 <Fragment set:html={metadataHtml} />

--- a/packages/core/src/components/EmDashHead.astro
+++ b/packages/core/src/components/EmDashHead.astro
@@ -17,6 +17,7 @@
  * ```
  */
 import type { PublicPageContext, PageMetadataContribution } from "../plugins/types.js";
+// @ts-ignore - virtual module
 import virtualConfig from "virtual:emdash/config";
 import {
 	registerJsonLdCspHashes,

--- a/packages/core/src/page/metadata.ts
+++ b/packages/core/src/page/metadata.ts
@@ -80,6 +80,33 @@ export async function createSha256CspHash(value: string): Promise<string> {
 	return `sha256-${btoa(binary)}`;
 }
 
+interface CspScriptHashSink {
+	insertScriptHash(hash: string): void;
+}
+
+/**
+ * Register JSON-LD hashes with Astro's CSP runtime when CSP is enabled.
+ *
+ * The getter stays lazy because Astro warns when `Astro.csp` is accessed on a
+ * project that has not enabled its built-in CSP support.
+ */
+export async function registerJsonLdCspHashes(
+	enabled: boolean,
+	getCsp: () => CspScriptHashSink | undefined,
+	scripts: ReadonlyArray<{ json: string }>,
+): Promise<void> {
+	if (!enabled || scripts.length === 0) return;
+
+	const csp = getCsp();
+	if (!csp) return;
+
+	await Promise.all(
+		scripts.map(async ({ json }) => {
+			csp.insertScriptHash(await createSha256CspHash(json));
+		}),
+	);
+}
+
 // ── Merge / dedupe ──────────────────────────────────────────────
 
 /**

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -21,6 +21,7 @@ declare module "virtual:emdash/config" {
 		authProviders?: AuthProviderDescriptor[];
 		i18n?: I18nConfig | null;
 		toolbar?: "server" | "client" | false;
+		astroCspEnabled?: boolean;
 	}
 
 	const config: VirtualConfig;

--- a/packages/core/tests/unit/plugins/page-metadata.test.ts
+++ b/packages/core/tests/unit/plugins/page-metadata.test.ts
@@ -335,11 +335,13 @@ describe("registerJsonLdCspHashes", () => {
 		const scripts = [{ json: '{"@type":"WebSite"}' }, { json: '{"@type":"Organization"}' }];
 
 		await registerJsonLdCspHashes(true, getCsp, scripts);
+		const hash0 = await createSha256CspHash(scripts[0].json);
+		const hash1 = await createSha256CspHash(scripts[1].json);
 
 		expect(getCsp).toHaveBeenCalledOnce();
 		expect(insertScriptHash).toHaveBeenCalledTimes(2);
-		expect(insertScriptHash).toHaveBeenNthCalledWith(1, await createSha256CspHash(scripts[0].json));
-		expect(insertScriptHash).toHaveBeenNthCalledWith(2, await createSha256CspHash(scripts[1].json));
+		expect(insertScriptHash).toHaveBeenCalledWith(hash0);
+		expect(insertScriptHash).toHaveBeenCalledWith(hash1);
 	});
 });
 

--- a/packages/core/tests/unit/plugins/page-metadata.test.ts
+++ b/packages/core/tests/unit/plugins/page-metadata.test.ts
@@ -8,7 +8,7 @@
  * - HTML attribute escaping
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import {
 	resolvePageMetadata,
@@ -16,6 +16,7 @@ import {
 	safeJsonLdSerialize,
 	escapeHtmlAttr,
 	createSha256CspHash,
+	registerJsonLdCspHashes,
 } from "../../../src/page/metadata.js";
 import type { PageMetadataContribution } from "../../../src/plugins/types.js";
 
@@ -314,6 +315,31 @@ describe("createSha256CspHash", () => {
 		await expect(createSha256CspHash(json)).resolves.toBe(
 			"sha256-jYad5jvuDVG3xtskggDVT0+GiHcapqamItZJ8eGfvCQ=",
 		);
+	});
+});
+
+describe("registerJsonLdCspHashes", () => {
+	it("does not access Astro's CSP getter when CSP is disabled", async () => {
+		const getCsp = vi.fn(() => {
+			throw new Error("CSP getter must stay lazy");
+		});
+
+		await registerJsonLdCspHashes(false, getCsp, [{ json: '{"@type":"WebSite"}' }]);
+
+		expect(getCsp).not.toHaveBeenCalled();
+	});
+
+	it("registers every JSON-LD hash when CSP is enabled", async () => {
+		const insertScriptHash = vi.fn();
+		const getCsp = vi.fn(() => ({ insertScriptHash }));
+		const scripts = [{ json: '{"@type":"WebSite"}' }, { json: '{"@type":"Organization"}' }];
+
+		await registerJsonLdCspHashes(true, getCsp, scripts);
+
+		expect(getCsp).toHaveBeenCalledOnce();
+		expect(insertScriptHash).toHaveBeenCalledTimes(2);
+		expect(insertScriptHash).toHaveBeenNthCalledWith(1, await createSha256CspHash(scripts[0].json));
+		expect(insertScriptHash).toHaveBeenNthCalledWith(2, await createSha256CspHash(scripts[1].json));
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Avoids Astro CSP warnings from `EmDashHead` when a host project has not enabled Astro's built-in CSP support.

This is a follow-up to #1695. The JSON-LD integration currently reads `Astro.csp` before it knows whether CSP is enabled. Astro 7 warns on every affected production render even when the page does not need CSP handling.

The fix:

- records the normalized CSP-enabled state in EmDash's virtual config;
- keeps access to `Astro.csp` lazy when CSP is disabled;
- preserves JSON-LD script hash registration when CSP is enabled;
- adds regression coverage for both paths.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] `pnpm --filter emdash typecheck` passes
- [x] Changed-file type-aware lint passes
- [x] Targeted tests pass
- [x] `pnpm format:check` passes
- [x] I added regression coverage
- [x] No user-visible admin strings were added
- [x] I added a changeset
- [ ] New features link to an approved Discussion (not applicable; bug fix)

## Validation

- `pnpm --filter emdash exec vitest run tests/unit/plugins/page-metadata.test.ts` - 33 tests passed
- `pnpm --filter emdash typecheck`
- changed-file type-aware `oxlint`
- `pnpm format:check`
- `git diff --check`
- production SSR reproduction with the simple demo:
  - current `main`: request returns 200 and logs `context.csp was used ... but CSP was not configured`
  - this branch: request returns 200 with no CSP warning
