### PR TITLE
feat(labeler): acquire consumer, SSRF egress, image stage, and gate lift (slice B)

### DIFF
--- a/.changeset/core-ssrf-doh-export.md
+++ b/.changeset/core-ssrf-doh-export.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds a `emdash/security/ssrf` subpath export exposing the `cloudflareDohResolver` DNS-over-HTTPS resolver and the SSRF URL/address validation helpers for reuse in Workers that fetch untrusted URLs.

--- a/.changeset/registry-verification-ipv6-ssrf.md
+++ b/.changeset/registry-verification-ipv6-ssrf.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-verification": patch
+---
+
+Rejects additional IPv6-encoded private/metadata addresses in the verified-fetch SSRF guard: deprecated IPv4-compatible (`::a.b.c.d`) and NAT64 (`64:ff9b::a.b.c.d`) forms that embed a private or link-local IPv4 address are now resolved to their embedded address and blocked.

--- a/apps/labeler/package.json
+++ b/apps/labeler/package.json
@@ -34,6 +34,7 @@
 		"@emdash-cms/registry-lexicons": "workspace:*",
 		"@emdash-cms/registry-moderation": "workspace:*",
 		"@emdash-cms/registry-verification": "workspace:*",
+		"emdash": "workspace:*",
 		"jose": "^6.1.3",
 		"ulidx": "^2.4.1"
 	},

--- a/apps/labeler/src/artifact-acquisition.ts
+++ b/apps/labeler/src/artifact-acquisition.ts
@@ -123,6 +123,11 @@ export interface AcquisitionTarget {
 	 * declaration when present. */
 	readonly pinnedChecksum?: string | null;
 	readonly pinnedArtifactId?: string | null;
+	/** The release's advertised human description (the publisher's package-profile
+	 * description), for the code/image stages' stated-purpose analysis. Best-effort
+	 * — absent when the profile is unindexed. Carried through to the acquired
+	 * artifact; never an integrity input. */
+	readonly description?: string;
 }
 
 export interface AcquiredArtifact {
@@ -133,6 +138,9 @@ export interface AcquiredArtifact {
 	readonly files: readonly CodeAnalysisFile[];
 	/** The checksum-verified compressed bundle bytes. */
 	readonly bytes: Uint8Array;
+	/** The release's advertised description, carried from the target for the
+	 * analysis stages' stated-purpose input. Absent when unindexed. */
+	readonly description?: string;
 }
 
 export type AcquisitionResult =
@@ -312,6 +320,7 @@ async function verifyAndUnpack(
 			bundle: bundle.value,
 			files: fileSet.files,
 			bytes,
+			...(target.description !== undefined ? { description: target.description } : {}),
 		},
 	};
 }

--- a/apps/labeler/src/artifact-egress.ts
+++ b/apps/labeler/src/artifact-egress.ts
@@ -1,0 +1,45 @@
+/**
+ * Production SSRF egress for artifact acquisition (plan W7.2, Slice-B design
+ * 2026-07-17). Constructs the `{ fetch, resolveHostname }` pair
+ * `fetchVerifiedResource` injects into every declared-URL artifact download.
+ *
+ * The security posture lives entirely in `fetchVerifiedResource`
+ * (`@emdash-cms/registry-verification`): HTTPS-only, credential-free URLs,
+ * manual per-hop redirect re-validation with per-hop hostname re-resolution,
+ * private/reserved-IP rejection, and byte/time budgets. This module supplies
+ * only the two injected primitives and adds NOTHING to the request — no
+ * ambient credentials, no header injection, no redirect following of its own.
+ *
+ *  - `resolveHostname` is the ratified `cloudflareDohResolver` (DoH against a
+ *    fixed trusted host, A+AAAA, fails closed). `fetchVerifiedResource` checks
+ *    every returned address against the private/reserved blocklist before each
+ *    hop, so a rebinding or private-IP host is rejected before any fetch.
+ *  - `fetch` is a thin pass-through over `globalThis.fetch`. It forwards the
+ *    method/redirect/signal `fetchVerifiedResource` sets verbatim and never
+ *    overrides them, so the hardened posture is preserved.
+ *
+ * No recursion into the SSRF-checked path: `cloudflareDohResolver` reaches its
+ * fixed DoH host with its own plain `globalThis.fetch`, never through the
+ * `fetch` this module returns, so resolving a hostname does not itself trigger
+ * another resolve.
+ */
+
+import type { FetchImplementation, HostnameResolver } from "@emdash-cms/registry-verification";
+import { cloudflareDohResolver } from "emdash/security/ssrf";
+
+export interface ArtifactEgress {
+	readonly fetch: FetchImplementation;
+	readonly resolveHostname: HostnameResolver;
+}
+
+/**
+ * Forwards `fetchVerifiedResource`'s pre-built request unchanged. Wrapping
+ * `globalThis.fetch` in an arrow rather than passing the bare reference keeps
+ * the call bound to the global and makes the "no added headers/credentials"
+ * contract explicit at the call site.
+ */
+const passthroughFetch: FetchImplementation = (input, init) => globalThis.fetch(input, init);
+
+export function createArtifactEgress(): ArtifactEgress {
+	return { fetch: passthroughFetch, resolveHostname: cloudflareDohResolver };
+}

--- a/apps/labeler/src/assessment-orchestrator.ts
+++ b/apps/labeler/src/assessment-orchestrator.ts
@@ -174,18 +174,25 @@ export class AssessmentOrchestrator {
 			}
 		}
 
+		// Validate and resolve the findings gathered so far even on transient
+		// exhaustion: a stage that already returned a BLOCKING finding must not be
+		// discarded because a LATER stage failed transiently. A block is monotonic —
+		// no unfinished stage can lift it, only add labels — so finalizing `blocked`
+		// on partial coverage is correct and safe, and it stops a crafted input that
+		// reliably exhausts a later stage from suppressing a real block on every
+		// rerun. Anything short of an already-confirmed block on an incomplete run
+		// still finalizes `error` (below) and retries — an unrun stage might have
+		// found a block.
+		//
 		// validateFindings throws on a malformed finding; uncaught, it aborts the
 		// run (assessment stays `running`, like any non-transient stage error).
 		// Resolution and persistence below read validatedFindings, never the raw
 		// stage output.
-		let validatedFindings: NormalizedFinding[] = [];
-		if (!transientExhausted) {
-			const resolvableEvidenceIds = await listEvidenceObjectIds(this.db, assessment.id);
-			validatedFindings = validateFindings(findings, {
-				allowedCategories: allowedFindingCategories(this.policy),
-				resolvableEvidenceIds,
-			});
-		}
+		const resolvableEvidenceIds = await listEvidenceObjectIds(this.db, assessment.id);
+		const validatedFindings = validateFindings(findings, {
+			allowedCategories: allowedFindingCategories(this.policy),
+			resolvableEvidenceIds,
+		});
 
 		// Re-read subject currency immediately before finalizing: a deleted or
 		// CID-superseded subject finalizes as `stale` — no labels, pointer
@@ -204,9 +211,15 @@ export class AssessmentOrchestrator {
 			return transitionAssessmentState(this.db, { id: runId, from: "running", to: "stale", now });
 		}
 
+		const resolved = resolvePolicyOutcome(validatedFindings, this.policy);
+		// On transient exhaustion, honor an already-confirmed block; every other
+		// incomplete outcome (clean or warn) is an `error` to retry, never a
+		// `passed`/`warned` finalized over an unrun stage.
 		const outcome = transientExhausted
-			? null
-			: resolvePolicyOutcome(validatedFindings, this.policy);
+			? resolved.toState === "blocked"
+				? resolved
+				: null
+			: resolved;
 		return this.finalize(assessment, outcome, now);
 	}
 

--- a/apps/labeler/src/assessment-orchestrator.ts
+++ b/apps/labeler/src/assessment-orchestrator.ts
@@ -7,13 +7,10 @@
  * run executes as one Workflow instance whose id is the run's runKey, so a
  * redelivered discovery event dedups onto the same instance rather than starting
  * a duplicate (see assessment-dispatch.ts). The Workflow constructs this
- * orchestrator per run and calls `runAssessment`. Until the acquire-consumer
- * slice assembles the real stage adapters (acquire, code/metadata AI, image
- * AI, history), that wiring runs `stubStages` — every stage resolves with no findings, so
- * `resolvePolicyOutcome` returns `passed` and finalization issues a real signed
- * `assessment-passed` label for EVERY subject (not merely clearing its own
- * `assessment-pending`). That is a hard deploy gate — see the DEPLOY GATE note
- * in assessment-workflow.ts.
+ * orchestrator per run and calls `runAssessment` with the real stage adapters
+ * that `assessment-workflow.ts` `buildStages` assembles (acquire, code AI, image
+ * AI, history). `stubStages` remains exported only for tests that need an
+ * empty-findings pass; production never runs it.
  */
 
 import type { LabelSigner } from "@emdash-cms/registry-moderation";

--- a/apps/labeler/src/assessment-stages.ts
+++ b/apps/labeler/src/assessment-stages.ts
@@ -8,11 +8,8 @@
  *
  * Keeping this here rather than in the adapter modules preserves those modules'
  * purity (no DB, no orchestrator types) so they stay independently testable.
- *
- * The image stage and the whole `buildStages` assembly are deferred to the
- * acquire-consumer slice, when a production bundle producer (verified
- * acquisition + image-metadata extraction) exists to feed them; until then the
- * orchestrator's production gate keeps stub stages from running.
+ * `assessment-workflow.ts` `buildStages` assembles these factories with the
+ * acquire stage into the run's `OrchestratorStages`.
  */
 
 import { declaredAccessToCapabilities } from "@emdash-cms/plugin-types";
@@ -28,6 +25,13 @@ import {
 	type CodeAnalysisResult,
 } from "./code-ai-adapter.js";
 import { analyzeHistory, type PublisherVerificationReader } from "./history-context.js";
+import {
+	analyzeImages,
+	type ImageAiBinding,
+	type ImageAnalysisInput,
+	type ImageAnalysisResult,
+} from "./image-ai-adapter.js";
+import { extractBundleImages } from "./image-metadata.js";
 import type { ModerationPolicy } from "./policy.js";
 import { parseAtUri } from "./record-verification.js";
 
@@ -39,25 +43,36 @@ import { parseAtUri } from "./record-verification.js";
  */
 export interface CoverageAccumulator {
 	code?: { readonly coverage: "complete" | "partial"; readonly droppedFiles: readonly string[] };
+	images?: {
+		readonly coverage: "complete" | "partial" | "not-present";
+		readonly droppedImages: readonly string[];
+	};
 }
 
 /** Coverage axis value for an analysis that did not run this assessment (its
- * input was unavailable or its stage is not yet wired). */
+ * input was unavailable — e.g. acquisition produced no bundle, or the stage
+ * transient-exhausted before completing). */
 const UNAVAILABLE = "unavailable";
 
 /**
  * Serializes the accumulated coverage into the `coverage_json` blob shape
  * `public-assessment.ts` reads (`{ code, images, metadata }`, extra keys
- * ignored). `images` and `metadata` stay `unavailable` until their producers
- * land in the acquire-consumer slice. `droppedFiles` records which code files
- * were dropped to fit the model budget when `code` is `partial`.
+ * ignored). `code`/`images` reflect what each AI stage recorded this run;
+ * `metadata` stays `unavailable` (metadata analysis folds into the code stage,
+ * with no separate coverage producer). An axis its stage left unset serializes
+ * `unavailable` — this is how a post-code transient exhaustion honestly reports
+ * `code: complete, images: unavailable` (the image stage never completed). The
+ * `images` axis also carries `not-present` for a bundle with no image files.
+ * `droppedFiles`/`droppedImages` record what each stage dropped to fit its
+ * model budget.
  */
 export function serializeCoverage(coverage: CoverageAccumulator): string {
 	return JSON.stringify({
 		code: coverage.code?.coverage ?? UNAVAILABLE,
-		images: UNAVAILABLE,
+		images: coverage.images?.coverage ?? UNAVAILABLE,
 		metadata: UNAVAILABLE,
 		droppedFiles: coverage.code ? [...coverage.code.droppedFiles] : [],
+		droppedImages: coverage.images ? [...coverage.images.droppedImages] : [],
 	});
 }
 
