### PR TITLE
fix(aggregator): rename labellers table via forward migration

### DIFF
--- a/apps/aggregator/migrations/0004_rename_labellers_to_labelers.sql
+++ b/apps/aggregator/migrations/0004_rename_labellers_to_labelers.sql
@@ -1,0 +1,12 @@
+-- Rename `labellers` -> `labelers` to match the spelling every query in
+-- `src/` uses (`labeler-resolver.ts`, `labels-consumer.ts`,
+-- `request-policy.ts`, `index.ts`). `0001_init.sql` shipped the table as
+-- `labellers` and is immutable once applied, so the correction has to land as
+-- a forward migration: databases provisioned by `0001` keep `labellers` and
+-- only this migration brings them to `labelers`.
+--
+-- No indexes, triggers, or views reference the table, so SQLite's
+-- `ALTER TABLE ... RENAME TO` is sufficient — there are no explicitly-named
+-- objects embedding the old spelling to recreate.
+
+ALTER TABLE labellers RENAME TO labelers;

--- a/apps/aggregator/test/fixtures/main-migrations/0001_init.sql
+++ b/apps/aggregator/test/fixtures/main-migrations/0001_init.sql
@@ -1,3 +1,10 @@
+-- Frozen snapshot of `migrations/0001_init.sql` as it shipped on `main`
+-- (with the `labellers` table spelling). The upgrade test in
+-- `migration-upgrade.test.ts` applies this directory (main's shipped migration
+-- set) to reproduce a database provisioned before the `labellers` ->
+-- `labelers` rename, then applies the live migration set on top. Do not "fix"
+-- the spelling here: this file must keep reproducing the historical schema.
+--
 -- EmDash plugin registry aggregator: initial schema.
 --
 -- Lands every table that the v1 read API + ingest pipeline + label hydration

--- a/apps/aggregator/test/fixtures/main-migrations/0002_indexed_at.sql
+++ b/apps/aggregator/test/fixtures/main-migrations/0002_indexed_at.sql
@@ -1,0 +1,35 @@
+-- Add `indexed_at` to the four content tables that the read API exposes via
+-- the `packageView` / `releaseView` lexicon shapes.
+--
+-- Why a separate column from `verified_at`: `verified_at` tracks "when the
+-- aggregator last verified this record", and is bumped on every upsert
+-- (including no-op re-verifications). The read API needs "when the aggregator
+-- first observed this record" so the lexicon's `indexedAt` field is stable
+-- across re-ingest. They diverge whenever a record is re-fetched (e.g.
+-- backfill catching up on a record we already had via Jetstream).
+--
+-- Defaulting to `verified_at` for any rows that pre-date this migration: the
+-- closest approximation we can make for already-indexed content. Going
+-- forward, the consumer's INSERTs set `indexed_at` to `now()` on first write
+-- and COALESCE the existing value on conflict (see records-consumer.ts).
+--
+-- NOT NULL after backfill from `verified_at`. SQLite's `ALTER TABLE` doesn't
+-- support DEFAULT-with-NOT-NULL in one step, so we add the column nullable,
+-- backfill, then move the constraint via the new-table dance — except SQLite
+-- also can't add NOT NULL via ALTER, so we keep the column nullable at the
+-- schema level and have the writer (consumer) treat it as required. The
+-- read-API code defends against NULL by falling back to verified_at if
+-- indexed_at is somehow missing on a row, which won't happen for new writes
+-- but covers the historical-data corner case without a table rebuild.
+
+ALTER TABLE packages ADD COLUMN indexed_at TEXT;
+UPDATE packages SET indexed_at = verified_at WHERE indexed_at IS NULL;
+
+ALTER TABLE releases ADD COLUMN indexed_at TEXT;
+UPDATE releases SET indexed_at = verified_at WHERE indexed_at IS NULL;
+
+ALTER TABLE publishers ADD COLUMN indexed_at TEXT;
+UPDATE publishers SET indexed_at = verified_at WHERE indexed_at IS NULL;
+
+ALTER TABLE publisher_verifications ADD COLUMN indexed_at TEXT;
+UPDATE publisher_verifications SET indexed_at = verified_at WHERE indexed_at IS NULL;

