### PR TITLE
i18n(sv): add Swedish translations

### DIFF
--- a/.changeset/swedish-admin-locale.md
+++ b/.changeset/swedish-admin-locale.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds Swedish (Svenska) translations for the admin UI.

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -51,6 +51,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 	{ code: "es-419", label: "Español (Latinoamérica)", enabled: true }, // Spanish (Latin America)
 	{ code: "es-ES", label: "Español (España)", enabled: true }, // Spanish (Spain) - BCP 47
+	{ code: "sv", label: "Svenska", enabled: true }, // Swedish
 	{ code: "th", label: "ไทย", enabled: true }, // Thai
 	{ code: "tr", label: "Türkçe", enabled: true }, // Turkish
 	// Pseudo-locale for i18n testing - never enabled in the admin UI by default.

--- a/packages/admin/src/locales/sv/messages.po
+++ b/packages/admin/src/locales/sv/messages.po
@@ -1,0 +1,8587 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-07-18 00:00+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: sv\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: packages/admin/src/routes/bylines.tsx:447
+msgid " - Guest"
+msgstr " - Gäst"
+
+#: packages/admin/src/routes/bylines.tsx:447
+msgid " - Linked"
+msgstr " - Länkad"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:81
+msgid " (default)"
+msgstr " (standard)"
+
+#: packages/admin/src/components/MenuEditor.tsx:521
+msgid " (opens in new window)"
+msgstr " (öppnas i nytt fönster)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:802
+#: packages/admin/src/components/MediaPickerModal.tsx:885
+msgid " (selected)"
+msgstr " (vald)"
+
+#: packages/admin/src/routes/bylines.tsx:707
+msgid "-- Select --"
+msgstr "-- Välj --"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", eller öppna administratörsgränssnittet på"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": använd"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:736
+msgid "(from {0})"
+msgstr "(från {0})"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:520
+msgid "(pre-release)"
+msgstr "(förhandsversion)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:156
+msgid "(synced)"
+msgstr "(synkroniserad)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:523
+msgid "(too new)"
+msgstr "(för ny)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(med din utvecklingsport)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# objekt)} other {(# objekt)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# samling} other {# samlingar}}"
+
+#. placeholder {0}: result.comments.imported
+#: packages/admin/src/components/WordPressImport.tsx:2263
+msgid "{0, plural, one {# comment imported} other {# comments imported}}"
+msgstr "{0, plural, one {# kommentar importerad} other {# kommentarer importerade}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1464
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr "{0, plural, one {# kommentar uppdaterad} other {# kommentarer uppdaterade}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:344
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# kommentar} other {# kommentarer}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2274
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {# innehållsfel} other {# innehållsfel}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {# innehållsobjekt importerat} other {# innehållsobjekt importerade}}"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:587
+#: packages/admin/src/components/MenuList.tsx:217
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# objekt} other {# objekt}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {# mediefel} other {# mediefel}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2231
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {# mediefil importerad} other {# mediefiler importerade}}"
+
+#. placeholder {0}: result.menus.created
+#: packages/admin/src/components/WordPressImport.tsx:2255
+msgid "{0, plural, one {# menu imported} other {# menus imported}}"
+msgstr "{0, plural, one {# meny importerad} other {# menyer importerade}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1903
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {# meny kommer att importeras} other {# menyer kommer att importeras}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:399
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# behörighet} other {# behörigheter}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2486
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# inlägg} other {# inlägg}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:444
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {# omdirigering ingår i en loop.} other {# omdirigeringar ingår i en loop.}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:228
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {# vald} other {# valda}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2223
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {# överhoppad (finns redan)} other {# överhoppade (finns redan)}}"
+
+#. placeholder {0}: result.taxonomyAssignments
+#: packages/admin/src/components/WordPressImport.tsx:2247
+msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
+msgstr "{0, plural, one {# taxonomitilldelning} other {# taxonomitilldelningar}}"
+
+#. placeholder {0}: result.taxonomiesCreated.length
+#: packages/admin/src/components/WordPressImport.tsx:2239
+msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
+msgstr "{0, plural, one {# taxonomi skapad} other {# taxonomier skapade}}"
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:585
+msgid "{0, plural, one {field} other {fields}}"
+msgstr "{0, plural, one {fält} other {fält}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:160
+msgid "{0, plural, one {Media file} other {Media files}}"
+msgstr "{0, plural, one {Mediefil} other {Mediefiler}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:165
+msgid "{0, plural, one {User} other {Users}}"
+msgstr "{0, plural, one {Användare} other {Användare}}"
+
+#. placeholder {0}: envLabel(m.key)
+#. placeholder {1}: m.required
+#. placeholder {2}: m.host
+#: packages/admin/src/components/RegistryPluginDetail.tsx:623
+msgid "{0} {1} required — you have {2}."
+msgstr "{0} {1} krävs – du har {2}."
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:215
+msgid "{0} • {1}"
+msgstr "{0} • {1}"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:412
+msgid "{0} banner"
+msgstr "{0}-banner"
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1303
+msgid "{0} detected"
+msgstr "{0} upptäckt"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:111
+msgid "{0} has been deactivated"
+msgstr "{0} har inaktiverats"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:306
+msgid "{0} has been removed"
+msgstr "{0} har tagits bort"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:424
+msgid "{0} icon"
+msgstr "{0}-ikon"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:202
+msgid "{0} installs"
+msgstr "{0} installationer"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:92
+msgid "{0} is now active"
+msgstr "{0} är nu aktiv"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1973
+msgid "{0} items → {1}"
+msgstr "{0} objekt → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "{0} items will be imported"
+msgstr "{0} objekt kommer att importeras"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:534
+msgid "{0} of {total} could not be deleted"
+msgstr "{0} av {total} kunde inte tas bort"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:490
+msgid "{0} of {total} could not be published"
+msgstr "{0} av {total} kunde inte publiceras"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:513
+msgid "{0} of {total} could not be updated"
+msgstr "{0} av {total} kunde inte uppdateras"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "{0} plugins"
+msgstr "{0} tillägg"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:206
+msgid "{0} preview"
+msgstr "{0}-förhandsgranskning"
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:583
+msgid "{0} system + {1} custom {2}"
+msgstr "{0} system + {1} anpassade {2}"
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:347
+msgid "{0} updated"
+msgstr "{0} uppdaterad"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "{0} updated to v{1}"
+msgstr "{0} uppdaterad till v{1}"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:802
+#: packages/admin/src/components/MediaPickerModal.tsx:885
+msgid "{0}{1}"
+msgstr "{0}{1}"
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:195
+msgid "{0}/160 characters"
+msgstr "{0}/160 tecken"
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:256
+msgid "{base} to: {0}"
+msgstr "{base} till: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:345
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# ändring från nästa revision} other {# ändringar från nästa revision}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# fil} other {# filer}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# objekt} other {# objekt}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "{current} of {total}"
+msgstr "{current} av {total}"
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:933
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr "{filteredCount, plural, one {#{0} objekt} other {#{1} objekt}}"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — ingen översättning"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — visa översättning"
+
+#: packages/admin/src/components/ContentList.tsx:922
+msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{matchCount, plural, one {# objekt matchar \"{searchQuery}\"} other {# objekt matchar \"{searchQuery}\"}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2473
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "{matchedCount} av {totalCount} tilldelade"
+
+#: packages/admin/src/components/WordPressImport.tsx:2461
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "{matchedCount} av {totalCount} författare matchade via e-post"
+
+#: packages/admin/src/components/WordPressImport.tsx:1879
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {# ny samling kommer att skapas} other {# nya samlingar kommer att skapas}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1888
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {Fält kommer att läggas till i # befintlig samling} other {Fält kommer att läggas till i # befintliga samlingar}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} begär ytterligare behörigheter:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:80
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} kräver följande behörigheter:"
+
+#: packages/admin/src/components/MediaLibrary.tsx:298
+msgid "{resultCount, plural, one {# item} other {# items}}"
+msgstr "{resultCount, plural, one {# objekt} other {# objekt}}"
+
+#: packages/admin/src/components/ContentList.tsx:405
+msgid "{selectedCount, plural, one {# selected} other {# selected}}"
+msgstr "{selectedCount, plural, one {# vald} other {# valda}}"
+
+#: packages/admin/src/components/ContentList.tsx:446
+msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
+msgstr "{selectedCount, plural, one {Flytta # objekt till papperskorgen? Du kan återställa det senare.} other {Flytta # objekt till papperskorgen? Du kan återställa dem senare.}}"
+
+#: packages/admin/src/components/ContentList.tsx:928
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr "{total, plural, one {# objekt} other {# objekt}}"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:149
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {# totalt} other {# totalt}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:211
+#: packages/admin/src/components/MediaLibrary.tsx:247
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {Fil uppladdad} other {# filer uppladdade}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:216
+#: packages/admin/src/components/MediaLibrary.tsx:252
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {Uppladdning misslyckades} other {Alla # uppladdningar misslyckades}}"
+
+#: packages/admin/src/components/Dashboard.tsx:146
+msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
+msgstr "{totalDrafts, plural, one {Utkast} other {Utkast}}"
+
+#: packages/admin/src/components/Dashboard.tsx:153
+msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
+msgstr "{totalScheduled, plural, one {Schemalagd} other {Schemalagda}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:357
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {Dölj # oförändrad} other {Dölj # oförändrade}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:358
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {Visa # oförändrad} other {Visa # oförändrade}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:221
+#: packages/admin/src/components/MediaLibrary.tsx:257
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "{uploaded} uppladdade, {failed} misslyckades"
+
+#: packages/admin/src/components/Redirects.tsx:141
+msgid "/new-page or /articles/[slug]"
+msgstr "/ny-sida eller /artiklar/[slug]"
+
+#: packages/admin/src/components/Redirects.tsx:132
+msgid "/old-page or /blog/[slug]"
+msgstr "/gammal-sida eller /blogg/[slug]"
+
+#: packages/admin/src/components/WordPressImport.tsx:2093
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• Filer laddas ner från din WordPress-webbplats"
+
+#: packages/admin/src/components/WordPressImport.tsx:2094
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• Laddas upp till ditt EmDash-mediebibliotek"
+
+#: packages/admin/src/components/WordPressImport.tsx:2095
+msgid "• URLs in your content are updated automatically"
+msgstr "• URL:er i ditt innehåll uppdateras automatiskt"
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1601
+msgid "← Back"
+msgstr "← Tillbaka"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "1 year"
+msgstr "1 år"
+
+#: packages/admin/src/components/WordPressImport.tsx:1522
+msgid "1. Log into your WordPress admin"
+msgstr "1. Logga in på din WordPress-administration"
+
+#: packages/admin/src/components/WordPressImport.tsx:1275
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. Logga in på din WordPress-adminpanel"
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "2. Go to"
+msgstr "2. Gå till"
+
+#: packages/admin/src/components/WordPressImport.tsx:1523
+msgid "2. Go to Users → Profile"
+msgstr "2. Gå till Användare → Profil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1524
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. Bläddra ner till \"Application Passwords\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1279
+msgid "3. Select \"All content\""
+msgstr "3. Välj \"All content\""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "30 days"
+msgstr "30 dagar"
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "301 Permanent"
+msgstr "301 Permanent"
+
+#: packages/admin/src/components/Redirects.tsx:156
+msgid "302 Temporary"
+msgstr "302 Tillfällig"
+
+#: packages/admin/src/components/Redirects.tsx:157
+msgid "307 Temporary (Strict)"
+msgstr "307 Tillfällig (strikt)"
+
+#: packages/admin/src/components/Redirects.tsx:158
+msgid "308 Permanent (Strict)"
+msgstr "308 Permanent (strikt)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1280
+msgid "4. Click \"Download Export File\""
+msgstr "4. Klicka på \"Download Export File\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1525
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. Ange \"EmDash\" och klicka på \"Add New\""
+
+#: packages/admin/src/components/Redirects.tsx:394
+msgid "404 Errors"
+msgstr "404-fel"
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "410 Content Deleted (Gone)"
+msgstr "410 Innehåll borttaget (Gone)"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "451 Unavailable for legal reasons"
+msgstr "451 Ej tillgänglig av juridiska skäl"
+
+#: packages/admin/src/components/WordPressImport.tsx:1526
+msgid "5. Copy the generated password"
+msgstr "5. Kopiera det genererade lösenordet"
+
+#: packages/admin/src/components/WordPressImport.tsx:1281
+msgid "5. Upload the file here"
+msgstr "5. Ladda upp filen här"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "7 days"
+msgstr "7 dagar"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "90 days"
+msgstr "90 dagar"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:416
+msgid "A brief description of this content type"
+msgstr "En kort beskrivning av denna innehållstyp"
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr "En helbredds hero-banner med rubrik, text och CTA-knapp"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:142
+msgid "A short description of your site"
+msgstr "En kort beskrivning av din webbplats"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:172
+msgid "Accept & Install"
+msgstr "Acceptera och installera"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:171
+msgid "Accept & Update"
+msgstr "Acceptera och uppdatera"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:238
+msgid "Accept Invite"
+msgstr "Acceptera inbjudan"
+
+#: packages/admin/src/routes/byline-schema.tsx:174
+msgid "Access denied"
+msgstr "Åtkomst nekad"
+
+#: packages/admin/src/router.tsx:1484
+msgid "Access Denied"
+msgstr "Åtkomst nekad"
+
+#: packages/admin/src/lib/api/marketplace.ts:225
+#: packages/admin/src/lib/api/marketplace.ts:233
+msgid "Access your media library"
+msgstr "Få åtkomst till mediebiblioteket"
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr "Konto"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:153
+msgid "Account already exists"
+msgstr "Kontot finns redan"
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Account exists"
+msgstr "Kontot finns"
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr "Kontoinformation"
+
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "ACF Fields"
+msgstr "ACF-fält"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:299
+#: packages/admin/src/components/ContentList.tsx:528
+#: packages/admin/src/components/ContentList.tsx:649
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/TaxonomyManager.tsx:823
+#: packages/admin/src/routes/byline-schema.tsx:249
+msgid "Actions"
+msgstr "Åtgärder"
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr "Aktiv"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentSettingsPanel.tsx:801
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/TaxonomySidebar.tsx:478
+msgid "Add"
+msgstr "Lägg till"
+
+#. placeholder {0}: field.item_label
+#. placeholder {0}: taxonomyDef.labelSingular || t`Term`
+#: packages/admin/src/components/PortableTextEditor.tsx:1746
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Add {0}"
+msgstr "Lägg till {0}"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:266
+msgid "Add {label}"
+msgstr "Lägg till {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+msgid "Add a new passkey"
+msgstr "Lägg till en ny passkey"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Add an allowed domain"
+msgstr "Lägg till en tillåten domän"
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "Lägg till minst ett underfält för att definiera repeaterstrukturen."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3191
+msgid "Add column after"
+msgstr "Lägg till kolumn efter"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3185
+msgid "Add column before"
+msgstr "Lägg till kolumn före"
+
+#: packages/admin/src/components/MenuEditor.tsx:378
+#: packages/admin/src/components/MenuEditor.tsx:493
+msgid "Add Content"
+msgstr "Lägg till innehåll"
+
+#: packages/admin/src/components/MenuEditor.tsx:390
+#: packages/admin/src/components/MenuEditor.tsx:397
+#: packages/admin/src/components/MenuEditor.tsx:496
+msgid "Add Custom Link"
+msgstr "Lägg till anpassad länk"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:316
+msgid "Add Domain"
+msgstr "Lägg till domän"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:591
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Add Field"
+msgstr "Lägg till fält"
+
+#: packages/admin/src/components/WordPressImport.tsx:1984
+msgid "Add fields"
+msgstr "Lägg till fält"
+
+#: packages/admin/src/routes/byline-schema.tsx:293
+msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+msgstr "Lägg till fält som \"Jobbtitel\" eller \"Pronomen\" för att berika varje byline."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:613
+msgid "Add fields to define the structure of your content"
+msgstr "Lägg till fält för att definiera strukturen på ditt innehåll"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:616
+msgid "Add First Field"
+msgstr "Lägg till första fältet"
+
+#: packages/admin/src/components/RepeaterField.tsx:174
+msgid "Add First Item"
+msgstr "Lägg till första objektet"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1746
+msgid "Add item"
+msgstr "Lägg till objekt"
+
+#: packages/admin/src/components/RepeaterField.tsx:158
+msgid "Add Item"
+msgstr "Lägg till objekt"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3121
+msgid "Add link"
+msgstr "Lägg till länk"
+
+#: packages/admin/src/components/MenuEditor.tsx:486
+msgid "Add links to build your navigation menu"
+msgstr "Lägg till länkar för att bygga din navigeringsmeny"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr "Lägg till MIME-typ eller filändelse"
+
+#: packages/admin/src/components/ContentList.tsx:342
+msgid "Add New"
+msgstr "Lägg till ny"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:490
+msgid "Add new {0}"
+msgstr "Lägg till ny {0}"
+
+#: packages/admin/src/components/SeoPanel.tsx:227
+msgid "Add noindex meta tag"
+msgstr "Lägg till noindex-metatagg"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:200
+msgid "Add Passkey"
+msgstr "Lägg till passkey"
+
+#: packages/admin/src/components/PluginManager.tsx:206
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "Lägg till tillägg i din astro.config.mjs för att utöka EmDash-funktionaliteten."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3212
+msgid "Add row after"
+msgstr "Lägg till rad efter"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3206
+msgid "Add row before"
+msgstr "Lägg till rad före"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr "Lägg till SEO-metadatafält (titel, beskrivning, bild) och inkludera i webbplatskartan"
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr "Lägg till underfält"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:265
+msgid "Add tags..."
+msgstr "Lägg till taggar …"
+
+#: packages/admin/src/components/Widgets.tsx:398
+msgid "Add Widget Area"
+msgstr "Lägg till widgetområde"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:102
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "Lägg till dina profiler för sociala medier. De är tillgängliga för webbplatsens tema och kan visas i sidhuvuden, sidfötter eller författarbiografier."
+
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+msgid "Adding..."
+msgstr "Lägger till …"
+
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Additional data to import."
+msgstr "Ytterligare data att importera."
+
+#: packages/admin/src/components/WordPressImport.tsx:1483
+msgid "admin"
+msgstr "admin"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
+#: packages/admin/src/components/Sidebar.tsx:469
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "Administratör"
+
+#: packages/admin/src/components/Sidebar.tsx:419
+msgid "Admin navigation"
+msgstr "Administrationsnavigering"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "Administratör"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:196
+msgid "After send:"
+msgstr "Efter sändning:"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3508
+msgid "Align Center"
+msgstr "Centrera"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3501
+msgid "Align Left"
+msgstr "Vänsterjustera"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3515
+msgid "Align Right"
+msgstr "Högerjustera"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
+msgid "Alignment"
+msgstr "Justering"
+
+#: packages/admin/src/components/ContentList.tsx:369
+msgid "All"
+msgstr "Alla"
+
+#: packages/admin/src/components/ContentList.tsx:773
+#: packages/admin/src/components/ContentList.tsx:777
+msgid "All authors"
+msgstr "Alla författare"
+
+#: packages/admin/src/routes/bylines.tsx:413
+msgid "All bylines"
+msgstr "Alla bylines"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr "Alla behörigheter"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:133
+msgid "All collections"
+msgstr "Alla samlingar"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr "Alla kommentarer kräver godkännande"
+
+#: packages/admin/src/components/WordPressImport.tsx:2518
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "Allt importerat innehåll blir otilldelat. Du kan tilldela författare på nytt senare i innehållsredigeraren."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "Alla språk"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "Alla roller"
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "Alla källor"
+
+#: packages/admin/src/components/ContentList.tsx:728
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "All statuses"
+msgstr "Alla statusar"
+
+#: packages/admin/src/components/MediaLibrary.tsx:433
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "All types"
+msgstr "Alla typer"
+
+#: packages/admin/src/components/Settings.tsx:100
+msgid "Allow users from specific domains to sign up"
+msgstr "Tillåt användare från specifika domäner att registrera sig"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr "Tillåt besökare att lämna kommentarer på innehållet i denna samling"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Allowed Domains"
+msgstr "Tillåtna domäner"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr "Tillåtna typer"
+
+#: packages/admin/src/components/SignupPage.tsx:437
+msgid "Already have an account?"
+msgstr "Har du redan ett konto?"
+
+#: packages/admin/src/components/PluginManager.tsx:634
+msgid "Also delete plugin storage data"
+msgstr "Ta även bort tilläggets lagrade data"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:231
+#: packages/admin/src/components/MediaLibrary.tsx:589
+msgid "Alt text"
+msgstr "Alt-text"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
+#: packages/admin/src/components/MediaDetailPanel.tsx:354
+#: packages/admin/src/components/MediaDetailPanel.tsx:371
+msgid "Alt Text"
+msgstr "Alt-text"
+
+#: packages/admin/src/components/MediaLibrary.tsx:833
+#: packages/admin/src/components/MediaLibrary.tsx:890
+msgid "Alt text set"
+msgstr "Alt-text angiven"
+
+#: packages/admin/src/components/WordPressImport.tsx:1395
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "Alternativt kan du exportera från WordPress (Verktyg → Exportera) och ladda upp filen."
+
+#: packages/admin/src/components/DialogError.tsx:14
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:98
+#: packages/admin/src/components/PluginManager.tsx:117
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:71
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:95
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+#: packages/admin/src/components/settings/BackupSettings.tsx:85
+#: packages/admin/src/components/settings/BackupSettings.tsx:105
+#: packages/admin/src/components/settings/EmailSettings.tsx:51
+#: packages/admin/src/components/settings/GeneralSettings.tsx:51
+#: packages/admin/src/components/settings/SecuritySettings.tsx:54
+#: packages/admin/src/components/settings/SecuritySettings.tsx:71
+#: packages/admin/src/components/settings/SeoSettings.tsx:45
+#: packages/admin/src/components/settings/SocialSettings.tsx:43
+#: packages/admin/src/components/TaxonomySidebar.tsx:352
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:422
+#: packages/admin/src/router.tsx:437
+#: packages/admin/src/router.tsx:451
+#: packages/admin/src/router.tsx:465
+#: packages/admin/src/router.tsx:942
+#: packages/admin/src/router.tsx:995
+#: packages/admin/src/router.tsx:1013
+#: packages/admin/src/router.tsx:1031
+#: packages/admin/src/router.tsx:1052
+#: packages/admin/src/router.tsx:1073
+#: packages/admin/src/router.tsx:1094
+#: packages/admin/src/router.tsx:1125
+#: packages/admin/src/router.tsx:1145
+#: packages/admin/src/router.tsx:1429
+#: packages/admin/src/router.tsx:1445
+#: packages/admin/src/router.tsx:1470
+#: packages/admin/src/router.tsx:1959
+#: packages/admin/src/routes/byline-schema.tsx:103
+#: packages/admin/src/routes/byline-schema.tsx:123
+#: packages/admin/src/routes/byline-schema.tsx:139
+#: packages/admin/src/routes/byline-schema.tsx:153
+msgid "An error occurred"
+msgstr "Ett fel uppstod"
+
+#: packages/admin/src/routes/byline-schema.tsx:272
+msgid "An unexpected error occurred."
+msgstr "Ett oväntat fel uppstod."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:249
+msgid "An unknown error occurred"
+msgstr "Ett okänt fel uppstod"
+
+#: packages/admin/src/components/WordPressImport.tsx:1575
+msgid "Analyzing export file..."
+msgstr "Analyserar exportfil …"
+
+#: packages/admin/src/components/WordPressImport.tsx:810
+msgid "Analyzing WordPress site..."
+msgstr "Analyserar WordPress-webbplats …"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr "Alla mediatyper tillåtna (med förbehåll för globala gränser)."
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
+msgid "API Tokens"
+msgstr "API-tokens"
+
+#: packages/admin/src/components/Widgets.tsx:435
+msgid "Appears on posts and pages"
+msgstr "Visas på inlägg och sidor"
+
+#: packages/admin/src/components/WordPressImport.tsx:1490
+msgid "Application Password"
+msgstr "Applikationslösenord"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3591
+msgid "Apply"
+msgstr "Använd"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:181
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:182
+msgid "Apply language"
+msgstr "Använd språk"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3061
+#: packages/admin/src/components/PortableTextEditor.tsx:3062
+msgid "Apply link"
+msgstr "Använd länk"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:237
+#: packages/admin/src/components/comments/CommentInbox.tsx:489
+msgid "Approve"
+msgstr "Godkänn"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "godkänd"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:202
+msgid "Approved"
+msgstr "Godkänd"
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr "Godtycklig JSON-data"
+
+#: packages/admin/src/components/ContentList.tsx:1164
+msgid "archived"
+msgstr "arkiverad"
+
+#: packages/admin/src/components/ContentList.tsx:732
+#: packages/admin/src/components/Dashboard.tsx:350
+msgid "Archived"
+msgstr "Arkiverad"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+#: packages/admin/src/components/Widgets.tsx:156
+msgid "Archives"
+msgstr "Arkiv"
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:375
+msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+msgstr "Är du säker på att du vill ta bort \"{0}\"? Inga lagrade värden refererar till detta fält."
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "Är du säker på att du vill ta bort \"{0}\"? Detta tar även bort allt innehåll i denna samling."
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:669
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr "Är du säker på att du vill ta bort fältet \"{0}\"?"
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "Är du säker på att du vill ta bort den här menyn? Detta tar även bort alla menyobjekt. Åtgärden kan inte ångras."
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "Som administratör kan du bjuda in andra användare från avsnittet Användare."
+
+#: packages/admin/src/components/WordPressImport.tsx:2456
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "Tilldela WordPress-författare till EmDash-användare. Inlägg tillskrivs den valda användaren."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:28
+msgid "Astro"
+msgstr "Astro"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+#: packages/admin/src/components/MediaLibrary.tsx:436
+msgid "Audio"
+msgstr "Ljud"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:277
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "Autentiseringsfel: {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:195
+msgid "Authentication error: {error}"
+msgstr "Autentiseringsfel: {error}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:254
+msgid "Authentication failed"
+msgstr "Autentisering misslyckades"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:120
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "Autentisering hanteras av en extern leverantör ({0}). Passkey-inställningar är inte tillgängliga vid extern autentisering."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:261
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "Autentiseringen avbröts eller tog för lång tid. Försök igen."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:287
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1011
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "Författare"
+
+#: packages/admin/src/components/WordPressImport.tsx:2471
+msgid "Author Mapping"
+msgstr "Författartilldelning"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "Auktorisering nekad"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr "Auktorisering misslyckades"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "Auktorisera"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "Auktorisera enhet"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "Auktoriserar …"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:672
+msgid "Authors"
+msgstr "Författare"
+
+#: packages/admin/src/components/Redirects.tsx:521
+msgid "auto"
+msgstr "auto"
+
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "Auto (slug change)"
+msgstr "Auto (slug-ändring)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:539
+msgid "Auto-approve authenticated users"
+msgstr "Godkänn autentiserade användare automatiskt"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:408
+msgid "Auto-generated from name (you can edit)"
+msgstr "Genereras automatiskt från namnet (kan redigeras)"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:167
+msgid "Automatic Backups"
+msgstr "Automatiska säkerhetskopior"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:207
+msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
+msgstr "Automatiska säkerhetskopior kräver en lagringsbackend (R2, S3 eller lokal lagring). Konfigurera lagring i din EmDash-konfiguration för att aktivera dem."
+
+#: packages/admin/src/router.tsx:994
+msgid "Autosave failed"
+msgstr "Automatisk sparning misslyckades"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:661
+msgid "Available media"
+msgstr "Tillgängliga medier"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:205
+msgid "Available Providers"
+msgstr "Tillgängliga leverantörer"
+
+#: packages/admin/src/components/Widgets.tsx:461
+msgid "Available Widgets"
+msgstr "Tillgängliga widgetar"
+
+#: packages/admin/src/components/BylineAvatarField.tsx:46
+#: packages/admin/src/components/BylineAvatarField.tsx:71
+msgid "Avatar"
+msgstr "Avatar"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:257
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/WordPressImport.tsx:1510
+#: packages/admin/src/components/WordPressImport.tsx:2527
+msgid "Back"
+msgstr "Tillbaka"
+
+#: packages/admin/src/components/ContentEditor.tsx:634
+msgid "Back to {collectionLabel} list"
+msgstr "Tillbaka till listan {collectionLabel}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr "Tillbaka till innehållstyper"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:171
+#: packages/admin/src/components/LoginPage.tsx:117
+#: packages/admin/src/components/LoginPage.tsx:153
+#: packages/admin/src/components/LoginPage.tsx:311
+#: packages/admin/src/components/SignupPage.tsx:281
+msgid "Back to login"
+msgstr "Tillbaka till inloggning"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:115
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:391
+msgid "Back to marketplace"
+msgstr "Tillbaka till marknadsplatsen"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:805
+msgid "Back to plugins"
+msgstr "Tillbaka till tillägg"
+
+#: packages/admin/src/components/SectionEditor.tsx:72
+#: packages/admin/src/components/SectionEditor.tsx:173
+msgid "Back to sections"
+msgstr "Tillbaka till sektioner"
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr "Tillbaka till inställningar"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr "Tillbaka till teman"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Back up now"
+msgstr "Säkerhetskopiera nu"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Backing up..."
+msgstr "Säkerhetskopierar …"
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:97
+msgid "Backup created: {0}"
+msgstr "Säkerhetskopia skapad: {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:80
+msgid "Backup settings saved"
+msgstr "Säkerhetskopieringsinställningar sparade"
+
+#: packages/admin/src/components/Settings.tsx:122
+#: packages/admin/src/components/settings/BackupSettings.tsx:133
+#: packages/admin/src/components/settings/BackupSettings.tsx:148
+msgid "Backups"
+msgstr "Säkerhetskopior"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:182
+msgid "Backups to keep"
+msgstr "Säkerhetskopior att behålla"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:29
+msgid "Bash"
+msgstr "Bash"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:191
+msgid "Before send:"
+msgstr "Före sändning:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Bing Verification"
+msgstr "Bing-verifiering"
+
+#: packages/admin/src/routes/bylines.tsx:497
+msgid "Bio"
+msgstr "Biografi"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
+msgid "Block actions - drag to reorder, click for menu"
+msgstr "Blockåtgärder – dra för att ändra ordning, klicka för meny"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3085
+#: packages/admin/src/components/PortableTextEditor.tsx:3419
+msgid "Bold"
+msgstr "Fet"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:55
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr "Boolean"
+
+#: packages/admin/src/components/SeoPanel.tsx:184
+msgid "Brief summary shown below the title in search results"
+msgstr "Kort sammanfattning som visas under titeln i sökresultat"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr "Bläddra bland och installera tillägg som publicerats till det decentraliserade registret."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr "Bläddra bland och installera tillägg för att utöka din webbplats."
+
+#: packages/admin/src/components/WordPressImport.tsx:1124
+#: packages/admin/src/components/WordPressImport.tsx:1594
+msgid "Browse Files"
+msgstr "Bläddra bland filer"
+
+#: packages/admin/src/components/PluginManager.tsx:199
+msgid "Browse the"
+msgstr "Bläddra i"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr "Bläddra bland teman och förhandsgranska dem med ditt eget innehåll."
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:102
+#: packages/admin/src/components/PortableTextEditor.tsx:1056
+#: packages/admin/src/components/PortableTextEditor.tsx:3467
+msgid "Bullet List"
+msgstr "Punktlista"
+
+#: packages/admin/src/routes/byline-schema.tsx:218
+#: packages/admin/src/routes/bylines.tsx:384
+msgid "Byline schema"
+msgstr "Byline-schema"
+
+#: packages/admin/src/components/Sidebar.tsx:347
+msgid "Byline Schema"
+msgstr "Byline-schema"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:513
+#: packages/admin/src/components/Sidebar.tsx:342
+#: packages/admin/src/routes/bylines.tsx:376
+msgid "Bylines"
+msgstr "Bylines"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:30
+msgid "C"
+msgstr "C"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:32
+msgid "C#"
+msgstr "C#"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:31
+msgid "C++"
+msgstr "C++"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "Kan skapa innehåll"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "Kan hantera allt innehåll"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "Kan publicera eget innehåll"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "Kan visa innehåll"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:315
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:163
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentList.tsx:455
+#: packages/admin/src/components/ContentList.tsx:1052
+#: packages/admin/src/components/ContentList.tsx:1123
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/ContentSettingsPanel.tsx:84
+#: packages/admin/src/components/ContentSettingsPanel.tsx:464
+#: packages/admin/src/components/ContentSettingsPanel.tsx:612
+#: packages/admin/src/components/ContentSettingsPanel.tsx:915
+#: packages/admin/src/components/ContentSettingsPanel.tsx:968
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:193
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:194
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:586
+#: packages/admin/src/components/editor/ImageNode.tsx:252
+#: packages/admin/src/components/editor/ImageNode.tsx:253
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:649
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:743
+#: packages/admin/src/components/MenuEditor.tsx:438
+#: packages/admin/src/components/MenuEditor.tsx:623
+#: packages/admin/src/components/MenuList.tsx:172
+#: packages/admin/src/components/PluginManager.tsx:640
+#: packages/admin/src/components/PortableTextEditor.tsx:3575
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:280
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:390
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:323
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:451
+#: packages/admin/src/components/settings/SecuritySettings.tsx:179
+#: packages/admin/src/components/TaxonomyManager.tsx:187
+#: packages/admin/src/components/TaxonomyManager.tsx:472
+#: packages/admin/src/components/TaxonomyManager.tsx:686
+#: packages/admin/src/components/users/InviteUserModal.tsx:198
+#: packages/admin/src/components/Widgets.tsx:446
+#: packages/admin/src/components/WordPressImport.tsx:1917
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr "Avbryt (Esc)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "Avbryt namnändring"
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr "Sektioner från temat kan inte tas bort"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:412
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr "Kan inte fastställa MIME-typ från URL. Använd en URL som slutar med en igenkänd bildfiländelse (t.ex. .jpg, .png, .webp)."
+
+#: packages/admin/src/components/SeoPanel.tsx:212
+#: packages/admin/src/components/SeoPanel.tsx:216
+msgid "Canonical URL"
+msgstr "Kanonisk URL"
+
+#: packages/admin/src/components/PluginManager.tsx:473
+msgid "Capabilities"
+msgstr "Behörigheter"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:65
+msgid "Capability consent"
+msgstr "Samtycke till behörigheter"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:352
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:541
+#: packages/admin/src/components/MediaDetailPanel.tsx:381
+msgid "Caption"
+msgstr "Bildtext"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr "Bildtexter/undertexter"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+#: packages/admin/src/components/Widgets.tsx:133
+msgid "Categories"
+msgstr "Kategorier"
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1785
+msgid "Categories ({0})"
+msgstr "Kategorier ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "Categories & Tags"
+msgstr "Kategorier och taggar"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
+msgid "Center"
+msgstr "Centrera"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1647
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/ImageFieldRenderer.tsx:122
+#: packages/admin/src/components/ImageFieldRenderer.tsx:151
+#: packages/admin/src/components/SeoImageField.tsx:53
+msgid "Change"
+msgstr "Ändra"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr "Ändra <0>{0}</0> från <1>{1}</1> till <2>{2}</2>? Personen förlorar då åtkomst till funktioner på högre nivå."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:239
+msgid "Change Favicon"
+msgstr "Ändra favicon"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:167
+msgid "Change Image"
+msgstr "Ändra bild"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:185
+msgid "Change Logo"
+msgstr "Ändra logotyp"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:793
+msgid "Changelog"
+msgstr "Ändringslogg"
+
+#: packages/admin/src/router.tsx:1045
+msgid "Changes discarded"
+msgstr "Ändringarna kasserades"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:129
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "Tecken mellan sidtitel och webbplatsnamn (t.ex. \"Mitt inlägg | Min webbplats\")"
+
+#: packages/admin/src/components/PluginManager.tsx:162
+msgid "Check for updates"
+msgstr "Sök efter uppdateringar"
+
+#: packages/admin/src/components/WordPressImport.tsx:1095
+msgid "Check Site"
+msgstr "Kontrollera webbplats"
+
+#: packages/admin/src/components/LoginPage.tsx:101
+#: packages/admin/src/components/SignupPage.tsx:130
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Check your email"
+msgstr "Kontrollera din e-post"
+
+#: packages/admin/src/components/WordPressImport.tsx:776
+msgid "Checking {urlInput}..."
+msgstr "Kontrollerar {urlInput} …"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "Kontrollerar autentisering …"
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:362
+msgid "Checking how many stored values reference \"{0}\"…"
+msgstr "Kontrollerar hur många lagrade värden som refererar till \"{0}\"…"
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr "Välj hur du vill logga in"
+
+#: packages/admin/src/components/Settings.tsx:137
+msgid "Choose your preferred admin language"
+msgstr "Välj ditt föredragna administrationsspråk"
+
+#: packages/admin/src/components/ContentList.tsx:481
+msgid "Clear"
+msgstr "Rensa"
+
+#: packages/admin/src/components/ContentList.tsx:825
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr "Rensa filter"
+
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/MediaLibrary.tsx:521
+msgid "Clear search"
+msgstr "Rensa sökning"
+
+#: packages/admin/src/components/SignupPage.tsx:138
+msgid "Click the link in the email to continue setting up your account."
+msgstr "Klicka på länken i e-postmeddelandet för att fortsätta konfigurera ditt konto."
+
+#: packages/admin/src/components/LoginPage.tsx:112
+msgid "Click the link in the email to sign in."
+msgstr "Klicka på länken i e-postmeddelandet för att logga in."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:212
+#: packages/admin/src/components/BylineFieldEditor.tsx:218
+#: packages/admin/src/components/BylineFieldEditor.tsx:222
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:227
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:229
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:414
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:436
+#: packages/admin/src/components/MediaDetailPanel.tsx:229
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:481
+#: packages/admin/src/components/MediaPickerModal.tsx:487
+#: packages/admin/src/components/MediaPickerModal.tsx:491
+#: packages/admin/src/components/MenuEditor.tsx:400
+#: packages/admin/src/components/MenuEditor.tsx:406
+#: packages/admin/src/components/MenuEditor.tsx:410
+#: packages/admin/src/components/MenuEditor.tsx:576
+#: packages/admin/src/components/MenuEditor.tsx:582
+#: packages/admin/src/components/MenuEditor.tsx:586
+#: packages/admin/src/components/MenuList.tsx:136
+#: packages/admin/src/components/MenuList.tsx:142
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/PortableTextEditor.tsx:1530
+#: packages/admin/src/components/PortableTextEditor.tsx:1536
+#: packages/admin/src/components/PortableTextEditor.tsx:1540
+#: packages/admin/src/components/Redirects.tsx:114
+#: packages/admin/src/components/Redirects.tsx:120
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:338
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:348
+#: packages/admin/src/components/TaxonomyManager.tsx:164
+#: packages/admin/src/components/TaxonomyManager.tsx:371
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/components/TaxonomyManager.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:605
+#: packages/admin/src/components/TaxonomyManager.tsx:611
+#: packages/admin/src/components/TaxonomyManager.tsx:615
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:408
+#: packages/admin/src/components/Widgets.tsx:414
+#: packages/admin/src/components/Widgets.tsx:418
+msgid "Close"
+msgstr "Stäng"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:518
+msgid "Close comments after (days)"
+msgstr "Stäng kommentarer efter (dagar)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr "Stäng panel"
+
+#: packages/admin/src/components/ContentEditor.tsx:1019
+msgid "Close settings"
+msgstr "Stäng inställningar"
+
+#: packages/admin/src/components/ContentTypeList.tsx:242
+#: packages/admin/src/components/PortableTextEditor.tsx:3113
+#: packages/admin/src/components/Redirects.tsx:469
+msgid "Code"
+msgstr "Kod"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:94
+#: packages/admin/src/components/PortableTextEditor.tsx:1086
+#: packages/admin/src/components/PortableTextEditor.tsx:3488
+msgid "Code Block"
+msgstr "Kodblock"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Collapse"
+msgstr "Fäll ihop"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Collapse details"
+msgstr "Dölj detaljer"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:156
+msgid "colleague@example.com"
+msgstr "kollega@example.com"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr "Samling"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "Samling:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Collections"
+msgstr "Samlingar"
+
+#: packages/admin/src/components/WordPressImport.tsx:2327
+msgid "Collections created:"
+msgstr "Samlingar skapade:"
+
+#: packages/admin/src/components/SectionEditor.tsx:275
+msgid "Comma-separated keywords for search."
+msgstr "Kommaseparerade nyckelord för sökning."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Comment"
+msgstr "Kommentar"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "Kommentardetaljer"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:146
+#: packages/admin/src/components/ContentTypeEditor.tsx:485
+#: packages/admin/src/components/Sidebar.tsx:326
+msgid "Comments"
+msgstr "Kommentarer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:542
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr "Kommentarer från inloggade CMS-användare godkänns automatiskt"
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Complete signup"
+msgstr "Slutför registrering"
+
+#: packages/admin/src/components/Widgets.tsx:914
+msgid "Component"
+msgstr "Komponent"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr "Konfigurera fält"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:313
+msgid "Confirm"
+msgstr "Bekräfta"
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+#: packages/admin/src/components/WordPressImport.tsx:1054
+msgid "Connect"
+msgstr "Anslut"
+
+#: packages/admin/src/components/WordPressImport.tsx:1507
+msgid "Connect & Analyze"
+msgstr "Anslut och analysera"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1457
+msgid "Connect to {0}"
+msgstr "Anslut till {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Connect with WordPress"
+msgstr "Anslut med WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr "{0} ansluten"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:293
+#: packages/admin/src/components/Dashboard.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:2326
+#: packages/admin/src/components/SectionEditor.tsx:193
+#: packages/admin/src/components/Sidebar.tsx:451
+#: packages/admin/src/components/Widgets.tsx:882
+msgid "Content"
+msgstr "Innehåll"
+
+#: packages/admin/src/components/Widgets.tsx:96
+msgid "Content Block"
+msgstr "Innehållsblock"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2382
+msgid "Content Errors ({0})"
+msgstr "Innehållsfel ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1317
+msgid "Content found:"
+msgstr "Innehåll hittat:"
+
+#: packages/admin/src/router.tsx:1067
+msgid "Content has been scheduled for publishing"
+msgstr "Innehållet har schemalagts för publicering"
+
+#: packages/admin/src/components/RevisionHistory.tsx:123
+msgid "Content has been updated to the selected revision."
+msgstr "Innehållet har uppdaterats till den valda revisionen."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "Innehålls-ID:"
+
+#: packages/admin/src/router.tsx:1008
+msgid "Content is now live"
+msgstr "Innehållet är nu publicerat"
+
+#: packages/admin/src/components/WordPressImport.tsx:2371
+msgid "content items"
+msgstr "innehållsobjekt"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
+msgid "Content Read"
+msgstr "Läsa innehåll"
+
+#: packages/admin/src/router.tsx:1026
+msgid "Content removed from public view"
+msgstr "Innehållet har tagits bort från offentlig visning"
+
+#: packages/admin/src/router.tsx:1088
+msgid "Content reverted to draft"
+msgstr "Innehållet återställdes till utkast"
+
+#: packages/admin/src/components/RevisionHistory.tsx:304
+msgid "Content snapshot:"
+msgstr "Ögonblicksbild av innehåll:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1731
+msgid "Content to Import"
+msgstr "Innehåll att importera"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:346
+msgid "Content Types"
+msgstr "Innehållstyper"
+
+#: packages/admin/src/components/WordPressImport.tsx:2310
+msgid "Content was skipped because it already exists"
+msgstr "Innehållet hoppades över eftersom det redan finns"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
+msgid "Content Write"
+msgstr "Skriva innehåll"
+
+#: packages/admin/src/components/SignupPage.tsx:91
+msgid "Continue"
+msgstr "Fortsätt"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr "Fortsätt →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2529
+msgid "Continue Import"
+msgstr "Fortsätt import"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "Bidragsgivare"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:224
+#: packages/admin/src/components/users/InviteUserModal.tsx:133
+msgid "Copied to clipboard"
+msgstr "Kopierat till urklipp"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr "Kopiera {0} till urklipp"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "Kopiera inbjudningslänk"
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr "Kopiera slug"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
+msgid "Copy this token now — it won't be shown again."
+msgstr "Kopiera denna token nu — den visas inte igen."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copy token"
+msgstr "Kopiera token"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+#: packages/admin/src/components/MediaDetailPanel.tsx:301
+msgid "Copy URL"
+msgstr "Kopiera URL"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:136
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "Kunde inte kopiera automatiskt. Markera URL:en ovan och kopiera manuellt."
+
+#: packages/admin/src/components/Dashboard.tsx:84
+msgid "Could not load dashboard data"
+msgstr "Kunde inte läsa in översiktsdata"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:438
+msgid "Could not load image from URL"
+msgstr "Kunde inte läsa in bild från URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1264
+msgid "Couldn't detect WordPress"
+msgstr "Kunde inte identifiera WordPress"
+
+#: packages/admin/src/routes/byline-schema.tsx:268
+msgid "Couldn't load byline fields."
+msgstr "Kunde inte läsa in byline-fält."
+
+#: packages/admin/src/routes/bylines.tsx:548
+msgid "Couldn't load custom fields."
+msgstr "Kunde inte läsa in anpassade fält."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr "Kunde inte matcha \"{draft}\" mot en MIME-typ. Ange MIME-typen direkt."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:807
+msgid "Couldn't search bylines. Please try again."
+msgstr "Kunde inte söka bland bylines. Försök igen."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:369
+msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+msgstr "Kunde inte kontrollera hur många värden som refererar till \"{0}\". Borttagning tar fortfarande bort alla lagrade värden för detta fält — men antalet ovan kunde inte kontrolleras."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:822
+msgid "Count"
+msgstr "Antal"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:939
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:191
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:479
+#: packages/admin/src/components/Widgets.tsx:449
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Create"
+msgstr "Skapa"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:292
+msgid "Create \"{trimmedInput}\""
+msgstr "Skapa \"{trimmedInput}\""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1057
+msgid "Create a bullet list"
+msgstr "Skapa en punktlista"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:367
+msgid "Create a new {0}"
+msgstr "Skapa en ny {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1067
+msgid "Create a numbered list"
+msgstr "Skapa en numrerad lista"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:83
+#: packages/admin/src/components/SignupPage.tsx:220
+msgid "Create Account"
+msgstr "Skapa konto"
+
+#: packages/admin/src/components/SignupPage.tsx:399
+msgid "Create an account"
+msgstr "Skapa ett konto"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:887
+#: packages/admin/src/routes/bylines.tsx:477
+msgid "Create byline"
+msgstr "Skapa byline"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr "Skapa innehållstyp"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Create field"
+msgstr "Skapa fält"
+
+#: packages/admin/src/components/MenuList.tsx:126
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "Create Menu"
+msgstr "Skapa meny"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "Create New Menu"
+msgstr "Skapa ny meny"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:394
+msgid "Create New Token"
+msgstr "Skapa ny token"
+
+#: packages/admin/src/components/WordPressImport.tsx:1501
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "Skapa ett i WordPress: Användare → Profil → Applikationslösenord"
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr "Skapa passkey"
+
+#: packages/admin/src/components/Settings.tsx:111
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
+msgid "Create personal access tokens for programmatic API access"
+msgstr "Skapa personliga åtkomsttoken för programmatisk API-åtkomst"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:247
+msgid "Create redirect for {0}"
+msgstr "Skapa omdirigering för {0}"
+
+#: packages/admin/src/components/Redirects.tsx:246
+msgid "Create redirect for this path"
+msgstr "Skapa omdirigering för denna sökväg"
+
+#: packages/admin/src/components/Redirects.tsx:461
+msgid "Create redirect rules to manage URL changes."
+msgstr "Skapa omdirigeringsregler för att hantera URL-ändringar."
+
+#: packages/admin/src/components/WordPressImport.tsx:1921
+msgid "Create Schema & Import"
+msgstr "Skapa schema och importera"
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr "Skapa sektion"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr "Skapa sektioner i sektionsbiblioteket för att använda dem här"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:598
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+msgid "Create Taxonomy"
+msgstr "Skapa taxonomi"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:256
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:448
+msgid "Create Token"
+msgstr "Skapa token"
+
+#: packages/admin/src/components/Widgets.tsx:405
+msgid "Create Widget Area"
+msgstr "Skapa widgetområde"
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr "Skapa ditt konto"
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "Create your first navigation menu to get started"
+msgstr "Skapa din första navigeringsmeny för att komma igång"
+
+#: packages/admin/src/components/ContentList.tsx:556
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr "Skapa din första"
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr "Skapa din första återanvändbara innehållssektion för att komma igång."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:74
+#: packages/admin/src/components/SignupPage.tsx:211
+msgid "Create your passkey"
+msgstr "Skapa din passkey"
+
+#: packages/admin/src/lib/api/marketplace.ts:223
+#: packages/admin/src/lib/api/marketplace.ts:232
+msgid "Create, update, and delete content"
+msgstr "Skapa, uppdatera och ta bort innehåll"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Create, update, and delete navigation menus"
+msgstr "Skapa, uppdatera och ta bort navigeringsmenyer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Create, update, and delete taxonomy terms"
+msgstr "Skapa, uppdatera och ta bort taxonomitermer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Create, update, delete content"
+msgstr "Skapa, uppdatera, ta bort innehåll"
+
+#: packages/admin/src/components/ContentList.tsx:736
+#: packages/admin/src/components/ContentSettingsPanel.tsx:486
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr "Skapad"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:96
+msgid "Created \"{0}\"."
+msgstr "Skapade \"{0}\"."
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:295
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr "Skapad {0}"
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:1119
+msgid "Created {0} translation"
+msgstr "Skapade {0}-översättning"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr "Skapad"
+
+#: packages/admin/src/components/WordPressImport.tsx:887
+msgid "Creating collections and fields..."
+msgstr "Skapar samlingar och fält …"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:939
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:188
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:448
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+#: packages/admin/src/components/TaxonomySidebar.tsx:292
+msgid "Creating..."
+msgstr "Skapar …"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:33
+msgid "CSS"
+msgstr "CSS"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:83
+msgid "current"
+msgstr "aktuell"
+
+#: packages/admin/src/components/RevisionHistory.tsx:272
+msgid "Current"
+msgstr "Aktuell"
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr "Anpassad"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:623
+msgid "Custom Fields"
+msgstr "Anpassade fält"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:210
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "Anpassat innehåll för robots.txt. Lämna tomt för att använda standarden."
+
+#: packages/admin/src/components/SectionEditor.tsx:183
+msgid "Custom Section"
+msgstr "Anpassad sektion"
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Custom Taxonomies"
+msgstr "Anpassade taxonomier"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:176
+msgid "Daily automatic backups"
+msgstr "Dagliga automatiska säkerhetskopior"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "mörk"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "Mörk"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/Dashboard.tsx:50
+#: packages/admin/src/components/Sidebar.tsx:312
+#: packages/admin/src/components/Sidebar.tsx:442
+msgid "Dashboard"
+msgstr "Översikt"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:296
+#: packages/admin/src/components/ContentList.tsx:525
+msgid "Date"
+msgstr "Datum"
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr "Datum och tid"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr "Väljare för datum och tid"
+
+#: packages/admin/src/components/ContentList.tsx:790
+msgid "Date field to filter on"
+msgstr "Datumfält att filtrera på"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:281
+msgid "Date Format"
+msgstr "Datumformat"
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr "Decimaltal"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:737
+msgid "Declared permissions"
+msgstr "Deklarerade behörigheter"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:294
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:356
+msgid "Default Role"
+msgstr "Standardroll"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:233
+msgid "Default role:"
+msgstr "Standardroll:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:147
+msgid "Default social image"
+msgstr "Standardbild för sociala medier"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:138
+msgid "Default Social Image"
+msgstr "Standardbild för sociala medier"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:601
+msgid "Define a new taxonomy for classifying content"
+msgstr "Definiera en ny taxonomi för att klassificera innehåll"
+
+#: packages/admin/src/routes/byline-schema.tsx:220
+msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+msgstr "Definiera anpassade fält som lagras på varje byline – jobbtitel, pronomen, användarnamn för sociala medier med mera."
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr "Definiera strukturen på ditt innehåll"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:360
+msgid "Defined in code"
+msgstr "Definierad i kod"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:267
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+#: packages/admin/src/components/ContentTypeEditor.tsx:672
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:301
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:130
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:453
+#: packages/admin/src/components/MenuEditor.tsx:549
+#: packages/admin/src/components/MenuList.tsx:255
+#: packages/admin/src/components/Redirects.tsx:582
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/settings/BackupSettings.tsx:284
+#: packages/admin/src/components/TaxonomyManager.tsx:886
+#: packages/admin/src/components/Widgets.tsx:699
+#: packages/admin/src/routes/byline-schema.tsx:378
+#: packages/admin/src/routes/bylines.tsx:589
+#: packages/admin/src/routes/bylines.tsx:625
+msgid "Delete"
+msgstr "Ta bort"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:452
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "Ta bort \"{0}\"? Detta kan inte ångras."
+
+#. placeholder {0}: archive.name
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:227
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:252
+#: packages/admin/src/components/settings/BackupSettings.tsx:245
+#: packages/admin/src/components/TaxonomyManager.tsx:97
+#: packages/admin/src/components/Widgets.tsx:800
+#: packages/admin/src/routes/byline-schema.tsx:458
+msgid "Delete {0}"
+msgstr "Ta bort {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:749
+msgid "Delete {0} field"
+msgstr "Ta bort fältet {0}"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:237
+msgid "Delete {0} menu"
+msgstr "Ta bort menyn {0}"
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:647
+msgid "Delete {0} widget area"
+msgstr "Ta bort widgetområdet {0}"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:882
+msgid "Delete {0}?"
+msgstr "Ta bort {0}?"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:282
+msgid "Delete backup?"
+msgstr "Ta bort säkerhetskopia?"
+
+#: packages/admin/src/routes/byline-schema.tsx:358
+msgid "Delete byline field?"
+msgstr "Ta bort byline-fält?"
+
+#: packages/admin/src/routes/bylines.tsx:623
+msgid "Delete Byline?"
+msgstr "Ta bort byline?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3197
+msgid "Delete column"
+msgstr "Ta bort kolumn"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:405
+msgid "Delete Comment?"
+msgstr "Ta bort kommentar?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr "Ta bort innehållstyp?"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr "Ta bort inbäddning"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:666
+msgid "Delete Field?"
+msgstr "Ta bort fält?"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
+msgid "Delete HTML block"
+msgstr "Ta bort HTML-block"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:220
+#: packages/admin/src/components/editor/ImageNode.tsx:221
+msgid "Delete image"
+msgstr "Ta bort bild"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:451
+msgid "Delete Media?"
+msgstr "Ta bort media?"
+
+#: packages/admin/src/components/MenuList.tsx:253
+msgid "Delete Menu"
+msgstr "Ta bort meny"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:525
+msgid "Delete permanently"
+msgstr "Ta bort permanent"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:1134
+msgid "Delete Permanently"
+msgstr "Ta bort permanent"
+
+#: packages/admin/src/components/ContentList.tsx:1114
+msgid "Delete Permanently?"
+msgstr "Ta bort permanent?"
+
+#: packages/admin/src/components/Redirects.tsx:535
+msgid "Delete redirect"
+msgstr "Ta bort omdirigering"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:536
+msgid "Delete redirect {0}"
+msgstr "Ta bort omdirigering {0}"
+
+#: packages/admin/src/components/Redirects.tsx:580
+msgid "Delete Redirect?"
+msgstr "Ta bort omdirigering?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3216
+msgid "Delete row"
+msgstr "Ta bort rad"
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr "Ta bort sektion?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3231
+msgid "Delete table"
+msgstr "Ta bort tabell"
+
+#: packages/admin/src/components/Widgets.tsx:697
+msgid "Delete Widget Area?"
+msgstr "Ta bort widgetområde?"
+
+#: packages/admin/src/components/ContentList.tsx:646
+msgid "Deleted"
+msgstr "Borttagen"
+
+#. placeholder {0}: deletingField.label
+#. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
+#: packages/admin/src/routes/byline-schema.tsx:371
+msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+msgstr "Att ta bort \"{0}\" tar även bort {1, plural, one {# lagrat värde} other {# lagrade värden}} från alla bylines. Detta kan inte ångras."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:673
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:454
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:583
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/settings/BackupSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:887
+#: packages/admin/src/components/Widgets.tsx:700
+#: packages/admin/src/routes/bylines.tsx:626
+msgid "Deleting..."
+msgstr "Tar bort …"
+
+#: packages/admin/src/routes/byline-schema.tsx:379
+msgid "Deleting…"
+msgstr "Tar bort …"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr "Demo"
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr "Nedgradera användare"
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr "Nedgradera användare?"
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr "Nedgraderar …"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "Neka"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:238
+msgid "Describe the image..."
+msgstr "Beskriv bilden …"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
+#: packages/admin/src/components/MediaDetailPanel.tsx:374
+msgid "Describe this image for accessibility"
+msgstr "Beskriv denna bild för tillgänglighet"
+
+#: packages/admin/src/components/SectionEditor.tsx:264
+msgid "Describe what this section is for..."
+msgstr "Beskriv vad denna sektion är till för …"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:413
+#: packages/admin/src/components/RegistryPluginDetail.tsx:790
+#: packages/admin/src/components/SectionEditor.tsx:261
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:433
+msgid "Description"
+msgstr "Beskrivning"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:434
+msgid "Description (optional)"
+msgstr "Beskrivning (valfri)"
+
+#: packages/admin/src/components/Redirects.tsx:468
+msgid "Destination"
+msgstr "Mål"
+
+#: packages/admin/src/components/Redirects.tsx:140
+msgid "Destination path"
+msgstr "Målsökväg"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "details"
+msgstr "detaljer"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "Enhet auktoriserad"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "Enhetskod"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr "Enhetsbunden"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Enhetsbunden passkey"
+
+#: packages/admin/src/components/SignupPage.tsx:143
+msgid "Didn't receive the email?"
+msgstr "Fick du inte e-postmeddelandet?"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:34
+msgid "Diff"
+msgstr "Diff"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:280
+msgid "Dimensions:"
+msgstr "Dimensioner:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr "Inaktivera"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Disable plugin"
+msgstr "Inaktivera tillägg"
+
+#: packages/admin/src/components/Redirects.tsx:504
+msgid "Disable redirect"
+msgstr "Inaktivera omdirigering"
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr "Inaktivera användare"
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr "Inaktivera användare?"
+
+#: packages/admin/src/components/PluginManager.tsx:354
+#: packages/admin/src/components/Redirects.tsx:418
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: packages/admin/src/components/PluginManager.tsx:531
+msgid "Disabled:"
+msgstr "Inaktiverad:"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr "Om du inaktiverar <0>{0}</0> kan personen inte logga in förrän kontot aktiveras igen. Personens innehåll behålls."
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr "Inaktiverar …"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:438
+msgid "Discard"
+msgstr "Kassera"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:71
+#: packages/admin/src/components/ContentSettingsPanel.tsx:91
+msgid "Discard changes"
+msgstr "Kassera ändringar"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:436
+msgid "Discard changes?"
+msgstr "Kassera ändringar?"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:76
+msgid "Discard draft changes?"
+msgstr "Kassera ändringar i utkastet?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:439
+msgid "Discarding..."
+msgstr "Kasserar …"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:231
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
+msgid "Dismiss"
+msgstr "Stäng"
+
+#: packages/admin/src/components/Widgets.tsx:125
+msgid "Display a list of recent posts"
+msgstr "Visa en lista med senaste inläggen"
+
+#: packages/admin/src/components/Widgets.tsx:103
+msgid "Display a navigation menu"
+msgstr "Visa en navigeringsmeny"
+
+#: packages/admin/src/components/Widgets.tsx:134
+msgid "Display category list"
+msgstr "Visa kategorilista"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:890
+#: packages/admin/src/components/ContentSettingsPanel.tsx:952
+#: packages/admin/src/routes/bylines.tsx:482
+msgid "Display name"
+msgstr "Visningsnamn"
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Display name for admin interface"
+msgstr "Visningsnamn för administrationsgränssnittet"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:269
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:458
+msgid "Display Size"
+msgstr "Visningsstorlek"
+
+#: packages/admin/src/components/Widgets.tsx:142
+msgid "Display tag cloud"
+msgstr "Visa taggmoln"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
+msgid "Displayed below the image as a visible caption."
+msgstr "Visas under bilden som en synlig bildtext."
+
+#: packages/admin/src/components/ContentEditor.tsx:704
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "Distraktionsfritt läge (⌘⇧\\)"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1111
+msgid "Divider"
+msgstr "Avdelare"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:35
+msgid "Dockerfile"
+msgstr "Dockerfile"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+#: packages/admin/src/components/MediaLibrary.tsx:437
+msgid "Documents"
+msgstr "Dokument"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:286
+msgid "Domain"
+msgstr "Domän"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:66
+msgid "Domain added successfully"
+msgstr "Domänen lades till"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain removed"
+msgstr "Domänen togs bort"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Domain updated"
+msgstr "Domänen uppdaterades"
+
+#: packages/admin/src/components/LoginPage.tsx:332
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "Har du inget konto? <0>Registrera dig</0>"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:142
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Done"
+msgstr "Klar"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:833
+msgid "Down"
+msgstr "Ner"
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:238
+msgid "Download {0}"
+msgstr "Ladda ner {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:158
+msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
+msgstr "Ladda ner en fullständig säkerhetskopia av din webbplats: allt innehåll (inklusive utkast och papperskorg), samlingar, taxonomier, menyer, widgetar, mediemetadata och webbplatsinställningar. Användarkonton och hemligheter ingår aldrig."
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:160
+msgid "Download backup"
+msgstr "Ladda ner säkerhetskopia"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:155
+msgid "Download Backup"
+msgstr "Ladda ner säkerhetskopia"
+
+#: packages/admin/src/components/Settings.tsx:123
+msgid "Download backups and schedule automatic backups to storage"
+msgstr "Ladda ner säkerhetskopior och schemalägg automatiska säkerhetskopior till lagring"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:479
+msgid "Download SBOM"
+msgstr "Ladda ner SBOM"
+
+#: packages/admin/src/components/WordPressImport.tsx:2126
+msgid "Downloading"
+msgstr "Laddar ner"
+
+#: packages/admin/src/components/ContentList.tsx:1160
+msgid "draft"
+msgstr "utkast"
+
+#: packages/admin/src/components/ContentList.tsx:730
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+#: packages/admin/src/components/ContentSettingsPanel.tsx:406
+#: packages/admin/src/components/Dashboard.tsx:346
+msgid "Draft"
+msgstr "Utkast"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr "utkast, publicerad eller arkiverad"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:251
+msgid "Drafts"
+msgstr "Utkast"
+
+#: packages/admin/src/components/WordPressImport.tsx:1166
+msgid "Drafts & Private"
+msgstr "Utkast och privat"
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "Dra och släpp eller klicka för att bläddra (.xml)"
+
+#: packages/admin/src/components/Widgets.tsx:683
+msgid "Drag here to add"
+msgstr "Dra hit för att lägga till"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1922
+msgid "Drag to reorder"
+msgstr "Dra för att ändra ordning"
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:716
+#: packages/admin/src/components/Widgets.tsx:785
+msgid "Drag to reorder {0}"
+msgstr "Dra för att ändra ordning på {0}"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:338
+msgid "Drag to reorder block"
+msgstr "Dra för att ändra ordning på block"
+
+#: packages/admin/src/components/Widgets.tsx:687
+msgid "Drag widgets here to add them"
+msgstr "Dra widgetar hit för att lägga till dem"
+
+#: packages/admin/src/components/Widgets.tsx:462
+msgid "Drag widgets into an area to add them"
+msgstr "Dra widgetar till ett område för att lägga till dem"
+
+#: packages/admin/src/components/Widgets.tsx:683
+msgid "Drop to add widget"
+msgstr "Släpp för att lägga till widget"
+
+#: packages/admin/src/components/WordPressImport.tsx:1588
+msgid "Drop your WordPress export file here"
+msgstr "Släpp din WordPress-exportfil här"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:292
+msgid "Duplicate"
+msgstr "Duplicera"
+
+#: packages/admin/src/components/ContentList.tsx:1025
+msgid "Duplicate {title}"
+msgstr "Duplicera {title}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr "t.ex. application/zip eller .pdf"
+
+#: packages/admin/src/components/Redirects.tsx:167
+msgid "e.g. import, blog"
+msgstr "t.ex. import, blogg"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:408
+msgid "e.g., CI/CD Pipeline"
+msgstr "t.ex. CI/CD-pipeline"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "t.ex. MacBook Pro, iPhone"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:842
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:544
+#: packages/admin/src/components/MenuList.tsx:231
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TranslationsPanel.tsx:93
+msgid "Edit"
+msgstr "Redigera"
+
+#. placeholder {0}: block?.label || ""
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:218
+#: packages/admin/src/components/PortableTextEditor.tsx:1527
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:243
+#: packages/admin/src/components/TaxonomyManager.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/routes/byline-schema.tsx:449
+#: packages/admin/src/routes/bylines.tsx:477
+msgid "Edit {0}"
+msgstr "Redigera {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:741
+msgid "Edit {0} field"
+msgstr "Redigera fältet {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:651
+msgid "Edit {collectionLabel}"
+msgstr "Redigera {collectionLabel}"
+
+#: packages/admin/src/components/ContentList.tsx:1017
+msgid "Edit {title}"
+msgstr "Redigera {title}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:949
+msgid "Edit byline"
+msgstr "Redigera byline"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "Edit byline field"
+msgstr "Redigera byline-fält"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:331
+msgid "Edit Domain"
+msgstr "Redigera domän"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr "Redigera fält"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3121
+msgid "Edit link"
+msgstr "Redigera länk"
+
+#: packages/admin/src/components/MenuEditor.tsx:573
+msgid "Edit Menu Item"
+msgstr "Redigera menyobjekt"
+
+#: packages/admin/src/components/MenuEditor.tsx:369
+msgid "Edit menu items"
+msgstr "Redigera menyobjekt"
+
+#: packages/admin/src/components/Redirects.tsx:527
+msgid "Edit redirect"
+msgstr "Redigera omdirigering"
+
+#: packages/admin/src/components/Redirects.tsx:105
+msgid "Edit Redirect"
+msgstr "Redigera omdirigering"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:528
+msgid "Edit redirect {0}"
+msgstr "Redigera omdirigering {0}"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr "Redigera URL"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "Redaktör"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr ""
+"Redaktör\n"
+"Reporter\n"
+"Fotograf"
+
+#: packages/admin/src/components/WordPressImport.tsx:1044
+msgid "em1.…"
+msgstr "em1.…"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:61
+#: packages/admin/src/components/Settings.tsx:116
+#: packages/admin/src/components/SignupPage.tsx:197
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr "E-post"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:330
+msgid "Email (optional)"
+msgstr "E-post (valfri)"
+
+#: packages/admin/src/components/LoginPage.tsx:126
+#: packages/admin/src/components/SignupPage.tsx:66
+#: packages/admin/src/components/users/InviteUserModal.tsx:152
+msgid "Email address"
+msgstr "E-postadress"
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:49
+msgid "Email is required"
+msgstr "E-post krävs"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "Email Middleware"
+msgstr "E-postmellanvara"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:99
+msgid "Email Pipeline"
+msgstr "E-postpipeline"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:172
+msgid "Email provider active"
+msgstr "E-postleverantör aktiv"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:77
+#: packages/admin/src/components/settings/EmailSettings.tsx:92
+msgid "Email Settings"
+msgstr "E-postinställningar"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr "E-post verifierad"
+
+#: packages/admin/src/components/SignupPage.tsx:189
+msgid "Email verified!"
+msgstr "E-post verifierad!"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2340
+msgid "Embed a {0}"
+msgstr "Bädda in ett {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2343
+msgid "Embeds"
+msgstr "Inbäddningar"
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1307
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "Tillägget EmDash Exporter upptäcktes! Du kan importera direkt."
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr "Aktivera"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:493
+msgid "Enable comments"
+msgstr "Aktivera kommentarer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr "Aktivera fritextsökning för denna samling"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Enable plugin"
+msgstr "Aktivera tillägg"
+
+#: packages/admin/src/components/Redirects.tsx:504
+msgid "Enable redirect"
+msgstr "Aktivera omdirigering"
+
+#: packages/admin/src/components/Redirects.tsx:175
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "Enabled"
+msgstr "Aktiverad"
+
+#: packages/admin/src/components/MenuEditor.tsx:423
+#: packages/admin/src/components/MenuEditor.tsx:601
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "Ange en URL (https://…) eller en relativ sökväg (/…)"
+
+#: packages/admin/src/components/ContentEditor.tsx:1425
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr "Ange en giltig URL (t.ex. https://example.com)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1380
+msgid "Enter credentials manually"
+msgstr "Ange inloggningsuppgifter manuellt"
+
+#: packages/admin/src/components/ContentEditor.tsx:703
+msgid "Enter distraction-free mode"
+msgstr "Aktivera distraktionsfritt läge"
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr "Ange e-post"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
+msgid "Enter HTML..."
+msgstr "Ange HTML …"
+
+#: packages/admin/src/components/ContentEditor.tsx:1199
+msgid "Enter markdown content..."
+msgstr "Ange markdown-innehåll …"
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr "Ange namn"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "Ange koden från din terminal"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr "Ange URL …"
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "Enter your handle to sign in."
+msgstr "Ange ditt användarnamn för att logga in."
+
+#: packages/admin/src/components/WordPressImport.tsx:1459
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "Ange dina WordPress-inloggningsuppgifter för att importera innehåll direkt."
+
+#: packages/admin/src/components/WordPressImport.tsx:1082
+msgid "Enter your WordPress site URL"
+msgstr "Ange URL:en till din WordPress-webbplats"
+
+#: packages/admin/src/components/MenuEditor.tsx:155
+#: packages/admin/src/components/MenuEditor.tsx:193
+#: packages/admin/src/components/MenuEditor.tsx:233
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:752
+#: packages/admin/src/router.tsx:2142
+msgid "Error"
+msgstr "Fel"
+
+#: packages/admin/src/components/Widgets.tsx:234
+msgid "Error adding widget"
+msgstr "Fel vid tillägg av widget"
+
+#: packages/admin/src/components/Widgets.tsx:295
+msgid "Error reordering widgets"
+msgstr "Fel vid ändring av widgetordning"
+
+#: packages/admin/src/components/SectionEditor.tsx:51
+msgid "Error saving section"
+msgstr "Fel vid sparande av sektion"
+
+#: packages/admin/src/components/Widgets.tsx:767
+msgid "Error updating widget"
+msgstr "Fel vid uppdatering av widget"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:583
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr "Alla publicerade versioner av detta tillägg har återkallats eller kunde inte verifieras. Försök igen senare eller kontakta utgivaren."
+
+#: packages/admin/src/components/WordPressImport.tsx:2010
+msgid "Exists"
+msgstr "Finns"
+
+#: packages/admin/src/components/ContentEditor.tsx:645
+msgid "Exit distraction-free mode"
+msgstr "Avsluta distraktionsfritt läge"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3627
+msgid "Exit Spotlight Mode"
+msgstr "Avsluta fokusläge"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Expand"
+msgstr "Expandera"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Expand details"
+msgstr "Visa detaljer"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+msgid "Expires {0}"
+msgstr "Upphör {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:434
+msgid "Expiry"
+msgstr "Utgångsdatum"
+
+#: packages/admin/src/components/WordPressImport.tsx:1273
+msgid "Export from WordPress manually"
+msgstr "Exportera från WordPress manuellt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1397
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "Exportera ditt innehåll från WordPress för att importera allt, inklusive utkast."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:118
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr "Misslyckades"
+
+#: packages/admin/src/components/WordPressImport.tsx:2130
+msgid "Failed"
+msgstr "Misslyckades"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:188
+msgid "Failed security audit"
+msgstr "Säkerhetsgranskning misslyckades"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:70
+msgid "Failed to add domain"
+msgstr "Det gick inte att lägga till domänen"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:188
+msgid "Failed to add passkey"
+msgstr "Det gick inte att lägga till passkey"
+
+#: packages/admin/src/components/WordPressImport.tsx:413
+msgid "Failed to analyze WordPress site"
+msgstr "Det gick inte att analysera WordPress-webbplatsen"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr "Det gick inte att kommunicera med tillägget"
+
+#: packages/admin/src/lib/api/media.ts:155
+msgid "Failed to confirm upload"
+msgstr "Det gick inte att bekräfta uppladdningen"
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr "Det gick inte att skapa administratören"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:104
+#: packages/admin/src/lib/api/backups.ts:51
+msgid "Failed to create backup"
+msgstr "Det gick inte att skapa säkerhetskopia"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:933
+msgid "Failed to create byline"
+msgstr "Det gick inte att skapa byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:120
+msgid "Failed to create byline field"
+msgstr "Det gick inte att skapa byline-fält"
+
+#: packages/admin/src/routes/byline-schema.tsx:102
+msgid "Failed to create field"
+msgstr "Det gick inte att skapa fält"
+
+#: packages/admin/src/lib/api/sections.ts:88
+msgid "Failed to create section"
+msgstr "Det gick inte att skapa sektion"
+
+#: packages/admin/src/components/WordPressImport.tsx:1714
+msgid "Failed to create some collections"
+msgstr "Det gick inte att skapa vissa samlingar"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:497
+msgid "Failed to create term"
+msgstr "Det gick inte att skapa term"
+
+#: packages/admin/src/router.tsx:1124
+msgid "Failed to create translation"
+msgstr "Det gick inte att skapa översättning"
+
+#: packages/admin/src/router.tsx:421
+#: packages/admin/src/router.tsx:450
+#: packages/admin/src/router.tsx:533
+#: packages/admin/src/router.tsx:1144
+msgid "Failed to delete"
+msgstr "Det gick inte att ta bort"
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr "Det gick inte att ta bort den tillåtna domänen"
+
+#: packages/admin/src/lib/api/backups.ts:58
+msgid "Failed to delete backup"
+msgstr "Det gick inte att ta bort säkerhetskopian"
+
+#: packages/admin/src/lib/api/bylines.ts:143
+msgid "Failed to delete byline"
+msgstr "Det gick inte att ta bort byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:143
+msgid "Failed to delete byline field"
+msgstr "Det gick inte att ta bort byline-fält"
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr "Det gick inte att ta bort samlingen"
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1444
+msgid "Failed to delete comment"
+msgstr "Det gick inte att ta bort kommentaren"
+
+#: packages/admin/src/lib/api/content.ts:279
+msgid "Failed to delete content"
+msgstr "Det gick inte att ta bort innehållet"
+
+#: packages/admin/src/lib/api/schema.ts:278
+#: packages/admin/src/routes/byline-schema.tsx:138
+msgid "Failed to delete field"
+msgstr "Det gick inte att ta bort fältet"
+
+#: packages/admin/src/lib/api/media.ts:389
+msgid "Failed to delete from provider"
+msgstr "Det gick inte att ta bort från leverantören"
+
+#: packages/admin/src/lib/api/media.ts:259
+msgid "Failed to delete media"
+msgstr "Det gick inte att ta bort media"
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr "Det gick inte att ta bort menyn"
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr "Det gick inte att ta bort menyobjektet"
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr "Det gick inte att ta bort passkey"
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr "Det gick inte att ta bort omdirigeringen"
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr "Det gick inte att ta bort sektionen"
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr "Det gick inte att ta bort termen"
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr "Det gick inte att ta bort widgeten"
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr "Det gick inte att ta bort widgetområdet"
+
+#: packages/admin/src/components/PluginManager.tsx:116
+#: packages/admin/src/lib/api/plugins.ts:91
+msgid "Failed to disable plugin"
+msgstr "Det gick inte att inaktivera tillägget"
+
+#: packages/admin/src/lib/api/search.ts:32
+msgid "Failed to disable search"
+msgstr "Det gick inte att inaktivera sökning"
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr "Det gick inte att inaktivera användaren"
+
+#: packages/admin/src/router.tsx:1051
+msgid "Failed to discard changes"
+msgstr "Det gick inte att kassera ändringarna"
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr "Det gick inte att stänga välkomstmeddelandet"
+
+#: packages/admin/src/router.tsx:464
+msgid "Failed to duplicate"
+msgstr "Det gick inte att duplicera"
+
+#: packages/admin/src/components/PluginManager.tsx:97
+#: packages/admin/src/lib/api/plugins.ts:77
+msgid "Failed to enable plugin"
+msgstr "Det gick inte att aktivera tillägget"
+
+#: packages/admin/src/lib/api/search.ts:31
+msgid "Failed to enable search"
+msgstr "Det gick inte att aktivera sökning"
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr "Det gick inte att aktivera användaren"
+
+#: packages/admin/src/components/WordPressImport.tsx:340
+msgid "Failed to execute import"
+msgstr "Det gick inte att köra importen"
+
+#: packages/admin/src/lib/api/client.ts:227
+msgid "Failed to fetch auth mode"
+msgstr "Det gick inte att hämta autentiseringsläge"
+
+#: packages/admin/src/lib/api/backups.ts:37
+msgid "Failed to fetch backup settings"
+msgstr "Det gick inte att hämta säkerhetskopieringsinställningar"
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr "Det gick inte att hämta samlingen"
+
+#: packages/admin/src/lib/api/dashboard.ts:42
+msgid "Failed to fetch dashboard stats"
+msgstr "Det gick inte att hämta översiktsstatistik"
+
+#: packages/admin/src/lib/api/email-settings.ts:34
+msgid "Failed to fetch email settings"
+msgstr "Det gick inte att hämta e-postinställningar"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:93
+msgid "Failed to fetch entry terms"
+msgstr "Det gick inte att hämta termer för posten"
+
+#: packages/admin/src/lib/api/client.ts:210
+msgid "Failed to fetch manifest"
+msgstr "Det gick inte att hämta manifestet"
+
+#: packages/admin/src/lib/api/media.ts:76
+msgid "Failed to fetch media"
+msgstr "Det gick inte att hämta media"
+
+#: packages/admin/src/lib/api/media.ts:89
+msgid "Failed to fetch media item"
+msgstr "Det gick inte att hämta mediefilen"
+
+#: packages/admin/src/lib/api/media.ts:325
+msgid "Failed to fetch media providers"
+msgstr "Det gick inte att hämta medieleverantörer"
+
+#: packages/admin/src/lib/api/plugins.ts:59
+#: packages/admin/src/lib/api/plugins.ts:63
+msgid "Failed to fetch plugin"
+msgstr "Det gick inte att hämta tillägget"
+
+#: packages/admin/src/lib/api/plugins.ts:45
+msgid "Failed to fetch plugins"
+msgstr "Det gick inte att hämta tillägg"
+
+#: packages/admin/src/lib/api/media.ts:355
+msgid "Failed to fetch provider media"
+msgstr "Det gick inte att hämta media från leverantören"
+
+#: packages/admin/src/lib/api/content.ts:556
+#: packages/admin/src/lib/api/content.ts:561
+msgid "Failed to fetch revision"
+msgstr "Det gick inte att hämta revisionen"
+
+#: packages/admin/src/lib/api/sections.ts:76
+msgid "Failed to fetch section"
+msgstr "Det gick inte att hämta sektionen"
+
+#: packages/admin/src/lib/api/sections.ts:68
+msgid "Failed to fetch sections"
+msgstr "Det gick inte att hämta sektioner"
+
+#: packages/admin/src/lib/api/settings.ts:50
+msgid "Failed to fetch settings"
+msgstr "Det gick inte att hämta inställningar"
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr "Det gick inte att hämta konfigurationsstatus"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:74
+msgid "Failed to fetch terms"
+msgstr "Det gick inte att hämta termer"
+
+#: packages/admin/src/lib/api/current-user.ts:22
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:851
+#: packages/admin/src/router.tsx:1375
+msgid "Failed to fetch user"
+msgstr "Det gick inte att hämta användaren"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:263
+msgid "Failed to generate preview"
+msgstr "Det gick inte att skapa förhandsgranskningen"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr "Det gick inte att skapa förhandsgranskningens URL"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr "Det gick inte att hämta autentiseringsalternativ"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr "Det gick inte att hämta registreringsalternativ"
+
+#: packages/admin/src/lib/api/media.ts:131
+msgid "Failed to get upload URL"
+msgstr "Det gick inte att hämta uppladdnings-URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:436
+msgid "Failed to import from WordPress"
+msgstr "Det gick inte att importera från WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:365
+#: packages/admin/src/lib/api/import.ts:422
+msgid "Failed to import media"
+msgstr "Det gick inte att importera media"
+
+#: packages/admin/src/lib/api/marketplace.ts:160
+#: packages/admin/src/lib/api/registry.ts:692
+msgid "Failed to install plugin"
+msgstr "Det gick inte att installera tillägget"
+
+#: packages/admin/src/lib/api/byline-fields.ts:98
+msgid "Failed to list byline fields"
+msgstr "Det gick inte att lista byline-fält"
+
+#: packages/admin/src/router.tsx:281
+msgid "Failed to load admin"
+msgstr "Det gick inte att läsa in administrationsgränssnittet"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "Failed to load allowed domains"
+msgstr "Det gick inte att läsa in tillåtna domäner"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:135
+msgid "Failed to load backup settings"
+msgstr "Det gick inte att läsa in säkerhetskopieringsinställningar"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:366
+msgid "Failed to load bylines: {0}"
+msgstr "Det gick inte att läsa in bylines: {0}"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:81
+msgid "Failed to load email settings"
+msgstr "Det gick inte att läsa in e-postinställningar"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:421
+msgid "Failed to load image"
+msgstr "Det gick inte att läsa in bilden"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:135
+msgid "Failed to load passkeys"
+msgstr "Det gick inte att läsa in passkeys"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:110
+msgid "Failed to load plugin"
+msgstr "Det gick inte att läsa in tillägget"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:145
+msgid "Failed to load plugins: {0}"
+msgstr "Det gick inte att läsa in tillägg: {0}"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:95
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr "Det gick inte att läsa in tillägg. Registeraggregatorn kan vara otillgänglig."
+
+#: packages/admin/src/components/RevisionHistory.tsx:188
+msgid "Failed to load revisions"
+msgstr "Det gick inte att läsa in revisioner"
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr "Det gick inte att läsa in konfigurationen"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr "Det gick inte att läsa in temat"
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr "Det gick inte att läsa in användare: {0}"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr "Det gick inte att läsa in widgeten"
+
+#: packages/admin/src/router.tsx:1469
+msgid "Failed to perform bulk action"
+msgstr "Det gick inte att utföra massåtgärden"
+
+#: packages/admin/src/lib/api/content.ts:322
+msgid "Failed to permanently delete content"
+msgstr "Det gick inte att ta bort innehållet permanent"
+
+#: packages/admin/src/components/WordPressImport.tsx:321
+msgid "Failed to prepare import"
+msgstr "Det gick inte att förbereda importen"
+
+#: packages/admin/src/router.tsx:489
+#: packages/admin/src/router.tsx:1012
+msgid "Failed to publish"
+msgstr "Det gick inte att publicera"
+
+#: packages/admin/src/lib/api/byline-fields.ts:106
+msgid "Failed to read byline field usage"
+msgstr "Det gick inte att läsa användningen av byline-fältet"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:112
+msgid "Failed to remove domain"
+msgstr "Det gick inte att ta bort domänen"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:70
+msgid "Failed to remove passkey"
+msgstr "Det gick inte att ta bort passkey"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:53
+msgid "Failed to rename passkey"
+msgstr "Det gick inte att byta namn på passkey"
+
+#: packages/admin/src/lib/api/byline-fields.ts:156
+msgid "Failed to reorder byline fields"
+msgstr "Det gick inte att ändra ordning på byline-fält"
+
+#: packages/admin/src/lib/api/schema.ts:293
+#: packages/admin/src/routes/byline-schema.tsx:152
+msgid "Failed to reorder fields"
+msgstr "Det gick inte att ändra ordning på fält"
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr "Det gick inte att ändra ordning på widgetar"
+
+#: packages/admin/src/router.tsx:436
+msgid "Failed to restore"
+msgstr "Det gick inte att återställa"
+
+#: packages/admin/src/lib/api/content.ts:311
+msgid "Failed to restore content"
+msgstr "Det gick inte att återställa innehållet"
+
+#: packages/admin/src/lib/api/content.ts:578
+#: packages/admin/src/lib/api/content.ts:583
+msgid "Failed to restore revision"
+msgstr "Det gick inte att återställa revisionen"
+
+#: packages/admin/src/lib/api/api-tokens.ts:98
+msgid "Failed to revoke API token"
+msgstr "Det gick inte att återkalla API-token"
+
+#: packages/admin/src/components/WordPressImport.tsx:378
+msgid "Failed to rewrite URLs"
+msgstr "Det gick inte att skriva om URL:erna"
+
+#: packages/admin/src/router.tsx:941
+#: packages/admin/src/router.tsx:1958
+msgid "Failed to save"
+msgstr "Det gick inte att spara"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:84
+msgid "Failed to save backup settings"
+msgstr "Det gick inte att spara säkerhetskopieringsinställningar"
+
+#: packages/admin/src/routes/byline-schema.tsx:122
+msgid "Failed to save field"
+msgstr "Det gick inte att spara fältet"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:50
+#: packages/admin/src/components/settings/SeoSettings.tsx:44
+#: packages/admin/src/components/settings/SocialSettings.tsx:42
+msgid "Failed to save settings"
+msgstr "Det gick inte att spara inställningar"
+
+#: packages/admin/src/router.tsx:1072
+msgid "Failed to schedule"
+msgstr "Det gick inte att schemalägga"
+
+#: packages/admin/src/components/LoginPage.tsx:70
+#: packages/admin/src/components/LoginPage.tsx:75
+msgid "Failed to send magic link"
+msgstr "Det gick inte att skicka magisk länk"
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr "Det gick inte att skicka återställningslänk"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:50
+#: packages/admin/src/lib/api/email-settings.ts:45
+msgid "Failed to send test email"
+msgstr "Det gick inte att skicka testmejlet"
+
+#: packages/admin/src/components/SignupPage.tsx:349
+msgid "Failed to send verification email"
+msgstr "Det gick inte att skicka bekräftelsemejlet"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:116
+msgid "Failed to set entry terms"
+msgstr "Det gick inte att ange termer för posten"
+
+#: packages/admin/src/lib/api/marketplace.ts:192
+#: packages/admin/src/lib/api/registry.ts:831
+msgid "Failed to uninstall plugin"
+msgstr "Det gick inte att avinstallera tillägget"
+
+#: packages/admin/src/router.tsx:1030
+msgid "Failed to unpublish"
+msgstr "Det gick inte att avpublicera"
+
+#: packages/admin/src/router.tsx:1093
+msgid "Failed to unschedule"
+msgstr "Det gick inte att avboka schemaläggningen"
+
+#: packages/admin/src/router.tsx:512
+msgid "Failed to update"
+msgstr "Det gick inte att uppdatera"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:351
+msgid "Failed to update {0}"
+msgstr "Det gick inte att uppdatera {0}"
+
+#: packages/admin/src/lib/api/backups.ts:46
+msgid "Failed to update backup settings"
+msgstr "Det gick inte att uppdatera säkerhetskopieringsinställningar"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:983
+msgid "Failed to update byline"
+msgstr "Det gick inte att uppdatera byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:135
+msgid "Failed to update byline field"
+msgstr "Det gick inte att uppdatera byline-fältet"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:94
+msgid "Failed to update domain"
+msgstr "Det gick inte att uppdatera domänen"
+
+#: packages/admin/src/lib/api/media.ts:276
+msgid "Failed to update media"
+msgstr "Det gick inte att uppdatera media"
+
+#: packages/admin/src/lib/api/marketplace.ts:176
+#: packages/admin/src/lib/api/registry.ts:763
+msgid "Failed to update plugin"
+msgstr "Det gick inte att uppdatera tillägget"
+
+#: packages/admin/src/lib/api/sections.ts:100
+msgid "Failed to update section"
+msgstr "Det gick inte att uppdatera sektionen"
+
+#: packages/admin/src/lib/api/settings.ts:64
+msgid "Failed to update settings"
+msgstr "Det gick inte att uppdatera inställningar"
+
+#: packages/admin/src/router.tsx:1428
+msgid "Failed to update status"
+msgstr "Det gick inte att uppdatera statusen"
+
+#: packages/admin/src/lib/api/media.ts:173
+msgid "Failed to upload file"
+msgstr "Det gick inte att ladda upp filen"
+
+#: packages/admin/src/lib/api/media.ts:218
+msgid "Failed to upload media"
+msgstr "Det gick inte att ladda upp media"
+
+#: packages/admin/src/lib/api/media.ts:377
+msgid "Failed to upload to provider"
+msgstr "Det gick inte att ladda upp till leverantören"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:248
+msgid "Failed to verify authentication"
+msgstr "Det gick inte att verifiera autentiseringen"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr "Det gick inte att verifiera registreringen"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:792
+msgid "FAQ"
+msgstr "Vanliga frågor"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:213
+#: packages/admin/src/components/settings/GeneralSettings.tsx:219
+msgid "Favicon"
+msgstr "Favicon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1180
+msgid "Feature"
+msgstr "Funktion"
+
+#: packages/admin/src/components/WordPressImport.tsx:1148
+msgid "Featured Images"
+msgstr "Utvalda bilder"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:440
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr "Funktioner"
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "Hämtar innehåll från EmDash Exporter-API:et."
+
+#: packages/admin/src/routes/byline-schema.tsx:95
+msgid "Field created"
+msgstr "Fält skapat"
+
+#: packages/admin/src/routes/byline-schema.tsx:133
+msgid "Field deleted"
+msgstr "Fält borttaget"
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr "Fältetikett"
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr "Fältetikett"
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr "Fältets slug kan inte ändras efter att den skapats"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:268
+msgid "Field type cannot be changed after creation."
+msgstr "Fälttyp kan inte ändras efter att den skapats."
+
+#: packages/admin/src/routes/byline-schema.tsx:115
+msgid "Field updated"
+msgstr "Fält uppdaterat"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:581
+msgid "Fields"
+msgstr "Fält"
+
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Fields created:"
+msgstr "Fält skapade:"
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr "Fil"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2158
+msgid "File {0}"
+msgstr "Fil {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr "Fil från mediebibliotek"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:325
+#: packages/admin/src/components/MediaDetailPanel.tsx:342
+#: packages/admin/src/components/MediaLibrary.tsx:586
+msgid "Filename"
+msgstr "Filnamn"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:120
+msgid "Filename cannot be changed after upload"
+msgstr "Filnamnet kan inte ändras efter uppladdning"
+
+#: packages/admin/src/components/WordPressImport.tsx:2366
+msgid "files imported"
+msgstr "filer importerade"
+
+#: packages/admin/src/components/ContentList.tsx:769
+msgid "Filter by author"
+msgstr "Filtrera efter författare"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr "Filtrera efter behörighet"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:177
+msgid "Filter by collection"
+msgstr "Filtrera efter samling"
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr "Filtrera efter roll"
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr "Filtrera efter källa"
+
+#: packages/admin/src/components/ContentList.tsx:754
+#: packages/admin/src/components/Redirects.tsx:419
+msgid "Filter by status"
+msgstr "Filtrera efter status"
+
+#: packages/admin/src/components/MediaLibrary.tsx:439
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "Filter by type"
+msgstr "Filtrera efter typ"
+
+#: packages/admin/src/routes/bylines.tsx:409
+msgid "Filter byline type"
+msgstr "Filtrera byline-typ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr "Endast förstagångskommentatorer"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr "Typsnitt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1398
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "För en fullständig import inklusive utkast och allt innehåll, exportera från WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1207
+msgid "For the best import experience, install the"
+msgstr "För den bästa importupplevelsen, installera"
+
+#: packages/admin/src/components/ContentList.tsx:806
+msgid "From date"
+msgstr "Från datum"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
+#: packages/admin/src/components/WordPressImport.tsx:1155
+msgid "Full"
+msgstr "Full"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "Full åtkomst"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Full admin access"
+msgstr "Full administratörsåtkomst"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "General"
+msgstr "Allmänt"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:96
+#: packages/admin/src/components/settings/GeneralSettings.tsx:124
+msgid "General Settings"
+msgstr "Allmänna inställningar"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "Genres"
+msgstr "Genrer"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "Kom igång"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:112
+msgid "GitHub"
+msgstr "GitHub"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "Ge denna passkey ett namn så att du känner igen den senare."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:36
+msgid "Go"
+msgstr "Go"
+
+#: packages/admin/src/components/WordPressImport.tsx:2418
+#: packages/admin/src/router.tsx:2162
+msgid "Go to Dashboard"
+msgstr "Gå till översikten"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:194
+msgid "Google Verification"
+msgstr "Google-verifiering"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:37
+msgid "GraphQL"
+msgstr "GraphQL"
+
+#: packages/admin/src/components/MediaLibrary.tsx:460
+msgid "Grid view"
+msgstr "Rutnätsvy"
+
+#: packages/admin/src/components/Redirects.tsx:166
+msgid "Group (optional)"
+msgstr "Grupp (valfri)"
+
+#: packages/admin/src/components/Widgets.tsx:160
+msgid "Group by"
+msgstr "Gruppera efter"
+
+#: packages/admin/src/routes/bylines.tsx:556
+msgid "Guest byline"
+msgstr "Gäst-byline"
+
+#: packages/admin/src/routes/bylines.tsx:414
+msgid "Guest only"
+msgstr "Endast gäst"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:62
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
+#: packages/admin/src/components/PortableTextEditor.tsx:1026
+msgid "Heading 1"
+msgstr "Rubrik 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:70
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:33
+#: packages/admin/src/components/PortableTextEditor.tsx:1036
+msgid "Heading 2"
+msgstr "Rubrik 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:78
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:34
+#: packages/admin/src/components/PortableTextEditor.tsx:1046
+msgid "Heading 3"
+msgstr "Rubrik 3"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
+msgid "Heading 4"
+msgstr "Rubrik 4"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
+msgid "Heading 5"
+msgstr "Rubrik 5"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
+msgid "Heading 6"
+msgstr "Rubrik 6"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:154
+msgid "Headings"
+msgstr "Rubriker"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
+msgid "Height"
+msgstr "Höjd"
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr "Hero-banner"
+
+#: packages/admin/src/components/SectionEditor.tsx:273
+msgid "hero, banner, cta"
+msgstr "hero, banner, cta"
+
+#: packages/admin/src/components/SeoPanel.tsx:230
+#: packages/admin/src/components/SeoPanel.tsx:233
+msgid "Hide from search engines"
+msgstr "Dölj för sökmotorer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Hide token"
+msgstr "Dölj token"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:649
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "Hierarkisk (som kategorier, med relationer mellan förälder och barn)"
+
+#: packages/admin/src/components/Redirects.tsx:225
+#: packages/admin/src/components/Redirects.tsx:470
+msgid "Hits"
+msgstr "Träffar"
+
+#: packages/admin/src/components/MenuEditor.tsx:416
+msgid "Home"
+msgstr "Hem"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr "Startsida"
+
+#: packages/admin/src/components/PluginManager.tsx:385
+msgid "Hooks"
+msgstr "Hooks"
+
+#: packages/admin/src/components/WordPressImport.tsx:1520
+msgid "How to create an Application Password"
+msgstr "Så skapar du ett applikationslösenord"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:38
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
+#: packages/admin/src/components/PortableTextEditor.tsx:1096
+msgid "HTML"
+msgstr "HTML"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
+msgid "HTML source"
+msgstr "HTML-källa"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3048
+#: packages/admin/src/components/PortableTextEditor.tsx:3557
+msgid "https://..."
+msgstr "https://…"
+
+#: packages/admin/src/components/MenuEditor.tsx:424
+msgid "https://example.com or /about"
+msgstr "https://example.com eller /about"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:507
+msgid "https://example.com/image.jpg"
+msgstr "https://example.com/image.jpg"
+
+#: packages/admin/src/components/WordPressImport.tsx:1089
+msgid "https://yoursite.com"
+msgstr "https://dinwebbplats.com"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:142
+msgid "Icon blurred due to image audit"
+msgstr "Ikonen är suddig på grund av bildgranskning"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:103
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "Om det finns ett konto för <0>{email}</0> har vi skickat en inloggningslänk."
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/FieldEditor.tsx:587
+#: packages/admin/src/components/PortableTextEditor.tsx:2307
+msgid "Image"
+msgstr "Bild"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr "Bild från mediebibliotek"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ImageFieldRenderer.tsx:113
+msgid "Image not found"
+msgstr "Bilden hittades inte"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:208
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Image settings"
+msgstr "Bildinställningar"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
+msgid "Image Settings"
+msgstr "Bildinställningar"
+
+#: packages/admin/src/components/SeoImageField.tsx:43
+msgid "Image shown when this page is shared on social media"
+msgstr "Bild som visas när sidan delas på sociala medier"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:508
+msgid "Image URL"
+msgstr "Bild-URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:2370
+msgid "image URLs updated in"
+msgstr "bild-URL:er uppdaterade i"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+#: packages/admin/src/components/MediaLibrary.tsx:434
+msgid "Images"
+msgstr "Bilder"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:378
+#: packages/admin/src/components/WordPressImport.tsx:738
+msgid "Import"
+msgstr "Importera"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "Import {0}"
+msgstr "Importera {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1366
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "Importera allt innehåll direkt, inklusive utkast, anpassade inläggstyper, ACF-fält och SEO-data. Ingen filnedladdning krävs."
+
+#: packages/admin/src/components/WordPressImport.tsx:2416
+msgid "Import Another File"
+msgstr "Importera en annan fil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1174
+msgid "Import Capabilities"
+msgstr "Importmöjligheter"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Import Complete"
+msgstr "Importen slutförd"
+
+#: packages/admin/src/components/WordPressImport.tsx:2305
+msgid "Import Completed with Errors"
+msgstr "Importen slutförd med fel"
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Import failed"
+msgstr "Importen misslyckades"
+
+#: packages/admin/src/components/WordPressImport.tsx:691
+msgid "Import from WordPress"
+msgstr "Importera från WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "Import Media"
+msgstr "Importera media"
+
+#: packages/admin/src/components/WordPressImport.tsx:2060
+msgid "Import Media Files"
+msgstr "Importera mediefiler"
+
+#: packages/admin/src/components/WordPressImport.tsx:693
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "Importera inlägg, sidor och anpassade inläggstyper från WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1814
+msgid "Import site configuration from WordPress."
+msgstr "Importera webbplatskonfiguration från WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Import via EmDash Exporter"
+msgstr "Importera via EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr "Importerad"
+
+#: packages/admin/src/components/WordPressImport.tsx:2344
+msgid "Imported by Collection"
+msgstr "Importerad per samling"
+
+#. placeholder {0}: wpImportProgress.comments
+#: packages/admin/src/components/WordPressImport.tsx:903
+msgid "Importing comments... {0}"
+msgstr "Importerar kommentarer … {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:920
+msgid "Importing content..."
+msgstr "Importerar innehåll …"
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:901
+msgid "Importing content... {0}"
+msgstr "Importerar innehåll … {0}"
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:900
+msgid "Importing content... {0} of {totalSelectedPosts}"
+msgstr "Importerar innehåll … {0} av {totalSelectedPosts}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Importing Media"
+msgstr "Importerar media"
+
+#: packages/admin/src/components/WordPressImport.tsx:904
+msgid "Importing menus and site settings..."
+msgstr "Importerar menyer och webbplatsinställningar …"
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr "Inkludera exempelinnehåll (rekommenderas för nya webbplatser)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1980
+msgid "Incompatible"
+msgstr "Inkompatibel"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:493
+msgid "Indexed"
+msgstr "Indexerad"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3447
+msgid "Inline Code"
+msgstr "Inline-kod"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:519
+#: packages/admin/src/components/MediaPickerModal.tsx:746
+msgid "Insert"
+msgstr "Infoga"
+
+#. placeholder {0}: block?.label || ""
+#: packages/admin/src/components/PortableTextEditor.tsx:1527
+msgid "Insert {0}"
+msgstr "Infoga {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1077
+msgid "Insert a blockquote"
+msgstr "Infoga ett citat"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1087
+msgid "Insert a code block"
+msgstr "Infoga ett kodblock"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1112
+msgid "Insert a horizontal rule"
+msgstr "Infoga en horisontell linje"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2323
+msgid "Insert a reusable section"
+msgstr "Infoga en återanvändbar sektion"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1122
+msgid "Insert a table"
+msgstr "Infoga en tabell"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2308
+msgid "Insert an image"
+msgstr "Infoga en bild"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1356
+msgid "Insert block"
+msgstr "Infoga block"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3411
+msgid "Insert block after current block"
+msgstr "Infoga block efter aktuellt block"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
+msgid "Insert block below"
+msgstr "Infoga block nedanför"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:501
+msgid "Insert from URL"
+msgstr "Infoga från URL"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3543
+msgid "Insert Link"
+msgstr "Infoga länk"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1097
+msgid "Insert raw HTML"
+msgstr "Infoga rå HTML"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr "Infoga sektion"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:192
+#: packages/admin/src/components/RegistryPluginDetail.tsx:541
+msgid "Install"
+msgstr "Installera"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:155
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "Installera och aktivera ett tillägg för e-postleverantör för att aktivera e-postfunktioner som inbjudningar, magiska länkar och lösenordsåterställning."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:186
+msgid "Install blocked"
+msgstr "Installation blockerad"
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
+msgstr "Installera tillägget EmDash Exporter på din WordPress-webbplats och generera en nyckel under Tools → EmDash Migration."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:791
+msgid "Installation"
+msgstr "Installation"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:173
+#: packages/admin/src/components/RegistryBrowse.tsx:198
+#: packages/admin/src/components/RegistryPluginDetail.tsx:533
+msgid "Installed"
+msgstr "Installerad"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:500
+msgid "Installed from marketplace (v{0})"
+msgstr "Installerad från marknadsplats (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:519
+msgid "Installed:"
+msgstr "Installerad:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:169
+msgid "Installing..."
+msgstr "Installerar …"
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr "Heltal"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:151
+msgid "Invalid invite link"
+msgstr "Ogiltig inbjudningslänk"
+
+#: packages/admin/src/components/ContentEditor.tsx:1494
+msgid "Invalid JSON"
+msgstr "Ogiltig JSON"
+
+#: packages/admin/src/components/SignupPage.tsx:259
+msgid "Invalid link"
+msgstr "Ogiltig länk"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:239
+msgid "Invite Error"
+msgstr "Inbjudningsfel"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:149
+msgid "Invite expired"
+msgstr "Inbjudan har gått ut"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "Inbjudningslänk skapad"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr "Bjud in användare"
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr "Bjud in din första teammedlem"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3092
+#: packages/admin/src/components/PortableTextEditor.tsx:3426
+msgid "Italic"
+msgstr "Kursiv"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1908
+#: packages/admin/src/components/RepeaterField.tsx:239
+msgid "Item {0}"
+msgstr "Objekt {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Item added"
+msgstr "Objekt tillagt"
+
+#: packages/admin/src/components/MenuEditor.tsx:187
+msgid "Item deleted"
+msgstr "Objekt borttaget"
+
+#: packages/admin/src/components/MenuEditor.tsx:212
+msgid "Item updated"
+msgstr "Objekt uppdaterat"
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:205
+msgid "Jane Doe"
+msgstr "Anna Andersson"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:39
+msgid "Java"
+msgstr "Java"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:40
+msgid "JavaScript"
+msgstr "JavaScript"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:235
+msgid "Job title"
+msgstr "Jobbtitel"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:246
+msgid "job_title"
+msgstr "job_title"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:41
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr "JSON"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:42
+msgid "JSX"
+msgstr "JSX"
+
+#: packages/admin/src/components/WordPressImport.tsx:916
+msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
+msgstr "Håll denna flik öppen. Importen körs i små steg och kan köras om säkert om den avbryts."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:812
+msgid "Keep typing to narrow down more bylines."
+msgstr "Fortsätt skriva för att begränsa antalet bylines ytterligare."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:293
+#: packages/admin/src/components/SectionEditor.tsx:270
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr "Nyckelord"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:43
+msgid "Kotlin"
+msgstr "Kotlin"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:232
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:416
+#: packages/admin/src/components/MenuEditor.tsx:593
+#: packages/admin/src/components/MenuList.tsx:166
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+#: packages/admin/src/components/Widgets.tsx:431
+#: packages/admin/src/routes/byline-schema.tsx:234
+msgid "Label"
+msgstr "Etikett"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:392
+msgid "Label (Plural)"
+msgstr "Etikett (plural)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:384
+msgid "Label (Singular)"
+msgstr "Etikett (singular)"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:162
+#: packages/admin/src/components/LoginPage.tsx:345
+#: packages/admin/src/components/Settings.tsx:136
+#: packages/admin/src/components/Settings.tsx:141
+msgid "Language"
+msgstr "Språk"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1027
+msgid "Large section heading"
+msgstr "Stor sektionsrubrik"
+
+#: packages/admin/src/components/PluginManager.tsx:525
+msgid "Last enabled:"
+msgstr "Senast aktiverad:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr "Senaste inloggning"
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr "Senaste inloggning"
+
+#: packages/admin/src/components/Redirects.tsx:226
+msgid "Last seen"
+msgstr "Senast sedd"
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr "Senast uppdaterad"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:159
+msgid "Last used"
+msgstr "Senast använd"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr "Senast använd {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:274
+msgid "Learn more"
+msgstr "Läs mer"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:339
+msgid "Leave blank to use a discoverable passkey."
+msgstr "Lämna tomt för att använda en identifierbar passkey."
+
+#: packages/admin/src/components/WordPressImport.tsx:2497
+msgid "Leave unassigned"
+msgstr "Lämna otilldelad"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
+msgid "Left"
+msgstr "Vänster"
+
+#: packages/admin/src/components/MediaLibrary.tsx:136
+#: packages/admin/src/components/MediaLibrary.tsx:273
+#: packages/admin/src/components/MediaLibrary.tsx:356
+#: packages/admin/src/components/MediaPickerModal.tsx:202
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Library"
+msgstr "Bibliotek"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr "Licens"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "ljus"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "Ljus"
+
+#: packages/admin/src/components/Widgets.tsx:163
+msgid "Limit"
+msgstr "Gräns"
+
+#: packages/admin/src/components/SignupPage.tsx:257
+msgid "Link expired"
+msgstr "Länken har gått ut"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr "Länka till ett annat innehållsobjekt"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr "Länkade konton ({0})"
+
+#: packages/admin/src/routes/bylines.tsx:415
+msgid "Linked only"
+msgstr "Endast länkad"
+
+#: packages/admin/src/routes/bylines.tsx:507
+msgid "Linked user"
+msgstr "Länkad användare"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:130
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr "Länkar"
+
+#: packages/admin/src/components/MediaLibrary.tsx:469
+msgid "List view"
+msgstr "Listvy"
+
+#: packages/admin/src/components/ContentEditor.tsx:685
+#: packages/admin/src/components/ContentEditor.tsx:732
+#: packages/admin/src/components/ContentSettingsPanel.tsx:234
+msgid "Live View"
+msgstr "Live-vy"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:469
+msgid "Load more"
+msgstr "Läs in mer"
+
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:722
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr "Läs in mer"
+
+#: packages/admin/src/routes/byline-schema.tsx:257
+msgid "Loading byline fields…"
+msgstr "Läser in byline-fält …"
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr "Läser in samlingar …"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:307
+msgid "Loading comments..."
+msgstr "Läser in kommentarer …"
+
+#: packages/admin/src/router.tsx:2131
+msgid "Loading configuration..."
+msgstr "Läser in konfiguration …"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr "Läser in innehåll …"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2856
+msgid "Loading editor..."
+msgstr "Läser in redigerare …"
+
+#: packages/admin/src/components/MenuEditor.tsx:342
+msgid "Loading menu..."
+msgstr "Läser in meny …"
+
+#: packages/admin/src/components/MenuList.tsx:94
+msgid "Loading menus..."
+msgstr "Läser in menyer …"
+
+#: packages/admin/src/components/PluginManager.tsx:136
+msgid "Loading plugins..."
+msgstr "Läser in tillägg …"
+
+#: packages/admin/src/components/Redirects.tsx:456
+msgid "Loading redirects..."
+msgstr "Läser in omdirigeringar …"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr "Läser in sektioner …"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:99
+#: packages/admin/src/components/settings/SeoSettings.tsx:93
+#: packages/admin/src/components/settings/SocialSettings.tsx:73
+msgid "Loading settings..."
+msgstr "Läser in inställningar …"
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr "Läser in konfiguration …"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:827
+msgid "Loading terms..."
+msgstr "Läser in termer …"
+
+#: packages/admin/src/components/Widgets.tsx:370
+msgid "Loading widgets..."
+msgstr "Läser in widgetar …"
+
+#: packages/admin/src/components/ContentList.tsx:538
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:659
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:722
+#: packages/admin/src/components/PortableTextEditor.tsx:2035
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:161
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/TaxonomyManager.tsx:779
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:469
+msgid "Loading..."
+msgstr "Läser in …"
+
+#: packages/admin/src/components/ContentList.tsx:518
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "Språk"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Lock aspect ratio"
+msgstr "Lås bildförhållande"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:291
+msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
+msgstr "Låst eftersom detta fält har lagrade värden. Ta bort värdena (eller fältet) för att ändra detta."
+
+#: packages/admin/src/components/Header.tsx:109
+msgid "Log out"
+msgstr "Logga ut"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "Logo"
+msgstr "Logotyp"
+
+#: packages/admin/src/components/WordPressImport.tsx:1832
+msgid "Logo & favicon"
+msgstr "Logotyp och favicon"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:53
+msgid "Long text"
+msgstr "Lång text"
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr "Lång text"
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "Endast gemener, siffror och bindestreck"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:641
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "Endast gemener, siffror och understreck, måste börja med en bokstav"
+
+#: packages/admin/src/components/Widgets.tsx:431
+msgid "Main Sidebar"
+msgstr "Huvudsidofält"
+
+#: packages/admin/src/lib/api/marketplace.ts:228
+#: packages/admin/src/lib/api/marketplace.ts:236
+msgid "Make network requests"
+msgstr "Skicka nätverksförfrågningar"
+
+#: packages/admin/src/lib/api/marketplace.ts:229
+#: packages/admin/src/lib/api/marketplace.ts:237
+msgid "Make network requests to any host (unrestricted)"
+msgstr "Skicka nätverksförfrågningar till valfri värd (obegränsat)"
+
+#: packages/admin/src/components/Sidebar.tsx:461
+msgid "Manage"
+msgstr "Hantera"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:798
+msgid "Manage {0} for {1}"
+msgstr "Hantera {0} för {1}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:774
+msgid "Manage bylines in {entryLocale}"
+msgstr "Hantera bylines i {entryLocale}"
+
+#: packages/admin/src/components/Widgets.tsx:386
+msgid "Manage content widgets in your widget areas"
+msgstr "Hantera innehållswidgetar i dina widgetområden"
+
+#: packages/admin/src/components/PluginManager.tsx:175
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "Hantera installerade tillägg. Aktivera eller inaktivera tillägg för att styra deras funktionalitet."
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Manage navigation menus for your site"
+msgstr "Hantera navigeringsmenyer för din webbplats"
+
+#: packages/admin/src/components/Redirects.tsx:359
+msgid "Manage URL redirects and view 404 errors."
+msgstr "Hantera URL-omdirigeringar och visa 404-fel."
+
+#: packages/admin/src/components/Settings.tsx:94
+msgid "Manage your passkeys and authentication"
+msgstr "Hantera dina passkeys och autentisering"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:317
+msgid "Managed by {providerName}"
+msgstr "Hanteras av {providerName}"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:318
+msgid "Managed by an external media provider"
+msgstr "Hanteras av en extern medieleverantör"
+
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "Manual"
+msgstr "Manuell"
+
+#: packages/admin/src/components/WordPressImport.tsx:2454
+msgid "Map Authors"
+msgstr "Tilldela författare"
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2502
+msgid "Map WordPress user {0} to EmDash user"
+msgstr "Tilldela WordPress-användaren {0} till en EmDash-användare"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:255
+msgid "Mark {0} as Gone (410)"
+msgstr "Markera {0} som borttagen (410)"
+
+#: packages/admin/src/components/Redirects.tsx:254
+msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
+msgstr "Markera som borttagen (410) – talar om för sökmotorer att den permanent tagits bort"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:501
+msgid "Mark as spam"
+msgstr "Markera som skräppost"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:44
+msgid "Markdown"
+msgstr "Markdown"
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "marketplace"
+msgstr "marknadsplats"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:167
+#: packages/admin/src/components/PluginManager.tsx:355
+#: packages/admin/src/components/Sidebar.tsx:362
+msgid "Marketplace"
+msgstr "Marknadsplats"
+
+#: packages/admin/src/components/FieldEditor.tsx:627
+msgid "Max Items"
+msgstr "Max antal"
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr "Maxlängd"
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr "Maxvärde"
+
+#: packages/admin/src/components/Widgets.tsx:145
+msgid "Maximum tags"
+msgstr "Max antal taggar"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:45
+msgid "MDX"
+msgstr "MDX"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2311
+#: packages/admin/src/components/Sidebar.tsx:321
+#: packages/admin/src/components/WordPressImport.tsx:752
+#: packages/admin/src/components/WordPressImport.tsx:1145
+#: packages/admin/src/components/WordPressImport.tsx:1334
+msgid "Media"
+msgstr "Media"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:222
+msgid "Media Details"
+msgstr "Mediedetaljer"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2400
+msgid "Media Errors ({0})"
+msgstr "Mediefel ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Media Import"
+msgstr "Medieimport"
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Media Import Complete"
+msgstr "Medieimport slutförd"
+
+#: packages/admin/src/components/WordPressImport.tsx:2314
+msgid "Media import was skipped"
+msgstr "Medieimport hoppades över"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:322
+msgid "Media Library"
+msgstr "Mediebibliotek"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Media Read"
+msgstr "Läsa media"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Media Write"
+msgstr "Redigera media"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1037
+msgid "Medium section heading"
+msgstr "Medelstor sektionsrubrik"
+
+#: packages/admin/src/components/Widgets.tsx:102
+#: packages/admin/src/components/Widgets.tsx:897
+msgid "Menu"
+msgstr "Meny"
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:144
+msgid "Menu \"{0}\" ({1}) created."
+msgstr "Menyn \"{0}\" ({1}) skapades."
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu \"{0}\" has been created."
+msgstr "Menyn \"{0}\" har skapats."
+
+#: packages/admin/src/components/MenuList.tsx:54
+msgid "Menu created"
+msgstr "Meny skapad"
+
+#: packages/admin/src/components/MenuList.tsx:74
+msgid "Menu deleted"
+msgstr "Meny borttagen"
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Menu item has been added."
+msgstr "Menyobjektet har lagts till."
+
+#: packages/admin/src/components/MenuEditor.tsx:188
+msgid "Menu item has been deleted."
+msgstr "Menyobjektet har tagits bort."
+
+#: packages/admin/src/components/MenuEditor.tsx:213
+msgid "Menu item has been updated."
+msgstr "Menyobjektet har uppdaterats."
+
+#: packages/admin/src/components/MenuEditor.tsx:350
+msgid "Menu not found"
+msgstr "Menyn hittades inte"
+
+#: packages/admin/src/components/MenuEditor.tsx:228
+msgid "Menu order has been updated."
+msgstr "Menyordningen har uppdaterats."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:103
+#: packages/admin/src/components/Sidebar.tsx:331
+#: packages/admin/src/components/WordPressImport.tsx:1149
+msgid "Menus"
+msgstr "Menyer"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1767
+msgid "Menus ({0})"
+msgstr "Menyer ({0})"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Menus Manage"
+msgstr "Hantera menyer"
+
+#: packages/admin/src/components/SeoPanel.tsx:188
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Meta Description"
+msgstr "Metabeskrivning"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:203
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "Metatagg-innehåll för verifiering med Bing Webmaster Tools"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:197
+msgid "Meta tag content for Google Search Console verification"
+msgstr "Metatagg-innehåll för verifiering med Google Search Console"
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "Meta titles, descriptions, and social images"
+msgstr "Metatitlar, beskrivningar och bilder för sociala medier"
+
+#: packages/admin/src/components/WordPressImport.tsx:1051
+msgid "Migration key"
+msgstr "Migreringsnyckel"
+
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Min Items"
+msgstr "Min antal"
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr "Minlängd"
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr "Minvärde"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:504
+msgid "Moderation"
+msgstr "Moderering"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "Modereringssignaler"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr "Ändrad"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Modify collection schemas"
+msgstr "Ändra samlingsscheman"
+
+#: packages/admin/src/components/Widgets.tsx:161
+msgid "Monthly"
+msgstr "Månadsvis"
+
+#: packages/admin/src/components/Widgets.tsx:157
+msgid "Monthly/yearly archives"
+msgstr "Månads-/årsarkiv"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr "Mest populära"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:439
+msgid "Move \"{0}\" down"
+msgstr "Flytta \"{0}\" nedåt"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:429
+msgid "Move \"{0}\" up"
+msgstr "Flytta \"{0}\" uppåt"
+
+#: packages/admin/src/components/ContentList.tsx:1046
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "Flytta \"{title}\" till papperskorgen? Du kan återställa det senare."
+
+#: packages/admin/src/components/ContentList.tsx:1037
+msgid "Move {title} to trash"
+msgstr "Flytta {title} till papperskorgen"
+
+#: packages/admin/src/components/MenuEditor.tsx:537
+msgid "Move down"
+msgstr "Flytta nedåt"
+
+#: packages/admin/src/components/ContentList.tsx:439
+msgid "Move to trash"
+msgstr "Flytta till papperskorgen"
+
+#: packages/admin/src/components/ContentList.tsx:466
+#: packages/admin/src/components/ContentList.tsx:1059
+#: packages/admin/src/components/ContentSettingsPanel.tsx:599
+#: packages/admin/src/components/ContentSettingsPanel.tsx:619
+msgid "Move to Trash"
+msgstr "Flytta till papperskorgen"
+
+#: packages/admin/src/components/ContentList.tsx:444
+#: packages/admin/src/components/ContentList.tsx:1044
+#: packages/admin/src/components/ContentSettingsPanel.tsx:604
+msgid "Move to Trash?"
+msgstr "Flytta till papperskorgen?"
+
+#: packages/admin/src/components/MenuEditor.tsx:528
+msgid "Move up"
+msgstr "Flytta uppåt"
+
+#: packages/admin/src/router.tsx:509
+msgid "Moved {total} items to draft"
+msgstr "Flyttade {total} objekt till utkast"
+
+#: packages/admin/src/router.tsx:530
+msgid "Moved {total} items to trash"
+msgstr "Flyttade {total} objekt till papperskorgen"
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr "Flerval"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr "Flerradig text"
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr "Flera val från alternativ"
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr "Min fantastiska blogg"
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:154
+#: packages/admin/src/components/TaxonomyManager.tsx:389
+#: packages/admin/src/components/TaxonomyManager.tsx:632
+#: packages/admin/src/components/TaxonomyManager.tsx:821
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:425
+msgid "Name"
+msgstr "Namn"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:558
+msgid "Name and label are required"
+msgstr "Namn och etikett krävs"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "Namnet måste börja med en bokstav och får endast innehålla gemener, siffror och understreck"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "Navigering"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr "Aldrig"
+
+#: packages/admin/src/router.tsx:1119
+msgid "new"
+msgstr "ny"
+
+#: packages/admin/src/routes/bylines.tsx:427
+msgid "New"
+msgstr "Ny"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:107
+msgid "NEW"
+msgstr "NY"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:466
+msgid "New {0}"
+msgstr "Ny {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:651
+msgid "New {collectionLabel}"
+msgstr "Ny {collectionLabel}"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "New byline field"
+msgstr "Nytt byline-fält"
+
+#: packages/admin/src/components/WordPressImport.tsx:1982
+msgid "New collection"
+msgstr "Ny samling"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr "Ny innehållstyp"
+
+#: packages/admin/src/routes/byline-schema.tsx:224
+msgid "New field"
+msgstr "Nytt fält"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:118
+msgid "New public routes"
+msgstr "Nya offentliga rutter"
+
+#: packages/admin/src/components/Redirects.tsx:105
+#: packages/admin/src/components/Redirects.tsx:362
+msgid "New Redirect"
+msgstr "Ny omdirigering"
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr "Ny sektion"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "ny flik"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:811
+msgid "New Taxonomy"
+msgstr "Ny taxonomi"
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:433
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:612
+msgid "New window"
+msgstr "Nytt fönster"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr "Nyaste"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:392
+msgid "News"
+msgstr "Nyheter"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr "Nästa"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:371
+#: packages/admin/src/components/ContentList.tsx:618
+msgid "Next page"
+msgstr "Nästa sida"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:463
+msgid "Next screenshot"
+msgstr "Nästa skärmbild"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "No"
+msgstr "Nej"
+
+#: packages/admin/src/routes/byline-schema.tsx:420
+msgid "No (shared across translations)"
+msgstr "Nej (delat mellan översättningar)"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:436
+msgid "No {0} available."
+msgstr "Ingen {0} tillgänglig."
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:549
+msgid "No {0} yet."
+msgstr "Ingen {0} ännu."
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:830
+msgid "No {0} yet. Create one to get started."
+msgstr "Ingen {0} ännu. Skapa en för att komma igång."
+
+#: packages/admin/src/components/Redirects.tsx:217
+msgid "No 404 errors recorded yet."
+msgstr "Inga 404-fel registrerade ännu."
+
+#: packages/admin/src/components/MediaLibrary.tsx:833
+#: packages/admin/src/components/MediaLibrary.tsx:890
+msgid "No alt text"
+msgstr "Ingen alt-text"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:268
+msgid "No API tokens yet. Create one to get started."
+msgstr "Inga API-token ännu. Skapa en för att komma igång."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No approved comments yet."
+msgstr "Inga godkända kommentarer ännu."
+
+#: packages/admin/src/routes/byline-schema.tsx:291
+msgid "No byline fields yet."
+msgstr "Inga byline-fält ännu."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:766
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr "Inga bylines tillgängliga i {entryLocale}. Skapa en variant på sidan Bylines innan du krediterar den på denna post."
+
+#: packages/admin/src/routes/bylines.tsx:453
+msgid "No bylines found"
+msgstr "Inga bylines hittades"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:874
+msgid "No bylines selected."
+msgstr "Inga bylines valda."
+
+#: packages/admin/src/components/Dashboard.tsx:226
+msgid "No collections configured"
+msgstr "Inga samlingar konfigurerade"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:546
+msgid "No comments awaiting moderation."
+msgstr "Inga kommentarer väntar på moderering."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:542
+msgid "No comments match your search."
+msgstr "Inga kommentarer matchar din sökning."
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:82
+msgid "No content"
+msgstr "Inget innehåll"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr "Inget innehåll hittades"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr "Inget innehåll i denna samling"
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr "Inga innehållstyper ännu."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:612
+msgid "No custom fields yet"
+msgstr "Inga anpassade fält ännu"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:264
+msgid "No detailed description available."
+msgstr "Ingen detaljerad beskrivning tillgänglig."
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:262
+msgid "No domains configured. Users must be invited individually."
+msgstr "Inga domäner konfigurerade. Användare måste bjudas in individuellt."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:152
+msgid "No email provider configured"
+msgstr "Ingen e-postleverantör konfigurerad"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "Ingen e-postleverantör konfigurerad. Dela denna länk manuellt."
+
+#: packages/admin/src/components/WordPressImport.tsx:2516
+msgid "No EmDash users found"
+msgstr "Inga EmDash-användare hittades"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
+msgid "No expiry"
+msgstr "Inget utgångsdatum"
+
+#: packages/admin/src/components/RevisionHistory.tsx:335
+msgid "No fields to compare"
+msgstr "Inga fält att jämföra"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:204
+msgid "No headings in document"
+msgstr "Inga rubriker i dokumentet"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:581
+msgid "No installable releases"
+msgstr "Inga installerbara versioner"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:191
+msgid "No invite token provided"
+msgstr "Ingen inbjudningstoken angiven"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1831
+#: packages/admin/src/components/RepeaterField.tsx:165
+msgid "No items yet"
+msgstr "Inga objekt ännu"
+
+#: packages/admin/src/components/FieldEditor.tsx:631
+msgid "No limit"
+msgstr "Ingen gräns"
+
+#: packages/admin/src/routes/bylines.tsx:518
+msgid "No linked user"
+msgstr "Ingen länkad användare"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "No matches"
+msgstr "Inga matchningar"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:809
+msgid "No matching bylines."
+msgstr "Inga matchande bylines."
+
+#: packages/admin/src/components/MediaLibrary.tsx:489
+#: packages/admin/src/components/MediaLibrary.tsx:517
+msgid "No matching media"
+msgstr "Inga matchande mediefiler"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:264
+msgid "No matching passkey found for this account."
+msgstr "Ingen matchande passkey hittades för detta konto."
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr "Inget maxvärde"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:645
+msgid "No media available from this provider"
+msgstr "Ingen media tillgänglig från denna leverantör"
+
+#: packages/admin/src/components/MediaLibrary.tsx:540
+msgid "No media available from this provider."
+msgstr "Ingen media tillgänglig från denna leverantör."
+
+#: packages/admin/src/components/MediaLibrary.tsx:539
+#: packages/admin/src/components/MediaPickerModal.tsx:639
+msgid "No media found"
+msgstr "Ingen media hittades"
+
+#: packages/admin/src/components/MenuEditor.tsx:485
+msgid "No menu items yet"
+msgstr "Inga menyobjekt ännu"
+
+#: packages/admin/src/components/MenuList.tsx:186
+msgid "No menus yet"
+msgstr "Inga menyer ännu"
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr "Inget minimivärde"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr "Ingen moderering (godkänn alla automatiskt)"
+
+#: packages/admin/src/components/MenuEditor.tsx:329
+msgid "No parent (top level)"
+msgstr "Ingen förälder (toppnivå)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr "Inga passkeys registrerade"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:168
+msgid "No passkeys registered yet."
+msgstr "Inga passkeys registrerade ännu."
+
+#: packages/admin/src/components/PluginManager.tsx:195
+msgid "No plugins configured"
+msgstr "Inga tillägg konfigurerade"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "Inga tillägg hittades"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:117
+msgid "No plugins have been published to this registry yet."
+msgstr "Inga tillägg har publicerats till detta register ännu."
+
+#: packages/admin/src/components/RegistryBrowse.tsx:116
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr "Inga tillägg matchar \"{debouncedQuery}\"."
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr "Ingen förhandsgranskning"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:304
+msgid "No public URL available"
+msgstr "Ingen offentlig URL tillgänglig"
+
+#: packages/admin/src/components/Dashboard.tsx:304
+msgid "No recent activity"
+msgstr "Ingen senaste aktivitet"
+
+#: packages/admin/src/components/Redirects.tsx:460
+msgid "No redirects yet"
+msgstr "Inga omdirigeringar ännu"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1381
+#: packages/admin/src/components/RepeaterField.tsx:374
+msgid "No results"
+msgstr "Inga resultat"
+
+#: packages/admin/src/components/ContentList.tsx:546
+#: packages/admin/src/components/ContentList.tsx:565
+msgid "No results for \"{activeSearch}\""
+msgstr "Inga resultat för \"{activeSearch}\""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "Inga resultat för \"{debouncedQuery}\". Försök med ett annat sökord."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "Inga resultat hittades"
+
+#: packages/admin/src/components/RevisionHistory.tsx:191
+msgid "No revisions yet"
+msgstr "Inga revisioner ännu"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr "Inga sektioner tillgängliga"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr "Inga sektioner hittades"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr "Inga sektioner ännu"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No spam comments."
+msgstr "Inga skräppostkommentarer."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr "Inga teman hittades"
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr "Inga användare matchar dina filter."
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr "Inga användare ännu."
+
+#: packages/admin/src/components/Widgets.tsx:499
+msgid "No widget areas yet. Create one to get started."
+msgstr "Inga widgetområden ännu. Skapa ett för att komma igång."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
+msgid "None"
+msgstr "Ingen"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:418
+#: packages/admin/src/components/TaxonomyManager.tsx:424
+msgid "None (top level)"
+msgstr "Ingen (toppnivå)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:616
+msgid "Not compatible with this environment"
+msgstr "Inte kompatibel med denna miljö"
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr "Tal"
+
+#: packages/admin/src/components/Widgets.tsx:127
+msgid "Number of posts"
+msgstr "Antal inlägg"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:278
+msgid "Number of posts to show per page on list views"
+msgstr "Antal inlägg som visas per sida i listvyer"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:110
+#: packages/admin/src/components/PortableTextEditor.tsx:1066
+#: packages/admin/src/components/PortableTextEditor.tsx:3474
+msgid "Numbered List"
+msgstr "Numrerad lista"
+
+#: packages/admin/src/components/WordPressImport.tsx:494
+msgid "OAuth authorization requires HTTPS. Please use manual credentials."
+msgstr "OAuth-auktorisering kräver HTTPS. Använd manuella inloggningsuppgifter istället."
+
+#: packages/admin/src/components/SeoImageField.tsx:46
+msgid "OG Image"
+msgstr "OG-bild"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "på ett anpassat värdnamn behandlas inte som säkert, inte heller vid loopback."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "Auktorisera endast koder du känner igen."
+
+#: packages/admin/src/components/SignupPage.tsx:96
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "Endast e-postadresser från tillåtna domäner kan registrera sig."
+
+#: packages/admin/src/components/MenuList.tsx:159
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "Endast gemener, siffror och bindestreck"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr "Endast de listade MIME-typerna accepteras för detta fält."
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Oops!"
+msgstr "Hoppsan!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:379
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:380
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:568
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:569
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr "Öppna i ny flik"
+
+#: packages/admin/src/components/WordPressImport.tsx:1534
+msgid "Open WordPress Profile"
+msgstr "Öppna WordPress-profil"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr ""
+"Alternativ 1\n"
+"Alternativ 2\n"
+"Alternativ 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
+msgid "Optional caption displayed below the image"
+msgstr "Valfri bildtext som visas under bilden"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:384
+msgid "Optional caption for display"
+msgstr "Valfri bildtext för visning"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+msgid "Optional description"
+msgstr "Valfri beskrivning"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:553
+msgid "Optional tooltip on hover"
+msgstr "Valfritt verktygstips när du hovrar"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:302
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr "Alternativ (ett per rad)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:531
+msgid "or choose from library"
+msgstr "eller välj från biblioteket"
+
+#: packages/admin/src/components/WordPressImport.tsx:1590
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "Eller klicka för att bläddra. Accepterar .xml-filer exporterade från WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1071
+msgid "or connect by URL"
+msgstr "eller anslut via URL"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:96
+#: packages/admin/src/components/LoginPage.tsx:261
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr "Eller fortsätt med"
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Or upload an export file"
+msgstr "Eller ladda upp en exportfil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "or upload directly"
+msgstr "eller ladda upp direkt"
+
+#: packages/admin/src/components/MenuEditor.tsx:227
+msgid "Order saved"
+msgstr "Ordning sparad"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
+msgid "Original:"
+msgstr "Original:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:182
+msgid "Outline"
+msgstr "Disposition"
+
+#: packages/admin/src/components/SeoPanel.tsx:164
+msgid "Overrides the page title in search engine results"
+msgstr "Åsidosätter sidtiteln i sökmotorresultat"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:500
+msgid "Ownership"
+msgstr "Ägarskap"
+
+#: packages/admin/src/components/PluginManager.tsx:509
+msgid "Package"
+msgstr "Paket"
+
+#: packages/admin/src/router.tsx:2157
+msgid "Page Not Found"
+msgstr "Sidan hittades inte"
+
+#: packages/admin/src/components/PluginManager.tsx:373
+#: packages/admin/src/components/WordPressImport.tsx:1328
+msgid "Pages"
+msgstr "Sidor"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:54
+msgid "Paragraph"
+msgstr "Stycke"
+
+#: packages/admin/src/components/MenuEditor.tsx:615
+#: packages/admin/src/components/TaxonomyManager.tsx:414
+msgid "Parent"
+msgstr "Överordnad"
+
+#: packages/admin/src/components/Redirects.tsx:509
+#: packages/admin/src/components/Redirects.tsx:515
+msgid "Part of a redirect loop"
+msgstr "Del av en omdirigeringsloop"
+
+#: packages/admin/src/components/WordPressImport.tsx:1153
+msgid "Partial"
+msgstr "Delvis"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr "Godkänd"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:89
+msgid "Passkey added successfully"
+msgstr "Passkey har lagts till"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "Passkey-namn"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "Passkey-namn (valfritt)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "Passkey har registrerats!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Passkey removed"
+msgstr "Passkey borttagen"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:49
+msgid "Passkey renamed"
+msgstr "Passkey har fått nytt namn"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:150
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr "Passkeys"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr "Passkeys ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:154
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Passkeys är ett säkert, lösenordsfritt sätt att logga in på ditt konto. Du kan registrera flera passkeys för olika enheter."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:76
+#: packages/admin/src/components/SignupPage.tsx:213
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Passkeys är ett säkert, lösenordsfritt sätt att logga in med hjälp av enhetens biometri, PIN-kod eller säkerhetsnyckel."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:301
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "Passkeys är inte tillgängliga här"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:305
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Passkeys kräver en"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Passkeys kräver HTTPS eller http://localhost (med din port); detta värdnamn är inte en säker webbläsarkontext."
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "Paste your migration key"
+msgstr "Klistra in din migreringsnyckel"
+
+#: packages/admin/src/components/Redirects.tsx:224
+msgid "Path"
+msgstr "Sökväg"
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr "Mönster (regex)"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:435
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr "Mönster för att generera URL:er, t.ex. /blog/{0}"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:431
+msgid "Pattern must include a {0} placeholder"
+msgstr "Mönstret måste innehålla en {0}-platshållare"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr "PDF"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:1183
+msgid "pending"
+msgstr "väntande"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:197
+#: packages/admin/src/components/Dashboard.tsx:348
+msgid "Pending"
+msgstr "Väntande"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:405
+msgid "Pending changes"
+msgstr "Väntande ändringar"
+
+#: packages/admin/src/components/ContentList.tsx:1117
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "Ta bort \"{title}\" permanent? Detta kan inte ångras."
+
+#: packages/admin/src/components/ContentList.tsx:1106
+msgid "Permanently delete {title}"
+msgstr "Ta bort {title} permanent"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:273
+msgid "Permissions"
+msgstr "Behörigheter"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:46
+msgid "PHP"
+msgstr "PHP"
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr "Välj en valfri metod för att skapa ditt administratörskonto."
+
+#: packages/admin/src/components/Widgets.tsx:152
+msgid "Placeholder text"
+msgstr "Platshållartext"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:311
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "Vanlig"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:27
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:120
+msgid "Plain text"
+msgstr "Vanlig text"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:165
+msgid "Please ask your administrator to send a new invite."
+msgstr "Be din administratör att skicka en ny inbjudan."
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr "Ange en giltig e-postadress"
+
+#: packages/admin/src/components/SignupPage.tsx:54
+msgid "Please enter a valid email address"
+msgstr "Ange en giltig e-postadress"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:398
+msgid "Please enter a valid URL"
+msgstr "Ange en giltig URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1182
+msgid "Plugin"
+msgstr "Tillägg"
+
+#: packages/admin/src/lib/api/plugins.ts:57
+msgid "Plugin \"{pluginId}\" not found"
+msgstr "Tillägget \"{pluginId}\" hittades inte"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:749
+msgid "Plugin details"
+msgstr "Tilläggsdetaljer"
+
+#: packages/admin/src/components/PluginManager.tsx:110
+msgid "Plugin disabled"
+msgstr "Tillägg inaktiverat"
+
+#: packages/admin/src/components/PluginManager.tsx:91
+msgid "Plugin enabled"
+msgstr "Tillägg aktiverat"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr "Tilläggsfel"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr "Tilläggsfel ({0})"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:112
+msgid "Plugin not found"
+msgstr "Tillägget hittades inte"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:398
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr "Tillägget hittades inte. Utgivarens användarnamn eller slug kan vara felaktig."
+
+#: packages/admin/src/components/WordPressImport.tsx:1209
+msgid "plugin on your WordPress site."
+msgstr "-tillägget på din WordPress-webbplats."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Plugin Permissions"
+msgstr "Tilläggsbehörigheter"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:70
+msgid "Plugin Registry"
+msgstr "Tilläggsregister"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr "Tillägget svarade med {0}: {text}"
+
+#: packages/admin/src/components/PluginManager.tsx:305
+msgid "Plugin uninstalled"
+msgstr "Tillägg avinstallerat"
+
+#: packages/admin/src/lib/api/registry.ts:783
+msgid "Plugin update requires re-consent"
+msgstr "Uppdatering av tillägg kräver nytt samtycke"
+
+#: packages/admin/src/components/PluginManager.tsx:258
+msgid "Plugin updated"
+msgstr "Tillägg uppdaterat"
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
+msgid "Plugin widget error"
+msgstr "Fel i tilläggswidget"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:135
+#: packages/admin/src/components/PluginManager.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:153
+#: packages/admin/src/components/Sidebar.tsx:349
+#: packages/admin/src/components/Sidebar.tsx:477
+msgid "Plugins"
+msgstr "Tillägg"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:264
+msgid "Point-in-Time Restore"
+msgstr "Återställning till en tidpunkt"
+
+#: packages/admin/src/components/SeoPanel.tsx:208
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "Pekar sökmotorer till den ursprungliga versionen av sidan, om den är duplicerad från en annan URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:387
+msgid "Post"
+msgstr "Inlägg"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:395
+#: packages/admin/src/components/WordPressImport.tsx:1322
+msgid "Posts"
+msgstr "Inlägg"
+
+#: packages/admin/src/components/WordPressImport.tsx:1144
+msgid "Posts & Pages"
+msgstr "Inlägg och sidor"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:272
+msgid "Posts Per Page"
+msgstr "Inlägg per sida"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:465
+msgid "Pre-release"
+msgstr "Förhandsversion"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "Förbereder registrering …"
+
+#: packages/admin/src/components/WordPressImport.tsx:2179
+msgid "Preparing to download files from WordPress..."
+msgstr "Förbereder nedladdning av filer från WordPress …"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr "Förbereder …"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:143
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:585
+msgid "Preview"
+msgstr "Förhandsgranskning"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr "Förhandsgranska innehåll innan publicering"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:143
+msgid "Preview draft"
+msgstr "Förhandsgranska utkast"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr "Föregående"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:352
+#: packages/admin/src/components/ContentList.tsx:606
+msgid "Previous page"
+msgstr "Föregående sida"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:445
+msgid "Previous screenshot"
+msgstr "Föregående skärmbild"
+
+#: packages/admin/src/components/MenuList.tsx:166
+msgid "Primary Navigation"
+msgstr "Primär navigering"
+
+#: packages/admin/src/components/Dashboard.tsx:349
+msgid "Private"
+msgstr "Privat"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:174
+msgid "Provider:"
+msgstr "Leverantör:"
+
+#: packages/admin/src/components/ContentList.tsx:415
+#: packages/admin/src/components/ContentSettingsPanel.tsx:171
+#: packages/admin/src/components/ContentSettingsPanel.tsx:390
+msgid "Publish"
+msgstr "Publicera"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:178
+msgid "Publish changes"
+msgstr "Publicera ändringar"
+
+#: packages/admin/src/components/ContentList.tsx:1158
+msgid "published"
+msgstr "publicerad"
+
+#: packages/admin/src/components/ContentList.tsx:729
+#: packages/admin/src/components/ContentList.tsx:738
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/ContentSettingsPanel.tsx:404
+#: packages/admin/src/components/Dashboard.tsx:245
+#: packages/admin/src/components/Dashboard.tsx:345
+#: packages/admin/src/router.tsx:1008
+msgid "Published"
+msgstr "Publicerad"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:326
+msgid "Published {0}"
+msgstr "Publicerad {0}"
+
+#: packages/admin/src/router.tsx:486
+msgid "Published {total} items"
+msgstr "Publicerade {total} objekt"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr "Publicerad"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:459
+msgid "Published by"
+msgstr "Publicerad av"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:47
+msgid "Python"
+msgstr "Python"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:882
+msgid "Quick create byline"
+msgstr "Snabbskapa byline"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:196
+#: packages/admin/src/components/editor/ImageNode.tsx:197
+msgid "Quick edit alt text"
+msgstr "Redigera alt-text direkt"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:86
+#: packages/admin/src/components/PortableTextEditor.tsx:1076
+#: packages/admin/src/components/PortableTextEditor.tsx:3481
+msgid "Quote"
+msgstr "Citat"
+
+#: packages/admin/src/components/WordPressImport.tsx:1162
+msgid "Raw meta"
+msgstr "Rå metadata"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Read collection schemas"
+msgstr "Läsa samlingsscheman"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Read content entries"
+msgstr "Läsa innehållsposter"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Read media files"
+msgstr "Läsa mediefiler"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Read site settings"
+msgstr "Läsa webbplatsinställningar"
+
+#: packages/admin/src/lib/api/marketplace.ts:227
+#: packages/admin/src/lib/api/marketplace.ts:235
+msgid "Read user accounts"
+msgstr "Läsa användarkonton"
+
+#: packages/admin/src/lib/api/marketplace.ts:222
+#: packages/admin/src/lib/api/marketplace.ts:231
+msgid "Read your content"
+msgstr "Läsa ditt innehåll"
+
+#: packages/admin/src/lib/api/marketplace.ts:224
+msgid "Read your taxonomies and terms"
+msgstr "Läsa dina taxonomier och termer"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:269
+msgid "Reading"
+msgstr "Läsning"
+
+#: packages/admin/src/components/WordPressImport.tsx:1986
+msgid "Ready"
+msgstr "Klar"
+
+#: packages/admin/src/components/Dashboard.tsx:298
+msgid "Recent Activity"
+msgstr "Senaste aktivitet"
+
+#: packages/admin/src/components/Widgets.tsx:124
+msgid "Recent Posts"
+msgstr "Senaste inläggen"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr "Senast uppdaterad"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:118
+msgid "Recipient email"
+msgstr "Mottagarens e-post"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr "Återställningslänk skickad till {0}"
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Redirect loop detected"
+msgstr "Omdirigeringsloop upptäckt"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "Omdirigerar till inloggning …"
+
+#: packages/admin/src/components/Redirects.tsx:358
+#: packages/admin/src/components/Redirects.tsx:377
+#: packages/admin/src/components/Sidebar.tsx:332
+msgid "Redirects"
+msgstr "Omdirigeringar"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3614
+msgid "Redo"
+msgstr "Gör om"
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr "Referens"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:228
+msgid "Referenced favicon unavailable."
+msgstr "Den refererade favicon-filen är inte tillgänglig."
+
+#: packages/admin/src/components/Dashboard.tsx:85
+msgid "Refresh the page or try again."
+msgstr "Uppdatera sidan eller försök igen."
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr "Registrera"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "Register Passkey"
+msgstr "Registrera passkey"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "Registrerad användare"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr "Registreringen misslyckades"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "Registreringen avbröts eller tog för lång tid. Försök igen."
+
+#: packages/admin/src/components/Sidebar.tsx:355
+msgid "Registry"
+msgstr "Register"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:597
+msgid "Release is too new to install"
+msgstr "Versionen är för ny för att installeras"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentSettingsPanel.tsx:851
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:199
+#: packages/admin/src/components/PortableTextEditor.tsx:3587
+#: packages/admin/src/components/settings/GeneralSettings.tsx:194
+#: packages/admin/src/components/settings/GeneralSettings.tsx:248
+#: packages/admin/src/components/settings/PasskeyItem.tsx:185
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+#: packages/admin/src/components/settings/SeoSettings.tsx:176
+msgid "Remove"
+msgstr "Ta bort"
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+#: packages/admin/src/components/TaxonomySidebar.tsx:246
+msgid "Remove {0}"
+msgstr "Ta bort {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr "Ta bort {entry}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1655
+msgid "Remove {label}"
+msgstr "Ta bort {label}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:397
+msgid "Remove Domain"
+msgstr "Ta bort domän"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+msgid "Remove Domain?"
+msgstr "Ta bort domän?"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:130
+#: packages/admin/src/components/ImageFieldRenderer.tsx:159
+#: packages/admin/src/components/SeoImageField.tsx:61
+msgid "Remove image"
+msgstr "Ta bort bild"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:392
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:582
+msgid "Remove Image"
+msgstr "Ta bort bild"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
+msgid "Remove Image?"
+msgstr "Ta bort bild?"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1947
+#: packages/admin/src/components/RepeaterField.tsx:275
+msgid "Remove item {0}"
+msgstr "Ta bort objekt {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3073
+#: packages/admin/src/components/PortableTextEditor.tsx:3074
+msgid "Remove link"
+msgstr "Ta bort länk"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+msgid "Remove passkey"
+msgstr "Ta bort passkey"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:201
+msgid "Remove passkey?"
+msgstr "Ta bort passkey?"
+
+#: packages/admin/src/components/FieldEditor.tsx:611
+msgid "Remove sub-field"
+msgstr "Ta bort underfält"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:198
+msgid "Remove this image from the document?"
+msgstr "Ta bort denna bild från dokumentet?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:200
+#: packages/admin/src/components/settings/PasskeyItem.tsx:208
+msgid "Removing..."
+msgstr "Tar bort …"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:174
+msgid "Rename"
+msgstr "Byt namn"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename {0}"
+msgstr "Byt namn på {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename passkey"
+msgstr "Byt namn på passkey"
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr "Repeater"
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr "Upprepad grupp av fält"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:435
+msgid "Replace Image"
+msgstr "Ersätt bild"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "Svara till:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr "Kodarkiv"
+
+#: packages/admin/src/components/SignupPage.tsx:273
+msgid "Request a new link"
+msgstr "Begär en ny länk"
+
+#: packages/admin/src/lib/api/client.ts:198
+msgid "Request failed"
+msgstr "Begäran misslyckades"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:280
+#: packages/admin/src/components/ContentTypeEditor.tsx:730
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:593
+#: packages/admin/src/routes/byline-schema.tsx:246
+msgid "Required"
+msgstr "Obligatorisk"
+
+#: packages/admin/src/components/WordPressImport.tsx:1999
+msgid "Required fields:"
+msgstr "Obligatoriska fält:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "Krävs för tillgänglighet. Beskriver bilden för skärmläsare."
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:324
+msgid "Requires EmDash {0}"
+msgstr "Kräver EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend email"
+msgstr "Skicka e-post igen"
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend in {resendCooldown}s"
+msgstr "Skicka igen om {resendCooldown} s"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:277
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+msgid "Reset to original"
+msgstr "Återställ till original"
+
+#: packages/admin/src/components/RevisionHistory.tsx:228
+msgid "Restore"
+msgstr "Återställ"
+
+#: packages/admin/src/components/ContentList.tsx:1094
+msgid "Restore {title}"
+msgstr "Återställ {title}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:128
+msgid "Restore failed"
+msgstr "Återställningen misslyckades"
+
+#: packages/admin/src/components/RevisionHistory.tsx:222
+msgid "Restore Revision?"
+msgstr "Återställa revision?"
+
+#: packages/admin/src/components/RevisionHistory.tsx:289
+#: packages/admin/src/components/RevisionHistory.tsx:290
+msgid "Restore this version"
+msgstr "Återställ denna version"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:225
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "Återställa denna version från {0}? Detta uppdaterar det aktuella innehållet till denna revisions data."
+
+#: packages/admin/src/components/RevisionHistory.tsx:229
+msgid "Restoring..."
+msgstr "Återställer …"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:2145
+#: packages/admin/src/routes/byline-schema.tsx:280
+msgid "Retry"
+msgstr "Försök igen"
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr "Återanvändbara innehållsblock som du kan infoga i vilket innehåll som helst"
+
+#: packages/admin/src/router.tsx:1046
+msgid "Reverted to published version"
+msgstr "Återställd till publicerad version"
+
+#: packages/admin/src/components/WordPressImport.tsx:724
+msgid "Review"
+msgstr "Granska"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Review New Permissions"
+msgstr "Granska nya behörigheter"
+
+#: packages/admin/src/components/RevisionHistory.tsx:122
+msgid "Revision restored"
+msgstr "Revision återställd"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:158
+msgid "Revisions"
+msgstr "Revisioner"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:331
+msgid "Revoke token"
+msgstr "Återkalla token"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:306
+msgid "Revoke?"
+msgstr "Återkalla?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:313
+msgid "Revoking..."
+msgstr "Återkallar …"
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr "Rik text"
+
+#: packages/admin/src/components/Widgets.tsx:97
+msgid "Rich text content"
+msgstr "Innehåll med rik text"
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr "Redigerare för rik text"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
+msgid "Right"
+msgstr "Höger"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:311
+msgid "Risk score: {0}/100"
+msgstr "Riskpoäng: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:164
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr "Roll"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "Roll {role}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:856
+msgid "Role label"
+msgstr "Rolletikett"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:48
+msgid "Ruby"
+msgstr "Ruby"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:49
+msgid "Rust"
+msgstr "Rust"
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:432
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:611
+msgid "Same window"
+msgstr "Samma fönster"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:989
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:395
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:589
+#: packages/admin/src/components/editor/ImageNode.tsx:264
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/Redirects.tsx:190
+#: packages/admin/src/components/SaveButton.tsx:32
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/Widgets.tsx:966
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Save"
+msgstr "Spara"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr "Spara (Enter)"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:265
+msgid "Save alt text"
+msgstr "Spara alt-text"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Save changes"
+msgstr "Spara ändringar"
+
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr "Spara ändringar"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr "Spara innehåll som utkast innan publicering"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "Spara namn"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+msgid "Save SEO Settings"
+msgstr "Spara SEO-inställningar"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+msgid "Save Settings"
+msgstr "Spara inställningar"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Save Social Links"
+msgstr "Spara sociala länkar"
+
+#: packages/admin/src/components/SaveButton.tsx:34
+msgid "Saved"
+msgstr "Sparad"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:116
+msgid "Saved \"{0}\"."
+msgstr "Sparade \"{0}\"."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:989
+#: packages/admin/src/components/FieldEditor.tsx:660
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/Redirects.tsx:187
+#: packages/admin/src/components/SaveButton.tsx:33
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:966
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Saving..."
+msgstr "Sparar …"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Saving…"
+msgstr "Sparar …"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:469
+msgid "SBOM"
+msgstr "SBOM"
+
+#. placeholder {0}: sbom.format
+#: packages/admin/src/components/RegistryPluginDetail.tsx:467
+msgid "SBOM · {0}"
+msgstr "SBOM · {0}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:453
+msgid "Schedule"
+msgstr "Schemalägg"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:439
+msgid "Schedule for"
+msgstr "Schemalägg till"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:476
+msgid "Schedule for later"
+msgstr "Schemalägg för senare"
+
+#: packages/admin/src/components/ContentList.tsx:1162
+msgid "scheduled"
+msgstr "schemalagd"
+
+#: packages/admin/src/components/ContentList.tsx:731
+#: packages/admin/src/components/ContentSettingsPanel.tsx:407
+#: packages/admin/src/components/Dashboard.tsx:347
+#: packages/admin/src/router.tsx:1066
+msgid "Scheduled"
+msgstr "Schemalagd"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentSettingsPanel.tsx:427
+msgid "Scheduled for: {0}"
+msgstr "Schemalagd till: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "Schema Changes"
+msgstr "Schemaändringar"
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Schema preparation failed"
+msgstr "Förberedelse av schema misslyckades"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Schema Read"
+msgstr "Läsa schema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Schema Write"
+msgstr "Redigera schema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:414
+msgid "Scopes"
+msgstr "Omfattning"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:282
+msgid "Scopes: {0}"
+msgstr "Omfattning: {0}"
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:243
+#: packages/admin/src/components/RegistryPluginDetail.tsx:642
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr "Skärmbild {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:453
+msgid "Screenshot {0} of {1}"
+msgstr "Skärmbild {0} av {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:246
+msgid "Screenshot blurred due to image audit"
+msgstr "Skärmbilden är suddig på grund av bildgranskning"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:431
+msgid "Screenshot viewer"
+msgstr "Skärmbildsvisare"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:233
+#: packages/admin/src/components/RegistryPluginDetail.tsx:636
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr "Skärmbilder"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:50
+msgid "SCSS"
+msgstr "SCSS"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+#: packages/admin/src/components/Widgets.tsx:149
+msgid "Search"
+msgstr "Sök"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:353
+msgid "Search {0}"
+msgstr "Sök i {0}"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:352
+msgid "Search {0}..."
+msgstr "Sök i {0} …"
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:577
+msgid "Search by filename..."
+msgstr "Sök efter filnamn …"
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr "Sök efter namn eller e-post …"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:783
+#: packages/admin/src/routes/bylines.tsx:402
+msgid "Search bylines"
+msgstr "Sök bland bylines"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:782
+msgid "Search bylines to add..."
+msgstr "Sök bland bylines att lägga till …"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments"
+msgstr "Sök i kommentarer"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:162
+msgid "Search comments..."
+msgstr "Sök i kommentarer …"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "Sök i innehåll …"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:122
+msgid "Search Engine Optimization"
+msgstr "Sökmotoroptimering"
+
+#: packages/admin/src/components/Settings.tsx:83
+msgid "Search engine optimization and verification"
+msgstr "Sökmotoroptimering och verifiering"
+
+#: packages/admin/src/components/Widgets.tsx:150
+msgid "Search form"
+msgstr "Sökformulär"
+
+#: packages/admin/src/components/MediaLibrary.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:578
+msgid "Search media"
+msgstr "Sök i media"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "Sök i sidor och innehåll …"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+#: packages/admin/src/components/RegistryBrowse.tsx:84
+msgid "Search plugins"
+msgstr "Sök i tillägg"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+#: packages/admin/src/components/RegistryBrowse.tsx:80
+msgid "Search plugins..."
+msgstr "Sök i tillägg …"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr "Sök i sektioner …"
+
+#: packages/admin/src/components/Redirects.tsx:409
+msgid "Search source or destination..."
+msgstr "Sök i källa eller mål …"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr "Sök i teman"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr "Sök i teman …"
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr "Sök i användare"
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:577
+msgid "Search..."
+msgstr "Sök …"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr "Sökbar"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:787
+msgid "Searching..."
+msgstr "Söker …"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2322
+msgid "Section"
+msgstr "Sektion"
+
+#: packages/admin/src/components/SectionEditor.tsx:81
+msgid "Section \"{slug}\" could not be found."
+msgstr "Sektionen \"{slug}\" kunde inte hittas."
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr "Sektion skapad"
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr "Sektion borttagen"
+
+#: packages/admin/src/components/SectionEditor.tsx:235
+msgid "Section Details"
+msgstr "Sektionsdetaljer"
+
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section Not Found"
+msgstr "Sektionen hittades inte"
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "Section title"
+msgstr "Sektionstitel"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:334
+msgid "Sections"
+msgstr "Sektioner"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:306
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "säker kontext"
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr "Säkra ditt konto"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:794
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Security"
+msgstr "Säkerhet"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:307
+msgid "Security Audit"
+msgstr "Säkerhetsgranskning"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr "Säkerhetsgranskningen misslyckades"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr "Säkerhetsgranskningen flaggade problem"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:150
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "Säkerhetsgranskningen flaggade potentiella problem med detta tillägg."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:151
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "Säkerhetsgranskningen flaggade detta tillägg som potentiellt osäkert."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr "Säkerhetsgranskningen godkändes"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:705
+msgid "Security contacts"
+msgstr "Säkerhetskontakter"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:270
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "Säkerhetsfel. Kontrollera att du använder en säker anslutning."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/settings/SecuritySettings.tsx:95
+msgid "Security Settings"
+msgstr "Säkerhetsinställningar"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:56
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr "Välj"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1667
+#: packages/admin/src/components/ContentEditor.tsx:1683
+#: packages/admin/src/components/ImageFieldRenderer.tsx:187
+msgid "Select {label}"
+msgstr "Välj {label}"
+
+#: packages/admin/src/components/ContentList.tsx:973
+msgid "Select {title}"
+msgstr "Välj {title}"
+
+#: packages/admin/src/components/Widgets.tsx:939
+msgid "Select a component..."
+msgstr "Välj en komponent …"
+
+#: packages/admin/src/components/Widgets.tsx:902
+msgid "Select a menu..."
+msgstr "Välj en meny …"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:283
+msgid "Select all"
+msgstr "Markera alla"
+
+#: packages/admin/src/components/ContentList.tsx:497
+msgid "Select all on this page"
+msgstr "Markera alla på denna sida"
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:456
+msgid "Select comment by {0}"
+msgstr "Markera kommentar från {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "Välj innehåll"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:235
+msgid "Select Default Social Image"
+msgstr "Välj standardbild för sociala medier"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:260
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Select Favicon"
+msgstr "Välj favicon"
+
+#: packages/admin/src/components/ContentEditor.tsx:1671
+msgid "Select file"
+msgstr "Välj fil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+msgid "Select File"
+msgstr "Välj fil"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:175
+msgid "Select image"
+msgstr "Välj bild"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+#: packages/admin/src/components/PortableTextEditor.tsx:2917
+#: packages/admin/src/components/settings/SeoSettings.tsx:188
+msgid "Select Image"
+msgstr "Välj bild"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:206
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Select Logo"
+msgstr "Välj logotyp"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr "Välj media"
+
+#: packages/admin/src/components/SeoImageField.tsx:76
+msgid "Select OG image"
+msgstr "Välj OG-bild"
+
+#: packages/admin/src/components/SeoImageField.tsx:85
+msgid "Select OG Image"
+msgstr "Välj OG-bild"
+
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "Select which content types to import."
+msgstr "Välj vilka innehållstyper som ska importeras."
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:2042
+#: packages/admin/src/components/RepeaterField.tsx:372
+msgid "Select..."
+msgstr "Välj …"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1372
+msgid "Selected {selectedItemTitle}"
+msgstr "Vald {selectedItemTitle}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:733
+msgid "Selected:"
+msgstr "Vald:"
+
+#: packages/admin/src/components/Settings.tsx:99
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:152
+msgid "Self-Signup Domains"
+msgstr "Domäner för självregistrering"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:113
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "Skicka ett testmejl genom hela kedjan för att verifiera din e-postkonfiguration."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "Skicka ett inbjudningsmejl till en ny teammedlem."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+msgid "Send Invite"
+msgstr "Skicka inbjudan"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+msgid "Send magic link"
+msgstr "Skicka magisk länk"
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr "Skicka återställningslänk"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+msgid "Send Test"
+msgstr "Skicka test"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:110
+msgid "Send Test Email"
+msgstr "Skicka testmejl"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+#: packages/admin/src/components/SignupPage.tsx:88
+#: packages/admin/src/components/SignupPage.tsx:151
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr "Skickar …"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:564
+#: packages/admin/src/components/ContentTypeEditor.tsx:472
+#: packages/admin/src/components/Settings.tsx:82
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SeoSettings.tsx:115
+msgid "SEO Settings"
+msgstr "SEO-inställningar"
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "SEO settings (Yoast)"
+msgstr "SEO-inställningar (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:40
+msgid "SEO settings saved"
+msgstr "SEO-inställningar sparade"
+
+#: packages/admin/src/components/SeoPanel.tsx:168
+#: packages/admin/src/components/SeoPanel.tsx:172
+msgid "SEO Title"
+msgstr "SEO-titel"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
+msgid "Set a custom display size for this image instance."
+msgstr "Ange en anpassad visningsstorlek för denna bildinstans."
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:146
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:150
+msgid "Set language"
+msgstr "Ange språk"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:147
+msgid "Set language (current: {label})"
+msgstr "Ange språk (aktuellt: {label})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:529
+msgid "Set to 0 to never close comments automatically."
+msgstr "Sätt till 0 för att aldrig stänga kommentarer automatiskt."
+
+#: packages/admin/src/components/ContentList.tsx:425
+msgid "Set to draft"
+msgstr "Ändra till utkast"
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr "Konfigurera din webbplats"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr "Konfigurerar …"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/ContentEditor.tsx:799
+#: packages/admin/src/components/ContentEditor.tsx:1005
+#: packages/admin/src/components/ContentTypeEditor.tsx:381
+#: packages/admin/src/components/Header.tsx:101
+#: packages/admin/src/components/PluginManager.tsx:437
+#: packages/admin/src/components/Settings.tsx:63
+#: packages/admin/src/components/Sidebar.tsx:379
+#: packages/admin/src/components/WordPressImport.tsx:1811
+msgid "Settings"
+msgstr "Inställningar"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
+msgid "Settings Manage"
+msgstr "Hantera inställningar"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Settings Read"
+msgstr "Läsa inställningar"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:43
+msgid "Settings saved successfully"
+msgstr "Inställningarna sparades"
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr "Konfigurationen misslyckades"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "Dela denna länk med den inbjudna användaren"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:294
+msgid "Shared across all translations of the same byline."
+msgstr "Delas mellan alla översättningar av samma byline."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:52
+msgid "Short text"
+msgstr "Kort text"
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr "Kort text"
+
+#: packages/admin/src/components/Widgets.tsx:144
+msgid "Show count"
+msgstr "Visa antal"
+
+#: packages/admin/src/components/Widgets.tsx:129
+msgid "Show date"
+msgstr "Visa datum"
+
+#: packages/admin/src/components/Widgets.tsx:137
+msgid "Show hierarchy"
+msgstr "Visa hierarki"
+
+#: packages/admin/src/components/Widgets.tsx:136
+msgid "Show post count"
+msgstr "Visa antal inlägg"
+
+#: packages/admin/src/components/Widgets.tsx:128
+msgid "Show thumbnails"
+msgstr "Visa miniatyrer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Show token"
+msgstr "Visa token"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:365
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:554
+msgid "Shown when hovering over the image."
+msgstr "Visas när du hovrar över bilden."
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Sign in"
+msgstr "Logga in"
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr "Logga in"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:161
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr "Logga in istället"
+
+#: packages/admin/src/components/LoginPage.tsx:232
+msgid "Sign in to your site"
+msgstr "Logga in på din webbplats"
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:231
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr "Logga in med {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:229
+msgid "Sign in with email"
+msgstr "Logga in med e-post"
+
+#: packages/admin/src/components/LoginPage.tsx:290
+msgid "Sign in with email link"
+msgstr "Logga in med e-postlänk"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:252
+msgid "Sign in with Passkey"
+msgstr "Logga in med passkey"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "Inloggad som {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr "Enkelval från alternativ"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr "Enradig textinmatning"
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr "Webbplats"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:130
+msgid "Site Identity"
+msgstr "Webbplatsidentitet"
+
+#: packages/admin/src/components/WordPressImport.tsx:2270
+msgid "site identity applied (title, tagline, logo)"
+msgstr "webbplatsidentitet tillämpad (titel, slogan, logotyp)"
+
+#: packages/admin/src/components/Settings.tsx:71
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "Webbplatsidentitet, logotyp, favicon och läsinställningar"
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+#: packages/admin/src/components/WordPressImport.tsx:1151
+msgid "Site Settings"
+msgstr "Webbplatsinställningar"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:133
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr "Webbplatstitel"
+
+#: packages/admin/src/components/WordPressImport.tsx:1823
+msgid "Site title & tagline"
+msgstr "Webbplatstitel och slogan"
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr "Webbplatstitel krävs"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:145
+msgid "Site URL"
+msgstr "Webbplats-URL"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:267
+msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
+msgstr "Webbplatser på Cloudflare D1 kan dessutom återställa databasen till valfri minut inom de senaste 30 dagarna med D1 Time Travel – alltid aktivt, ingen konfiguration krävs."
+
+#: packages/admin/src/components/MediaLibrary.tsx:588
+msgid "Size"
+msgstr "Storlek"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:274
+msgid "Size:"
+msgstr "Storlek:"
+
+#: packages/admin/src/components/WordPressImport.tsx:2104
+msgid "Skip Media Import"
+msgstr "Hoppa över medieimport"
+
+#: packages/admin/src/components/WordPressImport.tsx:2129
+msgid "Skipped"
+msgstr "Överhoppad"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:239
+#: packages/admin/src/components/ContentSettingsPanel.tsx:394
+#: packages/admin/src/components/ContentSettingsPanel.tsx:898
+#: packages/admin/src/components/ContentSettingsPanel.tsx:960
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:402
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:246
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:398
+#: packages/admin/src/routes/byline-schema.tsx:237
+#: packages/admin/src/routes/bylines.tsx:487
+msgid "Slug"
+msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr "Slug kopierad till urklipp"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:251
+msgid "Slugs cannot be changed after the field is created."
+msgstr "Slugs kan inte ändras efter att fältet har skapats."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1047
+msgid "Small section heading"
+msgstr "Liten sektionsrubrik"
+
+#: packages/admin/src/components/Settings.tsx:76
+#: packages/admin/src/components/settings/SocialSettings.tsx:70
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
+msgid "Social Links"
+msgstr "Sociala länkar"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:38
+msgid "Social links saved"
+msgstr "Sociala länkar sparade"
+
+#: packages/admin/src/components/Settings.tsx:77
+msgid "Social media profile links"
+msgstr "Länkar till profiler på sociala medier"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:100
+msgid "Social Profiles"
+msgstr "Sociala profiler"
+
+#: packages/admin/src/components/WordPressImport.tsx:1860
+msgid "Some content types cannot be imported"
+msgstr "Vissa innehållstyper kan inte importeras"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:154
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Something went wrong"
+msgstr "Något gick fel"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr "Sortera tillägg"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr "Sortera teman"
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:560
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:214
+#: packages/admin/src/components/PluginManager.tsx:497
+#: packages/admin/src/components/Redirects.tsx:466
+#: packages/admin/src/components/SectionEditor.tsx:281
+msgid "Source"
+msgstr "Källa"
+
+#: packages/admin/src/components/Redirects.tsx:131
+msgid "Source path"
+msgstr "Källsökväg"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "skräppost"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:207
+#: packages/admin/src/components/comments/CommentInbox.tsx:247
+msgid "Spam"
+msgstr "Skräppost"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3627
+msgid "Spotlight Mode"
+msgstr "Fokusläge"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr "Kalkylblad"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:51
+msgid "SQL"
+msgstr "SQL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1922
+msgid "Start Import"
+msgstr "Starta import"
+
+#: packages/admin/src/components/ContentEditor.tsx:1177
+#: packages/admin/src/components/PortableTextEditor.tsx:2201
+#: packages/admin/src/components/PortableTextEditor.tsx:2202
+msgid "Start writing, or type '/' for commands"
+msgstr "Börja skriva, eller skriv \"/\" för kommandon"
+
+#: packages/admin/src/components/ContentList.tsx:511
+#: packages/admin/src/components/ContentSettingsPanel.tsx:401
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:471
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr "Status"
+
+#: packages/admin/src/components/Redirects.tsx:151
+msgid "Status code"
+msgstr "Statuskod"
+
+#: packages/admin/src/components/Dashboard.tsx:357
+msgid "Status: {status}"
+msgstr "Status: {status}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:173
+msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
+msgstr "Spara en daglig säkerhetskopia i webbplatsens lagringsbucket. Gamla säkerhetskopior tas bort automatiskt."
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:218
+msgid "Stored Backups"
+msgstr "Lagrade säkerhetskopior"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:293
+msgid "Stored per locale — each translation of a byline gets its own value."
+msgstr "Lagras per språkversion – varje översättning av en byline får sitt eget värde."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3106
+#: packages/admin/src/components/PortableTextEditor.tsx:3440
+msgid "Strikethrough"
+msgstr "Genomstruken text"
+
+#: packages/admin/src/components/WordPressImport.tsx:1752
+msgid "Structure"
+msgstr "Struktur"
+
+#: packages/admin/src/components/WordPressImport.tsx:1164
+msgid "Structured"
+msgstr "Strukturerad"
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr "Underfält"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "Prenumerant"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:52
+msgid "Svelte"
+msgstr "Svelte"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:53
+msgid "Swift"
+msgstr "Swift"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr "Synkroniserad"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Synkroniserad passkey"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:777
+msgid "System"
+msgstr "System"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "System ({resolvedLabel})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:599
+msgid "System Fields"
+msgstr "Systemfält"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1121
+msgid "Table"
+msgstr "Tabell"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3180
+msgid "Table controls"
+msgstr "Tabellkontroller"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:139
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr "Slogan"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+#: packages/admin/src/components/Widgets.tsx:141
+msgid "Tags"
+msgstr "Taggar"
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1797
+msgid "Tags ({0})"
+msgstr "Taggar ({0})"
+
+#: packages/admin/src/components/MenuEditor.tsx:427
+#: packages/admin/src/components/MenuEditor.tsx:606
+msgid "Target"
+msgstr "Mål"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:172
+msgid "Target locale"
+msgstr "Målspråk"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:543
+msgid "Taxonomies"
+msgstr "Taxonomier"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Taxonomies Manage"
+msgstr "Hantera taxonomier"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:898
+msgid "Taxonomy created"
+msgstr "Taxonomi skapad"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:785
+msgid "Taxonomy not found:"
+msgstr "Taxonomi hittades inte:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:159
+msgid "Taxonomy: {taxonomyName}"
+msgstr "Taxonomi: {taxonomyName}"
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr "Mall:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Term"
+msgstr "Term"
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:759
+msgid "Term \"{0}\" created in {1}."
+msgstr "Termen \"{0}\" skapades i {1}."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:741
+msgid "Term deleted"
+msgstr "Term borttagen"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:122
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3397
+msgid "Text formatting"
+msgstr "Textformatering"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "Enheten kommer inte att beviljas åtkomst."
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "The existing collection has fields with incompatible types."
+msgstr "Den befintliga samlingen har fält med inkompatibla typer."
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "Följande tabeller innehåller innehåll men är inte registrerade som samlingar. Registrera dem för att hantera innehållet i administrationsgränssnittet."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:179
+msgid "The invited user will have this role once they complete registration."
+msgstr "Den inbjudna användaren får denna roll när registreringen är slutförd."
+
+#: packages/admin/src/components/LoginPage.tsx:113
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "The link will expire in 15 minutes."
+msgstr "Länken går ut om 15 minuter."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "Marknadsplatsen är tom. Kom tillbaka senare för nya tillägg."
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "The menu has been deleted."
+msgstr "Menyn har tagits bort."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:136
+msgid "The name of your site, used in the header and metadata"
+msgstr "Namnet på din webbplats, används i sidhuvudet och metadata"
+
+#: packages/admin/src/router.tsx:2159
+msgid "The page you're looking for doesn't exist."
+msgstr "Sidan du letar efter finns inte."
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
+msgid "The plugin field widget failed to render."
+msgstr "Tilläggets fältwidget kunde inte renderas."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:149
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "Den offentliga URL:en till din webbplats (används för kanoniska länkar och webbplatskartor)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr "Den refererade bilden är inte längre tillgänglig. Välj en ny eller ta bort referensen."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:174
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr "Den refererade logotypen är inte längre tillgänglig. Välj en ny eller ta bort referensen."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr "Temamarknadsplatsen är tom. Kom tillbaka senare."
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr "Tema"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:294
+msgid "Theme ID: {0}"
+msgstr "Tema-ID: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr "Temat hittades inte"
+
+#: packages/admin/src/components/SectionEditor.tsx:183
+msgid "Theme Section"
+msgstr "Temasektion"
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "Sektioner från temat kan inte tas bort. Redigera sektionen för att skapa en anpassad kopia, och ta bort den istället."
+
+#: packages/admin/src/components/ThemeToggle.tsx:33
+msgid "Theme: {label}"
+msgstr "Tema: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:371
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr "Teman"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:370
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr "Denna samling är definierad i kod. Vissa inställningar kan inte ändras här. Redigera filen live.config.ts för att ändra schemat."
+
+#: packages/admin/src/components/WordPressImport.tsx:1059
+msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
+msgstr "Detta ser inte ut som en giltig migreringsnyckel. Generera en ny i tillägget och klistra in hela strängen som börjar med \"em1.\"."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:417
+msgid "This field does not accept {sniffedMime} files."
+msgstr "Detta fält accepterar inte filer av typen {sniffedMime}."
+
+#: packages/admin/src/components/ContentEditor.tsx:1686
+#: packages/admin/src/components/ImageFieldRenderer.tsx:191
+msgid "This field is required"
+msgstr "Detta fält är obligatoriskt"
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "This is a custom section."
+msgstr "Detta är en anpassad sektion."
+
+#: packages/admin/src/components/WordPressImport.tsx:1308
+msgid "This is a WordPress site."
+msgstr "Detta är en WordPress-webbplats."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "Denna länk går ut om 7 dagar och kan endast användas en gång."
+
+#: packages/admin/src/components/WordPressImport.tsx:921
+msgid "This may take a while for large exports."
+msgstr "Detta kan ta en stund för stora exporter."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "Denna passkey är redan registrerad på den här enheten."
+
+#. placeholder {0}: archiveToDelete?.name ?? ""
+#: packages/admin/src/components/settings/BackupSettings.tsx:283
+msgid "This permanently deletes {0} from storage."
+msgstr "Detta tar bort {0} permanent från lagringen."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:276
+msgid "This plugin requires no special permissions."
+msgstr "Detta tillägg kräver inga särskilda behörigheter."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:566
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr "Denna utgivare gör anspråk på ett namn de inte kunde bevisa att de äger — möjligen för att utge sig för att vara någon annan. Installation är inaktiverad. Om du känner utgivaren och litar på dem, be dem åtgärda sin identitetskonfiguration innan du försöker igen."
+
+#: packages/admin/src/components/Redirects.tsx:581
+msgid "This redirect rule will be permanently removed."
+msgstr "Denna omdirigeringsregel tas bort permanent."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:618
+msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
+msgstr "Denna version kräver en nyare miljö än den din webbplats för närvarande körs i. Uppgradera innan du installerar."
+
+#: packages/admin/src/routes/bylines.tsx:624
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr "Detta tar bort bylineprofilen. Länkar till bylines i innehåll tas bort och huvudreferenser rensas."
+
+#: packages/admin/src/components/SectionEditor.tsx:285
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "Denna sektion tillhandahålls av temat. Om du redigerar den skapas en anpassad kopia som åsidosätter temats version."
+
+#: packages/admin/src/components/SectionEditor.tsx:290
+msgid "This section was imported from another system."
+msgstr "Denna sektion importerades från ett annat system."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:121
+msgid "This update exposes the following routes without authentication:"
+msgstr "Denna uppdatering exponerar följande rutter utan autentisering:"
+
+#: packages/admin/src/components/Widgets.tsx:698
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr "Detta tar bort widgetområdet och alla dess widgetar. Åtgärden kan inte ångras."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "Detta ger CLI-åtkomst med dina behörigheter."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:606
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "Detta flyttar objektet till papperskorgen. Du kan återställa det senare från papperskorgen."
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:884
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "Detta tar bort \"{0}\" permanent och tar bort det från allt innehåll."
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "Detta tar bort \"{0}\" permanent. Åtgärden kan inte ångras."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "Detta tar bort denna kommentar permanent. Åtgärden kan inte ångras."
+
+#: packages/admin/src/components/PluginManager.tsx:629
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "Detta tar bort tillägget och dess paket från din webbplats."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:78
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "Detta återställer till den publicerade versionen. Dina utkastsändringar går förlorade."
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr "Tankar, guider och mer"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:287
+msgid "Timezone"
+msgstr "Tidszon"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:290
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "Tidszon för visning av datum (t.ex. Europe/Stockholm)"
+
+#: packages/admin/src/components/ContentList.tsx:505
+#: packages/admin/src/components/ContentList.tsx:643
+#: packages/admin/src/components/SectionEditor.tsx:238
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:874
+msgid "Title"
+msgstr "Titel"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:361
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:550
+msgid "Title (Tooltip)"
+msgstr "Titel (verktygstips)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+msgid "Title Separator"
+msgstr "Titelavgränsare"
+
+#: packages/admin/src/components/ContentList.tsx:811
+msgid "to"
+msgstr "till"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "för att stänga"
+
+#: packages/admin/src/components/ContentList.tsx:815
+msgid "To date"
+msgstr "Till datum"
+
+#: packages/admin/src/components/PluginManager.tsx:203
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "för att installera tillägg, eller lägg till dem i din astro.config.mjs."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "för att välja"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3225
+msgid "Toggle header row"
+msgstr "Växla rubrikrad"
+
+#: packages/admin/src/components/ThemeToggle.tsx:31
+#: packages/admin/src/components/ThemeToggle.tsx:42
+msgid "Toggle theme (current: {label})"
+msgstr "Växla tema (aktuellt: {label})"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
+msgid "Token created: {0}"
+msgstr "Token skapad: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:405
+msgid "Token Name"
+msgstr "Tokennamn"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:54
+msgid "TOML"
+msgstr "TOML"
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "Tools → Export"
+msgstr "Verktyg → Exportera"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr "Spåra innehållshistorik"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:287
+#: packages/admin/src/routes/byline-schema.tsx:243
+msgid "Translatable"
+msgstr "Översättningsbar"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:83
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translate"
+msgstr "Översätt"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:156
+msgid "Translate \"{0}\""
+msgstr "Översätt \"{0}\""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:80
+msgid "Translate {0}"
+msgstr "Översätt {0}"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translating..."
+msgstr "Översätter …"
+
+#: packages/admin/src/components/MenuEditor.tsx:143
+#: packages/admin/src/components/TaxonomyManager.tsx:758
+#: packages/admin/src/router.tsx:1118
+msgid "Translation created"
+msgstr "Översättning skapad"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:60
+msgid "Translations"
+msgstr "Översättningar"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "papperskorg"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:216
+#: packages/admin/src/components/comments/CommentInbox.tsx:257
+#: packages/admin/src/components/comments/CommentInbox.tsx:513
+#: packages/admin/src/components/ContentList.tsx:375
+msgid "Trash"
+msgstr "Papperskorg"
+
+#: packages/admin/src/components/ContentList.tsx:666
+msgid "Trash is empty"
+msgstr "Papperskorgen är tom"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "Trash is empty."
+msgstr "Papperskorgen är tom."
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr "Sant/falskt-brytare"
+
+#: packages/admin/src/components/MediaLibrary.tsx:493
+msgid "Try a broader media type or clear your filters."
+msgstr "Försök med en bredare mediatyp eller rensa dina filter."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:642
+msgid "Try a different search term"
+msgstr "Försök med ett annat sökord"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr "Försök justera din sökning"
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr "Försök justera din sökning eller dina filter."
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr "Försök igen"
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Try Again"
+msgstr "Försök igen"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "Försök med en annan kod"
+
+#: packages/admin/src/components/MediaLibrary.tsx:518
+msgid "Try another filename or clear your search."
+msgstr "Försök med ett annat filnamn eller rensa din sökning."
+
+#: packages/admin/src/components/MediaLibrary.tsx:492
+msgid "Try another filename, or clear your search and filters."
+msgstr "Försök med ett annat filnamn, eller rensa din sökning och dina filter."
+
+#: packages/admin/src/components/WordPressImport.tsx:1286
+#: packages/admin/src/components/WordPressImport.tsx:1408
+msgid "Try Another URL"
+msgstr "Försök med en annan URL"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr "Försök med mina data"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:55
+msgid "TSX"
+msgstr "TSX"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:282
+msgid "Turn into"
+msgstr "Omvandla till"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:106
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:260
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:587
+#: packages/admin/src/routes/byline-schema.tsx:240
+msgid "Type"
+msgstr "Typ"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:2018
+msgid "Type mismatch ({0})"
+msgstr "Typmismatchning ({0})"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:56
+msgid "TypeScript"
+msgstr "TypeScript"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr "Kunde inte nå marknadsplatsen"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1003
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1020
+msgid "Unassigned"
+msgstr "Otilldelad"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3099
+#: packages/admin/src/components/PortableTextEditor.tsx:3433
+msgid "Underline"
+msgstr "Understrykning"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3607
+msgid "Undo"
+msgstr "Ångra"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:180
+#: packages/admin/src/components/PluginManager.tsx:547
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstall"
+msgstr "Avinstallera"
+
+#: packages/admin/src/components/PluginManager.tsx:627
+msgid "Uninstall {pluginName}?"
+msgstr "Avinstallera {pluginName}?"
+
+#: packages/admin/src/components/PluginManager.tsx:622
+msgid "Uninstall confirmation"
+msgstr "Bekräfta avinstallation"
+
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstalling..."
+msgstr "Avinstallerar …"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:731
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr "Unik"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr "Unik identifierare (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "Okänd"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "Okänd roll"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Unlock aspect ratio"
+msgstr "Lås upp bildförhållande"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr "Namnlös passkey"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:184
+msgid "Unpublish"
+msgstr "Avpublicera"
+
+#: packages/admin/src/router.tsx:1026
+msgid "Unpublished"
+msgstr "Avpublicerad"
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr "Oregistrerade innehållstabeller hittades"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:429
+msgid "Unschedule"
+msgstr "Avboka schemaläggning"
+
+#: packages/admin/src/router.tsx:1087
+msgid "Unscheduled"
+msgstr "Ej schemalagd"
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr "Widgetelementtyp som inte stöds: {0}"
+
+#: packages/admin/src/components/Dashboard.tsx:317
+msgid "Untitled"
+msgstr "Utan titel"
+
+#: packages/admin/src/components/ContentEditor.tsx:1589
+msgid "Untitled file"
+msgstr "Fil utan namn"
+
+#: packages/admin/src/components/Widgets.tsx:531
+#: packages/admin/src/components/Widgets.tsx:792
+msgid "Untitled Widget"
+msgstr "Widget utan namn"
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr "Overifierad utgivare"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:830
+msgid "Up"
+msgstr "Upp"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:478
+msgid "Update"
+msgstr "Uppdatera"
+
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Update Field"
+msgstr "Uppdatera fält"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:334
+msgid "Update settings for {0}"
+msgstr "Uppdatera inställningar för {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Update site settings"
+msgstr "Uppdatera webbplatsinställningar"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:366
+msgid "Update the {0} details"
+msgstr "Uppdatera detaljerna för {0}"
+
+#: packages/admin/src/components/Redirects.tsx:109
+msgid "Update this redirect rule."
+msgstr "Uppdatera denna omdirigeringsregel."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Update to v{0}"
+msgstr "Uppdatera till v{0}"
+
+#: packages/admin/src/components/ContentList.tsx:737
+#: packages/admin/src/components/ContentSettingsPanel.tsx:490
+#: packages/admin/src/components/RegistryPluginDetail.tsx:488
+msgid "Updated"
+msgstr "Uppdaterad"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr "Uppdaterad"
+
+#: packages/admin/src/components/WordPressImport.tsx:946
+msgid "Updating content URLs..."
+msgstr "Uppdaterar innehålls-URL:er …"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:168
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Updating..."
+msgstr "Uppdaterar …"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:600
+msgid "Upload"
+msgstr "Ladda upp"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:146
+msgid "Upload a file to get started"
+msgstr "Ladda upp en fil för att komma igång"
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Upload an export file"
+msgstr "Ladda upp en exportfil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:147
+msgid "Upload an image to get started"
+msgstr "Ladda upp en bild för att komma igång"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Upload and delete media"
+msgstr "Ladda upp och ta bort media"
+
+#: packages/admin/src/lib/api/marketplace.ts:226
+#: packages/admin/src/lib/api/marketplace.ts:234
+msgid "Upload and manage media"
+msgstr "Ladda upp och hantera media"
+
+#: packages/admin/src/components/WordPressImport.tsx:1284
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Upload Export File"
+msgstr "Ladda upp exportfil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:620
+msgid "Upload failed: {uploadError}"
+msgstr "Uppladdning misslyckades: {uploadError}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:612
+msgid "Upload file"
+msgstr "Ladda upp fil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:148
+msgid "Upload File"
+msgstr "Ladda upp fil"
+
+#: packages/admin/src/components/MediaLibrary.tsx:365
+msgid "Upload files"
+msgstr "Ladda upp filer"
+
+#: packages/admin/src/components/MediaLibrary.tsx:508
+#: packages/admin/src/components/MediaLibrary.tsx:532
+msgid "Upload Files"
+msgstr "Ladda upp filer"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:148
+msgid "Upload Image"
+msgstr "Ladda upp bild"
+
+#: packages/admin/src/components/MediaLibrary.tsx:505
+msgid "Upload images, videos, and documents to keep reusable assets in one place."
+msgstr "Ladda upp bilder, videor och dokument för att samla återanvändbara resurser på ett ställe."
+
+#: packages/admin/src/components/Dashboard.tsx:111
+msgid "Upload Media"
+msgstr "Ladda upp media"
+
+#: packages/admin/src/components/MediaLibrary.tsx:529
+msgid "Upload media to keep reusable assets in one place."
+msgstr "Ladda upp media för att samla återanvändbara resurser på ett ställe."
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:356
+msgid "Upload to {0}"
+msgstr "Ladda upp till {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "Upload WordPress export file"
+msgstr "Ladda upp WordPress-exportfil"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:289
+msgid "Uploaded:"
+msgstr "Uppladdad:"
+
+#: packages/admin/src/components/WordPressImport.tsx:2127
+msgid "Uploading"
+msgstr "Laddar upp"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:331
+msgid "Uploading {0}/{1}..."
+msgstr "Laddar upp {0}/{1} …"
+
+#: packages/admin/src/components/MediaLibrary.tsx:332
+#: packages/admin/src/components/MediaPickerModal.tsx:600
+msgid "Uploading..."
+msgstr "Laddar upp …"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:54
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:418
+#: packages/admin/src/components/MenuEditor.tsx:596
+#: packages/admin/src/components/PortableTextEditor.tsx:3053
+#: packages/admin/src/components/PortableTextEditor.tsx:3552
+#: packages/admin/src/components/PortableTextEditor.tsx:3562
+msgid "URL"
+msgstr "URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:423
+msgid "URL Pattern"
+msgstr "URL-mönster"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr "URL-vänlig identifierare"
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "URL-vänlig identifierare (t.ex. \"primary\", \"footer\")"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:295
+msgid "URL:"
+msgstr "URL:"
+
+#: packages/admin/src/components/Redirects.tsx:110
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "Använd [param] eller [...rest] i sökvägar för mönstermatchning."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:364
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "Använd enhetens biometriska autentisering, säkerhetsnyckel eller PIN-kod för att logga in."
+
+#: packages/admin/src/components/LoginPage.tsx:326
+msgid "Use your registered passkey to sign in securely."
+msgstr "Använd din registrerade passkey för att logga in säkert."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr "Används som reservbild för Open Graph när en sida saknar bild. Rekommenderad storlek: 1200×630."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:644
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "Används som identifierare. Endast gemener, siffror och understreck."
+
+#: packages/admin/src/components/ContentEditor.tsx:1276
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "Används som huvudbild för detta inlägg på listsidor och högst upp i inlägget"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:122
+msgid "Used by screen readers and when image fails to load"
+msgstr "Används av skärmläsare och när bilden inte kan läsas in"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:408
+msgid "Used in URLs and API endpoints"
+msgstr "Används i URL:er och API-slutpunkter"
+
+#: packages/admin/src/components/SectionEditor.tsx:256
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "Används för att identifiera denna sektion. Endast gemener, siffror och bindestreck."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:43
+#: packages/admin/src/components/Header.tsx:83
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr "Användare"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:177
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "Användaråtkomst hanteras av en extern leverantör ({0}). Inställningar för självregistreringsdomän är inte tillgängliga vid extern autentisering."
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr "Användardetaljer"
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr "Användaren hittades inte"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:348
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr "Användare"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:383
+msgid "Users from"
+msgstr "Användare från"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:211
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "Användare med e-postadresser från dessa domäner kan registrera sig utan inbjudan. De tilldelas automatiskt den angivna rollen."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:358
+msgid "v{0} available"
+msgstr "v{0} tillgänglig"
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr "Validering"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:186
+#: packages/admin/src/components/RegistryPluginDetail.tsx:449
+msgid "Verified publisher"
+msgstr "Verifierad utgivare"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:448
+msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
+msgstr "Verifierad utgivare, bekräftad av märkaren {verifiedLabeller}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:439
+msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+msgstr "Verifierad utgivare. En märkare ({verifiedLabeller}) har bekräftat denna utgivares identitet."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:440
+msgid "Verified publisher. A labeller has confirmed this publisher's identity."
+msgstr "Verifierad utgivare. En märkare har bekräftat denna utgivares identitet."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:226
+msgid "Verifying your invite..."
+msgstr "Verifierar din inbjudan …"
+
+#: packages/admin/src/components/SignupPage.tsx:386
+msgid "Verifying your link..."
+msgstr "Verifierar din länk …"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:211
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "Verifierar …"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:320
+#: packages/admin/src/components/RegistryPluginDetail.tsx:502
+msgid "Version"
+msgstr "Version"
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:464
+msgid "Version {0}"
+msgstr "Version {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+#: packages/admin/src/components/MediaLibrary.tsx:435
+msgid "Video"
+msgstr "Video"
+
+#: packages/admin/src/components/Settings.tsx:117
+msgid "View email provider status and send test emails"
+msgstr "Visa status för e-postleverantör och skicka testmejl"
+
+#: packages/admin/src/components/PluginManager.tsx:429
+msgid "View in Marketplace"
+msgstr "Visa i marknadsplatsen"
+
+#: packages/admin/src/components/MediaLibrary.tsx:447
+msgid "View mode"
+msgstr "Visningsläge"
+
+#: packages/admin/src/components/ContentList.tsx:1009
+msgid "View published {title}"
+msgstr "Visa publicerad {title}"
+
+#: packages/admin/src/components/Header.tsx:59
+msgid "View Site"
+msgstr "Visa webbplats"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:663
+msgid "View source"
+msgstr "Visa källa"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:916
+msgid "View the {license} license on spdx.org"
+msgstr "Visa licensen {license} på spdx.org"
+
+#: packages/admin/src/components/Redirects.tsx:448
+msgid "Visitors hitting these paths will see an error."
+msgstr "Besökare som når dessa sökvägar ser ett fel."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:57
+msgid "Vue"
+msgstr "Vue"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "Väntar på passkey …"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr "Varning"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1266
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "Vi kunde inte ansluta till en WordPress-webbplats på {0}. Det kan betyda att webbplatsen inte är WordPress, att REST-API:et är inaktiverat, eller att webbplatsen inte är tillgänglig."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:564
+msgid "We couldn't verify this publisher's identity"
+msgstr "Vi kunde inte verifiera denna utgivares identitet"
+
+#: packages/admin/src/components/WordPressImport.tsx:1084
+msgid "We'll check what import options are available for your site."
+msgstr "Vi kontrollerar vilka importalternativ som är tillgängliga för din webbplats."
+
+#: packages/admin/src/components/LoginPage.tsx:323
+msgid "We'll send you a link to sign in without a password."
+msgstr "Vi skickar en länk så att du kan logga in utan lösenord."
+
+#: packages/admin/src/components/SignupPage.tsx:132
+msgid "We've sent a verification link to"
+msgstr "Vi har skickat en bekräftelselänk till"
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr "Webbadress"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "WebAuthn stöds inte i denna webbläsare"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/RegistryPluginDetail.tsx:688
+msgid "Website"
+msgstr "Webbplats"
+
+#: packages/admin/src/routes/bylines.tsx:492
+msgid "Website URL"
+msgstr "Webbplats-URL"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "Välkommen till EmDash, {firstName}!"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "Välkommen till EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "What happens when you import:"
+msgstr "Vad som händer när du importerar:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1874
+msgid "What will happen when you import"
+msgstr "Vad som kommer att hända när du importerar"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr "När posten skapades"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr "När posten senast ändrades"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr "När posten publicerades"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:658
+msgid "Which content types can use this taxonomy"
+msgstr "Vilka innehållstyper som kan använda denna taxonomi"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr "Heltal"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:121
+msgid "Why can't this be changed?"
+msgstr "Varför kan detta inte ändras?"
+
+#: packages/admin/src/components/SeoPanel.tsx:209
+msgid "Why is this important for duplicate pages?"
+msgstr "Varför är detta viktigt för duplicerade sidor?"
+
+#: packages/admin/src/components/SeoPanel.tsx:185
+msgid "Why is this important for search result summaries?"
+msgstr "Varför är detta viktigt för sammanfattningar i sökresultat?"
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Why is this important for search result titles?"
+msgstr "Varför är detta viktigt för titlar i sökresultat?"
+
+#: packages/admin/src/components/SeoPanel.tsx:228
+msgid "Why is this important for search visibility?"
+msgstr "Varför är detta viktigt för synlighet i sökmotorer?"
+
+#: packages/admin/src/components/SeoImageField.tsx:44
+msgid "Why is this important for social sharing?"
+msgstr "Varför är detta viktigt för delning i sociala medier?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:123
+msgid "Why is this important?"
+msgstr "Varför är detta viktigt?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
+msgid "Wide"
+msgstr "Bred"
+
+#: packages/admin/src/components/Widgets.tsx:785
+#: packages/admin/src/components/Widgets.tsx:800
+msgid "widget"
+msgstr "widget"
+
+#: packages/admin/src/components/Widgets.tsx:230
+msgid "Widget added"
+msgstr "Widget tillagd"
+
+#: packages/admin/src/components/Widgets.tsx:218
+msgid "Widget area created"
+msgstr "Widgetområde skapat"
+
+#: packages/admin/src/components/Widgets.tsx:628
+msgid "Widget area deleted"
+msgstr "Widgetområde borttaget"
+
+#: packages/admin/src/components/Widgets.tsx:748
+msgid "Widget deleted"
+msgstr "Widget borttagen"
+
+#: packages/admin/src/components/Widgets.tsx:877
+msgid "Widget title"
+msgstr "Widgettitel"
+
+#: packages/admin/src/components/Widgets.tsx:763
+msgid "Widget updated"
+msgstr "Widget uppdaterad"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:379
+#: packages/admin/src/components/Sidebar.tsx:333
+#: packages/admin/src/components/Widgets.tsx:385
+#: packages/admin/src/components/WordPressImport.tsx:1157
+msgid "Widgets"
+msgstr "Widgetar"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:284
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:473
+msgid "Width"
+msgstr "Bredd"
+
+#: packages/admin/src/components/WordPressImport.tsx:2014
+msgid "Will create"
+msgstr "Kommer att skapa"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:384
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "kommer inte längre att kunna registrera sig utan inbjudan. Befintliga användare påverkas inte."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:158
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "Utan en e-postleverantör måste inbjudningslänkar delas manuellt."
+
+#: packages/admin/src/components/WordPressImport.tsx:210
+msgid "WordPress authorization was rejected"
+msgstr "WordPress-auktoriseringen nekades"
+
+#: packages/admin/src/components/WordPressImport.tsx:1476
+msgid "WordPress Username"
+msgstr "WordPress-användarnamn"
+
+#: packages/admin/src/components/ContentList.tsx:404
+msgid "Working on {selectedCount} items…"
+msgstr "Bearbetar {selectedCount} objekt …"
+
+#: packages/admin/src/components/Widgets.tsx:887
+msgid "Write widget content..."
+msgstr "Skriv widgetinnehåll …"
+
+#: packages/admin/src/components/WordPressImport.tsx:1181
+msgid "WXR File"
+msgstr "WXR-fil"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:58
+msgid "XML"
+msgstr "XML"
+
+#: packages/admin/src/components/WordPressImport.tsx:1497
+msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
+msgstr "xxxx xxxx xxxx xxxx xxxx xxxx"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:59
+msgid "YAML"
+msgstr "YAML"
+
+#: packages/admin/src/components/Widgets.tsx:161
+msgid "Yearly"
+msgstr "Årligen"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:420
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "Yes"
+msgstr "Ja"
+
+#: packages/admin/src/components/WordPressImport.tsx:1160
+msgid "Yoast/RankMath"
+msgstr "Yoast/RankMath"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "Du kan stänga denna sida och gå tillbaka till din terminal."
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "Du kan skapa och redigera ditt eget innehåll."
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "Du kan hantera innehåll, media, menyer och taxonomier."
+
+#: packages/admin/src/routes/bylines.tsx:550
+msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+msgstr "Du kan fortfarande redigera de fasta fälten ovan. Att spara påverkar inte lagrade värden för anpassade fält."
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "Du kan visa och bidra till webbplatsen."
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr "Du kan inte ändra din egen roll"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "Du har full åtkomst att hantera denna webbplats, inklusive användare, inställningar och allt innehåll."
+
+#: packages/admin/src/routes/byline-schema.tsx:175
+msgid "You need admin permissions to manage byline schema."
+msgstr "Du behöver administratörsbehörighet för att hantera byline-schema."
+
+#: packages/admin/src/router.tsx:1485
+msgid "You need Editor permissions to moderate comments."
+msgstr "Du behöver redaktörsbehörighet för att moderera kommentarer."
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "Du kommer inte längre kunna använda \"{0}\" för att logga in. Åtgärden kan inte ångras."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "Du kommer inte längre kunna använda denna passkey för att logga in. Åtgärden kan inte ångras."
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:54
+msgid "You'll be joining as <0>{0}</0>"
+msgstr "Du kommer att gå med som <0>{0}</0>"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "Du kommer att uppmanas att använda enhetens biometriska autentisering, säkerhetsnyckel eller PIN-kod."
+
+#: packages/admin/src/components/WordPressImport.tsx:1369
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "Du kommer att omdirigeras till WordPress för att auktorisera anslutningen."
+
+#: packages/admin/src/components/SignupPage.tsx:191
+msgid "You'll be signing up as"
+msgstr "Du kommer att registrera dig som"
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr "Du är inloggad via Cloudflare Access"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:52
+msgid "You've been invited!"
+msgstr "Du har blivit inbjuden!"
+
+#: packages/admin/src/components/SignupPage.tsx:70
+msgid "you@company.com"
+msgstr "du@foretag.se"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:334
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr "du@exempel.se"
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "Ditt konto har skapats."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:316
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "Din webbläsare stöder inte passkeys. Använd en modern webbläsare som Chrome, Safari, Firefox eller Edge."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:267
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "Din enhet stöder inte de nödvändiga säkerhetsfunktionerna."
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr "Din e-post"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:121
+msgid "Your Facebook page or profile username"
+msgstr "Användarnamnet för din Facebook-sida eller -profil"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:115
+msgid "Your GitHub username"
+msgstr "Ditt GitHub-användarnamn"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:127
+msgid "Your Instagram username"
+msgstr "Ditt Instagram-användarnamn"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:133
+msgid "Your LinkedIn profile username"
+msgstr "Användarnamnet för din LinkedIn-profil"
+
+#: packages/admin/src/components/MediaLibrary.tsx:504
+#: packages/admin/src/components/MediaLibrary.tsx:528
+msgid "Your media library is empty"
+msgstr "Ditt mediebibliotek är tomt"
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr "Ditt namn"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:64
+#: packages/admin/src/components/SignupPage.tsx:201
+msgid "Your name (optional)"
+msgstr "Ditt namn (valfritt)"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "Din roll"
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:599
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr "Din webbplats kräver att versioner är minst {0} gamla innan de kan installeras. Denna version blir installerbar senare."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:109
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "Ditt Twitter/X-användarnamn (t.ex. @användarnamn)"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:437
+msgid "Your unsaved media changes will be lost."
+msgstr "Dina osparade ändringar av media går förlorade."
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:2062
+msgid "Your WordPress export contains {0} media files."
+msgstr "Din WordPress-export innehåller {0} mediefiler."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:139
+msgid "Your YouTube channel ID or handle"
+msgstr "Ditt YouTube-kanal-ID eller användarnamn"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:136
+msgid "YouTube"
+msgstr "YouTube"


### PR DESCRIPTION
## What does this PR do?

Adds a complete Swedish (Svenska, `sv`) translation of the admin UI. It registers the `sv` locale in `locales.ts`, ships a fully translated `messages.po` catalog (100% coverage), and enables the locale in the admin UI.

I used AI (Cursor + Grok) for a first pass, then reviewed every string manually as a fluent Swedish speaker and previewed them in the running admin UI (login, settings, navigation). Placeholders, ICU plurals, and component tags (`<0>…</0>`) are preserved. Since coverage is 100% I set `enabled: true`, but I'm happy to flip it to `false` if you'd rather enable it yourself.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a for a translation
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). This is a translation PR, so it intentionally includes `sv/messages.po`. The diff is limited to `sv/messages.po` and `locales.ts` — no extracted catalog churn in other locales.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Grok, with fluent-speaker review of every string and a preview in the running admin UI

## Screenshots / test output

Verified in the `demos/simple` admin UI: Settings → language switcher → Svenska. Spot-checked navigation, settings, and content screens for layout/truncation.