### PR TITLE
fix(core): include success field in API responses

### DIFF
--- a/.changeset/api-response-success-field.md
+++ b/.changeset/api-response-success-field.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes API responses to include the `success` field documented in the REST API reference: successful responses are now `{ success: true, data }` and error responses `{ success: false, error }`. The existing `data` and `error` fields are unchanged, so existing clients keep working.

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -49,9 +49,9 @@ function formatValidationIssues(error: Record<string, unknown>): string | undefi
 /**
  * Throw an error with the message from the API response body if available,
  * falling back to a generic message. All API error responses use the shape
- * `{ error: { code, message, details? } }`. For validation errors, the
- * field-level messages in `error.details.issues` are surfaced instead of
- * the generic "Invalid request data" top-level message.
+ * `{ success: false, error: { code, message, details? } }`. For validation
+ * errors, the field-level messages in `error.details.issues` are surfaced
+ * instead of the generic "Invalid request data" top-level message.
  */
 export async function throwResponseError(res: Response, fallback: string): Promise<never> {
 	const body: unknown = await res.json().catch(() => ({}));
@@ -216,7 +216,7 @@ export interface AdminManifest {
 }
 
 /**
- * Parse an API response with the { data: T } envelope.
+ * Parse an API response with the { success, data: T } envelope.
  *
  * Handles error responses via throwResponseError, then unwraps the data envelope.
  * Replaces both bare `response.json()` and field-unwrap patterns.

--- a/packages/admin/src/lib/api/import.ts
+++ b/packages/admin/src/lib/api/import.ts
@@ -422,7 +422,7 @@ export async function importWxrMedia(
 	if (!response.ok) await throwResponseError(response, i18n._(msg`Failed to import media`));
 
 	// If no progress callback, just parse as JSON (non-streaming mode)
-	// Note: streaming NDJSON responses are excluded from the { data } envelope
+	// Note: streaming NDJSON responses are excluded from the { success, data } envelope
 	if (!onProgress) {
 		return parseApiResponse<MediaImportResult>(response, "Failed to import media");
 	}

--- a/packages/core/src/api/error.ts
+++ b/packages/core/src/api/error.ts
@@ -25,8 +25,8 @@ const API_CACHE_HEADERS: HeadersInit = {
 /**
  * Create a standardized error response.
  *
- * Always returns `{ error: { code, message } }` with correct Content-Type.
- * Use this for all error responses in API routes.
+ * Always returns `{ success: false, error: { code, message } }` with correct
+ * Content-Type. Use this for all error responses in API routes.
  */
 export function apiError(
 	code: string,
@@ -39,17 +39,17 @@ export function apiError(
 		message,
 	};
 	if (details !== undefined) error.details = details;
-	return Response.json({ error }, { status, headers: API_CACHE_HEADERS });
+	return Response.json({ success: false, error }, { status, headers: API_CACHE_HEADERS });
 }
 
 /**
  * Create a standardized success response.
  *
- * Always returns `{ data: T }` with correct status code.
+ * Always returns `{ success: true, data: T }` with correct status code.
  * Use this for all success responses in API routes.
  */
 export function apiSuccess<T>(data: T, status = 200): Response {
-	return Response.json({ data }, { status, headers: API_CACHE_HEADERS });
+	return Response.json({ success: true, data }, { status, headers: API_CACHE_HEADERS });
 }
 
 /**

--- a/packages/core/src/api/openapi/document.ts
+++ b/packages/core/src/api/openapi/document.ts
@@ -2389,7 +2389,7 @@ export function generateOpenApiDocument(
 			title: "EmDash CMS API",
 			version: "0.1.0",
 			description:
-				"REST API for the EmDash CMS. All endpoints require authentication and return responses wrapped in a `{ data }` envelope.",
+				"REST API for the EmDash CMS. All endpoints require authentication and return responses wrapped in a `{ success, data }` envelope.",
 		},
 		servers: [
 			{

--- a/packages/core/src/api/parse.ts
+++ b/packages/core/src/api/parse.ts
@@ -113,21 +113,7 @@ function validate<T extends z.ZodType>(schema: T, data: unknown): ParseResult<z.
 		message: issue.message,
 	}));
 
-	return Response.json(
-		{
-			error: {
-				code: "VALIDATION_ERROR",
-				message: "Invalid request data",
-				details: { issues },
-			},
-		},
-		{
-			status: 400,
-			headers: {
-				"Cache-Control": "private, no-store",
-			},
-		},
-	);
+	return apiError("VALIDATION_ERROR", "Invalid request data", 400, { issues });
 }
 
 /**

--- a/packages/core/src/api/schemas/common.ts
+++ b/packages/core/src/api/schemas/common.ts
@@ -73,6 +73,7 @@ export const localeFilterQuery = z
 /** Standard API error response */
 export const apiErrorSchema = z
 	.object({
+		success: z.literal(false).meta({ description: "Discriminant: always false for errors" }),
 		error: z.object({
 			code: z.string().meta({ description: "Machine-readable error code", example: "NOT_FOUND" }),
 			message: z.string().meta({ description: "Human-readable error message" }),
@@ -80,9 +81,12 @@ export const apiErrorSchema = z
 	})
 	.meta({ id: "ApiError" });
 
-/** Wrap a data schema in the standard success envelope: { data: T } */
+/** Wrap a data schema in the standard success envelope: { success: true, data: T } */
 export function successEnvelope<T extends z.ZodType>(dataSchema: T) {
-	return z.object({ data: dataSchema });
+	return z.object({
+		success: z.literal(true).meta({ description: "Discriminant: always true for success" }),
+		data: dataSchema,
+	});
 }
 
 /** Standard delete response */

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -60,13 +60,7 @@ function isUnsafeMethod(method: string): boolean {
 }
 
 function csrfRejectedResponse(): Response {
-	return new Response(
-		JSON.stringify({ error: { code: "CSRF_REJECTED", message: "Missing required header" } }),
-		{
-			status: 403,
-			headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
-		},
-	);
+	return apiError("CSRF_REJECTED", "Missing required header", 403);
 }
 
 function mcpUnauthorizedResponse(
@@ -224,15 +218,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
 			const csrfHeader = context.request.headers.get("X-EmDash-Request");
 			if (csrfHeader !== "1") {
-				return new Response(
-					JSON.stringify({
-						error: { code: "CSRF_REJECTED", message: "Missing required header" },
-					}),
-					{
-						status: 403,
-						headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
-					},
-				);
+				return apiError("CSRF_REJECTED", "Missing required header", 403);
 			}
 		}
 		return next();
@@ -418,13 +404,7 @@ async function handlePluginRouteAuth(
 		if (bearerResult === "invalid") {
 			// A token was presented but is invalid/expired — return 401 so the
 			// caller knows their token is bad (don't silently downgrade to no-auth).
-			return new Response(
-				JSON.stringify({ error: { code: "INVALID_TOKEN", message: "Invalid or expired token" } }),
-				{
-					status: 401,
-					headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
-				},
-			);
+			return apiError("INVALID_TOKEN", "Invalid or expired token", 401);
 		}
 		// "none" — no token presented, try external/session auth below.
 	} catch (error) {
@@ -701,10 +681,7 @@ async function handlePasskeyAuth(
 
 		if (!sessionUser?.id) {
 			if (isApiRoute) {
-				return Response.json(
-					{ error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" } },
-					{ status: 401, headers: MW_CACHE_HEADERS },
-				);
+				return apiError("NOT_AUTHENTICATED", "Not authenticated", 401);
 			}
 			const loginUrl = new URL("/_emdash/admin/login", getPublicOrigin(url, emdash?.config));
 			loginUrl.searchParams.set("redirect", url.pathname);
@@ -719,10 +696,7 @@ async function handlePasskeyAuth(
 			// User no longer exists - clear session
 			session?.destroy();
 			if (isApiRoute) {
-				return Response.json(
-					{ error: { code: "NOT_FOUND", message: "User not found" } },
-					{ status: 401, headers: MW_CACHE_HEADERS },
-				);
+				return apiError("NOT_FOUND", "User not found", 401);
 			}
 			const loginUrl = new URL("/_emdash/admin/login", getPublicOrigin(url, emdash?.config));
 			return context.redirect(loginUrl.toString());
@@ -834,28 +808,12 @@ function enforceTokenScope(
 		if (ruleMethod === "*" || (ruleMethod === "WRITE" && isWrite) || ruleMethod === method) {
 			if (hasScope(tokenScopes, scope)) return null;
 
-			return new Response(
-				JSON.stringify({
-					error: {
-						code: "INSUFFICIENT_SCOPE",
-						message: `Token lacks required scope: ${scope}`,
-					},
-				}),
-				{ status: 403, headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS } },
-			);
+			return apiError("INSUFFICIENT_SCOPE", `Token lacks required scope: ${scope}`, 403);
 		}
 	}
 
 	// No rule matched — default to admin scope (fail-closed)
 	if (hasScope(tokenScopes, "admin")) return null;
 
-	return new Response(
-		JSON.stringify({
-			error: {
-				code: "INSUFFICIENT_SCOPE",
-				message: "Token lacks required scope: admin",
-			},
-		}),
-		{ status: 403, headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS } },
-	);
+	return apiError("INSUFFICIENT_SCOPE", "Token lacks required scope: admin", 403);
 }

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -68,16 +68,13 @@ function mcpUnauthorizedResponse(
 	config?: Parameters<typeof getPublicOrigin>[1],
 ): Response {
 	const origin = getPublicOrigin(url, config);
-	return Response.json(
-		{ error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" } },
-		{
-			status: 401,
-			headers: {
-				"WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
-				...MW_CACHE_HEADERS,
-			},
-		},
+	const response = apiError("NOT_AUTHENTICATED", "Not authenticated", 401);
+	// Preserve the OAuth discovery header so MCP clients can find the auth server.
+	response.headers.set(
+		"WWW-Authenticate",
+		`Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
 	);
+	return response;
 }
 
 /**
@@ -236,20 +233,16 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	const bearerResult = await handleBearerAuth(context);
 
 	if (bearerResult === "invalid") {
-		const headers: Record<string, string> = {
-			"Content-Type": "application/json",
-			...MW_CACHE_HEADERS,
-		};
+		const response = apiError("INVALID_TOKEN", "Invalid or expired token", 401);
 		// Add WWW-Authenticate header on MCP endpoint 401s to trigger OAuth discovery
 		if (url.pathname === "/_emdash/api/mcp") {
 			const origin = getPublicOrigin(url, context.locals.emdash?.config);
-			headers["WWW-Authenticate"] =
-				`Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`;
+			response.headers.set(
+				"WWW-Authenticate",
+				`Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+			);
 		}
-		return new Response(
-			JSON.stringify({ error: { code: "INVALID_TOKEN", message: "Invalid or expired token" } }),
-			{ status: 401, headers },
-		);
+		return response;
 	}
 
 	const isTokenAuth = bearerResult === "authenticated";

--- a/packages/core/src/astro/routes/api/admin/bylines/[id]/translations.ts
+++ b/packages/core/src/astro/routes/api/admin/bylines/[id]/translations.ts
@@ -15,7 +15,7 @@
 import type { APIRoute } from "astro";
 
 import { requirePerm } from "#api/authorize.js";
-import { handleError, requireDb, unwrapResult } from "#api/error.js";
+import { apiError, handleError, requireDb, unwrapResult } from "#api/error.js";
 import { handleBylineCreate, handleBylineTranslations } from "#api/handlers/bylines.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { bylineTranslationCreateBody } from "#api/schemas.js";
@@ -65,10 +65,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		const repo = new BylineRepository(emdash.db);
 		const source = await repo.findById(id);
 		if (!source) {
-			return new Response(
-				JSON.stringify({ error: { code: "NOT_FOUND", message: "Byline not found" } }),
-				{ status: 404, headers: { "Content-Type": "application/json" } },
-			);
+			return apiError("NOT_FOUND", "Byline not found", 404);
 		}
 
 		const result = await handleBylineCreate(emdash.db, {

--- a/packages/core/src/astro/routes/api/admin/plugins/updates.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/updates.ts
@@ -15,7 +15,7 @@
 import type { APIRoute } from "astro";
 
 import { requirePerm } from "#api/authorize.js";
-import { apiError } from "#api/error.js";
+import { apiError, apiSuccess } from "#api/error.js";
 import { handleMarketplaceUpdateCheck, handleRegistryUpdateCheck } from "#api/index.js";
 
 export const prerender = false;
@@ -59,7 +59,5 @@ export const GET: APIRoute = async ({ locals }) => {
 	if (marketplace?.success) items.push(...marketplace.data.items);
 	if (registry?.success) items.push(...registry.data.items);
 
-	// Match the rest of the admin API envelope (`{ data: ... }`) so the
-	// admin client's `parseApiResponse` unwraps `body.data`.
-	return Response.json({ data: { items } });
+	return apiSuccess({ items });
 };

--- a/packages/core/src/astro/routes/api/auth/mode.ts
+++ b/packages/core/src/astro/routes/api/auth/mode.ts
@@ -11,6 +11,7 @@
 
 import type { APIRoute } from "astro";
 
+import { apiSuccess } from "#api/error.js";
 import { getAuthMode } from "#auth/mode.js";
 
 export const prerender = false;
@@ -40,18 +41,9 @@ export const GET: APIRoute = async ({ locals }) => {
 		label: p.label,
 	}));
 
-	return Response.json(
-		{
-			data: {
-				authMode: authMode.type === "external" ? authMode.providerType : "passkey",
-				signupEnabled,
-				providers,
-			},
-		},
-		{
-			headers: {
-				"Cache-Control": "private, no-store",
-			},
-		},
-	);
+	return apiSuccess({
+		authMode: authMode.type === "external" ? authMode.providerType : "passkey",
+		signupEnabled,
+		providers,
+	});
 };

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -9,7 +9,7 @@
 
 import type { APIRoute } from "astro";
 
-import { handleError } from "#api/error.js";
+import { apiSuccess, handleError } from "#api/error.js";
 import { getAuthMode } from "#auth/mode.js";
 import { OptionsRepository } from "#db/repositories/options.js";
 
@@ -94,14 +94,7 @@ export const GET: APIRoute = async ({ locals }) => {
 					admin: adminBranding,
 				};
 
-		return Response.json(
-			{ data: manifest },
-			{
-				headers: {
-					"Cache-Control": "private, no-store",
-				},
-			},
-		);
+		return apiSuccess(manifest);
 	} catch (error) {
 		return handleError(error, "Failed to build manifest", "MANIFEST_BUILD_ERROR");
 	}

--- a/packages/core/src/auth/scopes.ts
+++ b/packages/core/src/auth/scopes.ts
@@ -6,6 +6,8 @@
  * Token-authenticated requests must have the required scope (or "admin").
  */
 
+import { apiError } from "#api/error.js";
+
 import { hasScope } from "./api-tokens.js";
 
 /**
@@ -21,13 +23,5 @@ export function requireScope(locals: { tokenScopes?: string[] }, scope: string):
 
 	if (hasScope(locals.tokenScopes, scope)) return null;
 
-	return new Response(
-		JSON.stringify({
-			error: {
-				code: "INSUFFICIENT_SCOPE",
-				message: `Token lacks required scope: ${scope}`,
-			},
-		}),
-		{ status: 403, headers: { "Content-Type": "application/json" } },
-	);
+	return apiError("INSUFFICIENT_SCOPE", `Token lacks required scope: ${scope}`, 403);
 }

--- a/packages/core/src/client/transport.ts
+++ b/packages/core/src/client/transport.ts
@@ -163,7 +163,7 @@ export function refreshInterceptor(options: {
 
 		const json = (await res.json()) as Record<string, unknown>;
 
-		// The token endpoint wraps the response in { data: ... } via apiSuccess.
+		// The token endpoint wraps the response in { success, data: ... } via apiSuccess.
 		// Handle both wrapped and bare shapes for robustness.
 		const tokenData: TokenFields =
 			json.data && typeof json.data === "object" && "access_token" in json.data

--- a/packages/core/src/plugin-utils.ts
+++ b/packages/core/src/plugin-utils.ts
@@ -44,13 +44,14 @@ export function getPublicPluginApiRouteHandler(
 }
 
 /**
- * Parse an API response, unwrapping the `{ data: T }` envelope.
+ * Parse an API response, unwrapping the `{ success, data: T }` envelope.
  *
- * All plugin API routes return success responses wrapped in `{ data: ... }`
- * by `apiSuccess()`. This helper unwraps that envelope and handles errors.
+ * All plugin API routes return success responses wrapped in
+ * `{ success: true, data: ... }` by `apiSuccess()`. This helper unwraps that
+ * envelope and handles errors.
  *
  * On error responses (non-2xx), throws an Error with the server's message
- * (from `{ error: { message } }`) or the fallback message.
+ * (from `{ success: false, error: { message } }`) or the fallback message.
  *
  * @example
  * ```ts
@@ -72,8 +73,9 @@ export async function parseApiResponse<T>(
 /**
  * Extract the error message from a failed API response.
  *
- * Error responses use the shape `{ error: { code, message } }`. This helper
- * parses that body and returns the message, falling back to the provided default.
+ * Error responses use the shape `{ success: false, error: { code, message } }`.
+ * This helper parses that body and returns the message, falling back to the
+ * provided default.
  * Swallows JSON parse failures gracefully.
  *
  * @example

--- a/packages/core/src/visual-editing/toolbar.ts
+++ b/packages/core/src/visual-editing/toolbar.ts
@@ -730,7 +730,7 @@ export function renderToolbar(config: ToolbarConfig): string {
     manifestPromise = ecFetch("/_emdash/api/manifest", { credentials: "same-origin" })
       .then(function(r) { return r.json(); })
       .then(function(m) {
-        // The manifest endpoint wraps the payload in a { data } envelope (ApiResponse shape).
+        // The manifest endpoint wraps the payload in a { success, data } envelope (ApiResponse shape).
         // Unwrap it so getFieldKind can read manifest.collections directly.
         manifestCache = m && m.data ? m.data : m;
         return manifestCache;

--- a/packages/core/tests/integration/client/client-lifecycle.test.ts
+++ b/packages/core/tests/integration/client/client-lifecycle.test.ts
@@ -40,10 +40,17 @@ function encodeRev(item: StoredItem): string {
 	return btoa(`${item.version}:${item.updatedAt}`);
 }
 
-/** Wraps body in `{ data: body }` to match the standard API response envelope. */
+/**
+ * Mirrors the API response envelope: `{ success: true, data }` on 2xx and
+ * `{ success: false, error }` on 4xx/5xx.
+ */
 function jsonRes(body: unknown, status = 200): Response {
-	// Error responses (4xx/5xx) are NOT wrapped in { data }
-	const payload = status >= 400 ? body : { data: body };
+	// Error callers already pass `{ error: ... }`; add the discriminant so the
+	// fixture matches what `apiError()` actually sends.
+	const payload =
+		status >= 400
+			? { success: false, ...(typeof body === "object" && body !== null ? body : {}) }
+			: { success: true, data: body };
 	return new Response(JSON.stringify(payload), {
 		status,
 		headers: { "Content-Type": "application/json" },

--- a/packages/core/tests/integration/openapi/openapi.test.ts
+++ b/packages/core/tests/integration/openapi/openapi.test.ts
@@ -60,7 +60,7 @@ describe("OpenAPI spec validation", () => {
 		}
 	});
 
-	it("wraps all success responses in the { data } envelope", () => {
+	it("wraps all success responses in the { success, data } envelope", () => {
 		const doc = generateOpenApiDocument();
 		const paths = doc.paths ?? {};
 
@@ -85,8 +85,9 @@ describe("OpenAPI spec validation", () => {
 						`${method.toUpperCase()} ${path} ${statusCode} missing schema`,
 					).toBeDefined();
 
-					// The envelope must have a "data" property (either directly or via $ref that wraps it)
-					// Check for direct properties or allOf/oneOf patterns
+					// The envelope must have "success" and "data" properties (either
+					// directly or via $ref that wraps them). Check for direct
+					// properties or allOf/oneOf patterns.
 					const props = (schema as Record<string, unknown>)?.properties as
 						| Record<string, unknown>
 						| undefined;
@@ -95,6 +96,10 @@ describe("OpenAPI spec validation", () => {
 							props,
 							`${method.toUpperCase()} ${path} ${statusCode} envelope missing "data" property`,
 						).toHaveProperty("data");
+						expect(
+							props,
+							`${method.toUpperCase()} ${path} ${statusCode} envelope missing "success" property`,
+						).toHaveProperty("success");
 					}
 				}
 			}

--- a/packages/core/tests/integration/openapi/openapi.test.ts
+++ b/packages/core/tests/integration/openapi/openapi.test.ts
@@ -191,8 +191,37 @@ describe("OpenAPI spec validation", () => {
 						schema,
 						`${method.toUpperCase()} ${path} ${statusCode} error missing schema`,
 					).toBeDefined();
+
+					// Error responses either $ref the shared ApiError component or
+					// inline its shape; both must carry the `success` discriminant.
+					const props = (schema as Record<string, unknown>)?.properties as
+						| Record<string, unknown>
+						| undefined;
+					const ref = (schema as Record<string, unknown>)?.$ref as string | undefined;
+					const usesApiError = typeof ref === "string" && ref.endsWith("/ApiError");
+					if (props) {
+						expect(
+							props,
+							`${method.toUpperCase()} ${path} ${statusCode} error envelope missing "success"`,
+						).toHaveProperty("success");
+					} else {
+						expect(
+							usesApiError,
+							`${method.toUpperCase()} ${path} ${statusCode} error is neither a $ref to ApiError nor inline`,
+						).toBe(true);
+					}
 				}
 			}
 		}
+	});
+
+	it("declares the success discriminant on the ApiError component", () => {
+		const doc = generateOpenApiDocument();
+		const apiError = (doc.components?.schemas ?? {})["ApiError"] as
+			| { properties?: Record<string, unknown> }
+			| undefined;
+		expect(apiError, "ApiError component missing").toBeDefined();
+		expect(apiError?.properties).toHaveProperty("success");
+		expect(apiError?.properties).toHaveProperty("error");
 	});
 });

--- a/packages/core/tests/unit/api/cache-headers.test.ts
+++ b/packages/core/tests/unit/api/cache-headers.test.ts
@@ -20,7 +20,7 @@ describe("API cache headers", () => {
 			const response = apiSuccess({ id: "123" }, 201);
 			expect(response.status).toBe(201);
 			const body = await response.json();
-			expect(body).toEqual({ data: { id: "123" } });
+			expect(body).toEqual({ success: true, data: { id: "123" } });
 		});
 	});
 
@@ -39,7 +39,10 @@ describe("API cache headers", () => {
 			const response = apiError("FORBIDDEN", "Access denied", 403);
 			expect(response.status).toBe(403);
 			const body = await response.json();
-			expect(body).toEqual({ error: { code: "FORBIDDEN", message: "Access denied" } });
+			expect(body).toEqual({
+				success: false,
+				error: { code: "FORBIDDEN", message: "Access denied" },
+			});
 		});
 	});
 