--- a/apps/aggregator/test/migration-upgrade.test.ts
+++ b/apps/aggregator/test/migration-upgrade.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Upgrade-path regression for the `labellers` -> `labelers` rename.
+ *
+ * `0001_init.sql` shipped on `main` creating a `labellers` table, then a later
+ * revision renamed it in place. Editing an applied migration is invisible to
+ * databases that already recorded it, so instances deployed off `main` kept
+ * `labellers` while `src/` moved to querying `labelers` -> every such query
+ * failed with `no such table`. The rename now lands as a forward migration.
+ *
+ * This test provisions the schema the way a `main` deployment had it (via the
+ * `MAIN_MIGRATIONS` fixture, a frozen copy of `main`'s shipped migration set),
+ * then applies the live migration set on top. `applyD1Migrations` skips
+ * migrations already recorded by name, so neither frozen file is re-run —
+ * exactly what happens on a real upgrade. It lives in its own file because the workers pool isolates
+ * D1 storage per test file, not per test, and this scenario needs a database
+ * that starts from `main`'s schema rather than the live one.
+ */
+
+import { applyD1Migrations, env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+	MAIN_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+
+const testEnv = env as unknown as TestEnv;
+
+describe("labellers -> labelers upgrade", () => {
+	it("converges an already-migrated main database on the labelers table", async () => {
+		await applyD1Migrations(testEnv.DB, testEnv.MAIN_MIGRATIONS);
+		expect((await testEnv.DB.prepare(`SELECT did FROM labellers`).all()).success).toBe(true);
+
+		const did = "did:web:labels.example.test";
+		await testEnv.DB.prepare(
+			`INSERT INTO labellers (did, endpoint, signing_key, signing_key_id, trusted, added_at, last_resolved_at)
+			 VALUES (?, ?, ?, ?, 1, ?, ?)`,
+		)
+			.bind(
+				did,
+				"https://labels.example.test/subscribe",
+				"zKey",
+				`${did}#atproto_label`,
+				"2026-01-01T00:00:00.000Z",
+				"2026-01-01T00:00:00.000Z",
+			)
+			.run();
+
+		await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+
+		// The RENAME must carry the existing row across, not drop/recreate the table.
+		const result = await testEnv.DB.prepare(
+			`SELECT did FROM labelers WHERE trusted = 1 ORDER BY did ASC`,
+		).all<{ did: string }>();
+		expect(result.success).toBe(true);
+		expect(result.results?.map((row) => row.did)).toContain(did);
+
+		await expect(testEnv.DB.prepare(`SELECT did FROM labellers`).all()).rejects.toThrow();
+	});
+});

--- a/apps/aggregator/test/smoke.test.ts
+++ b/apps/aggregator/test/smoke.test.ts
@@ -84,6 +84,14 @@ describe("aggregator scaffold smoke test", () => {
 		expect(result?.slug).toBe("searchable");
 	});
 
+	it("exposes a queryable labelers table under the name src queries", async () => {
+		// `0001_init.sql` creates the table as `labellers`; `0004` renames it to
+		// `labelers`, the spelling every query in `src/` uses. A fresh install
+		// must land on `labelers`.
+		const result = await testEnv.DB.prepare(`SELECT did FROM labelers`).all();
+		expect(result.success).toBe(true);
+	});
+
 	it("rejects a release whose did/package does not match an existing profile (FK)", async () => {
 		// Releases reference packages via composite FK; SQLite enforces this when
 		// FK checks are enabled. workers-pool's miniflare D1 has FK checks on by

--- a/apps/aggregator/vitest.config.ts
+++ b/apps/aggregator/vitest.config.ts
@@ -28,6 +28,14 @@ import { defineConfig } from "vitest/config";
 const migrationsPath = fileURLToPath(new URL("./migrations", import.meta.url));
 const migrations = await readD1Migrations(migrationsPath);
 
+// Frozen copy of the schema `main` shipped (pre `labellers` -> `labelers`
+// rename), exposed so the upgrade test can provision a database the way an
+// already-deployed instance was before applying the live migration set.
+const mainMigrationsPath = fileURLToPath(
+	new URL("./test/fixtures/main-migrations", import.meta.url),
+);
+const mainMigrations = await readD1Migrations(mainMigrationsPath);
+
 export default defineConfig({
 	plugins: [
 		cloudflareTest({
@@ -35,6 +43,7 @@ export default defineConfig({
 			miniflare: {
 				bindings: {
 					TEST_MIGRATIONS: migrations,
+					MAIN_MIGRATIONS: mainMigrations,
 					// Stub admin auth token so tests can exercise the auth-gated
 					// admin routes without needing a real secret in the test
 					// environment. Production deploys pull from


### PR DESCRIPTION
## What does this PR do?

Fixes a broken upgrade path in the aggregator flagged in review of umbrella #1909 (RFC #694): migration `0001_init.sql` — which shipped on `main` creating the table as `labellers` — was later edited **in place** on this branch to spell it `labelers` (commit `e87f81f8`). D1 records applied migrations by filename, so a database that ran main's `0001` skips the edited file on upgrade and keeps `labellers`, while every query in `src/` reads `labelers` → `no such table: labelers` on every labeler-resolver/ingest/policy path.

**Fix:**
- Restore `0001_init.sql` **byte-for-byte** to main's version (`git diff origin/main` on the file is empty). Applied migrations are immutable.
- Add `0004_rename_labellers_to_labelers.sql` — a bare `ALTER TABLE ... RENAME TO` (verified: no indexes, triggers, or views reference the table, so nothing dangles). Fresh installs (`0001` → … → `0004`) and main upgrades (`0001`+`0002` recorded → `0003`+`0004`) converge on the same schema.
- Add an upgrade regression test (`test/migration-upgrade.test.ts`): provisions a DB from a **frozen copy of main's shipped migration set** (`test/fixtures/main-migrations/`, frozen copies whose DDL matches main; a short snapshot header marks them as never-to-be-"fixed"), then applies the live set — reproducing exactly what a real upgrade does. Pre-fix it fails with `D1_ERROR: no such table: labelers`. A fresh-install assertion is added to `smoke.test.ts`.

Adversarially reviewed (restoration fidelity, rename completeness, 0002/0003 sequence coherence for both histories, src spelling sweep, test non-vacuity, wrangler config): clean. One accepted quirk: the restored `0001`'s comment example uses the historical `labeller:` spelling — unavoidable under byte-fidelity, no runtime effect (main's src never wrote ingest cursors).

Targets the `feat/plugin-registry-labelling-service` integration branch. Part of #1909; addresses the migration-immutability review finding.

## Type of change

- [x] Bug fix
- [ ] Feature (requires a Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (aggregator: clean)
- [x] `pnpm lint` passes (0 diagnostics)
- [x] `pnpm test` passes (aggregator suite: 315 passed / 15 files, including the new upgrade + fresh-install tests; TDD: the upgrade test fails pre-fix with `no such table: labelers`)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server-side migration.
- [x] I have added a changeset (if this PR changes a published package) — **n/a**: `@emdash-cms/aggregator` is `private: true`.
- [x] New features link to an approved Discussion — **n/a**: bug fix; umbrella #1909 tracks RFC #694.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation + adversarial review), orchestrated/reviewed by **Claude Fable 5**

## Screenshots / test output

```
 Test Files  15 passed (15)
      Tests  315 passed (315)
```

Pre-fix repro (upgrade test against the edited-0001 migration set):

```
FAIL > converges an already-migrated main database on the labelers table
Error: D1_ERROR: no such table: labelers: SQLITE_ERROR
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-aggregator-sol-r1-migration-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/aggregator-sol-r1-migration`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

**On the edited-migration lineage:** a database initialized from the in-place-edited `0001` (already carrying `labelers`) is out of scope by decision — the aggregator is pre-launch (experimental NSIDs, staging not yet provisioned), so any such database is discardable/resettable. The two lineages that reach production — fresh install and main-upgrade — are both tested; this PR does not commit to supporting an edited-migration lineage.