@@ -90,19 +105,19 @@ export function createCodeAiStage(options: CodeAiStageOptions): StageAdapter {
 		// The declared surface is passed capabilities-only, matching the calibration
 		// input shape; the production declaredAccess vocabulary (from
 		// declaredAccessToCapabilities) differs from the legacy fixture vocabulary and
-		// must be re-validated by the calibration sweep. Second calibration-input
-		// divergence for that sweep: `description` is empty below — the bundle
-		// manifest carries no name/description, and the misleading-metadata and
-		// privacy-risk categories are rooted in the plugin's stated purpose, so they
-		// run near-inert until the acquire-consumer slice threads the release
-		// record's description through these options.
+		// must be re-validated by the calibration sweep. `description` is the release's
+		// advertised profile description resolved during acquisition — the stated
+		// purpose the misleading-metadata and privacy-risk categories key on; the
+		// calibration sweep must run against this real-description input (its second
+		// input divergence). Absent when the profile is unindexed, leaving those
+		// categories near-inert for that run only.
 		const { capabilities } = declaredAccessToCapabilities(acquired.bundle.declaredAccess);
 		const input: CodeAnalysisInput = {
 			files: acquired.files,
 			declaredAccess: capabilities,
 			metadata: {
 				name: acquired.bundle.manifest.id,
-				description: "",
+				description: acquired.description ?? "",
 				publisherDid: parseAtUri(ctx.assessment.uri).did,
 				version: acquired.bundle.manifest.version,
 			},
@@ -122,6 +137,71 @@ export function createCodeAiStage(options: CodeAiStageOptions): StageAdapter {
 		}
 
 		options.coverage.code = { coverage: result.coverage, droppedFiles: result.droppedFiles };
+		return result.findings;
+	};
+}
+
+export interface ImageAiStageOptions {
+	readonly holder: AcquisitionHolder;
+	readonly ai: ImageAiBinding;
+	readonly policy: ModerationPolicy;
+	readonly promptVersion: string;
+	readonly modelId?: string;
+	readonly coverage: CoverageAccumulator;
+}
+
+/**
+ * Builds the orchestrator's `imageAi` stage. With no acquired bundle there is
+ * nothing to analyze. Otherwise the deterministic extractor turns the bundle's
+ * binary files into the vision adapter's image set: no image files records
+ * `not-present` and skips the model; any images run `analyzeImages`. Image
+ * coverage is `partial` when the extractor skipped an unreadable/over-cap image
+ * OR the adapter dropped one for its input budget. A `ModelTransientError`
+ * becomes a `StageTransientError` so the orchestrator retries rather than
+ * finalizing on a flaky model call.
+ */
+export function createImageAiStage(options: ImageAiStageOptions): StageAdapter {
+	return async (ctx) => {
+		const acquired = options.holder.result;
+		if (!acquired) return [];
+
+		const { images, skipped } = await extractBundleImages(acquired.bundle.files);
+		if (images.length === 0) {
+			options.coverage.images =
+				skipped.length > 0
+					? { coverage: "partial", droppedImages: skipped }
+					: { coverage: "not-present", droppedImages: [] };
+			return [];
+		}
+
+		const input: ImageAnalysisInput = {
+			images,
+			metadata: {
+				name: acquired.bundle.manifest.id,
+				description: acquired.description ?? "",
+				publisherDid: parseAtUri(ctx.assessment.uri).did,
+				version: acquired.bundle.manifest.version,
+			},
+		};
+
+		let result: ImageAnalysisResult;
+		try {
+			result = await analyzeImages(input, {
+				ai: options.ai,
+				policy: options.policy,
+				promptVersion: options.promptVersion,
+				...(options.modelId !== undefined ? { modelId: options.modelId } : {}),
+			});
+		} catch (err) {
+			if (err instanceof ModelTransientError) throw new StageTransientError(err.message);
+			throw err;
+		}
+
+		const partial = skipped.length > 0 || result.coverage === "partial";
+		options.coverage.images = {
+			coverage: partial ? "partial" : "complete",
+			droppedImages: [...skipped, ...result.droppedImages],
+		};
 		return result.findings;
 	};
 }

--- a/apps/labeler/src/assessment-workflow.ts
+++ b/apps/labeler/src/assessment-workflow.ts
@@ -5,12 +5,16 @@
  * it through the orchestrator's stages and atomic finalization inside a single
  * durable step.
  *
- * DEPLOY GATE: with `stubStages`, a run finalizes `passed` and issues a real
- * signed `assessment-passed` label for EVERY subject — an unconditional "this is
- * safe" attestation over unscanned content. This shell must NOT reach an
- * enforcing or label-consuming production deployment until the real analysis
- * stages land in the acquire-consumer slice; shipping it live before then would
- * vouch for everything.
+ * PROD safety (the lifted deploy gate): `buildStages` now assembles four REAL
+ * stages — acquire (SSRF-hardened verified fetch + aggregator release
+ * resolution), code AI, image AI, and publisher history. A `passed` outcome is
+ * therefore only ever reached after a real acquire produced a checksum-verified
+ * bundle that the AI stages analyzed clean; there is no stub path that would
+ * sign `assessment-passed` over unscanned content. The invariant that makes
+ * this safe: the acquire stage returns no findings ONLY when it has published a
+ * verified bundle to the holder (a permanent failure returns a blocking
+ * finding, a transient one throws), so a run cannot finalize `passed` with the
+ * holder empty. `buildStages` fails loudly if a required binding is missing.
  *
  * The whole run executes in one `step.do`, not one step per stage: the
  * orchestrator accumulates stage findings in memory and the acquire stage
@@ -20,24 +24,33 @@
  * finalization intact. The tradeoff is coarse resume granularity: a mid-run
  * eviction re-runs the whole step. `executeAssessmentInstance` makes that
  * idempotent — a terminal row short-circuits, and `runAssessment` resumes a row
- * left `running` by a crashed attempt. Finer, per-stage durable resume lands
- * with the real-stage wiring.
+ * left `running` by a crashed attempt.
  */
 
 import { WorkflowEntrypoint } from "cloudflare:workers";
 import type { WorkflowEvent, WorkflowStep } from "cloudflare:workers";
 
+import { AggregatorClient } from "./aggregator-client.js";
+import { createAcquireStage, type AcquisitionHolder } from "./artifact-acquisition.js";
+import { createArtifactEgress, type ArtifactEgress } from "./artifact-egress.js";
 import type { AssessmentWorkflowParams } from "./assessment-dispatch.js";
 import { TERMINAL_STATES, type AssessmentState } from "./assessment-lifecycle.js";
+import { AssessmentOrchestrator, type OrchestratorStages } from "./assessment-orchestrator.js";
 import {
-	AssessmentOrchestrator,
-	stubStages,
-	type OrchestratorStages,
-} from "./assessment-orchestrator.js";
+	createCodeAiStage,
+	createHistoryStage,
+	createImageAiStage,
+	serializeCoverage,
+	type CoverageAccumulator,
+} from "./assessment-stages.js";
 import { getAssessment, type Assessment } from "./assessment-store.js";
-import { getLabelerIdentityConfig } from "./config.js";
+import type { AiBinding } from "./code-ai-adapter.js";
+import { getLabelerIdentityConfig, type LabelerConfig } from "./config.js";
+import type { PublisherVerificationReader } from "./history-context.js";
+import type { ImageAiBinding } from "./image-ai-adapter.js";
 import { createNotifyDeps, notifyAssessmentOutcome } from "./notification-triggers.js";
-import { MODERATION_POLICY } from "./policy.js";
+import { MODERATION_POLICY, type ModerationPolicy } from "./policy.js";
+import { createReleaseResolver, type ReleaseReader } from "./release-resolution.js";
 import { createRuntimeSigner, getRuntimeSigningSecret } from "./signing-runtime.js";
 
 const RUN_STEP_CONFIG = {
@@ -80,14 +93,31 @@ export async function executeAssessmentInstance(
 		return existing.state;
 	}
 
+	assertRequiredBindings(env);
 	const config = await getLabelerIdentityConfig(env);
 	const versioned = await createRuntimeSigner(config, getRuntimeSigningSecret(env));
+	// Per-run state shared by reference across this run's stages: the acquire
+	// stage publishes its verified bundle to `holder`; the AI stages read it and
+	// record into `coverage`, which `resolveCoverageJson` serializes at finalization.
+	const holder: AcquisitionHolder = {};
+	const coverage: CoverageAccumulator = {};
+	const aggregator = new AggregatorClient(env.AGGREGATOR);
 	const orchestrator = new AssessmentOrchestrator({
 		db: env.DB,
 		config,
 		signer: versioned.signer,
 		policy: MODERATION_POLICY,
-		stages: buildStages(),
+		stages: buildStages({
+			holder,
+			coverage,
+			config,
+			policy: MODERATION_POLICY,
+			db: env.DB,
+			egress: createArtifactEgress(),
+			aggregator,
+			ai: env.AI,
+		}),
+		resolveCoverageJson: () => serializeCoverage(coverage),
 	});
 	const finalized = await orchestrator.runAssessment(assessmentId);
 	await notifyOutcome(env, finalized);
@@ -113,24 +143,75 @@ async function notifyOutcome(env: Env, assessment: Assessment): Promise<void> {
 	}
 }
 
+/** Prompt version stamped into AI-stage findings and their prompt hash. The
+ * calibration sweep re-validates the production prompt before enforcement
+ * launch (see the calibration-fidelity flags in `assessment-stages.ts`). */
+export const ASSESSMENT_PROMPT_VERSION = "1";
+
+export interface BuildStagesInput {
+	readonly holder: AcquisitionHolder;
+	readonly coverage: CoverageAccumulator;
+	readonly config: LabelerConfig;
+	readonly policy: ModerationPolicy;
+	readonly db: D1Database;
+	/** SSRF-hardened egress for the acquire stage's declared-URL fetch. */
+	readonly egress: ArtifactEgress;
+	/** Aggregator reads: release resolution (acquire) and publisher verification
+	 * (history). `AggregatorClient` satisfies both. */
+	readonly aggregator: ReleaseReader & PublisherVerificationReader;
+	/** Workers AI binding for both AI stages. */
+	readonly ai: AiBinding & ImageAiBinding;
+	readonly promptVersion?: string;
+}
+
 /**
- * The orchestrator's stage adapters, built per instance execution. Real
- * adapters attach here in the acquire-consumer follow-on — acquire (via the
- * aggregator client), code/metadata AI, image AI, and publisher history; today
- * the run executes the exported stub stages. Building them per execution rather
- * than sharing module-scope state keeps per-run state — notably the acquire
- * stage's `AcquisitionHolder` — isolated to this instance, never shared across
- * concurrent subjects.
+ * Assembles the orchestrator's four real stage adapters for one run. Built per
+ * execution rather than sharing module-scope state so per-run state — the
+ * acquire stage's `AcquisitionHolder` and the AI stages' `CoverageAccumulator`
+ * — stays isolated to this instance, never shared across concurrent subjects.
+ * `acquire` fetches the release's declared artifact under the SSRF-hardened
+ * egress and publishes the verified bundle; `codeAi`/`imageAi` read it; `history`
+ * runs last as best-effort operator context. Pure over its injected deps (no
+ * `env`, no network), so tests drive it with fakes; `executeAssessmentInstance`
+ * supplies the production deps and enforces binding presence.
  */
