### PR TITLE
i18n(nl): translate built-in widget UI strings

### DIFF
--- a/.changeset/nl-widget-strings.md
+++ b/.changeset/nl-widget-strings.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Completes the Dutch (Nederlands) translations for the built-in widget UI labels, descriptions, and prop-field options in the admin.

--- a/packages/admin/src/locales/nl/messages.po
+++ b/packages/admin/src/locales/nl/messages.po
@@ -2518,7 +2518,7 @@ msgstr "Sluiten"
 
 #: packages/admin/src/components/Widgets.tsx:125
 msgid "Display a list of recent posts"
-msgstr ""
+msgstr "Een lijst met recente berichten weergeven"
 
 #: packages/admin/src/components/Widgets.tsx:103
 msgid "Display a navigation menu"
@@ -2526,7 +2526,7 @@ msgstr "Een navigatiemenu weergeven"
 
 #: packages/admin/src/components/Widgets.tsx:134
 msgid "Display category list"
-msgstr ""
+msgstr "Een lijst met categorieën weergeven"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:890
 #: packages/admin/src/components/ContentSettingsPanel.tsx:952
@@ -2545,7 +2545,7 @@ msgstr "Weergavegrootte"
 
 #: packages/admin/src/components/Widgets.tsx:142
 msgid "Display tag cloud"
-msgstr ""
+msgstr "Een tagwolk weergeven"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
@@ -3808,7 +3808,7 @@ msgstr "Groep (optioneel)"
 
 #: packages/admin/src/components/Widgets.tsx:160
 msgid "Group by"
-msgstr ""
+msgstr "Groeperen op"
 
 #: packages/admin/src/routes/bylines.tsx:556
 msgid "Guest byline"
@@ -4407,7 +4407,7 @@ msgstr "Licht"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Limit"
-msgstr ""
+msgstr "Limiet"
 
 #: packages/admin/src/components/SignupPage.tsx:257
 msgid "Link expired"
@@ -4706,7 +4706,7 @@ msgstr "Max. waarde"
 
 #: packages/admin/src/components/Widgets.tsx:145
 msgid "Maximum tags"
-msgstr ""
+msgstr "Maximumaantal tags"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:45
 msgid "MDX"
@@ -4869,11 +4869,11 @@ msgstr "Collectieschema's wijzigen"
 
 #: packages/admin/src/components/Widgets.tsx:161
 msgid "Monthly"
-msgstr ""
+msgstr "Maandelijks"
 
 #: packages/admin/src/components/Widgets.tsx:157
 msgid "Monthly/yearly archives"
-msgstr ""
+msgstr "Maandelijkse/jaarlijkse archieven"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
@@ -5377,7 +5377,7 @@ msgstr "Getal"
 
 #: packages/admin/src/components/Widgets.tsx:127
 msgid "Number of posts"
-msgstr ""
+msgstr "Aantal berichten"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:278
 msgid "Number of posts to show per page on list views"
@@ -5669,7 +5669,7 @@ msgstr "Kies een methode om je adminaccount aan te maken."
 
 #: packages/admin/src/components/Widgets.tsx:152
 msgid "Placeholder text"
-msgstr ""
+msgstr "Placeholdertekst"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:311
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
@@ -5965,7 +5965,7 @@ msgstr "Recente activiteit"
 
 #: packages/admin/src/components/Widgets.tsx:124
 msgid "Recent Posts"
-msgstr ""
+msgstr "Recente berichten"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:43
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
@@ -6564,7 +6564,7 @@ msgstr "Zoekmachineoptimalisatie en verificatie"
 
 #: packages/admin/src/components/Widgets.tsx:150
 msgid "Search form"
-msgstr ""
+msgstr "Zoekformulier"
 
 #: packages/admin/src/components/MediaLibrary.tsx:416
 #: packages/admin/src/components/MediaPickerModal.tsx:578
@@ -6954,23 +6954,23 @@ msgstr "Korte tekst"
 
 #: packages/admin/src/components/Widgets.tsx:144
 msgid "Show count"
-msgstr ""
+msgstr "Aantal tonen"
 
 #: packages/admin/src/components/Widgets.tsx:129
 msgid "Show date"
-msgstr ""
+msgstr "Datum tonen"
 
 #: packages/admin/src/components/Widgets.tsx:137
 msgid "Show hierarchy"
-msgstr ""
+msgstr "Hiërarchie tonen"
 
 #: packages/admin/src/components/Widgets.tsx:136
 msgid "Show post count"
-msgstr ""
+msgstr "Aantal berichten tonen"
 
 #: packages/admin/src/components/Widgets.tsx:128
 msgid "Show thumbnails"
-msgstr ""
+msgstr "Miniaturen tonen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Show token"
@@ -8417,7 +8417,7 @@ msgstr "YAML"
 
 #: packages/admin/src/components/Widgets.tsx:161
 msgid "Yearly"
-msgstr ""
+msgstr "Jaarlijks"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:420


### PR DESCRIPTION
## What does this PR do?

Follow-up to [#2035 review comment](https://github.com/emdash-cms/emdash/pull/2035#issuecomment-4980656698).

PR #2057 (*i18n(admin): localize built-in widget UI labels*) introduced new `msg` source strings for the built-in widget UI (Recent Posts, category list, tag cloud, search form, monthly/yearly archives) plus their prop-field and option labels, but shipped no translations. The merge-time `pnpm locale:extract` added these 18 msgids to the catalogs untranslated.

This PR fills in the Dutch translations for all 18 new widget msgids in `packages/admin/src/locales/nl/messages.po`, following the existing catalog's register: informal, sentence case, infinitive button/label forms.

| English | Dutch |
| --- | --- |
| Recent Posts | Recente berichten |
| Display a list of recent posts | Een lijst met recente berichten weergeven |
| Display category list | Een lijst met categorieën weergeven |
| Display tag cloud | Een tagwolk weergeven |
| Search form | Zoekformulier |
| Monthly/yearly archives | Maandelijkse/jaarlijkse archieven |
| Number of posts | Aantal berichten |
| Show thumbnails | Miniaturen tonen |
| Show date | Datum tonen |
| Show post count | Aantal berichten tonen |
| Show hierarchy | Hiërarchie tonen |
| Show count | Aantal tonen |
| Maximum tags | Maximumaantal tags |
| Placeholder text | Placeholdertekst |
| Group by | Groeperen op |
| Limit | Limiet |
| Monthly | Maandelijks |
| Yearly | Jaarlijks |

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — n/a, translation-only (`.po`); no code changed
- [x] `pnpm lint` passes — n/a, `.po` file not linted; no new diagnostics
- [x] `pnpm test` passes — n/a, translation-only
- [x] `pnpm format` has been run — n/a, `.po` files are not oxfmt-managed
- [ ] I have added/updated tests for my changes (if applicable) — n/a, translation-only
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — This **is** a translation PR; only the `nl` catalog changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — `@emdash-cms/admin` patch
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (1M context)

## Screenshots / test output

Translation-only change to `packages/admin/src/locales/nl/messages.po` (18 msgstr filled in). No behavior or code changed.

