### PR TITLE
fix(labeler): Access custom-group roles + PDS-fetch SSRF guard (review round 1)

### DIFF
--- a/apps/labeler/src/access-auth.ts
+++ b/apps/labeler/src/access-auth.ts
@@ -129,7 +129,13 @@ export async function verifyAccessRequest(
 	}
 
 	const principal = identity.kind === "service" ? identity.commonName : identity.email;
-	const principals = new Set<string>([principal, ...groupPrincipals(payload.groups)]);
+	// Group membership authorizes humans only. A service token carries no IdP
+	// identity — it is authorized solely by common_name — so a `custom.groups`
+	// on a service token must never confer a role.
+	const principals = new Set<string>([
+		principal,
+		...(identity.kind === "human" ? groupPrincipals(payload.custom) : []),
+	]);
 	const roles: OperatorRole[] = [];
 	if (config.admins.some((admin) => principals.has(admin))) roles.push("admin");
 	if (config.reviewers.some((reviewer) => principals.has(reviewer))) roles.push("reviewer");
@@ -137,7 +143,12 @@ export async function verifyAccessRequest(
 	return { ...identity, roles };
 }
 
-function groupPrincipals(groups: unknown): readonly string[] {
+// Cloudflare Access surfaces IdP group membership inside the verified token's
+// `custom` object (as a `groups` claim configured on the SAML/OIDC integration),
+// never as a top-level claim. Read the group principals from there.
+function groupPrincipals(custom: unknown): readonly string[] {
+	if (!isRecord(custom)) return [];
+	const groups = custom.groups;
 	if (!Array.isArray(groups)) return [];
 	return groups.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 }

--- a/apps/labeler/src/access-auth.ts
+++ b/apps/labeler/src/access-auth.ts
@@ -110,7 +110,10 @@ export async function verifyAccessRequest(
 	}
 
 	const sub = payload.sub;
-	if (typeof sub !== "string" || sub.length === 0)
+	// Cloudflare Access sets sub: "" for non-identity (service-token) JWTs, so
+	// only reject a non-string sub here; the human path below additionally
+	// requires it to be non-empty.
+	if (typeof sub !== "string")
 		throw new AccessAuthError("invalid-token", "Access assertion is missing sub");
 
 	const commonName = payload.common_name;
@@ -120,6 +123,8 @@ export async function verifyAccessRequest(
 	if (typeof commonName === "string" && commonName.length > 0) {
 		identity = { kind: "service", commonName, sub, roles: [] };
 	} else if (typeof email === "string" && email.length > 0) {
+		if (sub.length === 0)
+			throw new AccessAuthError("invalid-token", "Access assertion is missing sub");
 		identity = { kind: "human", email, sub, roles: [] };
 	} else {
 		throw new AccessAuthError(

--- a/apps/labeler/src/discovery-consumer.ts
+++ b/apps/labeler/src/discovery-consumer.ts
@@ -32,6 +32,7 @@ import {
 	PlcDidDocumentResolver,
 } from "@atcute/identity-resolver";
 import type { LabelSigner } from "@emdash-cms/registry-moderation";
+import { cloudflareDohResolver, type DnsResolver } from "emdash/security/ssrf";
 
 import {
 	AssessmentDispatchError,
@@ -94,6 +95,9 @@ export interface DiscoveryConsumerDeps {
 	 * (assessment-dispatch.ts). */
 	assessmentWorkflow: AssessmentWorkflowBinding;
 	fetch?: typeof fetch;
+	/** Resolves each PDS hop's hostname for the SSRF egress guard; defaults to
+	 * the DoH resolver used by artifact acquisition. */
+	resolveHostname?: DnsResolver;
 	now?: () => Date;
 	/**
 	 * Optional override for the record-verification step. Used by tests to
@@ -107,6 +111,7 @@ export interface DiscoveryConsumerDeps {
 		cid: string;
 		didDocumentResolver: DidDocumentResolverLike;
 		fetch?: typeof fetch;
+		resolveHostname?: DnsResolver;
 	}) => Promise<VerifiedPdsRecord>;
 	/** Override for the delete-path absence check; defaults to
 	 * `confirmRecordAbsent`. Returns `true` when the record is verifiably gone. */
@@ -114,6 +119,7 @@ export interface DiscoveryConsumerDeps {
 		uri: string;
 		didDocumentResolver: DidDocumentResolverLike;
 		fetch?: typeof fetch;
+		resolveHostname?: DnsResolver;
 	}) => Promise<boolean>;
 }
 
@@ -137,6 +143,7 @@ export type DiscoveryDeadLetterReason =
 	| "RESPONSE_TOO_LARGE"
 	| "INVALID_PROOF"
 	| "PDS_HTTP_ERROR"
+	| "PDS_HOST_BLOCKED"
 	| "DELETE_RECORD_PRESENT"
 	| RecordVerificationFailureReason
 	| "UNEXPECTED_ERROR";
@@ -215,6 +222,7 @@ export async function processDiscoveryMessage(
 				uri,
 				didDocumentResolver: deps.didDocumentResolver,
 				...(deps.fetch ? { fetch: deps.fetch } : {}),
+				...(deps.resolveHostname ? { resolveHostname: deps.resolveHostname } : {}),
 			});
 			if (!absent) {
 				await writeDeadLetter(
@@ -349,6 +357,7 @@ async function verifyAndCreateRun(
 		cid: job.cid,
 		didDocumentResolver: deps.didDocumentResolver,
 		...(deps.fetch ? { fetch: deps.fetch } : {}),
+		...(deps.resolveHostname ? { resolveHostname: deps.resolveHostname } : {}),
 	});
 
 	await createSubject(deps.db, {
@@ -521,6 +530,7 @@ function mapPdsReason(reason: VerificationFailureReason): DiscoveryDeadLetterRea
 		case "RESPONSE_TOO_LARGE":
 		case "INVALID_PROOF":
 		case "PDS_HTTP_ERROR":
+		case "PDS_HOST_BLOCKED":
 			return reason;
 		case "PDS_NETWORK_ERROR":
 			throw new Error(
@@ -554,6 +564,9 @@ async function createProductionDiscoveryDeps(env: Env): Promise<DiscoveryConsume
 		// bound wrapper rather than letting pds-verify.ts fall back to bare
 		// global `fetch`.
 		fetch: boundFetch,
+		// SSRF egress guard for the publisher-controlled PDS endpoint and any
+		// redirect it serves — the same DoH resolver artifact acquisition uses.
+		resolveHostname: cloudflareDohResolver,
 	};
 }
 

--- a/apps/labeler/src/discovery-consumer.ts
+++ b/apps/labeler/src/discovery-consumer.ts
@@ -126,8 +126,10 @@ export interface DiscoveryConsumerDeps {
 /** Subset of `cloudflare:workers` `Message` we use; defining inline so tests
  * don't need to import workerd types. */
 export interface MessageController {
+	/** 1 on first delivery, incremented on each redelivery. */
+	readonly attempts: number;
 	ack(): void;
-	retry(): void;
+	retry(options?: { delaySeconds?: number }): void;
 }
 
 /** Subset of a `MessageBatch`. Workers' real batch object satisfies this. */
@@ -301,7 +303,10 @@ async function classifyDiscoveryError(
 	}
 	if (err instanceof PdsVerificationError) {
 		if (isTransient(err.reason, err.status)) {
-			controller.retry();
+			// Back off so a DNS-propagation or PDS blip has time to clear before
+			// max_retries is exhausted; an immediate re-delivery would burn every
+			// attempt in a couple of batches.
+			controller.retry({ delaySeconds: transientRetryDelaySeconds(controller.attempts) });
 			return;
 		}
 		let mapped: DiscoveryDeadLetterReason;
@@ -515,6 +520,20 @@ async function negatePendingForDeletedRuns(
 
 function jobUri(job: DiscoveryJob): string {
 	return `at://${job.did}/${job.collection}/${job.rkey}`;
+}
+
+/** Capped exponential backoff for a transient PDS failure. The queue has no
+ * `retry_delay`, so a bare `retry()` re-delivers in the next batch — with only
+ * `max_retries` attempts, an immediate loop can exhaust every attempt before
+ * ordinary DNS propagation completes (the empty-answer/resolver-failure path
+ * routes propagation lag here). Delaying each retry gives the host time to
+ * resolve without an unbounded backlog. */
+const RETRY_BASE_DELAY_SECONDS = 15;
+const RETRY_MAX_DELAY_SECONDS = 300;
+
+function transientRetryDelaySeconds(attempts: number): number {
+	const exponent = Math.max(0, attempts - 1);
+	return Math.min(RETRY_BASE_DELAY_SECONDS * 2 ** exponent, RETRY_MAX_DELAY_SECONDS);
 }
 
 /**

--- a/apps/labeler/src/pds-verify.ts
+++ b/apps/labeler/src/pds-verify.ts
@@ -41,6 +41,11 @@ const MAX_PDS_REDIRECTS = 3;
  * case from the permanent one. A test pins it so a core wording change fails
  * loudly instead of silently mis-classifying. */
 const SSRF_RESOLVER_FAILURE_PREFIX = "Could not resolve hostname:";
+/** `resolveAndValidateExternalUrl` raises this exact `SsrfError` when the
+ * resolver returns no addresses (NXDOMAIN / NODATA). A host mid-DNS-propagation
+ * produces a temporary negative answer, so this is retryable — not a permanent
+ * block. Pinned by a test so a core wording change fails loudly. */
+const SSRF_EMPTY_ANSWER_MESSAGE = "Hostname resolved to no addresses";
 
 export type VerificationFailureReason =
 	| "PDS_NETWORK_ERROR"
@@ -163,11 +168,15 @@ async function assertAllowedPdsUrl(url: string, resolveHostname: DnsResolver): P
 		await resolveAndValidateExternalUrl(url, { resolver: resolveHostname });
 	} catch (err) {
 		if (err instanceof SsrfError) {
-			// A resolver failure (DoH network error, SERVFAIL, timeout) is
-			// transient infrastructure — retry it rather than permanently
-			// dead-lettering a legitimate record. A true address/scheme block is
-			// permanent.
-			if (err.message.startsWith(SSRF_RESOLVER_FAILURE_PREFIX)) {
+			// Two transient resolver outcomes: the resolver itself failed (DoH
+			// network error, SERVFAIL, timeout), or it returned an empty answer
+			// (NXDOMAIN / NODATA, which a host mid-DNS-propagation produces).
+			// Both retry rather than permanently dead-lettering a legitimate
+			// record. A true private/reserved-address or scheme block is permanent.
+			if (
+				err.message.startsWith(SSRF_RESOLVER_FAILURE_PREFIX) ||
+				err.message === SSRF_EMPTY_ANSWER_MESSAGE
+			) {
 				throw new PdsVerificationError(
 					"PDS_NETWORK_ERROR",
 					`PDS host resolution failed: ${err.message}`,

--- a/apps/labeler/src/pds-verify.ts
+++ b/apps/labeler/src/pds-verify.ts
@@ -34,6 +34,13 @@ const DEFAULT_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 /** Redirect hops we'll follow before giving up. Each hop is independently
  * re-validated against the SSRF egress rules before it is fetched. */
 const MAX_PDS_REDIRECTS = 3;
+/** `resolveAndValidateExternalUrl` raises `SsrfError` both for a permanent
+ * address/scheme block and for a transient resolver failure (DoH network error,
+ * SERVFAIL, timeout). Core exposes no structured discriminator, so this prefix
+ * — the exact wording it wraps a thrown resolver in — separates the retryable
+ * case from the permanent one. A test pins it so a core wording change fails
+ * loudly instead of silently mis-classifying. */
+const SSRF_RESOLVER_FAILURE_PREFIX = "Could not resolve hostname:";
 
 export type VerificationFailureReason =
 	| "PDS_NETWORK_ERROR"
@@ -135,8 +142,9 @@ function buildGetRecordUrl(pds: string, did: string, collection: string, rkey: s
 /**
  * Reject a PDS URL that is not HTTPS or whose host resolves to a
  * private/reserved address. The publisher controls the PDS endpoint (and any
- * redirect it serves), so this reuses the same DNS-aware SSRF validator that
- * guards artifact acquisition rather than duplicating any address logic.
+ * redirect it serves), so this validates every hop through core's DNS-aware
+ * `resolveAndValidateExternalUrl` (private/reserved-address rejection) rather
+ * than duplicating any address logic.
  */
 async function assertAllowedPdsUrl(url: string, resolveHostname: DnsResolver): Promise<void> {
 	let parsed: URL;
@@ -155,6 +163,18 @@ async function assertAllowedPdsUrl(url: string, resolveHostname: DnsResolver): P
 		await resolveAndValidateExternalUrl(url, { resolver: resolveHostname });
 	} catch (err) {
 		if (err instanceof SsrfError) {
+			// A resolver failure (DoH network error, SERVFAIL, timeout) is
+			// transient infrastructure — retry it rather than permanently
+			// dead-lettering a legitimate record. A true address/scheme block is
+			// permanent.
+			if (err.message.startsWith(SSRF_RESOLVER_FAILURE_PREFIX)) {
+				throw new PdsVerificationError(
+					"PDS_NETWORK_ERROR",
+					`PDS host resolution failed: ${err.message}`,
+					undefined,
+					err,
+				);
+			}
 			throw new PdsVerificationError(
 				"PDS_HOST_BLOCKED",
 				`PDS host rejected: ${err.message}`,

--- a/apps/labeler/src/pds-verify.ts
+++ b/apps/labeler/src/pds-verify.ts
@@ -20,18 +20,28 @@
 import type { PublicKey } from "@atcute/crypto";
 import { type AtprotoDid, isDid } from "@atcute/lexicons/syntax";
 import { verifyRecord } from "@atcute/repo";
+import {
+	cloudflareDohResolver,
+	type DnsResolver,
+	resolveAndValidateExternalUrl,
+	SsrfError,
+} from "emdash/security/ssrf";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 /** 5 MB ceiling. Records and their proofs are tiny (sub-KB typical); this is
  * a defence against a hostile or broken PDS streaming an unbounded body. */
 const DEFAULT_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+/** Redirect hops we'll follow before giving up. Each hop is independently
+ * re-validated against the SSRF egress rules before it is fetched. */
+const MAX_PDS_REDIRECTS = 3;
 
 export type VerificationFailureReason =
 	| "PDS_NETWORK_ERROR"
 	| "PDS_HTTP_ERROR"
 	| "RECORD_NOT_FOUND"
 	| "RESPONSE_TOO_LARGE"
-	| "INVALID_PROOF";
+	| "INVALID_PROOF"
+	| "PDS_HOST_BLOCKED";
 
 export class PdsVerificationError extends Error {
 	override readonly name = "PdsVerificationError";
@@ -57,6 +67,10 @@ export interface FetchAndVerifyOptions {
 	maxResponseBytes?: number;
 	/** Inject for tests; defaults to `globalThis.fetch`. */
 	fetch?: typeof fetch;
+	/** Resolves each hop's hostname so its addresses can be checked against the
+	 * private/reserved-IP blocklist before the request is made. Inject for
+	 * tests; defaults to the DoH resolver used by artifact acquisition. */
+	resolveHostname?: DnsResolver;
 }
 
 export interface VerifiedPdsRecord {
@@ -73,6 +87,7 @@ export async function fetchAndVerifyRecord(
 	const fetchImpl = opts.fetch ?? fetch;
 	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	const maxResponseBytes = opts.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+	const resolveHostname = opts.resolveHostname ?? cloudflareDohResolver;
 
 	if (!isAtprotoDid(opts.did)) {
 		// Caller is expected to have validated this upstream (the resolver
@@ -84,7 +99,7 @@ export async function fetchAndVerifyRecord(
 		);
 	}
 	const url = buildGetRecordUrl(opts.pds, opts.did, opts.collection, opts.rkey);
-	const carBytes = await fetchCar(fetchImpl, url, timeoutMs, maxResponseBytes);
+	const carBytes = await fetchCar(fetchImpl, url, timeoutMs, maxResponseBytes, resolveHostname);
 
 	try {
 		const result = await verifyRecord({
@@ -117,31 +132,126 @@ function buildGetRecordUrl(pds: string, did: string, collection: string, rkey: s
 	return url.toString();
 }
 
+/**
+ * Reject a PDS URL that is not HTTPS or whose host resolves to a
+ * private/reserved address. The publisher controls the PDS endpoint (and any
+ * redirect it serves), so this reuses the same DNS-aware SSRF validator that
+ * guards artifact acquisition rather than duplicating any address logic.
+ */
+async function assertAllowedPdsUrl(url: string, resolveHostname: DnsResolver): Promise<void> {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new PdsVerificationError("PDS_HOST_BLOCKED", `PDS URL is not a valid URL: ${url}`);
+	}
+	if (parsed.protocol !== "https:") {
+		throw new PdsVerificationError(
+			"PDS_HOST_BLOCKED",
+			`PDS URL must use https, got ${parsed.protocol}`,
+		);
+	}
+	try {
+		await resolveAndValidateExternalUrl(url, { resolver: resolveHostname });
+	} catch (err) {
+		if (err instanceof SsrfError) {
+			throw new PdsVerificationError(
+				"PDS_HOST_BLOCKED",
+				`PDS host rejected: ${err.message}`,
+				undefined,
+				err,
+			);
+		}
+		throw err;
+	}
+}
+
+/**
+ * Fetch `initialUrl`, following redirects manually so every hop — the
+ * publisher-controlled PDS endpoint and any `Location` it names — is
+ * re-validated against the SSRF egress rules before the request is made. A
+ * hop pointing at a forbidden scheme or address rejects with
+ * `PDS_HOST_BLOCKED`.
+ */
+async function fetchWithRedirectGuard(
+	fetchImpl: typeof fetch,
+	initialUrl: string,
+	signal: AbortSignal,
+	timeoutMs: number,
+	resolveHostname: DnsResolver,
+): Promise<Response> {
+	let currentUrl = initialUrl;
+	for (let hop = 0; ; hop++) {
+		await assertAllowedPdsUrl(currentUrl, resolveHostname);
+
+		let response: Response;
+		try {
+			response = await fetchImpl(currentUrl, {
+				signal,
+				redirect: "manual",
+				headers: { accept: "application/vnd.ipld.car" },
+			});
+		} catch (err) {
+			// Whether the fetch threw because we aborted (timeout) or because the
+			// network failed at the OS layer, the right caller behaviour is the
+			// same: retry. Lump them under PDS_NETWORK_ERROR.
+			throw new PdsVerificationError(
+				"PDS_NETWORK_ERROR",
+				err instanceof Error && err.name === "AbortError"
+					? `PDS fetch aborted after ${timeoutMs}ms`
+					: `PDS fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+				undefined,
+				err,
+			);
+		}
+
+		if (response.status < 300 || response.status >= 400) return response;
+
+		if (hop >= MAX_PDS_REDIRECTS) {
+			throw new PdsVerificationError(
+				"PDS_HTTP_ERROR",
+				`PDS exceeded ${MAX_PDS_REDIRECTS} redirects`,
+				response.status,
+			);
+		}
+		const location = response.headers.get("location");
+		if (location === null) {
+			throw new PdsVerificationError(
+				"PDS_HTTP_ERROR",
+				`PDS redirect ${response.status} without a location header`,
+				response.status,
+			);
+		}
+		try {
+			currentUrl = new URL(location, currentUrl).toString();
+		} catch {
+			throw new PdsVerificationError(
+				"PDS_HOST_BLOCKED",
+				`PDS redirect location is not a valid URL: ${location}`,
+				response.status,
+			);
+		}
+	}
+}
+
 async function fetchCar(
 	fetchImpl: typeof fetch,
 	url: string,
 	timeoutMs: number,
 	maxBytes: number,
+	resolveHostname: DnsResolver,
 ): Promise<Uint8Array> {
+	const deadline = Date.now() + timeoutMs;
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
 	let response: Response;
 	try {
-		response = await fetchImpl(url, {
-			signal: controller.signal,
-			headers: { accept: "application/vnd.ipld.car" },
-		});
-	} catch (err) {
-		// Whether the fetch threw because we aborted (timeout) or because the
-		// network failed at the OS layer, the right caller behaviour is the
-		// same: retry. Lump them under PDS_NETWORK_ERROR.
-		throw new PdsVerificationError(
-			"PDS_NETWORK_ERROR",
-			err instanceof Error && err.name === "AbortError"
-				? `PDS fetch aborted after ${timeoutMs}ms`
-				: `PDS fetch failed: ${err instanceof Error ? err.message : String(err)}`,
-			undefined,
-			err,
+		response = await fetchWithRedirectGuard(
+			fetchImpl,
+			url,
+			controller.signal,
+			timeoutMs,
+			resolveHostname,
 		);
 	} finally {
 		clearTimeout(timer);
@@ -172,12 +282,34 @@ async function fetchCar(
 	if (!reader) {
 		throw new PdsVerificationError("INVALID_PROOF", "PDS response body is null");
 	}
+	return readCarBody(reader, maxBytes, deadline, timeoutMs);
+}
+
+/**
+ * Buffer the CAR body, bounding both its size (`maxBytes`) and its total wall
+ * time (`deadline`) — the header-phase abort timer is already cleared by the
+ * time we stream, so without this a slow-drip PDS could hold the read open
+ * indefinitely. Each read is raced against the remaining budget; exhausting it
+ * rejects as a transient `PDS_NETWORK_ERROR` so the consumer retries.
+ */
+async function readCarBody(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	maxBytes: number,
+	deadline: number,
+	timeoutMs: number,
+): Promise<Uint8Array> {
 	const chunks: Uint8Array[] = [];
 	let total = 0;
 	try {
-		// biome-ignore lint/correctness/noConstantCondition: drains the stream
-		while (true) {
-			const { done, value } = await reader.read();
+		for (;;) {
+			const remaining = deadline - Date.now();
+			if (remaining <= 0) {
+				throw new PdsVerificationError(
+					"PDS_NETWORK_ERROR",
+					`PDS body read exceeded ${timeoutMs}ms`,
+				);
+			}
+			const { done, value } = await readWithDeadline(reader, remaining, timeoutMs);
 			if (done) break;
 			total += value.byteLength;
 			if (total > maxBytes) {
@@ -193,10 +325,11 @@ async function fetchCar(
 		await reader.cancel().catch(() => {
 			/* swallow — we already have a primary error to surface */
 		});
-		// A read error after headers (socket drop, stream abort) is transient —
-		// re-wrap it so the consumer retries rather than dead-lettering it as an
-		// unexpected failure. Our own PdsVerificationErrors (e.g. too-large)
-		// carry their own classification and pass through.
+		// A read error after headers (socket drop, stream abort, stall) is
+		// transient — re-wrap it so the consumer retries rather than
+		// dead-lettering it as an unexpected failure. Our own
+		// PdsVerificationErrors (too-large, budget exceeded) carry their own
+		// classification and pass through.
 		if (err instanceof PdsVerificationError) throw err;
 		throw new PdsVerificationError(
 			"PDS_NETWORK_ERROR",
@@ -215,6 +348,44 @@ async function fetchCar(
 		offset += chunk.byteLength;
 	}
 	return out;
+}
+
+/**
+ * Race a single `reader.read()` against a per-read timeout. Handlers are
+ * attached to the read promise so a read that loses the race cannot later
+ * surface as an unhandled rejection.
+ */
+function readWithDeadline(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	remainingMs: number,
+	timeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			reject(
+				new PdsVerificationError("PDS_NETWORK_ERROR", `PDS body read exceeded ${timeoutMs}ms`),
+			);
+		}, remainingMs);
+		void reader.read().then(
+			(result) => {
+				if (settled) return undefined;
+				settled = true;
+				clearTimeout(timer);
+				resolve(result);
+				return undefined;
+			},
+			(err: unknown) => {
+				if (settled) return undefined;
+				settled = true;
+				clearTimeout(timer);
+				reject(err);
+				return undefined;
+			},
+		);
+	});
 }
 
 /**

--- a/apps/labeler/src/record-verification.ts
+++ b/apps/labeler/src/record-verification.ts
@@ -22,6 +22,7 @@ import {
 } from "@atcute/crypto";
 import { type DidDocument, getAtprotoVerificationMaterial, getPdsEndpoint } from "@atcute/identity";
 import { type Did, isDid } from "@atcute/lexicons/syntax";
+import type { DnsResolver } from "emdash/security/ssrf";
 
 import {
 	fetchAndVerifyRecord,
@@ -77,6 +78,9 @@ export interface FetchAndVerifyExactRecordOptions {
 	didDocumentResolver: DidDocumentResolverLike;
 	/** Inject for tests; defaults to `globalThis.fetch`. */
 	fetch?: typeof fetch;
+	/** Inject for tests; defaults to the DoH resolver used by artifact
+	 * acquisition. Threaded into the SSRF egress guard around the PDS fetch. */
+	resolveHostname?: DnsResolver;
 	timeoutMs?: number;
 	maxResponseBytes?: number;
 }
@@ -178,6 +182,7 @@ async function fetchAndVerifyLatestRecord(
 		rkey,
 		publicKey,
 		...(opts.fetch ? { fetch: opts.fetch } : {}),
+		...(opts.resolveHostname ? { resolveHostname: opts.resolveHostname } : {}),
 		...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
 		...(opts.maxResponseBytes !== undefined ? { maxResponseBytes: opts.maxResponseBytes } : {}),
 	});

--- a/apps/labeler/test/access-auth.test.ts
+++ b/apps/labeler/test/access-auth.test.ts
@@ -88,8 +88,10 @@ describe("verifyAccessRequest", () => {
 		});
 	});
 
-	it("accepts a valid service token identified by common_name", async () => {
-		const token = await mintToken({ common_name: "ci-automation" }, signKey);
+	it("accepts a valid service token identified by common_name (empty sub)", async () => {
+		// Cloudflare Access sets sub: "" for non-identity (service-token) JWTs and
+		// identifies the token via common_name (the CF-Access-Client-Id).
+		const token = await mintToken({ common_name: "ci-automation", sub: "" }, signKey);
 		const identity = await verifyAccessRequest(
 			requestWith({ "Cf-Access-Jwt-Assertion": token }),
 			baseConfig({ admins: ["ci-automation"] }),
@@ -98,9 +100,22 @@ describe("verifyAccessRequest", () => {
 		expect(identity).toEqual<OperatorIdentity>({
 			kind: "service",
 			commonName: "ci-automation",
-			sub: "user-sub-1",
+			sub: "",
 			roles: ["admin"],
 		});
+	});
+
+	it("rejects a human token with an empty sub", async () => {
+		// An empty sub is only legitimate for a service token (common_name path);
+		// a human/email identity must carry a non-empty subject.
+		const token = await mintToken({ email: "admin@example.com", sub: "" }, signKey);
+		await expect(
+			verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			),
+		).rejects.toMatchObject({ reason: "invalid-token" });
 	});
 
 	it("maps roles from a groups claim nested under the verified custom object", async () => {
@@ -409,7 +424,7 @@ describe("verifyAccessRequest", () => {
 		// happens to match an allowlist entry must NOT confer a role — otherwise
 		// moving the group claim under `custom` opens a fail-open path.
 		const unauthorized = await mintToken(
-			{ common_name: "unknown-service", custom: { groups: ["emdash-labeler-admins"] } },
+			{ common_name: "unknown-service", sub: "", custom: { groups: ["emdash-labeler-admins"] } },
 			signKey,
 		);
 		const identityA = await verifyAccessRequest(
@@ -422,7 +437,7 @@ describe("verifyAccessRequest", () => {
 		// A service token authorized by common_name keeps exactly that role; a
 		// reviewer group in its custom object adds nothing.
 		const authorized = await mintToken(
-			{ common_name: "ci-automation", custom: { groups: ["emdash-labeler-reviewers"] } },
+			{ common_name: "ci-automation", sub: "", custom: { groups: ["emdash-labeler-reviewers"] } },
 			signKey,
 		);
 		const identityB = await verifyAccessRequest(
@@ -433,7 +448,7 @@ describe("verifyAccessRequest", () => {
 		expect(identityB).toEqual<OperatorIdentity>({
 			kind: "service",
 			commonName: "ci-automation",
-			sub: "user-sub-1",
+			sub: "",
 			roles: ["admin"],
 		});
 	});

--- a/apps/labeler/test/access-auth.test.ts
+++ b/apps/labeler/test/access-auth.test.ts
@@ -28,6 +28,7 @@ interface MintOverrides {
 	email?: string;
 	common_name?: string;
 	groups?: unknown;
+	custom?: unknown;
 	issuer?: string;
 	audience?: string;
 	expiresInSeconds?: number;
@@ -102,9 +103,9 @@ describe("verifyAccessRequest", () => {
 		});
 	});
 
-	it("maps roles from a groups claim", async () => {
+	it("maps roles from a groups claim nested under the verified custom object", async () => {
 		const token = await mintToken(
-			{ email: "someone@example.com", groups: ["emdash-labeler-reviewers"] },
+			{ email: "someone@example.com", custom: { groups: ["emdash-labeler-reviewers"] } },
 			signKey,
 		);
 		const identity = await verifyAccessRequest(
@@ -113,6 +114,35 @@ describe("verifyAccessRequest", () => {
 			resolver,
 		);
 		expect(identity.roles).toEqual(["reviewer"]);
+	});
+
+	it("ignores a top-level groups claim (Access places IdP groups under custom)", async () => {
+		const token = await mintToken(
+			{ email: "someone@example.com", groups: ["emdash-labeler-admins"] },
+			signKey,
+		);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identity.roles).toEqual([]);
+	});
+
+	it("maps both admin and reviewer when custom.groups lists both", async () => {
+		const token = await mintToken(
+			{
+				email: "someone@example.com",
+				custom: { groups: ["emdash-labeler-admins", "emdash-labeler-reviewers"] },
+			},
+			signKey,
+		);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": token }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identity.roles).toEqual(["admin", "reviewer"]);
 	});
 
 	it("grants only reviewer role for a reviewer-only principal", async () => {
@@ -330,33 +360,39 @@ describe("verifyAccessRequest", () => {
 		).rejects.toMatchObject({ reason: "invalid-token" });
 	});
 
-	it("ignores a groups claim of the wrong shape without crashing", async () => {
-		const stringShape = await mintToken(
-			{ email: "reviewer@example.com", groups: "emdash-labeler-reviewers" },
-			signKey,
-		);
-		const numberArrayShape = await mintToken(
-			{ email: "reviewer@example.com", groups: [1, 2, 3] },
-			signKey,
-		);
+	it("ignores malformed custom / groups shapes without crashing", async () => {
+		// custom itself is not an object; custom.groups is a string not an array;
+		// custom.groups is a non-string array; custom is absent. None should throw
+		// and none should leak a group principal — the reviewer role here comes
+		// only from the email allowlist.
+		const shapes: unknown[] = [
+			"custom-is-a-string",
+			{ groups: "emdash-labeler-reviewers" },
+			{ groups: [1, 2, 3] },
+			{ groups: { nested: true } },
+		];
+		for (const custom of shapes) {
+			const token = await mintToken({ email: "reviewer@example.com", custom }, signKey);
+			const identity = await verifyAccessRequest(
+				requestWith({ "Cf-Access-Jwt-Assertion": token }),
+				baseConfig(),
+				resolver,
+			);
+			expect(identity.roles).toEqual(["reviewer"]);
+		}
 
-		const identityA = await verifyAccessRequest(
-			requestWith({ "Cf-Access-Jwt-Assertion": stringShape }),
+		const noCustom = await mintToken({ email: "reviewer@example.com" }, signKey);
+		const identity = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": noCustom }),
 			baseConfig(),
 			resolver,
 		);
-		const identityB = await verifyAccessRequest(
-			requestWith({ "Cf-Access-Jwt-Assertion": numberArrayShape }),
-			baseConfig(),
-			resolver,
-		);
-		expect(identityA.roles).toEqual(["reviewer"]);
-		expect(identityB.roles).toEqual(["reviewer"]);
+		expect(identity.roles).toEqual(["reviewer"]);
 	});
 
-	it("does not treat an empty-string group entry as a principal", async () => {
+	it("does not treat an empty-string custom group entry as a principal", async () => {
 		const token = await mintToken(
-			{ email: "nobody@example.com", groups: ["", "not-a-configured-group"] },
+			{ email: "nobody@example.com", custom: { groups: ["", "not-a-configured-group"] } },
 			signKey,
 		);
 		// An empty-string allowlist entry can only match if an empty group leaks in as a principal.
@@ -366,6 +402,40 @@ describe("verifyAccessRequest", () => {
 			resolver,
 		);
 		expect(identity.roles).toEqual([]);
+	});
+
+	it("never lets a service token gain a role from custom.groups (service = common_name only)", async () => {
+		// A service token carries no IdP identity, so a `custom.groups` that
+		// happens to match an allowlist entry must NOT confer a role — otherwise
+		// moving the group claim under `custom` opens a fail-open path.
+		const unauthorized = await mintToken(
+			{ common_name: "unknown-service", custom: { groups: ["emdash-labeler-admins"] } },
+			signKey,
+		);
+		const identityA = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": unauthorized }),
+			baseConfig(),
+			resolver,
+		);
+		expect(identityA.roles).toEqual([]);
+
+		// A service token authorized by common_name keeps exactly that role; a
+		// reviewer group in its custom object adds nothing.
+		const authorized = await mintToken(
+			{ common_name: "ci-automation", custom: { groups: ["emdash-labeler-reviewers"] } },
+			signKey,
+		);
+		const identityB = await verifyAccessRequest(
+			requestWith({ "Cf-Access-Jwt-Assertion": authorized }),
+			baseConfig({ admins: ["ci-automation"] }),
+			resolver,
+		);
+		expect(identityB).toEqual<OperatorIdentity>({
+			kind: "service",
+			commonName: "ci-automation",
+			sub: "user-sub-1",
+			roles: ["admin"],
+		});
 	});
 
 	it("never includes the raw token in a thrown error message", async () => {

--- a/apps/labeler/test/console-mutation-api.test.ts
+++ b/apps/labeler/test/console-mutation-api.test.ts
@@ -1743,6 +1743,7 @@ describe("console mutation: automation replay and idempotency", () => {
 class KillSwitchMessage implements MessageController {
 	acked = 0;
 	retried = 0;
+	readonly attempts = 1;
 	ack() {
 		this.acked += 1;
 	}

--- a/apps/labeler/test/discovery-consumer.test.ts
+++ b/apps/labeler/test/discovery-consumer.test.ts
@@ -115,11 +115,14 @@ class StubResolver implements DidDocumentResolverLike {
 class FakeMessage implements MessageController {
 	acked = 0;
 	retried = 0;
+	retryDelaySeconds: number | undefined;
+	constructor(readonly attempts = 1) {}
 	ack() {
 		this.acked += 1;
 	}
-	retry() {
+	retry(options?: { delaySeconds?: number }) {
 		this.retried += 1;
+		this.retryDelaySeconds = options?.delaySeconds;
 	}
 }
 
@@ -394,6 +397,8 @@ describe("processDiscoveryMessage: verification failures", () => {
 
 		expect(msg.acked).toBe(1);
 		expect(msg.retried).toBe(0);
+		// A permanent failure dead-letters immediately — no retry, so no delay.
+		expect(msg.retryDelaySeconds).toBeUndefined();
 
 		const dl = await testEnv.DB.prepare(`SELECT reason FROM dead_letters WHERE rkey = ?`)
 			.bind(job.rkey)
@@ -477,10 +482,38 @@ describe("processDiscoveryMessage: verification failures", () => {
 
 		expect(msg.retried).toBe(1);
 		expect(msg.acked).toBe(0);
+		// The transient retry must carry a backoff delay so DNS propagation / PDS
+		// blips have time to clear before max_retries is exhausted.
+		expect(msg.retryDelaySeconds).toBeGreaterThan(0);
 		const dl = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM dead_letters WHERE rkey = ?`)
 			.bind(job.rkey)
 			.first<{ n: number }>();
 		expect(dl?.n).toBe(0);
+	});
+
+	it("scales the transient retry backoff with delivery attempts", async () => {
+		const job = await jobFor({ rkey: rkey() });
+		const deps = await buildDeps();
+		const transient = {
+			...deps,
+			verify: () =>
+				Promise.reject(
+					new PdsVerificationError(
+						"PDS_NETWORK_ERROR",
+						"PDS host resolution failed: Hostname resolved to no addresses",
+					),
+				),
+		};
+
+		const first = new FakeMessage(1);
+		const later = new FakeMessage(4);
+		await processDiscoveryMessage(job, first, transient);
+		await processDiscoveryMessage(job, later, transient);
+
+		expect(first.retryDelaySeconds).toBeGreaterThan(0);
+		// A later delivery attempt backs off longer (capped), giving slow
+		// propagation more time before the DLQ.
+		expect(later.retryDelaySeconds).toBeGreaterThan(first.retryDelaySeconds!);
 	});
 
 	it("transient PDS 5xx retries, no dead letter", async () => {

--- a/apps/labeler/test/pds-verify.test.ts
+++ b/apps/labeler/test/pds-verify.test.ts
@@ -17,7 +17,7 @@ import { P256PrivateKeyExportable, P256PublicKey } from "@atcute/crypto";
 import type { DnsResolver } from "emdash/security/ssrf";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { fetchAndVerifyRecord, PdsVerificationError } from "../src/pds-verify.js";
+import { fetchAndVerifyRecord, isTransient, PdsVerificationError } from "../src/pds-verify.js";
 
 const TEST_DID = "did:plc:test00000000000000000000";
 const TEST_PDS = "https://pds.test.example";
@@ -94,6 +94,32 @@ describe("fetchAndVerifyRecord — SSRF egress guard", () => {
 			),
 		);
 		expect(err.reason).toBe("PDS_HOST_BLOCKED");
+		// A true address block is permanent — the consumer dead-letters it.
+		expect(isTransient(err.reason, err.status)).toBe(false);
+		expect(called).toBe(false);
+	});
+
+	it("classifies a resolver failure (DoH blip) as transient PDS_NETWORK_ERROR, not a permanent block", async () => {
+		let called = false;
+		const fetchImpl: typeof fetch = () => {
+			called = true;
+			return Promise.resolve(new Response(new Uint8Array([1]), { status: 200 }));
+		};
+		// A throwing resolver stands in for a DoH network error / SERVFAIL /
+		// timeout. `resolveAndValidateExternalUrl` wraps it in an SsrfError whose
+		// message prefix we key on; if core changes that wording this test fails
+		// (the mapping would silently fall through to a permanent block instead).
+		const err = await captureRejection(
+			fetchAndVerifyRecord(
+				buildOpts({
+					fetch: fetchImpl,
+					resolveHostname: () => Promise.reject(new Error("DoH request timed out")),
+				}),
+			),
+		);
+		expect(err.reason).toBe("PDS_NETWORK_ERROR");
+		// The consumer retries transient reasons rather than dead-lettering them.
+		expect(isTransient(err.reason, err.status)).toBe(true);
 		expect(called).toBe(false);
 	});
 

--- a/apps/labeler/test/pds-verify.test.ts
+++ b/apps/labeler/test/pds-verify.test.ts
@@ -1,0 +1,202 @@
+/**
+ * pds-verify SSRF-egress + HTTP-shaping unit tests.
+ *
+ * The PDS endpoint (and any redirect it serves) is publisher-controlled, so the
+ * CAR fetch is routed through the same SSRF egress guard artifact acquisition
+ * uses: HTTPS-only, DoH resolution with private/reserved-IP rejection, and
+ * per-hop redirect re-resolution. These tests inject a fake `fetch` and a fake
+ * `resolveHostname` so no real network or DoH round-trip happens.
+ *
+ * The crypto handoff to `@atcute/repo`'s `verifyRecord` is not exercised
+ * end-to-end (a valid signed CAR would re-implement what the library already
+ * tests, and its fixture can't load inside `@cloudflare/vitest-pool-workers`);
+ * reaching `verifyRecord` at all is proof the request passed the egress guard.
+ */
+
+import { P256PrivateKeyExportable, P256PublicKey } from "@atcute/crypto";
+import type { DnsResolver } from "emdash/security/ssrf";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { fetchAndVerifyRecord, PdsVerificationError } from "../src/pds-verify.js";
+
+const TEST_DID = "did:plc:test00000000000000000000";
+const TEST_PDS = "https://pds.test.example";
+const PUBLIC_IP = "93.184.216.34";
+
+let publicKey: P256PublicKey;
+
+beforeAll(async () => {
+	const kp = await P256PrivateKeyExportable.createKeypair();
+	publicKey = await P256PublicKey.importRaw(await kp.exportPublicKey("raw"));
+});
+
+const resolvePublic: DnsResolver = () => Promise.resolve([PUBLIC_IP]);
+
+async function captureRejection<T>(promise: Promise<T>): Promise<PdsVerificationError> {
+	try {
+		await promise;
+	} catch (err) {
+		if (err instanceof PdsVerificationError) return err;
+		throw err;
+	}
+	throw new Error("expected promise to reject with PdsVerificationError");
+}
+
+function buildOpts(overrides: {
+	fetch: typeof fetch;
+	pds?: string;
+	resolveHostname?: DnsResolver;
+	timeoutMs?: number;
+	maxResponseBytes?: number;
+}) {
+	return {
+		pds: overrides.pds ?? TEST_PDS,
+		did: TEST_DID,
+		collection: "com.emdashcms.experimental.package.profile",
+		rkey: "demo",
+		publicKey,
+		resolveHostname: overrides.resolveHostname ?? resolvePublic,
+		fetch: overrides.fetch,
+		...(overrides.timeoutMs !== undefined ? { timeoutMs: overrides.timeoutMs } : {}),
+		...(overrides.maxResponseBytes !== undefined
+			? { maxResponseBytes: overrides.maxResponseBytes }
+			: {}),
+	};
+}
+
+function redirectTo(location: string, status = 302): Response {
+	return new Response(null, { status, headers: { location } });
+}
+
+describe("fetchAndVerifyRecord — SSRF egress guard", () => {
+	it("rejects a non-HTTPS PDS with PDS_HOST_BLOCKED before fetching", async () => {
+		let called = false;
+		const fetchImpl: typeof fetch = () => {
+			called = true;
+			return Promise.resolve(new Response(new Uint8Array([1]), { status: 200 }));
+		};
+		const err = await captureRejection(
+			fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl, pds: "http://pds.test.example" })),
+		);
+		expect(err.reason).toBe("PDS_HOST_BLOCKED");
+		expect(called).toBe(false);
+	});
+
+	it("rejects a PDS whose host resolves to a private address", async () => {
+		let called = false;
+		const fetchImpl: typeof fetch = () => {
+			called = true;
+			return Promise.resolve(new Response(new Uint8Array([1]), { status: 200 }));
+		};
+		const err = await captureRejection(
+			fetchAndVerifyRecord(
+				buildOpts({ fetch: fetchImpl, resolveHostname: () => Promise.resolve(["10.0.0.1"]) }),
+			),
+		);
+		expect(err.reason).toBe("PDS_HOST_BLOCKED");
+		expect(called).toBe(false);
+	});
+
+	it("rejects when the resolver returns no addresses (fails closed)", async () => {
+		const fetchImpl: typeof fetch = () =>
+			Promise.resolve(new Response(new Uint8Array([1]), { status: 200 }));
+		const err = await captureRejection(
+			fetchAndVerifyRecord(
+				buildOpts({ fetch: fetchImpl, resolveHostname: () => Promise.resolve([]) }),
+			),
+		);
+		expect(err.reason).toBe("PDS_HOST_BLOCKED");
+	});
+
+	it("rejects a redirect that points at a private address (per-hop re-resolution)", async () => {
+		let calls = 0;
+		const fetchImpl: typeof fetch = () => {
+			calls += 1;
+			return Promise.resolve(redirectTo("https://internal.example/xrpc"));
+		};
+		const resolveByHost: DnsResolver = (hostname) =>
+			Promise.resolve(hostname === "internal.example" ? ["10.0.0.1"] : [PUBLIC_IP]);
+		const err = await captureRejection(
+			fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl, resolveHostname: resolveByHost })),
+		);
+		expect(err.reason).toBe("PDS_HOST_BLOCKED");
+		// Only the first hop was fetched; the private redirect target is blocked
+		// before its request is made.
+		expect(calls).toBe(1);
+	});
+
+	it("rejects a redirect that downgrades to a non-HTTPS scheme", async () => {
+		const fetchImpl: typeof fetch = () =>
+			Promise.resolve(redirectTo("http://pds.test.example/xrpc"));
+		const err = await captureRejection(fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl })));
+		expect(err.reason).toBe("PDS_HOST_BLOCKED");
+	});
+
+	it("stops after the redirect limit with PDS_HTTP_ERROR", async () => {
+		const fetchImpl: typeof fetch = () =>
+			Promise.resolve(redirectTo("https://loop.test.example/next"));
+		const err = await captureRejection(fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl })));
+		expect(err.reason).toBe("PDS_HTTP_ERROR");
+	});
+});
+
+describe("fetchAndVerifyRecord — the guard permits public hosts", () => {
+	it("follows an allowed HTTPS redirect and re-resolves each hop", async () => {
+		let calls = 0;
+		const fetchImpl: typeof fetch = () => {
+			calls += 1;
+			if (calls === 1) return Promise.resolve(redirectTo("https://mirror.test.example/xrpc"));
+			return Promise.resolve(new Response("", { status: 404 }));
+		};
+		const err = await captureRejection(fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl })));
+		// Reaching the 404 proves the redirect was followed and both hops passed
+		// the egress guard.
+		expect(err.reason).toBe("RECORD_NOT_FOUND");
+		expect(err.status).toBe(404);
+		expect(calls).toBe(2);
+	});
+
+	it("maps a 404 to RECORD_NOT_FOUND with status", async () => {
+		const fetchImpl: typeof fetch = () => Promise.resolve(new Response("", { status: 404 }));
+		const err = await captureRejection(fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl })));
+		expect(err.reason).toBe("RECORD_NOT_FOUND");
+		expect(err.status).toBe(404);
+	});
+
+	it("maps a 5xx to PDS_HTTP_ERROR with status", async () => {
+		const fetchImpl: typeof fetch = () => Promise.resolve(new Response("", { status: 503 }));
+		const err = await captureRejection(fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl })));
+		expect(err.reason).toBe("PDS_HTTP_ERROR");
+		expect(err.status).toBe(503);
+	});
+
+	it("surfaces a network error from an allowed host as PDS_NETWORK_ERROR", async () => {
+		const fetchImpl: typeof fetch = () => Promise.reject(new TypeError("connection refused"));
+		const err = await captureRejection(fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl })));
+		expect(err.reason).toBe("PDS_NETWORK_ERROR");
+	});
+
+	it("bounds a slow-drip body read by the timeout budget", async () => {
+		// The stream yields one chunk then stalls forever: the next read never
+		// resolves, so only the per-read time budget can end it.
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array([1, 2, 3]));
+			},
+		});
+		const fetchImpl: typeof fetch = () => Promise.resolve(new Response(stream, { status: 200 }));
+		const err = await captureRejection(
+			fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl, timeoutMs: 40 })),
+		);
+		expect(err.reason).toBe("PDS_NETWORK_ERROR");
+		expect(err.message).toMatch(/exceeded 40ms/);
+	});
+
+	it("hands successful body bytes to verifyRecord (INVALID_PROOF on garbage)", async () => {
+		const garbage = new Uint8Array([1, 2, 3, 4, 5]);
+		const fetchImpl: typeof fetch = () => Promise.resolve(new Response(garbage, { status: 200 }));
+		const err = await captureRejection(fetchAndVerifyRecord(buildOpts({ fetch: fetchImpl })));
+		expect(err.reason).toBe("INVALID_PROOF");
+		expect(err.cause).toBeDefined();
+	});
+});