-function buildStages(): OrchestratorStages {
-	// Mechanical enforcement of the DEPLOY GATE above: a production build must not
-	// run stub stages (which would sign `assessment-passed` for every unscanned
-	// subject). `import.meta.env.PROD` is a Vite compile-time constant — true in
-	// `vite build`, false in dev and the vitest pool — so this cannot be spoofed
-	// at runtime. Remove once real stages are wired here.
-	if (import.meta.env.PROD)
+export function buildStages(input: BuildStagesInput): OrchestratorStages {
+	const promptVersion = input.promptVersion ?? ASSESSMENT_PROMPT_VERSION;
+	return {
+		acquire: createAcquireStage({
+			deps: input.egress,
+			resolveTarget: createReleaseResolver(input.aggregator),
+			holder: input.holder,
+		}),
+		codeAi: createCodeAiStage({
+			holder: input.holder,
+			ai: input.ai,
+			policy: input.policy,
+			promptVersion,
+			coverage: input.coverage,
+		}),
+		imageAi: createImageAiStage({
+			holder: input.holder,
+			ai: input.ai,
+			policy: input.policy,
+			promptVersion,
+			coverage: input.coverage,
+		}),
+		history: createHistoryStage({
+			db: input.db,
+			src: input.config.labelerDid,
+			aggregator: input.aggregator,
+		}),
+	};
+}
+
+/** Fails loudly when a binding the run cannot proceed without is absent, so a
+ * misconfigured deployment errors before any stage runs rather than silently
+ * scanning nothing and finalizing `passed`. */
+function assertRequiredBindings(env: Env): void {
+	const missing = (["AI", "AGGREGATOR", "DB"] as const).filter((name) => !env[name]);
+	if (missing.length > 0)
 		throw new Error(
-			"AssessmentWorkflow has only stub stages in a production build — refusing to issue assessment-passed for unscanned subjects. Wire the real analysis stages (the acquire-consumer slice) before deploying.",
+			`AssessmentWorkflow is missing required bindings: ${missing.join(", ")} — refusing to run an assessment that cannot fetch, scan, or persist.`,
 		);
-	return stubStages;
 }

--- a/apps/labeler/src/discovery-consumer.ts
+++ b/apps/labeler/src/discovery-consumer.ts
@@ -7,8 +7,8 @@
  * (assessment-dispatch.ts), so a redelivered discovery event dedups onto the
  * same instance while a later re-assessment (distinct trigger → distinct
  * runKey) gets its own. `AssessmentWorkflow` (assessment-workflow.ts) then
- * drives `pending → running → finalization` through the orchestrator (still
- * stub stages until W7/W8 land real stage adapters).
+ * drives `pending → running → finalization` through the orchestrator's real
+ * acquire → code → image → history stages.
  *
  * Error policy mirrors the aggregator's records-consumer with one
  * difference (spec §9.1): a forged or unverifiable event is ALWAYS a dead

--- a/apps/labeler/src/image-metadata.ts
+++ b/apps/labeler/src/image-metadata.ts
@@ -1,0 +1,327 @@
+/**
+ * Deterministic image-metadata extractor (plan W8.3 / Slice-B design
+ * 2026-07-17). Turns the raw binary files carried on a validated plugin
+ * bundle (`ValidatedBundleFile[]` — `{ path, bytes }`) into the
+ * `ImageAnalysisImage[]` the vision adapter consumes: MIME sniffed from magic
+ * bytes (never the filename extension), SHA-256 + base64 of the exact bytes,
+ * pixel dimensions parsed from the format header, and an advisory
+ * icon/screenshot classification.
+ *
+ * Pure and total: every parser bounds-checks each read and returns `null` on a
+ * truncated or malformed header rather than throwing. An image the extractor
+ * cannot process (unreadable dimensions, over-cap size/count) is reported as
+ * `skipped`, degrading image coverage to `partial`; a crafted or corrupt file
+ * never crashes the assessment run. Non-image files (code, unknown binaries)
+ * are ignored entirely — they are not part of the image surface.
+ *
+ * Caps mirror the vision adapter's (`MAX_IMAGES`, `MAX_IMAGE_BYTES`,
+ * `MAX_TOTAL_IMAGE_BYTES`), enforced here against the predicted base64 length
+ * so an over-cap image is dropped BEFORE its base64 is materialised — the
+ * adapter measures `dataBase64.length`, so predicting it keeps the two in step
+ * and bounds this module's own memory use on a bundle stuffed with images.
+ */
+
+import type { ValidatedBundleFile } from "@emdash-cms/registry-verification";
+
+import {
+	MAX_IMAGE_BYTES,
+	MAX_IMAGES,
+	MAX_TOTAL_IMAGE_BYTES,
+	type ImageAnalysisImage,
+} from "./image-ai-adapter.js";
+
+export interface ExtractedBundleImages {
+	readonly images: readonly ImageAnalysisImage[];
+	/** Paths of files that sniffed as a supported image but could not be turned
+	 * into an analysable image (unreadable dimensions, or dropped to fit the
+	 * count/size caps). Drives `partial` image coverage. */
+	readonly skipped: readonly string[];
+}
+
+/** Whichever dimension is smaller for an icon; larger, or non-square, reads as
+ * a screenshot. Advisory only — `kind` is context shown to the vision model,
+ * never a security boundary — so a coarse rule is sufficient. */
+const ICON_MAX_DIMENSION = 512;
+const ICON_MIN_ASPECT = 0.8;
+const ICON_MAX_ASPECT = 1.25;
+
+/**
+ * Extracts the analysable image set from a validated bundle's files, in tar
+ * order. The optional `iconPath` names the bundle-relative path the manifest
+ * declares as its icon, forcing that file's classification; absent (the plugin
+ * manifest carries no icon field today), classification falls back to
+ * dimensions/aspect.
+ */
+export async function extractBundleImages(
+	files: readonly ValidatedBundleFile[],
+	iconPath?: string,
+): Promise<ExtractedBundleImages> {
+	const images: ImageAnalysisImage[] = [];
+	const skipped: string[] = [];
+	let totalBase64 = 0;
+
+	for (const file of files) {
+		const mime = detectImageMime(file.bytes);
+		if (mime === null) continue; // not an image — not part of the image surface
+
+		// From here the file IS a supported image, so any reason it cannot be
+		// analysed (unreadable header, over a cap) records it as skipped, degrading
+		// coverage, rather than silently dropping it.
+		const dims = parseImageDimensions(mime, file.bytes);
+		if (!dims) {
+			skipped.push(file.path);
+			continue;
+		}
+
+		const base64Length = predictedBase64Length(file.bytes.length);
+		if (
+			base64Length > MAX_IMAGE_BYTES ||
+			images.length >= MAX_IMAGES ||
+			totalBase64 + base64Length > MAX_TOTAL_IMAGE_BYTES
+		) {
+			skipped.push(file.path);
+			continue;
+		}
+
+		const sha256 = await sha256Hex(file.bytes);
+		images.push({
+			path: file.path,
+			mime,
+			sha256,
+			dataBase64: toBase64(file.bytes),
+			width: dims.width,
+			height: dims.height,
+			kind: classifyKind(file.path, dims, iconPath),
+		});
+		totalBase64 += base64Length;
+	}
+
+	return { images, skipped };
+}
+
+/** Supported raster format from leading magic bytes, or `null` for a non-image
+ * file. Never trusts the filename extension. */
+function detectImageMime(bytes: Uint8Array): string | null {
+	if (isPng(bytes)) return "image/png";
+	if (isJpeg(bytes)) return "image/jpeg";
+	if (isGif(bytes)) return "image/gif";
+	if (isWebp(bytes)) return "image/webp";
+	return null;
+}
+
+/** Intrinsic dimensions for an already-sniffed format, or `null` when the
+ * header is truncated/malformed — the caller records that as a skipped image. */
+function parseImageDimensions(mime: string, bytes: Uint8Array): Dimensions | null {
+	switch (mime) {
+		case "image/png":
+			return parsePngDimensions(bytes);
+		case "image/jpeg":
+			return parseJpegDimensions(bytes);
+		case "image/gif":
+			return parseGifDimensions(bytes);
+		case "image/webp":
+			return parseWebpDimensions(bytes);
+		default:
+			return null;
+	}
+}
+
+interface Dimensions {
+	readonly width: number;
+	readonly height: number;
+}
+
+function isPng(b: Uint8Array): boolean {
+	return (
+		b.length >= 8 &&
+		b[0] === 0x89 &&
+		b[1] === 0x50 &&
+		b[2] === 0x4e &&
+		b[3] === 0x47 &&
+		b[4] === 0x0d &&
+		b[5] === 0x0a &&
+		b[6] === 0x1a &&
+		b[7] === 0x0a
+	);
+}
+
+function isJpeg(b: Uint8Array): boolean {
+	return b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff;
+}
+
+function isGif(b: Uint8Array): boolean {
+	// "GIF87a" or "GIF89a".
+	return (
+		b.length >= 6 &&
+		b[0] === 0x47 &&
+		b[1] === 0x49 &&
+		b[2] === 0x46 &&
+		b[3] === 0x38 &&
+		(b[4] === 0x37 || b[4] === 0x39) &&
+		b[5] === 0x61
+	);
+}
+
+function isWebp(b: Uint8Array): boolean {
+	// "RIFF" .... "WEBP".
+	return (
+		b.length >= 12 &&
+		b[0] === 0x52 &&
+		b[1] === 0x49 &&
+		b[2] === 0x46 &&
+		b[3] === 0x46 &&
+		b[8] === 0x57 &&
+		b[9] === 0x45 &&
+		b[10] === 0x42 &&
+		b[11] === 0x50
+	);
+}
+
+/** PNG IHDR: 8-byte signature, 4-byte chunk length, 4-byte "IHDR" type, then
+ * width and height as big-endian uint32 at offsets 16 and 20. */
+function parsePngDimensions(b: Uint8Array): Dimensions | null {
+	if (b.length < 24) return null;
+	if (b[12] !== 0x49 || b[13] !== 0x48 || b[14] !== 0x44 || b[15] !== 0x52) return null;
+	const width = readU32BE(b, 16);
+	const height = readU32BE(b, 20);
+	return validDimensions(width, height);
+}
+
+/** GIF logical screen descriptor: width and height as little-endian uint16 at
+ * offsets 6 and 8. */
+function parseGifDimensions(b: Uint8Array): Dimensions | null {
+	if (b.length < 10) return null;
+	return validDimensions(readU16LE(b, 6), readU16LE(b, 8));
+}
+
+/** JPEG: walk segment markers from offset 2 to the first Start-Of-Frame
+ * (SOF0–SOF15, excluding the DHT/JPG/DAC markers C4/C8/CC), whose payload is
+ * precision(1), height(2 BE), width(2 BE). */
+function parseJpegDimensions(b: Uint8Array): Dimensions | null {
+	let offset = 2;
+	while (offset + 1 < b.length) {
+		if (b[offset] !== 0xff) {
+			offset += 1;
+			continue;
+		}
+		let marker = b[offset + 1]!;
+		// Skip fill bytes (a run of 0xff) and standalone markers (RSTn, SOI, EOI,
+		// TEM) that carry no length.
+		while (marker === 0xff && offset + 1 < b.length) {
+			offset += 1;
+			marker = b[offset + 1]!;
+		}
+		offset += 2;
+		if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7) || marker === 0x01)
+			continue;
+		if (offset + 1 >= b.length) return null;
+		const segmentLength = readU16BE(b, offset);
+		if (segmentLength < 2) return null;
+		const isSof =
+			marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+		if (isSof) {
+			if (offset + 7 >= b.length) return null;
+			const height = readU16BE(b, offset + 3);
+			const width = readU16BE(b, offset + 5);
+			return validDimensions(width, height);
+		}
+		offset += segmentLength;
+	}
+	return null;
+}
+
+/** WebP RIFF container: the fourCC at offset 12 selects the bitstream variant
+ * (VP8 lossy, VP8L lossless, VP8X extended), each carrying dimensions at a
+ * different offset and encoding. */
+function parseWebpDimensions(b: Uint8Array): Dimensions | null {
+	if (b.length < 16) return null;
+	const fourCc = String.fromCharCode(b[12]!, b[13]!, b[14]!, b[15]!);
+	if (fourCc === "VP8 ") return parseWebpLossy(b);
+	if (fourCc === "VP8L") return parseWebpLossless(b);
+	if (fourCc === "VP8X") return parseWebpExtended(b);
+	return null;
+}
+
+/** Simple (lossy) WebP: after the 0x9d012a start code, 14-bit width and height
+ * (little-endian) at offsets 26 and 28. */
+function parseWebpLossy(b: Uint8Array): Dimensions | null {
+	if (b.length < 30) return null;
+	const width = readU16LE(b, 26) & 0x3fff;
+	const height = readU16LE(b, 28) & 0x3fff;
+	return validDimensions(width, height);
+}
+
+/** Lossless WebP: a 0x2f signature byte at offset 20, then a 32-bit
+ * little-endian field packing (width-1) in bits 0–13 and (height-1) in bits
+ * 14–27. */
+function parseWebpLossless(b: Uint8Array): Dimensions | null {
+	if (b.length < 25 || b[20] !== 0x2f) return null;
+	const bits = readU32LE(b, 21);
+	const width = (bits & 0x3fff) + 1;
+	const height = ((bits >> 14) & 0x3fff) + 1;
+	return validDimensions(width, height);
+}
+
+/** Extended WebP: canvas (width-1) and (height-1) as 24-bit little-endian
+ * values at offsets 24 and 27. */
+function parseWebpExtended(b: Uint8Array): Dimensions | null {
+	if (b.length < 30) return null;
+	const width = readU24LE(b, 24) + 1;
+	const height = readU24LE(b, 27) + 1;
+	return validDimensions(width, height);
+}
+
+function classifyKind(path: string, dims: Dimensions, iconPath?: string): "icon" | "screenshot" {
+	if (iconPath !== undefined && path === iconPath) return "icon";
+	const maxDimension = Math.max(dims.width, dims.height);
+	const aspect = dims.width / dims.height;
+	const nearSquare = aspect >= ICON_MIN_ASPECT && aspect <= ICON_MAX_ASPECT;
+	return maxDimension <= ICON_MAX_DIMENSION && nearSquare ? "icon" : "screenshot";
+}
+
+function validDimensions(width: number, height: number): Dimensions | null {
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+	return { width, height };
+}
+
+function readU16BE(b: Uint8Array, o: number): number {
+	return (b[o]! << 8) | b[o + 1]!;
+}
+
+function readU16LE(b: Uint8Array, o: number): number {
+	return b[o]! | (b[o + 1]! << 8);
+}
+
+function readU24LE(b: Uint8Array, o: number): number {
+	return b[o]! | (b[o + 1]! << 8) | (b[o + 2]! << 16);
+}
+
+function readU32BE(b: Uint8Array, o: number): number {
+	return (b[o]! * 0x1000000 + (b[o + 1]! << 16) + (b[o + 2]! << 8) + b[o + 3]!) >>> 0;
+}
+
+function readU32LE(b: Uint8Array, o: number): number {
+	return (b[o]! + (b[o + 1]! << 8) + (b[o + 2]! << 16) + b[o + 3]! * 0x1000000) >>> 0;
+}
+
+/** Base64 length of `n` raw bytes: 4 characters per 3-byte group, padded. */
+function predictedBase64Length(n: number): number {
+	return Math.ceil(n / 3) * 4;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", bytes);
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/** Standard (padded) base64 of the raw bytes for the adapter's `data:` URL.
+ * Chunked so `String.fromCharCode` never receives an image-sized argument
+ * list, which would overflow the call stack. */
+function toBase64(bytes: Uint8Array): string {
+	let binary = "";
+	const chunkSize = 0x8000;
+	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+		binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+	}
+	return btoa(binary);
+}

