### PR TITLE
feat(labeler): reclassify undeclared-access as a warning, not a block

### DIFF
--- a/.changeset/undeclared-access-warning.md
+++ b/.changeset/undeclared-access-warning.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-moderation": minor
+---
+
+Reclassifies the `undeclared-access` moderation label from a hard block to a warning — releases carrying it stay eligible and surface it as a warning rather than being blocked from install.

--- a/apps/labeler/calibration/fixtures/clean-with-images/manifest.json
+++ b/apps/labeler/calibration/fixtures/clean-with-images/manifest.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"capabilities": ["read:content"],
 	"allowedHosts": [],
-	"storage": {},
+	"storage": { "gallery": { "indexes": [] } },
 	"hooks": ["content:afterSave"],
 	"routes": [],
 	"admin": {}

--- a/apps/labeler/docs/moderation-model.md
+++ b/apps/labeler/docs/moderation-model.md
@@ -11,7 +11,7 @@ Labels are grouped into categories. Each label carries:
 - a **`cidRule`** — `required` (targets one exact release CID), `forbidden` (URI-wide, whole record or publisher), or `optional` (either); and
 - **issuance modes** — who may issue it: `automated`, `reviewer`, or `admin`.
 
-The policy document is served publicly at `/.well-known/emdash-labeler-policy.json`. The current `policyVersion` is `2026-07-15.experimental.1`.
+The policy document is served publicly at `/.well-known/emdash-labeler-policy.json`. The current `policyVersion` is `2026-07-17.experimental.1`.
 
 ## Vocabulary
 
@@ -28,7 +28,6 @@ The policy document is served publicly at `/.well-known/emdash-labeler-policy.js
 | `critical-vulnerability`     | automated-block | block   | release → required                        | automated, reviewer |
 | `artifact-integrity-failure` | automated-block | block   | release → required                        | automated, reviewer |
 | `invalid-bundle`             | automated-block | block   | release → required                        | automated, reviewer |
-| `undeclared-access`          | automated-block | block   | release → required                        | automated, reviewer |
 | `impersonation`              | automated-block | block   | release → required                        | automated, reviewer |
 | `hateful-imagery`            | automated-block | block   | release → required                        | automated, reviewer |
 | `explicit-imagery`           | automated-block | block   | release → required                        | automated, reviewer |
@@ -39,6 +38,7 @@ The policy document is served publicly at `/.well-known/emdash-labeler-policy.js
 | `misleading-metadata`        | warning         | warn    | release → required                        | automated, reviewer |
 | `low-quality`                | warning         | warn    | release → required                        | automated, reviewer |
 | `broken-release`             | warning         | warn    | release → required                        | automated, reviewer |
+| `undeclared-access`          | warning         | warn    | release → required                        | automated, reviewer |
 | `content-warning`            | warning         | warn    | release → required                        | automated, reviewer |
 | `!takedown`                  | manual-system   | redact  | release / package / publisher → forbidden | admin               |
 | `security-yanked`            | manual-system   | block   | release → forbidden                       | reviewer            |