--- a/apps/labeler/test/pds-verify.test.ts
+++ b/apps/labeler/test/pds-verify.test.ts
@@ -123,15 +123,25 @@ describe("fetchAndVerifyRecord — SSRF egress guard", () => {
 		expect(called).toBe(false);
 	});
 
-	it("rejects when the resolver returns no addresses (fails closed)", async () => {
-		const fetchImpl: typeof fetch = () =>
-			Promise.resolve(new Response(new Uint8Array([1]), { status: 200 }));
+	it("classifies an empty DNS answer (NXDOMAIN/NODATA) as transient, not a permanent block", async () => {
+		let called = false;
+		const fetchImpl: typeof fetch = () => {
+			called = true;
+			return Promise.resolve(new Response(new Uint8Array([1]), { status: 200 }));
+		};
+		// An empty resolver answer is what a host mid-DNS-propagation yields.
+		// `resolveAndValidateExternalUrl` raises the pinned "Hostname resolved to
+		// no addresses" SsrfError; it must retry (so the record survives a
+		// temporary negative answer) rather than dead-letter. A core wording
+		// change would fail this test instead of silently mis-classifying.
 		const err = await captureRejection(
 			fetchAndVerifyRecord(
 				buildOpts({ fetch: fetchImpl, resolveHostname: () => Promise.resolve([]) }),
 			),
 		);
-		expect(err.reason).toBe("PDS_HOST_BLOCKED");
+		expect(err.reason).toBe("PDS_NETWORK_ERROR");
+		expect(isTransient(err.reason, err.status)).toBe(true);
+		expect(called).toBe(false);
 	});
 
 	it("rejects a redirect that points at a private address (per-hop re-resolution)", async () => {

--- a/apps/labeler/test/record-verification.test.ts
+++ b/apps/labeler/test/record-verification.test.ts
@@ -160,6 +160,7 @@ describe("fetchAndVerifyExactRecord: PDS fetch propagation", () => {
 				cid: "bafkreiplaceholder00000000000000000000000000000000000000000",
 				didDocumentResolver: resolver,
 				fetch: () => Promise.resolve(new Response("", { status: 404 })),
+				resolveHostname: () => Promise.resolve(["93.184.216.34"]),
 			}),
 		).rejects.toBeInstanceOf(PdsVerificationError);
 		try {
@@ -168,6 +169,7 @@ describe("fetchAndVerifyExactRecord: PDS fetch propagation", () => {
 				cid: "bafkreiplaceholder00000000000000000000000000000000000000000",
 				didDocumentResolver: resolver,
 				fetch: () => Promise.resolve(new Response("", { status: 404 })),
+				resolveHostname: () => Promise.resolve(["93.184.216.34"]),
 			});
 			throw new Error("expected rejection");
 		} catch (err) {


### PR DESCRIPTION
## What does this PR do?

Fixes two high-severity security findings from the adversarial review of umbrella #1909 (RFC #694), one commit each. Both TDD'd and passed an independent adversarial review plus a delta re-review of the amendments.

**1. `fix(labeler)`: read operator group membership from the Access token's `custom` object.** Role mapping read a top-level `groups` claim from the Cloudflare Access JWT — a claim Access never populates (the application-token claim set is `aud/email/exp/iat/nbf/iss/type/identity_nonce/sub/country/custom`; IdP group membership arrives under `custom`). With a group-only reviewer/admin mapping, every human operator got **zero roles** — fail-closed lockout, but the console would be unusable in production. Now reads a strictly-guarded `groups` array from the verified `custom` object (malformed shapes ignored; service-token path unchanged; a stray `custom.groups` on a service token grants nothing).
   Operational note for the runbooks (follow-up docs touch): the Access application's group claim must be named exactly `groups`; a differently-named claim fails closed to zero roles.

**2. `fix(labeler)`: SSRF-guard the PDS record fetch.** The PDS endpoint comes from a publisher-controlled DID document, and `fetchCar` fetched it with default redirect-following and no scheme/DNS/address validation — a blind request primitive onto internal/reserved addresses via a hostile DID or PDS redirect. Now: HTTPS-only, every hop (initial + each redirect, `redirect: "manual"`, max 3) is resolved through `cloudflareDohResolver` and validated (loopback, RFC1918, link-local/metadata, IPv4-mapped/NAT64 all rejected; fails closed if the resolver is omitted), and the body read is bounded by an absolute wall-clock deadline spanning header + streaming phases (slow-drip PDS → transient error → bounded queue retries, instead of an unbounded hang). A new permanent `PDS_HOST_BLOCKED` dead-letter reason is threaded through the discovery consumer; the 404→`RECORD_NOT_FOUND` (delete-confirmation) and 5xx→transient-retry classifications are preserved exactly — deliberately not routed through `fetchVerifiedResource`, which would collapse them.
   Documented residual (adversary-verified): the shared core predicate doesn't cover a few exotic ranges (CGNAT, benchmarking, multicast) that artifact acquisition's private predicate does; all high-value targets are covered by both.

Known sibling gaps tracked for follow-up (pre-existing, out of scope here): the `did:web` DID-document fetch and the aggregator's own `pds-verify.ts` remain unguarded — same hardening idiom, separate PR.

Targets the `feat/plugin-registry-labelling-service` integration branch. Part of #1909; addresses two review findings there.

## Type of change

- [x] Bug fix
- [ ] Feature (requires a Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all three labeler projects)
- [x] `pnpm lint` passes (type-aware, 0 diagnostics)
- [x] `pnpm test` passes (labeler: 848 + 136 + 39 = 1023) — TDD: the auth tests fail pre-fix (`[]` vs expected roles), the six SSRF cases fail pre-fix (fetches proceeded), the slow-drip test fails pre-fix (unbounded hang)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server-side auth/egress.
- [x] I have added a changeset (if this PR changes a published package) — **n/a**: `@emdash-cms/labeler` is private; no published package touched.
- [x] New features link to an approved Discussion — **n/a**: security fixes; umbrella #1909 tracks RFC #694.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation + independent adversarial review + delta re-review), orchestrated/reviewed by **Claude Fable 5**

## Screenshots / test output

```
labeler: 848 + 136 + 39 = 1023 passed (0 failures)

Pre-fix repros:
- access-auth: "maps roles from a groups claim nested under the verified custom object"
  → expected ["admin"], got []
- pds-verify: redirect-to-private / non-HTTPS / resolver-empty cases
  → fetches proceeded (INVALID_PROOF/PDS_HTTP_ERROR) instead of blocked
- slow-drip body: unbounded hang pre-fix; now PDS_NETWORK_ERROR "/exceeded 40ms/"
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-labeler-sol-r1-auth-ssrf-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/labeler-sol-r1-auth-ssrf`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