--- a/apps/labeler/src/release-resolution.ts
+++ b/apps/labeler/src/release-resolution.ts
@@ -1,0 +1,170 @@
+/**
+ * Release resolution for artifact acquisition (Slice-B design 2026-07-17). Maps
+ * an assessment to the `AcquisitionTarget` the acquire stage fetches, reading
+ * the signed release over the `AGGREGATOR` service binding (the ratified W8.4
+ * slice-3 read-path pattern) — the declared artifact URL is not stored
+ * labeler-side, only the pinned `artifact_id`/`artifact_checksum`.
+ *
+ * The release view is addressed by `(did, package)`, both derived from the
+ * assessment's release URI: the DID is the URI authority and the package slug
+ * is the rkey prefix (a release rkey is `<package>:<version>`). `getLatestRelease`
+ * is the fast path; when its CID differs from the assessment's pinned CID (a
+ * newer release now leads the package) a `listReleases` scan finds the exact
+ * pinned release, since the aggregator exposes no by-CID release endpoint.
+ *
+ * A release the aggregator has not indexed (or not yet re-indexed for this CID)
+ * throws `StageTransientError`: that is aggregator lag, the existing transient
+ * acquisition failure — never a permanent finding, since absence is not
+ * evidence the plugin is bad, and reconciliation owns true deletions. The
+ * declared-vs-pinned checksum/id drift check is NOT done here — the target
+ * carries both the declared coordinates and the pinned ones so acquisition's
+ * `crossCheckCoordinates` raises the ratified integrity finding on drift.
+ */
+
+import type { AggregatorDefs, AggregatorListReleases } from "@emdash-cms/registry-lexicons";
+
+import type { AcquisitionTarget } from "./artifact-acquisition.js";
+import { StageTransientError } from "./assessment-orchestrator.js";
+import type { Assessment } from "./assessment-store.js";
+import { parseAtUri, RecordVerificationError } from "./record-verification.js";
+
+/** Bounds the `listReleases` scan for the pinned CID. Newest-first paging means
+ * the pinned release is normally on an early page; a not-found within this many
+ * pages classifies as aggregator lag (transient), same as an absent release. */
+const MAX_RELEASE_SCAN_PAGES = 20;
+
+/** The aggregator reads this resolver needs, narrowed so tests inject a plain
+ * object. `AggregatorClient` satisfies it structurally. */
+export interface ReleaseReader {
+	getLatestRelease(did: string, pkg: string): Promise<AggregatorDefs.ReleaseView | null>;
+	listReleases(
+		did: string,
+		pkg: string,
+		cursor?: string,
+	): Promise<AggregatorListReleases.$output | null>;
+	getPackage(did: string, slug: string): Promise<AggregatorDefs.PackageView | null>;
+}
+
+export type ReleaseTargetResolver = (assessment: Assessment) => Promise<AcquisitionTarget>;
+
+export function createReleaseResolver(aggregator: ReleaseReader): ReleaseTargetResolver {
+	return async (assessment) => {
+		const { did, pkg } = parseReleaseCoordinates(assessment.uri);
+		const view = await resolveReleaseView(aggregator, did, pkg, assessment.cid);
+		const artifact = extractPackageArtifact(view.release);
+		if (!artifact) {
+			throw new StageTransientError(
+				`release ${assessment.uri} is missing a package artifact declaration in the aggregator view`,
+			);
+		}
+		const description = await resolveDescription(aggregator, did, view.package);
+		return {
+			url: artifact.url,
+			checksum: artifact.checksum,
+			slug: view.package,
+			version: view.version,
+			...(artifact.artifactId !== undefined ? { artifactId: artifact.artifactId } : {}),
+			pinnedChecksum: assessment.artifactChecksum,
+			pinnedArtifactId: assessment.artifactId,
+			...(description !== undefined ? { description } : {}),
+		};
+	};
+}
+
+interface ReleaseCoordinates {
+	readonly did: string;
+	readonly pkg: string;
+}
+
+function parseReleaseCoordinates(uri: string): ReleaseCoordinates {
+	let parsed;
+	try {
+		parsed = parseAtUri(uri);
+	} catch (err) {
+		if (err instanceof RecordVerificationError) throw new StageTransientError(err.message);
+		throw err;
+	}
+	const separator = parsed.rkey.indexOf(":");
+	const pkg = separator === -1 ? "" : parsed.rkey.slice(0, separator);
+	if (pkg.length === 0) {
+		throw new StageTransientError(`release URI ${uri} has no package slug in its record key`);
+	}
+	return { did: parsed.did, pkg };
+}
+
+/** The latest release when it is the pinned CID, otherwise the pinned CID found
+ * by scanning `listReleases`. A miss on either path is aggregator lag. */
+async function resolveReleaseView(
+	aggregator: ReleaseReader,
+	did: string,
+	pkg: string,
+	cid: string,
+): Promise<AggregatorDefs.ReleaseView> {
+	const latest = await aggregator.getLatestRelease(did, pkg);
+	if (latest && latest.cid === cid) return latest;
+
+	let cursor: string | undefined;
+	for (let page = 0; page < MAX_RELEASE_SCAN_PAGES; page += 1) {
+		const result = await aggregator.listReleases(did, pkg, cursor);
+		if (!result) break;
+		const match = result.releases.find((release) => release.cid === cid);
+		if (match) return match;
+		if (!result.cursor) break;
+		cursor = result.cursor;
+	}
+
+	throw new StageTransientError(
+		`release ${did}/${pkg}@${cid} is not indexed by the aggregator yet`,
+	);
+}
+
+/** Best-effort human description from the package profile, for the code/image
+ * stages' stated-purpose analysis. A profile-fetch failure or an unindexed
+ * profile leaves it absent — the description is analysis context, never an
+ * integrity input, so it must not fail acquisition of a verified artifact. */
+async function resolveDescription(
+	aggregator: ReleaseReader,
+	did: string,
+	slug: string,
+): Promise<string | undefined> {
+	try {
+		const view = await aggregator.getPackage(did, slug);
+		if (!view) return undefined;
+		return extractProfileDescription(view.profile);
+	} catch {
+		return undefined;
+	}
+}
+
+interface PackageArtifact {
+	readonly url: string;
+	readonly checksum: string;
+	readonly artifactId?: string;
+}
+
+/** Reads `artifacts.package.{ url, checksum, id }` from the verbatim signed
+ * release record without lexicon re-validation (the aggregator already
+ * validated it; the fetched bytes are re-verified against `checksum`
+ * downstream). Returns `null` when the required fields are absent. */
+function extractPackageArtifact(release: unknown): PackageArtifact | null {
+	if (!isRecord(release)) return null;
+	const artifacts = release.artifacts;
+	if (!isRecord(artifacts)) return null;
+	const pkg = artifacts.package;
+	if (!isRecord(pkg)) return null;
+	if (typeof pkg.url !== "string" || typeof pkg.checksum !== "string") return null;
+	return {
+		url: pkg.url,
+		checksum: pkg.checksum,
+		...(typeof pkg.id === "string" ? { artifactId: pkg.id } : {}),
+	};
+}
+
+function extractProfileDescription(profile: unknown): string | undefined {
+	if (!isRecord(profile)) return undefined;
+	return typeof profile.description === "string" ? profile.description : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/labeler/src/release-resolution.ts
+++ b/apps/labeler/src/release-resolution.ts
@@ -33,6 +33,14 @@ import { parseAtUri, RecordVerificationError } from "./record-verification.js";
  * pages classifies as aggregator lag (transient), same as an absent release. */
 const MAX_RELEASE_SCAN_PAGES = 20;
 
+/** Cap on the publisher-supplied release description threaded into the AI
+ * stages' metadata. The description is best-effort context, but it is
+ * publisher-controlled and reaches both models' fixed prompt overhead; an
+ * uncapped padded description could exceed `MAX_MODEL_INPUT_CHARS` and make the
+ * adapter throw a non-transient error that stalls the run — a block-suppression
+ * vector. Truncating at ingestion (far under the model budget) closes it. */
+export const MAX_RELEASE_DESCRIPTION_CHARS = 4096;
+
 /** The aggregator reads this resolver needs, narrowed so tests inject a plain
  * object. `AggregatorClient` satisfies it structurally. */
 export interface ReleaseReader {
@@ -162,7 +170,10 @@ function extractPackageArtifact(release: unknown): PackageArtifact | null {
 
 function extractProfileDescription(profile: unknown): string | undefined {
 	if (!isRecord(profile)) return undefined;
-	return typeof profile.description === "string" ? profile.description : undefined;
+	if (typeof profile.description !== "string") return undefined;
+	const description = profile.description;
+	if (description.length <= MAX_RELEASE_DESCRIPTION_CHARS) return description;
+	return `${description.slice(0, MAX_RELEASE_DESCRIPTION_CHARS - 1)}…`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/labeler/test/artifact-egress.test.ts
+++ b/apps/labeler/test/artifact-egress.test.ts
@@ -1,0 +1,123 @@
+/**
+ * SSRF egress wiring. The hardening itself lives in `fetchVerifiedResource`
+ * (covered by `artifact-acquisition.test.ts`); these tests prove this module
+ * wires the ratified DoH resolver and a credential-free pass-through fetch, and
+ * that the composed egress drives the resolver-gated fetch — a fake DoH keeps
+ * every case off the network.
+ */
+
+import type { HostnameResolver } from "@emdash-cms/registry-verification";
+import { cloudflareDohResolver } from "emdash/security/ssrf";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { acquireArtifact, type AcquisitionDeps } from "../src/artifact-acquisition.js";
+import { createArtifactEgress } from "../src/artifact-egress.js";
+import { canonicalBundle, checksumOf } from "./bundle-fixture.js";
+
+const PUBLIC_ADDRESS = "203.0.113.5";
+const PRIVATE_ADDRESS = "10.0.0.5";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+async function target(url = "https://cdn.example.test/plugin.tgz") {
+	const bytes = await canonicalBundle();
+	return { url, checksum: await checksumOf(bytes), slug: "test-plugin", version: "1.0.0" };
+}
+
+function egressDeps(resolveHostname: HostnameResolver): AcquisitionDeps {
+	const { fetch } = createArtifactEgress();
+	return { fetch, resolveHostname };
+}
+
+describe("createArtifactEgress: wiring", () => {
+	it("resolves hostnames with the ratified cloudflareDohResolver", () => {
+		expect(createArtifactEgress().resolveHostname).toBe(cloudflareDohResolver);
+	});
+
+	it("forwards to globalThis.fetch without adding headers or credentials", async () => {
+		const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new Uint8Array()));
+		const { fetch } = createArtifactEgress();
+		const url = new URL("https://cdn.example.test/plugin.tgz");
+		const init = {
+			method: "GET",
+			redirect: "manual",
+			signal: new AbortController().signal,
+		} as const;
+
+		await fetch(url, init);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(url, init);
+		const [, forwardedInit] = spy.mock.calls[0]!;
+		expect(forwardedInit).toBe(init);
+		expect((forwardedInit as RequestInit).headers).toBeUndefined();
+	});
+});
+
+describe("createArtifactEgress: composed SSRF enforcement", () => {
+	it("fetches through the pass-through when the host resolves public", async () => {
+		const bytes = await canonicalBundle();
+		const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(bytes));
+
+		const result = await acquireArtifact(
+			egressDeps(async () => [PUBLIC_ADDRESS]),
+			await target(),
+		);
+
+		expect(result.success).toBe(true);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects a host that resolves to a private address before any fetch is made", async () => {
+		const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new Uint8Array()));
+
+		const result = await acquireArtifact(
+			egressDeps(async () => [PRIVATE_ADDRESS]),
+			await target(),
+		);
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error).toMatchObject({ kind: "policy-rejection", code: "HOST_REJECTED" });
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("fails closed and does not fetch when DoH resolves no addresses", async () => {
+		const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new Uint8Array()));
+
+		const result = await acquireArtifact(
+			egressDeps(async () => []),
+			await target(),
+		);
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error).toMatchObject({ code: "HOST_REJECTED" });
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("re-resolves each redirect hop and rejects a redirect into a private host", async () => {
+		const spy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(
+				new Response(null, {
+					status: 302,
+					headers: { location: "https://internal.example.test/plugin.tgz" },
+				}),
+			)
+			.mockResolvedValue(new Response(new Uint8Array()));
+		const resolveHostname: HostnameResolver = async (hostname) =>
+			hostname === "internal.example.test" ? [PRIVATE_ADDRESS] : [PUBLIC_ADDRESS];
+
+		const result = await acquireArtifact(egressDeps(resolveHostname), await target());
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error).toMatchObject({ kind: "policy-rejection", code: "HOST_REJECTED" });
+		// The first hop was fetched; the private redirect target was rejected at
+		// resolution, before its own fetch.
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/labeler/test/assessment-orchestrator.test.ts
+++ b/apps/labeler/test/assessment-orchestrator.test.ts
@@ -556,6 +556,76 @@ describe("AssessmentOrchestrator: transient exhaustion", () => {
 		expect(pendingNeg?.neg).toBe(1);
 	});
 
+	it("preserves an already-confirmed block when a later stage transient-exhausts", async () => {
+		const run = await pendingRun({
+			name: "block-preserved",
+			cidValue: await cid("block-preserved"),
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			codeAi: () => Promise.resolve([finding({ category: "malware", severity: "critical" })]),
+			imageAi: () => Promise.reject(new StageTransientError("vision model unavailable")),
+		};
+
+		const result = await (
+			await buildOrchestrator(stages, { maxStageRetries: 1 })
+		).runAssessment(run.id);
+
+		expect(result.state).toBe("blocked");
+		const block = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'malware'`,
+		)
+			.bind(run.uri, run.cid)
+			.first<{ neg: number }>();
+		expect(block?.neg).toBe(0);
+		// A confirmed block is monotonic: the run finalizes blocked, never error or a
+		// spurious pass, even though a later stage never completed.
+		const error = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'assessment-error'`,
+		)
+			.bind(run.uri, run.cid)
+			.first<{ neg: number }>();
+		expect(error).toBeNull();
+		const passed = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'assessment-passed'`,
+		)
+			.bind(run.uri, run.cid)
+			.first<{ neg: number }>();
+		expect(passed).toBeNull();
+	});
+
+	it("finalizes error, not warned, when only a warning preceded a later stage's exhaustion", async () => {
+		const run = await pendingRun({
+			name: "warn-then-exhaust",
+			cidValue: await cid("warn-then-exhaust"),
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			codeAi: () => Promise.resolve([finding({ category: "obfuscated-code", severity: "medium" })]),
+			imageAi: () => Promise.reject(new StageTransientError("vision model unavailable")),
+		};
+
+		const result = await (
+			await buildOrchestrator(stages, { maxStageRetries: 1 })
+		).runAssessment(run.id);
+
+		// A warning is not monotonic — an unrun stage might have found a block — so
+		// an incomplete run with only a warning must retry as error, never warned.
+		expect(result.state).toBe("error");
+		const errorLabel = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'assessment-error'`,
+		)
+			.bind(run.uri, run.cid)
+			.first<{ neg: number }>();
+		expect(errorLabel?.neg).toBe(0);
+		const warnLabel = await testEnv.DB.prepare(
+			`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = 'obfuscated-code'`,
+		)
+			.bind(run.uri, run.cid)
+			.first<{ neg: number }>();
+		expect(warnLabel).toBeNull();
+	});
+
 	it("a second error run for the same subject leaves assessment-error active, not self-negated", async () => {
 		const cidValue = await cid("double-error");
 		const flaky: OrchestratorStages = {

--- a/apps/labeler/test/assessment-stages.test.ts
+++ b/apps/labeler/test/assessment-stages.test.ts
@@ -21,6 +21,7 @@ import {
 import {
 	createCodeAiStage,
 	createHistoryStage,
+	createImageAiStage,
 	serializeCoverage,
 	type CoverageAccumulator,
 } from "../src/assessment-stages.js";
@@ -31,6 +32,7 @@ import {
 } from "../src/assessment-store.js";
 import type { AiBinding, AiRunInputs } from "../src/code-ai-adapter.js";
 import type { PublisherVerificationReader } from "../src/history-context.js";
+import type { ImageAiBinding } from "../src/image-ai-adapter.js";
 import { MODERATION_POLICY } from "../src/policy.js";
 import { initializeSigningState } from "../src/signing-rotation.js";
 import { canonicalBundle, checksumOf, file } from "./bundle-fixture.js";
@@ -395,6 +397,234 @@ describe("analysis stages: acquire produced no bundle", () => {
 		expect(holder.result).toBeUndefined();
 		expect(await labelNeg(run.uri, run.cid, "artifact-integrity-failure")).toBe(0);
 		expect(JSON.parse(result.coverageJson).code).toBe("unavailable");
+	});
+});
+
+function pngBytes(width: number, height: number): Uint8Array {
+	const bytes = new Uint8Array(24);
+	bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+	bytes.set([0x00, 0x00, 0x00, 0x0d], 8);
+	bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+	const view = new DataView(bytes.buffer);
+	view.setUint32(16, width);
+	view.setUint32(20, height);
+	return bytes;
+}
+
+function imageFakeAi(run: (model: string, inputs: unknown) => Promise<unknown>): ImageAiBinding {
+	return { run: run as ImageAiBinding["run"] };
+}
+
+const IMAGE_WARN_FINDING = {
+	category: "obfuscated-code",
+	severity: "medium",
+	title: "suspicious UI",
+	publicSummary: "the icon mimics a system dialog",
+	privateDetail: "icon.png renders a fake credential prompt",
+	affectedImages: ["icon.png"],
+};
+
+/** Acquire stage variant that pins a description onto the resolved target, so
+ * the AI stages receive a real stated-purpose input. */
+function acquireStageWithDescription(
+	bytes: Uint8Array,
+	checksum: string,
+	holder: AcquisitionHolder,
+	description: string,
+) {
+	return createAcquireStage({
+		deps: {
+			fetch: async () => new Response(bytes),
+			resolveHostname: async () => ["203.0.113.5"],
+		},
+		resolveTarget: async () => ({
+			url: "https://cdn.example.test/plugin.tgz",
+			checksum,
+			slug: "test-plugin",
+			version: "1.0.0",
+			description,
+		}),
+		holder,
+	});
+}
+
+describe("analysis stages: image AI stage", () => {
+	it("runs the vision model over extracted images and flows findings into the outcome", async () => {
+		const run = await pendingRun("image-warn");
+		const bytes = await canonicalBundle([file("icon.png", pngBytes(128, 128))]);
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const codeAi = fakeAi(() => Promise.resolve(findingResponse([])));
+		const imageAi = imageFakeAi(() =>
+			Promise.resolve({ response: JSON.stringify({ findings: [IMAGE_WARN_FINDING] }) }),
+		);
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai: codeAi,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			imageAi: createImageAiStage({
+				holder,
+				ai: imageAi,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("warned");
+		expect(await labelNeg(run.uri, run.cid, "obfuscated-code")).toBe(0);
+		expect(JSON.parse(result.coverageJson).images).toBe("complete");
+	});
+
+	it("records not-present and never calls the model when the bundle has no images", async () => {
+		const run = await pendingRun("image-none");
+		const bytes = await canonicalBundle();
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		let imageModelCalled = false;
+		const imageAi = imageFakeAi(() => {
+			imageModelCalled = true;
+			return Promise.resolve({ response: JSON.stringify({ findings: [] }) });
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai: fakeAi(() => Promise.resolve(findingResponse([]))),
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			imageAi: createImageAiStage({
+				holder,
+				ai: imageAi,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("passed");
+		expect(imageModelCalled).toBe(false);
+		expect(JSON.parse(result.coverageJson).images).toBe("not-present");
+	});
+
+	it("keeps a code-stage block when the image stage transient-exhausts (not discarded to error)", async () => {
+		const run = await pendingRun("image-block-preserved");
+		const bytes = await canonicalBundle([file("icon.png", pngBytes(128, 128))]);
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const codeAi = fakeAi(() => Promise.resolve(findingResponse([BLOCK_FINDING])));
+		const imageAi = imageFakeAi(() => Promise.reject(new Error("vision model overloaded")));
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai: codeAi,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			imageAi: createImageAiStage({
+				holder,
+				ai: imageAi,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (
+			await buildOrchestrator(stages, { coverage, maxStageRetries: 1 })
+		).runAssessment(run.id);
+
+		expect(result.state).toBe("blocked");
+		expect(await labelNeg(run.uri, run.cid, "malware")).toBe(0);
+		expect(await labelNeg(run.uri, run.cid, "assessment-error")).toBeUndefined();
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBeUndefined();
+	});
+
+	it("finalizes error on a transient image model failure and reports code complete, images unavailable", async () => {
+		const run = await pendingRun("image-transient");
+		const bytes = await canonicalBundle([file("icon.png", pngBytes(128, 128))]);
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const imageAi = imageFakeAi(() => Promise.reject(new Error("vision model overloaded")));
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStage(bytes, await checksumOf(bytes), holder),
+			codeAi: createCodeAiStage({
+				holder,
+				ai: fakeAi(() => Promise.resolve(findingResponse([]))),
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			imageAi: createImageAiStage({
+				holder,
+				ai: imageAi,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (
+			await buildOrchestrator(stages, { coverage, maxStageRetries: 1 })
+		).runAssessment(run.id);
+
+		expect(result.state).toBe("error");
+		const parsed = JSON.parse(result.coverageJson);
+		expect(parsed.code).toBe("complete");
+		expect(parsed.images).toBe("unavailable");
+	});
+});
+
+describe("analysis stages: release description threading", () => {
+	it("passes the resolved release description into the code model input", async () => {
+		const run = await pendingRun("desc-thread");
+		const bytes = await canonicalBundle();
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const description = "Imports your contacts and posts on your behalf.";
+		let capturedInput = "";
+		const codeAi = fakeAi((_model, inputs) => {
+			capturedInput = JSON.stringify(inputs);
+			return Promise.resolve(findingResponse([]));
+		});
+		const stages: OrchestratorStages = {
+			...stubStages,
+			acquire: acquireStageWithDescription(bytes, await checksumOf(bytes), holder, description),
+			codeAi: createCodeAiStage({
+				holder,
+				ai: codeAi,
+				policy: MODERATION_POLICY,
+				promptVersion: PROMPT_VERSION,
+				coverage,
+			}),
+			history: createHistoryStage({ db: testEnv.DB, src: LABELER_DID }),
+		};
+
+		const result = await (await buildOrchestrator(stages, { coverage })).runAssessment(run.id);
+
+		expect(result.state).toBe("passed");
+		expect(capturedInput).toContain(description);
 	});
 });
 

--- a/apps/labeler/test/assessment-workflow.test.ts
+++ b/apps/labeler/test/assessment-workflow.test.ts
@@ -1,27 +1,46 @@
 /**
- * The assessment Workflow is a thin durable shell over `AssessmentOrchestrator`
- * (whose stage execution and finalization `assessment-orchestrator.test.ts`
- * already covers). Cloudflare's Workflow runtime has no local test harness and
- * the entrypoint class cannot be constructed in the workers pool, so these
- * tests exercise `executeAssessmentInstance` — the shell body `run` wraps in a
- * durable step — directly: it must load the pending run, compose the
- * orchestrator, and finalize, plus resume idempotently on a re-run.
+ * The assessment Workflow is a thin durable shell over `AssessmentOrchestrator`.
+ * Two layers are exercised here:
+ *
+ *  - `executeAssessmentInstance` (the shell body `run` wraps in a durable step):
+ *    the idempotent terminal short-circuit, the not-found guard, and the
+ *    fail-loud binding check.
+ *  - `buildStages` assembled end-to-end through a real orchestrator with a fake
+ *    aggregator, fake SSRF egress, fake AI, and a bundle fixture — the lifted
+ *    deploy gate: a `passed` outcome now means a real acquire→scan ran, and a
+ *    declared-vs-pinned drift blocks rather than fetching the wrong artifact.
+ *
+ * Cloudflare's Workflow runtime has no local harness, so the entrypoint class
+ * is not constructed; both layers are driven directly.
  */
 
 import { CODEC_RAW, create as createCid, toString as cidToString } from "@atcute/cid";
+import {
+	createLabelSigner,
+	type LabelDidDocument,
+	type LabelSigner,
+} from "@emdash-cms/registry-moderation";
 import { applyD1Migrations, env } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import type { AcquisitionHolder } from "../src/artifact-acquisition.js";
+import type { ArtifactEgress } from "../src/artifact-egress.js";
 import { computeRunKey, initialTriggerId } from "../src/assessment-lifecycle.js";
+import { AssessmentOrchestrator } from "../src/assessment-orchestrator.js";
+import { serializeCoverage, type CoverageAccumulator } from "../src/assessment-stages.js";
 import {
 	createAssessmentRun,
 	createSubject,
-	getAssessment,
 	transitionAssessmentState,
 } from "../src/assessment-store.js";
-import { executeAssessmentInstance } from "../src/assessment-workflow.js";
+import { buildStages, executeAssessmentInstance } from "../src/assessment-workflow.js";
+import type { AiBinding } from "../src/code-ai-adapter.js";
+import type { PublisherVerificationReader } from "../src/history-context.js";
+import type { ImageAiBinding } from "../src/image-ai-adapter.js";
 import { MODERATION_POLICY } from "../src/policy.js";
+import type { ReleaseReader } from "../src/release-resolution.js";
 import { initializeSigningState } from "../src/signing-rotation.js";
+import { canonicalBundle, checksumOf } from "./bundle-fixture.js";
 
 interface TestEnv {
 	DB: D1Database;
@@ -31,7 +50,9 @@ interface TestEnv {
 const testEnv = env as unknown as TestEnv;
 const LABELER_DID = "did:web:labels.emdashcms.com";
 const PUBLISHER_DID = "did:plc:publisher000000000000000000";
+const PRIVATE_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE";
 const MULTIKEY = "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ";
+const config = { labelerDid: LABELER_DID, signingKeyVersion: "v1" };
 
 beforeAll(async () => {
 	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
@@ -41,6 +62,28 @@ beforeAll(async () => {
 		publicKeyMultibase: MULTIKEY,
 	});
 });
+
+function document(): LabelDidDocument {
+	return {
+		id: LABELER_DID,
+		verificationMethod: [
+			{
+				id: "#atproto_label",
+				type: "Multikey",
+				controller: LABELER_DID,
+				publicKeyMultibase: MULTIKEY,
+			},
+		],
+	};
+}
+
+function signer(): Promise<LabelSigner> {
+	return createLabelSigner({
+		issuerDid: LABELER_DID,
+		privateKey: PRIVATE_KEY,
+		resolveDid: async () => document(),
+	});
+}
 
 async function cid(seed: string): Promise<string> {
 	const bytes = new TextEncoder().encode(seed);
@@ -55,7 +98,10 @@ function releaseUri(name: string): string {
 }
 
 /** Creates a verified subject and a `pending` assessment run. */
-async function pendingRun(name: string): Promise<{ id: string; uri: string; cid: string }> {
+async function pendingRun(
+	name: string,
+	pins: { artifactChecksum?: string; artifactId?: string } = {},
+): Promise<{ id: string; uri: string; cid: string }> {
 	const uri = releaseUri(name);
 	const cidValue = await cid(name);
 	await createSubject(testEnv.DB, {
@@ -83,6 +129,8 @@ async function pendingRun(name: string): Promise<{ id: string; uri: string; cid:
 		triggerId,
 		policyVersion: MODERATION_POLICY.policyVersion,
 		coverageJson: "{}",
+		...(pins.artifactChecksum !== undefined ? { artifactChecksum: pins.artifactChecksum } : {}),
+		...(pins.artifactId !== undefined ? { artifactId: pins.artifactId } : {}),
 	});
 	await transitionAssessmentState(testEnv.DB, {
 		id: assessment.id,
@@ -97,53 +145,211 @@ async function pendingRun(name: string): Promise<{ id: string; uri: string; cid:
 	return { id: assessment.id, uri, cid: cidValue };
 }
 
-const workflowEnv = env as unknown as Env;
+function servingEgress(bytes: Uint8Array): ArtifactEgress {
+	return { fetch: async () => new Response(bytes), resolveHostname: async () => ["203.0.113.5"] };
+}
 
-describe("executeAssessmentInstance", () => {
-	it("drives a pending run through the orchestrator to finalization (passed, stub stages)", async () => {
-		const run = await pendingRun("wf-happy");
+function fakeAi(findings: unknown[]): AiBinding & ImageAiBinding {
+	const run = () => Promise.resolve({ response: JSON.stringify({ findings }) });
+	return { run } as unknown as AiBinding & ImageAiBinding;
+}
 
-		const state = await executeAssessmentInstance(workflowEnv, run.id);
+function fakeAggregator(
+	runCid: string,
+	declaredChecksum: string,
+): ReleaseReader & PublisherVerificationReader {
+	const view = {
+		cid: runCid,
+		did: PUBLISHER_DID,
+		indexedAt: "2026-07-17T00:00:00.000Z",
+		package: "test-plugin",
+		version: "1.0.0",
+		uri: releaseUri("test-plugin"),
+		release: {
+			$type: "com.emdashcms.experimental.package.release",
+			package: "test-plugin",
+			version: "1.0.0",
+			artifacts: {
+				package: { url: "https://cdn.example.test/plugin.tgz", checksum: declaredChecksum },
+			},
+		},
+	};
+	return {
+		getLatestRelease: async () => view as never,
+		listReleases: async () => ({ releases: [view] }) as never,
+		getPackage: async () => null,
+		getPublisherVerification: async () => null,
+	};
+}
 
-		expect(state).toBe("passed");
-		const finalized = await getAssessment(testEnv.DB, run.id);
-		expect(finalized?.state).toBe("passed");
+async function runFullPath(
+	runId: string,
+	runCid: string,
+	options: {
+		bundle: Uint8Array;
+		declaredChecksum: string;
+		ai?: AiBinding & ImageAiBinding;
+	},
+) {
+	const holder: AcquisitionHolder = {};
+	const coverage: CoverageAccumulator = {};
+	const stages = buildStages({
+		holder,
+		coverage,
+		config,
+		policy: MODERATION_POLICY,
+		db: testEnv.DB,
+		egress: servingEgress(options.bundle),
+		aggregator: fakeAggregator(runCid, options.declaredChecksum),
+		ai: options.ai ?? fakeAi([]),
+	});
+	const orchestrator = new AssessmentOrchestrator({
+		db: testEnv.DB,
+		config,
+		signer: await signer(),
+		policy: MODERATION_POLICY,
+		stages,
+		sleep: () => Promise.resolve(),
+		resolveCoverageJson: () => serializeCoverage(coverage),
+	});
+	return orchestrator.runAssessment(runId);
+}
 
-		// The run's own assessment-pending is negated on finalization.
-		const pending = await testEnv.DB.prepare(
-			`SELECT l.neg FROM issued_labels l JOIN issuance_actions a ON a.id = l.action_id
-			 WHERE l.uri = ? AND l.cid = ? AND l.val = 'assessment-pending'`,
-		)
-			.bind(run.uri, run.cid)
-			.first<{ neg: number }>();
-		expect(pending?.neg).toBe(1);
+async function labelNeg(uri: string, cidValue: string, val: string): Promise<number | undefined> {
+	const row = await testEnv.DB.prepare(
+		`SELECT neg FROM issued_labels WHERE uri = ? AND cid = ? AND val = ? ORDER BY sequence DESC LIMIT 1`,
+	)
+		.bind(uri, cidValue, val)
+		.first<{ neg: number }>();
+	return row?.neg;
+}
+
+const minimalEnv = { DB: testEnv.DB } as unknown as Env;
+
+describe("buildStages: assembled production path (deploy gate lifted)", () => {
+	it("does not throw when assembling the four real stages", async () => {
+		const bytes = await canonicalBundle();
+		expect(() =>
+			buildStages({
+				holder: {},
+				coverage: {},
+				config,
+				policy: MODERATION_POLICY,
+				db: testEnv.DB,
+				egress: servingEgress(bytes),
+				aggregator: fakeAggregator("cid", "checksum"),
+				ai: fakeAi([]),
+			}),
+		).not.toThrow();
 	});
 
-	it("resumes idempotently: a re-run of an already-finalized assessment returns its state without re-entering the orchestrator", async () => {
-		const run = await pendingRun("wf-resume");
+	it("acquires, scans clean, and finalizes passed with real coverage", async () => {
+		const run = await pendingRun("wf-full-pass");
+		const bytes = await canonicalBundle();
+		const result = await runFullPath(run.id, run.cid, {
+			bundle: bytes,
+			declaredChecksum: await checksumOf(bytes),
+		});
 
-		expect(await executeAssessmentInstance(workflowEnv, run.id)).toBe("passed");
-		// A second execution (as a durable retry would do) must not throw on the
-		// now-terminal row — the orchestrator's pending-guard would otherwise
-		// reject it.
-		expect(await executeAssessmentInstance(workflowEnv, run.id)).toBe("passed");
+		expect(result.state).toBe("passed");
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBe(0);
+		expect(JSON.parse(result.coverageJson)).toMatchObject({
+			code: "complete",
+			images: "not-present",
+		});
 	});
 
-	it("resumes a run left `running` by a crashed attempt and finalizes it", async () => {
-		const run = await pendingRun("wf-running-resume");
-		// Simulate a prior attempt that made the pending→running CAS then crashed
-		// (e.g. a durable step evicted mid-finalize) before finalizing.
-		await transitionAssessmentState(testEnv.DB, { id: run.id, from: "pending", to: "running" });
+	it("blocks on a code-model block finding across the assembled stages", async () => {
+		const run = await pendingRun("wf-full-block");
+		const bytes = await canonicalBundle();
+		const result = await runFullPath(run.id, run.cid, {
+			bundle: bytes,
+			declaredChecksum: await checksumOf(bytes),
+			ai: fakeAi([
+				{
+					category: "malware",
+					severity: "critical",
+					title: "malware",
+					publicSummary: "ships a payload",
+					privateDetail: "backend.js drops a dropper",
+					affectedFiles: ["backend.js"],
+				},
+			]),
+		});
 
-		const state = await executeAssessmentInstance(workflowEnv, run.id);
-
-		expect(state).toBe("passed");
-		expect((await getAssessment(testEnv.DB, run.id))?.state).toBe("passed");
+		expect(result.state).toBe("blocked");
+		expect(await labelNeg(run.uri, run.cid, "malware")).toBe(0);
+		expect(await labelNeg(run.uri, run.cid, "assessment-passed")).toBeUndefined();
 	});
 
+	it("blocks on declared-vs-pinned checksum drift without fetching the wrong artifact", async () => {
+		const bytes = await canonicalBundle();
+		const declared = await checksumOf(bytes);
+		const run = await pendingRun("wf-drift", { artifactChecksum: `${declared}-tampered` });
+
+		let fetched = false;
+		const egress: ArtifactEgress = {
+			fetch: async () => {
+				fetched = true;
+				return new Response(bytes);
+			},
+			resolveHostname: async () => ["203.0.113.5"],
+		};
+		const holder: AcquisitionHolder = {};
+		const coverage: CoverageAccumulator = {};
+		const stages = buildStages({
+			holder,
+			coverage,
+			config,
+			policy: MODERATION_POLICY,
+			db: testEnv.DB,
+			egress,
+			aggregator: fakeAggregator(run.cid, declared),
+			ai: fakeAi([]),
+		});
+		const orchestrator = new AssessmentOrchestrator({
+			db: testEnv.DB,
+			config,
+			signer: await signer(),
+			policy: MODERATION_POLICY,
+			stages,
+			sleep: () => Promise.resolve(),
+			resolveCoverageJson: () => serializeCoverage(coverage),
+		});
+		const result = await orchestrator.runAssessment(run.id);
+
+		expect(result.state).toBe("blocked");
+		expect(fetched).toBe(false);
+		expect(holder.result).toBeUndefined();
+		expect(await labelNeg(run.uri, run.cid, "artifact-integrity-failure")).toBe(0);
+	});
+});
+
+describe("executeAssessmentInstance: shell", () => {
 	it("throws when the assessment does not exist", async () => {
 		await expect(
-			executeAssessmentInstance(workflowEnv, "asmt_00000000000000000000000000"),
+			executeAssessmentInstance(minimalEnv, "asmt_00000000000000000000000000"),
 		).rejects.toThrow(/not found/);
+	});
+
+	it("short-circuits idempotently on an already-finalized terminal row", async () => {
+		const run = await pendingRun("wf-idempotent");
+		const bytes = await canonicalBundle();
+		const first = await runFullPath(run.id, run.cid, {
+			bundle: bytes,
+			declaredChecksum: await checksumOf(bytes),
+		});
+		expect(first.state).toBe("passed");
+
+		// A durable-step retry re-enters with the row now terminal: it must return
+		// the finalized state without rebuilding stages (minimalEnv has no bindings).
+		expect(await executeAssessmentInstance(minimalEnv, run.id)).toBe("passed");
+	});
+
+	it("fails loudly when a required binding is missing", async () => {
+		const run = await pendingRun("wf-missing-binding");
+		await expect(executeAssessmentInstance(minimalEnv, run.id)).rejects.toThrow(
+			/missing required bindings/,
+		);
 	});
 });

--- a/apps/labeler/test/image-metadata.test.ts
+++ b/apps/labeler/test/image-metadata.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Deterministic image-metadata extractor. Crafted format headers exercise each
+ * parser; truncated/renamed/oversized inputs prove it never throws and only
+ * degrades coverage.
+ */
+
+import type { ValidatedBundleFile } from "@emdash-cms/registry-verification";
+import { describe, expect, it } from "vitest";
+
+import { extractBundleImages } from "../src/image-metadata.js";
+
+const encoder = new TextEncoder();
+
+function bundleFile(path: string, bytes: Uint8Array): ValidatedBundleFile {
+	return { path, bytes };
+}
+
+function png(width: number, height: number, extra = 0): Uint8Array {
+	const bytes = new Uint8Array(24 + extra);
+	bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+	bytes.set([0x00, 0x00, 0x00, 0x0d], 8);
+	bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+	const view = new DataView(bytes.buffer);
+	view.setUint32(16, width);
+	view.setUint32(20, height);
+	return bytes;
+}
+
+function gif(width: number, height: number): Uint8Array {
+	const bytes = new Uint8Array(10);
+	bytes.set([0x47, 0x49, 0x46, 0x38, 0x39, 0x61], 0);
+	const view = new DataView(bytes.buffer);
+	view.setUint16(6, width, true);
+	view.setUint16(8, height, true);
+	return bytes;
+}
+
+function jpeg(width: number, height: number): Uint8Array {
+	const bytes = new Uint8Array(12);
+	bytes.set([0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08], 0);
+	const view = new DataView(bytes.buffer);
+	view.setUint16(7, height);
+	view.setUint16(9, width);
+	return bytes;
+}
+
+function webpHeader(fourCc: string, length: number): Uint8Array {
+	const bytes = new Uint8Array(length);
+	bytes.set([0x52, 0x49, 0x46, 0x46], 0); // RIFF
+	bytes.set([0x57, 0x45, 0x42, 0x50], 8); // WEBP
+	bytes.set(encoder.encode(fourCc), 12);
+	return bytes;
+}
+
+function webpLossy(width: number, height: number): Uint8Array {
+	const bytes = webpHeader("VP8 ", 30);
+	const view = new DataView(bytes.buffer);
+	view.setUint16(26, width & 0x3fff, true);
+	view.setUint16(28, height & 0x3fff, true);
+	return bytes;
+}
+
+function webpLossless(width: number, height: number): Uint8Array {
+	const bytes = webpHeader("VP8L", 25);
+	bytes[20] = 0x2f;
+	const bits = ((width - 1) & 0x3fff) | (((height - 1) & 0x3fff) << 14);
+	new DataView(bytes.buffer).setUint32(21, bits >>> 0, true);
+	return bytes;
+}
+
+function webpExtended(width: number, height: number): Uint8Array {
+	const bytes = webpHeader("VP8X", 30);
+	const w = width - 1;
+	const h = height - 1;
+	bytes[24] = w & 0xff;
+	bytes[25] = (w >> 8) & 0xff;
+	bytes[26] = (w >> 16) & 0xff;
+	bytes[27] = h & 0xff;
+	bytes[28] = (h >> 8) & 0xff;
+	bytes[29] = (h >> 16) & 0xff;
+	return bytes;
+}
+
+describe("extractBundleImages: format parsing", () => {
+	it("parses PNG dimensions and mime from the IHDR header", async () => {
+		const { images, skipped } = await extractBundleImages([bundleFile("a.png", png(640, 480))]);
+		expect(skipped).toEqual([]);
+		expect(images).toHaveLength(1);
+		expect(images[0]).toMatchObject({ mime: "image/png", width: 640, height: 480 });
+	});
+
+	it("parses JPEG dimensions from the SOF marker", async () => {
+		const { images } = await extractBundleImages([bundleFile("a.jpg", jpeg(800, 600))]);
+		expect(images[0]).toMatchObject({ mime: "image/jpeg", width: 800, height: 600 });
+	});
+
+	it("parses GIF dimensions from the logical screen descriptor", async () => {
+		const { images } = await extractBundleImages([bundleFile("a.gif", gif(120, 90))]);
+		expect(images[0]).toMatchObject({ mime: "image/gif", width: 120, height: 90 });
+	});
+
+	it("parses all three WebP bitstream variants", async () => {
+		const files = [
+			bundleFile("lossy.webp", webpLossy(200, 100)),
+			bundleFile("lossless.webp", webpLossless(300, 150)),
+			bundleFile("extended.webp", webpExtended(1024, 768)),
+		];
+		const { images } = await extractBundleImages(files);
+		expect(images.map((i) => [i.mime, i.width, i.height])).toEqual([
+			["image/webp", 200, 100],
+			["image/webp", 300, 150],
+			["image/webp", 1024, 768],
+		]);
+	});
+});
+
+describe("extractBundleImages: magic-byte sniffing", () => {
+	it("sniffs mime from bytes, not the filename extension", async () => {
+		const { images } = await extractBundleImages([bundleFile("actually-a-png.txt", png(16, 16))]);
+		expect(images[0]?.mime).toBe("image/png");
+	});
+
+	it("does not treat a text file with an image extension as an image", async () => {
+		const source = encoder.encode("export default function () {}\n");
+		const { images, skipped } = await extractBundleImages([bundleFile("evil.png", source)]);
+		expect(images).toEqual([]);
+		expect(skipped).toEqual([]);
+	});
+
+	it("ignores non-image files entirely — not counted as images or skips", async () => {
+		const { images, skipped } = await extractBundleImages([
+			bundleFile("manifest.json", encoder.encode("{}")),
+			bundleFile("icon.png", png(32, 32)),
+		]);
+		expect(images).toHaveLength(1);
+		expect(skipped).toEqual([]);
+	});
+});
+
+describe("extractBundleImages: malformed input never throws", () => {
+	it("skips a truncated PNG whose IHDR is incomplete", async () => {
+		const truncated = png(64, 64).subarray(0, 18);
+		const { images, skipped } = await extractBundleImages([bundleFile("broken.png", truncated)]);
+		expect(images).toEqual([]);
+		expect(skipped).toEqual(["broken.png"]);
+	});
+
+	it("skips a JPEG with no SOF marker", async () => {
+		const headerOnly = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
+		const { images, skipped } = await extractBundleImages([bundleFile("empty.jpg", headerOnly)]);
+		expect(images).toEqual([]);
+		expect(skipped).toEqual(["empty.jpg"]);
+	});
+
+	it("skips a zero-dimension image rather than emitting it", async () => {
+		const { images, skipped } = await extractBundleImages([bundleFile("zero.gif", gif(0, 0))]);
+		expect(images).toEqual([]);
+		expect(skipped).toEqual(["zero.gif"]);
+	});
+});
+
+describe("extractBundleImages: caps degrade coverage to partial", () => {
+	it("skips an image over the per-image byte cap", async () => {
+		const big = png(64, 64, 1_600_000);
+		const { images, skipped } = await extractBundleImages([bundleFile("huge.png", big)]);
+		expect(images).toEqual([]);
+		expect(skipped).toEqual(["huge.png"]);
+	});
+
+	it("keeps at most MAX_IMAGES and skips the overflow", async () => {
+		const files = Array.from({ length: 13 }, (_, i) => bundleFile(`icon-${i}.png`, png(16, 16)));
+		const { images, skipped } = await extractBundleImages(files);
+		expect(images).toHaveLength(12);
+		expect(skipped).toEqual(["icon-12.png"]);
+	});
+
+	it("skips images that would exceed the aggregate byte cap", async () => {
+		// Each image is exactly 1.2 MB raw → 1.6 MB base64; five reach the 8 MB
+		// aggregate cap exactly, the sixth overflows and is skipped.
+		const files = Array.from({ length: 6 }, (_, i) =>
+			bundleFile(`shot-${i}.png`, png(64, 64, 1_200_000 - 24)),
+		);
+		const { images, skipped } = await extractBundleImages(files);
+		expect(images).toHaveLength(5);
+		expect(skipped).toEqual(["shot-5.png"]);
+	});
+});
+
+describe("extractBundleImages: classification and hashing", () => {
+	it("classifies a small near-square image as an icon and a large one as a screenshot", async () => {
+		const { images } = await extractBundleImages([
+			bundleFile("icon.png", png(128, 128)),
+			bundleFile("shot.png", png(1280, 720)),
+		]);
+		expect(images.find((i) => i.path === "icon.png")?.kind).toBe("icon");
+		expect(images.find((i) => i.path === "shot.png")?.kind).toBe("screenshot");
+	});
+
+	it("honours a declared manifest icon path over the dimension heuristic", async () => {
+		const { images } = await extractBundleImages(
+			[bundleFile("assets/brand.png", png(1280, 720))],
+			"assets/brand.png",
+		);
+		expect(images[0]?.kind).toBe("icon");
+	});
+
+	it("emits the SHA-256 hex and base64 of the exact bytes", async () => {
+		const bytes = png(16, 16);
+		const { images } = await extractBundleImages([bundleFile("a.png", bytes)]);
+		const digest = await crypto.subtle.digest("SHA-256", bytes);
+		const expectedHex = Array.from(new Uint8Array(digest), (b) =>
+			b.toString(16).padStart(2, "0"),
+		).join("");
+		expect(images[0]?.sha256).toBe(expectedHex);
+		const decoded = Uint8Array.from(atob(images[0]!.dataBase64), (c) => c.charCodeAt(0));
+		expect(decoded).toEqual(bytes);
+	});
+});

--- a/apps/labeler/test/release-resolution.test.ts
+++ b/apps/labeler/test/release-resolution.test.ts
@@ -11,7 +11,11 @@ import { describe, expect, it } from "vitest";
 
 import { StageTransientError } from "../src/assessment-orchestrator.js";
 import type { Assessment } from "../src/assessment-store.js";
-import { createReleaseResolver, type ReleaseReader } from "../src/release-resolution.js";
+import {
+	createReleaseResolver,
+	MAX_RELEASE_DESCRIPTION_CHARS,
+	type ReleaseReader,
+} from "../src/release-resolution.js";
 
 const PUBLISHER_DID = "did:plc:publisher000000000000000000";
 const RELEASE_URI = `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.release/test-plugin:1.0.0`;
@@ -166,6 +170,20 @@ describe("createReleaseResolver", () => {
 		const targetResult = await resolve(assessment());
 
 		expect(targetResult.description).toBe("A friendly plugin that does one thing well.");
+	});
+
+	it("truncates an over-cap publisher description to the ingestion cap", async () => {
+		const resolve = createReleaseResolver(
+			reader({
+				getLatestRelease: async () => releaseView({ cid: "bafyPinnedCid" }),
+				getPackage: async () => packageView("x".repeat(MAX_RELEASE_DESCRIPTION_CHARS * 4)),
+			}),
+		);
+
+		const targetResult = await resolve(assessment());
+
+		expect(targetResult.description).toHaveLength(MAX_RELEASE_DESCRIPTION_CHARS);
+		expect(targetResult.description?.endsWith("…")).toBe(true);
 	});
 
 	it("leaves the description absent when the profile fetch fails, still resolving the artifact", async () => {

--- a/apps/labeler/test/release-resolution.test.ts
+++ b/apps/labeler/test/release-resolution.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Release resolution: mapping an assessment to an `AcquisitionTarget` over the
+ * aggregator reads. A fake `ReleaseReader` returns canned views — no binding,
+ * no network. Drift detection is not asserted here (the target only carries the
+ * pinned coordinates; `acquireArtifact` raises the finding), but the pinned
+ * fields must be threaded so that check can fire.
+ */
+
+import type { AggregatorDefs, AggregatorListReleases } from "@emdash-cms/registry-lexicons";
+import { describe, expect, it } from "vitest";
+
+import { StageTransientError } from "../src/assessment-orchestrator.js";
+import type { Assessment } from "../src/assessment-store.js";
+import { createReleaseResolver, type ReleaseReader } from "../src/release-resolution.js";
+
+const PUBLISHER_DID = "did:plc:publisher000000000000000000";
+const RELEASE_URI = `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.release/test-plugin:1.0.0`;
+const PROFILE_URI = `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.profile/test-plugin`;
+
+function assessment(overrides: Partial<Assessment> = {}): Assessment {
+	return {
+		id: "asmt_0000000000000000000000000000",
+		runKey: "run_0000000000000000000000000000",
+		uri: RELEASE_URI,
+		cid: "bafyPinnedCid",
+		artifactId: null,
+		artifactChecksum: null,
+		state: "running",
+		trigger: "initial",
+		triggerId: "trg",
+		policyVersion: "1",
+		modelId: null,
+		promptHash: null,
+		publicSummary: null,
+		coverageJson: "{}",
+		supersedesAssessmentId: null,
+		startedAt: null,
+		completedAt: null,
+		createdAt: "2026-07-17T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+function releaseView(overrides: {
+	cid: string;
+	url?: string;
+	checksum?: string;
+	artifactId?: string;
+	pkg?: string;
+	version?: string;
+}): AggregatorDefs.ReleaseView {
+	const artifact: Record<string, unknown> = {
+		url: overrides.url ?? "https://cdn.example.test/plugin.tgz",
+		checksum: overrides.checksum ?? "bDeclaredChecksum",
+	};
+	if (overrides.artifactId !== undefined) artifact["id"] = overrides.artifactId;
+	return {
+		cid: overrides.cid,
+		did: PUBLISHER_DID,
+		indexedAt: "2026-07-17T00:00:00.000Z",
+		package: overrides.pkg ?? "test-plugin",
+		version: overrides.version ?? "1.0.0",
+		uri: RELEASE_URI,
+		release: {
+			$type: "com.emdashcms.experimental.package.release",
+			package: overrides.pkg ?? "test-plugin",
+			version: overrides.version ?? "1.0.0",
+			artifacts: { package: artifact },
+		},
+	} as AggregatorDefs.ReleaseView;
+}
+
+function packageView(description?: string): AggregatorDefs.PackageView {
+	return {
+		cid: "bafyProfileCid",
+		did: PUBLISHER_DID,
+		indexedAt: "2026-07-17T00:00:00.000Z",
+		slug: "test-plugin",
+		uri: PROFILE_URI,
+		profile: {
+			$type: "com.emdashcms.experimental.package.profile",
+			...(description !== undefined ? { description } : {}),
+		},
+	} as AggregatorDefs.PackageView;
+}
+
+function reader(overrides: Partial<ReleaseReader> = {}): ReleaseReader {
+	return {
+		getLatestRelease: overrides.getLatestRelease ?? (async () => null),
+		listReleases: overrides.listReleases ?? (async () => ({ releases: [] })),
+		getPackage: overrides.getPackage ?? (async () => null),
+	};
+}
+
+describe("createReleaseResolver", () => {
+	it("uses the latest release when its CID matches the pinned CID", async () => {
+		const resolve = createReleaseResolver(
+			reader({
+				getLatestRelease: async () =>
+					releaseView({
+						cid: "bafyPinnedCid",
+						url: "https://cdn.example.test/pkg.tgz",
+						artifactId: "pkg-1",
+					}),
+			}),
+		);
+
+		const targetResult = await resolve(
+			assessment({ artifactChecksum: "bDeclaredChecksum", artifactId: "pkg-1" }),
+		);
+
+		expect(targetResult).toMatchObject({
+			url: "https://cdn.example.test/pkg.tgz",
+			checksum: "bDeclaredChecksum",
+			slug: "test-plugin",
+			version: "1.0.0",
+			artifactId: "pkg-1",
+			pinnedChecksum: "bDeclaredChecksum",
+			pinnedArtifactId: "pkg-1",
+		});
+	});
+
+	it("scans listReleases for the pinned CID when the latest release differs", async () => {
+		let listCalls = 0;
+		const resolve = createReleaseResolver(
+			reader({
+				getLatestRelease: async () => releaseView({ cid: "bafyNewerCid" }),
+				listReleases: async (): Promise<AggregatorListReleases.$output> => {
+					listCalls += 1;
+					return {
+						releases: [releaseView({ cid: "bafyNewerCid" }), releaseView({ cid: "bafyPinnedCid" })],
+					};
+				},
+			}),
+		);
+
+		const targetResult = await resolve(assessment());
+
+		expect(listCalls).toBe(1);
+		expect(targetResult.checksum).toBe("bDeclaredChecksum");
+	});
+
+	it("throws a transient error when the pinned CID is not indexed (aggregator lag)", async () => {
+		const resolve = createReleaseResolver(reader({ getLatestRelease: async () => null }));
+		await expect(resolve(assessment())).rejects.toBeInstanceOf(StageTransientError);
+	});
+
+	it("throws a transient error when the listReleases scan exhausts without the pinned CID", async () => {
+		const resolve = createReleaseResolver(
+			reader({
+				getLatestRelease: async () => releaseView({ cid: "bafyNewerCid" }),
+				listReleases: async () => ({ releases: [releaseView({ cid: "bafyOtherCid" })] }),
+			}),
+		);
+		await expect(resolve(assessment())).rejects.toBeInstanceOf(StageTransientError);
+	});
+
+	it("threads the package-profile description into the target", async () => {
+		const resolve = createReleaseResolver(
+			reader({
+				getLatestRelease: async () => releaseView({ cid: "bafyPinnedCid" }),
+				getPackage: async () => packageView("A friendly plugin that does one thing well."),
+			}),
+		);
+
+		const targetResult = await resolve(assessment());
+
+		expect(targetResult.description).toBe("A friendly plugin that does one thing well.");
+	});
+
+	it("leaves the description absent when the profile fetch fails, still resolving the artifact", async () => {
+		const resolve = createReleaseResolver(
+			reader({
+				getLatestRelease: async () => releaseView({ cid: "bafyPinnedCid" }),
+				getPackage: async () => {
+					throw new Error("aggregator profile read failed");
+				},
+			}),
+		);
+
+		const targetResult = await resolve(assessment());
+
+		expect(targetResult.description).toBeUndefined();
+		expect(targetResult.url).toBe("https://cdn.example.test/plugin.tgz");
+	});
+
+	it("throws a transient error when the release view has no package artifact", async () => {
+		const resolve = createReleaseResolver(
+			reader({
+				getLatestRelease: async () =>
+					({
+						cid: "bafyPinnedCid",
+						did: PUBLISHER_DID,
+						indexedAt: "2026-07-17T00:00:00.000Z",
+						package: "test-plugin",
+						version: "1.0.0",
+						uri: RELEASE_URI,
+						release: { $type: "com.emdashcms.experimental.package.release", artifacts: {} },
+					}) as AggregatorDefs.ReleaseView,
+			}),
+		);
+		await expect(resolve(assessment())).rejects.toBeInstanceOf(StageTransientError);
+	});
+
+	it("throws a transient error when the release record key has no package slug", async () => {
+		const resolve = createReleaseResolver(
+			reader({ getLatestRelease: async () => releaseView({ cid: "bafyPinnedCid" }) }),
+		);
+		const badUri = `at://${PUBLISHER_DID}/com.emdashcms.experimental.package.release/no-separator`;
+		await expect(resolve(assessment({ uri: badUri }))).rejects.toBeInstanceOf(StageTransientError);
+	});
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,10 @@
     "./plugin": {
       "types": "./dist/plugin-types.d.mts"
     },
+    "./security/ssrf": {
+      "types": "./dist/security/ssrf.d.mts",
+      "default": "./dist/security/ssrf.mjs"
+    },
     "./middleware": {
       "types": "./dist/astro/middleware.d.mts",
       "default": "./dist/astro/middleware.mjs"

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -73,6 +73,8 @@ export default defineConfig({
 		"src/index.ts",
 		// Request context (ALS singleton - must be a separate entry for dedup)
 		"src/request-context.ts",
+		// SSRF egress primitives (DoH resolver) — consumed by the registry labeler Worker
+		"src/security/ssrf.ts",
 		// Astro integration (build-time)
 		"src/astro/index.ts",
 		"src/astro/middleware.ts",

--- a/packages/registry-verification/src/fetch.ts
+++ b/packages/registry-verification/src/fetch.ts
@@ -361,13 +361,23 @@ function isForbiddenAddress(address: string): boolean {
 	const isPrivate = (first & 0xfe00) === 0xfc00;
 	const isLinkLocal = (first & 0xffc0) === 0xfe80;
 	const isMulticast = (first & 0xff00) === 0xff00;
+	// IPv4-mapped (::ffff:a.b.c.d), deprecated IPv4-compatible (::a.b.c.d, i.e.
+	// ::/96), and NAT64 (64:ff9b::a.b.c.d) all embed an IPv4 address in the low
+	// 32 bits. A public AAAA record of any of these forms is an SSRF vector onto
+	// the embedded address, so resolve it and apply the IPv4 rules.
 	const mappedIpv4 = ipv6.slice(0, 5).every((part) => part === 0) && ipv6[5] === 0xffff;
-	if (mappedIpv4) {
-		return isForbiddenAddress(
-			`${ipv6[6]! >>> 8}.${ipv6[6]! & 0xff}.${ipv6[7]! >>> 8}.${ipv6[7]! & 0xff}`,
-		);
+	const ipv4Compatible = ipv6.slice(0, 6).every((part) => part === 0);
+	const nat64 =
+		ipv6[0] === 0x0064 && ipv6[1] === 0xff9b && ipv6.slice(2, 6).every((part) => part === 0);
+	if (mappedIpv4 || ipv4Compatible || nat64) {
+		return isForbiddenAddress(embeddedIpv4(ipv6));
 	}
 	return isUnspecified || isLoopback || isPrivate || isLinkLocal || isMulticast;
+}
+
+/** Dotted-quad of the IPv4 embedded in the low 32 bits of an 8-hextet IPv6. */
+function embeddedIpv4(ipv6: number[]): string {
+	return `${ipv6[6]! >>> 8}.${ipv6[6]! & 0xff}.${ipv6[7]! >>> 8}.${ipv6[7]! & 0xff}`;
 }
 
 function parseIpv4(value: string): [number, number, number, number] | null {

--- a/packages/registry-verification/tests/fetch.test.ts
+++ b/packages/registry-verification/tests/fetch.test.ts
@@ -122,6 +122,26 @@ describe("fetchVerifiedResource", () => {
 		expect(fetch).toHaveBeenCalledTimes(1);
 	});
 
+	it("rejects an IPv4-compatible IPv6 address embedding a private IPv4", async () => {
+		const fetch = vi.fn();
+		const result = await fetchVerifiedResource("https://sneaky.example.test/artifact", {
+			fetch,
+			resolveHostname: async () => ["::7f00:1"],
+		});
+		expect(result).toMatchObject({ success: false, error: { code: "HOST_REJECTED" } });
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("rejects a NAT64 IPv6 address embedding the link-local metadata IPv4", async () => {
+		const fetch = vi.fn();
+		const result = await fetchVerifiedResource("https://sneaky.example.test/artifact", {
+			fetch,
+			resolveHostname: async () => ["64:ff9b::a9fe:a9fe"],
+		});
+		expect(result).toMatchObject({ success: false, error: { code: "HOST_REJECTED" } });
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
 	it("rejects oversize content-length and streaming bodies", async () => {
 		const contentLength = await fetchVerifiedResource("https://example.test/file", {
 			fetch: vi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
       '@emdash-cms/registry-verification':
         specifier: workspace:*
         version: link:../../packages/registry-verification
+      emdash:
+        specifier: workspace:*
+        version: link:../../packages/core
       jose:
         specifier: ^6.1.3
         version: 6.1.3


### PR DESCRIPTION
## What does this PR do?

The keystone slice: it makes the labeler perform a **real production assessment** and lifts the deploy gate. Targets the `feat/plugin-registry-labelling-service` integration branch (RFC #694, umbrella #1909), stacked on the stage-wiring slice (#2090).

Until now the assessment orchestrator ran deploy-gated stub stages — a production build refused to start, because with stubs every subject would finalize `passed` and sign a real `assessment-passed` label over unscanned content. This slice supplies the missing bundle-production half so all four stages are real, then removes the gate.

- **`artifact-egress.ts`** — the SSRF-hardened `{ fetch, resolveHostname }` for artifact acquisition. `resolveHostname` is the ratified `cloudflareDohResolver` (DoH, **fails closed**); `fetch` is a bare `globalThis.fetch` pass-through so `fetchVerifiedResource` keeps full control of redirects, budgets, and per-hop re-resolution. No recursion — the DoH lookup uses its own fetch to a fixed trusted host.
- **`release-resolution.ts`** — `resolveTarget` reads the assessment's pinned release from the aggregator `ReleaseView` (`getLatestRelease`, falling back to a `listReleases` scan for the pinned CID) and extracts the **signed** declared URL + checksum, setting the pinned coordinates so acquisition's `crossCheckCoordinates` raises a permanent integrity finding on any drift. Aggregator-miss classifies transient (retry), never a false block. Threads the package description (best-effort) into the code stage so misleading-metadata / privacy-risk detection isn't fed an empty purpose.
- **`image-metadata.ts`** — deterministic bundle-bytes → `ImageAnalysisImage`: magic-byte MIME (never extension-trust), header dimensions with bounds-checks, SHA-256 + base64 with the size cap enforced **before** base64 materialization; a malformed image is skipped (→ partial coverage), never thrown.
- **`createImageAiStage`** + real image coverage; **`buildStages`** assembles the four real stages over injected deps (pure — no `env`, no network — so tests drive it with fakes); `executeAssessmentInstance` builds the per-run holder/coverage, asserts required bindings, and threads them. **The `import.meta.env.PROD` gate is removed.**
- **Orchestrator hardening:** a later stage's transient exhaustion no longer discards a block an earlier stage already found — the run finalizes `blocked` on partial coverage (a confirmed block is monotonic; no unrun stage can lift it), while clean/warn-incomplete still finalizes `error`. This closes an indefinite block-evasion (a plugin pairing block-worthy code with a model-breaking image).
- **`registry-verification` SSRF guard:** rejects IPv4-compatible (`::a.b.c.d`) and NAT64 (`64:ff9b::a.b.c.d`) IPv6 encodings of private/metadata addresses it previously missed (strictly more restrictive).
- Exposes `emdash/security/ssrf` for the DoH resolver.

### PROD-safety argument for the gate lift

A run reaches `passed` only after the acquire stage returned no finding, and the acquire stage returns no finding **iff** it published a checksum-verified, structurally-valid bundle to the holder: a permanent failure returns a blocking finding, a transient failure (incl. aggregator lag) throws, and a malformed state aborts the run `running`. There is no path where the holder is empty/unverified yet the run finalizes `passed`, and the code/image stages report clean only after really analyzing the real bundle. `assertRequiredBindings` fails loudly on a missing binding before any stage runs. Verified by an adversarial review pass (gate-lift core invariant and SSRF main path both confirmed HOLD) and by tests.

Follows #2090. Part of #1909. Related to #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all three labeler projects)
- [x] `pnpm lint` passes (no new diagnostics)
- [x] `pnpm test` passes (new units for egress, release-resolution, image-metadata; orchestrator block-preserve + workflow end-to-end cases; full labeler suite 1003, registry-verification 96+36)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server-only.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — **yes**: two — `emdash` (patch, the new `security/ssrf` export) and `@emdash-cms/registry-verification` (patch, the SSRF-guard hardening). The labeler app itself is private.
- [x] New features link to an approved Discussion — the umbrella #1909 tracks RFC #694; this is one slice under it.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation + adversarial review), orchestrated by **Claude Fable 5**

## Screenshots / test output

```
labeler suite:            1003 passed
registry-verification:    96 + 36 passed
typecheck (3 projects):   clean
```

Adversary-confirmed invariants: the gate-lift admits no false `passed`, and the SSRF main path reaches no private/internal address (with the two IPv6-encoding gaps now closed). Note: actual production enforcement additionally awaits the calibration sweep (the production prompt + capabilities-only + real-description inputs must be re-validated; `model_id`/`prompt_hash` provenance is provisional until then) and the operator-owned Email Sending onboarding — both tracked separately.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-acquire-consumer-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-acquire-consumer`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
