### PR TITLE
fix(labeler): dispatch the assessment Workflow on operator rerun

### DIFF
--- a/apps/labeler/src/console-mutation-api.ts
+++ b/apps/labeler/src/console-mutation-api.ts
@@ -22,6 +22,10 @@ import type {
 	OperatorRole,
 } from "./access-auth.js";
 import {
+	type AssessmentWorkflowBinding,
+	dispatchAssessmentWorkflow,
+} from "./assessment-dispatch.js";
+import {
 	automatedIdempotencyKey,
 	computeRunKey,
 	operatorTriggerId,
@@ -162,6 +166,10 @@ export interface ConsoleMutationDeps {
 	 * cannot join the D1 batch, so it runs in the deferred tail; the discovery
 	 * consumer's `runKey` dedup absorbs a duplicate re-drive. */
 	sendDiscoveryJob: (job: DiscoveryJob) => Promise<void>;
+	/** Dispatches a rerun's fresh assessment run to its Workflow instance (the same
+	 * binding discovery uses). The instance id is the run's `runKey`, so a
+	 * redelivered or replayed rerun dedups onto the same instance. */
+	assessmentWorkflow: AssessmentWorkflowBinding;
 	/** Publisher-notification deps (plan W10.5). When present, a label-affecting
 	 * operator action fires a post-commit publisher notice in the deferred tail
 	 * (never blocking or failing the label). Omitted in tests that don't exercise
@@ -569,7 +577,19 @@ function deferRerunTail(deps: ConsoleMutationDeps, runId: string, pendingKey: st
 		(async () => {
 			try {
 				const run = await getAssessment(deps.db, runId);
-				if (run) await advanceAssessmentToPending(deps.db, run, deps.now());
+				if (run) {
+					await advanceAssessmentToPending(deps.db, run, deps.now());
+					// The run's runKey is its Workflow instance id, so a re-driven tail
+					// (defer retry or replay branch) dedups onto the same instance. A
+					// dispatch failure here is logged and dropped — unlike discovery,
+					// which retries the queue message, this deferred tail has no retry
+					// lever, so a dropped dispatch strands the run `pending` until the
+					// reconciliation stuck-run sweep surfaces it for a manual re-trigger.
+					await dispatchAssessmentWorkflow(deps.assessmentWorkflow, {
+						runKey: run.runKey,
+						assessmentId: runId,
+					});
+				}
 			} catch (error) {
 				console.error("[console-mutation] rerun advance failed", error);
 			}
@@ -639,11 +659,11 @@ function deferReconsiderationNotify(
  * `POST /admin/api/assessments/:id/rerun` — mints the immutable operator trigger
  * (`operator:<actionId>`), creates a fresh run for the assessment's exact URI+CID
  * anchored to that trigger, and re-issues `assessment-pending`, all in one atomic
- * batch with the audit row (spec §10/§11.2). Initial discovery now dispatches an
- * assessment Workflow after `pending`; this rerun path still stops at `pending`
- * (its own Workflow dispatch is a follow-on). The operator trigger yields a
- * distinct `runKey`, so the rerun maps to its own Workflow instance id rather
- * than colliding with the prior run's — the re-assessment is not stranded.
+ * batch with the audit row (spec §10/§11.2). The deferred tail then advances the
+ * fresh run to `pending` and dispatches its assessment Workflow, mirroring
+ * discovery. The operator trigger yields a distinct `runKey`, so the rerun maps
+ * to its own Workflow instance id rather than colliding with the prior run's —
+ * the re-assessment runs rather than stranding `pending`.
  */
 async function runRerun(
 	request: Request,

--- a/apps/labeler/src/index.ts
+++ b/apps/labeler/src/index.ts
@@ -206,6 +206,7 @@ async function handleConsoleApiRequest(
 			sendDiscoveryJob: async (job) => {
 				await env.DISCOVERY_QUEUE.send(job);
 			},
+			assessmentWorkflow: env.ASSESSMENT_WORKFLOW,
 			notify: await safeCreateNotifyDeps(env),
 		});
 	}

--- a/apps/labeler/test/console-assessment-mutations.test.ts
+++ b/apps/labeler/test/console-assessment-mutations.test.ts
@@ -9,6 +9,10 @@ import { generateKeyPair, SignJWT } from "jose";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import type { AccessKeyResolver } from "../src/access-auth.js";
+import type {
+	AssessmentWorkflowBinding,
+	AssessmentWorkflowParams,
+} from "../src/assessment-dispatch.js";
 import { computeRunKey, initialTriggerId } from "../src/assessment-lifecycle.js";
 import {
 	createAssessmentRun,
@@ -91,6 +95,37 @@ function testSigner() {
 	});
 }
 
