### PR TITLE
feat(admin): add trusted content editor extension panels

### DIFF
--- a/.changeset/movable-editor-extension-panels.md
+++ b/.changeset/movable-editor-extension-panels.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds main-editor placement, live draft context, host-owned field and SEO actions, and per-user browser layout controls to trusted native content editor panels. New entries are supported, malformed saved layouts are reconciled safely, and memo, forwardRef, and lazy React components are accepted by the extension registry.

--- a/.changeset/movable-editor-extension-panels.md
+++ b/.changeset/movable-editor-extension-panels.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": minor
 ---
 
-Adds main-editor placement, live draft context, host-owned field and SEO actions, and per-user browser layout controls to trusted native content editor panels. New entries are supported, malformed saved layouts are reconciled safely, and memo, forwardRef, and lazy React components are accepted by the extension registry.
+Adds main-editor placement, live draft context, host-owned field and SEO actions, pointer and keyboard reordering, and per-user browser layout controls to trusted native content editor panels. It also introduces guarded native editor slots, beginning with SEO, so a plugin can append to or replace a core section body without duplicating host chrome; failed replacements automatically fall back to the native body. New entries are supported, malformed saved layouts are reconciled safely, and memo, forwardRef, and lazy React components are accepted by the extension registry.

--- a/.changeset/trusted-content-extension-slots.md
+++ b/.changeset/trusted-content-extension-slots.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds typed native-plugin extension slots for content-list columns and content-editor sidebar panels, including collection and role filtering, disabled-plugin lifecycle handling, and per-contribution error isolation.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -163,6 +163,10 @@ export default defineConfig({
 									slug: "plugins/creating-native-plugins/react-admin",
 								},
 								{
+									label: "List Columns & Editor Panels",
+									slug: "plugins/creating-native-plugins/admin-extensions",
+								},
+								{
 									label: "Portable Text Components",
 									slug: "plugins/creating-native-plugins/portable-text-components",
 								},

--- a/docs/src/content/docs/plugins/creating-native-plugins/admin-extensions.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/admin-extensions.mdx
@@ -9,6 +9,7 @@ Native plugins can extend two content-focused admin surfaces with typed React co
 
 - **Content list columns** — extra columns in a collection's content list
 - **Editor panels** — extra sections in the main editor or its settings sidebar
+- **Native editor slots** — plugin-owned bodies inside explicitly exposed core sections, without duplicate host chrome
 
 Contributions travel the same trusted path as [React admin pages and widgets](/plugins/creating-native-plugins/react-admin/): your `admin` entry point exports them, EmDash bundles that module into the admin at build time, and the host screens render them. There are no DOM queries, mutation observers, or global hooks involved — the host owns placement, semantics, and error isolation.
 
@@ -147,7 +148,7 @@ Panels render for saved entries and new entries. `entry` is the last saved snaps
 
 ### Placement and user arrangement
 
-`placement` is only the initial preference. Every panel gets an accessible arrangement menu for moving it up or down within its surface or between the main editor and settings sidebar. EmDash stores the resulting order per authenticated user and collection in that browser. Preferences are versioned and reconciled against the live registry, so disabled or removed panels disappear and newly installed panels append to their declared default. This browser preference is intentionally not server-synced.
+`placement` is only the initial preference. Every panel gets a drag handle with pointer and keyboard support plus an accessible arrangement menu for moving it up or down within its surface or between the main editor and settings sidebar. EmDash stores the resulting order per authenticated user and collection in that browser. Preferences are versioned and reconciled against the live registry, so disabled or removed panels disappear and newly installed panels append to their declared default. This browser preference is intentionally not server-synced.
 
 Sidebar panels appear after the core SEO section and before the document outline, revisions, and trash action. Main panels appear after the collection fields. When a Portable Text block takes over the sidebar (for example the image detail panel), core sidebar sections and contributed sidebar panels are both replaced until it closes; main panels remain in place.
 
@@ -157,6 +158,31 @@ Sidebar panels appear after the core SEO section and before the document outline
 	assume a wide viewport — a sidebar panel must not force horizontal overflow. Use
 	`placement: "main"` when the workflow genuinely needs more horizontal space.
 </Aside>
+
+### Owning a native editor section
+
+Use a named slot when a plugin should enhance an existing EmDash section instead of adding a second titled panel. The first named slot is `"seo"`, available on saved entries in collections with SEO enabled. EmDash continues to own the section heading, border, placement, and responsive behavior; the plugin renders only the section body:
+
+```tsx title="src/admin.tsx"
+import type { ContentEditorPanelExtension } from "@emdash-cms/admin";
+
+import { AdvancedSeoBody } from "./components/AdvancedSeoBody";
+
+export const contentEditorPanels: ContentEditorPanelExtension[] = [
+	{
+		id: "my-plugin:seo",
+		title: "Advanced SEO",
+		collections: ["posts", "pages"],
+		slot: "seo",
+		mode: "replace",
+		panel: AdvancedSeoBody,
+	},
+];
+```
+
+`mode: "replace"` replaces the native body. If the plugin is disabled, does not apply to the collection, or throws while rendering, EmDash restores the native SEO body automatically. When more than one replacement applies, the first contribution in deterministic `order`/`id` order owns the slot; later replacements are ignored. `mode: "append"` (the default for a named slot) renders after the selected body, including after a replacement.
+
+Named-slot contributions are intentionally not draggable and do not accept `placement`: their section belongs to the host's editor structure. Use a regular panel when the user should be able to move the whole workflow.
 
 ## Error isolation
 

--- a/docs/src/content/docs/plugins/creating-native-plugins/admin-extensions.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/admin-extensions.mdx
@@ -1,0 +1,158 @@
+---
+title: Content list columns and editor panels
+description: Extend the admin content list and entry editor sidebar with typed React contributions from a native plugin.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Native plugins can extend two content-focused admin surfaces with typed React contributions:
+
+- **Content list columns** — extra columns in a collection's content list
+- **Editor sidebar panels** — extra sections in the entry editor's settings sidebar
+
+Contributions travel the same trusted path as [React admin pages and widgets](/plugins/creating-native-plugins/react-admin/): your `admin` entry point exports them, EmDash bundles that module into the admin at build time, and the host screens render them. There are no DOM queries, mutation observers, or global hooks involved — the host owns placement, semantics, and error isolation.
+
+<Aside type="caution" title="Trusted plugins only">
+	These slots ship your JavaScript into the admin SPA, so they are available only to
+	`format: "native"` plugins — the same rule as `adminEntry` itself. Sandboxed plugins cannot
+	declare an admin entry (EmDash rejects it at config time) and never appear in the admin
+	registry, so they can never reach these React slots. Sandboxed plugins describe admin UI as
+	[Block Kit](/plugins/creating-plugins/block-kit/) instead.
+</Aside>
+
+## Registering contributions
+
+Export `contentListColumns` and/or `contentEditorPanels` from your admin entry point, alongside `pages`, `widgets`, and `fields`:
+
+```tsx title="src/admin.tsx"
+import type {
+	ContentEditorPanelExtension,
+	ContentListColumnExtension,
+} from "@emdash-cms/admin";
+
+import { ReviewStatusCell } from "./components/ReviewStatusCell";
+import { ReviewStatusPanel } from "./components/ReviewStatusPanel";
+
+export const contentListColumns: ContentListColumnExtension[] = [
+	{
+		id: "my-plugin:review-status",
+		label: "Review",
+		collections: ["posts"],
+		cell: ReviewStatusCell,
+	},
+];
+
+export const contentEditorPanels: ContentEditorPanelExtension[] = [
+	{
+		id: "my-plugin:review-status",
+		title: "Review status",
+		collections: ["posts"],
+		minRole: 40, // Editor and up
+		panel: ReviewStatusPanel,
+	},
+];
+```
+
+Both contribution kinds share the same base fields:
+
+| Field         | Type                                          | Meaning                                                                                                     |
+| ------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `id`          | `string`                                      | Stable unique id, by convention `"<plugin-id>:<name>"`. Duplicates keep the first (in sorted plugin order) and log a warning — never a silent overwrite. An id stays claimed by its first registrant even on screens where that contribution is filtered out. |
+| `order`       | `number?`                                     | Sort key within the slot (default `0`). Ties break by `id`, so ordering is deterministic.                    |
+| `collections` | `string[] \| ((collection: string) => boolean)?` | Which collections the contribution applies to. Omit for all. A throwing predicate counts as "not applicable". |
+| `minRole`     | `number?`                                     | Minimum numeric role (`40` Editor, `50` Admin) required to *see* the contribution. Server authorization still applies to any data it requests. |
+
+When a contribution doesn't apply — wrong collection, insufficient role, plugin disabled, or nothing registered at all — the host renders exactly its classic markup: no empty columns, headers, cells, or section chrome. Disabling a plugin in the Plugin Manager removes its columns and panels along with its pages and widgets.
+
+## Content list columns
+
+A column contributes a header label and a cell component. The host renders the `<th scope="col">` and one `<td>` per row; your `cell` component renders inside the `<td>`:
+
+```tsx title="src/components/ReviewStatusCell.tsx"
+import type { ContentListColumnCellContext } from "@emdash-cms/admin";
+
+export function ReviewStatusCell({ item }: ContentListColumnCellContext) {
+	const reviewed = item.data.reviewedAt != null;
+	return <span>{reviewed ? "Reviewed" : "Pending"}</span>;
+}
+```
+
+The cell context is read-only host data:
+
+- `collection` — the collection slug the list is showing
+- `locale` — the active list locale (`undefined` when the site has no i18n config)
+- `item` — the saved entry for this row (`ContentItem`: id, slug, status, locale, `data`, timestamps, revision ids)
+
+`align: "end"` right-aligns the column in LTR and left-aligns it in RTL (alignment is logical). Column *width* is intentionally not configurable — the list table auto-sizes. An optional `header` component replaces the plain label; if it crashes, the header falls back to the label so the column stays identifiable. Columns apply to the main list only, never to the Trash tab.
+
+### Loading data without N+1
+
+Cells receive the already-loaded row — the host never issues a request per row on your behalf, and neither should you. If a column needs data beyond the entry itself, batch it: use **one react-query key for the whole column**, so every cell shares a single in-flight request:
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import type { ContentListColumnCellContext } from "@emdash-cms/admin";
+
+export function ScoreCell({ collection, locale, item }: ContentListColumnCellContext) {
+	// One key per (collection, locale) — NOT per row. All cells share the
+	// same cached result and the same in-flight promise.
+	const { data, isError } = useQuery({
+		queryKey: ["my-plugin", "scores", collection, locale],
+		queryFn: () => fetchScoresForCollection(collection, locale),
+	});
+
+	if (isError) {
+		return (
+			<span className="text-kumo-subtle">
+				<span aria-hidden="true">—</span>
+				<span className="sr-only">Scores unavailable</span>
+			</span>
+		);
+	}
+	if (!data) return <span className="text-kumo-subtle">…</span>; // fixed-size placeholder
+	return <span>{data[item.id] ?? "—"}</span>;
+}
+```
+
+Keying a query by `item.id` re-introduces one request per row and is a bug. While loading, render a small fixed-size placeholder so the table doesn't shift.
+
+## Editor sidebar panels
+
+A panel contributes a titled section to the entry settings sidebar. The host renders the section wrapper and heading; your `panel` component renders the body:
+
+```tsx title="src/components/ReviewStatusPanel.tsx"
+import type { ContentEditorPanelContext } from "@emdash-cms/admin";
+
+export function ReviewStatusPanel({ collection, entry, locale }: ContentEditorPanelContext) {
+	return (
+		<dl className="space-y-1 text-sm">
+			<div className="flex items-center justify-between gap-2">
+				<dt>Entry</dt>
+				<dd className="truncate">{entry.slug ?? entry.id}</dd>
+			</div>
+			<div className="flex items-center justify-between gap-2">
+				<dt>Locale</dt>
+				<dd>{locale ?? "—"}</dd>
+			</div>
+		</dl>
+	);
+}
+```
+
+Panels render **for saved entries only** — a brand-new entry has no id or saved state to expose. They appear after the core content sections (Publish, Ownership, Bylines, Translations, Taxonomies, SEO) and before the document outline, revision history, and trash action. When a Portable Text block takes over the sidebar (for example the image detail panel), core sections and contributed panels are both replaced until it closes.
+
+The panel context carries the same host data as the cell context — `collection`, the saved entry snapshot (named `entry` here; list cells call it `item` to match their row framing), and the entry's `locale`. Edits in progress are deliberately not exposed — read the saved state, and use the [plugin API](/plugins/creating-native-plugins/react-admin/#plugin-api-hook) for anything richer.
+
+<Aside type="tip" title="Design for a narrow sidebar">
+	The settings sidebar is ~20rem wide on small screens and becomes an off-canvas sheet below
+	the `lg` breakpoint. Let content wrap, use logical (`ms-*`/`ps-*`) spacing for RTL, and never
+	assume a wide viewport — a panel must not force horizontal overflow.
+</Aside>
+
+## Error isolation
+
+Every contributed header, cell, and panel is wrapped in an error boundary. A contribution that throws degrades to a quiet, accessible fallback — a placeholder in list cells, a short note with a Retry action in panels — without breaking the table, the row, the editor, or other contributions. The error object is logged to the browser console for developers and never rendered into the admin UI.
+
+## Localization
+
+`label` and `title` accept a plain string (rendered as-is) or a Lingui `MessageDescriptor` (translated with the admin's active locale). Plugin strings are not part of the admin's catalogs, so most plugins pass plain strings; descriptors exist so contributions defined inside the admin package itself stay translatable.

--- a/docs/src/content/docs/plugins/creating-native-plugins/admin-extensions.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/admin-extensions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Content list columns and editor panels
-description: Extend the admin content list and entry editor sidebar with typed React contributions from a native plugin.
+description: Extend content lists and the entry editor with typed React contributions from a native plugin.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -8,7 +8,7 @@ import { Aside } from "@astrojs/starlight/components";
 Native plugins can extend two content-focused admin surfaces with typed React contributions:
 
 - **Content list columns** — extra columns in a collection's content list
-- **Editor sidebar panels** — extra sections in the entry editor's settings sidebar
+- **Editor panels** — extra sections in the main editor or its settings sidebar
 
 Contributions travel the same trusted path as [React admin pages and widgets](/plugins/creating-native-plugins/react-admin/): your `admin` entry point exports them, EmDash bundles that module into the admin at build time, and the host screens render them. There are no DOM queries, mutation observers, or global hooks involved — the host owns placement, semantics, and error isolation.
 
@@ -48,6 +48,7 @@ export const contentEditorPanels: ContentEditorPanelExtension[] = [
 		title: "Review status",
 		collections: ["posts"],
 		minRole: 40, // Editor and up
+		placement: "main", // Optional; defaults to "sidebar"
 		panel: ReviewStatusPanel,
 	},
 ];
@@ -116,37 +117,45 @@ export function ScoreCell({ collection, locale, item }: ContentListColumnCellCon
 
 Keying a query by `item.id` re-introduces one request per row and is a bug. While loading, render a small fixed-size placeholder so the table doesn't shift.
 
-## Editor sidebar panels
+## Editor panels
 
-A panel contributes a titled section to the entry settings sidebar. The host renders the section wrapper and heading; your `panel` component renders the body:
+A panel contributes a titled section to the main editor or the entry settings sidebar. Set `placement: "main"` for a wide workflow; omit it (or use `"sidebar"`) for compact settings. The host renders the section wrapper, heading, and arrangement menu; your `panel` component renders only the body:
 
 ```tsx title="src/components/ReviewStatusPanel.tsx"
 import type { ContentEditorPanelContext } from "@emdash-cms/admin";
 
-export function ReviewStatusPanel({ collection, entry, locale }: ContentEditorPanelContext) {
+export function ReviewStatusPanel({ entry, locale, draft, actions }: ContentEditorPanelContext) {
 	return (
-		<dl className="space-y-1 text-sm">
-			<div className="flex items-center justify-between gap-2">
-				<dt>Entry</dt>
-				<dd className="truncate">{entry.slug ?? entry.id}</dd>
-			</div>
-			<div className="flex items-center justify-between gap-2">
-				<dt>Locale</dt>
-				<dd>{locale ?? "—"}</dd>
-			</div>
-		</dl>
+		<div className="space-y-3 text-sm">
+			<p>{entry ? `Editing ${entry.id}` : "Creating a new entry"}</p>
+			<p>Locale: {locale ?? "—"}</p>
+			<label>
+				Review note
+				<input
+					value={String(draft.data.reviewNote ?? "")}
+					onChange={(event) => actions.updateField("reviewNote", event.target.value)}
+				/>
+			</label>
+		</div>
 	);
 }
 ```
 
-Panels render **for saved entries only** — a brand-new entry has no id or saved state to expose. They appear after the core content sections (Publish, Ownership, Bylines, Translations, Taxonomies, SEO) and before the document outline, revision history, and trash action. When a Portable Text block takes over the sidebar (for example the image detail panel), core sections and contributed panels are both replaced until it closes.
+Panels render for saved entries and new entries. `entry` is the last saved snapshot, or `null` while creating a new entry. `draft` always contains the current field data, slug, status, dirty/new flags, and saved SEO metadata when available. Use the host-owned `actions.updateField`, `actions.updateSlug`, and optional `actions.updateSeo` callbacks to change editor state; do not mutate `draft` or `entry` directly.
 
-The panel context carries the same host data as the cell context — `collection`, the saved entry snapshot (named `entry` here; list cells call it `item` to match their row framing), and the entry's `locale`. Edits in progress are deliberately not exposed — read the saved state, and use the [plugin API](/plugins/creating-native-plugins/react-admin/#plugin-api-hook) for anything richer.
+`updateField` and `updateSlug` update the live draft and follow the editor's normal save/autosave path. `updateSeo` delegates to the collection's existing SEO persistence path and is absent when SEO is not enabled. Server authorization still applies to every request a plugin makes; visibility and host callbacks are not an authorization boundary.
+
+### Placement and user arrangement
+
+`placement` is only the initial preference. Every panel gets an accessible arrangement menu for moving it up or down within its surface or between the main editor and settings sidebar. EmDash stores the resulting order per authenticated user and collection in that browser. Preferences are versioned and reconciled against the live registry, so disabled or removed panels disappear and newly installed panels append to their declared default. This browser preference is intentionally not server-synced.
+
+Sidebar panels appear after the core SEO section and before the document outline, revisions, and trash action. Main panels appear after the collection fields. When a Portable Text block takes over the sidebar (for example the image detail panel), core sidebar sections and contributed sidebar panels are both replaced until it closes; main panels remain in place.
 
 <Aside type="tip" title="Design for a narrow sidebar">
 	The settings sidebar is ~20rem wide on small screens and becomes an off-canvas sheet below
 	the `lg` breakpoint. Let content wrap, use logical (`ms-*`/`ps-*`) spacing for RTL, and never
-	assume a wide viewport — a panel must not force horizontal overflow.
+	assume a wide viewport — a sidebar panel must not force horizontal overflow. Use
+	`placement: "main"` when the workflow genuinely needs more horizontal space.
 </Aside>
 
 ## Error isolation

--- a/packages/admin/src/components/AdminExtensionBoundary.tsx
+++ b/packages/admin/src/components/AdminExtensionBoundary.tsx
@@ -1,0 +1,86 @@
+import { Trans } from "@lingui/react/macro";
+import * as React from "react";
+
+interface Props {
+	children: React.ReactNode;
+	/**
+	 * Where the extension renders, which decides the fallback shape:
+	 * - `"cell"`: a quiet placeholder that keeps the table cell's size and
+	 *   semantics (no card chrome inside a `<td>`).
+	 * - `"panel"`: a restrained note with a retry action, matching the
+	 *   plugin-field boundary's tone.
+	 */
+	variant: "cell" | "panel";
+	/** Replaces the variant's default fallback (e.g. a header's plain label). */
+	fallback?: React.ReactNode;
+	/**
+	 * Accessible name of the failed extension (e.g. the panel title), added
+	 * screen-reader-only to the retry action so two broken panels don't
+	 * produce two indistinguishable "Retry" buttons.
+	 */
+	label?: string;
+}
+
+interface State {
+	hasError: boolean;
+}
+
+/**
+ * Error boundary around trusted admin extensions (content-list columns and
+ * editor sidebar panels). One broken contribution degrades to a small,
+ * accessible fallback instead of unmounting the list or the editor.
+ *
+ * Unlike `PluginFieldErrorBoundary`, the error message itself is never
+ * rendered — extension failures can wrap arbitrary data, and the admin UI
+ * must not leak it. The error is logged to the console for developers.
+ */
+export class AdminExtensionBoundary extends React.Component<Props, State> {
+	constructor(props: Props) {
+		super(props);
+		this.state = { hasError: false };
+	}
+
+	static getDerivedStateFromError(): State {
+		return { hasError: true };
+	}
+
+	override componentDidCatch(error: Error, info: React.ErrorInfo) {
+		console.error("[admin-extensions] An admin extension failed to render.", error, info);
+	}
+
+	override render() {
+		if (this.state.hasError) {
+			if (this.props.fallback !== undefined) {
+				return this.props.fallback;
+			}
+			if (this.props.variant === "cell") {
+				return (
+					<span className="text-kumo-subtle">
+						<span aria-hidden="true">—</span>
+						<span className="sr-only">
+							<Trans>Extension failed to render</Trans>
+						</span>
+					</span>
+				);
+			}
+			return (
+				// `alert` is the role designed to announce content that appears
+				// after render, which is exactly how a boundary fallback mounts.
+				<div role="alert" className="text-sm text-kumo-subtle">
+					<p>
+						<Trans>This extension failed to render.</Trans>
+					</p>
+					<button
+						type="button"
+						className="mt-1 text-xs font-medium text-kumo-brand underline"
+						onClick={() => this.setState({ hasError: false })}
+					>
+						<Trans>Retry</Trans>
+						{this.props.label !== undefined && <span className="sr-only"> {this.props.label}</span>}
+					</button>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -42,6 +42,10 @@ import { useLocale } from "../locales/useLocale.js";
 import { ArrowPrev } from "./ArrowIcons.js";
 import { BlockKitFieldWidget } from "./BlockKitFieldWidget.js";
 import {
+	ContentEditorExtensionPanels,
+	ContentEditorExtensionPanelsProvider,
+} from "./ContentEditorExtensionPanels.js";
+import {
 	ContentSettingsPanel,
 	DiscardDraftDialog,
 	PreviewButton,
@@ -552,6 +556,25 @@ export function ContentEditor({
 		setSlug(value);
 		setSlugTouched(true);
 	}, []);
+	const extensionDraft = React.useMemo(
+		() => ({
+			data: formData,
+			slug,
+			status,
+			seo: item?.seo,
+			isNew: Boolean(isNew),
+			isDirty,
+		}),
+		[formData, slug, status, item?.seo, isNew, isDirty],
+	);
+	const extensionActions = React.useMemo(
+		() => ({
+			updateField: handleFieldChange,
+			updateSlug: handleSlugChange,
+			updateSeo: onSeoChange ? handleSeoChange : undefined,
+		}),
+		[handleFieldChange, handleSlugChange, handleSeoChange, onSeoChange],
+	);
 
 	const isPublished = status === "published";
 
@@ -599,281 +622,292 @@ export function ContentEditor({
 			{/* Wraps the whole layout so the strip's Settings button and the
 			    block-panel sync can reach the sidebar context. Below lg Kumo
 			    renders the panel as an inline (not portaled) sheet. */}
-			<Sidebar.Provider
-				contained={!isBelowLg}
-				defaultOpen
-				side={panelSide}
-				collapsible="offcanvas"
-				mobileBreakpoint={1024}
-				className={cn(!isDistractionFree && "h-full min-h-0")}
-				style={
-					{
-						"--sidebar-width": isBelowLg ? "20rem" : "23rem",
-					} as React.CSSProperties
-				}
+			<ContentEditorExtensionPanelsProvider
+				collection={collection}
+				entry={item ?? null}
+				locale={item?.locale ?? entryLocale ?? undefined}
+				userId={currentUser?.id}
+				userRole={currentUser?.role ?? 0}
+				draft={extensionDraft}
+				actions={extensionActions}
 			>
-				<div className={cn(isDistractionFree ? "w-full" : "flex-1 min-w-0 overflow-y-auto p-6")}>
-					{/* In distraction-free mode the header is a hover-revealed overlay. */}
-					<div
-						className={cn(
-							"flex flex-wrap items-center justify-between gap-y-2",
-							isDistractionFree
-								? "opacity-0 hover:opacity-100 transition-opacity duration-200 fixed top-0 start-0 end-0 bg-kumo-base/95 backdrop-blur p-4 z-10"
-								: cn(
-										"mx-auto mb-6 max-w-3xl",
-										isBelowLg && "sticky top-0 z-20 bg-kumo-base/95 py-3 backdrop-blur",
-									),
-						)}
-					>
-						<div className="flex items-center gap-4">
-							{!isDistractionFree && (
-								<RouterLinkButton
-									to="/content/$collection"
-									params={{ collection }}
-									search={{ locale: undefined }}
-									aria-label={t`Back to ${collectionLabel} list`}
-									variant="ghost"
-									shape="square"
-									icon={<ArrowPrev />}
-								/>
+				<Sidebar.Provider
+					contained={!isBelowLg}
+					defaultOpen
+					side={panelSide}
+					collapsible="offcanvas"
+					mobileBreakpoint={1024}
+					className={cn(!isDistractionFree && "h-full min-h-0")}
+					style={
+						{
+							"--sidebar-width": isBelowLg ? "20rem" : "23rem",
+						} as React.CSSProperties
+					}
+				>
+					<div className={cn(isDistractionFree ? "w-full" : "flex-1 min-w-0 overflow-y-auto p-6")}>
+						{/* In distraction-free mode the header is a hover-revealed overlay. */}
+						<div
+							className={cn(
+								"flex flex-wrap items-center justify-between gap-y-2",
+								isDistractionFree
+									? "opacity-0 hover:opacity-100 transition-opacity duration-200 fixed top-0 start-0 end-0 bg-kumo-base/95 backdrop-blur p-4 z-10"
+									: cn(
+											"mx-auto mb-6 max-w-3xl",
+											isBelowLg && "sticky top-0 z-20 bg-kumo-base/95 py-3 backdrop-blur",
+										),
 							)}
-							{isDistractionFree && (
-								<Button
-									variant="ghost"
-									shape="square"
-									onClick={() => setIsDistractionFree(false)}
-									aria-label={t`Exit distraction-free mode`}
-								>
-									<ArrowsInSimple className="h-5 w-5" aria-hidden="true" />
-								</Button>
-							)}
-							<h1 className="text-2xl font-bold">
-								{isNew ? t`New ${collectionLabel}` : t`Edit ${collectionLabel}`}
-							</h1>
-							{i18n && item?.locale && (
-								<Badge variant="outline" className="uppercase text-xs">
-									{item.locale}
-								</Badge>
-							)}
-						</div>
-						<div className="flex items-center gap-2">
-							{!isDistractionFree ? (
-								// Below lg, actions move here from the (hidden) panel.
-								<>
-									{isBelowLg && (
-										<div className="flex flex-wrap items-center justify-end gap-2">
-											{!isNew && supportsPreview && (
-												<PreviewButton
-													hasPendingChanges={hasPendingChanges}
-													isLoadingPreview={isLoadingPreview}
-													onPreview={handlePreview}
-												/>
-											)}
-											<SaveButton
-												type="submit"
-												isDirty={isDirty}
-												isSaving={Boolean(saveFeedbackActive || autosaveFeedbackActive)}
-												disabled={isContentOperationPending}
-											/>
-											{liveViewUrl && (
-												<LinkButton
-													href={liveViewUrl}
-													external
-													variant="outline"
-													icon={<ArrowSquareOut />}
-												>
-													{t`Live View`}
-												</LinkButton>
-											)}
-											<PublishActions
-												isNew={isNew}
-												isLive={isLive}
-												hasPendingChanges={hasPendingChanges}
-												onPublish={onPublish}
-												onUnpublish={onUnpublish}
-											/>
-											<MobileSettingsButton />
-										</div>
-									)}
+						>
+							<div className="flex items-center gap-4">
+								{!isDistractionFree && (
+									<RouterLinkButton
+										to="/content/$collection"
+										params={{ collection }}
+										search={{ locale: undefined }}
+										aria-label={t`Back to ${collectionLabel} list`}
+										variant="ghost"
+										shape="square"
+										icon={<ArrowPrev />}
+									/>
+								)}
+								{isDistractionFree && (
 									<Button
 										variant="ghost"
 										shape="square"
-										type="button"
-										onClick={() => setIsDistractionFree(true)}
-										aria-label={t`Enter distraction-free mode`}
-										title={t`Distraction-free mode (⌘⇧\\)`}
+										onClick={() => setIsDistractionFree(false)}
+										aria-label={t`Exit distraction-free mode`}
 									>
-										<ArrowsOutSimple className="h-4 w-4" aria-hidden="true" />
+										<ArrowsInSimple className="h-5 w-5" aria-hidden="true" />
 									</Button>
-								</>
-							) : (
-								// Distraction-free: this overlay is the only save/exit surface.
-								<>
-									{!isNew && supportsPreview && (
-										<PreviewButton
-											hasPendingChanges={hasPendingChanges}
-											isLoadingPreview={isLoadingPreview}
-											onPreview={handlePreview}
-										/>
-									)}
-									<SaveButton
-										type="submit"
-										isDirty={isDirty}
-										isSaving={Boolean(saveFeedbackActive || autosaveFeedbackActive)}
-										disabled={isContentOperationPending}
-									/>
-									{liveViewUrl && (
-										<LinkButton
-											href={liveViewUrl}
-											external
-											variant="outline"
-											icon={<ArrowSquareOut />}
+								)}
+								<h1 className="text-2xl font-bold">
+									{isNew ? t`New ${collectionLabel}` : t`Edit ${collectionLabel}`}
+								</h1>
+								{i18n && item?.locale && (
+									<Badge variant="outline" className="uppercase text-xs">
+										{item.locale}
+									</Badge>
+								)}
+							</div>
+							<div className="flex items-center gap-2">
+								{!isDistractionFree ? (
+									// Below lg, actions move here from the (hidden) panel.
+									<>
+										{isBelowLg && (
+											<div className="flex flex-wrap items-center justify-end gap-2">
+												{!isNew && supportsPreview && (
+													<PreviewButton
+														hasPendingChanges={hasPendingChanges}
+														isLoadingPreview={isLoadingPreview}
+														onPreview={handlePreview}
+													/>
+												)}
+												<SaveButton
+													type="submit"
+													isDirty={isDirty}
+													isSaving={Boolean(saveFeedbackActive || autosaveFeedbackActive)}
+													disabled={isContentOperationPending}
+												/>
+												{liveViewUrl && (
+													<LinkButton
+														href={liveViewUrl}
+														external
+														variant="outline"
+														icon={<ArrowSquareOut />}
+													>
+														{t`Live View`}
+													</LinkButton>
+												)}
+												<PublishActions
+													isNew={isNew}
+													isLive={isLive}
+													hasPendingChanges={hasPendingChanges}
+													onPublish={onPublish}
+													onUnpublish={onUnpublish}
+												/>
+												<MobileSettingsButton />
+											</div>
+										)}
+										<Button
+											variant="ghost"
+											shape="square"
+											type="button"
+											onClick={() => setIsDistractionFree(true)}
+											aria-label={t`Enter distraction-free mode`}
+											title={t`Distraction-free mode (⌘⇧\\)`}
 										>
-											{t`Live View`}
-										</LinkButton>
-									)}
-									{!isNew && (
-										<>
-											{supportsDrafts && hasPendingChanges && onDiscardDraft && (
-												<DiscardDraftDialog onDiscard={onDiscardDraft} triggerVariant="outline" />
-											)}
-											<PublishActions
-												isLive={isLive}
+											<ArrowsOutSimple className="h-4 w-4" aria-hidden="true" />
+										</Button>
+									</>
+								) : (
+									// Distraction-free: this overlay is the only save/exit surface.
+									<>
+										{!isNew && supportsPreview && (
+											<PreviewButton
 												hasPendingChanges={hasPendingChanges}
-												onPublish={onPublish}
-												onUnpublish={onUnpublish}
+												isLoadingPreview={isLoadingPreview}
+												onPreview={handlePreview}
 											/>
-										</>
-									)}
-								</>
+										)}
+										<SaveButton
+											type="submit"
+											isDirty={isDirty}
+											isSaving={Boolean(saveFeedbackActive || autosaveFeedbackActive)}
+											disabled={isContentOperationPending}
+										/>
+										{liveViewUrl && (
+											<LinkButton
+												href={liveViewUrl}
+												external
+												variant="outline"
+												icon={<ArrowSquareOut />}
+											>
+												{t`Live View`}
+											</LinkButton>
+										)}
+										{!isNew && (
+											<>
+												{supportsDrafts && hasPendingChanges && onDiscardDraft && (
+													<DiscardDraftDialog onDiscard={onDiscardDraft} triggerVariant="outline" />
+												)}
+												<PublishActions
+													isLive={isLive}
+													hasPendingChanges={hasPendingChanges}
+													onPublish={onPublish}
+													onUnpublish={onUnpublish}
+												/>
+											</>
+										)}
+									</>
+								)}
+							</div>
+						</div>
+
+						<div
+							className={cn(
+								isDistractionFree ? "max-w-4xl mx-auto pt-16" : "mx-auto max-w-3xl space-y-6",
 							)}
+						>
+							<div className="space-y-4">
+								{Object.entries(fields).map(([name, field]) => {
+									// Key by item id so all field editors remount cleanly when the
+									// underlying content item changes (e.g. switching translations).
+									// PortableTextEditor in particular freezes its initial content on
+									// mount; without this key, navigating between translations leaves
+									// the previous locale's body in the editor and silently overwrites
+									// the new translation on the next edit.
+									const fieldKey = `${name}:${item?.id ?? "new"}`;
+									const fieldEl = (
+										<FieldRenderer
+											key={fieldKey}
+											name={name}
+											field={field}
+											value={formData[name]}
+											onChange={handleFieldChange}
+											onEditorReady={
+												field.kind === "portableText" && name === "content"
+													? setPortableTextEditor
+													: undefined
+											}
+											minimal={isDistractionFree}
+											pluginBlocks={pluginBlocks}
+											onBlockSidebarOpen={
+												field.kind === "portableText" ? handleBlockSidebarOpen : undefined
+											}
+											onBlockSidebarClose={
+												field.kind === "portableText" ? handleBlockSidebarClose : undefined
+											}
+											manifest={manifest}
+										/>
+									);
+									return fieldEl;
+								})}
+							</div>
+							<ContentEditorExtensionPanels placement="main" />
 						</div>
 					</div>
 
-					<div
-						className={cn(
-							isDistractionFree ? "max-w-4xl mx-auto pt-16" : "mx-auto max-w-3xl space-y-6",
-						)}
-					>
-						<div className="space-y-4">
-							{Object.entries(fields).map(([name, field]) => {
-								// Key by item id so all field editors remount cleanly when the
-								// underlying content item changes (e.g. switching translations).
-								// PortableTextEditor in particular freezes its initial content on
-								// mount; without this key, navigating between translations leaves
-								// the previous locale's body in the editor and silently overwrites
-								// the new translation on the next edit.
-								const fieldKey = `${name}:${item?.id ?? "new"}`;
-								const fieldEl = (
-									<FieldRenderer
-										key={fieldKey}
-										name={name}
-										field={field}
-										value={formData[name]}
-										onChange={handleFieldChange}
-										onEditorReady={
-											field.kind === "portableText" && name === "content"
-												? setPortableTextEditor
-												: undefined
-										}
-										minimal={isDistractionFree}
-										pluginBlocks={pluginBlocks}
-										onBlockSidebarOpen={
-											field.kind === "portableText" ? handleBlockSidebarOpen : undefined
-										}
-										onBlockSidebarClose={
-											field.kind === "portableText" ? handleBlockSidebarClose : undefined
-										}
-										manifest={manifest}
-									/>
-								);
-								return fieldEl;
-							})}
-						</div>
-					</div>
-				</div>
-
-				{/* Hidden (not unmounted) in distraction-free mode so panel-local
+					{/* Hidden (not unmounted) in distraction-free mode so panel-local
 			    state survives the round trip; `hidden` on the pane's own layout
 			    element leaves no gap. */}
-				<Sidebar aria-label={t`Settings`} className={cn(isDistractionFree && "hidden")}>
-					{/* The action bar absorbs the high-frequency props (isDirty,
+					<Sidebar aria-label={t`Settings`} className={cn(isDistractionFree && "hidden")}>
+						{/* The action bar absorbs the high-frequency props (isDirty,
 					    isSaving, isAutosaving) so they never reach the memoized panel. */}
-					{!isBelowLg && (
-						<SettingsActionBar
-							isNew={isNew}
-							isDirty={isDirty}
-							isSaving={Boolean(saveFeedbackActive)}
-							isAutosaving={autosaveFeedbackActive}
-							saveDisabled={isContentOperationPending}
-							isLive={isLive}
-							hasPendingChanges={hasPendingChanges}
-							liveViewUrl={liveViewUrl}
-							supportsPreview={supportsPreview}
-							isLoadingPreview={isLoadingPreview}
-							onPreview={handlePreview}
-							onPublish={onPublish}
-							onUnpublish={onUnpublish}
-							announceSaveStatus={!isDistractionFree}
-						/>
-					)}
-					<div
-						className="flex-1 overflow-y-auto overflow-x-hidden"
-						style={isBelowLg ? { paddingTop: ADMIN_HEADER_HEIGHT_PX } : undefined}
-					>
-						{isBelowLg && (
-							<div className="flex justify-end px-4 pt-3">
-								<MobileSettingsCloseButton />
-							</div>
+						{!isBelowLg && (
+							<SettingsActionBar
+								isNew={isNew}
+								isDirty={isDirty}
+								isSaving={Boolean(saveFeedbackActive)}
+								isAutosaving={autosaveFeedbackActive}
+								saveDisabled={isContentOperationPending}
+								isLive={isLive}
+								hasPendingChanges={hasPendingChanges}
+								liveViewUrl={liveViewUrl}
+								supportsPreview={supportsPreview}
+								isLoadingPreview={isLoadingPreview}
+								onPreview={handlePreview}
+								onPublish={onPublish}
+								onUnpublish={onUnpublish}
+								announceSaveStatus={!isDistractionFree}
+							/>
 						)}
-						<ContentSettingsPanel
-							collection={collection}
-							item={item}
-							isNew={isNew}
-							entryLocale={entryLocale}
-							slug={slug}
-							onSlugChange={handleSlugChange}
-							status={status}
-							supportsDrafts={supportsDrafts}
-							isLive={isLive}
-							hasPendingChanges={hasPendingChanges}
-							hasSchedule={hasSchedule}
-							supportsRevisions={supportsRevisions}
-							canSchedule={canSchedule}
-							onSchedule={onSchedule}
-							onUnschedule={onUnschedule}
-							isScheduling={isScheduling}
-							onDiscardDraft={onDiscardDraft}
-							onDelete={onDelete}
-							isDeleting={isDeleting}
-							currentUser={currentUser}
-							users={users}
-							onAuthorChange={onAuthorChange}
-							activeBylines={activeBylines}
-							availableBylines={availableBylines}
-							availableBylinesLoaded={availableBylinesLoaded}
-							onBylinesChange={handleBylinesChange}
-							onQuickCreateByline={onQuickCreateByline}
-							onQuickEditByline={onQuickEditByline}
-							i18n={i18n}
-							translations={translations}
-							onTranslate={onTranslate}
-							hasSeo={hasSeo}
-							onSeoChange={onSeoChange ? handleSeoChange : undefined}
-							portableTextEditor={portableTextEditor}
-							blockSidebarPanel={blockSidebarPanel}
-							onBlockSidebarClose={handleBlockSidebarClose}
-							onBlockSidebarDelete={handleBlockSidebarDelete}
-						/>
-					</div>
-				</Sidebar>
+						<div
+							className="flex-1 overflow-y-auto overflow-x-hidden"
+							style={isBelowLg ? { paddingTop: ADMIN_HEADER_HEIGHT_PX } : undefined}
+						>
+							{isBelowLg && (
+								<div className="flex justify-end px-4 pt-3">
+									<MobileSettingsCloseButton />
+								</div>
+							)}
+							<ContentSettingsPanel
+								collection={collection}
+								item={item}
+								isNew={isNew}
+								entryLocale={entryLocale}
+								slug={slug}
+								onSlugChange={handleSlugChange}
+								status={status}
+								supportsDrafts={supportsDrafts}
+								isLive={isLive}
+								hasPendingChanges={hasPendingChanges}
+								hasSchedule={hasSchedule}
+								supportsRevisions={supportsRevisions}
+								canSchedule={canSchedule}
+								onSchedule={onSchedule}
+								onUnschedule={onUnschedule}
+								isScheduling={isScheduling}
+								onDiscardDraft={onDiscardDraft}
+								onDelete={onDelete}
+								isDeleting={isDeleting}
+								currentUser={currentUser}
+								users={users}
+								onAuthorChange={onAuthorChange}
+								activeBylines={activeBylines}
+								availableBylines={availableBylines}
+								availableBylinesLoaded={availableBylinesLoaded}
+								onBylinesChange={handleBylinesChange}
+								onQuickCreateByline={onQuickCreateByline}
+								onQuickEditByline={onQuickEditByline}
+								i18n={i18n}
+								translations={translations}
+								onTranslate={onTranslate}
+								hasSeo={hasSeo}
+								onSeoChange={onSeoChange ? handleSeoChange : undefined}
+								portableTextEditor={portableTextEditor}
+								blockSidebarPanel={blockSidebarPanel}
+								onBlockSidebarClose={handleBlockSidebarClose}
+								onBlockSidebarDelete={handleBlockSidebarDelete}
+							/>
+						</div>
+					</Sidebar>
 
-				{/* Below lg, opening a block detail panel must open the sheet.
+					{/* Below lg, opening a block detail panel must open the sheet.
 				    Suspended in distraction-free mode: the nav is hidden there but
 				    Kumo's separate backdrop would still scrim the whole screen. */}
-				<MobileBlockSidebarSync active={!!blockSidebarPanel} suspended={isDistractionFree} />
-				<MobileSidebarPortalGuard />
-			</Sidebar.Provider>
+					<MobileBlockSidebarSync active={!!blockSidebarPanel} suspended={isDistractionFree} />
+					<MobileSidebarPortalGuard />
+				</Sidebar.Provider>
+			</ContentEditorExtensionPanelsProvider>
 		</form>
 	);
 }

--- a/packages/admin/src/components/ContentEditorExtensionPanels.tsx
+++ b/packages/admin/src/components/ContentEditorExtensionPanels.tsx
@@ -1,8 +1,25 @@
 import { Button, DropdownMenu, Text } from "@cloudflare/kumo";
+import {
+	closestCenter,
+	DndContext,
+	type DragEndEvent,
+	KeyboardSensor,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	sortableKeyboardCoordinates,
+	SortableContext,
+	useSortable,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowDown,
 	ArrowUp,
+	DotsSixVertical,
 	DotsThreeVertical,
 	Layout,
 	SidebarSimple,
@@ -13,6 +30,7 @@ import {
 	moveContentEditorPanel,
 	parseContentEditorPanelLayout,
 	placeContentEditorPanel,
+	reorderContentEditorPanel,
 	resolveContentEditorPanelLayout,
 	type ContentEditorPanelLayout,
 	type ContentEditorPanelPlacement,
@@ -20,6 +38,7 @@ import {
 import {
 	selectContentEditorPanels,
 	type ContentEditorDraftState,
+	type ContentEditorNativeSlot,
 	type ContentEditorPanelActions,
 	type ContentEditorPanelContext,
 	type ContentEditorPanelExtension,
@@ -32,10 +51,12 @@ import { AdminExtensionBoundary } from "./AdminExtensionBoundary.js";
 const STORAGE_PREFIX = "emdash:content-editor-panels:v1";
 
 interface ExtensionPanelHostContext {
+	panels: readonly ContentEditorPanelExtension[];
 	panelsById: ReadonlyMap<string, ContentEditorPanelExtension>;
 	layout: ContentEditorPanelLayout;
 	panelContext: ContentEditorPanelContext;
 	move(id: string, direction: "up" | "down"): void;
+	reorder(id: string, overId: string): void;
 	place(id: string, placement: ContentEditorPanelPlacement): void;
 }
 
@@ -86,6 +107,10 @@ export function ContentEditorExtensionPanelsProvider({
 		() => selectContentEditorPanels(pluginAdmins, { collection, userRole, disabledPluginIds }),
 		[pluginAdmins, collection, userRole, disabledPluginIds],
 	);
+	const movablePanels = React.useMemo(
+		() => panels.filter((panel) => (panel.slot ?? "panel") === "panel"),
+		[panels],
+	);
 	const storageKey = userId
 		? `${STORAGE_PREFIX}:${encodeURIComponent(userId)}:${encodeURIComponent(collection)}`
 		: null;
@@ -98,8 +123,8 @@ export function ContentEditorExtensionPanelsProvider({
 	}, [storageKey]);
 
 	const layout = React.useMemo(
-		() => resolveContentEditorPanelLayout(panels, storedLayout),
-		[panels, storedLayout],
+		() => resolveContentEditorPanelLayout(movablePanels, storedLayout),
+		[movablePanels, storedLayout],
 	);
 	const panelsById = React.useMemo(
 		() => new Map(panels.map((panel) => [panel.id, panel])),
@@ -113,12 +138,12 @@ export function ContentEditorExtensionPanelsProvider({
 	const updateLayout = React.useCallback(
 		(recipe: (current: ContentEditorPanelLayout) => ContentEditorPanelLayout) => {
 			setStoredLayout((current) => {
-				const next = recipe(resolveContentEditorPanelLayout(panels, current));
+				const next = recipe(resolveContentEditorPanelLayout(movablePanels, current));
 				writeStoredLayout(storageKey, next);
 				return next;
 			});
 		},
-		[panels, storageKey],
+		[movablePanels, storageKey],
 	);
 	const move = React.useCallback(
 		(id: string, direction: "up" | "down") => {
@@ -132,10 +157,16 @@ export function ContentEditorExtensionPanelsProvider({
 		},
 		[updateLayout],
 	);
+	const reorder = React.useCallback(
+		(id: string, overId: string) => {
+			updateLayout((current) => reorderContentEditorPanel(current, id, overId));
+		},
+		[updateLayout],
+	);
 
 	const value = React.useMemo<ExtensionPanelHostContext>(
-		() => ({ panelsById, layout, panelContext, move, place }),
-		[panelsById, layout, panelContext, move, place],
+		() => ({ panels, panelsById, layout, panelContext, move, reorder, place }),
+		[panels, panelsById, layout, panelContext, move, reorder, place],
 	);
 	return <ExtensionPanelContext.Provider value={value}>{children}</ExtensionPanelContext.Provider>;
 }
@@ -146,18 +177,142 @@ export function ContentEditorExtensionPanels({
 	placement: ContentEditorPanelPlacement;
 }) {
 	const host = React.useContext(ExtensionPanelContext);
-	const { t } = useLingui();
 	if (!host) return null;
 
 	const ids = host.layout[placement];
-	return ids.map((id, index) => {
-		const extensionPanel = host.panelsById.get(id);
-		if (!extensionPanel) return null;
-		const Panel = extensionPanel.panel;
-		const title =
-			typeof extensionPanel.title === "string" ? extensionPanel.title : t(extensionPanel.title);
-		const panelKey = `${extensionPanel.id}:${host.panelContext.entry?.id ?? "new"}`;
-		const menu = (
+	if (ids.length === 0) return null;
+
+	return <SortableContentEditorExtensionPanels host={host} ids={ids} placement={placement} />;
+}
+
+function SortableContentEditorExtensionPanels({
+	host,
+	ids,
+	placement,
+}: {
+	host: ExtensionPanelHostContext;
+	ids: readonly string[];
+	placement: ContentEditorPanelPlacement;
+}) {
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+	);
+	const onDragEnd = React.useCallback(
+		(event: DragEndEvent) => {
+			if (!event.over || event.active.id === event.over.id) return;
+			host.reorder(String(event.active.id), String(event.over.id));
+		},
+		[host],
+	);
+
+	return (
+		<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+			<SortableContext items={[...ids]} strategy={verticalListSortingStrategy}>
+				{ids.map((id, index) => {
+					const extensionPanel = host.panelsById.get(id);
+					if (!extensionPanel) return null;
+					return (
+						<SortableExtensionPanel
+							key={`${extensionPanel.id}:${host.panelContext.entry?.id ?? "new"}`}
+							extensionPanel={extensionPanel}
+							index={index}
+							ids={ids}
+							placement={placement}
+							host={host}
+						/>
+					);
+				})}
+			</SortableContext>
+		</DndContext>
+	);
+}
+
+export function ContentEditorExtensionSlot({
+	name,
+	fallback,
+}: {
+	name: ContentEditorNativeSlot;
+	fallback: React.ReactNode;
+}) {
+	const host = React.useContext(ExtensionPanelContext);
+	const { t } = useLingui();
+	if (!host) return fallback;
+
+	const contributions = host.panels.filter((panel) => panel.slot === name);
+	const replacement = contributions.find((panel) => panel.mode === "replace");
+	const appended = contributions.filter((panel) => panel.mode !== "replace");
+	const slotBody = replacement ? (
+		<AdminExtensionBoundary
+			key={`${replacement.id}:${host.panelContext.entry?.id ?? "new"}`}
+			variant="panel"
+			label={typeof replacement.title === "string" ? replacement.title : t(replacement.title)}
+			fallback={fallback}
+		>
+			{React.createElement(replacement.panel, host.panelContext)}
+		</AdminExtensionBoundary>
+	) : (
+		fallback
+	);
+
+	return (
+		<>
+			{slotBody}
+			{appended.map((extensionPanel) => {
+				const Panel = extensionPanel.panel;
+				const title =
+					typeof extensionPanel.title === "string" ? extensionPanel.title : t(extensionPanel.title);
+				return (
+					<AdminExtensionBoundary
+						key={`${extensionPanel.id}:${host.panelContext.entry?.id ?? "new"}`}
+						variant="panel"
+						label={title}
+					>
+						<Panel {...host.panelContext} />
+					</AdminExtensionBoundary>
+				);
+			})}
+		</>
+	);
+}
+
+function SortableExtensionPanel({
+	extensionPanel,
+	index,
+	ids,
+	placement,
+	host,
+}: {
+	extensionPanel: ContentEditorPanelExtension;
+	index: number;
+	ids: readonly string[];
+	placement: ContentEditorPanelPlacement;
+	host: ExtensionPanelHostContext;
+}) {
+	const { t } = useLingui();
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+		id: extensionPanel.id,
+	});
+	const Panel = extensionPanel.panel;
+	const title =
+		typeof extensionPanel.title === "string" ? extensionPanel.title : t(extensionPanel.title);
+	const style: React.CSSProperties = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+		zIndex: isDragging ? 10 : undefined,
+	};
+	const controls = (
+		<div className="flex shrink-0 items-center gap-1">
+			<button
+				type="button"
+				{...attributes}
+				{...listeners}
+				className="grid size-8 cursor-grab place-items-center rounded-md text-kumo-subtle hover:bg-kumo-tint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-accent active:cursor-grabbing"
+				aria-label={t`Drag to reorder ${title}`}
+				title={t`Drag to reorder ${title}`}
+			>
+				<DotsSixVertical size={18} aria-hidden="true" />
+			</button>
 			<DropdownMenu>
 				<DropdownMenu.Trigger
 					render={(props) => (
@@ -177,61 +332,66 @@ export function ContentEditorExtensionPanels({
 					<DropdownMenu.Item
 						icon={<ArrowUp />}
 						disabled={index === 0}
-						onClick={() => host.move(id, "up")}
+						onClick={() => host.move(extensionPanel.id, "up")}
 					>
 						{t`Move up`}
 					</DropdownMenu.Item>
 					<DropdownMenu.Item
 						icon={<ArrowDown />}
 						disabled={index === ids.length - 1}
-						onClick={() => host.move(id, "down")}
+						onClick={() => host.move(extensionPanel.id, "down")}
 					>
 						{t`Move down`}
 					</DropdownMenu.Item>
 					<DropdownMenu.Separator />
 					<DropdownMenu.Item
 						icon={placement === "main" ? <SidebarSimple /> : <Layout />}
-						onClick={() => host.place(id, placement === "main" ? "sidebar" : "main")}
+						onClick={() => host.place(extensionPanel.id, placement === "main" ? "sidebar" : "main")}
 					>
 						{placement === "main" ? t`Move to settings sidebar` : t`Move to main editor`}
 					</DropdownMenu.Item>
 				</DropdownMenu.Content>
 			</DropdownMenu>
-		);
+		</div>
+	);
 
-		if (placement === "sidebar") {
-			return (
-				<section key={panelKey} className="min-w-0 border-t p-4">
-					<div className="mb-4 flex min-w-0 items-center justify-between gap-2">
-						<Text bold as="h3" DANGEROUS_className="min-w-0 break-words">
-							{title}
-						</Text>
-						{menu}
-					</div>
-					<AdminExtensionBoundary variant="panel" label={title}>
-						<Panel {...host.panelContext} />
-					</AdminExtensionBoundary>
-				</section>
-			);
-		}
-
+	if (placement === "sidebar") {
 		return (
 			<section
-				key={panelKey}
-				className="min-w-0 overflow-hidden rounded-lg border border-kumo-line bg-kumo-base"
+				ref={setNodeRef}
+				style={style}
+				className={`min-w-0 border-t bg-kumo-base p-4 ${isDragging ? "opacity-60 shadow-lg" : ""}`}
 			>
-				<header className="flex min-w-0 items-center justify-between gap-3 border-b px-4 py-3">
-					<Text bold as="h2" DANGEROUS_className="min-w-0 break-words">
+				<div className="mb-4 flex min-w-0 items-center justify-between gap-2">
+					<Text bold as="h3" DANGEROUS_className="min-w-0 break-words">
 						{title}
 					</Text>
-					{menu}
-				</header>
-				<div className="min-w-0 p-4">
-					<AdminExtensionBoundary variant="panel" label={title}>
-						<Panel {...host.panelContext} />
-					</AdminExtensionBoundary>
+					{controls}
 				</div>
+				<AdminExtensionBoundary variant="panel" label={title}>
+					<Panel {...host.panelContext} />
+				</AdminExtensionBoundary>
 			</section>
 		);
-	});
+	}
+
+	return (
+		<section
+			ref={setNodeRef}
+			style={style}
+			className={`min-w-0 overflow-hidden rounded-lg border border-kumo-line bg-kumo-base ${isDragging ? "opacity-60 shadow-lg" : ""}`}
+		>
+			<header className="flex min-w-0 items-center justify-between gap-3 border-b px-4 py-3">
+				<Text bold as="h2" DANGEROUS_className="min-w-0 break-words">
+					{title}
+				</Text>
+				{controls}
+			</header>
+			<div className="min-w-0 p-4">
+				<AdminExtensionBoundary variant="panel" label={title}>
+					<Panel {...host.panelContext} />
+				</AdminExtensionBoundary>
+			</div>
+		</section>
+	);
 }

--- a/packages/admin/src/components/ContentEditorExtensionPanels.tsx
+++ b/packages/admin/src/components/ContentEditorExtensionPanels.tsx
@@ -1,0 +1,237 @@
+import { Button, DropdownMenu, Text } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import {
+	ArrowDown,
+	ArrowUp,
+	DotsThreeVertical,
+	Layout,
+	SidebarSimple,
+} from "@phosphor-icons/react";
+import * as React from "react";
+
+import {
+	moveContentEditorPanel,
+	parseContentEditorPanelLayout,
+	placeContentEditorPanel,
+	resolveContentEditorPanelLayout,
+	type ContentEditorPanelLayout,
+	type ContentEditorPanelPlacement,
+} from "../lib/admin-editor-panel-layout.js";
+import {
+	selectContentEditorPanels,
+	type ContentEditorDraftState,
+	type ContentEditorPanelActions,
+	type ContentEditorPanelContext,
+	type ContentEditorPanelExtension,
+} from "../lib/admin-extensions.js";
+import type { ContentItem } from "../lib/api";
+import { useDisabledPluginIds } from "../lib/api/manifest.js";
+import { usePluginAdmins } from "../lib/plugin-context.js";
+import { AdminExtensionBoundary } from "./AdminExtensionBoundary.js";
+
+const STORAGE_PREFIX = "emdash:content-editor-panels:v1";
+
+interface ExtensionPanelHostContext {
+	panelsById: ReadonlyMap<string, ContentEditorPanelExtension>;
+	layout: ContentEditorPanelLayout;
+	panelContext: ContentEditorPanelContext;
+	move(id: string, direction: "up" | "down"): void;
+	place(id: string, placement: ContentEditorPanelPlacement): void;
+}
+
+const ExtensionPanelContext = React.createContext<ExtensionPanelHostContext | null>(null);
+
+export interface ContentEditorExtensionPanelsProviderProps {
+	children: React.ReactNode;
+	collection: string;
+	entry: ContentItem | null;
+	locale?: string;
+	userId?: string;
+	userRole: number;
+	draft: ContentEditorDraftState;
+	actions: ContentEditorPanelActions;
+}
+
+function readStoredLayout(storageKey: string | null): ContentEditorPanelLayout | null {
+	if (!storageKey || typeof window === "undefined") return null;
+	try {
+		return parseContentEditorPanelLayout(window.localStorage.getItem(storageKey));
+	} catch {
+		return null;
+	}
+}
+
+function writeStoredLayout(storageKey: string | null, layout: ContentEditorPanelLayout): void {
+	if (!storageKey || typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(storageKey, JSON.stringify(layout));
+	} catch {
+		// Browser storage is an enhancement; the in-memory layout still works.
+	}
+}
+
+export function ContentEditorExtensionPanelsProvider({
+	children,
+	collection,
+	entry,
+	locale,
+	userId,
+	userRole,
+	draft,
+	actions,
+}: ContentEditorExtensionPanelsProviderProps) {
+	const pluginAdmins = usePluginAdmins();
+	const disabledPluginIds = useDisabledPluginIds();
+	const panels = React.useMemo(
+		() => selectContentEditorPanels(pluginAdmins, { collection, userRole, disabledPluginIds }),
+		[pluginAdmins, collection, userRole, disabledPluginIds],
+	);
+	const storageKey = userId
+		? `${STORAGE_PREFIX}:${encodeURIComponent(userId)}:${encodeURIComponent(collection)}`
+		: null;
+	const [storedLayout, setStoredLayout] = React.useState<ContentEditorPanelLayout | null>(() =>
+		readStoredLayout(storageKey),
+	);
+
+	React.useEffect(() => {
+		setStoredLayout(readStoredLayout(storageKey));
+	}, [storageKey]);
+
+	const layout = React.useMemo(
+		() => resolveContentEditorPanelLayout(panels, storedLayout),
+		[panels, storedLayout],
+	);
+	const panelsById = React.useMemo(
+		() => new Map(panels.map((panel) => [panel.id, panel])),
+		[panels],
+	);
+	const panelContext = React.useMemo<ContentEditorPanelContext>(
+		() => ({ collection, entry, locale, draft, actions }),
+		[collection, entry, locale, draft, actions],
+	);
+
+	const updateLayout = React.useCallback(
+		(recipe: (current: ContentEditorPanelLayout) => ContentEditorPanelLayout) => {
+			setStoredLayout((current) => {
+				const next = recipe(resolveContentEditorPanelLayout(panels, current));
+				writeStoredLayout(storageKey, next);
+				return next;
+			});
+		},
+		[panels, storageKey],
+	);
+	const move = React.useCallback(
+		(id: string, direction: "up" | "down") => {
+			updateLayout((current) => moveContentEditorPanel(current, id, direction));
+		},
+		[updateLayout],
+	);
+	const place = React.useCallback(
+		(id: string, placement: ContentEditorPanelPlacement) => {
+			updateLayout((current) => placeContentEditorPanel(current, id, placement));
+		},
+		[updateLayout],
+	);
+
+	const value = React.useMemo<ExtensionPanelHostContext>(
+		() => ({ panelsById, layout, panelContext, move, place }),
+		[panelsById, layout, panelContext, move, place],
+	);
+	return <ExtensionPanelContext.Provider value={value}>{children}</ExtensionPanelContext.Provider>;
+}
+
+export function ContentEditorExtensionPanels({
+	placement,
+}: {
+	placement: ContentEditorPanelPlacement;
+}) {
+	const host = React.useContext(ExtensionPanelContext);
+	const { t } = useLingui();
+	if (!host) return null;
+
+	const ids = host.layout[placement];
+	return ids.map((id, index) => {
+		const extensionPanel = host.panelsById.get(id);
+		if (!extensionPanel) return null;
+		const Panel = extensionPanel.panel;
+		const title =
+			typeof extensionPanel.title === "string" ? extensionPanel.title : t(extensionPanel.title);
+		const panelKey = `${extensionPanel.id}:${host.panelContext.entry?.id ?? "new"}`;
+		const menu = (
+			<DropdownMenu>
+				<DropdownMenu.Trigger
+					render={(props) => (
+						<Button
+							{...props}
+							type="button"
+							shape="square"
+							size="sm"
+							variant="ghost"
+							icon={<DotsThreeVertical />}
+							aria-label={t`Arrange ${title}`}
+							title={t`Arrange ${title}`}
+						/>
+					)}
+				/>
+				<DropdownMenu.Content>
+					<DropdownMenu.Item
+						icon={<ArrowUp />}
+						disabled={index === 0}
+						onClick={() => host.move(id, "up")}
+					>
+						{t`Move up`}
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						icon={<ArrowDown />}
+						disabled={index === ids.length - 1}
+						onClick={() => host.move(id, "down")}
+					>
+						{t`Move down`}
+					</DropdownMenu.Item>
+					<DropdownMenu.Separator />
+					<DropdownMenu.Item
+						icon={placement === "main" ? <SidebarSimple /> : <Layout />}
+						onClick={() => host.place(id, placement === "main" ? "sidebar" : "main")}
+					>
+						{placement === "main" ? t`Move to settings sidebar` : t`Move to main editor`}
+					</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu>
+		);
+
+		if (placement === "sidebar") {
+			return (
+				<section key={panelKey} className="min-w-0 border-t p-4">
+					<div className="mb-4 flex min-w-0 items-center justify-between gap-2">
+						<Text bold as="h3" DANGEROUS_className="min-w-0 break-words">
+							{title}
+						</Text>
+						{menu}
+					</div>
+					<AdminExtensionBoundary variant="panel" label={title}>
+						<Panel {...host.panelContext} />
+					</AdminExtensionBoundary>
+				</section>
+			);
+		}
+
+		return (
+			<section
+				key={panelKey}
+				className="min-w-0 overflow-hidden rounded-lg border border-kumo-line bg-kumo-base"
+			>
+				<header className="flex min-w-0 items-center justify-between gap-3 border-b px-4 py-3">
+					<Text bold as="h2" DANGEROUS_className="min-w-0 break-words">
+						{title}
+					</Text>
+					{menu}
+				</header>
+				<div className="min-w-0 p-4">
+					<AdminExtensionBoundary variant="panel" label={title}>
+						<Panel {...host.panelContext} />
+					</AdminExtensionBoundary>
+				</div>
+			</section>
+		);
+	});
+}

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -27,10 +27,18 @@ import {
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
+import {
+	selectContentListColumns,
+	type ContentListColumnExtension,
+} from "../lib/admin-extensions.js";
 import type { ContentAuthor, ContentDateField, ContentItem, TrashedContentItem } from "../lib/api";
+import { useCurrentUser } from "../lib/api/current-user";
+import { useDisabledPluginIds } from "../lib/api/manifest.js";
 import { useDebouncedValue } from "../lib/hooks.js";
+import { usePluginAdmins } from "../lib/plugin-context";
 import { contentUrl } from "../lib/url.js";
 import { cn } from "../lib/utils";
+import { AdminExtensionBoundary } from "./AdminExtensionBoundary.js";
 import { CaretNext, CaretPrev } from "./ArrowIcons.js";
 import { LocaleSwitcher } from "./LocaleSwitcher";
 import { RouterLinkButton } from "./RouterLinkButton.js";
@@ -194,6 +202,20 @@ export function ContentList({
 	const [page, setPage] = React.useState(0);
 	const [selectedIds, setSelectedIds] = React.useState<Set<string>>(() => new Set());
 
+	// Trusted-plugin list columns. With no registered extensions this selects
+	// an empty array and the table renders exactly its classic markup. Role
+	// defaults to 0 while the current user loads, so role-gated columns stay
+	// hidden rather than flashing in (same rule as the sidebar nav), and
+	// disabled plugins' columns are skipped like every other admin surface.
+	const pluginAdmins = usePluginAdmins();
+	const { data: currentUser } = useCurrentUser();
+	const disabledPluginIds = useDisabledPluginIds();
+	const userRole = currentUser?.role ?? 0;
+	const extensionColumns = React.useMemo(
+		() => selectContentListColumns(pluginAdmins, { collection, userRole, disabledPluginIds }),
+		[pluginAdmins, collection, userRole, disabledPluginIds],
+	);
+
 	// Bulk selection is opt-in: the checkbox column + toolbar only render when
 	// the parent wired at least one bulk handler.
 	const bulkEnabled = !!(onBulkPublish || onBulkUnpublish || onBulkDelete);
@@ -315,7 +337,7 @@ export function ContentList({
 			}
 		})();
 	};
-	const colSpan = (i18n ? 5 : 4) + (bulkEnabled ? 1 : 0);
+	const colSpan = (i18n ? 5 : 4) + (bulkEnabled ? 1 : 0) + extensionColumns.length;
 
 	return (
 		<div className="space-y-4">
@@ -524,6 +546,30 @@ export function ContentList({
 										onSortChange={onSortChange}
 										label={t`Date`}
 									/>
+									{extensionColumns.map((column) => {
+										const label = typeof column.label === "string" ? column.label : t(column.label);
+										const HeaderContent = column.header;
+										return (
+											<th
+												key={column.id}
+												scope="col"
+												className={cn(
+													"px-4 py-3 text-sm font-medium",
+													column.align === "end" ? "text-end" : "text-start",
+												)}
+											>
+												{HeaderContent ? (
+													// A broken custom header falls back to the plain
+													// label so the column stays identifiable.
+													<AdminExtensionBoundary variant="cell" fallback={label}>
+														<HeaderContent collection={collection} locale={activeLocale} />
+													</AdminExtensionBoundary>
+												) : (
+													label
+												)}
+											</th>
+										);
+									})}
 									<th scope="col" className="px-4 py-3 text-end text-sm font-medium">
 										{t`Actions`}
 									</th>
@@ -578,6 +624,8 @@ export function ContentList({
 											selectable={bulkEnabled}
 											selected={selectedIds.has(item.id)}
 											onToggleSelect={toggleOne}
+											extensionColumns={extensionColumns}
+											activeLocale={activeLocale}
 										/>
 									))
 								)}
@@ -946,6 +994,10 @@ interface ContentListItemProps {
 	selectable?: boolean;
 	selected?: boolean;
 	onToggleSelect?: (id: string) => void;
+	/** Trusted-plugin columns, already filtered and ordered for this list. */
+	extensionColumns?: ContentListColumnExtension[];
+	/** Active list locale, forwarded to extension cells. */
+	activeLocale?: string;
 }
 
 function ContentListItem({
@@ -958,6 +1010,8 @@ function ContentListItem({
 	selectable,
 	selected,
 	onToggleSelect,
+	extensionColumns,
+	activeLocale,
 }: ContentListItemProps) {
 	const { t } = useLingui();
 	const title = getItemTitle(item);
@@ -998,6 +1052,21 @@ function ContentListItem({
 				</td>
 			)}
 			<td className="px-4 py-3 text-sm text-kumo-subtle">{date.toLocaleDateString()}</td>
+			{extensionColumns?.map((column) => {
+				const Cell = column.cell;
+				return (
+					<td
+						key={column.id}
+						className={cn("px-4 py-3 text-sm", column.align === "end" && "text-end")}
+					>
+						{/* Each cell is isolated: one broken contribution degrades to a
+						    quiet placeholder without breaking the row or the table. */}
+						<AdminExtensionBoundary variant="cell">
+							<Cell collection={collection} locale={activeLocale} item={item} />
+						</AdminExtensionBoundary>
+					</td>
+				);
+			})}
 			<td className="px-4 py-3 text-end">
 				<div className="flex items-center justify-end space-x-1">
 					{item.status === "published" && item.slug && (

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -28,7 +28,10 @@ import { fetchBylines } from "../lib/api";
 import { useDebouncedValue } from "../lib/hooks.js";
 import { slugify } from "../lib/utils";
 import type { CurrentUserInfo } from "./ContentEditor.js";
-import { ContentEditorExtensionPanels } from "./ContentEditorExtensionPanels.js";
+import {
+	ContentEditorExtensionPanels,
+	ContentEditorExtensionSlot,
+} from "./ContentEditorExtensionPanels.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { ImageDetailPanel } from "./editor/ImageDetailPanel";
 import type { ImageAttributes } from "./editor/ImageDetailPanel";
@@ -564,10 +567,15 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 					<Text bold as="h3" DANGEROUS_className="mb-4">
 						{t`SEO`}
 					</Text>
-					<SeoPanel
-						contentKey={item?.id ?? `new:${collection}`}
-						seo={item?.seo}
-						onChange={onSeoChange}
+					<ContentEditorExtensionSlot
+						name="seo"
+						fallback={
+							<SeoPanel
+								contentKey={item?.id ?? `new:${collection}`}
+								seo={item?.seo}
+								onChange={onSeoChange}
+							/>
+						}
 					/>
 				</div>
 			)}

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 
+import { selectContentEditorPanels } from "../lib/admin-extensions.js";
 import type {
 	BylineCreditInput,
 	BylineSummary,
@@ -25,8 +26,11 @@ import type {
 	UserListItem,
 } from "../lib/api";
 import { fetchBylines } from "../lib/api";
+import { useDisabledPluginIds } from "../lib/api/manifest.js";
 import { useDebouncedValue } from "../lib/hooks.js";
+import { usePluginAdmins } from "../lib/plugin-context";
 import { slugify } from "../lib/utils";
+import { AdminExtensionBoundary } from "./AdminExtensionBoundary.js";
 import type { CurrentUserInfo } from "./ContentEditor.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { ImageDetailPanel } from "./editor/ImageDetailPanel";
@@ -354,6 +358,19 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 	const [showScheduler, setShowScheduler] = React.useState(false);
 	const showDiscard = !isNew && supportsDrafts && hasPendingChanges && !!onDiscardDraft;
 
+	// Trusted-plugin sidebar panels. Read from context (referentially stable)
+	// rather than a prop so this memoized subtree gains no new prop to keep
+	// stable. With no registered extensions the panel renders exactly its
+	// classic markup; disabled plugins' panels are skipped like every other
+	// admin surface.
+	const pluginAdmins = usePluginAdmins();
+	const disabledPluginIds = useDisabledPluginIds();
+	const userRole = currentUser?.role ?? 0;
+	const extensionPanels = React.useMemo(
+		() => selectContentEditorPanels(pluginAdmins, { collection, userRole, disabledPluginIds }),
+		[pluginAdmins, collection, userRole, disabledPluginIds],
+	);
+
 	const handleScheduleSubmit = () => {
 		if (scheduleDate && onSchedule) {
 			const date = new Date(scheduleDate);
@@ -570,6 +587,34 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 					/>
 				</div>
 			)}
+
+			{/* Trusted-plugin panels render for saved entries only (a never-saved
+			    entry has no id or saved state to expose). Keyed by entry id so
+			    panel-local state resets when switching translations. min-w-0 keeps
+			    a panel from forcing horizontal overflow in the narrow sidebar. */}
+			{item &&
+				!isNew &&
+				extensionPanels.map((extensionPanel) => {
+					const Panel = extensionPanel.panel;
+					const title =
+						typeof extensionPanel.title === "string"
+							? extensionPanel.title
+							: t(extensionPanel.title);
+					return (
+						<div key={`${extensionPanel.id}:${item.id}`} className="p-4 border-t min-w-0">
+							<Text bold as="h3" DANGEROUS_className="mb-4">
+								{title}
+							</Text>
+							<AdminExtensionBoundary variant="panel" label={title}>
+								<Panel
+									collection={collection}
+									entry={item}
+									locale={item.locale ?? entryLocale ?? undefined}
+								/>
+							</AdminExtensionBoundary>
+						</div>
+					);
+				})}
 
 			{portableTextEditor && (
 				<div className="p-4 border-t">

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -16,7 +16,6 @@ import { useNavigate } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 
-import { selectContentEditorPanels } from "../lib/admin-extensions.js";
 import type {
 	BylineCreditInput,
 	BylineSummary,
@@ -26,12 +25,10 @@ import type {
 	UserListItem,
 } from "../lib/api";
 import { fetchBylines } from "../lib/api";
-import { useDisabledPluginIds } from "../lib/api/manifest.js";
 import { useDebouncedValue } from "../lib/hooks.js";
-import { usePluginAdmins } from "../lib/plugin-context";
 import { slugify } from "../lib/utils";
-import { AdminExtensionBoundary } from "./AdminExtensionBoundary.js";
 import type { CurrentUserInfo } from "./ContentEditor.js";
+import { ContentEditorExtensionPanels } from "./ContentEditorExtensionPanels.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { ImageDetailPanel } from "./editor/ImageDetailPanel";
 import type { ImageAttributes } from "./editor/ImageDetailPanel";
@@ -358,19 +355,6 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 	const [showScheduler, setShowScheduler] = React.useState(false);
 	const showDiscard = !isNew && supportsDrafts && hasPendingChanges && !!onDiscardDraft;
 
-	// Trusted-plugin sidebar panels. Read from context (referentially stable)
-	// rather than a prop so this memoized subtree gains no new prop to keep
-	// stable. With no registered extensions the panel renders exactly its
-	// classic markup; disabled plugins' panels are skipped like every other
-	// admin surface.
-	const pluginAdmins = usePluginAdmins();
-	const disabledPluginIds = useDisabledPluginIds();
-	const userRole = currentUser?.role ?? 0;
-	const extensionPanels = React.useMemo(
-		() => selectContentEditorPanels(pluginAdmins, { collection, userRole, disabledPluginIds }),
-		[pluginAdmins, collection, userRole, disabledPluginIds],
-	);
-
 	const handleScheduleSubmit = () => {
 		if (scheduleDate && onSchedule) {
 			const date = new Date(scheduleDate);
@@ -588,33 +572,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 				</div>
 			)}
 
-			{/* Trusted-plugin panels render for saved entries only (a never-saved
-			    entry has no id or saved state to expose). Keyed by entry id so
-			    panel-local state resets when switching translations. min-w-0 keeps
-			    a panel from forcing horizontal overflow in the narrow sidebar. */}
-			{item &&
-				!isNew &&
-				extensionPanels.map((extensionPanel) => {
-					const Panel = extensionPanel.panel;
-					const title =
-						typeof extensionPanel.title === "string"
-							? extensionPanel.title
-							: t(extensionPanel.title);
-					return (
-						<div key={`${extensionPanel.id}:${item.id}`} className="p-4 border-t min-w-0">
-							<Text bold as="h3" DANGEROUS_className="mb-4">
-								{title}
-							</Text>
-							<AdminExtensionBoundary variant="panel" label={title}>
-								<Panel
-									collection={collection}
-									entry={item}
-									locale={item.locale ?? entryLocale ?? undefined}
-								/>
-							</AdminExtensionBoundary>
-						</div>
-					);
-				})}
+			<ContentEditorExtensionPanels placement="sidebar" />
 
 			{portableTextEditor && (
 				<div className="p-4 border-t">

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -26,6 +26,16 @@ export {
 	type PluginAdmins,
 } from "./lib/plugin-context";
 
+// Admin extension slots for trusted (native) plugins. Contribution and
+// context types only — the selection helpers are host internals.
+export type {
+	ContentEditorPanelContext,
+	ContentEditorPanelExtension,
+	ContentListColumnCellContext,
+	ContentListColumnExtension,
+	ContentListColumnHeaderContext,
+} from "./lib/admin-extensions.js";
+
 // Auth provider context (for accessing pluggable auth provider components)
 export {
 	AuthProviderProvider,

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -33,6 +33,7 @@ export type {
 	ContentEditorDraftState,
 	ContentEditorPanelActions,
 	ContentEditorPanelExtension,
+	ContentEditorNativeSlot,
 	ContentListColumnCellContext,
 	ContentListColumnExtension,
 	ContentListColumnHeaderContext,

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -30,6 +30,8 @@ export {
 // context types only — the selection helpers are host internals.
 export type {
 	ContentEditorPanelContext,
+	ContentEditorDraftState,
+	ContentEditorPanelActions,
 	ContentEditorPanelExtension,
 	ContentListColumnCellContext,
 	ContentListColumnExtension,

--- a/packages/admin/src/lib/admin-editor-panel-layout.ts
+++ b/packages/admin/src/lib/admin-editor-panel-layout.ts
@@ -1,0 +1,101 @@
+import type { ContentEditorPanelExtension } from "./admin-extensions.js";
+
+export const CONTENT_EDITOR_PANEL_LAYOUT_VERSION = 1 as const;
+
+export type ContentEditorPanelPlacement = "main" | "sidebar";
+
+export interface ContentEditorPanelLayout {
+	version: typeof CONTENT_EDITOR_PANEL_LAYOUT_VERSION;
+	main: string[];
+	sidebar: string[];
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+/** Parse an untrusted browser preference without letting it break the editor. */
+export function parseContentEditorPanelLayout(raw: string | null): ContentEditorPanelLayout | null {
+	if (!raw) return null;
+	try {
+		const value = JSON.parse(raw) as Partial<ContentEditorPanelLayout> | null;
+		if (
+			value?.version !== CONTENT_EDITOR_PANEL_LAYOUT_VERSION ||
+			!isStringArray(value.main) ||
+			!isStringArray(value.sidebar)
+		) {
+			return null;
+		}
+		return {
+			version: CONTENT_EDITOR_PANEL_LAYOUT_VERSION,
+			main: [...value.main],
+			sidebar: [...value.sidebar],
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Reconcile a saved layout with the currently registered panels. Stale and
+ * duplicate ids disappear; new panels append to their declared placement in
+ * registry order.
+ */
+export function resolveContentEditorPanelLayout(
+	panels: readonly ContentEditorPanelExtension[],
+	stored: ContentEditorPanelLayout | null,
+): ContentEditorPanelLayout {
+	const known = new Set(panels.map((panel) => panel.id));
+	const seen = new Set<string>();
+	const takeKnown = (ids: readonly string[] | undefined) =>
+		(ids ?? []).filter((id) => {
+			if (!known.has(id) || seen.has(id)) return false;
+			seen.add(id);
+			return true;
+		});
+
+	const main = takeKnown(stored?.main);
+	const sidebar = takeKnown(stored?.sidebar);
+
+	for (const panel of panels) {
+		if (seen.has(panel.id)) continue;
+		(panel.placement === "main" ? main : sidebar).push(panel.id);
+		seen.add(panel.id);
+	}
+
+	return { version: CONTENT_EDITOR_PANEL_LAYOUT_VERSION, main, sidebar };
+}
+
+export function moveContentEditorPanel(
+	layout: ContentEditorPanelLayout,
+	id: string,
+	direction: "up" | "down",
+): ContentEditorPanelLayout {
+	const placement: ContentEditorPanelPlacement | null = layout.main.includes(id)
+		? "main"
+		: layout.sidebar.includes(id)
+			? "sidebar"
+			: null;
+	if (!placement) return layout;
+
+	const current = layout[placement];
+	const index = current.indexOf(id);
+	const target = direction === "up" ? index - 1 : index + 1;
+	if (target < 0 || target >= current.length) return layout;
+
+	const next = [...current];
+	[next[index], next[target]] = [next[target] as string, next[index] as string];
+	return { ...layout, [placement]: next };
+}
+
+export function placeContentEditorPanel(
+	layout: ContentEditorPanelLayout,
+	id: string,
+	placement: ContentEditorPanelPlacement,
+): ContentEditorPanelLayout {
+	const main = layout.main.filter((entry) => entry !== id);
+	const sidebar = layout.sidebar.filter((entry) => entry !== id);
+	const target = placement === "main" ? main : sidebar;
+	target.push(id);
+	return { ...layout, main, sidebar };
+}

--- a/packages/admin/src/lib/admin-editor-panel-layout.ts
+++ b/packages/admin/src/lib/admin-editor-panel-layout.ts
@@ -14,13 +14,18 @@ function isStringArray(value: unknown): value is string[] {
 	return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
 /** Parse an untrusted browser preference without letting it break the editor. */
 export function parseContentEditorPanelLayout(raw: string | null): ContentEditorPanelLayout | null {
 	if (!raw) return null;
 	try {
-		const value = JSON.parse(raw) as Partial<ContentEditorPanelLayout> | null;
+		const value: unknown = JSON.parse(raw);
 		if (
-			value?.version !== CONTENT_EDITOR_PANEL_LAYOUT_VERSION ||
+			!isRecord(value) ||
+			value.version !== CONTENT_EDITOR_PANEL_LAYOUT_VERSION ||
 			!isStringArray(value.main) ||
 			!isStringArray(value.sidebar)
 		) {
@@ -84,7 +89,11 @@ export function moveContentEditorPanel(
 	if (target < 0 || target >= current.length) return layout;
 
 	const next = [...current];
-	[next[index], next[target]] = [next[target] as string, next[index] as string];
+	const currentValue = next[index];
+	const targetValue = next[target];
+	if (currentValue === undefined || targetValue === undefined) return layout;
+	next[index] = targetValue;
+	next[target] = currentValue;
 	return { ...layout, [placement]: next };
 }
 

--- a/packages/admin/src/lib/admin-editor-panel-layout.ts
+++ b/packages/admin/src/lib/admin-editor-panel-layout.ts
@@ -88,6 +88,31 @@ export function moveContentEditorPanel(
 	return { ...layout, [placement]: next };
 }
 
+/** Reorder a panel relative to another panel on the same editor surface. */
+export function reorderContentEditorPanel(
+	layout: ContentEditorPanelLayout,
+	id: string,
+	overId: string,
+): ContentEditorPanelLayout {
+	const placement: ContentEditorPanelPlacement | null = layout.main.includes(id)
+		? "main"
+		: layout.sidebar.includes(id)
+			? "sidebar"
+			: null;
+	if (!placement || id === overId) return layout;
+
+	const current = layout[placement];
+	const from = current.indexOf(id);
+	const to = current.indexOf(overId);
+	if (from < 0 || to < 0) return layout;
+
+	const next = [...current];
+	const [moved] = next.splice(from, 1);
+	if (!moved) return layout;
+	next.splice(to, 0, moved);
+	return { ...layout, [placement]: next };
+}
+
 export function placeContentEditorPanel(
 	layout: ContentEditorPanelLayout,
 	id: string,

--- a/packages/admin/src/lib/admin-extensions.ts
+++ b/packages/admin/src/lib/admin-extensions.ts
@@ -5,7 +5,7 @@
  * hooks, or private patches:
  *
  *   - Content list columns (`contentListColumns` on the plugin admin module)
- *   - Content editor sidebar panels (`contentEditorPanels`)
+ *   - Content editor panels (`contentEditorPanels`)
  *
  * Contributions travel the existing trusted registration path: a native
  * plugin's `adminEntry` module exports them, the core integration bundles
@@ -22,7 +22,7 @@
 import type { MessageDescriptor } from "@lingui/core";
 import type * as React from "react";
 
-import type { ContentItem } from "./api";
+import type { ContentItem, ContentSeo, ContentSeoInput } from "./api";
 
 // ── Contribution contexts (host → extension, read-only) ────────────
 
@@ -45,14 +45,44 @@ export interface ContentListColumnCellContext extends ContentListColumnHeaderCon
 	item: ContentItem;
 }
 
-/** Context passed to a contributed editor sidebar panel component. */
+/** Live draft state exposed to a contributed editor panel. */
+export interface ContentEditorDraftState {
+	/** Current unsaved field values. Treat as read-only host state. */
+	data: Readonly<Record<string, unknown>>;
+	/** Current unsaved slug. */
+	slug: string;
+	/** Current editor status. */
+	status: string;
+	/** Current saved SEO metadata, when SEO is enabled for the collection. */
+	seo?: ContentSeo;
+	/** Whether this editor is creating a never-saved entry. */
+	isNew: boolean;
+	/** Whether the field/slug draft differs from the last saved state. */
+	isDirty: boolean;
+}
+
+/** Host-owned mutations a contributed editor panel may request. */
+export interface ContentEditorPanelActions {
+	/** Update one field in the live editor draft. */
+	updateField(name: string, value: unknown): void;
+	/** Update the live slug draft. */
+	updateSlug(value: string): void;
+	/** Persist SEO metadata through the host, when SEO is enabled. */
+	updateSeo?: (seo: ContentSeoInput) => void;
+}
+
+/** Context passed to a contributed editor panel component. */
 export interface ContentEditorPanelContext {
 	/** Collection slug of the entry being edited. */
 	collection: string;
-	/** The saved entry snapshot. Panels render only for saved entries. */
-	entry: ContentItem;
+	/** Saved entry snapshot, or null while creating a new entry. */
+	entry: ContentItem | null;
 	/** Locale the entry is bound to (undefined when i18n is off). */
 	locale?: string;
+	/** Live editor state. */
+	draft: ContentEditorDraftState;
+	/** Host-owned editor mutations. */
+	actions: ContentEditorPanelActions;
 }
 
 // ── Contribution shapes (extension → host) ─────────────────────────
@@ -117,17 +147,18 @@ export interface ContentListColumnExtension extends AdminExtensionBase {
 }
 
 /**
- * A content-editor sidebar panel contributed by a trusted plugin.
+ * A content-editor panel contributed by a trusted plugin.
  *
- * Rendered as a titled section in the entry settings sidebar, for saved
- * entries only (new, never-saved entries have no id/state to expose). The
+ * Rendered as a titled section in the main editor or settings sidebar. The
  * sidebar is narrow (20rem on small screens) and becomes an off-canvas
- * sheet below the `lg` breakpoint: panels must wrap instead of forcing
- * horizontal overflow and must not assume a wide viewport.
+ * sheet below the `lg` breakpoint: sidebar panels must wrap instead of
+ * forcing horizontal overflow and must not assume a wide viewport.
  */
 export interface ContentEditorPanelExtension extends AdminExtensionBase {
 	/** Section title. Strings render as-is; descriptors are translated. */
 	title: string | MessageDescriptor;
+	/** Preferred initial surface. Users may move it later. @default "sidebar" */
+	placement?: "main" | "sidebar";
 	/** Panel body component. */
 	panel: React.ComponentType<ContentEditorPanelContext>;
 }
@@ -173,6 +204,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
 
+const REACT_COMPONENT_SYMBOLS = new Set([
+	Symbol.for("react.memo"),
+	Symbol.for("react.forward_ref"),
+	Symbol.for("react.lazy"),
+]);
+
+function isReactComponent(value: unknown): boolean {
+	if (typeof value === "function") return true;
+	return isRecord(value) && REACT_COMPONENT_SYMBOLS.has(value.$$typeof as symbol);
+}
+
 function isDisplayText(value: unknown): value is string | MessageDescriptor {
 	return (
 		typeof value === "string" ||
@@ -195,7 +237,7 @@ function isValidExtensionShape<T extends AdminExtensionBase>(
 		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): its ${textKey} is invalid.`);
 		return false;
 	}
