### PR TITLE
feat(labeler): reconsideration operator console UI (W10.6 client)

### DIFF
--- a/apps/labeler/console/src/api/client.test.ts
+++ b/apps/labeler/console/src/api/client.test.ts
@@ -48,6 +48,27 @@ describe("fixture client", () => {
 		expect(ids).toEqual(ids.toSorted((a, b) => b - a));
 		expect(page.items.some((d) => d.status === "new")).toBe(true);
 	});
+
+	it("lists reconsiderations with an open and a resolved case", async () => {
+		const page = await apiClient.listReconsiderations();
+		expect(page.items.length).toBeGreaterThan(0);
+		expect(page.items.some((r) => r.state === "open")).toBe(true);
+		expect(page.items.some((r) => r.state === "resolved" && r.outcome !== null)).toBe(true);
+	});
+
+	it("returns a reconsideration case with its oldest-first note thread", async () => {
+		const [first] = (await apiClient.listReconsiderations()).items;
+		expect(first).toBeDefined();
+		const detail = await apiClient.getReconsideration(first!.id);
+		expect(detail?.reconsideration.id).toBe(first!.id);
+		expect(detail!.notes.length).toBeGreaterThan(0);
+		const timestamps = detail!.notes.map((n) => Date.parse(n.createdAt));
+		expect(timestamps).toEqual(timestamps.toSorted((a, b) => a - b));
+	});
+
+	it("returns null for an unknown reconsideration id", async () => {
+		expect(await apiClient.getReconsideration("recon_missing")).toBeNull();
+	});
 });
 
 describe("fetch client label actions", () => {
@@ -278,5 +299,111 @@ describe("fetch client label actions", () => {
 				negate: ["malware"],
 			}),
 		).rejects.toThrow("key already used");
+	});
+
+	it("GETs the reconsideration list", async () => {
+		stubFetch(() => Response.json({ data: { items: [{ id: "recon_1", state: "open" }] } }));
+		const page = await fetchClient.listReconsiderations({ cursor: "c1", limit: 25 });
+		expect(page.items).toEqual([{ id: "recon_1", state: "open" }]);
+		const url = calls[0]!.url;
+		expect(url).toContain("/admin/api/reconsiderations?");
+		expect(url).toContain("cursor=c1");
+		expect(url).toContain("limit=25");
+	});
+
+	it("GETs one reconsideration, mapping 404 to null", async () => {
+		stubFetch(() => new Response(null, { status: 404 }));
+		expect(await fetchClient.getReconsideration("recon_missing")).toBeNull();
+		expect(calls[0]!.url).toBe("/admin/api/reconsiderations/recon_missing");
+	});
+
+	it("POSTs an open with the CSRF header, JSON content type, and threaded key", async () => {
+		stubFetch(() => Response.json({ data: { actionId: "oact_1", reconsiderationId: "recon_1" } }));
+		const result = await fetchClient.openReconsideration({
+			assessmentId: "asmt_target",
+			note: "publisher appealed",
+			reason: "opening",
+			idempotencyKey: input.idempotencyKey,
+		});
+		expect(result).toMatchObject({ reconsiderationId: "recon_1" });
+		const call = calls[0]!;
+		expect(call.url).toBe("/admin/api/reconsiderations/open");
+		expect(call.init.method).toBe("POST");
+		const headers = new Headers(call.init.headers);
+		expect(headers.get("X-EmDash-Request")).toBe("1");
+		expect(headers.get("Content-Type")).toBe("application/json");
+		expect(JSON.parse(call.init.body as string)).toMatchObject({
+			assessmentId: "asmt_target",
+			note: "publisher appealed",
+			reason: "opening",
+			idempotencyKey: input.idempotencyKey,
+		});
+	});
+
+	it("POSTs a note to the case note route", async () => {
+		stubFetch(() => Response.json({ data: { actionId: "oact_1", noteId: "rnote_1" } }));
+		await fetchClient.addReconsiderationNote("recon_1", {
+			note: "another note",
+			reason: "context",
+			idempotencyKey: input.idempotencyKey,
+		});
+		expect(calls[0]!.url).toBe("/admin/api/reconsiderations/recon_1/note");
+		expect(calls[0]!.init.method).toBe("POST");
+		expect(JSON.parse(calls[0]!.init.body as string)).toMatchObject({ note: "another note" });
+	});
+
+	it("POSTs a resolve to the resolve route with the outcome", async () => {
+		stubFetch(() => Response.json({ data: { actionId: "oact_1", outcome: "granted" } }));
+		await fetchClient.resolveReconsideration("recon_1", {
+			outcome: "granted",
+			reason: "false positive",
+			idempotencyKey: input.idempotencyKey,
+		});
+		expect(calls[0]!.url).toBe("/admin/api/reconsiderations/recon_1/resolve");
+		expect(calls[0]!.init.method).toBe("POST");
+		expect(JSON.parse(calls[0]!.init.body as string).outcome).toBe("granted");
+	});
+
+	it("surfaces the server 409 open-exists message", async () => {
+		stubFetch(() =>
+			Response.json(
+				{
+					error: {
+						code: "RECONSIDERATION_OPEN_EXISTS",
+						message: "An open reconsideration already exists for this subject",
+					},
+				},
+				{ status: 409 },
+			),
+		);
+		await expect(
+			fetchClient.openReconsideration({
+				assessmentId: "asmt_target",
+				note: "n",
+				reason: "r",
+				idempotencyKey: input.idempotencyKey,
+			}),
+		).rejects.toThrow("An open reconsideration already exists for this subject");
+	});
+
+	it("surfaces the server 409 already-resolved message on a resolve", async () => {
+		stubFetch(() =>
+			Response.json(
+				{
+					error: {
+						code: "RECONSIDERATION_RESOLVED",
+						message: "Reconsideration is already resolved",
+					},
+				},
+				{ status: 409 },
+			),
+		);
+		await expect(
+			fetchClient.resolveReconsideration("recon_1", {
+				outcome: "denied",
+				reason: "r",
+				idempotencyKey: input.idempotencyKey,
+			}),
+		).rejects.toThrow("Reconsideration is already resolved");
 	});
 });

--- a/apps/labeler/console/src/api/client.ts
+++ b/apps/labeler/console/src/api/client.ts
@@ -4,6 +4,8 @@ import {
 	FIXTURE_FINDINGS_BY_ASSESSMENT,
 	FIXTURE_LABELS_BY_ASSESSMENT,
 	FIXTURE_OPERATOR_ACTIONS,
+	FIXTURE_RECONSIDERATION_DETAIL,
+	FIXTURE_RECONSIDERATIONS,
 	FIXTURE_SUBJECT_HISTORY,
 	FIXTURE_SYSTEM_STATUS,
 } from "../fixtures/index.js";