+interface FakeInstance {
+	id: string;
+	params: AssessmentWorkflowParams;
+}
+
+/** In-memory stand-in for the assessment Workflow binding, mirroring the
+ * discovery consumer test's fake: `create` throws when the id is already taken
+ * (the run-key instance-id lock), `get` resolves it, and `createError`
+ * simulates an infrastructure failure. */
+class FakeAssessmentWorkflow implements AssessmentWorkflowBinding {
+	readonly instances = new Map<string, FakeInstance>();
+	readonly created: FakeInstance[] = [];
+	createError: Error | undefined;
+
+	create(options: { id: string; params: AssessmentWorkflowParams }): Promise<{ id: string }> {
+		if (this.createError) return Promise.reject(this.createError);
+		if (this.instances.has(options.id))
+			return Promise.reject(new Error(`instance ${options.id} already exists`));
+		const instance = { id: options.id, params: options.params };
+		this.instances.set(options.id, instance);
+		this.created.push(instance);
+		return Promise.resolve({ id: options.id });
+	}
+
+	get(id: string): Promise<{ id: string }> {
+		const instance = this.instances.get(id);
+		if (!instance) return Promise.reject(new Error(`instance ${id} not found`));
+		return Promise.resolve({ id });
+	}
+}
+
 function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): ConsoleMutationDeps {
 	return {
 		db: testEnv.DB,
@@ -109,8 +144,28 @@ function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): ConsoleMuta
 			void work;
 		},
 		sendDiscoveryJob: async () => {},
+		assessmentWorkflow: new FakeAssessmentWorkflow(),
 		...overrides,
 	};
+}
+
+/** Captures deferred tail work so a test can settle it and observe the rerun's
+ * Workflow dispatch — the default `mutationDeps` drops deferred work. */
+function captureDeferred(overrides: Partial<ConsoleMutationDeps> = {}): {
+	deps: ConsoleMutationDeps;
+	workflow: FakeAssessmentWorkflow;
+	settle: () => Promise<unknown>;
+} {
+	const workflow = new FakeAssessmentWorkflow();
+	const deferred: Promise<unknown>[] = [];
+	const deps = mutationDeps({
+		assessmentWorkflow: workflow,
+		defer: (work) => {
+			deferred.push(work);
+		},
+		...overrides,
+	});
+	return { deps, workflow, settle: () => Promise.all(deferred.splice(0)) };
 }
 
 function readDeps(overrides: Partial<ConsoleApiDeps> = {}): ConsoleApiDeps {
@@ -424,6 +479,89 @@ describe("rerun", () => {
 			mutationDeps(),
 		);
 		expect(response.status).toBe(404);
+	});
+
+	it("dispatches the rerun's fresh run to its own Workflow instance", async () => {
+		const { id } = await seedRun("rerun-dispatch");
+		const { deps, workflow, settle } = captureDeferred();
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, {
+				confirmation: CID,
+				reason: "re-assess this release",
+				idempotencyKey: nextKey(),
+			}),
+			deps,
+		);
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<{ runId: string }>(response);
+
+		// Dispatch is off the response path; the deferred tail carries it.
+		expect(workflow.created).toHaveLength(0);
+		await settle();
+
+		const run = await getAssessment(testEnv.DB, descriptor.runId);
+		// The tail advances the fresh run to pending, then hands it to a Workflow
+		// instance whose id is the run's runKey — distinct from the original run.
+		expect(run?.state).toBe("pending");
+		expect(workflow.created).toHaveLength(1);
+		expect(workflow.created[0]).toMatchObject({
+			id: run!.runKey,
+			params: { assessmentId: descriptor.runId },
+		});
+	});
+
+	it("re-dispatches the same run-key idempotently on replay", async () => {
+		const { id } = await seedRun("rerun-dispatch-replay");
+		const workflow = new FakeAssessmentWorkflow();
+		const deferred: Promise<unknown>[] = [];
+		const deps = mutationDeps({
+			assessmentWorkflow: workflow,
+			defer: (work) => {
+				deferred.push(work);
+			},
+		});
+		const body = { confirmation: CID, reason: "replay me", idempotencyKey: nextKey() };
+
+		const first = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, body),
+			deps,
+		);
+		expect(first.status).toBe(200);
+		const second = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, body),
+			deps,
+		);
+		expect(second.status).toBe(200);
+
+		// Both the proceed tail and the replay tail dispatch the same runKey; the
+		// instance-id lock dedups the second onto the existing instance.
+		await Promise.all(deferred.splice(0));
+		expect(workflow.created).toHaveLength(1);
+	});
+
+	it("keeps the rerun a success when the Workflow dispatch fails in the tail", async () => {
+		const { id } = await seedRun("rerun-dispatch-fail");
+		const { deps, workflow, settle } = captureDeferred();
+		workflow.createError = new Error("workflow binding unavailable");
+		const response = await handleConsoleMutation(
+			post(`/admin/api/assessments/${id}/rerun`, {
+				confirmation: CID,
+				reason: "re-assess this release",
+				idempotencyKey: nextKey(),
+			}),
+			deps,
+		);
+		// The label committed and the response is a success; a dispatch failure lives
+		// only in the deferred tail and must not surface or throw.
+		expect(response.status).toBe(200);
+		const descriptor = await bodyData<{ runId: string }>(response);
+		await expect(settle()).resolves.not.toThrow();
+
+		// The run advanced to pending but nothing dispatched — it is stranded until
+		// the reconciliation stuck-run sweep surfaces it.
+		const run = await getAssessment(testEnv.DB, descriptor.runId);
+		expect(run?.state).toBe("pending");
+		expect(workflow.created).toHaveLength(0);
 	});
 });
 

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -127,6 +127,10 @@ function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): ConsoleMuta
 			void work;
 		},
 		sendDiscoveryJob: async () => {},