-	if (typeof value[componentKey] !== "function") {
+	if (!isReactComponent(value[componentKey])) {
 		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): its component is not a React component.`);
 		return false;
 	}
@@ -239,7 +281,7 @@ function isContentListColumnExtension(
 		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): align must be "start" or "end".`);
 		return false;
 	}
-	if (value.header !== undefined && typeof value.header !== "function") {
+	if (value.header !== undefined && !isReactComponent(value.header)) {
 		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): its header is not a React component.`);
 		return false;
 	}
@@ -250,7 +292,18 @@ function isContentEditorPanelExtension(
 	value: unknown,
 	pluginId: string,
 ): value is ContentEditorPanelExtension {
-	return isValidExtensionShape<ContentEditorPanelExtension>(value, pluginId, "title", "panel");
+	if (!isValidExtensionShape<ContentEditorPanelExtension>(value, pluginId, "title", "panel")) {
+		return false;
+	}
+	if (
+		value.placement !== undefined &&
+		value.placement !== "main" &&
+		value.placement !== "sidebar"
+	) {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): placement must be "main" or "sidebar".`);
+		return false;
+	}
+	return true;
 }
 
 function isApplicableToCollection(
@@ -354,9 +407,9 @@ export function selectContentListColumns(
 }
 
 /**
- * Editor sidebar panels applicable to a collection for the current user,
+ * Editor panels applicable to a collection for the current user,
  * deterministically ordered. Returns `[]` when no plugin contributes any —
- * the settings sidebar renders exactly its classic markup in that case.
+ * the editor renders exactly its classic markup in that case.
  */
 export function selectContentEditorPanels(
 	source: AdminExtensionSource,

--- a/packages/admin/src/lib/admin-extensions.ts
+++ b/packages/admin/src/lib/admin-extensions.ts
@@ -238,7 +238,11 @@ const REACT_COMPONENT_SYMBOLS = new Set([
 
 function isReactComponent(value: unknown): boolean {
 	if (typeof value === "function") return true;
-	return isRecord(value) && REACT_COMPONENT_SYMBOLS.has(value.$$typeof as symbol);
+	return (
+		isRecord(value) &&
+		typeof value.$$typeof === "symbol" &&
+		REACT_COMPONENT_SYMBOLS.has(value.$$typeof)
+	);
 }
 
 function isDisplayText(value: unknown): value is string | MessageDescriptor {

--- a/packages/admin/src/lib/admin-extensions.ts
+++ b/packages/admin/src/lib/admin-extensions.ts
@@ -154,14 +154,40 @@ export interface ContentListColumnExtension extends AdminExtensionBase {
  * sheet below the `lg` breakpoint: sidebar panels must wrap instead of
  * forcing horizontal overflow and must not assume a wide viewport.
  */
-export interface ContentEditorPanelExtension extends AdminExtensionBase {
+interface ContentEditorPanelExtensionBase extends AdminExtensionBase {
 	/** Section title. Strings render as-is; descriptors are translated. */
 	title: string | MessageDescriptor;
-	/** Preferred initial surface. Users may move it later. @default "sidebar" */
-	placement?: "main" | "sidebar";
 	/** Panel body component. */
 	panel: React.ComponentType<ContentEditorPanelContext>;
 }
+
+/** Native editor sections that trusted plugins may extend without duplicating host chrome. */
+export type ContentEditorNativeSlot = "seo";
+
+/**
+ * A movable editor panel or a contribution to a named native editor section.
+ *
+ * Movable panels may declare an initial `placement`. Named-slot contributions
+ * instead declare `mode`; the discriminated union prevents combining the two
+ * contracts in typed plugins, while runtime validation protects untyped builds.
+ */
+export type ContentEditorPanelExtension = ContentEditorPanelExtensionBase &
+	(
+		| {
+				/** Movable, user-positioned panel. @default "panel" */
+				slot?: "panel";
+				mode?: never;
+				/** Preferred initial surface. Users may move it later. @default "sidebar" */
+				placement?: "main" | "sidebar";
+		  }
+		| {
+				/** Native editor section whose host-owned body this contribution extends. */
+				slot: ContentEditorNativeSlot;
+				/** Append after the native body, or replace it with automatic fallback. @default "append" */
+				mode?: "append" | "replace";
+				placement?: never;
+		  }
+	);
 
 /**
  * Structural view of the plugin admin registry consumed by the selectors —
@@ -301,6 +327,22 @@ function isContentEditorPanelExtension(
 		value.placement !== "sidebar"
 	) {
 		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): placement must be "main" or "sidebar".`);
+		return false;
+	}
+	if (value.slot !== undefined && value.slot !== "panel" && value.slot !== "seo") {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): slot must be "panel" or "seo".`);
+		return false;
+	}
+	if (value.mode !== undefined && value.mode !== "append" && value.mode !== "replace") {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): mode must be "append" or "replace".`);
+		return false;
+	}
+	if ((value.slot === undefined || value.slot === "panel") && value.mode !== undefined) {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): mode requires a named slot.`);
+		return false;
+	}
+	if (value.slot !== undefined && value.slot !== "panel" && value.placement !== undefined) {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): named slots do not accept placement.`);
 		return false;
 	}
 	return true;

--- a/packages/admin/src/lib/admin-extensions.ts
+++ b/packages/admin/src/lib/admin-extensions.ts
@@ -1,0 +1,371 @@
+/**
+ * Typed admin extension slots for trusted (native) plugins.
+ *
+ * Native companions extend two admin surfaces without DOM bridges, global
+ * hooks, or private patches:
+ *
+ *   - Content list columns (`contentListColumns` on the plugin admin module)
+ *   - Content editor sidebar panels (`contentEditorPanels`)
+ *
+ * Contributions travel the existing trusted registration path: a native
+ * plugin's `adminEntry` module exports them, the core integration bundles
+ * that module into `virtual:emdash/admin-registry` (native descriptors only —
+ * core rejects `adminEntry` on sandboxed/standard plugins at config time),
+ * and `PluginAdminProvider` delivers them here. Sandboxed plugins never
+ * appear in that registry, so they can never reach these React slots.
+ *
+ * This module is pure (no hooks, no React rendering) so selection semantics
+ * — ordering, duplicate handling, collection/role filtering — are testable
+ * without a DOM, mirroring the pure nav helpers in `components/Sidebar.tsx`.
+ */
+
+import type { MessageDescriptor } from "@lingui/core";
+import type * as React from "react";
+
+import type { ContentItem } from "./api";
+
+// ── Contribution contexts (host → extension, read-only) ────────────
+
+/** Context passed to a contributed list-column header component. */
+export interface ContentListColumnHeaderContext {
+	/** Collection slug the list is showing. */
+	collection: string;
+	/** Active list locale (undefined when the site has no i18n config). */
+	locale?: string;
+}
+
+/**
+ * Context passed to a contributed list-column cell component, one per row.
+ * The entry field is named `item` to match the list domain (`ContentItem`
+ * rows); the editor panel context names its saved entry `entry` because the
+ * editor edits one entry, not a row in a list.
+ */
+export interface ContentListColumnCellContext extends ContentListColumnHeaderContext {
+	/** The saved entry this row renders. Treat as read-only host data. */
+	item: ContentItem;
+}
+
+/** Context passed to a contributed editor sidebar panel component. */
+export interface ContentEditorPanelContext {
+	/** Collection slug of the entry being edited. */
+	collection: string;
+	/** The saved entry snapshot. Panels render only for saved entries. */
+	entry: ContentItem;
+	/** Locale the entry is bound to (undefined when i18n is off). */
+	locale?: string;
+}
+
+// ── Contribution shapes (extension → host) ─────────────────────────
+
+interface AdminExtensionBase {
+	/**
+	 * Stable unique id, unique within its slot. Convention:
+	 * `"<plugin-id>:<name>"`. Duplicate ids are dropped deterministically
+	 * (first in sorted plugin order wins) with a console warning.
+	 */
+	id: string;
+	/**
+	 * Sort key within the slot; lower renders first. Ties break by `id`,
+	 * so ordering is deterministic regardless of registration order.
+	 * @default 0
+	 */
+	order?: number;
+	/**
+	 * Collection applicability: a list of collection slugs, or a predicate
+	 * over the slug. Omit to apply to every collection. A predicate that
+	 * throws marks the contribution inapplicable (fault isolation).
+	 */
+	collections?: readonly string[] | ((collection: string) => boolean);
+	/**
+	 * Minimum numeric role required to see the contribution (matching
+	 * `@emdash-cms/auth` levels, e.g. 40 = Editor, 50 = Admin). Omit for
+	 * every authenticated admin user. This gates visibility only — server
+	 * authorization still applies to any data the extension requests.
+	 */
+	minRole?: number;
+}
+
+/**
+ * A content-list column contributed by a trusted plugin.
+ *
+ * The host renders the header `<th>` (from `label`, or `header` when given)
+ * and one `<td>` per row mounting `cell`. Both are wrapped in an error
+ * boundary, so a broken contribution degrades to a quiet placeholder without
+ * breaking the table.
+ *
+ * Data loading: `cell` receives the already-loaded row (`item`) — the host
+ * never issues per-row requests for extension columns. A cell that needs
+ * remote data must batch it: use one react-query key shared by every cell
+ * (e.g. `[pluginId, "list-data", collection, locale]`) whose fetcher loads
+ * the whole collection's data in one request; concurrent cells share the
+ * in-flight promise. Per-row query keys re-introduce N+1 and are a bug.
+ * While loading, render a fixed-size placeholder to avoid layout shift.
+ */
+export interface ContentListColumnExtension extends AdminExtensionBase {
+	/** Header label. Strings render as-is; descriptors are translated. */
+	label: string | MessageDescriptor;
+	/**
+	 * Logical cell/header alignment (RTL-safe). Column width is intentionally
+	 * not configurable: the list table auto-sizes to content.
+	 * @default "start"
+	 */
+	align?: "start" | "end";
+	/** Cell component, mounted once per visible row. */
+	cell: React.ComponentType<ContentListColumnCellContext>;
+	/** Optional custom header content; falls back to `label` on error. */
+	header?: React.ComponentType<ContentListColumnHeaderContext>;
+}
+
+/**
+ * A content-editor sidebar panel contributed by a trusted plugin.
+ *
+ * Rendered as a titled section in the entry settings sidebar, for saved
+ * entries only (new, never-saved entries have no id/state to expose). The
+ * sidebar is narrow (20rem on small screens) and becomes an off-canvas
+ * sheet below the `lg` breakpoint: panels must wrap instead of forcing
+ * horizontal overflow and must not assume a wide viewport.
+ */
+export interface ContentEditorPanelExtension extends AdminExtensionBase {
+	/** Section title. Strings render as-is; descriptors are translated. */
+	title: string | MessageDescriptor;
+	/** Panel body component. */
+	panel: React.ComponentType<ContentEditorPanelContext>;
+}
+
+/**
+ * Structural view of the plugin admin registry consumed by the selectors —
+ * kept structural (rather than importing `PluginAdmins`) so this module has
+ * no dependency on the React context module.
+ */
+export type AdminExtensionSource = Record<
+	string,
+	| {
+			contentListColumns?: readonly ContentListColumnExtension[];
+			contentEditorPanels?: readonly ContentEditorPanelExtension[];
+	  }
+	| undefined
+>;
+
+export interface SelectAdminExtensionsOptions {
+	/** Collection slug the host screen is showing. */
+	collection: string;
+	/** Current user's numeric role; use 0 while the user is still loading. */
+	userRole: number;
+	/**
+	 * Plugin ids whose contributions must be skipped because the plugin is
+	 * disabled in the runtime manifest (`plugins[id].enabled === false`) —
+	 * the same lifecycle rule dashboard widgets and plugin pages follow.
+	 */
+	disabledPluginIds?: ReadonlySet<string>;
+}
+
+// ── Selection (pure) ────────────────────────────────────────────────
+
+function compareStrings(a: string, b: string): number {
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function warn(message: string): void {
+	console.warn(`[admin-extensions] ${message}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isDisplayText(value: unknown): value is string | MessageDescriptor {
+	return (
+		typeof value === "string" ||
+		(isRecord(value) && typeof value.id === "string" && value.id.length > 0)
+	);
+}
+
+function isValidExtensionShape<T extends AdminExtensionBase>(
+	value: unknown,
+	pluginId: string,
+	textKey: "label" | "title",
+	componentKey: "cell" | "panel",
+): value is T {
+	if (!isRecord(value) || typeof value.id !== "string" || value.id === "") {
+		warn(`Ignoring a contribution without a string id from plugin "${pluginId}".`);
+		return false;
+	}
+
+	if (!isDisplayText(value[textKey])) {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): its ${textKey} is invalid.`);
+		return false;
+	}
+	if (typeof value[componentKey] !== "function") {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): its component is not a React component.`);
+		return false;
+	}
+	if (
+		value.order !== undefined &&
+		(typeof value.order !== "number" || !Number.isFinite(value.order))
+	) {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): order must be a finite number.`);
+		return false;
+	}
+	if (
+		value.minRole !== undefined &&
+		(typeof value.minRole !== "number" || !Number.isFinite(value.minRole))
+	) {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): minRole must be a finite number.`);
+		return false;
+	}
+	if (
+		value.collections !== undefined &&
+		typeof value.collections !== "function" &&
+		(!Array.isArray(value.collections) ||
+			!value.collections.every((collection) => typeof collection === "string"))
+	) {
+		warn(
+			`Ignoring "${value.id}" (plugin "${pluginId}"): collections must be an array of strings or a predicate.`,
+		);
+		return false;
+	}
+
+	return true;
+}
+
+function isContentListColumnExtension(
+	value: unknown,
+	pluginId: string,
+): value is ContentListColumnExtension {
+	if (!isValidExtensionShape<ContentListColumnExtension>(value, pluginId, "label", "cell")) {
+		return false;
+	}
+	if (value.align !== undefined && value.align !== "start" && value.align !== "end") {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): align must be "start" or "end".`);
+		return false;
+	}
+	if (value.header !== undefined && typeof value.header !== "function") {
+		warn(`Ignoring "${value.id}" (plugin "${pluginId}"): its header is not a React component.`);
+		return false;
+	}
+	return true;
+}
+
+function isContentEditorPanelExtension(
+	value: unknown,
+	pluginId: string,
+): value is ContentEditorPanelExtension {
+	return isValidExtensionShape<ContentEditorPanelExtension>(value, pluginId, "title", "panel");
+}
+
+function isApplicableToCollection(
+	extension: AdminExtensionBase,
+	pluginId: string,
+	collection: string,
+): boolean {
+	const { collections } = extension;
+	if (collections === undefined) return true;
+	if (typeof collections === "function") {
+		try {
+			return collections(collection);
+		} catch (error) {
+			// A throwing predicate is a broken contribution; excluding it keeps
+			// the host screen intact (fault isolation at selection time).
+			console.error(
+				`[admin-extensions] Collection predicate of "${extension.id}" (plugin "${pluginId}") threw; treating as not applicable.`,
+				error,
+			);
+			return false;
+		}
+	}
+	return collections.includes(collection);
+}
+
+/**
+ * Collect one extension kind from the trusted plugin registry into a single
+ * deterministic, filtered, ordered list:
+ *
+ * 1. Plugins are processed in sorted-id order (object key order is a build
+ *    artifact, not a contract); plugins disabled in the runtime manifest
+ *    are skipped entirely.
+ * 2. A contributions export that isn't an array is ignored with a warning
+ *    (an untyped plugin build can export anything) — one broken plugin
+ *    never takes down the host screen.
+ * 3. Malformed entries (missing string `id` or component) are dropped with
+ *    a warning — one broken contribution never hides the rest.
+ * 4. Duplicate ids keep the first occurrence and warn; never silently
+ *    overwritten. The id is claimed even when that first occurrence is
+ *    later filtered out for this screen, so a given id resolves to the
+ *    same owner on every screen.
+ * 5. Collection applicability, then `minRole`, filter the rest.
+ * 6. Stable sort by (`order` ?? 0, `id`).
+ */
+function selectExtensions<T extends AdminExtensionBase>(
+	source: AdminExtensionSource,
+	pick: (module: NonNullable<AdminExtensionSource[string]>) => readonly T[] | undefined,
+	validate: (extension: unknown, pluginId: string) => extension is T,
+	options: SelectAdminExtensionsOptions,
+): T[] {
+	const seen = new Map<string, string>();
+	const selected: T[] = [];
+
+	for (const pluginId of Object.keys(source).toSorted(compareStrings)) {
+		if (options.disabledPluginIds?.has(pluginId)) continue;
+		const module = source[pluginId];
+		if (!module) continue;
+		const contributions = pick(module);
+		if (contributions === undefined) continue;
+		if (!Array.isArray(contributions)) {
+			warn(`Ignoring contributions from plugin "${pluginId}": expected an array.`);
+			continue;
+		}
+
+		for (const extension of contributions) {
+			if (!validate(extension, pluginId)) continue;
+			const owner = seen.get(extension.id);
+			if (owner !== undefined) {
+				warn(
+					`Duplicate extension id "${extension.id}" from plugin "${pluginId}" ignored (already registered by plugin "${owner}").`,
+				);
+				continue;
+			}
+			seen.set(extension.id, pluginId);
+
+			if (!isApplicableToCollection(extension, pluginId, options.collection)) continue;
+			if (extension.minRole !== undefined && options.userRole < extension.minRole) continue;
+
+			selected.push(extension);
+		}
+	}
+
+	return selected.toSorted((a, b) => (a.order ?? 0) - (b.order ?? 0) || compareStrings(a.id, b.id));
+}
+
+/**
+ * Content-list columns applicable to a collection for the current user,
+ * deterministically ordered. Returns `[]` when no plugin contributes any —
+ * the list renders exactly its classic markup in that case.
+ */
+export function selectContentListColumns(
+	source: AdminExtensionSource,
+	options: SelectAdminExtensionsOptions,
+): ContentListColumnExtension[] {
+	return selectExtensions(
+		source,
+		(module) => module.contentListColumns,
+		isContentListColumnExtension,
+		options,
+	);
+}
+
+/**
+ * Editor sidebar panels applicable to a collection for the current user,
+ * deterministically ordered. Returns `[]` when no plugin contributes any —
+ * the settings sidebar renders exactly its classic markup in that case.
+ */
+export function selectContentEditorPanels(
+	source: AdminExtensionSource,
+	options: SelectAdminExtensionsOptions,
+): ContentEditorPanelExtension[] {
+	return selectExtensions(
+		source,
+		(module) => module.contentEditorPanels,
+		isContentEditorPanelExtension,
+		options,
+	);
+}

--- a/packages/admin/src/lib/api/manifest.ts
+++ b/packages/admin/src/lib/api/manifest.ts
@@ -1,0 +1,37 @@
+/**
+ * Manifest-derived plugin lifecycle state, shared by the admin extension
+ * hosts (content list, editor settings sidebar).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import * as React from "react";
+
+import { fetchManifest } from "./client.js";
+
+const NO_DISABLED_PLUGINS: ReadonlySet<string> = new Set();
+
+/**
+ * Ids of plugins disabled in the runtime manifest. Extension hosts skip
+ * these plugins' contributions — the same lifecycle rule dashboard widgets
+ * and plugin pages already follow. Uses the shared `["manifest"]` query
+ * (always warm: the admin root blocks rendering until the manifest loads),
+ * so this subscribes to cached data rather than adding a request.
+ */
+export function useDisabledPluginIds(): ReadonlySet<string> {
+	const { data: manifest } = useQuery({
+		queryKey: ["manifest"],
+		queryFn: fetchManifest,
+		// The root layout owns manifest freshness. This observer only consumes
+		// its cache and must not trigger another request when a content surface
+		// mounts; explicit invalidation still refreshes active observers.
+		staleTime: Infinity,
+	});
+	const plugins = manifest?.plugins;
+	return React.useMemo(() => {
+		const disabled = new Set<string>();
+		for (const [pluginId, plugin] of Object.entries(plugins ?? {})) {
+			if (plugin.enabled === false) disabled.add(pluginId);
+		}
+		return disabled.size > 0 ? disabled : NO_DISABLED_PLUGINS;
+	}, [plugins]);
+}

--- a/packages/admin/src/lib/plugin-context.tsx
+++ b/packages/admin/src/lib/plugin-context.tsx
@@ -22,7 +22,7 @@ export interface PluginAdminModule {
 	fields?: Record<string, React.ComponentType>;
 	/** Columns added to content collection lists (see `admin-extensions.ts`). */
 	contentListColumns?: ContentListColumnExtension[];
-	/** Panels added to the content editor settings sidebar. */
+	/** Panels added to the content editor's main area or settings sidebar. */
 	contentEditorPanels?: ContentEditorPanelExtension[];
 }
 

--- a/packages/admin/src/lib/plugin-context.tsx
+++ b/packages/admin/src/lib/plugin-context.tsx
@@ -1,19 +1,29 @@
 /**
  * Plugin Admin Context
  *
- * Provides plugin admin modules (widgets, pages, fields) to the admin UI
- * via React context. This avoids cross-module registry issues by keeping
- * everything in React's component tree.
+ * Provides plugin admin modules (widgets, pages, fields, content-list
+ * columns, editor panels) to the admin UI via React context. This avoids
+ * cross-module registry issues by keeping everything in React's component
+ * tree.
  */
 
 import * as React from "react";
 import { createContext, useContext } from "react";
+
+import type {
+	ContentEditorPanelExtension,
+	ContentListColumnExtension,
+} from "./admin-extensions.js";
 
 /** Shape of a plugin's admin exports */
 export interface PluginAdminModule {
 	widgets?: Record<string, React.ComponentType>;
 	pages?: Record<string, React.ComponentType>;
 	fields?: Record<string, React.ComponentType>;
+	/** Columns added to content collection lists (see `admin-extensions.ts`). */
+	contentListColumns?: ContentListColumnExtension[];
+	/** Panels added to the content editor settings sidebar. */
+	contentEditorPanels?: ContentEditorPanelExtension[];
 }
 
 /** All plugin admin modules keyed by plugin ID */

--- a/packages/admin/tests/components/AdminContentExtensions.test.tsx
+++ b/packages/admin/tests/components/AdminContentExtensions.test.tsx
@@ -18,6 +18,10 @@ import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+import {
+	ContentEditorExtensionPanels,
+	ContentEditorExtensionPanelsProvider,
+} from "../../src/components/ContentEditorExtensionPanels";
 import { ContentList } from "../../src/components/ContentList";
 import {
 	ContentSettingsPanel,
@@ -174,10 +178,44 @@ function panelProps(overrides: Partial<ContentSettingsPanelProps> = {}): Content
 	};
 }
 
+function HostedSettingsPanel({
+	props = panelProps(),
+	draftData = props.item?.data ?? {},
+}: {
+	props?: ContentSettingsPanelProps;
+	draftData?: Record<string, unknown>;
+}) {
+	return (
+		<ContentEditorExtensionPanelsProvider
+			collection={props.collection}
+			entry={props.item ?? null}
+			locale={props.item?.locale ?? props.entryLocale ?? undefined}
+			userId={props.currentUser?.id}
+			userRole={props.currentUser?.role ?? 0}
+			draft={{
+				data: draftData,
+				slug: props.slug,
+				status: props.status,
+				seo: props.item?.seo,
+				isNew: Boolean(props.isNew),
+				isDirty: Boolean(props.isNew),
+			}}
+			actions={{
+				updateField: vi.fn(),
+				updateSlug: props.onSlugChange,
+				updateSeo: props.onSeoChange,
+			}}
+		>
+			<ContentSettingsPanel {...props} />
+		</ContentEditorExtensionPanelsProvider>
+	);
+}
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	currentUserState.role = 50;
 	manifestState.disabledPluginIds = [];
+	window.localStorage.clear();
 });
 
 afterEach(() => {
@@ -360,9 +398,9 @@ describe("ContentList extension columns", () => {
 });
 
 describe("ContentSettingsPanel extension panels", () => {
-	function ctxPanel({ collection, entry, locale }: ContentEditorPanelContext) {
+	function ctxPanel({ collection, entry, locale, draft }: ContentEditorPanelContext) {
 		return (
-			<div data-testid="ext-panel">{`panel:${collection}:${entry.id}:${locale ?? "none"}`}</div>
+			<div data-testid="ext-panel">{`panel:${collection}:${entry?.id ?? "new"}:${locale ?? "none"}:${String(draft.data.title ?? "untitled")}`}</div>
 		);
 	}
 
@@ -372,14 +410,14 @@ describe("ContentSettingsPanel extension panels", () => {
 				contentEditorPanels: [{ id: "p:insights", title: "Editorial Status", panel: ctxPanel }],
 			},
 		};
-		const screen = await render(<ContentSettingsPanel {...panelProps()} />, {
+		const screen = await render(<HostedSettingsPanel />, {
 			wrapper: withPlugins(registry),
 		});
 
 		await expect
 			.element(screen.getByRole("heading", { name: "Editorial Status" }))
 			.toBeInTheDocument();
-		await expect.element(screen.getByText("panel:posts:item-1:en")).toBeInTheDocument();
+		await expect.element(screen.getByText("panel:posts:item-1:en:My Post")).toBeInTheDocument();
 
 		// Deterministic placement: after the SEO section, before the outline —
 		// and Move to Trash stays the very last section.
@@ -396,19 +434,114 @@ describe("ContentSettingsPanel extension panels", () => {
 		expect(sections[extIndex]?.className).toContain("min-w-0");
 	});
 
-	it("renders nothing for new (never saved) entries", async () => {
+	it("renders panels for new entries with a nullable saved snapshot and live draft", async () => {
 		const registry: PluginAdmins = {
 			p: {
 				contentEditorPanels: [{ id: "p:insights", title: "Editorial Status", panel: ctxPanel }],
 			},
 		};
+		const props = panelProps({ item: null, isNew: true, entryLocale: "nl" });
 		const screen = await render(
-			<ContentSettingsPanel {...panelProps({ item: null, isNew: true })} />,
-			{ wrapper: withPlugins(registry) },
+			<HostedSettingsPanel props={props} draftData={{ title: "Draft" }} />,
+			{
+				wrapper: withPlugins(registry),
+			},
 		);
 
 		await expect.element(screen.getByRole("heading", { name: "Publish" })).toBeInTheDocument();
-		expect(screen.container.textContent).not.toContain("Editorial Status");
+		await expect
+			.element(screen.getByRole("heading", { name: "Editorial Status" }))
+			.toBeInTheDocument();
+		await expect.element(screen.getByText("panel:posts:new:nl:Draft")).toBeInTheDocument();
+	});
+
+	it("places wide panels in the main editor while keeping sidebar panels in settings", async () => {
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{ id: "p:wide", title: "Wide Panel", placement: "main", panel: ctxPanel },
+					{ id: "p:side", title: "Side Panel", panel: ctxPanel },
+				],
+			},
+		};
+		const props = panelProps();
+		const screen = await render(
+			<ContentEditorExtensionPanelsProvider
+				collection="posts"
+				entry={props.item ?? null}
+				locale="en"
+				userId="u1"
+				userRole={40}
+				draft={{
+					data: props.item?.data ?? {},
+					slug: props.slug,
+					status: props.status,
+					isNew: false,
+					isDirty: false,
+				}}
+				actions={{ updateField: vi.fn(), updateSlug: vi.fn() }}
+			>
+				<main data-testid="main-panels">
+					<ContentEditorExtensionPanels placement="main" />
+				</main>
+				<aside data-testid="sidebar-panels">
+					<ContentEditorExtensionPanels placement="sidebar" />
+				</aside>
+			</ContentEditorExtensionPanelsProvider>,
+			{ wrapper: withPlugins(registry) },
+		);
+
+		await expect.element(screen.getByRole("heading", { name: "Wide Panel" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("heading", { name: "Side Panel" })).toBeInTheDocument();
+		expect(screen.getByTestId("main-panels").element().textContent).toContain("Wide Panel");
+		expect(screen.getByTestId("main-panels").element().textContent).not.toContain("Side Panel");
+		expect(screen.getByTestId("sidebar-panels").element().textContent).toContain("Side Panel");
+	});
+
+	it("exposes live draft state through host-owned field actions", async () => {
+		function LivePanel({ draft, actions }: ContentEditorPanelContext) {
+			return (
+				<div>
+					<span data-testid="live-title">{String(draft.data.title)}</span>
+					<button type="button" onClick={() => actions.updateField("title", "Updated")}>
+						Update title
+					</button>
+				</div>
+			);
+		}
+		function LiveHarness() {
+			const [data, setData] = React.useState<Record<string, unknown>>({ title: "Initial" });
+			return (
+				<ContentEditorExtensionPanelsProvider
+					collection="posts"
+					entry={makeItem()}
+					locale="en"
+					userId="u1"
+					userRole={40}
+					draft={{ data, slug: "draft", status: "draft", isNew: false, isDirty: true }}
+					actions={{
+						updateField: (name, value) => setData((current) => ({ ...current, [name]: value })),
+						updateSlug: vi.fn(),
+					}}
+				>
+					<ContentEditorExtensionPanels placement="main" />
+				</ContentEditorExtensionPanelsProvider>
+			);
+		}
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{ id: "p:live", title: "Live Panel", placement: "main", panel: LivePanel },
+				],
+			},
+		};
+		const screen = await render(<LiveHarness />, { wrapper: withPlugins(registry) });
+
+		expect(screen.getByTestId("live-title").element().textContent).toBe("Initial");
+		screen.getByRole("button", { name: "Update title" }).element().click();
+		await vi.waitFor(() => {
+			expect(screen.getByTestId("live-title").element().textContent).toBe("Updated");
+		});
 	});
 
 	it("applies role and collection gates with no leftover section chrome", async () => {
@@ -421,7 +554,7 @@ describe("ContentSettingsPanel extension panels", () => {
 			},
 		};
 		// currentUser prop is role 40 (Editor) — below the 50 gate.
-		const screen = await render(<ContentSettingsPanel {...panelProps()} />, {
+		const screen = await render(<HostedSettingsPanel />, {
 			wrapper: withPlugins(registry),
 		});
 
@@ -447,7 +580,7 @@ describe("ContentSettingsPanel extension panels", () => {
 				],
 			},
 		};
-		const screen = await render(<ContentSettingsPanel {...panelProps()} />, {
+		const screen = await render(<HostedSettingsPanel />, {
 			wrapper: withPlugins(registry),
 		});
 
@@ -532,7 +665,7 @@ describe("plugin lifecycle", () => {
 
 		await list.unmount();
 
-		const panel = await render(<ContentSettingsPanel {...panelProps()} />, {
+		const panel = await render(<HostedSettingsPanel />, {
 			wrapper: withPlugins(registry),
 		});
 		await expect.element(panel.getByRole("heading", { name: "Publish" })).toBeInTheDocument();

--- a/packages/admin/tests/components/AdminContentExtensions.test.tsx
+++ b/packages/admin/tests/components/AdminContentExtensions.test.tsx
@@ -399,8 +399,9 @@ describe("ContentList extension columns", () => {
 
 describe("ContentSettingsPanel extension panels", () => {
 	function ctxPanel({ collection, entry, locale, draft }: ContentEditorPanelContext) {
+		const draftTitle = typeof draft.data.title === "string" ? draft.data.title : "untitled";
 		return (
-			<div data-testid="ext-panel">{`panel:${collection}:${entry?.id ?? "new"}:${locale ?? "none"}:${String(draft.data.title ?? "untitled")}`}</div>
+			<div data-testid="ext-panel">{`panel:${collection}:${entry?.id ?? "new"}:${locale ?? "none"}:${draftTitle}`}</div>
 		);
 	}
 

--- a/packages/admin/tests/components/AdminContentExtensions.test.tsx
+++ b/packages/admin/tests/components/AdminContentExtensions.test.tsx
@@ -1,0 +1,542 @@
+/**
+ * Admin extension slots — rendered behaviour of both host surfaces.
+ *
+ * Mounts the real ContentList and ContentSettingsPanel with contributions
+ * delivered through PluginAdminProvider (the same seam the trusted native
+ * registry uses in production) and pins: header/cell placement, zero-
+ * extension markup parity, collection/role filtering leaving no gaps,
+ * per-contribution fault isolation, typed context correctness, the batched
+ * (no per-row waterfall) data pattern, and that nothing outside the typed
+ * trusted registry can reach these slots.
+ *
+ * Selection semantics (ordering, duplicates, predicates) are covered in
+ * tests/lib/admin-extensions.test.ts.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import type { Editor } from "@tiptap/react";
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { ContentList } from "../../src/components/ContentList";
+import {
+	ContentSettingsPanel,
+	type ContentSettingsPanelProps,
+} from "../../src/components/ContentSettingsPanel";
+import type {
+	ContentEditorPanelContext,
+	ContentListColumnCellContext,
+} from "../../src/lib/admin-extensions";
+import type { ContentItem } from "../../src/lib/api";
+import { PluginAdminProvider, type PluginAdmins } from "../../src/lib/plugin-context";
+import { render } from "../utils/render.tsx";
+
+// Same child stubs as ContentSettingsPanel.test.tsx: panel tests assert
+// section composition, not child behaviour.
+vi.mock("../../src/components/RevisionHistory", () => ({
+	RevisionHistory: () => <div data-testid="revision-history">Revision History</div>,
+}));
+
+vi.mock("../../src/components/TaxonomySidebar", () => ({
+	TaxonomySidebar: () => <div data-testid="taxonomy-sidebar">Taxonomy</div>,
+}));
+
+vi.mock("../../src/components/editor/DocumentOutline", () => ({
+	DocumentOutline: () => <div data-testid="doc-outline">Outline</div>,
+}));
+
+vi.mock("../../src/components/editor/ImageDetailPanel", () => ({
+	ImageDetailPanel: () => <div data-testid="image-detail-panel">Image details</div>,
+}));
+
+vi.mock("../../src/components/SeoPanel", () => ({
+	SeoPanel: () => <div data-testid="seo-panel">SEO fields</div>,
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...actual,
+		useNavigate: () => vi.fn(),
+		Link: ({
+			children,
+			to,
+			params: _params,
+			...props
+		}: {
+			children: React.ReactNode;
+			to?: string;
+			params?: Record<string, string>;
+			[key: string]: unknown;
+		}) => (
+			<a href={typeof to === "string" ? to : "#"} {...props}>
+				{children}
+			</a>
+		),
+	};
+});
+
+vi.mock("../../src/lib/api", async () => {
+	const actual = await vi.importActual("../../src/lib/api");
+	return {
+		...actual,
+		fetchBylines: vi.fn(async () => ({ items: [], nextCursor: null })),
+	};
+});
+
+// ContentList resolves the current user's role itself; make it deterministic
+// and controllable per test (no network in browser mode).
+const currentUserState = vi.hoisted(() => ({ role: 50 }));
+
+vi.mock("../../src/lib/api/current-user", () => ({
+	useCurrentUser: () => ({
+		data: { id: "u1", email: "admin@example.com", role: currentUserState.role },
+	}),
+}));
+
+// Both hosts skip contributions from plugins disabled in the runtime
+// manifest; control that state per test without a network round-trip.
+const manifestState = vi.hoisted(() => ({ disabledPluginIds: [] as string[] }));
+
+vi.mock("../../src/lib/api/manifest", () => ({
+	useDisabledPluginIds: () => new Set(manifestState.disabledPluginIds),
+}));
+
+function makeItem(overrides: Partial<ContentItem> = {}): ContentItem {
+	return {
+		id: "item-1",
+		type: "posts",
+		slug: "my-post",
+		status: "draft",
+		locale: "en",
+		translationGroup: null,
+		data: { title: "My Post" },
+		authorId: null,
+		primaryBylineId: null,
+		createdAt: "2025-01-15T10:30:00Z",
+		updatedAt: "2025-01-15T10:30:00Z",
+		publishedAt: null,
+		scheduledAt: null,
+		liveRevisionId: null,
+		draftRevisionId: null,
+		...overrides,
+	};
+}
+
+function withPlugins(pluginAdmins: PluginAdmins) {
+	return function PluginWrapper({ children }: React.PropsWithChildren) {
+		return <PluginAdminProvider pluginAdmins={pluginAdmins}>{children}</PluginAdminProvider>;
+	};
+}
+
+const listProps = {
+	collection: "posts",
+	collectionLabel: "Posts",
+};
+
+function headerTexts(container: Element): string[] {
+	return Array.from(container.querySelectorAll("thead th"), (th) => th.textContent?.trim() ?? "");
+}
+
+const CLASSIC_HEADERS = ["Title", "Status", "Date", "Actions"];
+
+function panelProps(overrides: Partial<ContentSettingsPanelProps> = {}): ContentSettingsPanelProps {
+	return {
+		collection: "posts",
+		item: makeItem(),
+		isNew: false,
+		slug: "my-post",
+		onSlugChange: vi.fn(),
+		status: "draft",
+		supportsDrafts: true,
+		isLive: false,
+		hasPendingChanges: false,
+		hasSchedule: false,
+		supportsRevisions: true,
+		canSchedule: false,
+		onDelete: vi.fn(),
+		currentUser: { id: "u1", role: 40 },
+		users: [],
+		onAuthorChange: vi.fn(),
+		activeBylines: [],
+		availableBylines: [],
+		availableBylinesLoaded: true,
+		onBylinesChange: vi.fn(),
+		translations: [],
+		onTranslate: vi.fn(),
+		hasSeo: true,
+		onSeoChange: vi.fn(),
+		portableTextEditor: {} as Editor,
+		blockSidebarPanel: null,
+		onBlockSidebarClose: vi.fn(),
+		onBlockSidebarDelete: vi.fn(),
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	currentUserState.role = 50;
+	manifestState.disabledPluginIds = [];
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("ContentList extension columns", () => {
+	it("renders the contributed header between Date and Actions with one cell per row", async () => {
+		const registry: PluginAdmins = {
+			scorer: {
+				contentListColumns: [
+					{
+						id: "scorer:score",
+						label: "Score",
+						cell: ({ item }: ContentListColumnCellContext) => <span>score-{item.id}</span>,
+					},
+				],
+			},
+		};
+		const items = [makeItem({ id: "a1" }), makeItem({ id: "a2", data: { title: "Second" } })];
+		const screen = await render(<ContentList {...listProps} items={items} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByText("score-a1")).toBeInTheDocument();
+		await expect.element(screen.getByText("score-a2")).toBeInTheDocument();
+		expect(headerTexts(screen.container)).toEqual(["Title", "Status", "Date", "Score", "Actions"]);
+		// The contributed header is a real column header cell.
+		const scoreTh = [...screen.container.querySelectorAll("thead th")].find(
+			(th) => th.textContent === "Score",
+		);
+		expect(scoreTh?.getAttribute("scope")).toBe("col");
+	});
+
+	it("orders columns from multiple plugins deterministically", async () => {
+		const cell = () => <span />;
+		const registry: PluginAdmins = {
+			zeta: { contentListColumns: [{ id: "zeta:first", label: "First", order: -1, cell }] },
+			alpha: { contentListColumns: [{ id: "alpha:second", label: "Second", order: 2, cell }] },
+		};
+		const screen = await render(<ContentList {...listProps} items={[makeItem()]} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByText("My Post")).toBeInTheDocument();
+		expect(headerTexts(screen.container)).toEqual([
+			"Title",
+			"Status",
+			"Date",
+			"First",
+			"Second",
+			"Actions",
+		]);
+	});
+
+	it("keeps the classic markup byte-identical in spirit when no extensions are registered", async () => {
+		const screen = await render(<ContentList {...listProps} items={[makeItem()]} />, {
+			wrapper: withPlugins({}),
+		});
+		await expect.element(screen.getByText("My Post")).toBeInTheDocument();
+		expect(headerTexts(screen.container)).toEqual(CLASSIC_HEADERS);
+		expect(screen.container.querySelectorAll("tbody tr td").length).toBe(CLASSIC_HEADERS.length);
+	});
+
+	it("leaves no header, cell, or gap for inapplicable or role-gated columns", async () => {
+		currentUserState.role = 40;
+		const cell = () => <span>should-not-render</span>;
+		const registry: PluginAdmins = {
+			p: {
+				contentListColumns: [
+					{ id: "p:other-collection", label: "Elsewhere", collections: ["pages"], cell },
+					{ id: "p:admins-only", label: "Admins", minRole: 50, cell },
+				],
+			},
+		};
+		const screen = await render(<ContentList {...listProps} items={[makeItem()]} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByText("My Post")).toBeInTheDocument();
+		expect(headerTexts(screen.container)).toEqual(CLASSIC_HEADERS);
+		expect(screen.getByText("should-not-render").query()).toBeNull();
+		expect(screen.container.querySelectorAll("tbody tr td").length).toBe(CLASSIC_HEADERS.length);
+	});
+
+	it("isolates a throwing cell to a quiet placeholder without breaking the row", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const registry: PluginAdmins = {
+			p: {
+				contentListColumns: [
+					{
+						id: "p:broken",
+						label: "Broken",
+						cell: () => {
+							throw new Error("cell exploded");
+						},
+					},
+					{
+						id: "p:healthy",
+						label: "Healthy",
+						order: 1,
+						cell: ({ item }: ContentListColumnCellContext) => <span>ok-{item.id}</span>,
+					},
+				],
+			},
+		};
+		const screen = await render(<ContentList {...listProps} items={[makeItem({ id: "b1" })]} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		// The row itself and the healthy contribution survive.
+		await expect.element(screen.getByText("My Post")).toBeInTheDocument();
+		await expect.element(screen.getByText("ok-b1")).toBeInTheDocument();
+		// Table structure is preserved: header still announced, cell shows the
+		// accessible placeholder instead of collapsing.
+		expect(headerTexts(screen.container)).toEqual([
+			"Title",
+			"Status",
+			"Date",
+			"Broken",
+			"Healthy",
+			"Actions",
+		]);
+		await expect.element(screen.getByText("Extension failed to render")).toBeInTheDocument();
+		expect(consoleError).toHaveBeenCalled();
+		// The failure never leaks the error message into the UI.
+		expect(screen.container.textContent).not.toContain("cell exploded");
+	});
+
+	it("passes the typed read-only row context (collection, locale, saved item)", async () => {
+		const registry: PluginAdmins = {
+			p: {
+				contentListColumns: [
+					{
+						id: "p:ctx",
+						label: "Ctx",
+						cell: ({ collection, locale, item }: ContentListColumnCellContext) => (
+							<span>{`ctx:${collection}:${item.id}:${locale ?? "none"}:${String(item.data.title)}`}</span>
+						),
+					},
+				],
+			},
+		};
+		const screen = await render(
+			<ContentList {...listProps} items={[makeItem({ id: "c1" })]} activeLocale="ar" />,
+			{ wrapper: withPlugins(registry) },
+		);
+
+		await expect.element(screen.getByText("ctx:posts:c1:ar:My Post")).toBeInTheDocument();
+	});
+
+	it("shares one batched request across every cell instead of one per row", async () => {
+		const batchedFetch = vi.fn(async () => ({ value: "batched" }));
+		function BatchedCell({ collection }: ContentListColumnCellContext) {
+			// The documented pattern: one query key for the whole column;
+			// react-query hands every cell the same in-flight promise.
+			const { data } = useQuery({
+				queryKey: ["ext-batch", collection],
+				queryFn: batchedFetch,
+			});
+			return <span>{data ? `batch-${data.value}` : "batch-loading"}</span>;
+		}
+		const registry: PluginAdmins = {
+			p: { contentListColumns: [{ id: "p:batch", label: "Batch", cell: BatchedCell }] },
+		};
+		const items = [makeItem({ id: "r1" }), makeItem({ id: "r2" }), makeItem({ id: "r3" })];
+		const fetchSpy = vi.spyOn(window, "fetch");
+		const screen = await render(<ContentList {...listProps} items={items} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await vi.waitFor(() => {
+			expect(screen.container.textContent).toContain("batch-batched");
+		});
+		expect(screen.container.querySelectorAll("tbody tr").length).toBe(3);
+		// Three rows, one request — and the HOST issued no requests at all.
+		expect(batchedFetch).toHaveBeenCalledTimes(1);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("ContentSettingsPanel extension panels", () => {
+	function ctxPanel({ collection, entry, locale }: ContentEditorPanelContext) {
+		return (
+			<div data-testid="ext-panel">{`panel:${collection}:${entry.id}:${locale ?? "none"}`}</div>
+		);
+	}
+
+	it("renders a titled section for saved entries, above the trailing core sections", async () => {
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [{ id: "p:insights", title: "Editorial Status", panel: ctxPanel }],
+			},
+		};
+		const screen = await render(<ContentSettingsPanel {...panelProps()} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect
+			.element(screen.getByRole("heading", { name: "Editorial Status" }))
+			.toBeInTheDocument();
+		await expect.element(screen.getByText("panel:posts:item-1:en")).toBeInTheDocument();
+
+		// Deterministic placement: after the SEO section, before the outline —
+		// and Move to Trash stays the very last section.
+		const root = screen.container.firstElementChild;
+		const sections = [...(root?.children ?? [])];
+		const seoIndex = sections.findIndex((s) => s.querySelector('[data-testid="seo-panel"]'));
+		const extIndex = sections.findIndex((s) => s.querySelector('[data-testid="ext-panel"]'));
+		const outlineIndex = sections.findIndex((s) => s.querySelector('[data-testid="doc-outline"]'));
+		expect(seoIndex).toBeGreaterThan(-1);
+		expect(extIndex).toBe(seoIndex + 1);
+		expect(outlineIndex).toBe(extIndex + 1);
+		expect(root?.lastElementChild?.textContent).toContain("Move to Trash");
+		// Narrow-sidebar guard: the section must not force horizontal overflow.
+		expect(sections[extIndex]?.className).toContain("min-w-0");
+	});
+
+	it("renders nothing for new (never saved) entries", async () => {
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [{ id: "p:insights", title: "Editorial Status", panel: ctxPanel }],
+			},
+		};
+		const screen = await render(
+			<ContentSettingsPanel {...panelProps({ item: null, isNew: true })} />,
+			{ wrapper: withPlugins(registry) },
+		);
+
+		await expect.element(screen.getByRole("heading", { name: "Publish" })).toBeInTheDocument();
+		expect(screen.container.textContent).not.toContain("Editorial Status");
+	});
+
+	it("applies role and collection gates with no leftover section chrome", async () => {
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{ id: "p:admin-only", title: "Admins Only", minRole: 50, panel: ctxPanel },
+					{ id: "p:pages-only", title: "Pages Only", collections: ["pages"], panel: ctxPanel },
+				],
+			},
+		};
+		// currentUser prop is role 40 (Editor) — below the 50 gate.
+		const screen = await render(<ContentSettingsPanel {...panelProps()} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByRole("heading", { name: "Publish" })).toBeInTheDocument();
+		expect(screen.container.textContent).not.toContain("Admins Only");
+		expect(screen.container.textContent).not.toContain("Pages Only");
+		expect(screen.container.querySelector('[data-testid="ext-panel"]')).toBeNull();
+	});
+
+	it("isolates a throwing panel and keeps every other section alive", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{
+						id: "p:broken",
+						title: "Broken Panel",
+						panel: () => {
+							throw new Error("panel exploded");
+						},
+					},
+					{ id: "p:working", title: "Working Panel", order: 1, panel: ctxPanel },
+				],
+			},
+		};
+		const screen = await render(<ContentSettingsPanel {...panelProps()} />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByText("This extension failed to render.")).toBeInTheDocument();
+		// The retry action carries the panel title (screen-reader-only), so two
+		// broken panels never produce indistinguishable "Retry" buttons.
+		await expect
+			.element(screen.getByRole("button", { name: "Retry Broken Panel" }))
+			.toBeInTheDocument();
+		// The broken panel's own heading stays identifiable; siblings survive.
+		await expect.element(screen.getByRole("heading", { name: "Broken Panel" })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("heading", { name: "Working Panel" }))
+			.toBeInTheDocument();
+		await expect.element(screen.getByRole("heading", { name: "Publish" })).toBeInTheDocument();
+		expect(consoleError).toHaveBeenCalled();
+		expect(screen.container.textContent).not.toContain("panel exploded");
+	});
+});
+
+describe("trusted-registry boundary", () => {
+	it("consumes contributions only from the typed native registry fields", async () => {
+		// A sandboxed plugin is never present in pluginAdmins (core rejects
+		// `adminEntry` for non-native formats at config time), and manifest
+		// metadata offers no React path: anything outside the typed fields
+		// is ignored even if smuggled into the registry object.
+		const smuggled = {
+			p: {
+				adminPages: [{ path: "/x", label: "X" }],
+				blocks: [{ kind: "html", html: "<script>alert(1)</script>" }],
+				columns: [{ id: "p:nope", label: "Nope", cell: () => <span>nope</span> }],
+			},
+		} as unknown as PluginAdmins;
+
+		const screen = await render(<ContentList {...listProps} items={[makeItem()]} />, {
+			wrapper: withPlugins(smuggled),
+		});
+
+		await expect.element(screen.getByText("My Post")).toBeInTheDocument();
+		expect(headerTexts(screen.container)).toEqual(CLASSIC_HEADERS);
+		expect(screen.container.textContent).not.toContain("nope");
+	});
+
+	it("renders the classic list without any provider at all", async () => {
+		const screen = await render(<ContentList {...listProps} items={[makeItem()]} />);
+		await expect.element(screen.getByText("My Post")).toBeInTheDocument();
+		expect(headerTexts(screen.container)).toEqual(CLASSIC_HEADERS);
+	});
+});
+
+describe("plugin lifecycle", () => {
+	it("drops a disabled plugin's columns and panels like every other admin surface", async () => {
+		manifestState.disabledPluginIds = ["paused"];
+		const registry: PluginAdmins = {
+			paused: {
+				contentListColumns: [
+					{ id: "paused:col", label: "Paused Column", cell: () => <span>paused-cell</span> },
+				],
+				contentEditorPanels: [
+					{ id: "paused:panel", title: "Paused Panel", panel: () => <div>paused-panel</div> },
+				],
+			},
+			running: {
+				contentListColumns: [
+					{ id: "running:col", label: "Running Column", cell: () => <span>running-cell</span> },
+				],
+			},
+		};
+
+		const list = await render(<ContentList {...listProps} items={[makeItem()]} />, {
+			wrapper: withPlugins(registry),
+		});
+		await expect.element(list.getByText("running-cell")).toBeInTheDocument();
+		expect(headerTexts(list.container)).toEqual([
+			"Title",
+			"Status",
+			"Date",
+			"Running Column",
+			"Actions",
+		]);
+		expect(list.container.textContent).not.toContain("paused-cell");
+
+		await list.unmount();
+
+		const panel = await render(<ContentSettingsPanel {...panelProps()} />, {
+			wrapper: withPlugins(registry),
+		});
+		await expect.element(panel.getByRole("heading", { name: "Publish" })).toBeInTheDocument();
+		expect(panel.container.textContent).not.toContain("Paused Panel");
+		expect(panel.container.textContent).not.toContain("paused-panel");
+	});
+});

--- a/packages/admin/tests/components/AdminContentExtensions.test.tsx
+++ b/packages/admin/tests/components/AdminContentExtensions.test.tsx
@@ -420,7 +420,9 @@ describe("ContentSettingsPanel extension panels", () => {
 		await expect.element(screen.getByText("panel:posts:item-1:en:My Post")).toBeInTheDocument();
 
 		// Deterministic placement: after the SEO section, before the outline —
-		// and Move to Trash stays the very last section.
+		// and Move to Trash stays the very last section. DndContext inserts
+		// screen-reader helper nodes between sortable content and later sections,
+		// so assert semantic order rather than direct DOM adjacency there.
 		const root = screen.container.firstElementChild;
 		const sections = [...(root?.children ?? [])];
 		const seoIndex = sections.findIndex((s) => s.querySelector('[data-testid="seo-panel"]'));
@@ -428,7 +430,7 @@ describe("ContentSettingsPanel extension panels", () => {
 		const outlineIndex = sections.findIndex((s) => s.querySelector('[data-testid="doc-outline"]'));
 		expect(seoIndex).toBeGreaterThan(-1);
 		expect(extIndex).toBe(seoIndex + 1);
-		expect(outlineIndex).toBe(extIndex + 1);
+		expect(outlineIndex).toBeGreaterThan(extIndex);
 		expect(root?.lastElementChild?.textContent).toContain("Move to Trash");
 		// Narrow-sidebar guard: the section must not force horizontal overflow.
 		expect(sections[extIndex]?.className).toContain("min-w-0");
@@ -453,6 +455,180 @@ describe("ContentSettingsPanel extension panels", () => {
 			.element(screen.getByRole("heading", { name: "Editorial Status" }))
 			.toBeInTheDocument();
 		await expect.element(screen.getByText("panel:posts:new:nl:Draft")).toBeInTheDocument();
+	});
+
+	it("lets a trusted plugin replace the native SEO body without duplicating section chrome", async () => {
+		function SeoReplacement() {
+			return <div data-testid="seo-replacement">Advanced SEO workspace</div>;
+		}
+		function LaterReplacement() {
+			return <div data-testid="seo-later-replacement">Later replacement</div>;
+		}
+		function SeoAppend() {
+			return <div data-testid="seo-append">SEO helper</div>;
+		}
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{
+						id: "p:seo",
+						title: "Advanced SEO",
+						order: 10,
+						slot: "seo",
+						mode: "replace",
+						panel: SeoReplacement,
+					},
+					{
+						id: "p:seo-helper",
+						title: "SEO helper",
+						order: 20,
+						slot: "seo",
+						mode: "append",
+						panel: SeoAppend,
+					},
+					{
+						id: "p:seo-later",
+						title: "Later SEO",
+						order: 30,
+						slot: "seo",
+						mode: "replace",
+						panel: LaterReplacement,
+					},
+				],
+			},
+		};
+		const screen = await render(<HostedSettingsPanel />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByRole("heading", { name: "SEO" })).toBeInTheDocument();
+		await expect.element(screen.getByTestId("seo-replacement")).toBeInTheDocument();
+		await expect.element(screen.getByTestId("seo-append")).toBeInTheDocument();
+		expect(screen.container.querySelector('[data-testid="seo-panel"]')).toBeNull();
+		expect(screen.container.querySelector('[data-testid="seo-later-replacement"]')).toBeNull();
+	});
+
+	it("falls back to the native SEO body when a replacement fails", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		function BrokenSeoReplacement(): React.ReactNode {
+			throw new Error("broken replacement");
+		}
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{
+						id: "p:seo",
+						title: "Broken SEO",
+						slot: "seo",
+						mode: "replace",
+						panel: BrokenSeoReplacement,
+					},
+				],
+			},
+		};
+		const screen = await render(<HostedSettingsPanel />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByTestId("seo-panel")).toBeInTheDocument();
+		expect(consoleError).toHaveBeenCalled();
+	});
+
+	it("keeps the native SEO body when a replacement plugin is disabled", async () => {
+		function SeoReplacement() {
+			return <div data-testid="seo-replacement">Advanced SEO workspace</div>;
+		}
+		manifestState.disabledPluginIds = ["p"];
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{
+						id: "p:seo",
+						title: "Advanced SEO",
+						slot: "seo",
+						mode: "replace",
+						panel: SeoReplacement,
+					},
+				],
+			},
+		};
+		const screen = await render(<HostedSettingsPanel />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByTestId("seo-panel")).toBeInTheDocument();
+		expect(screen.container.querySelector('[data-testid="seo-replacement"]')).toBeNull();
+	});
+
+	it("keeps the native SEO body when a replacement does not apply to the collection", async () => {
+		function SeoReplacement() {
+			return <div data-testid="seo-replacement">Advanced SEO workspace</div>;
+		}
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{
+						id: "p:seo",
+						title: "Advanced SEO",
+						collections: ["pages"],
+						slot: "seo",
+						mode: "replace",
+						panel: SeoReplacement,
+					},
+				],
+			},
+		};
+		const screen = await render(<HostedSettingsPanel />, {
+			wrapper: withPlugins(registry),
+		});
+
+		await expect.element(screen.getByTestId("seo-panel")).toBeInTheDocument();
+		expect(screen.container.querySelector('[data-testid="seo-replacement"]')).toBeNull();
+	});
+
+	it("preserves named-slot panel state while the host draft context updates", async () => {
+		function StatefulSeoReplacement({ draft }: ContentEditorPanelContext) {
+			const [editing, setEditing] = React.useState(false);
+			return (
+				<div>
+					<button type="button" onClick={() => setEditing((current) => !current)}>
+						{editing ? "Close snippet editor" : "Edit snippet"}
+					</button>
+					<span data-testid="draft-title">{String(draft.data.title)}</span>
+				</div>
+			);
+		}
+		const registry: PluginAdmins = {
+			p: {
+				contentEditorPanels: [
+					{
+						id: "p:seo",
+						title: "Advanced SEO",
+						slot: "seo",
+						mode: "replace",
+						panel: StatefulSeoReplacement,
+					},
+				],
+			},
+		};
+		const screen = await render(
+			<HostedSettingsPanel draftData={{ title: "Initial title" }} />,
+			{ wrapper: withPlugins(registry) },
+		);
+
+		await screen.getByRole("button", { name: "Edit snippet" }).click();
+		await expect
+			.element(screen.getByRole("button", { name: "Close snippet editor" }))
+			.toBeInTheDocument();
+
+		await screen.rerender(
+			<HostedSettingsPanel draftData={{ title: "Updated title" }} />,
+		);
+
+		await expect
+			.element(screen.getByRole("button", { name: "Close snippet editor" }))
+			.toBeInTheDocument();
+		await expect.element(screen.getByTestId("draft-title")).toHaveTextContent("Updated title");
 	});
 
 	it("places wide panels in the main editor while keeping sidebar panels in settings", async () => {

--- a/packages/admin/tests/components/AdminContentExtensions.test.tsx
+++ b/packages/admin/tests/components/AdminContentExtensions.test.tsx
@@ -611,19 +611,16 @@ describe("ContentSettingsPanel extension panels", () => {
 				],
 			},
 		};
-		const screen = await render(
-			<HostedSettingsPanel draftData={{ title: "Initial title" }} />,
-			{ wrapper: withPlugins(registry) },
-		);
+		const screen = await render(<HostedSettingsPanel draftData={{ title: "Initial title" }} />, {
+			wrapper: withPlugins(registry),
+		});
 
 		await screen.getByRole("button", { name: "Edit snippet" }).click();
 		await expect
 			.element(screen.getByRole("button", { name: "Close snippet editor" }))
 			.toBeInTheDocument();
 
-		await screen.rerender(
-			<HostedSettingsPanel draftData={{ title: "Updated title" }} />,
-		);
+		await screen.rerender(<HostedSettingsPanel draftData={{ title: "Updated title" }} />);
 
 		await expect
 			.element(screen.getByRole("button", { name: "Close snippet editor" }))

--- a/packages/admin/tests/lib/admin-editor-panel-layout.test.ts
+++ b/packages/admin/tests/lib/admin-editor-panel-layout.test.ts
@@ -4,6 +4,7 @@ import {
 	moveContentEditorPanel,
 	parseContentEditorPanelLayout,
 	placeContentEditorPanel,
+	reorderContentEditorPanel,
 	resolveContentEditorPanelLayout,
 	type ContentEditorPanelLayout,
 } from "../../src/lib/admin-editor-panel-layout";
@@ -65,5 +66,12 @@ describe("panel layout moves", () => {
 		expect(placeContentEditorPanel(layout(["a", "b"], ["c"]), "a", "sidebar")).toEqual(
 			layout(["b"], ["c", "a"]),
 		);
+	});
+
+	it("reorders panels from a drag target without crossing surfaces", () => {
+		const start = layout(["a", "b", "c"], ["side"]);
+		expect(reorderContentEditorPanel(start, "c", "a")).toEqual(layout(["c", "a", "b"], ["side"]));
+		expect(reorderContentEditorPanel(start, "a", "side")).toBe(start);
+		expect(reorderContentEditorPanel(start, "missing", "a")).toBe(start);
 	});
 });

--- a/packages/admin/tests/lib/admin-editor-panel-layout.test.ts
+++ b/packages/admin/tests/lib/admin-editor-panel-layout.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	moveContentEditorPanel,
+	parseContentEditorPanelLayout,
+	placeContentEditorPanel,
+	resolveContentEditorPanelLayout,
+	type ContentEditorPanelLayout,
+} from "../../src/lib/admin-editor-panel-layout";
+import type { ContentEditorPanelExtension } from "../../src/lib/admin-extensions";
+
+const Panel = () => null;
+
+function panel(
+	id: string,
+	placement?: ContentEditorPanelExtension["placement"],
+): ContentEditorPanelExtension {
+	return { id, title: id, placement, panel: Panel };
+}
+
+const layout = (main: string[], sidebar: string[]): ContentEditorPanelLayout => ({
+	version: 1,
+	main,
+	sidebar,
+});
+
+describe("parseContentEditorPanelLayout", () => {
+	it("accepts the current version and rejects malformed browser data", () => {
+		expect(parseContentEditorPanelLayout(JSON.stringify(layout(["a"], ["b"])))).toEqual(
+			layout(["a"], ["b"]),
+		);
+		expect(parseContentEditorPanelLayout("not-json")).toBeNull();
+		expect(parseContentEditorPanelLayout('{"version":2,"main":[],"sidebar":[]}')).toBeNull();
+		expect(parseContentEditorPanelLayout('{"version":1,"main":[2],"sidebar":[]}')).toBeNull();
+	});
+});
+
+describe("resolveContentEditorPanelLayout", () => {
+	it("uses declared defaults when no preference exists", () => {
+		expect(resolveContentEditorPanelLayout([panel("side"), panel("wide", "main")], null)).toEqual(
+			layout(["wide"], ["side"]),
+		);
+	});
+
+	it("preserves user order, drops stale/duplicate ids, and appends new panels", () => {
+		const stored = layout(["b", "stale", "a"], ["a", "c"]);
+		expect(
+			resolveContentEditorPanelLayout(
+				[panel("a"), panel("b", "main"), panel("c"), panel("new", "main")],
+				stored,
+			),
+		).toEqual(layout(["b", "a", "new"], ["c"]));
+	});
+});
+
+describe("panel layout moves", () => {
+	it("moves within a surface without crossing its boundaries", () => {
+		const start = layout(["a", "b"], ["c"]);
+		expect(moveContentEditorPanel(start, "b", "up")).toEqual(layout(["b", "a"], ["c"]));
+		expect(moveContentEditorPanel(start, "a", "up")).toBe(start);
+		expect(moveContentEditorPanel(start, "missing", "down")).toBe(start);
+	});
+
+	it("moves a panel between surfaces and appends it to the destination", () => {
+		expect(placeContentEditorPanel(layout(["a", "b"], ["c"]), "a", "sidebar")).toEqual(
+			layout(["b"], ["c", "a"]),
+		);
+	});
+});

--- a/packages/admin/tests/lib/admin-extensions.test.ts
+++ b/packages/admin/tests/lib/admin-extensions.test.ts
@@ -255,6 +255,42 @@ describe("zero extensions and malformed contributions", () => {
 		]);
 		expect(consoleWarn).toHaveBeenCalledTimes(5);
 	});
+
+	it("accepts React memo, forwardRef, and lazy component forms", () => {
+		const MemoPanel = React.memo(() => null);
+		const ForwardPanel = React.forwardRef<HTMLDivElement>(() => null);
+		const LazyPanel = React.lazy(async () => ({ default: () => null }));
+		const registry = source({
+			p: {
+				contentEditorPanels: [
+					panel({ id: "p:memo", panel: MemoPanel }),
+					panel({ id: "p:forward", panel: ForwardPanel }),
+					panel({ id: "p:lazy", panel: LazyPanel }),
+				],
+			},
+		});
+
+		expect(selectContentEditorPanels(registry, posts).map((item) => item.id)).toEqual([
+			"p:forward",
+			"p:lazy",
+			"p:memo",
+		]);
+	});
+
+	it("rejects an invalid editor panel placement", () => {
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const registry = source({
+			p: {
+				contentEditorPanels: [
+					panel({ id: "p:bad", placement: "drawer" as "sidebar" }),
+					panel({ id: "p:good", placement: "main" }),
+				],
+			},
+		});
+
+		expect(selectContentEditorPanels(registry, posts).map((item) => item.id)).toEqual(["p:good"]);
+		expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("placement"));
+	});
 });
 
 describe("disabled plugins", () => {

--- a/packages/admin/tests/lib/admin-extensions.test.ts
+++ b/packages/admin/tests/lib/admin-extensions.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Admin extension selection — the registration contract.
+ *
+ * These pin the pure semantics both host surfaces (content list, editor
+ * sidebar) rely on: deterministic ordering independent of registration
+ * order, first-wins duplicate handling (never silent overwrite), collection
+ * and role filtering, fault isolation for throwing predicates, and the
+ * zero-extension no-op guarantee. No DOM — rendering is covered in
+ * tests/components/AdminContentExtensions.test.tsx.
+ */
+
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	selectContentEditorPanels,
+	selectContentListColumns,
+	type AdminExtensionSource,
+	type ContentEditorPanelExtension,
+	type ContentListColumnExtension,
+} from "../../src/lib/admin-extensions";
+
+const ROLE_EDITOR = 40;
+const ROLE_ADMIN = 50;
+
+const Noop: React.ComponentType<never> = () => null;
+
+function column(overrides: Partial<ContentListColumnExtension> & { id: string }) {
+	return { label: overrides.id, cell: Noop, ...overrides } as ContentListColumnExtension;
+}
+
+function panel(overrides: Partial<ContentEditorPanelExtension> & { id: string }) {
+	return { title: overrides.id, panel: Noop, ...overrides } as ContentEditorPanelExtension;
+}
+
+function source(modules: AdminExtensionSource): AdminExtensionSource {
+	return modules;
+}
+
+const posts = { collection: "posts", userRole: ROLE_ADMIN };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("selectContentListColumns ordering", () => {
+	it("orders by (order, id) regardless of plugin registration order", () => {
+		const registry = source({
+			// Intentionally registered in non-alphabetical plugin order.
+			zeta: { contentListColumns: [column({ id: "zeta:one", order: 1 })] },
+			alpha: {
+				contentListColumns: [
+					column({ id: "alpha:last", order: 10 }),
+					column({ id: "alpha:first", order: -5 }),
+				],
+			},
+			midway: { contentListColumns: [column({ id: "midway:tie", order: 1 })] },
+		});
+
+		expect(selectContentListColumns(registry, posts).map((c) => c.id)).toEqual([
+			"alpha:first",
+			"midway:tie", // order 1 tie broken by id: "midway:tie" < "zeta:one"
+			"zeta:one",
+			"alpha:last",
+		]);
+	});
+
+	it("defaults order to 0 and breaks ties by id", () => {
+		const registry = source({
+			p: { contentListColumns: [column({ id: "p:b" }), column({ id: "p:a" })] },
+		});
+		expect(selectContentListColumns(registry, posts).map((c) => c.id)).toEqual(["p:a", "p:b"]);
+	});
+});
+
+describe("collection applicability", () => {
+	it("filters by collection list and predicate, keeping unrestricted columns", () => {
+		const registry = source({
+			p: {
+				contentListColumns: [
+					column({ id: "p:everywhere" }),
+					column({ id: "p:posts-only", collections: ["posts"] }),
+					column({ id: "p:pages-only", collections: ["pages"] }),
+					column({ id: "p:predicate", collections: (slug) => slug.startsWith("po") }),
+				],
+			},
+		});
+
+		expect(selectContentListColumns(registry, posts).map((c) => c.id)).toEqual([
+			"p:everywhere",
+			"p:posts-only",
+			"p:predicate",
+		]);
+		expect(
+			selectContentListColumns(registry, { ...posts, collection: "pages" }).map((c) => c.id),
+		).toEqual(["p:everywhere", "p:pages-only"]);
+	});
+
+	it("treats a throwing predicate as not applicable without dropping others", () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const registry = source({
+			p: {
+				contentListColumns: [
+					column({
+						id: "p:broken",
+						collections: () => {
+							throw new Error("boom");
+						},
+					}),
+					column({ id: "p:fine" }),
+				],
+			},
+		});
+
+		expect(selectContentListColumns(registry, posts).map((c) => c.id)).toEqual(["p:fine"]);
+		expect(consoleError).toHaveBeenCalledOnce();
+	});
+});
+
+describe("permission (minRole) filtering", () => {
+	it("hides gated contributions below the required role", () => {
+		const registry = source({
+			p: {
+				contentEditorPanels: [
+					panel({ id: "p:any" }),
+					panel({ id: "p:editor", minRole: ROLE_EDITOR }),
+					panel({ id: "p:admin", minRole: ROLE_ADMIN }),
+				],
+			},
+		});
+
+		const ids = (role: number) =>
+			selectContentEditorPanels(registry, { collection: "posts", userRole: role }).map((p) => p.id);
+
+		expect(ids(0)).toEqual(["p:any"]);
+		expect(ids(ROLE_EDITOR)).toEqual(["p:any", "p:editor"]);
+		expect(ids(ROLE_ADMIN)).toEqual(["p:admin", "p:any", "p:editor"]);
+	});
+});
+
+describe("duplicate ids", () => {
+	it("keeps the first occurrence in sorted plugin order and warns — never silently overwrites", () => {
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const winner = vi.fn(() => null);
+		const loser = vi.fn(() => null);
+		const registry = source({
+			// "abc" sorts before "xyz", so abc's contribution must win even
+			// though "xyz" appears first in the object literal.
+			xyz: { contentListColumns: [column({ id: "shared:score", cell: loser })] },
+			abc: { contentListColumns: [column({ id: "shared:score", cell: winner })] },
+		});
+
+		const selected = selectContentListColumns(registry, posts);
+		expect(selected).toHaveLength(1);
+		expect(selected[0]?.cell).toBe(winner);
+		expect(consoleWarn).toHaveBeenCalledWith(
+			expect.stringContaining('Duplicate extension id "shared:score" from plugin "xyz"'),
+		);
+	});
+
+	it("deduplicates per slot: a column and a panel may share an id", () => {
+		const registry = source({
+			p: {
+				contentListColumns: [column({ id: "p:thing" })],
+				contentEditorPanels: [panel({ id: "p:thing" })],
+			},
+		});
+		expect(selectContentListColumns(registry, posts)).toHaveLength(1);
+		expect(selectContentEditorPanels(registry, posts)).toHaveLength(1);
+	});
+});
+
+describe("zero extensions and malformed contributions", () => {
+	it("returns an empty list for an empty registry and for modules without contributions", () => {
+		expect(selectContentListColumns({}, posts)).toEqual([]);
+		expect(selectContentEditorPanels(source({ p: {} }), posts)).toEqual([]);
+	});
+
+	it("skips malformed entries with a warning instead of failing the slot", () => {
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		// Deliberately malformed runtime data, as an untyped plugin build could produce.
+		const registry = source({
+			p: {
+				contentListColumns: [
+					{ label: "No id", cell: Noop } as ContentListColumnExtension,
+					{
+						id: "p:not-a-component",
+						label: "x",
+						cell: "nope",
+					} as unknown as ContentListColumnExtension,
+					column({ id: "p:valid" }),
+				],
+			},
+		});
+
+		expect(selectContentListColumns(registry, posts).map((c) => c.id)).toEqual(["p:valid"]);
+		expect(consoleWarn).toHaveBeenCalledTimes(2);
+	});
+
+	it("ignores a non-array contributions export instead of crashing the host screen", () => {
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		// An untyped build can export the wrong container shape entirely.
+		const registry = source({
+			broken: {
+				contentListColumns: { id: "broken:x", label: "x", cell: Noop },
+			} as unknown as AdminExtensionSource[string],
+			fine: { contentListColumns: [column({ id: "fine:ok" })] },
+		});
+
+		expect(selectContentListColumns(registry, posts).map((c) => c.id)).toEqual(["fine:ok"]);
+		expect(consoleWarn).toHaveBeenCalledWith(
+			expect.stringContaining('contributions from plugin "broken"'),
+		);
+	});
+
+	it("drops invalid metadata before it can break selection or host rendering", () => {
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const registry = source({
+			p: {
+				contentListColumns: [
+					{
+						id: "p:bad-collections",
+						label: "Bad collections",
+						cell: Noop,
+						collections: {},
+					} as unknown as ContentListColumnExtension,
+					{
+						id: "p:bad-label",
+						label: {},
+						cell: Noop,
+					} as unknown as ContentListColumnExtension,
+					column({ id: "p:bad-order", order: Number.NaN }),
+					{
+						id: "p:bad-header",
+						label: "Bad header",
+						cell: Noop,
+						header: "not-a-component",
+					} as unknown as ContentListColumnExtension,
+					column({ id: "p:valid" }),
+				],
+				contentEditorPanels: [
+					{
+						id: "p:bad-title",
+						title: {},
+						panel: Noop,
+					} as unknown as ContentEditorPanelExtension,
+					panel({ id: "p:valid-panel" }),
+				],
+			},
+		});
+
+		expect(selectContentListColumns(registry, posts).map((item) => item.id)).toEqual(["p:valid"]);
+		expect(selectContentEditorPanels(registry, posts).map((item) => item.id)).toEqual([
+			"p:valid-panel",
+		]);
+		expect(consoleWarn).toHaveBeenCalledTimes(5);
+	});
+});
+
+describe("disabled plugins", () => {
+	it("skips every contribution from a disabled plugin", () => {
+		const registry = source({
+			active: { contentListColumns: [column({ id: "active:col" })] },
+			paused: {
+				contentListColumns: [column({ id: "paused:col" })],
+				contentEditorPanels: [panel({ id: "paused:panel" })],
+			},
+		});
+		const options = { ...posts, disabledPluginIds: new Set(["paused"]) };
+
+		expect(selectContentListColumns(registry, options).map((c) => c.id)).toEqual(["active:col"]);
+		expect(selectContentEditorPanels(registry, options)).toEqual([]);
+	});
+
+	it("lets a duplicate id fall to the next plugin when the first owner is disabled", () => {
+		const registry = source({
+			aaa: { contentListColumns: [column({ id: "shared" })] },
+			zzz: { contentListColumns: [column({ id: "shared", order: 5 })] },
+		});
+		const selected = selectContentListColumns(registry, {
+			...posts,
+			disabledPluginIds: new Set(["aaa"]),
+		});
+		expect(selected).toHaveLength(1);
+		expect(selected[0]?.order).toBe(5);
+	});
+});

--- a/packages/admin/tests/lib/admin-extensions.test.ts
+++ b/packages/admin/tests/lib/admin-extensions.test.ts
@@ -291,6 +291,26 @@ describe("zero extensions and malformed contributions", () => {
 		expect(selectContentEditorPanels(registry, posts).map((item) => item.id)).toEqual(["p:good"]);
 		expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("placement"));
 	});
+
+	it("accepts named editor slots and rejects conflicting panel options", () => {
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const registry = source({
+			p: {
+				contentEditorPanels: [
+					panel({ id: "p:seo", slot: "seo", mode: "replace" }),
+					panel({ id: "p:bad-slot", slot: "publish" as "seo" }),
+					panel({ id: "p:bad-mode", slot: "seo", mode: "takeover" as "replace" }),
+					panel({ id: "p:bad-placement", slot: "seo", placement: "sidebar" }),
+					panel({ id: "p:bad-panel-mode", mode: "replace" }),
+				],
+			},
+		});
+
+		expect(selectContentEditorPanels(registry, posts).map((item) => item.id)).toEqual(["p:seo"]);
+		expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("slot"));
+		expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("mode"));
+		expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining("named slots"));
+	});
 });
 
 describe("disabled plugins", () => {

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -173,10 +173,12 @@ declare module "virtual:emdash/admin-registry" {
 	/**
 	 * Plugin admin module registry.
 	 * Each entry is the namespace import of the plugin's admin entry module.
-	 * Convention for exports:
+	 * Convention for exports (contribution types live in `@emdash-cms/admin`):
 	 *   - pages: Record<pageId, ComponentType>
 	 *   - widgets: Record<widgetId, ComponentType>
 	 *   - fields: Record<widgetName, ComponentType> (field widget renderers)
+	 *   - contentListColumns: ContentListColumnExtension[]
+	 *   - contentEditorPanels: ContentEditorPanelExtension[]
 	 */
 	export const pluginAdmins: Record<
 		string,
@@ -184,6 +186,8 @@ declare module "virtual:emdash/admin-registry" {
 			pages?: Record<string, unknown>;
 			widgets?: Record<string, unknown>;
 			fields?: Record<string, unknown>;
+			contentListColumns?: unknown[];
+			contentEditorPanels?: unknown[];
 		}
 	>;
 }


### PR DESCRIPTION
## What does this PR do?

Adds a typed trusted-native extension contract for content lists and the content editor. Native plugins can contribute isolated list columns, movable main/sidebar panels, and named host-owned slots without DOM injection or duplicated core chrome.

The first named slot is the core SEO panel body. A plugin may append to or replace that body while EmDash keeps the section heading and placement. If the plugin is disabled, does not apply, or throws, the native SEO body renders automatically. Panel ordering remains host-owned per user and collection, with pointer and keyboard controls.

Discussion: https://github.com/emdash-cms/emdash/discussions/2105

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/2105

## AI-generated code disclosure

- [ ] This PR includes AI-generated code — model/tool:

## Screenshots / test output

- Focused admin extension regressions: 43 tests passed
- Complete admin browser suite: 95 files / 1,185 tests passed
- Direct admin typecheck passed
- Production admin package build passed
- GitHub Format, CodeQL, CLA, preview-release, and security checks passed