@@ -25,6 +27,7 @@ import type {
 	ListAssessmentsParams,
 	ListAuditLogParams,
 	ListDeadLettersParams,
+	ListReconsiderationsParams,
 	OperatorAction,
 	OverrideActionInput,
 	OverrideEffectPreviewParams,
@@ -32,6 +35,14 @@ import type {
 	OverrideRetractResult,
 	OperatorFinding,
 	Page,
+	ReconsiderationDetail,
+	ReconsiderationNoteInput,
+	ReconsiderationNoteResult,
+	ReconsiderationOpenInput,
+	ReconsiderationOpenResult,
+	ReconsiderationResolveInput,
+	ReconsiderationResolveResult,
+	ReconsiderationView,
 	RerunResult,
 	SubjectHistoryView,
 	SubjectLabel,
@@ -54,6 +65,8 @@ export interface LabelerConsoleClient {
 	getSubjectLabels(uri: string, cid?: string): Promise<SubjectLabel[]>;
 	listAuditLog(params?: ListAuditLogParams): Promise<Page<OperatorAction>>;
 	listDeadLetters(params?: ListDeadLettersParams): Promise<Page<DeadLetter>>;
+	listReconsiderations(params?: ListReconsiderationsParams): Promise<Page<ReconsiderationView>>;
+	getReconsideration(id: string): Promise<ReconsiderationDetail | null>;
 	getSystemStatus(): Promise<SystemStatusSnapshot>;
 	whoami(): Promise<WhoamiIdentity>;
 	previewEffect(params: EffectPreviewParams): Promise<EffectPreview>;
@@ -72,6 +85,15 @@ export interface LabelerConsoleClient {
 	resumeAutomation(input: AutomationToggleInput): Promise<AutomationToggleResult>;
 	retryDeadLetter(id: number, input: DeadLetterActionInput): Promise<DeadLetterActionResult>;
 	quarantineDeadLetter(id: number, input: DeadLetterActionInput): Promise<DeadLetterActionResult>;
+	openReconsideration(input: ReconsiderationOpenInput): Promise<ReconsiderationOpenResult>;
+	addReconsiderationNote(
+		id: string,
+		input: ReconsiderationNoteInput,
+	): Promise<ReconsiderationNoteResult>;
+	resolveReconsideration(
+		id: string,
+		input: ReconsiderationResolveInput,
+	): Promise<ReconsiderationResolveResult>;
 }
 
 /** The admin-only emergency endpoints, keyed by action and direction. */
@@ -182,6 +204,18 @@ export function createFetchClient(): LabelerConsoleClient {
 			const response = await consoleApiFetch(`/dead-letters?${search.toString()}`);
 			return parseJson(response, "Failed to load dead letters");
 		},
+		async listReconsiderations(params = {}) {
+			const search = new URLSearchParams();
+			if (params.cursor) search.set("cursor", params.cursor);
+			if (params.limit) search.set("limit", String(params.limit));
+			const response = await consoleApiFetch(`/reconsiderations?${search.toString()}`);
+			return parseJson(response, "Failed to load reconsiderations");
+		},
+		async getReconsideration(id) {
+			const response = await consoleApiFetch(`/reconsiderations/${encodeURIComponent(id)}`);
+			if (response.status === 404) return null;
+			return parseJson(response, "Failed to load reconsideration");
+		},
 		async getSystemStatus() {
 			const response = await consoleApiFetch("/status");
 			return parseJson(response, "Failed to load system status");
@@ -259,6 +293,23 @@ export function createFetchClient(): LabelerConsoleClient {
 				"Failed to quarantine dead letter",
 			);
 		},
+		async openReconsideration(input) {
+			return postAction("/reconsiderations/open", input, "Failed to open reconsideration");
+		},
+		async addReconsiderationNote(id, input) {
+			return postAction(
+				`/reconsiderations/${encodeURIComponent(id)}/note`,
+				input,
+				"Failed to add note",
+			);
+		},
+		async resolveReconsideration(id, input) {
+			return postAction(
+				`/reconsiderations/${encodeURIComponent(id)}/resolve`,
+				input,
+				"Failed to resolve reconsideration",
+			);
+		},
 	};
 }
 
@@ -293,6 +344,12 @@ export function createFixtureClient(): LabelerConsoleClient {
 		},
 		async listDeadLetters() {
 			return { items: [...FIXTURE_DEAD_LETTERS] };
+		},
+		async listReconsiderations() {
+			return { items: [...FIXTURE_RECONSIDERATIONS] };
+		},
+		async getReconsideration(id) {
+			return FIXTURE_RECONSIDERATION_DETAIL[id] ?? null;
 		},
 		async getSystemStatus() {
 			return FIXTURE_SYSTEM_STATUS;
@@ -408,6 +465,34 @@ export function createFixtureClient(): LabelerConsoleClient {
 				actionId: "oact_fixture",
 				deadLetterId: id,
 				status: "quarantined",
+				cts: new Date().toISOString(),
+			};
+		},
+		async openReconsideration(input) {
+			return {
+				actionId: "oact_fixture",
+				reconsiderationId: "recon_fixture",
+				uri: "at://did:plc:x/com.emdashcms.experimental.package.release/rk1",
+				cid: "bafyfixture",
+				triggeringAssessmentId: input.assessmentId,
+				cts: new Date().toISOString(),
+			};
+		},
+		async addReconsiderationNote(id) {
+			return {
+				actionId: "oact_fixture",
+				reconsiderationId: id,
+				noteId: "rnote_fixture",
+				cts: new Date().toISOString(),
+			};
+		},
+		async resolveReconsideration(id, input) {
+			return {
+				actionId: "oact_fixture",
+				reconsiderationId: id,
+				outcome: input.outcome,
+				uri: "at://did:plc:x/com.emdashcms.experimental.package.release/rk1",
+				cid: "bafyfixture",
 				cts: new Date().toISOString(),
 			};
 		},

--- a/apps/labeler/console/src/api/types.ts
+++ b/apps/labeler/console/src/api/types.ts
@@ -394,6 +394,116 @@ export interface DeadLetterActionResult {
 	cts: string;
 }
 
+/** A reconsideration case's lifecycle state (mirrors the server's
+ * `ReconsiderationState`). A case opens `open` and terminates `resolved`. */
+export type ReconsiderationState = "open" | "resolved";
+
+/** The terminal decision on a resolved case (mirrors the server's
+ * `ReconsiderationOutcome`). `withdrawn` fires no publisher notice. */
+export type ReconsiderationOutcome = "granted" | "denied" | "withdrawn";
+
+/**
+ * A reconsideration case from `GET /admin/api/reconsiderations` — mirrors the
+ * server's `serializeReconsideration`. Every field is operator-only (Access-edge
+ * + reviewer gated), including the actor provenance. Humans carry an email,
+ * service tokens a common name. `outcome`/`resolvedBy*`/`resolvedAt` are non-null
+ * only once resolved. */
+export interface ReconsiderationView {
+	id: string;
+	subjectUri: string;
+	subjectCid: string;
+	triggeringAssessmentId: string;
+	state: ReconsiderationState;
+	outcome: ReconsiderationOutcome | null;
+	openedById: string;
+	openedByEmail: string | null;
+	openedByCommonName: string | null;
+	openedByRole: OperatorRole;
+	openedAt: string;
+	resolvedById: string | null;
+	resolvedByEmail: string | null;
+	resolvedByCommonName: string | null;
+	resolvedAt: string | null;
+	outcomeActionId: string | null;
+}
+
+/** A private reconsideration note (mirrors `serializeReconsiderationNote`). The
+ * `note` text is operator-only and never enters publisher notice copy. */
+export interface ReconsiderationNoteView {
+	id: string;
+	reconsiderationId: string;
+	authorId: string;
+	authorEmail: string | null;
+	authorCommonName: string | null;
+	authorRole: OperatorRole;
+	note: string;
+	createdAt: string;
+}
+
+/** One case plus its private note thread (oldest-first) from
+ * `GET /admin/api/reconsiderations/:id`. */
+export interface ReconsiderationDetail {
+	reconsideration: ReconsiderationView;
+	notes: ReconsiderationNoteView[];
+}
+
+/** Body for `POST /admin/api/reconsiderations/open`. `note` is required
+ * non-empty (≤10000 chars); `idempotencyKey` is minted client-side (ULID) per
+ * dialog open and reused across retries so a network retry replays rather than
+ * double-opens. */
+export interface ReconsiderationOpenInput {
+	assessmentId: string;
+	note: string;
+	reason: string;
+	idempotencyKey: string;
+}
+
+/** Body for `POST /admin/api/reconsiderations/:id/note`. Allowed in any state. */
+export interface ReconsiderationNoteInput {
+	note: string;
+	reason: string;
+	idempotencyKey: string;
+}
+
+/** Body for `POST /admin/api/reconsiderations/:id/resolve`. `note` is an
+ * optional final note; the server rejects a resolve of an already-resolved case
+ * with a 409 `RECONSIDERATION_RESOLVED`. */
+export interface ReconsiderationResolveInput {
+	outcome: ReconsiderationOutcome;
+	note?: string;
+	reason: string;
+	idempotencyKey: string;
+}
+
+/** Idempotent open result — the new case's id and subject, plus the triggering
+ * assessment it was opened from. */
+export interface ReconsiderationOpenResult {
+	actionId: string;
+	reconsiderationId: string;
+	uri: string;
+	cid: string;
+	triggeringAssessmentId: string;
+	cts: string;
+}
+
+/** Idempotent note result — the appended note's id. */
+export interface ReconsiderationNoteResult {
+	actionId: string;
+	reconsiderationId: string;
+	noteId: string;
+	cts: string;
+}
+
+/** Idempotent resolve result — the case's terminal outcome and subject. */
+export interface ReconsiderationResolveResult {
+	actionId: string;
+	reconsiderationId: string;
+	outcome: ReconsiderationOutcome;
+	uri: string;
+	cid: string;
+	cts: string;
+}
+
 export interface ListAssessmentsParams {
 	state?: PublicAssessmentState;
 	cursor?: string;
@@ -406,6 +516,11 @@ export interface ListAuditLogParams {
 }
 
 export interface ListDeadLettersParams {
+	cursor?: string;
+	limit?: number;
+}
+
+export interface ListReconsiderationsParams {
 	cursor?: string;
 	limit?: number;
 }

--- a/apps/labeler/console/src/components/OpenReconsiderationDialog.test.tsx
+++ b/apps/labeler/console/src/components/OpenReconsiderationDialog.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { ASSESSMENT_GAMMA } from "../fixtures/index.js";
+import { renderRoute } from "../test/harness.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+const DETAIL_PATH = `/assessments/${ASSESSMENT_GAMMA.id}`;
+
+async function openTheDialog(): Promise<HTMLElement> {
+	renderRoute(DETAIL_PATH);
+	fireEvent.click(await screen.findByRole("button", { name: "Open reconsideration" }));
+	return screen.findByRole("alertdialog");
+}
+
+describe("OpenReconsiderationDialog (via AssessmentDetail)", () => {
+	it("opens a case for this assessment and navigates to the new case detail", async () => {
+		const open = vi.spyOn(apiClient, "openReconsideration").mockResolvedValue({
+			actionId: "oact_1",
+			reconsiderationId: "recon_new",
+			uri: ASSESSMENT_GAMMA.uri,
+			cid: ASSESSMENT_GAMMA.cid,
+			triggeringAssessmentId: ASSESSMENT_GAMMA.id,
+			cts: "",
+		});
+		const dialog = await openTheDialog();
+
+		fireEvent.change(
+			within(dialog).getByPlaceholderText("Why this assessment is being reconsidered"),
+			{ target: { value: "publisher appealed the block" } },
+		);
+		fireEvent.change(within(dialog).getByPlaceholderText("Why this case is being opened"), {
+			target: { value: "opening for review" },
+		});
+		fireEvent.click(within(dialog).getByRole("button", { name: "Open reconsideration" }));
+
+		await waitFor(() => {
+			expect(open).toHaveBeenCalledWith(
+				expect.objectContaining({
+					assessmentId: ASSESSMENT_GAMMA.id,
+					note: "publisher appealed the block",
+					reason: "opening for review",
+				}),
+			);
+		});
+		// Navigation lands on the new case; getReconsideration("recon_new") is absent
+		// from the fixtures, so the detail resolves not-found — proof we navigated.
+		expect(await screen.findByText("Reconsideration not found.")).toBeTruthy();
+	});
+
+	it("surfaces the server 409 open-exists message inline", async () => {
+		vi.spyOn(apiClient, "openReconsideration").mockRejectedValue(
+			new Error("An open reconsideration already exists for this subject"),
+		);
+		const dialog = await openTheDialog();
+
+		fireEvent.change(
+			within(dialog).getByPlaceholderText("Why this assessment is being reconsidered"),
+			{ target: { value: "note" } },
+		);
+		fireEvent.change(within(dialog).getByPlaceholderText("Why this case is being opened"), {
+			target: { value: "reason" },
+		});
+		fireEvent.click(within(dialog).getByRole("button", { name: "Open reconsideration" }));
+
+		expect(
+			await within(dialog).findByText("An open reconsideration already exists for this subject"),
+		).toBeTruthy();
+	});
+});

--- a/apps/labeler/console/src/components/OpenReconsiderationDialog.tsx
+++ b/apps/labeler/console/src/components/OpenReconsiderationDialog.tsx
@@ -1,0 +1,108 @@
+import { Button, Dialog, InputArea } from "@cloudflare/kumo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+
+interface OpenReconsiderationDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** The assessment whose subject the case is opened for. */
+	assessmentId: string;
+	subjectUri: string;
+	invalidateKeys: readonly (readonly unknown[])[];
+}
+
+/**
+ * Opens a reconsideration case for this assessment's subject, with a required
+ * first note and reason. There is no by-subject lookup — a subject that already
+ * has an open case surfaces the server's 409 inline. On success it navigates to
+ * the new case detail. The idempotency key is minted per open and reused across
+ * retries so a network retry replays rather than double-opens.
+ */
+export function OpenReconsiderationDialog({
+	open,
+	onOpenChange,
+	assessmentId,
+	subjectUri,
+	invalidateKeys,
+}: OpenReconsiderationDialogProps) {
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const [note, setNote] = useState("");
+	const [reason, setReason] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setNote("");
+		setReason("");
+	}, [open]);
+
+	const mutation = useMutation({
+		mutationFn: () => apiClient.openReconsideration({ assessmentId, note, reason, idempotencyKey }),
+		onSuccess: async (result) => {
+			await Promise.all(
+				invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+			);
+			onOpenChange(false);
+			await navigate({ to: "/reconsiderations/$id", params: { id: result.reconsiderationId } });
+		},
+	});
+
+	const canSubmit = note.trim().length > 0 && reason.trim().length > 0 && !mutation.isPending;
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange} role="alertdialog">
+			<Dialog className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto p-6" size="lg">
+				<Dialog.Title className="text-lg font-semibold">Open reconsideration</Dialog.Title>
+				<Dialog.Description className="break-all font-mono text-xs text-kumo-subtle">
+					{subjectUri}
+				</Dialog.Description>
+
+				<p className="text-sm text-kumo-subtle">
+					Opens a case to reconsider this release's assessment. A subject can have only one open
+					case at a time.
+				</p>
+
+				<InputArea
+					label="First note"
+					value={note}
+					onValueChange={setNote}
+					placeholder="Why this assessment is being reconsidered"
+				/>
+
+				<InputArea
+					label="Reason"
+					value={reason}
+					onValueChange={setReason}
+					placeholder="Why this case is being opened"
+				/>
+
+				{mutation.isError && (
+					<p className="text-sm text-kumo-danger">
+						{mutation.error instanceof Error ? mutation.error.message : "Action failed"}
+					</p>
+				)}
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+						Cancel
+					</Dialog.Close>
+					<Button
+						variant="primary"
+						disabled={!canSubmit}
+						onClick={() => {
+							mutation.mutate();
+						}}
+					>
+						{mutation.isPending ? "Submitting…" : "Open reconsideration"}
+					</Button>
+				</div>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/apps/labeler/console/src/components/ReconsiderationBadges.tsx
+++ b/apps/labeler/console/src/components/ReconsiderationBadges.tsx
@@ -1,0 +1,39 @@
+import { Badge } from "@cloudflare/kumo";
+
+import type { ReconsiderationOutcome, ReconsiderationState } from "../api/types.js";
+
+type BadgeVariant = "neutral" | "info" | "success" | "warning" | "error";
+
+const STATE_VARIANT: Record<ReconsiderationState, BadgeVariant> = {
+	open: "warning",
+	resolved: "neutral",
+};
+
+const STATE_LABEL: Record<ReconsiderationState, string> = {
+	open: "Open",
+	resolved: "Resolved",
+};
+
+const OUTCOME_VARIANT: Record<ReconsiderationOutcome, BadgeVariant> = {
+	granted: "success",
+	denied: "error",
+	withdrawn: "neutral",
+};
+
+const OUTCOME_LABEL: Record<ReconsiderationOutcome, string> = {
+	granted: "Granted",
+	denied: "Denied",
+	withdrawn: "Withdrawn",
+};
+
+export function ReconsiderationStateBadge({ state }: { state: ReconsiderationState }) {
+	return (
+		<Badge variant={STATE_VARIANT[state]} appearance="dot">
+			{STATE_LABEL[state]}
+		</Badge>
+	);
+}
+
+export function ReconsiderationOutcomeBadge({ outcome }: { outcome: ReconsiderationOutcome }) {
+	return <Badge variant={OUTCOME_VARIANT[outcome]}>{OUTCOME_LABEL[outcome]}</Badge>;
+}