+		assessmentWorkflow: {
+			create: (options) => Promise.resolve({ id: options.id }),
+			get: (id) => Promise.resolve({ id }),
+		},
 		...overrides,
 	};
 }

--- a/apps/labeler/test/console-reconsiderations.test.ts
+++ b/apps/labeler/test/console-reconsiderations.test.ts
@@ -148,6 +148,10 @@ function mutationDeps(overrides: Partial<ConsoleMutationDeps> = {}): {
 			deferred.push(work);
 		},
 		sendDiscoveryJob: async () => {},
+		assessmentWorkflow: {
+			create: (options) => Promise.resolve({ id: options.id }),
+			get: (id) => Promise.resolve({ id }),
+		},
 		...overrides,
 	};
 	return { deps, settle: async () => void (await Promise.allSettled(deferred)) };


### PR DESCRIPTION
## What does this PR do?

Fixes a functional bug in the operator **Re-run an assessment** action: it minted a fresh run and gated the release with `assessment-pending`, but **never dispatched the Cloudflare Workflow that executes it** — so the release was stranded in `pending` indefinitely (until it surfaced as a reconciliation stuck-run alert). Targets the `feat/plugin-registry-labelling-service` integration branch (RFC #694, umbrella #1909).

**Root cause:** `ConsoleMutationDeps` never carried the `ASSESSMENT_WORKFLOW` binding at all, so `runRerun`'s deferred tail (`deferRerunTail`) advanced the run to `pending` and published the pending label but structurally *could not* dispatch. The discovery path got the binding and dispatches (`discovery-consumer.ts`); the console path never did — almost certainly because rerun was built while the analysis stages were stubbed and PROD-gated, and the dispatch wasn't reconnected when the real stages landed (#2090/#2091). The bug became live-visible only once the pipeline started producing real assessments.

**Fix:** thread `AssessmentWorkflowBinding` into `ConsoleMutationDeps` (wired from `env.ASSESSMENT_WORKFLOW` at the console-mutation construction site), and dispatch the run in `deferRerunTail` after advancing to `pending`, keyed on the run's persisted `runKey`:

```
await dispatchAssessmentWorkflow(deps.assessmentWorkflow, { runKey: run.runKey, assessmentId: runId });
```

**Why it's safe (the dedup rests on #2072's instance-id lock):**
- A rerun mints a **fresh** `runKey` (from the `operator:<actionId>` trigger, distinct from discovery's `initialTriggerId(cid)` and any prior rerun), so it dispatches its *own* new Workflow instance — no collision with the original run's.
- The Workflow instance id *is* the `runKey`, so a re-driven tail (a `defer` retry, or the guardMutation replay branch — which also runs this tail) re-dispatching the same `runKey` dedups to `"exists"`: no duplicate run, no duplicate labels.
- No new current-pointer/double-issue hazard: the rerun run traverses the identical Workflow → orchestrator → finalization path as a discovery run, with runKey-derived idempotency keys; the fix only lets a previously-stranded run actually execute.

**Dispatch-failure posture (documented):** the dispatch stays inside the existing guarded `deferRerunTail` try/catch — a failure is logged and dropped. Unlike discovery (which retries the queue message), this deferred tail has no retry lever, so a dropped dispatch strands the run `pending` until the reconciliation stuck-run sweep surfaces it for a manual re-trigger. A comment states this. Not escalated to an `operational_event` for a rare infra failure that the stuck-run alert already backstops — flagging in case you'd prefer immediate operator visibility.

## Type of change

- [x] Bug fix
- [ ] Feature (requires a Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all three labeler projects)
- [x] `pnpm lint` passes (oxlint type-aware, clean on all changed files)
- [x] `pnpm test` passes (rerun + discovery + dispatch suites 53; full labeler suite 833) — including TDD: the dispatch-assertion tests **fail against pre-fix code** (`expected [] to have length 1`, proving dispatch was never invoked) and pass post-fix.
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server-side; the console "Re-run" button already calls the endpoint, no UI change.
- [x] I have added a changeset (if this PR changes a published package) — **n/a**: `@emdash-cms/labeler` is `private: true`.
- [x] New features link to an approved Discussion — **n/a**: bug fix; the umbrella #1909 tracks RFC #694.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation + threat-model check), reviewed by **Claude Fable 5**

## Screenshots / test output

```
console-assessment-mutations: 24 passed  (incl. the rerun-dispatch + idempotent-replay + dispatch-failure cases)
discovery-consumer + assessment-dispatch: verified unaffected
full labeler suite: 833 passed
```

New tests: a rerun dispatches its fresh run to its own Workflow instance (id === runKey, params.assessmentId === runId); proceed + replay yields exactly one created instance (idempotent); a tail dispatch failure keeps the mutation a 200 and doesn't crash the tail.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-labeler-rerun-dispatch-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/labeler-rerun-dispatch`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
