### PR TITLE
Prevent byline action overflow in the content settings panel

### DIFF
--- a/.changeset/quiet-dragons-wrap.md
+++ b/.changeset/quiet-dragons-wrap.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Keep byline identity and action controls contained within narrow content editor settings panels.

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -820,15 +820,12 @@ function BylineCreditsEditor({
 						if (!byline) return null;
 						return (
 							<div key={`${credit.bylineId}-${index}`} className="rounded-lg border p-2 space-y-2">
-								<div
-									className="grid items-start gap-2"
-									style={{ gridTemplateColumns: "minmax(0, 1fr) auto" }}
-								>
+								<div className="grid min-w-0 items-start gap-2">
 									<div className="min-w-0">
 										<p className="truncate text-sm font-medium">{byline.displayName}</p>
 										<p className="truncate text-xs text-kumo-subtle">{byline.slug}</p>
 									</div>
-									<div className="flex shrink-0 gap-1">
+									<div className="flex min-w-0 flex-wrap gap-1">
 										<Button type="button" variant="ghost" size="sm" onClick={() => move(index, -1)}>
 											{t`Up`}
 										</Button>

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -1603,30 +1603,5 @@ describe("ContentEditor", () => {
 
 			await expect.element(screen.getByText("Ada Lovelace")).toBeInTheDocument();
 		});
-
-		it("keeps credited byline actions inside the settings panel", async () => {
-			const credited = makeByline({ id: "b-layout", slug: "ada", displayName: "Ada Lovelace" });
-			const item = makeItem({
-				data: { title: "Hello", body: "" },
-				bylines: [{ byline: credited, sortOrder: 0, roleLabel: "Author" }],
-			});
-
-			const screen = await renderEditor({
-				isNew: false,
-				item,
-				currentUser: { id: "u-1", role: 50 },
-				availableBylines: [credited],
-				availableBylinesLoaded: true,
-			});
-
-			const actionRow = screen.getByRole("button", { name: "Up" }).element().parentElement;
-			expect(actionRow?.className).toContain("flex-wrap");
-			expect(actionRow?.className).toContain("min-w-0");
-			expect(actionRow?.className).not.toContain("shrink-0");
-
-			const creditHeader = actionRow?.parentElement;
-			expect(creditHeader?.className).toContain("min-w-0");
-			expect(creditHeader?.style.gridTemplateColumns).toBe("");
-		});
 	});
 });

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -1603,5 +1603,30 @@ describe("ContentEditor", () => {
 
 			await expect.element(screen.getByText("Ada Lovelace")).toBeInTheDocument();
 		});
+
+		it("keeps credited byline actions inside the settings panel", async () => {
+			const credited = makeByline({ id: "b-layout", slug: "ada", displayName: "Ada Lovelace" });
+			const item = makeItem({
+				data: { title: "Hello", body: "" },
+				bylines: [{ byline: credited, sortOrder: 0, roleLabel: "Author" }],
+			});
+
+			const screen = await renderEditor({
+				isNew: false,
+				item,
+				currentUser: { id: "u-1", role: 50 },
+				availableBylines: [credited],
+				availableBylinesLoaded: true,
+			});
+
+			const actionRow = screen.getByRole("button", { name: "Up" }).element().parentElement;
+			expect(actionRow?.className).toContain("flex-wrap");
+			expect(actionRow?.className).toContain("min-w-0");
+			expect(actionRow?.className).not.toContain("shrink-0");
+
+			const creditHeader = actionRow?.parentElement;
+			expect(creditHeader?.className).toContain("min-w-0");
+			expect(creditHeader?.style.gridTemplateColumns).toBe("");
+		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Keeps credited byline controls inside the content editor settings panel at narrow sidebar widths.

The editor redesign in #1924 places the byline identity and all four text actions in a fixed two-column row. The action group cannot shrink or wrap, so translated labels and ordinary narrow settings panels can overlap the byline identity and extend outside the panel.

This follow-up stacks the identity and action group, lets actions wrap, and preserves the existing Kumo buttons, action order, and translated labels.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Targeted admin typecheck passes
- [x] Targeted changed-file lint passes
- [x] Regression coverage is included
- [x] Formatting has been run
- [x] I have added/updated tests for my changes
- [x] No new user-visible strings were added
- [x] I have added a changeset
- [x] This is a bug fix and does not require a feature Discussion

## Why

- Prevents settings-panel controls from becoming unreadable or unclickable at normal narrow editor widths.
- Keeps the fix generic to EmDash; no site-specific CSS or DOM bridge is involved.
- Adds regression coverage for the responsive layout contract.

## Validation

- `pnpm --filter @emdash-cms/admin... build`
- Admin `tsgo --noEmit`
- Changed-file `oxfmt --check`
- Changed-file `oxlint --type-aware --deny-warnings`
- Browser-mode regression coverage added; CI provides the browser runtime.
