### PR TITLE
feat(labeler): code-AI and history stage wiring + dead-stage removal (slice A)

### DIFF
--- a/apps/labeler/package.json
+++ b/apps/labeler/package.json
@@ -30,6 +30,7 @@
 		"@atcute/lexicons": "catalog:",
 		"@atcute/repo": "catalog:",
 		"@atcute/xrpc-server": "catalog:",
+		"@emdash-cms/plugin-types": "workspace:*",
 		"@emdash-cms/registry-lexicons": "workspace:*",
 		"@emdash-cms/registry-moderation": "workspace:*",
 		"@emdash-cms/registry-verification": "workspace:*",

--- a/apps/labeler/src/assessment-orchestrator.ts
+++ b/apps/labeler/src/assessment-orchestrator.ts
@@ -79,8 +79,6 @@ export type StageAdapter = (ctx: StageContext) => Promise<readonly StageFinding[
 
 export interface OrchestratorStages {
 	acquire: StageAdapter;
-	deterministic: StageAdapter;
-	dependency: StageAdapter;
 	codeAi: StageAdapter;
 	imageAi: StageAdapter;
 	/** Publisher-history context (plan W8.4). Runs last: its findings are
@@ -92,14 +90,7 @@ export interface OrchestratorStages {
 	history: StageAdapter;
 }
 
-const STAGE_ORDER = [
-	"acquire",
-	"deterministic",
-	"dependency",
-	"codeAi",
-	"imageAi",
-	"history",
-] as const;
+const STAGE_ORDER = ["acquire", "codeAi", "imageAi", "history"] as const;
 
 export interface AssessmentOrchestratorOptions {
 	db: D1Database;
@@ -113,6 +104,11 @@ export interface AssessmentOrchestratorOptions {
 	/** Sleep between stage retries; swap in tests to skip real waits. */
 	sleep?: (ms: number) => Promise<void>;
 	retryDelayMs?: number;
+	/** Resolves the `coverage_json` to stamp on the finalized row, called once
+	 * at finalization. The stage-wiring layer builds this over the coverage its
+	 * AI stages accumulate (`assessment-stages.ts`); `undefined` (or an undefined
+	 * return) leaves the stored value unchanged. */
+	resolveCoverageJson?: () => string | undefined;
 }
 
 export class AssessmentOrchestrator {
@@ -125,6 +121,7 @@ export class AssessmentOrchestrator {
 	private readonly maxStageRetries: number;
 	private readonly sleep: (ms: number) => Promise<void>;
 	private readonly retryDelayMs: number;
+	private readonly resolveCoverageJson: (() => string | undefined) | undefined;
 
 	constructor(opts: AssessmentOrchestratorOptions) {
 		this.db = opts.db;
@@ -136,6 +133,7 @@ export class AssessmentOrchestrator {
 		this.maxStageRetries = opts.maxStageRetries ?? 2;
 		this.sleep = opts.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
 		this.retryDelayMs = opts.retryDelayMs ?? 0;
+		this.resolveCoverageJson = opts.resolveCoverageJson;
 	}
 
 	async runAssessment(runId: string): Promise<Assessment> {
@@ -193,15 +191,14 @@ export class AssessmentOrchestrator {
 		// CID-superseded subject finalizes as `stale` — no labels, pointer
 		// untouched.
 		//
-		// This read narrows but does NOT close the window: `finalize` signs each
-		// label (an async round-trip) between here and `db.batch`, so a delete or
-		// a cancel landing in that window still commits labels — the finalization
-		// CAS guards its own row, but the issuance statements carry no
-		// assessment-state guard. The Workflow instance id (the runKey) dedups only
-		// redelivery of the same run (assessment-dispatch.ts) — not a delete or
-		// operator cancel against an in-flight run — so closing this window still
-		// needs an in-batch assessment-state guard on every issuance statement,
-		// tracked with the real-stage wiring.
+		// This read narrows the delete/cancel window; `finalize` closes it. Between
+		// here and `db.batch`, `finalize` signs each label (an async round-trip), so
+		// a delete or an operator cancel can still land in that window — but every
+		// issuance statement is gated on the run reaching `toState`
+		// (`requireAssessmentState`, see `finalize`) and the whole finalization batch
+		// is all-or-nothing against the run→toState CAS, so a race that moves the run
+		// out of `running` no-ops the CAS AND every label. Nothing leaks; the lost
+		// race raises `AssessmentFinalizationConflictError`.
 		const current = await isSubjectCurrent(this.db, { uri: assessment.uri, cid: assessment.cid });
 		if (!current) {
 			return transitionAssessmentState(this.db, { id: runId, from: "running", to: "stale", now });
@@ -250,6 +247,7 @@ export class AssessmentOrchestrator {
 		const toState: AssessmentState = outcome?.toState ?? "error";
 		const positiveLabels: readonly OutcomeLabel[] = outcome?.labels ?? [];
 
+		const coverageJson = this.resolveCoverageJson?.();
 		const finalization = buildFinalizationStatements(this.db, {
 			assessmentId: assessment.id,
 			fromState: "running",
@@ -258,6 +256,7 @@ export class AssessmentOrchestrator {
 			uri: assessment.uri,
 			cid: assessment.cid,
 			now,
+			...(coverageJson !== undefined ? { coverageJson } : {}),
 		});
 
 		const statements = [...finalization.statements];
@@ -389,8 +388,6 @@ export class AssessmentOrchestrator {
  */
 export const stubStages: OrchestratorStages = {
 	acquire: () => Promise.resolve([]),
-	deterministic: () => Promise.resolve([]),
-	dependency: () => Promise.resolve([]),
 	codeAi: () => Promise.resolve([]),
 	imageAi: () => Promise.resolve([]),
 	history: () => Promise.resolve([]),

--- a/apps/labeler/src/assessment-orchestrator.ts
+++ b/apps/labeler/src/assessment-orchestrator.ts
@@ -7,9 +7,9 @@
  * run executes as one Workflow instance whose id is the run's runKey, so a
  * redelivered discovery event dedups onto the same instance rather than starting
  * a duplicate (see assessment-dispatch.ts). The Workflow constructs this
- * orchestrator per run and calls `runAssessment`. Until W7/W8 supply the real stage adapters
- * (acquire, deterministic validation, dependency/SBOM, code/metadata AI, image
- * AI), that wiring runs `stubStages` — every stage resolves with no findings, so
+ * orchestrator per run and calls `runAssessment`. Until the acquire-consumer
+ * slice assembles the real stage adapters (acquire, code/metadata AI, image
+ * AI, history), that wiring runs `stubStages` — every stage resolves with no findings, so
  * `resolvePolicyOutcome` returns `passed` and finalization issues a real signed
  * `assessment-passed` label for EVERY subject (not merely clearing its own
  * `assessment-pending`). That is a hard deploy gate — see the DEPLOY GATE note

--- a/apps/labeler/src/assessment-stages.ts
+++ b/apps/labeler/src/assessment-stages.ts
@@ -1,0 +1,149 @@
+/**
+ * Orchestrator stage wiring (plan W-production-stage-wiring). Adapts the pure
+ * analysis modules (`code-ai-adapter.ts`, `history-context.ts`) to the
+ * orchestrator's `StageAdapter` contract, following the `createAcquireStage`
+ * closure idiom: each factory captures its deps plus the shared
+ * `AcquisitionHolder` at construction and returns a `StageAdapter` that reads
+ * `holder.result` (the acquired bundle + decoded file set) and `ctx.assessment`.
+ *
+ * Keeping this here rather than in the adapter modules preserves those modules'
+ * purity (no DB, no orchestrator types) so they stay independently testable.
+ *
+ * The image stage and the whole `buildStages` assembly are deferred to the
+ * acquire-consumer slice, when a production bundle producer (verified
+ * acquisition + image-metadata extraction) exists to feed them; until then the
+ * orchestrator's production gate keeps stub stages from running.
+ */
+
+import { declaredAccessToCapabilities } from "@emdash-cms/plugin-types";
+
+import type { AcquisitionHolder } from "./artifact-acquisition.js";
+import type { StageAdapter } from "./assessment-orchestrator.js";
+import { StageTransientError } from "./assessment-orchestrator.js";
+import {
+	analyzeCode,
+	ModelTransientError,
+	type AiBinding,
+	type CodeAnalysisInput,
+	type CodeAnalysisResult,
+} from "./code-ai-adapter.js";
+import { analyzeHistory, type PublisherVerificationReader } from "./history-context.js";
+import type { ModerationPolicy } from "./policy.js";
+import { parseAtUri } from "./record-verification.js";
+
+/**
+ * Per-run coverage the AI stages accumulate as they run, serialized onto the
+ * finalized assessment's `coverage_json` (read by `public-assessment.ts`).
+ * `createCodeAiStage` records `code`; the image stage records `images` in the
+ * acquire-consumer slice. Shared by reference across the stages of one run.
+ */
+export interface CoverageAccumulator {
+	code?: { readonly coverage: "complete" | "partial"; readonly droppedFiles: readonly string[] };
+}
+
+/** Coverage axis value for an analysis that did not run this assessment (its
+ * input was unavailable or its stage is not yet wired). */
+const UNAVAILABLE = "unavailable";
+
+/**
+ * Serializes the accumulated coverage into the `coverage_json` blob shape
+ * `public-assessment.ts` reads (`{ code, images, metadata }`, extra keys
+ * ignored). `images` and `metadata` stay `unavailable` until their producers
+ * land in the acquire-consumer slice. `droppedFiles` records which code files
+ * were dropped to fit the model budget when `code` is `partial`.
+ */
+export function serializeCoverage(coverage: CoverageAccumulator): string {
+	return JSON.stringify({
+		code: coverage.code?.coverage ?? UNAVAILABLE,
+		images: UNAVAILABLE,
+		metadata: UNAVAILABLE,
+		droppedFiles: coverage.code ? [...coverage.code.droppedFiles] : [],
+	});
+}
+
+/** Per-run state: `holder` and `coverage` are shared by reference across one
+ * run's stages, so a factory must be constructed per assessment execution —
+ * reusing one across runs leaks the prior run's bundle and coverage. */
+export interface CodeAiStageOptions {
+	readonly holder: AcquisitionHolder;
+	readonly ai: AiBinding;
+	readonly policy: ModerationPolicy;
+	readonly promptVersion: string;
+	readonly modelId?: string;
+	readonly coverage: CoverageAccumulator;
+}
+
+/**
+ * Builds the orchestrator's `codeAi` stage. When acquisition produced no
+ * bundle (a permanent deterministic finding, or a transient failure that never
+ * reached the holder) there is nothing to analyze, so it reports no findings.
+ * Otherwise it runs the code model over the decoded file set and returns its
+ * validated findings, recording the run's code coverage. A `ModelTransientError`
+ * (flaky model call, unparseable output) becomes a `StageTransientError` so the
+ * orchestrator retries the stage rather than aborting the run.
+ */
+export function createCodeAiStage(options: CodeAiStageOptions): StageAdapter {
+	return async (ctx) => {
+		const acquired = options.holder.result;
+		if (!acquired) return [];
+
+		// The declared surface is passed capabilities-only, matching the calibration
+		// input shape; the production declaredAccess vocabulary (from
+		// declaredAccessToCapabilities) differs from the legacy fixture vocabulary and
+		// must be re-validated by the calibration sweep. Second calibration-input
+		// divergence for that sweep: `description` is empty below — the bundle
+		// manifest carries no name/description, and the misleading-metadata and
+		// privacy-risk categories are rooted in the plugin's stated purpose, so they
+		// run near-inert until the acquire-consumer slice threads the release
+		// record's description through these options.
+		const { capabilities } = declaredAccessToCapabilities(acquired.bundle.declaredAccess);
+		const input: CodeAnalysisInput = {
+			files: acquired.files,
+			declaredAccess: capabilities,
+			metadata: {
+				name: acquired.bundle.manifest.id,
+				description: "",
+				publisherDid: parseAtUri(ctx.assessment.uri).did,
+				version: acquired.bundle.manifest.version,
+			},
+		};
+
+		let result: CodeAnalysisResult;
+		try {
+			result = await analyzeCode(input, {
+				ai: options.ai,
+				policy: options.policy,
+				promptVersion: options.promptVersion,
+				...(options.modelId !== undefined ? { modelId: options.modelId } : {}),
+			});
+		} catch (err) {
+			if (err instanceof ModelTransientError) throw new StageTransientError(err.message);
+			throw err;
+		}
+
+		options.coverage.code = { coverage: result.coverage, droppedFiles: result.droppedFiles };
+		return result.findings;
+	};
+}
+
+export interface HistoryStageOptions {
+	readonly db: D1Database;
+	/** The labeler's own DID (`src`) whose active manual labels count as context. */
+	readonly src: string;
+	/** Read-only aggregator surface for the publisher's verification state. */
+	readonly aggregator?: PublisherVerificationReader;
+}
+
+/**
+ * Builds the orchestrator's `history` stage over `analyzeHistory`. History is
+ * operator-only context that never becomes a label and `analyzeHistory` is
+ * best-effort (it swallows its own errors and returns `[]`), so this wrapper
+ * adds no error handling of its own.
+ */
+export function createHistoryStage(options: HistoryStageOptions): StageAdapter {
+	return (ctx) =>
+		analyzeHistory(options.db, ctx.assessment, {
+			src: options.src,
+			...(options.aggregator !== undefined ? { aggregator: options.aggregator } : {}),
+		});
+}

--- a/apps/labeler/src/assessment-workflow.ts
+++ b/apps/labeler/src/assessment-workflow.ts
@@ -9,7 +9,8 @@
  * signed `assessment-passed` label for EVERY subject — an unconditional "this is
  * safe" attestation over unscanned content. This shell must NOT reach an
  * enforcing or label-consuming production deployment until the real analysis
- * stages (W7/W8) land; shipping it live before then would vouch for everything.
+ * stages land in the acquire-consumer slice; shipping it live before then would
+ * vouch for everything.
  *
  * The whole run executes in one `step.do`, not one step per stage: the
  * orchestrator accumulates stage findings in memory and the acquire stage
@@ -129,7 +130,7 @@ function buildStages(): OrchestratorStages {
 	// at runtime. Remove once real stages are wired here.
 	if (import.meta.env.PROD)
 		throw new Error(
-			"AssessmentWorkflow has only stub stages in a production build — refusing to issue assessment-passed for unscanned subjects. Wire the real analysis stages (W7/W8) before deploying.",
+			"AssessmentWorkflow has only stub stages in a production build — refusing to issue assessment-passed for unscanned subjects. Wire the real analysis stages (the acquire-consumer slice) before deploying.",
 		);
 	return stubStages;
 }

--- a/apps/labeler/src/assessment-workflow.ts
+++ b/apps/labeler/src/assessment-workflow.ts
@@ -114,8 +114,8 @@ async function notifyOutcome(env: Env, assessment: Assessment): Promise<void> {
 
 /**
  * The orchestrator's stage adapters, built per instance execution. Real
- * adapters attach here in the W7/W8 follow-on — acquire (via the aggregator
- * client), deterministic/dependency/AI scanning, and publisher history; today
+ * adapters attach here in the acquire-consumer follow-on — acquire (via the
+ * aggregator client), code/metadata AI, image AI, and publisher history; today
  * the run executes the exported stub stages. Building them per execution rather
  * than sharing module-scope state keeps per-run state — notably the acquire
  * stage's `AcquisitionHolder` — isolated to this instance, never shared across

--- a/apps/labeler/test/assessment-orchestrator.test.ts
+++ b/apps/labeler/test/assessment-orchestrator.test.ts
@@ -453,7 +453,7 @@ describe("AssessmentOrchestrator: warning findings", () => {
 	});
 });
 
-describe("AssessmentOrchestrator: permanent deterministic failure", () => {
+describe("AssessmentOrchestrator: permanent blocking finding", () => {
 	it("finalizes blocked with the mapped automated-block label", async () => {
 		const run = await pendingRun({ name: "blocked", cidValue: await cid("blocked") });
 		const stages: OrchestratorStages = {

--- a/apps/labeler/test/assessment-orchestrator.test.ts
+++ b/apps/labeler/test/assessment-orchestrator.test.ts
@@ -234,8 +234,7 @@ describe("AssessmentOrchestrator: warning findings", () => {
 		const run = await pendingRun({ name: "warn", cidValue: await cid("warn") });
 		const stages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
-				Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+			codeAi: () => Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
 		};
 		const orchestrator = await buildOrchestrator(stages);
 
@@ -294,8 +293,7 @@ describe("AssessmentOrchestrator: warning findings", () => {
 		await transitionAssessmentState(testEnv.DB, { id: first.id, from: "verifying", to: "pending" });
 		const warningStages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
-				Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+			codeAi: () => Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
 		};
 		const firstResult = await (await buildOrchestrator(warningStages)).runAssessment(first.id);
 		expect(firstResult.state).toBe("warned");
@@ -386,8 +384,7 @@ describe("AssessmentOrchestrator: warning findings", () => {
 		await transitionAssessmentState(testEnv.DB, { id: first.id, from: "verifying", to: "pending" });
 		const warningStages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
-				Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+			codeAi: () => Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
 		};
 		const firstResult = await (await buildOrchestrator(warningStages)).runAssessment(first.id);
 		expect(firstResult.state).toBe("warned");
@@ -422,8 +419,7 @@ describe("AssessmentOrchestrator: warning findings", () => {
 		});
 		const blockingStages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
-				Promise.resolve([finding({ category: "malware", severity: "critical" })]),
+			codeAi: () => Promise.resolve([finding({ category: "malware", severity: "critical" })]),
 		};
 		const secondResult = await (await buildOrchestrator(blockingStages)).runAssessment(second.id);
 		expect(secondResult.state).toBe("blocked");
@@ -462,7 +458,7 @@ describe("AssessmentOrchestrator: permanent deterministic failure", () => {
 		const run = await pendingRun({ name: "blocked", cidValue: await cid("blocked") });
 		const stages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
+			codeAi: () =>
 				Promise.resolve([
 					finding({ category: "artifact-integrity-failure", severity: "critical" }),
 				]),
@@ -484,7 +480,7 @@ describe("AssessmentOrchestrator: permanent deterministic failure", () => {
 		const run = await pendingRun({ name: "multi-block", cidValue: await cid("multi-block") });
 		const stages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
+			codeAi: () =>
 				Promise.resolve([
 					finding({ category: "malware", severity: "critical" }),
 					finding({ category: "supply-chain-compromise", severity: "critical" }),
@@ -511,9 +507,11 @@ describe("AssessmentOrchestrator: permanent deterministic failure", () => {
 		const run = await pendingRun({ name: "block-and-warn", cidValue: await cid("block-and-warn") });
 		const stages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
-				Promise.resolve([finding({ category: "malware", severity: "critical" })]),
-			codeAi: () => Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+			codeAi: () =>
+				Promise.resolve([
+					finding({ category: "malware", severity: "critical" }),
+					finding({ category: "obfuscated-code", severity: "medium" }),
+				]),
 		};
 		const orchestrator = await buildOrchestrator(stages);
 
@@ -625,7 +623,7 @@ describe("AssessmentOrchestrator: deleted or superseded subject", () => {
 		// entry currency check passed, before finalize's re-check.
 		const stages: OrchestratorStages = {
 			...stubStages,
-			deterministic: async () => {
+			codeAi: async () => {
 				await deleteSubject(testEnv.DB, { uri: run.uri, cid: run.cid });
 				return [];
 			},
@@ -671,7 +669,7 @@ describe("AssessmentOrchestrator: invalid findings", () => {
 		});
 		const stages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
+			codeAi: () =>
 				Promise.resolve([finding({ category: "not-a-real-label", severity: "critical" })]),
 		};
 		const orchestrator = await buildOrchestrator(stages);
@@ -690,7 +688,7 @@ describe("AssessmentOrchestrator: invalid findings", () => {
 		});
 		const stages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
+			codeAi: () =>
 				Promise.resolve([
 					finding({
 						category: "obfuscated-code",
@@ -719,7 +717,7 @@ describe("AssessmentOrchestrator: resume from running", () => {
 			if (attempts === 1) throw new Error("stage crashed post-transition");
 			return Promise.resolve([]);
 		};
-		const orchestrator = await buildOrchestrator({ ...stubStages, deterministic: flaky });
+		const orchestrator = await buildOrchestrator({ ...stubStages, codeAi: flaky });
 
 		await expect(orchestrator.runAssessment(run.id)).rejects.toThrow(
 			"stage crashed post-transition",
@@ -756,7 +754,7 @@ describe("AssessmentOrchestrator: cancel racing finalization", () => {
 		};
 		const orchestrator = await buildOrchestrator({
 			...stubStages,
-			deterministic: cancelDuringStage,
+			codeAi: cancelDuringStage,
 		});
 
 		await expect(orchestrator.runAssessment(run.id)).rejects.toBeInstanceOf(
@@ -861,8 +859,7 @@ describe("AssessmentOrchestrator: supersession negation provenance (decision 6)"
 		await transitionAssessmentState(testEnv.DB, { id: first.id, from: "verifying", to: "pending" });
 		const blockingStages: OrchestratorStages = {
 			...stubStages,
-			deterministic: () =>
-				Promise.resolve([finding({ category: "malware", severity: "critical" })]),
+			codeAi: () => Promise.resolve([finding({ category: "malware", severity: "critical" })]),
 		};
 		const firstResult = await (await buildOrchestrator(blockingStages)).runAssessment(first.id);
 		expect(firstResult.state).toBe("blocked");

--- a/apps/labeler/test/assessment-stages.test.ts
+++ b/apps/labeler/test/assessment-stages.test.ts
@@ -1,0 +1,431 @@
+import { CODEC_RAW, create as createCid, toString as cidToString } from "@atcute/cid";
+import {
+	createLabelSigner,
+	type LabelDidDocument,
+	type LabelSigner,
+} from "@emdash-cms/registry-moderation";
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+	createAcquireStage,
+	type AcquisitionHolder,
+	type AcquisitionTarget,
+} from "../src/artifact-acquisition.js";
+import { computeRunKey, initialTriggerId } from "../src/assessment-lifecycle.js";
+import {
+	AssessmentOrchestrator,
+	stubStages,
+	type OrchestratorStages,
+} from "../src/assessment-orchestrator.js";
+import {
+	createCodeAiStage,
+	createHistoryStage,
+	serializeCoverage,
+	type CoverageAccumulator,
+} from "../src/assessment-stages.js";
+import {
+	createAssessmentRun,
+	createSubject,
+	transitionAssessmentState,
+} from "../src/assessment-store.js";
+import type { AiBinding, AiRunInputs } from "../src/code-ai-adapter.js";
+import type { PublisherVerificationReader } from "../src/history-context.js";
+import { MODERATION_POLICY } from "../src/policy.js";
+import { initializeSigningState } from "../src/signing-rotation.js";
+import { canonicalBundle, checksumOf, file } from "./bundle-fixture.js";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+const LABELER_DID = "did:web:labels.emdashcms.com";
+const PUBLISHER_DID = "did:plc:publisher000000000000000000";
+const PRIVATE_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE";
+const MULTIKEY = "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ";
+const PROMPT_VERSION = "prompt-test-v1";
+const config = { labelerDid: LABELER_DID, signingKeyVersion: "v1" };
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+	await initializeSigningState(testEnv.DB, {
+		issuerDid: LABELER_DID,
+		keyVersion: "v1",
+		publicKeyMultibase: MULTIKEY,
+	});
+});
+
+function document(): LabelDidDocument {
+	return {
+		id: LABELER_DID,
+		verificationMethod: [
+			{
+				id: "#atproto_label",
+				type: "Multikey",
+				controller: LABELER_DID,
+				publicKeyMultibase: MULTIKEY,
+			},
+		],
+	};
+}
+
+async function signer(): Promise<LabelSigner> {
+	return createLabelSigner({
+		issuerDid: LABELER_DID,
+		privateKey: PRIVATE_KEY,
+		resolveDid: async () => document(),
+	});
+}
+
+async function cid(seed: string): Promise<string> {
+	const bytes = new TextEncoder().encode(seed);
+	const buffer = new ArrayBuffer(bytes.byteLength);
+	new Uint8Array(buffer).set(bytes);
+	return cidToString(await createCid(CODEC_RAW, new Uint8Array(buffer)));
+}
+
+function releaseUri(name: string): string {
+	return `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.release/${name}:1.0.0`;
+}
+
+async function pendingRun(name: string): Promise<{ id: string; uri: string; cid: string }> {
+	const cidValue = await cid(name);
+	const uri = releaseUri(name);
+	await createSubject(testEnv.DB, {
+		uri,
+		cid: cidValue,
+		did: PUBLISHER_DID,
+		collection: "com.emdashcms.experimental.package.release",
+		rkey: `${name}:1.0.0`,
+	});
+	const triggerId = initialTriggerId(cidValue);
+	const runKey = await computeRunKey({
+		uri,
+		cid: cidValue,
+		policyVersion: MODERATION_POLICY.policyVersion,
+		modelId: "unassigned",
+		promptHash: "unassigned",
+		scannerSetVersion: "unassigned",
+		triggerId,
+	});
+	const { assessment } = await createAssessmentRun(testEnv.DB, {
+		runKey,
+		uri,
+		cid: cidValue,
+		trigger: "initial",
+		triggerId,
+		policyVersion: MODERATION_POLICY.policyVersion,
+		coverageJson: "{}",
+	});
+	await transitionAssessmentState(testEnv.DB, {
+		id: assessment.id,
+		from: "observed",
+		to: "verifying",
+	});
+	await transitionAssessmentState(testEnv.DB, {
+		id: assessment.id,
+		from: "verifying",
+		to: "pending",
+	});
+	return { id: assessment.id, uri, cid: cidValue };
+}
+
+async function buildOrchestrator(
+	stages: OrchestratorStages,
+	overrides: { coverage?: CoverageAccumulator; maxStageRetries?: number } = {},
+): Promise<AssessmentOrchestrator> {
+	return new AssessmentOrchestrator({
+		db: testEnv.DB,
+		config,
+		signer: await signer(),
+		policy: MODERATION_POLICY,
+		stages,
+		sleep: () => Promise.resolve(),
+		...(overrides.coverage !== undefined
+			? { resolveCoverageJson: () => serializeCoverage(overrides.coverage!) }
+			: {}),
+		...(overrides.maxStageRetries !== undefined
+			? { maxStageRetries: overrides.maxStageRetries }
+			: {}),
+	});
+}
+
+function fakeAi(run: (model: string, inputs: AiRunInputs) => Promise<unknown>): AiBinding {
+	return { run };
+}
+
+function findingResponse(findings: unknown[]): { response: string } {
+	return { response: JSON.stringify({ findings }) };
+}
+
+const nullAggregator: PublisherVerificationReader = { getPublisherVerification: async () => null };
+
+const BLOCK_FINDING = {
+	category: "malware",
+	severity: "critical",
+	title: "malware detected",
+	publicSummary: "the plugin ships a malicious payload",
+	privateDetail: "backend.js drops an obfuscated dropper",
+	affectedFiles: ["backend.js"],
+};
+
+const WARN_FINDING = {
+	category: "obfuscated-code",
+	severity: "medium",
+	title: "obfuscated payload",
+	publicSummary: "the code appears obfuscated",
+	privateDetail: "backend.js base64-decodes a runtime string",
+	affectedFiles: ["backend.js"],
+};
+
+function targetFor(checksum: string): (assessment: { uri: string }) => Promise<AcquisitionTarget> {
+	return async () => ({
+		url: "https://cdn.example.test/plugin.tgz",
+		checksum,
+		slug: "test-plugin",
+		version: "1.0.0",
+	});
+}
+
+/** Test-injected acquire stage that serves `bytes` and pins `checksum`. When
+ * `checksum` matches the bytes it publishes the bundle to `holder`; a mismatch
+ * yields the permanent artifact-integrity-failure finding and leaves `holder`
+ * empty — the two shapes the AI stages branch on. */
+function acquireStage(bytes: Uint8Array, checksum: string, holder: AcquisitionHolder) {
+	return createAcquireStage({
+		deps: {
+			fetch: async () => new Response(bytes),
+			resolveHostname: async () => ["203.0.113.5"],
+		},
+		resolveTarget: targetFor(checksum),
+		holder,
+	});
+}
+
+async function labelNeg(uri: string, cidValue: string, val: string): Promise<number | undefined> {
+	const row = await testEnv.DB.prepare(
+		`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = ? ORDER BY sequence DESC LIMIT 1`,
+	)
+		.bind(uri, cidValue, val)
+		.first<{ neg: number }>();
+	return row?.neg;
+}
+
+describe("analysis stages: code AI stage", () => {
+	it("blocks and issues the mapped label when the code model returns an automated-block finding", async () => {
+		const run = await pendingRun("code-block");
+		const bytes = await canonicalBundle();
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const ai = fakeAi(() => Promise.resolve(findingResponse([BLOCK_FINDING])));
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID, aggregator: nullAggregator }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("blocked");
+		expect(await labelNeg(run.uri, run.cid, "malware")).toBe(0);
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBeUndefined();
+	});
+
+	it("passes on a clean model response and records complete code coverage", async () => {
+		const run = await pendingRun("code-clean");
+		const bytes = await canonicalBundle();
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const ai = fakeAi(() => Promise.resolve(findingResponse([])));
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("passed");
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBe(0);
+		expect(JSON.parse(result.coverageJson)).toMatchObject({
+			code: "complete",
+			images: "unavailable",
+			metadata: "unavailable",
+			droppedFiles: [],
+		});
+	});
+
+	it("warns and issues the warning label alongside assessment-passed", async () => {
+		const run = await pendingRun("code-warn");
+		const bytes = await canonicalBundle();
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const ai = fakeAi(() => Promise.resolve(findingResponse([WARN_FINDING])));
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("warned");
+		expect(await labelNeg(run.uri, run.cid, "obfuscated-code")).toBe(0);
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBe(0);
+	});
+
+	it("finalizes error, never a spurious pass, when the model call keeps failing transiently", async () => {
+		const run = await pendingRun("code-transient");
+		const bytes = await canonicalBundle();
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		let calls = 0;
+		const ai = fakeAi(() => {
+			calls += 1;
+			return Promise.reject(new Error("model overloaded"));
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (
+			await buildOrchestrator(stages, { coverage, maxStageRetries: 1 })
+		).runAssessment(run.id);
+
+		expect(result.state).toBe("error");
+		expect(calls).toBe(2);
+		expect(await labelNeg(run.uri, run.cid, "assessment-error")).toBe(0);
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBeUndefined();
+	});
+
+	it("records partial coverage and the dropped file when the model input budget drops a file", async () => {
+		const run = await pendingRun("code-partial");
+		// Two files, each under the per-file bundle cap (128 KiB) but together over
+		// the model's 200k-char input budget, so the code adapter drops the larger.
+		const bytes = await canonicalBundle([
+			file("big-a.js", "a".repeat(125_000)),
+			file("big-b.js", "b".repeat(120_000)),
+		]);
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const ai = fakeAi(() => Promise.resolve(findingResponse([])));
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("passed");
+		const parsed = JSON.parse(result.coverageJson);
+		expect(parsed.code).toBe("partial");
+		expect(parsed.droppedFiles).toContain("big-a.js");
+	});
+});
+
+describe("analysis stages: acquire produced no bundle", () => {
+	it("no-ops the code stage and finalizes on the deterministic acquire finding", async () => {
+		const run = await pendingRun("acquire-permanent");
+		const served = await canonicalBundle([file("tampered.js", "steal();")]);
+		const pinned = await checksumOf(await canonicalBundle());
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		let modelCalled = false;
+		const ai = fakeAi(() => {
+			modelCalled = true;
+			return Promise.resolve(findingResponse([]));
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(served, pinned, holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("blocked");
+		expect(modelCalled).toBe(false);
+		expect(holder.result).toBeUndefined();
+		expect(await labelNeg(run.uri, run.cid, "artifact-integrity-failure")).toBe(0);
+		expect(JSON.parse(result.coverageJson).code).toBe("unavailable");
+	});
+});
+
+describe("analysis stages: history stage is best-effort", () => {
+	it("does not fail the run when the history stage's own lookup throws internally", async () => {
+		const run = await pendingRun("history-throws");
+		const bytes = await canonicalBundle();
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const ai = fakeAi(() => Promise.resolve(findingResponse([])));
+		const brokenDb = {
+			prepare() {
+				throw new Error("history db unavailable");
+			},
+		} as unknown as D1Database;
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: brokenDb, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("passed");
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBe(0);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
       '@atcute/xrpc-server':
         specifier: 'catalog:'
         version: 2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@emdash-cms/plugin-types':
+        specifier: workspace:*
+        version: link:../../packages/plugin-types
       '@emdash-cms/registry-lexicons':
         specifier: workspace:*
         version: link:../../packages/registry-lexicons


### PR DESCRIPTION
## What does this PR do?

Slice A of the production-stage wiring for the labeler's assessment pipeline (RFC #694, umbrella #1909). Targets the `feat/plugin-registry-labelling-service` integration branch.

The orchestrator has run deploy-gated stub stages since #1978. This slice adapts the two built analysis modules whose inputs already exist — the code-AI adapter and the publisher-history context — to the orchestrator's `StageAdapter` contract, and removes the two stages that a ratified scope decision made permanently dead. **The production deploy gate does not lift here**: scoping found the acquire stage has no production consumer (its release-resolution and SSRF-hardened egress don't exist yet), so a production build still refuses to run — the gate lifts only in the follow-up "acquire consumer" slice when the pipeline can genuinely run end-to-end. `buildStages`/`executeAssessmentInstance` are byte-untouched.

- **`assessment-stages.ts` (new):** `createCodeAiStage` — reads the acquired bundle's decoded files + a **capabilities-only** declared surface (matching the calibration input shape; allowedHosts are runtime-enforced, not a moderation signal) and runs `analyzeCode`; a `ModelTransientError` becomes a `StageTransientError` so a flaky model call **retries and can never finalize a spurious pass**. `createHistoryStage` — thin over the best-effort `analyzeHistory`. Plus the per-run `CoverageAccumulator` and its serializer.
- **Dead stages removed:** `deterministic` and `dependency` come out of the stage set (ratified 2026-07-17: plugins are dependency-free and the workerd sandbox enforces declared access at runtime, so scanner/capability stages have no work; integrity findings stay in the acquire stage).
- **Coverage seam:** an optional `resolveCoverageJson` thunk stamps analysis coverage into `coverage_json` **atomically with the finalization CAS** (existing COALESCE path). Production is unchanged this slice.
- **Comment fix:** the stale orchestrator comment claiming the finalization label-leak window still needed a guard is rewritten — the `requireAssessmentState` gate from #2072 already closes it. Comment-only; no behavior change.

An adversarial review pass ran before this PR: no HIGH/blocking findings; the gate was verified byte-identical, `droppedFiles` paths were verified unable to reach the public assessment view, and the transient-never-passes invariant is locked by a test. Two accepted items are documented for the acquire-consumer slice in the plan (threading the release record's description — the bundle manifest has none, so misleading-metadata/privacy-risk run near-inert until then, flagged as a calibration-input divergence; and the coverage-on-error semantics call).

Part of #1909. Related to #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all three labeler projects)
- [x] `pnpm lint` passes (0 new diagnostics; repo baseline unchanged)
- [x] `pnpm test` passes (7 new stage-wiring integration tests over fake AI/aggregator + real bundle fixtures; 22 migrated orchestrator tests; full labeler suite 788/788)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server-only.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — **n/a**: `@emdash-cms/labeler` is `private: true`; the new `@emdash-cms/plugin-types` dependency is `workspace:*` on an app, no published-package change.
- [x] New features link to an approved Discussion — the umbrella #1909 tracks RFC #694; this is one slice under it.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation + adversarial review), orchestrated by **Claude Fable 5**

## Screenshots / test output

```
assessment-stages.test.ts:      7 passed
assessment-orchestrator.test.ts: 22 passed
full labeler suite:             788 passed
```

Key cases: fake-AI malware finding → `blocked` with the label issued and no `assessment-passed`; clean response → `passed` with `coverage.code: "complete"`; persistent model failure → transient retries exhaust and finalize `error`, **not** a spurious pass; over-budget bundle → `partial` coverage with the dropped file recorded; checksum-mismatch acquire → AI never invoked, `blocked` on `artifact-integrity-failure`; history-stage DB failure → run still finalizes normally.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-stage-wiring-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-stage-wiring`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
