### PR TITLE
fix(core): watch sandbox plugin entries

### DIFF
--- a/.changeset/watch-sandbox-plugin-entries.md
+++ b/.changeset/watch-sandbox-plugin-entries.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Watch resolved sandbox plugin entry files so rebuilding a plugin invalidates its embedded virtual module during development.

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -598,12 +598,14 @@ function resolveModulePathFromProject(specifier: string, projectRoot: string): s
 /**
  * Generates the sandboxed plugins module.
  * Resolves plugin entrypoints to files, reads them, and embeds the code.
+ * Notifies the caller about each resolved entry so build tools can watch it.
  *
  * At runtime, middleware uses SandboxRunner to load these into isolates.
  */
 export function generateSandboxedPluginsModule(
 	sandboxed: PluginDescriptor[],
 	projectRoot: string,
+	onEntryResolved?: (filePath: string) => void,
 ): string {
 	if (sandboxed.length === 0) {
 		return `
@@ -629,6 +631,8 @@ export const sandboxedPlugins = [];
 					`and run the plugin's build step before building the site.`,
 			);
 		}
+
+		onEntryResolved?.(filePath);
 
 		const code = readFileSync(filePath, "utf-8");
 

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -271,7 +271,11 @@ export function createVirtualModulesPlugin(
 			if (id === RESOLVED_VIRTUAL_SANDBOXED_PLUGINS_ID) {
 				// Pass project root for proper module resolution
 				const projectRoot = fileURLToPath(astroConfig.root);
-				return generateSandboxedPluginsModule(resolvedConfig.sandboxed ?? [], projectRoot);
+				return generateSandboxedPluginsModule(
+					resolvedConfig.sandboxed ?? [],
+					projectRoot,
+					(filePath) => this.addWatchFile(filePath),
+				);
 			}
 			// Generate auth module that statically imports the configured auth provider
 			if (id === RESOLVED_VIRTUAL_AUTH_ID) {

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -1,15 +1,18 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import type { Plugin } from "vite";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PluginDescriptor } from "../../../../src/astro/integration/runtime.js";
 import {
 	generateConfigModule,
 	generateDialectModule,
 	generateSchedulerModule,
 	generateSeedModule,
+	RESOLVED_VIRTUAL_SANDBOXED_PLUGINS_ID,
 	RESOLVED_VIRTUAL_SCHEDULER_ID,
 } from "../../../../src/astro/integration/virtual-modules.js";
 import {
@@ -104,11 +107,16 @@ describe("generateSchedulerModule", () => {
 	});
 });
 
-describe("createVirtualModulesPlugin scheduler wiring", () => {
+describe("createVirtualModulesPlugin", () => {
 	// Invoke a Vite plugin hook that may be a function or { handler } object.
 	function callHook<T>(hook: unknown, ...args: unknown[]): T {
 		const fn = typeof hook === "function" ? hook : (hook as { handler: unknown }).handler;
 		return (fn as (...a: unknown[]) => T)(...args);
+	}
+
+	function callHookWithContext<T>(hook: unknown, context: unknown, ...args: unknown[]): T {
+		const fn = typeof hook === "function" ? hook : (hook as { handler: unknown }).handler;
+		return (fn as (...a: unknown[]) => T).call(context, ...args);
 	}
 
 	function buildPlugin(
@@ -144,6 +152,56 @@ describe("createVirtualModulesPlugin scheduler wiring", () => {
 		const out = callHook<string>(plugin.load, RESOLVED_VIRTUAL_SCHEDULER_ID);
 		expect(out).toContain("export const createScheduler = null");
 		expect(out).not.toContain("NodeCronScheduler");
+	});
+
+	it("watches resolved sandbox plugin entries", () => {
+		const projectRoot = mkdtempSync(join(tmpdir(), "emdash-sandbox-watch-test-"));
+		try {
+			const pluginDir = join(projectRoot, "node_modules", "@test", "watch-plugin");
+			const entryPath = join(pluginDir, "dist", "sandbox-entry.mjs");
+			mkdirSync(join(pluginDir, "dist"), { recursive: true });
+			writeFileSync(join(projectRoot, "package.json"), JSON.stringify({ name: "test-project" }));
+			writeFileSync(entryPath, "export default { hooks: {} };");
+			writeFileSync(
+				join(pluginDir, "package.json"),
+				JSON.stringify({
+					name: "@test/watch-plugin",
+					exports: { "./sandbox": "./dist/sandbox-entry.mjs" },
+				}),
+			);
+
+			const descriptor: PluginDescriptor = {
+				id: "watch-plugin",
+				version: "1.0.0",
+				entrypoint: "@test/watch-plugin/sandbox",
+				format: "standard",
+				capabilities: [],
+				allowedHosts: [],
+				storage: {},
+				adminPages: [],
+				adminWidgets: [],
+			};
+			const options = {
+				serializableConfig: {},
+				resolvedConfig: { sandboxed: [descriptor] },
+				pluginDescriptors: [],
+				astroConfig: { root: pathToFileURL(`${projectRoot}/`) },
+			} as unknown as VitePluginOptions;
+			const plugin = createVirtualModulesPlugin(options, "dev");
+			const addWatchFile = vi.fn();
+
+			const source = callHookWithContext<string>(
+				plugin.load,
+				{ addWatchFile },
+				RESOLVED_VIRTUAL_SANDBOXED_PLUGINS_ID,
+			);
+
+			expect(source).toContain("export default { hooks: {} };");
+			expect(addWatchFile).toHaveBeenCalledOnce();
+			expect(addWatchFile).toHaveBeenCalledWith(entryPath);
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Registers each resolved sandbox plugin entry file with Vite's watch graph while generating `virtual:emdash/sandboxed-plugins`.

Sandbox plugin code is read from disk and embedded into a virtual module. Because the resolved entry was neither statically imported nor registered with `addWatchFile`, rebuilding a sandbox plugin during development did not invalidate that module. The dev server could therefore continue executing the previous bundle until it was restarted.

The fix keeps module generation unchanged while notifying the Vite load hook about every resolved, built JavaScript entry. A regression test invokes the virtual-module load hook and verifies that the exact resolved entry is watched.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm --filter emdash typecheck` passes
- [x] Type-aware lint passes for the changed source and test files
- [x] Targeted tests pass
- [x] Formatting checks pass
- [x] I added regression coverage
- [x] No user-visible strings were added
- [x] A patch changeset is included

## Validation

- `vitest run tests/unit/astro/integration/virtual-modules.test.ts tests/unit/astro/virtual-modules-sandbox.test.ts` - 22 tests passed
- `pnpm --filter emdash typecheck`
- changed-file `oxlint --type-aware --deny-warnings`
- changed-file `oxfmt --check`
- `git diff --check`