--- a/packages/core/tests/unit/api/csrf.test.ts
+++ b/packages/core/tests/unit/api/csrf.test.ts
@@ -64,6 +64,7 @@ describe("checkPublicCsrf", () => {
 			expect(response!.status).toBe(403);
 			const body = await response!.json();
 			expect(body).toEqual({
+				success: false,
 				error: { code: "CSRF_REJECTED", message: "Cross-origin request blocked" },
 			});
 		});

--- a/packages/core/tests/unit/api/media-usage-summary.test.ts
+++ b/packages/core/tests/unit/api/media-usage-summary.test.ts
@@ -36,6 +36,7 @@ interface SuccessBody<T> {
 }
 
 interface ErrorBody {
+	success: false;
 	error: { code: string; message: string };
 }
 
@@ -425,6 +426,7 @@ describe("media usage summary handler and routes", () => {
 
 		expect(response.status).toBe(500);
 		expect((await response.json()) as ErrorBody).toEqual({
+			success: false,
 			error: { code: "MEDIA_USAGE_READ_ERROR", message: "Failed to read media usage" },
 		});
 		expect(errorSpy).toHaveBeenCalledOnce();
@@ -439,6 +441,7 @@ describe("media usage summary handler and routes", () => {
 
 		expect(response.status).toBe(500);
 		expect((await response.json()) as ErrorBody).toEqual({
+			success: false,
 			error: { code: "MEDIA_USAGE_READ_ERROR", message: "Failed to read media usage" },
 		});
 		// Kysely's query logger records the successful media lookup but not the failed statement.

--- a/packages/core/tests/unit/api/parse-envelope.test.ts
+++ b/packages/core/tests/unit/api/parse-envelope.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+import { isParseError, parseBody, parseQuery } from "../../../src/api/parse.js";
+
+/**
+ * `parseBody`/`parseQuery` are the shared request validators used by almost
+ * every route. Their validation-failure response must carry the documented
+ * `{ success: false, error }` envelope so it matches the OpenAPI `ApiError`
+ * schema attached to those routes.
+ */
+describe("request parser validation envelope", () => {
+	const schema = z.object({ limit: z.coerce.number().min(1) });
+
+	it("parseQuery returns a { success: false, error } envelope on invalid input", async () => {
+		const result = parseQuery(new URL("https://example.com/?limit=0"), schema);
+		expect(isParseError(result)).toBe(true);
+		if (!isParseError(result)) return;
+
+		expect(result.status).toBe(400);
+		const body = await result.json();
+		expect(body).toMatchObject({
+			success: false,
+			error: { code: "VALIDATION_ERROR", message: "Invalid request data" },
+		});
+		expect(body.error.details).toHaveProperty("issues");
+	});
+
+	it("parseBody returns a { success: false, error } envelope on invalid input", async () => {
+		const request = new Request("https://example.com", {
+			method: "POST",
+			body: JSON.stringify({ limit: -5 }),
+			headers: { "Content-Type": "application/json" },
+		});
+		const result = await parseBody(request, schema);
+		expect(isParseError(result)).toBe(true);
+		if (!isParseError(result)) return;
+
+		expect(result.status).toBe(400);
+		const body = await result.json();
+		expect(body).toMatchObject({
+			success: false,
+			error: { code: "VALIDATION_ERROR" },
+		});
+	});
+});

--- a/packages/core/tests/unit/api/response-envelope.test.ts
+++ b/packages/core/tests/unit/api/response-envelope.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+
+import { apiError, apiSuccess, unwrapResult } from "../../../src/api/error.js";
+
+/**
+ * The REST API reference documents a discriminated response envelope:
+ * successful responses are `{ success: true, data }` and error responses are
+ * `{ success: false, error }`. These tests pin the wire shape so it stays in
+ * sync with the documented contract.
+ */
+describe("API response envelope", () => {
+	describe("apiSuccess", () => {
+		it("wraps data in { success: true, data }", async () => {
+			const body = await apiSuccess({ id: "123" }).json();
+			expect(body).toEqual({ success: true, data: { id: "123" } });
+		});
+
+		it("keeps the discriminant on non-200 success responses", async () => {
+			const response = apiSuccess({ created: true }, 201);
+			expect(response.status).toBe(201);
+			const body = await response.json();
+			expect(body).toEqual({ success: true, data: { created: true } });
+		});
+	});
+
+	describe("apiError", () => {
+		it("wraps the error in { success: false, error }", async () => {
+			const body = await apiError("NOT_FOUND", "Missing", 404).json();
+			expect(body).toEqual({ success: false, error: { code: "NOT_FOUND", message: "Missing" } });
+		});
+
+		it("includes details when provided", async () => {
+			const body = await apiError("VALIDATION_ERROR", "Bad input", 400, { field: "title" }).json();
+			expect(body).toEqual({
+				success: false,
+				error: { code: "VALIDATION_ERROR", message: "Bad input", details: { field: "title" } },
+			});
+		});
+	});
+
+	describe("unwrapResult", () => {
+		it("emits the success discriminant for ok results", async () => {
+			const body = await unwrapResult({ success: true, data: { ok: true } }).json();
+			expect(body).toEqual({ success: true, data: { ok: true } });
+		});
+
+		it("emits the failure discriminant for error results", async () => {
+			const body = await unwrapResult({
+				success: false,
+				error: { code: "NOT_FOUND", message: "Missing" },
+			}).json();
+			expect(body).toEqual({ success: false, error: { code: "NOT_FOUND", message: "Missing" } });
+		});
+	});
+});

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -107,6 +107,7 @@ describe("MCP discovery auth middleware", () => {
 			'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
 		);
 		await expect(response.json()).resolves.toEqual({
+			success: false,
 			error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" },
 		});
 	});
@@ -151,6 +152,7 @@ describe("MCP discovery auth middleware", () => {
 			'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
 		);
 		await expect(response.json()).resolves.toEqual({
+			success: false,
 			error: { code: "INVALID_TOKEN", message: "Invalid or expired token" },
 		});
 	});
@@ -169,6 +171,7 @@ describe("MCP discovery auth middleware", () => {
 		expect(response.status).toBe(401);
 		expect(session.get).not.toHaveBeenCalled();
 		await expect(response.json()).resolves.toEqual({
+			success: false,
 			error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" },
 		});
 	});

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -182,6 +182,7 @@ describe("MCP discovery auth middleware", () => {
 		expect(next).not.toHaveBeenCalled();
 		expect(response.status).toBe(403);
 		await expect(response.json()).resolves.toEqual({
+			success: false,
 			error: { code: "CSRF_REJECTED", message: "Missing required header" },
 		});
 	});

--- a/packages/core/tests/unit/auth/passkey-verify-route.test.ts
+++ b/packages/core/tests/unit/auth/passkey-verify-route.test.ts
@@ -49,6 +49,7 @@ describe("passkey verify route", () => {
 
 		expect(response.status).toBe(401);
 		await expect(response.json()).resolves.toEqual({
+			success: false,
 			error: {
 				code: "UNAUTHORIZED",
 				message: "Authentication failed",

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -509,6 +509,7 @@ describe("EmDashClient", () => {
 
 				const body = await response.json();
 				expect(body).toEqual({
+					success: true,
 					data: expect.objectContaining({
 						collections: expect.arrayContaining([
 							expect.objectContaining({ slug: "page" }),

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -45,10 +45,17 @@ function createMockBackend(routes: MockRoute[]): Interceptor {
 	};
 }
 
-/** Wraps body in `{ data: body }` to match the standard API response envelope. */
+/**
+ * Mirrors the API response envelope: `{ success: true, data }` on 2xx and
+ * `{ success: false, error }` on 4xx/5xx.
+ */
 function jsonResponse(body: unknown, status: number = 200): Response {
-	// Error responses (4xx/5xx) are NOT wrapped in { data }
-	const payload = status >= 400 ? body : { data: body };
+	// Error callers already pass `{ error: ... }`; add the discriminant so the
+	// fixture matches what `apiError()` actually sends.
+	const payload =
+		status >= 400
+			? { success: false, ...(typeof body === "object" && body !== null ? body : {}) }
+			: { success: true, data: body };
 	return new Response(JSON.stringify(payload), {
 		status,
 		headers: { "Content-Type": "application/json" },

--- a/packages/core/tests/unit/client/transport.test.ts
+++ b/packages/core/tests/unit/client/transport.test.ts
@@ -232,7 +232,7 @@ describe("tokenInterceptor", () => {
 // ---------------------------------------------------------------------------
 
 describe("refreshInterceptor", () => {
-	it("unwraps { data: { access_token } } envelope from token endpoint", async () => {
+	it("unwraps { success, data: { access_token } } envelope from token endpoint", async () => {
 		let retryAuth: string | null = null;
 		let refreshedToken: string | null = null;
 		let refreshedRefresh: string | null = null;
@@ -253,9 +253,10 @@ describe("refreshInterceptor", () => {
 		globalThis.fetch = async (input: string | URL | Request) => {
 			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
 			if (url.includes("/oauth/token/refresh")) {
-				// Server wraps in { data: ... } via apiSuccess/unwrapResult
+				// Server wraps in { success, data: ... } via apiSuccess/unwrapResult
 				return new Response(
 					JSON.stringify({
+						success: true,
 						data: {
 							access_token: "new_access",
 							refresh_token: "new_refresh",

--- a/packages/core/tests/unit/middleware/oauth-csrf.test.ts
+++ b/packages/core/tests/unit/middleware/oauth-csrf.test.ts
@@ -152,6 +152,7 @@ describe("CSRF exemption for OAuth protocol endpoints", () => {
 		expect(next).not.toHaveBeenCalled();
 		expect(response.status).toBe(403);
 		await expect(response.json()).resolves.toEqual({
+			success: false,
 			error: { code: "CSRF_REJECTED", message: "Cross-origin request blocked" },
 		});
 	});

--- a/packages/core/tests/unit/visual-editing/toolbar.test.ts
+++ b/packages/core/tests/unit/visual-editing/toolbar.test.ts
@@ -61,9 +61,9 @@ describe("renderToolbar", () => {
 		expect(html).toContain("/_emdash/api/manifest");
 	});
 
-	it("unwraps the { data } envelope returned by /_emdash/api/manifest", () => {
+	it("unwraps the { success, data } envelope returned by /_emdash/api/manifest", () => {
 		// Regression for #103 / #445: the manifest endpoint wraps the payload in
-		// { data: manifest } (ApiResponse shape), but getFieldKind reads
+		// { success, data: manifest } (ApiResponse shape), but getFieldKind reads
 		// manifest.collections directly. Without the unwrap, getFieldKind returns
 		// null for every field kind, and every click on an edit annotation opens
 		// the admin in a new tab instead of inline-editing.


### PR DESCRIPTION
## What does this PR do?

The REST API reference documents a discriminated response envelope `{ success: true, data }` on success and `{ success: false, error }` on error (see [Response format](https://docs.emdashcms.com/reference/rest-api/#response-format) and [Plugin API routes](https://docs.emdashcms.com/plugins/creating-plugins/api-routes/)). In practice the `success` field was never emitted: `apiSuccess`/`apiError` returned bare `{ data }` / `{ error }`, and the generated OpenAPI schema (`successEnvelope` / `apiErrorSchema`) declared the same shape. Clients couldn't rely on the documented discriminant, and the published OpenAPI spec disagreed with the docs.

This adds `success` to both the runtime response helpers and the OpenAPI envelope schemas so responses match the reference. The existing `data` and `error` fields are unchanged, so this is backward compatible — existing consumers that read `data`/`error` keep working.

Notably, the internal `ApiResult<T>` type already carries the `success` discriminant; it was only being dropped at the HTTP boundary.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8