--- a/apps/labeler/console/src/components/ReconsiderationDialogs.test.tsx
+++ b/apps/labeler/console/src/components/ReconsiderationDialogs.test.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { renderWithClient } from "../test/harness.js";
+import { ReconsiderationNoteDialog } from "./ReconsiderationNoteDialog.js";
+import { ReconsiderationResolveDialog } from "./ReconsiderationResolveDialog.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+const RECON_ID = "recon_test";
+const SUBJECT_URI = "at://did:plc:x/com.emdashcms.experimental.package.release/rk1";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("ReconsiderationNoteDialog", () => {
+	it("threads the note and reason, keeping submit disabled until both are set", async () => {
+		const addNote = vi
+			.spyOn(apiClient, "addReconsiderationNote")
+			.mockResolvedValue({
+				actionId: "oact_1",
+				reconsiderationId: RECON_ID,
+				noteId: "rnote_1",
+				cts: "",
+			});
+		renderWithClient(
+			<ReconsiderationNoteDialog
+				open
+				onOpenChange={() => {}}
+				reconsiderationId={RECON_ID}
+				subjectUri={SUBJECT_URI}
+				invalidateKeys={[]}
+			/>,
+		);
+
+		const submit = screen.getByRole("button", { name: "Add note" }) as HTMLButtonElement;
+		expect(submit.disabled).toBe(true);
+
+		fireEvent.change(screen.getByPlaceholderText("A private note for the case thread"), {
+			target: { value: "publisher contests the finding" },
+		});
+		expect(submit.disabled).toBe(true);
+		fireEvent.change(screen.getByPlaceholderText("Why this note is being recorded"), {
+			target: { value: "recording the dispute" },
+		});
+		expect(submit.disabled).toBe(false);
+		fireEvent.click(submit);
+
+		await waitFor(() => {
+			expect(addNote).toHaveBeenCalledWith(
+				RECON_ID,
+				expect.objectContaining({
+					note: "publisher contests the finding",
+					reason: "recording the dispute",
+				}),
+			);
+		});
+		expect(addNote.mock.calls[0]![1].idempotencyKey.length).toBeGreaterThan(0);
+	});
+
+	it("surfaces the server error message on failure", async () => {
+		vi.spyOn(apiClient, "addReconsiderationNote").mockRejectedValue(new Error("boom"));
+		renderWithClient(
+			<ReconsiderationNoteDialog
+				open
+				onOpenChange={() => {}}
+				reconsiderationId={RECON_ID}
+				subjectUri={SUBJECT_URI}
+				invalidateKeys={[]}
+			/>,
+		);
+		fireEvent.change(screen.getByPlaceholderText("A private note for the case thread"), {
+			target: { value: "note" },
+		});
+		fireEvent.change(screen.getByPlaceholderText("Why this note is being recorded"), {
+			target: { value: "reason" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+		expect(await screen.findByText("boom")).toBeTruthy();
+	});
+});
+
+describe("ReconsiderationResolveDialog", () => {
+	it("resolves with the default granted outcome and reason, threading an idempotency key", async () => {
+		const resolve = vi.spyOn(apiClient, "resolveReconsideration").mockResolvedValue({
+			actionId: "oact_1",
+			reconsiderationId: RECON_ID,
+			outcome: "granted",
+			uri: SUBJECT_URI,
+			cid: "bafy",
+			cts: "",
+		});
+		renderWithClient(
+			<ReconsiderationResolveDialog
+				open
+				onOpenChange={() => {}}
+				reconsiderationId={RECON_ID}
+				subjectUri={SUBJECT_URI}
+				invalidateKeys={[]}
+			/>,
+		);
+
+		const submit = screen.getByRole("button", { name: "Resolve" }) as HTMLButtonElement;
+		expect(submit.disabled).toBe(true);
+		fireEvent.change(screen.getByPlaceholderText("Why this outcome was reached"), {
+			target: { value: "finding confirmed as false positive" },
+		});
+		expect(submit.disabled).toBe(false);
+		fireEvent.click(submit);
+
+		await waitFor(() => {
+			expect(resolve).toHaveBeenCalledWith(
+				RECON_ID,
+				expect.objectContaining({
+					outcome: "granted",
+					reason: "finding confirmed as false positive",
+				}),
+			);
+		});
+		// No final note was entered, so the optional field is omitted from the body.
+		expect(resolve.mock.calls[0]![1].note).toBeUndefined();
+	});
+
+	it("includes the optional final note when entered", async () => {
+		const resolve = vi.spyOn(apiClient, "resolveReconsideration").mockResolvedValue({
+			actionId: "oact_1",
+			reconsiderationId: RECON_ID,
+			outcome: "granted",
+			uri: SUBJECT_URI,
+			cid: "bafy",
+			cts: "",
+		});
+		renderWithClient(
+			<ReconsiderationResolveDialog
+				open
+				onOpenChange={() => {}}
+				reconsiderationId={RECON_ID}
+				subjectUri={SUBJECT_URI}
+				invalidateKeys={[]}
+			/>,
+		);
+		fireEvent.change(screen.getByPlaceholderText("A closing note for the case thread"), {
+			target: { value: "closing note" },
+		});
+		fireEvent.change(screen.getByPlaceholderText("Why this outcome was reached"), {
+			target: { value: "reason" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
+
+		await waitFor(() => {
+			expect(resolve).toHaveBeenCalledWith(
+				RECON_ID,
+				expect.objectContaining({ note: "closing note" }),
+			);
+		});
+	});
+
+	it("surfaces the server 409 already-resolved message inline", async () => {
+		vi.spyOn(apiClient, "resolveReconsideration").mockRejectedValue(
+			new Error("Reconsideration is already resolved"),
+		);
+		renderWithClient(
+			<ReconsiderationResolveDialog
+				open
+				onOpenChange={() => {}}
+				reconsiderationId={RECON_ID}
+				subjectUri={SUBJECT_URI}
+				invalidateKeys={[]}
+			/>,
+		);
+		fireEvent.change(screen.getByPlaceholderText("Why this outcome was reached"), {
+			target: { value: "reason" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
+		expect(await screen.findByText("Reconsideration is already resolved")).toBeTruthy();
+	});
+});

--- a/apps/labeler/console/src/components/ReconsiderationNoteDialog.tsx
+++ b/apps/labeler/console/src/components/ReconsiderationNoteDialog.tsx
@@ -1,0 +1,101 @@
+import { Button, Dialog, InputArea } from "@cloudflare/kumo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+
+interface ReconsiderationNoteDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	reconsiderationId: string;
+	/** The case subject, shown for context. */
+	subjectUri: string;
+	/** TanStack Query keys to invalidate on success so the thread re-renders. */
+	invalidateKeys: readonly (readonly unknown[])[];
+}
+
+/**
+ * Appends one private note to a reconsideration case. A note is allowed in any
+ * state (a resolved case still accepts post-hoc audit notes). A required note
+ * body and reason gate submit; the idempotency key is minted per open and reused
+ * across retries so a network retry replays rather than double-appends.
+ */
+export function ReconsiderationNoteDialog({
+	open,
+	onOpenChange,
+	reconsiderationId,
+	subjectUri,
+	invalidateKeys,
+}: ReconsiderationNoteDialogProps) {
+	const queryClient = useQueryClient();
+	const [note, setNote] = useState("");
+	const [reason, setReason] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setNote("");
+		setReason("");
+	}, [open]);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			apiClient.addReconsiderationNote(reconsiderationId, { note, reason, idempotencyKey }),
+		onSuccess: async () => {
+			await Promise.all(
+				invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+			);
+			onOpenChange(false);
+		},
+	});
+
+	const canSubmit = note.trim().length > 0 && reason.trim().length > 0 && !mutation.isPending;
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange} role="alertdialog">
+			<Dialog className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto p-6" size="lg">
+				<Dialog.Title className="text-lg font-semibold">Add note</Dialog.Title>
+				<Dialog.Description className="break-all font-mono text-xs text-kumo-subtle">
+					{subjectUri}
+				</Dialog.Description>
+
+				<InputArea
+					label="Note"
+					value={note}
+					onValueChange={setNote}
+					placeholder="A private note for the case thread"
+				/>
+
+				<InputArea
+					label="Reason"
+					value={reason}
+					onValueChange={setReason}
+					placeholder="Why this note is being recorded"
+				/>
+
+				{mutation.isError && (
+					<p className="text-sm text-kumo-danger">
+						{mutation.error instanceof Error ? mutation.error.message : "Action failed"}
+					</p>
+				)}
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+						Cancel
+					</Dialog.Close>
+					<Button
+						variant="primary"
+						disabled={!canSubmit}
+						onClick={() => {
+							mutation.mutate();
+						}}
+					>
+						{mutation.isPending ? "Submitting…" : "Add note"}
+					</Button>
+				</div>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/apps/labeler/console/src/components/ReconsiderationResolveDialog.tsx
+++ b/apps/labeler/console/src/components/ReconsiderationResolveDialog.tsx
@@ -1,0 +1,137 @@
+import { Button, Dialog, InputArea, Select } from "@cloudflare/kumo";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ulid } from "ulidx";
+
+import { apiClient } from "../api/client.js";
+import type { ReconsiderationOutcome } from "../api/types.js";
+
+interface ReconsiderationResolveDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	reconsiderationId: string;
+	/** The case subject, shown for context. */
+	subjectUri: string;
+	invalidateKeys: readonly (readonly unknown[])[];
+}
+
+const OUTCOMES: readonly ReconsiderationOutcome[] = ["granted", "denied", "withdrawn"];
+
+const OUTCOME_LABEL: Record<ReconsiderationOutcome, string> = {
+	granted: "Granted",
+	denied: "Denied",
+	withdrawn: "Withdrawn",
+};
+
+const OUTCOME_HELP: Record<ReconsiderationOutcome, string> = {
+	granted: "The reconsideration succeeds — the publisher is notified of the granted outcome.",
+	denied: "The reconsideration is refused — the publisher is notified of the denied outcome.",
+	withdrawn: "The case is closed with no decision. No publisher notice is sent.",
+};
+
+/**
+ * Resolves an open reconsideration: an outcome (granted / denied / withdrawn),
+ * an optional final note, and a required reason. A `granted` / `denied` resolve
+ * fires the publisher outcome notice; `withdrawn` notifies nothing. The server
+ * rejects a resolve of an already-resolved case with a 409, surfaced inline.
+ */
+export function ReconsiderationResolveDialog({
+	open,
+	onOpenChange,
+	reconsiderationId,
+	subjectUri,
+	invalidateKeys,
+}: ReconsiderationResolveDialogProps) {
+	const queryClient = useQueryClient();
+	const [outcome, setOutcome] = useState<ReconsiderationOutcome>("granted");
+	const [note, setNote] = useState("");
+	const [reason, setReason] = useState("");
+	const [idempotencyKey, setIdempotencyKey] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		setIdempotencyKey(ulid());
+		setOutcome("granted");
+		setNote("");
+		setReason("");
+	}, [open]);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			apiClient.resolveReconsideration(reconsiderationId, {
+				outcome,
+				...(note.trim().length > 0 ? { note } : {}),
+				reason,
+				idempotencyKey,
+			}),
+		onSuccess: async () => {
+			await Promise.all(
+				invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+			);
+			onOpenChange(false);
+		},
+	});
+
+	const canSubmit = reason.trim().length > 0 && !mutation.isPending;
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange} role="alertdialog">
+			<Dialog className="flex max-h-[85vh] flex-col gap-4 overflow-y-auto p-6" size="lg">
+				<Dialog.Title className="text-lg font-semibold">Resolve reconsideration</Dialog.Title>
+				<Dialog.Description className="break-all font-mono text-xs text-kumo-subtle">
+					{subjectUri}
+				</Dialog.Description>
+
+				<Select
+					label="Outcome"
+					value={outcome}
+					onValueChange={(value) => {
+						if (value) setOutcome(value);
+					}}
+				>
+					{OUTCOMES.map((value) => (
+						<Select.Option key={value} value={value}>
+							{OUTCOME_LABEL[value]}
+						</Select.Option>
+					))}
+				</Select>
+				<p className="text-sm text-kumo-subtle">{OUTCOME_HELP[outcome]}</p>
+
+				<InputArea
+					label="Final note (optional)"
+					value={note}
+					onValueChange={setNote}
+					placeholder="A closing note for the case thread"
+				/>
+
+				<InputArea
+					label="Reason"
+					value={reason}
+					onValueChange={setReason}
+					placeholder="Why this outcome was reached"
+				/>
+
+				{mutation.isError && (
+					<p className="text-sm text-kumo-danger">
+						{mutation.error instanceof Error ? mutation.error.message : "Action failed"}
+					</p>
+				)}
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close render={(props) => <Button variant="secondary" {...props} />}>
+						Cancel
+					</Dialog.Close>
+					<Button
+						variant="primary"
+						disabled={!canSubmit}
+						onClick={() => {
+							mutation.mutate();
+						}}
+					>
+						{mutation.isPending ? "Submitting…" : "Resolve"}
+					</Button>
+				</div>
+			</Dialog>
+		</Dialog.Root>
+	);
+}