--- a/apps/labeler/fixtures/moderation-policy.json
+++ b/apps/labeler/fixtures/moderation-policy.json
@@ -1,7 +1,7 @@
 {
 	"schemaVersion": 1,
-	"policyVersion": "2026-07-15.experimental.1",
-	"effectiveAt": "2026-07-15T00:00:00Z",
+	"policyVersion": "2026-07-17.experimental.1",
+	"effectiveAt": "2026-07-17T00:00:00Z",
 	"labelerDid": "did:web:labels.emdashcms.com",
 	"assessmentSchemaVersion": 1,
 	"supportedSubjects": {
@@ -219,8 +219,8 @@
 		},
 		{
 			"value": "undeclared-access",
-			"category": "automated-block",
-			"officialEffect": "block",
+			"category": "warning",
+			"officialEffect": "warn",
 			"subjectRules": [
 				{ "subject": "release", "cidRule": "required", "issuanceModes": ["automated", "reviewer"] }
 			],

--- a/apps/labeler/test/policy-resolver.test.ts
+++ b/apps/labeler/test/policy-resolver.test.ts
@@ -19,12 +19,12 @@ function finding(overrides: Partial<NormalizedFinding> & { category: string }): 
 describe("resolvePolicyOutcome: blocking", () => {
 	it("blocks on a deterministic finding at any severity", () => {
 		const outcome = resolvePolicyOutcome(
-			[finding({ source: "deterministic", category: "undeclared-access", severity: "low" })],
+			[finding({ source: "deterministic", category: "credential-harvesting", severity: "low" })],
 			MODERATION_POLICY,
 		);
 		expect(outcome.toState).toBe("blocked");
 		expect(outcome.labels).toEqual([
-			{ val: "undeclared-access", findingCategory: "undeclared-access", severity: "low" },
+			{ val: "credential-harvesting", findingCategory: "credential-harvesting", severity: "low" },
 		]);
 	});
 
@@ -140,6 +140,28 @@ describe("resolvePolicyOutcome: warnings", () => {
 		);
 		expect(outcome.toState).toBe("warned");
 		expect(outcome.labels.map((l) => l.val)).toEqual(["obfuscated-code", "assessment-passed"]);
+	});
+
+	it("warns rather than blocks on an undeclared-access finding, at any source or severity", () => {
+		const modelHigh = resolvePolicyOutcome(
+			[finding({ source: "model", category: "undeclared-access", severity: "high" })],
+			MODERATION_POLICY,
+		);
+		expect(modelHigh.toState).toBe("warned");
+		expect(modelHigh.labels).toEqual([
+			{ val: "undeclared-access", findingCategory: "undeclared-access", severity: "high" },
+			{ val: "assessment-passed" },
+		]);
+
+		const deterministicLow = resolvePolicyOutcome(
+			[finding({ source: "deterministic", category: "undeclared-access", severity: "low" })],
+			MODERATION_POLICY,
+		);
+		expect(deterministicLow.toState).toBe("warned");
+		expect(deterministicLow.labels).toEqual([
+			{ val: "undeclared-access", findingCategory: "undeclared-access", severity: "low" },
+			{ val: "assessment-passed" },
+		]);
 	});
 });
 

--- a/apps/labeler/test/policy.test.ts
+++ b/apps/labeler/test/policy.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("moderation policy fixture", () => {
 	it("loads the ratified fixture and exposes label lookups", () => {
-		expect(MODERATION_POLICY.policyVersion).toBe("2026-07-15.experimental.1");
+		expect(MODERATION_POLICY.policyVersion).toBe("2026-07-17.experimental.1");
 		expect(getLabelDefinition("malware")).toMatchObject({
 			value: "malware",
 			category: "automated-block",
@@ -25,6 +25,11 @@ describe("moderation policy fixture", () => {
 		expect(categories.has("malware")).toBe(true);
 		expect(categories.has("impersonation")).toBe(true);
 		expect(categories.has("low-quality")).toBe(false);
+		expect(categories.has("undeclared-access")).toBe(false);
+		expect(getLabelDefinition("undeclared-access")).toMatchObject({
+			category: "warning",
+			officialEffect: "warn",
+		});
 	});
 
 	it("includes the image-content categories as automated-block and content-warning as a warning", () => {

--- a/apps/labeler/test/service.test.ts
+++ b/apps/labeler/test/service.test.ts
@@ -78,7 +78,7 @@ describe("service identity", () => {
 		expect(response.headers.get("etag")).toMatch(/^"[a-f0-9]{64}"$/);
 		expect(await response.json()).toMatchObject({
 			schemaVersion: 1,
-			policyVersion: "2026-07-15.experimental.1",
+			policyVersion: "2026-07-17.experimental.1",
 			labelerDid: LABELER_DID,
 			assessmentSchemaVersion: 1,
 		});

--- a/apps/labeler/test/xrpc-router.test.ts
+++ b/apps/labeler/test/xrpc-router.test.ts
@@ -597,7 +597,7 @@ describe("getPolicy", () => {
 		expect(response.headers.get("cache-control")).toBe("public, max-age=300");
 		expect(await response.json()).toMatchObject({
 			schemaVersion: 1,
-			policyVersion: "2026-07-15.experimental.1",
+			policyVersion: "2026-07-17.experimental.1",
 			labelerDid: LABELER_DID,
 			assessmentSchemaVersion: 1,
 		});

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -172,7 +172,6 @@ const AUTOMATED_BLOCKS = new Set<string>([
 	"critical-vulnerability",
 	"artifact-integrity-failure",
 	"invalid-bundle",
-	"undeclared-access",
 	"impersonation",
 ]);
 
@@ -184,6 +183,7 @@ const WARNINGS = new Set<string>([
 	"low-quality",
 	"broken-release",
 	"package-disputed",
+	"undeclared-access",
 ]);
 
 const RELEASE_VALUES = new Set<string>([

--- a/packages/registry-moderation/tests/moderation.test.ts
+++ b/packages/registry-moderation/tests/moderation.test.ts
@@ -197,6 +197,18 @@ describe("release moderation", () => {
 		});
 	});
 
+	it("surfaces undeclared-access as a warning, keeping the release eligible", () => {
+		expect(RELEASE_BLOCK_VALUES).not.toContain("undeclared-access");
+		expect(
+			evaluate([label({ val: "assessment-passed" }), label({ val: "undeclared-access" })]),
+		).toMatchObject({
+			eligibility: "eligible",
+			blockingLabels: [],
+			warningLabels: ["undeclared-access"],
+			reasonCodes: ["eligible-assessment-pass", "warning-labels"],
+		});
+	});
+
 	it("suppresses only its source's automated findings with a valid override", () => {
 		const result = evaluate([
 			label({ val: "assessment-passed" }),


### PR DESCRIPTION
## What does this PR do?

Reclassifies the `undeclared-access` label from an automated **block** to a **warning**, from a finding in the severity-amended calibration sweep. Targets the `feat/plugin-registry-labelling-service` integration branch (RFC #694, umbrella #1909).

The sweep's only flagged code-lane false positive was glm-5.2 blocking a "clean" fixture on a real `undeclared-access` finding — the plugin declared `storage: {}` but its code called `ctx.storage.gallery.put(...)`. glm was *correct*, but the finding shouldn't block: **the runtime already enforces declared access.** The sandbox throws `Storage collection not declared` (`packages/cloudflare/src/sandbox/bridge.ts:300`), and the `allowedHosts` / capability gates reject undeclared network/content/media/users access — so an undeclared capability **cannot execute**. It's a manifest/behavior *mismatch* (the plugin's undeclared feature silently fails), not an executable threat. Genuine over-reach is already caught by the specific malicious categories (`data-exfiltration`, `credential-harvesting`, …) which block on their own merits. Hard-blocking (hiding from install surfaces) a merely-inaccurate manifest is over-enforcement; a warning is the honest signal.

- **Policy** (`moderation-policy.json`): `undeclared-access` `category` automated-block → warning, `officialEffect` block → warn; `policyVersion`/`effectiveAt` bumped to `2026-07-17.experimental.1`. The **label value is unchanged**, so `queryLabels`/subscription consumers are unaffected — only the effect softens (additive-safe). The resolver, code-AI prompt, and console are all policy-data-driven — **no code hardcodes the classification**, confirmed by grep.
- **Fixture fix** (`calibration/fixtures/clean-with-images`): declares its `gallery` storage collection so it's a genuine clean baseline (matching its name and `expected: passed`), rather than an accidental undeclared-access case.
- **Tests**: `undeclared-access` now resolves to `warned` at any source/severity (never blocked); the "deterministic blocks at any severity" test moved to `credential-harvesting` to keep its stated behavior true; policy-version-string pins updated; `docs/moderation-model.md` moved the row into the warning group.

**Adversary check (in the plan + verified):** is there a real threat that manifests *only* as `undeclared-access` with no other blocking finding, now let through with a warning? No. Runtime capability enforcement is *label-independent* — it gates execution, not the label — so undeclared access can never run regardless of the label; genuine malice either trips a specific blocking category (which still blocks, with undeclared-access riding along as a warning) or requires the attacker to *declare* the access to make it run, at which point it's judged as declared behavior. Residual executable harm: none.

**Follow-up:** because the code-AI system prompt is data-driven from the policy's block∪warn category sets, it now presents `undeclared-access` as a warning category — a confirming calibration re-sweep is warranted before enforcement launch (tracked; the label + fixture changes here are the code side).

Part of #1909. Related to #694.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all three labeler projects)
- [x] `pnpm lint` passes (no new diagnostics)
- [x] `pnpm test` passes (policy-resolver, policy, service, xrpc-router suites; full labeler suite 1005)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server/policy-fixture change; no admin UI strings.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — **n/a**: `moderation-policy.json` is a labeler-internal fixture; `@emdash-cms/labeler` is `private: true`.
- [x] New features link to an approved Discussion — the umbrella #1909 tracks RFC #694.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation + threat-model check), orchestrated by **Claude Fable 5**

## Screenshots / test output

```
policy-resolver + policy + service + xrpc-router: 76 passed
full labeler suite: 1005 passed
typecheck (3 projects): clean
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-labeler-undeclared-access-warn-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/labeler-undeclared-access-warn`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