--- a/apps/labeler/console/src/components/Sidebar.tsx
+++ b/apps/labeler/console/src/components/Sidebar.tsx
@@ -1,5 +1,11 @@
 import { Sidebar as KumoSidebar, useSidebar } from "@cloudflare/kumo";
-import { ClockCounterClockwise, Envelope, ShieldCheck, SquaresFour } from "@phosphor-icons/react";
+import {
+	ClockCounterClockwise,
+	Envelope,
+	Scales,
+	ShieldCheck,
+	SquaresFour,
+} from "@phosphor-icons/react";
 import { useLocation } from "@tanstack/react-router";
 import * as React from "react";
 
@@ -43,6 +49,7 @@ export function SidebarNav() {
 		{ to: "/", label: "Dashboard", icon: SquaresFour },
 		{ to: "/assessments", label: "Assessments", icon: ShieldCheck },
 		{ to: "/dead-letters", label: "Dead letters", icon: Envelope },
+		{ to: "/reconsiderations", label: "Reconsiderations", icon: Scales },
 		{ to: "/audit", label: "Audit log", icon: ClockCounterClockwise },
 	];
 

--- a/apps/labeler/console/src/fixtures/index.ts
+++ b/apps/labeler/console/src/fixtures/index.ts
@@ -17,6 +17,12 @@ export {
 export { FIXTURE_DEAD_LETTERS } from "./dead-letters.js";
 export { FIXTURE_LABELS_BY_ASSESSMENT } from "./labels.js";
 export { FIXTURE_OPERATOR_ACTIONS } from "./operator-actions.js";
+export {
+	FIXTURE_RECONSIDERATION_DETAIL,
+	FIXTURE_RECONSIDERATIONS,
+	RECONSIDERATION_BETA_GRANTED,
+	RECONSIDERATION_GAMMA_OPEN,
+} from "./reconsiderations.js";
 export { FIXTURE_SUBJECT_HISTORY } from "./subject-history.js";
 export {
 	FIXTURE_SUBJECTS,

--- a/apps/labeler/console/src/fixtures/reconsiderations.ts
+++ b/apps/labeler/console/src/fixtures/reconsiderations.ts
@@ -1,0 +1,112 @@
+import type {
+	ReconsiderationDetail,
+	ReconsiderationNoteView,
+	ReconsiderationView,
+} from "../api/types.js";
+import { ASSESSMENT_BETA, ASSESSMENT_GAMMA } from "./assessments.js";
+import { SUBJECT_BETA, SUBJECT_GAMMA } from "./subjects.js";
+
+/** An open case for the blocked gamma release — a publisher has asked the
+ * reviewers to reconsider the malware finding. */
+export const RECONSIDERATION_GAMMA_OPEN: ReconsiderationView = {
+	id: "recon_01J9ZM8R3N5U9W1Y3T5X7Z9C2D",
+	subjectUri: SUBJECT_GAMMA.uri,
+	subjectCid: SUBJECT_GAMMA.cid,
+	triggeringAssessmentId: ASSESSMENT_GAMMA.id,
+	state: "open",
+	outcome: null,
+	openedById: "access|8f2c1a90-6b3d-4e57-9a12-77c0de9b4a11",
+	openedByEmail: "reviewer@emdashcms.com",
+	openedByCommonName: null,
+	openedByRole: "reviewer",
+	openedAt: "2026-07-13T10:05:00.000Z",
+	resolvedById: null,
+	resolvedByEmail: null,
+	resolvedByCommonName: null,
+	resolvedAt: null,
+	outcomeActionId: null,
+};
+
+/** A resolved (granted) case for the warned beta release. */
+export const RECONSIDERATION_BETA_GRANTED: ReconsiderationView = {
+	id: "recon_01J9YJ4G6P8R0T2V4X6Z8B0D3E",
+	subjectUri: SUBJECT_BETA.uri,
+	subjectCid: SUBJECT_BETA.cid,
+	triggeringAssessmentId: ASSESSMENT_BETA.id,
+	state: "resolved",
+	outcome: "granted",
+	openedById: "access|8f2c1a90-6b3d-4e57-9a12-77c0de9b4a11",
+	openedByEmail: "reviewer@emdashcms.com",
+	openedByCommonName: null,
+	openedByRole: "reviewer",
+	openedAt: "2026-07-12T09:00:00.000Z",
+	resolvedById: "access|2a7d4c31-9e02-4b18-b5f6-1c8e0a4f2b90",
+	resolvedByEmail: "admin@emdashcms.com",
+	resolvedByCommonName: null,
+	resolvedAt: "2026-07-12T15:30:00.000Z",
+	outcomeActionId: "oact_01J9YK5H7Q9S1U3W5Y7A9C1E4F",
+};
+
+const GAMMA_NOTES: ReconsiderationNoteView[] = [
+	{
+		id: "rnote_01J9ZM9A0B2C4E6G8J0M2P4R6T",
+		reconsiderationId: RECONSIDERATION_GAMMA_OPEN.id,
+		authorId: RECONSIDERATION_GAMMA_OPEN.openedById,
+		authorEmail: "reviewer@emdashcms.com",
+		authorCommonName: null,
+		authorRole: "reviewer",
+		note: "Publisher disputes the malware flag; says the payload is a security-research proof-of-concept.",
+		createdAt: "2026-07-13T10:05:00.000Z",
+	},
+	{
+		id: "rnote_01J9ZMB1C3D5F7H9K1N3Q5S7U",
+		reconsiderationId: RECONSIDERATION_GAMMA_OPEN.id,
+		authorId: "access|2a7d4c31-9e02-4b18-b5f6-1c8e0a4f2b90",
+		authorEmail: "admin@emdashcms.com",
+		authorCommonName: null,
+		authorRole: "admin",
+		note: "Re-running the scanner against the pinned artifact before deciding.",
+		createdAt: "2026-07-13T11:20:00.000Z",
+	},
+];
+
+const BETA_NOTES: ReconsiderationNoteView[] = [
+	{
+		id: "rnote_01J9YJ5B2D4F6H8K0M2P4R6T8V",
+		reconsiderationId: RECONSIDERATION_BETA_GRANTED.id,
+		authorId: RECONSIDERATION_BETA_GRANTED.openedById,
+		authorEmail: "reviewer@emdashcms.com",
+		authorCommonName: null,
+		authorRole: "reviewer",
+		note: "Low-quality packaging warning contested — the manifest was fixed in a follow-up release.",
+		createdAt: "2026-07-12T09:00:00.000Z",
+	},
+	{
+		id: "rnote_01J9YK6C3E5G7J9L1N3Q5S7U9W",
+		reconsiderationId: RECONSIDERATION_BETA_GRANTED.id,
+		authorId: "access|2a7d4c31-9e02-4b18-b5f6-1c8e0a4f2b90",
+		authorEmail: "admin@emdashcms.com",
+		authorCommonName: null,
+		authorRole: "admin",
+		note: "Confirmed the warning no longer applies. Granting.",
+		createdAt: "2026-07-12T15:30:00.000Z",
+	},
+];
+
+/** Newest first, matching the labeler's `getReconsiderationsPage` ordering. */
+export const FIXTURE_RECONSIDERATIONS: readonly ReconsiderationView[] = [
+	RECONSIDERATION_GAMMA_OPEN,
+	RECONSIDERATION_BETA_GRANTED,
+];
+
+/** Case detail (case + oldest-first note thread) keyed by case id. */
+export const FIXTURE_RECONSIDERATION_DETAIL: Record<string, ReconsiderationDetail> = {
+	[RECONSIDERATION_GAMMA_OPEN.id]: {
+		reconsideration: RECONSIDERATION_GAMMA_OPEN,
+		notes: GAMMA_NOTES,
+	},
+	[RECONSIDERATION_BETA_GRANTED.id]: {
+		reconsideration: RECONSIDERATION_BETA_GRANTED,
+		notes: BETA_NOTES,
+	},
+};

--- a/apps/labeler/console/src/reconsiderations.ts
+++ b/apps/labeler/console/src/reconsiderations.ts
@@ -1,0 +1,12 @@
+/**
+ * Presentation helper for reconsideration actor provenance. Humans carry an
+ * email, service tokens a common name; both fall back to the raw Access subject
+ * id so a row always renders someone.
+ */
+export function reconsiderationActorName(actor: {
+	email: string | null;
+	commonName: string | null;
+	id: string;
+}): string {
+	return actor.email ?? actor.commonName ?? actor.id;
+}

--- a/apps/labeler/console/src/router.tsx
+++ b/apps/labeler/console/src/router.tsx
@@ -7,6 +7,8 @@ import { auditLogRoute } from "./routes/AuditLog.js";
 import { dashboardRoute } from "./routes/Dashboard.js";
 import { deadLetterQueueRoute } from "./routes/DeadLetterQueue.js";
 import { notFoundRoute } from "./routes/NotFound.js";
+import { reconsiderationDetailRoute } from "./routes/ReconsiderationDetail.js";
+import { reconsiderationsRoute } from "./routes/Reconsiderations.js";
 import { rootRoute, shellRoute } from "./routes/root.js";
 import { subjectHistoryRoute } from "./routes/SubjectHistory.js";
 
@@ -17,6 +19,8 @@ const shellRoutes = shellRoute.addChildren([
 	subjectHistoryRoute,
 	auditLogRoute,
 	deadLetterQueueRoute,
+	reconsiderationsRoute,
+	reconsiderationDetailRoute,
 	notFoundRoute,
 ]);
 

--- a/apps/labeler/console/src/routes/AssessmentDetail.tsx
+++ b/apps/labeler/console/src/routes/AssessmentDetail.tsx
@@ -8,6 +8,7 @@ import type { IssuableLabel } from "../api/types.js";
 import { AssessmentActionDialog } from "../components/AssessmentActionDialog.js";
 import { FindingCard } from "../components/FindingCard.js";
 import { LabelActionDialog } from "../components/LabelActionDialog.js";
+import { OpenReconsiderationDialog } from "../components/OpenReconsiderationDialog.js";
 import { OverrideDialog } from "../components/OverrideDialog.js";
 import { QueryError } from "../components/QueryError.js";
 import { StateBadge } from "../components/StateBadge.js";
@@ -76,6 +77,7 @@ function AssessmentDetail() {
 	const [rerunOpen, setRerunOpen] = useState(false);
 	const [overrideOpen, setOverrideOpen] = useState(false);
 	const [overrideRetractOpen, setOverrideRetractOpen] = useState(false);
+	const [openReconOpen, setOpenReconOpen] = useState(false);
 
 	if (isAssessmentError) {
 		return <QueryError title="Failed to load assessment" error={assessmentError} />;
@@ -164,6 +166,9 @@ function AssessmentDetail() {
 				<div className="flex flex-wrap gap-2">
 					<Button variant="secondary" onClick={() => setRerunOpen(true)}>
 						Rerun
+					</Button>
+					<Button variant="secondary" onClick={() => setOpenReconOpen(true)}>
+						Open reconsideration
 					</Button>
 					{activeBlocks.length > 0 && (
 						<Button variant="secondary" onClick={() => setOverrideOpen(true)}>
@@ -283,6 +288,13 @@ function AssessmentDetail() {
 						subjectUri={assessment.uri}
 						subjectCid={assessment.cid}
 						invalidateKeys={actionInvalidateKeys}
+					/>
+					<OpenReconsiderationDialog
+						open={openReconOpen}
+						onOpenChange={setOpenReconOpen}
+						assessmentId={id}
+						subjectUri={assessment.uri}
+						invalidateKeys={[["reconsiderations"]]}
 					/>
 				</>
 			)}

--- a/apps/labeler/console/src/routes/ReconsiderationDetail.tsx
+++ b/apps/labeler/console/src/routes/ReconsiderationDetail.tsx
@@ -1,0 +1,194 @@
+import { Badge, Button, LayerCard, Loader } from "@cloudflare/kumo";
+import { useQuery } from "@tanstack/react-query";
+import { createRoute, Link } from "@tanstack/react-router";
+import { useState, type ReactNode } from "react";
+
+import { apiClient } from "../api/client.js";
+import type { ReconsiderationNoteView } from "../api/types.js";
+import { QueryError } from "../components/QueryError.js";
+import {
+	ReconsiderationOutcomeBadge,
+	ReconsiderationStateBadge,
+} from "../components/ReconsiderationBadges.js";
+import { ReconsiderationNoteDialog } from "../components/ReconsiderationNoteDialog.js";
+import { ReconsiderationResolveDialog } from "../components/ReconsiderationResolveDialog.js";
+import { reconsiderationActorName } from "../reconsiderations.js";
+import { shellRoute } from "./root.js";
+
+function MetaRow({ label, value }: { label: string; value: ReactNode }) {
+	return (
+		<div className="flex flex-col gap-0.5">
+			<span className="text-xs text-kumo-subtle">{label}</span>
+			<span className="text-sm">{value}</span>
+		</div>
+	);
+}
+
+function NoteCard({ note }: { note: ReconsiderationNoteView }) {
+	return (
+		<LayerCard className="flex flex-col gap-2 p-4">
+			<div className="flex items-center gap-2">
+				<span className="text-sm font-medium">
+					{reconsiderationActorName({
+						email: note.authorEmail,
+						commonName: note.authorCommonName,
+						id: note.authorId,
+					})}
+				</span>
+				<Badge variant="neutral">{note.authorRole}</Badge>
+				<span className="text-xs text-kumo-subtle">
+					{new Date(note.createdAt).toLocaleString()}
+				</span>
+			</div>
+			<p className="whitespace-pre-wrap text-sm">{note.note}</p>
+		</LayerCard>
+	);
+}
+
+function ReconsiderationDetail() {
+	const { id } = reconsiderationDetailRoute.useParams();
+
+	const { data, isLoading, isError, error } = useQuery({
+		queryKey: ["reconsideration", id],
+		queryFn: () => apiClient.getReconsideration(id),
+	});
+	const { data: whoami } = useQuery({ queryKey: ["whoami"], queryFn: () => apiClient.whoami() });
+	const canAct = whoami?.roles.includes("reviewer") || whoami?.roles.includes("admin") || false;
+
+	const [noteOpen, setNoteOpen] = useState(false);
+	const [resolveOpen, setResolveOpen] = useState(false);
+
+	if (isError) {
+		return <QueryError title="Failed to load reconsideration" error={error} />;
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center py-16">
+				<Loader />
+			</div>
+		);
+	}
+
+	// A successful query that resolved to null is a genuine not-found, distinct
+	// from isError above -- that branch already returned.
+	if (!data) {
+		return (
+			<div className="p-8 text-center text-sm text-kumo-subtle">Reconsideration not found.</div>
+		);
+	}
+
+	const { reconsideration: recon, notes } = data;
+	const isOpen = recon.state === "open";
+	const invalidateKeys: readonly (readonly unknown[])[] = [
+		["reconsideration", id],
+		["reconsiderations"],
+	];
+
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex flex-col gap-2">
+				<div className="flex items-center gap-2">
+					<h1 className="text-xl font-semibold">Reconsideration</h1>
+					<ReconsiderationStateBadge state={recon.state} />
+					{recon.outcome && <ReconsiderationOutcomeBadge outcome={recon.outcome} />}
+				</div>
+				<span className="break-all font-mono text-sm text-kumo-subtle">{recon.subjectUri}</span>
+				<p className="text-sm text-kumo-subtle">
+					CID: <span className="font-mono">{recon.subjectCid}</span>
+				</p>
+			</div>
+
+			<LayerCard className="grid grid-cols-2 gap-4 p-4 md:grid-cols-4">
+				<MetaRow
+					label="Triggering assessment"
+					value={
+						<Link
+							to="/assessments/$id"
+							params={{ id: recon.triggeringAssessmentId }}
+							className="break-all font-mono text-kumo-link hover:underline"
+						>
+							{recon.triggeringAssessmentId}
+						</Link>
+					}
+				/>
+				<MetaRow
+					label="Opened by"
+					value={reconsiderationActorName({
+						email: recon.openedByEmail,
+						commonName: recon.openedByCommonName,
+						id: recon.openedById,
+					})}
+				/>
+				<MetaRow label="Opened at" value={new Date(recon.openedAt).toLocaleString()} />
+				<MetaRow
+					label="Resolved by"
+					value={
+						recon.resolvedAt
+							? reconsiderationActorName({
+									email: recon.resolvedByEmail,
+									commonName: recon.resolvedByCommonName,
+									id: recon.resolvedById ?? "",
+								})
+							: "—"
+					}
+				/>
+				<MetaRow
+					label="Resolved at"
+					value={recon.resolvedAt ? new Date(recon.resolvedAt).toLocaleString() : "—"}
+				/>
+			</LayerCard>
+
+			{canAct && (
+				<div className="flex flex-wrap gap-2">
+					<Button variant="secondary" onClick={() => setNoteOpen(true)}>
+						Add note
+					</Button>
+					{isOpen && (
+						<Button variant="primary" onClick={() => setResolveOpen(true)}>
+							Resolve
+						</Button>
+					)}
+				</div>
+			)}
+
+			<section className="flex flex-col gap-3">
+				<h2 className="text-lg font-semibold">Notes</h2>
+				{notes.length === 0 ? (
+					<p className="text-sm text-kumo-subtle">No notes on this case.</p>
+				) : (
+					<div className="flex flex-col gap-3">
+						{notes.map((note) => (
+							<NoteCard key={note.id} note={note} />
+						))}
+					</div>
+				)}
+			</section>
+
+			{canAct && (
+				<>
+					<ReconsiderationNoteDialog
+						open={noteOpen}
+						onOpenChange={setNoteOpen}
+						reconsiderationId={id}
+						subjectUri={recon.subjectUri}
+						invalidateKeys={invalidateKeys}
+					/>
+					<ReconsiderationResolveDialog
+						open={resolveOpen}
+						onOpenChange={setResolveOpen}
+						reconsiderationId={id}
+						subjectUri={recon.subjectUri}
+						invalidateKeys={invalidateKeys}
+					/>
+				</>
+			)}
+		</div>
+	);
+}
+
+export const reconsiderationDetailRoute = createRoute({
+	getParentRoute: () => shellRoute,
+	path: "/reconsiderations/$id",
+	component: ReconsiderationDetail,
+});

--- a/apps/labeler/console/src/routes/Reconsiderations.tsx
+++ b/apps/labeler/console/src/routes/Reconsiderations.tsx
@@ -1,0 +1,117 @@
+import { LayerCard, Loader, Table } from "@cloudflare/kumo";
+import { useQuery } from "@tanstack/react-query";
+import { createRoute, Link } from "@tanstack/react-router";
+
+import { apiClient } from "../api/client.js";
+import { QueryError } from "../components/QueryError.js";
+import {
+	ReconsiderationOutcomeBadge,
+	ReconsiderationStateBadge,
+} from "../components/ReconsiderationBadges.js";
+import { reconsiderationActorName } from "../reconsiderations.js";
+import { shellRoute } from "./root.js";
+
+function Reconsiderations() {
+	const { data, isLoading, isError, error } = useQuery({
+		queryKey: ["reconsiderations"],
+		queryFn: () => apiClient.listReconsiderations(),
+	});
+
+	return (
+		<div className="flex flex-col gap-4">
+			<h1 className="text-xl font-semibold">Reconsiderations</h1>
+			<p className="text-sm text-kumo-subtle">
+				Cases where a publisher has asked reviewers to reconsider an assessment. Open a case from an
+				assessment; resolve it granted, denied, or withdrawn.
+			</p>
+
+			{isError ? (
+				<QueryError title="Failed to load reconsiderations" error={error} />
+			) : (
+				<LayerCard className="p-0">
+					{isLoading || !data ? (
+						<div className="flex items-center justify-center py-16">
+							<Loader />
+						</div>
+					) : data.items.length === 0 ? (
+						<div className="p-8 text-center text-sm text-kumo-subtle">No reconsiderations.</div>
+					) : (
+						<Table>
+							<Table.Header>
+								<Table.Row>
+									<Table.Head>Subject</Table.Head>
+									<Table.Head>State</Table.Head>
+									<Table.Head>Outcome</Table.Head>
+									<Table.Head>Opened</Table.Head>
+									<Table.Head>Resolved</Table.Head>
+								</Table.Row>
+							</Table.Header>
+							<Table.Body>
+								{data.items.map((recon) => (
+									<Table.Row key={recon.id}>
+										<Table.Cell>
+											<Link
+												to="/reconsiderations/$id"
+												params={{ id: recon.id }}
+												className="font-mono font-medium text-kumo-link hover:underline"
+												title={recon.subjectUri}
+											>
+												{recon.subjectUri.split("/").pop()}
+											</Link>
+										</Table.Cell>
+										<Table.Cell>
+											<ReconsiderationStateBadge state={recon.state} />
+										</Table.Cell>
+										<Table.Cell>
+											{recon.outcome ? (
+												<ReconsiderationOutcomeBadge outcome={recon.outcome} />
+											) : (
+												<span className="text-sm text-kumo-subtle">—</span>
+											)}
+										</Table.Cell>
+										<Table.Cell>
+											<span className="block text-sm">
+												{reconsiderationActorName({
+													email: recon.openedByEmail,
+													commonName: recon.openedByCommonName,
+													id: recon.openedById,
+												})}
+											</span>
+											<span className="block text-sm text-kumo-subtle">
+												{new Date(recon.openedAt).toLocaleString()}
+											</span>
+										</Table.Cell>
+										<Table.Cell>
+											{recon.resolvedAt ? (
+												<>
+													<span className="block text-sm">
+														{reconsiderationActorName({
+															email: recon.resolvedByEmail,
+															commonName: recon.resolvedByCommonName,
+															id: recon.resolvedById ?? "",
+														})}
+													</span>
+													<span className="block text-sm text-kumo-subtle">
+														{new Date(recon.resolvedAt).toLocaleString()}
+													</span>
+												</>
+											) : (
+												<span className="text-sm text-kumo-subtle">—</span>
+											)}
+										</Table.Cell>
+									</Table.Row>
+								))}
+							</Table.Body>
+						</Table>
+					)}
+				</LayerCard>
+			)}
+		</div>
+	);
+}
+
+export const reconsiderationsRoute = createRoute({
+	getParentRoute: () => shellRoute,
+	path: "/reconsiderations",
+	component: Reconsiderations,
+});

--- a/apps/labeler/console/src/test/axe.test.tsx
+++ b/apps/labeler/console/src/test/axe.test.tsx
@@ -9,7 +9,9 @@ import { DeadLetterActions } from "../components/DeadLetterActions.js";
 import { EmergencyActionDialog } from "../components/EmergencyActionDialog.js";
 import { LabelActionDialog } from "../components/LabelActionDialog.js";
 import { OverrideDialog } from "../components/OverrideDialog.js";
-import { ASSESSMENT_GAMMA, SUBJECT_ALPHA } from "../fixtures/index.js";
+import { ReconsiderationNoteDialog } from "../components/ReconsiderationNoteDialog.js";
+import { ReconsiderationResolveDialog } from "../components/ReconsiderationResolveDialog.js";
+import { ASSESSMENT_GAMMA, RECONSIDERATION_GAMMA_OPEN, SUBJECT_ALPHA } from "../fixtures/index.js";
 import { RELEASE_ISSUABLE_LABELS } from "../labels.js";
 import { ADMIN_IDENTITY, renderRoute, renderWithClient } from "./harness.js";
 
@@ -76,6 +78,20 @@ describe("axe: routes", () => {
 		const { container } = renderRoute("/dead-letters");
 		await screen.findByRole("heading", { name: "Dead-letter queue", level: 1 });
 		await screen.findByRole("button", { name: "Retry" });
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("Reconsiderations", async () => {
+		const { container } = renderRoute("/reconsiderations");
+		await screen.findByRole("heading", { name: "Reconsiderations", level: 1 });
+		await screen.findByRole("table");
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("ReconsiderationDetail", async () => {
+		const { container } = renderRoute(`/reconsiderations/${RECONSIDERATION_GAMMA_OPEN.id}`);
+		await screen.findByRole("heading", { name: "Reconsideration", level: 1 });
+		await screen.findByRole("button", { name: "Resolve" });
 		expect(await axe(container)).toHaveNoViolations();
 	});
 
@@ -159,5 +175,31 @@ describe("axe: dialogs", () => {
 		const panel = await screen.findByRole("alertdialog");
 		await within(panel).findByText("Retry dead letter");
 		expect(await axe(panel)).toHaveNoViolations();
+	});
+
+	it("ReconsiderationNoteDialog", async () => {
+		renderWithClient(
+			<ReconsiderationNoteDialog
+				open
+				onOpenChange={() => {}}
+				reconsiderationId="recon_1"
+				subjectUri={RELEASE_URI}
+				invalidateKeys={[]}
+			/>,
+		);
+		await expectDialogClean("alertdialog");
+	});
+
+	it("ReconsiderationResolveDialog", async () => {
+		renderWithClient(
+			<ReconsiderationResolveDialog
+				open
+				onOpenChange={() => {}}
+				reconsiderationId="recon_1"
+				subjectUri={RELEASE_URI}
+				invalidateKeys={[]}
+			/>,
+		);
+		await expectDialogClean("alertdialog");
 	});
 });

--- a/apps/labeler/console/src/test/harness.tsx
+++ b/apps/labeler/console/src/test/harness.tsx
@@ -11,6 +11,8 @@ import { auditLogRoute } from "../routes/AuditLog.js";
 import { dashboardRoute } from "../routes/Dashboard.js";
 import { deadLetterQueueRoute } from "../routes/DeadLetterQueue.js";
 import { notFoundRoute } from "../routes/NotFound.js";
+import { reconsiderationDetailRoute } from "../routes/ReconsiderationDetail.js";
+import { reconsiderationsRoute } from "../routes/Reconsiderations.js";
 import { rootRoute, shellRoute } from "../routes/root.js";
 import { subjectHistoryRoute } from "../routes/SubjectHistory.js";
 
@@ -22,6 +24,8 @@ const routeTree = rootRoute.addChildren([
 		subjectHistoryRoute,
 		auditLogRoute,
 		deadLetterQueueRoute,
+		reconsiderationsRoute,
+		reconsiderationDetailRoute,
 		notFoundRoute,
 	]),
 ]);

--- a/apps/labeler/console/src/test/keyboard.test.tsx
+++ b/apps/labeler/console/src/test/keyboard.test.tsx
@@ -10,6 +10,8 @@ import { DeadLetterActions } from "../components/DeadLetterActions.js";
 import { EmergencyActionDialog } from "../components/EmergencyActionDialog.js";
 import { LabelActionDialog } from "../components/LabelActionDialog.js";
 import { OverrideDialog } from "../components/OverrideDialog.js";
+import { ReconsiderationNoteDialog } from "../components/ReconsiderationNoteDialog.js";
+import { ReconsiderationResolveDialog } from "../components/ReconsiderationResolveDialog.js";
 import { RELEASE_ISSUABLE_LABELS } from "../labels.js";
 import { renderWithClient } from "./harness.js";
 
@@ -111,6 +113,30 @@ const CASES: {
 				subjectUri={RELEASE_URI}
 				subjectCid="bafyfixture"
 				issuable={RELEASE_ISSUABLE_LABELS}
+				invalidateKeys={[]}
+			/>
+		),
+	},
+	{
+		name: "ReconsiderationNoteDialog",
+		role: "alertdialog",
+		build: (props) => (
+			<ReconsiderationNoteDialog
+				{...props}
+				reconsiderationId="recon_1"
+				subjectUri={RELEASE_URI}
+				invalidateKeys={[]}
+			/>
+		),
+	},
+	{
+		name: "ReconsiderationResolveDialog",
+		role: "alertdialog",
+		build: (props) => (
+			<ReconsiderationResolveDialog
+				{...props}
+				reconsiderationId="recon_1"
+				subjectUri={RELEASE_URI}
 				invalidateKeys={[]}
 			/>
 		),

--- a/apps/labeler/console/src/test/reconsiderations.test.tsx
+++ b/apps/labeler/console/src/test/reconsiderations.test.tsx
@@ -1,0 +1,74 @@
+import { screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "../api/client.js";
+import { RECONSIDERATION_BETA_GRANTED, RECONSIDERATION_GAMMA_OPEN } from "../fixtures/index.js";
+import { renderRoute, REVIEWER_IDENTITY } from "./harness.js";
+
+vi.mock("../api/client.js", async () => {
+	const actual = await vi.importActual<typeof import("../api/client.js")>("../api/client.js");
+	return { ...actual, apiClient: actual.createFixtureClient() };
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Reconsiderations list", () => {
+	it("renders a case per row with its state and outcome, linking to the detail", async () => {
+		renderRoute("/reconsiderations");
+		await screen.findByRole("heading", { name: "Reconsiderations", level: 1 });
+		const table = await screen.findByRole("table");
+
+		const openLink = within(table).getByRole("link", {
+			name: RECONSIDERATION_GAMMA_OPEN.subjectUri.split("/").pop(),
+		});
+		expect(openLink.getAttribute("href")).toContain(
+			`/reconsiderations/${RECONSIDERATION_GAMMA_OPEN.id}`,
+		);
+		expect(within(table).getByText("Open")).toBeTruthy();
+		expect(within(table).getByText("Granted")).toBeTruthy();
+	});
+
+	it("shows the empty state when there are no cases", async () => {
+		vi.spyOn(apiClient, "listReconsiderations").mockResolvedValue({ items: [] });
+		renderRoute("/reconsiderations");
+		await screen.findByRole("heading", { name: "Reconsiderations", level: 1 });
+		expect(await screen.findByText("No reconsiderations.")).toBeTruthy();
+	});
+});
+
+describe("Reconsideration detail", () => {
+	it("shows the note thread and offers Resolve for an open case", async () => {
+		vi.spyOn(apiClient, "whoami").mockResolvedValue(REVIEWER_IDENTITY);
+		renderRoute(`/reconsiderations/${RECONSIDERATION_GAMMA_OPEN.id}`);
+		await screen.findByRole("heading", { name: "Reconsideration", level: 1 });
+
+		expect(await screen.findByRole("button", { name: "Add note" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Resolve" })).toBeTruthy();
+		expect(screen.getByText(/Publisher disputes the malware flag/)).toBeTruthy();
+		// The triggering assessment cross-links to its detail.
+		const link = screen.getByRole("link", {
+			name: RECONSIDERATION_GAMMA_OPEN.triggeringAssessmentId,
+		});
+		expect(link.getAttribute("href")).toContain(
+			`/assessments/${RECONSIDERATION_GAMMA_OPEN.triggeringAssessmentId}`,
+		);
+	});
+
+	it("hides Resolve for a resolved case and shows its outcome", async () => {
+		vi.spyOn(apiClient, "whoami").mockResolvedValue(REVIEWER_IDENTITY);
+		renderRoute(`/reconsiderations/${RECONSIDERATION_BETA_GRANTED.id}`);
+		await screen.findByRole("heading", { name: "Reconsideration", level: 1 });
+
+		await screen.findByRole("button", { name: "Add note" });
+		expect(screen.queryByRole("button", { name: "Resolve" })).toBeNull();
+		expect(screen.getByText("Granted")).toBeTruthy();
+	});
+
+	it("renders a not-found state for an unknown case id", async () => {
+		vi.spyOn(apiClient, "getReconsideration").mockResolvedValue(null);
+		renderRoute("/reconsiderations/recon_missing");
+		expect(await screen.findByText("Reconsideration not found.")).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds the **operator console UI** (slice 2) for the W10.6 reconsideration workflow, over the slice-1 server API merged in #2083. Targets the `feat/plugin-registry-labelling-service` integration branch. Console-only — no server changes.

The workflow is operator-side (no authenticated appeals portal, per the plan). This PR gives operators the surface to run it:

- **Reconsiderations list route** — keyset-paginated cases with subject, state, outcome, and open/resolve provenance; rows link to the case detail.
- **Case detail** — the header (subject, state, outcome, triggering assessment), the private note thread (oldest-first, attributed), an **Add note** action, and — while the case is `open` — a **Resolve** action (outcome granted/denied/withdrawn + optional final note + required reason). The resolve dialog spells out that `withdrawn` sends no publisher notice.
- **"Open reconsideration"** on the assessment detail view — opens a case for that assessment's subject. There is no by-subject lookup API, so the UX is attempt-and-surface: a `409 RECONSIDERATION_OPEN_EXISTS` renders inline ("an open reconsideration already exists for this subject"). A `409 RECONSIDERATION_RESOLVED` on resolve surfaces inline too.

All of it reuses the console's existing seams: the shared `consoleApiFetch`/`postAction` helpers (CSRF header + JSON + credentials), the per-open `ulid()` idempotency key minted the same way as the other action dialogs, the TanStack Query `invalidateKeys` + dialog-per-action pattern, and the existing mutation-error surface. Client types mirror the slice-1 serializers field-for-field.

Part of #1909. Follows #2083.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (including the console project)
- [x] `pnpm lint` passes (0 diagnostics on touched files)
- [x] `pnpm test` passes (136 console tests, up from 100; includes the new routes/dialogs, both 409 paths, axe, and keyboard focus-trap)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: this is the labeler operator console (`apps/labeler/console`), a separate SPA that is not yet localized (per the W10.6 plan status); it uses plain-English strings matching the existing console routes (AuditLog/DeadLetterQueue/AssessmentDetail). No `packages/admin` catalogs touched. RTL-safe logical Tailwind classes throughout (the console's auto-scanning rtl-safety test covers the new files).
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — **n/a**: `@emdash-cms/labeler` is `private: true`.
- [x] New features link to an approved Discussion — the umbrella #1909 tracks RFC #694; this is one slice under it.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation), orchestrated + reviewed by **Claude Fable 5**

## Screenshots / test output

```
Test Files  15 passed (15)
     Tests  136 passed (136)
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-reconsideration-console-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-reconsideration-console`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
