### PR TITLE
i18n(uk): add Ukrainian translations for the admin UI

### DIFF
--- a/.changeset/red-bars-shave.md
+++ b/.changeset/red-bars-shave.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Completes Ukrainian (Українська) translations for the admin UI, including labels, descriptions, dialogs, and form fields.

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -48,6 +48,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "ko", label: "한국어", enabled: false }, // Korean
 	{ code: "nb", label: "Norsk bokmål", enabled: true }, // Norwegian Bokmål
 	{ code: "pl", label: "Polski", enabled: true }, // Polish
+	{ code: "uk", label: "Українська", enabled: true }, // Ukrainian
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 	{ code: "es-419", label: "Español (Latinoamérica)", enabled: true }, // Spanish (Latin America)
 	{ code: "es-ES", label: "Español (España)", enabled: true }, // Spanish (Spain) - BCP 47

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -48,13 +48,13 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "ko", label: "한국어", enabled: false }, // Korean
 	{ code: "nb", label: "Norsk bokmål", enabled: true }, // Norwegian Bokmål
 	{ code: "pl", label: "Polski", enabled: true }, // Polish
-	{ code: "uk", label: "Українська", enabled: true }, // Ukrainian
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 	{ code: "es-419", label: "Español (Latinoamérica)", enabled: true }, // Spanish (Latin America)
 	{ code: "es-ES", label: "Español (España)", enabled: true }, // Spanish (Spain) - BCP 47
 	{ code: "sv", label: "Svenska", enabled: true }, // Swedish
 	{ code: "th", label: "ไทย", enabled: true }, // Thai
 	{ code: "tr", label: "Türkçe", enabled: true }, // Turkish
+	{ code: "uk", label: "Українська", enabled: true }, // Ukrainian
 	// Pseudo-locale for i18n testing - never enabled in the admin UI by default.
 	// Set EMDASH_PSEUDO_LOCALE=1 in .env to expose it in the locale switcher (dev only).
 	{ code: "pseudo", label: "Pseudo", enabled: false },

--- a/packages/admin/src/locales/uk/messages.po
+++ b/packages/admin/src/locales/uk/messages.po
@@ -1,0 +1,8570 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-07-18 15:51+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=4; plural=((n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) ? 1 : ((n % 10 == 0 || (n % 10 >= 5 && n % 10 <= 9) || (n % 100 >= 11 && n % 100 <= 14)) ? 2 : 3)));\n"
+
+#: packages/admin/src/routes/bylines.tsx:447
+msgid " - Guest"
+msgstr " - Гість"
+
+#: packages/admin/src/routes/bylines.tsx:447
+msgid " - Linked"
+msgstr " - Пов'язано"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:81
+msgid " (default)"
+msgstr " (за замовчуванням)"
+
+#: packages/admin/src/components/MenuEditor.tsx:521
+msgid " (opens in new window)"
+msgstr " (відкривається в новому вікні)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:802
+#: packages/admin/src/components/MediaPickerModal.tsx:885
+msgid " (selected)"
+msgstr " (обрано)"
+
+#: packages/admin/src/routes/bylines.tsx:707
+msgid "-- Select --"
+msgstr "-- Оберіть --"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", або відкрийте адмін-панель за адресою"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": використовуйте"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:736
+msgid "(from {0})"
+msgstr "(від {0})"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:520
+msgid "(pre-release)"
+msgstr "(передреліз)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:156
+msgid "(synced)"
+msgstr "(синхронізовано)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:523
+msgid "(too new)"
+msgstr "(занадто новий)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(з вашим dev-портом)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# елемент)} few {(# елементи)} many {(# елементів)} other {(# елементів)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# колекція} few {# колекції} many {# колекцій} other {# колекцій}}"
+
+#. placeholder {0}: result.comments.imported
+#: packages/admin/src/components/WordPressImport.tsx:2263
+msgid "{0, plural, one {# comment imported} other {# comments imported}}"
+msgstr "{0, plural, one {# коментар імпортовано} few {# коментарі імпортовано} many {# коментарів імпортовано} other {# коментарів імпортовано}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1464
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr "{0, plural, one {# коментар оновлено} few {# коментарі оновлено} many {# коментарів оновлено} other {# коментарів оновлено}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:344
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# коментар} few {# коментарі} many {# коментарів} other {# коментарів}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2274
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {# помилка вмісту} few {# помилки вмісту} many {# помилок вмісту} other {# помилок вмісту}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {# елемент вмісту імпортовано} few {# елементи вмісту імпортовано} many {# елементів вмісту імпортовано} other {# елементів вмісту імпортовано}}"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:587
+#: packages/admin/src/components/MenuList.tsx:217
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# елемент} few {# елементи} many {# елементів} other {# елементів}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {# помилка медіа} few {# помилки медіа} many {# помилок медіа} other {# помилок медіа}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2231
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {# медіафайл імпортовано} few {# медіафайли імпортовано} many {# медіафайлів імпортовано} other {# медіафайлів імпортовано}}"
+
+#. placeholder {0}: result.menus.created
+#: packages/admin/src/components/WordPressImport.tsx:2255
+msgid "{0, plural, one {# menu imported} other {# menus imported}}"
+msgstr "{0, plural, one {# меню імпортовано} few {# меню імпортовано} many {# меню імпортовано} other {# меню імпортовано}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1903
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {# меню буде імпортовано} few {# меню буде імпортовано} many {# меню буде імпортовано} other {# меню буде імпортовано}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:399
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# дозвіл} few {# дозволи} many {# дозволів} other {# дозволів}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2486
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# допис} few {# дописи} many {# дописів} other {# дописів}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:444
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {# перенаправлення утворює цикл.} few {# перенаправлення утворюють цикл.} many {# перенаправлень утворюють цикл.} other {# перенаправлень утворюють цикл.}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:228
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {# обрано} few {# обрано} many {# обрано} other {# обрано}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2223
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {# пропущено (вже існує)} few {# пропущено (вже існують)} many {# пропущено (вже існує)} other {# пропущено (вже існує)}}"
+
+#. placeholder {0}: result.taxonomyAssignments
+#: packages/admin/src/components/WordPressImport.tsx:2247
+msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
+msgstr "{0, plural, one {# призначення таксономії} few {# призначення таксономій} many {# призначень таксономій} other {# призначень таксономій}}"
+
+#. placeholder {0}: result.taxonomiesCreated.length
+#: packages/admin/src/components/WordPressImport.tsx:2239
+msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
+msgstr "{0, plural, one {# таксономію створено} few {# таксономії створено} many {# таксономій створено} other {# таксономій створено}}"
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:585
+msgid "{0, plural, one {field} other {fields}}"
+msgstr "{0, plural, one {поле} few {поля} many {полів} other {полів}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:160
+msgid "{0, plural, one {Media file} other {Media files}}"
+msgstr "{0, plural, one {Медіафайл} few {Медіафайли} many {Медіафайлів} other {Медіафайлів}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:165
+msgid "{0, plural, one {User} other {Users}}"
+msgstr "{0, plural, one {Користувач} few {Користувачі} many {Користувачів} other {Користувачів}}"
+
+#. placeholder {0}: envLabel(m.key)
+#. placeholder {1}: m.required
+#. placeholder {2}: m.host
+#: packages/admin/src/components/RegistryPluginDetail.tsx:623
+msgid "{0} {1} required — you have {2}."
+msgstr "{0} {1} потрібно — у вас {2}."
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:215
+msgid "{0} • {1}"
+msgstr "{0} • {1}"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:412
+msgid "{0} banner"
+msgstr "{0} банер"
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1303
+msgid "{0} detected"
+msgstr "{0} виявлено"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:111
+msgid "{0} has been deactivated"
+msgstr "{0} деактивовано"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:306
+msgid "{0} has been removed"
+msgstr "{0} видалено"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:424
+msgid "{0} icon"
+msgstr "іконка {0}"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:202
+msgid "{0} installs"
+msgstr "{0} встановлень"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:92
+msgid "{0} is now active"
+msgstr "{0} тепер активний"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1973
+msgid "{0} items → {1}"
+msgstr "{0} елементів → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "{0} items will be imported"
+msgstr "{0} елементів буде імпортовано"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:534
+msgid "{0} of {total} could not be deleted"
+msgstr "{0} з {total} не вдалося видалити"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:490
+msgid "{0} of {total} could not be published"
+msgstr "{0} з {total} не вдалося опублікувати"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:513
+msgid "{0} of {total} could not be updated"
+msgstr "{0} з {total} не вдалося оновити"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "{0} plugins"
+msgstr "{0} плагінів"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:206
+msgid "{0} preview"
+msgstr "попередній перегляд {0}"
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:583
+msgid "{0} system + {1} custom {2}"
+msgstr "{0} системних + {1} власних {2}"
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:347
+msgid "{0} updated"
+msgstr "{0} оновлено"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "{0} updated to v{1}"
+msgstr "{0} оновлено до v{1}"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:802
+#: packages/admin/src/components/MediaPickerModal.tsx:885
+msgid "{0}{1}"
+msgstr "{0}{1}"
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:195
+msgid "{0}/160 characters"
+msgstr "{0}/160 символів"
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:256
+msgid "{base} to: {0}"
+msgstr "{base} на: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:345
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# зміна з наступної ревізії} few {# зміни з наступної ревізії} many {# змін з наступної ревізії} other {# змін з наступної ревізії}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# файл} few {# файли} many {# файлів} other {# файлів}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# елемент} few {# елементи} many {# елементів} other {# елементів}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "{current} of {total}"
+msgstr "{current} з {total}"
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:933
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr "{filteredCount, plural, one {#{0} елемент} few {#{0} елементи} many {#{1} елементів} other {#{1} елементів}}"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — без перекладу"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — переглянути переклад"
+
+#: packages/admin/src/components/ContentList.tsx:922
+msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{matchCount, plural, one {# елемент відповідає \"{searchQuery}\"} few {# елементи відповідають \"{searchQuery}\"} many {# елементів відповідають \"{searchQuery}\"} other {# елементів відповідають \"{searchQuery}\"}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2473
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "{matchedCount} з {totalCount} призначено"
+
+#: packages/admin/src/components/WordPressImport.tsx:2461
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "{matchedCount} з {totalCount} авторів зіставлено за email"
+
+#: packages/admin/src/components/WordPressImport.tsx:1879
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {# нову колекцію буде створено} few {# нові колекції буде створено} many {# нових колекцій буде створено} other {# нових колекцій буде створено}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1888
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {Поля буде додано до # наявної колекції} few {Поля буде додано до # наявних колекцій} many {Поля буде додано до # наявних колекцій} other {Поля буде додано до # наявних колекцій}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} запитує додаткові дозволи:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:80
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} потребує таких дозволів:"
+
+#: packages/admin/src/components/MediaLibrary.tsx:298
+msgid "{resultCount, plural, one {# item} other {# items}}"
+msgstr "{resultCount, plural, one {# елемент} few {# елементи} many {# елементів} other {# елементів}}"
+
+#: packages/admin/src/components/ContentList.tsx:405
+msgid "{selectedCount, plural, one {# selected} other {# selected}}"
+msgstr "{selectedCount, plural, one {# обрано} few {# обрано} many {# обрано} other {# обрано}}"
+
+#: packages/admin/src/components/ContentList.tsx:446
+msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
+msgstr "{selectedCount, plural, one {Перемістити # елемент у кошик? Пізніше його можна відновити.} few {Перемістити # елементи у кошик? Пізніше їх можна відновити.} many {Перемістити # елементів у кошик? Пізніше їх можна відновити.} other {Перемістити # елементів у кошик? Пізніше їх можна відновити.}}"
+
+#: packages/admin/src/components/ContentList.tsx:928
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr "{total, plural, one {# елемент} few {# елементи} many {# елементів} other {# елементів}}"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:149
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {# всього} few {# всього} many {# всього} other {# всього}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:211
+#: packages/admin/src/components/MediaLibrary.tsx:247
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {Файл завантажено} few {# файли завантажено} many {# файлів завантажено} other {# файлів завантажено}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:216
+#: packages/admin/src/components/MediaLibrary.tsx:252
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {Завантаження не вдалося} few {Усі # завантаження не вдалися} many {Усі # завантажень не вдалися} other {Усі # завантажень не вдалися}}"
+
+#: packages/admin/src/components/Dashboard.tsx:146
+msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
+msgstr "{totalDrafts, plural, one {Чернетка} few {Чернетки} many {Чернеток} other {Чернеток}}"
+
+#: packages/admin/src/components/Dashboard.tsx:153
+msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
+msgstr "{totalScheduled, plural, one {Заплановано} few {Заплановано} many {Заплановано} other {Заплановано}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:357
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {Приховати # без змін} few {Приховати # без змін} many {Приховати # без змін} other {Приховати # без змін}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:358
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {Показати # без змін} few {Показати # без змін} many {Показати # без змін} other {Показати # без змін}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:221
+#: packages/admin/src/components/MediaLibrary.tsx:257
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "{uploaded} завантажено, {failed} не вдалося"
+
+#: packages/admin/src/components/Redirects.tsx:141
+msgid "/new-page or /articles/[slug]"
+msgstr "/new-page або /articles/[slug]"
+
+#: packages/admin/src/components/Redirects.tsx:132
+msgid "/old-page or /blog/[slug]"
+msgstr "/old-page або /blog/[slug]"
+
+#: packages/admin/src/components/WordPressImport.tsx:2093
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• Файли завантажуються з вашого сайту WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:2094
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• Завантажуються до сховища медіа EmDash"
+
+#: packages/admin/src/components/WordPressImport.tsx:2095
+msgid "• URLs in your content are updated automatically"
+msgstr "• URL у вашому вмісті оновлюються автоматично"
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1601
+msgid "← Back"
+msgstr "← Назад"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "1 year"
+msgstr "1 рік"
+
+#: packages/admin/src/components/WordPressImport.tsx:1522
+msgid "1. Log into your WordPress admin"
+msgstr "1. Увійдіть до адмін-панелі WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1275
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. Увійдіть до панелі керування WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "2. Go to"
+msgstr "2. Перейдіть до"
+
+#: packages/admin/src/components/WordPressImport.tsx:1523
+msgid "2. Go to Users → Profile"
+msgstr "2. Перейдіть до Користувачі → Профіль"
+
+#: packages/admin/src/components/WordPressImport.tsx:1524
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. Прокрутіть до \"Паролів додатків\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1279
+msgid "3. Select \"All content\""
+msgstr "3. Виберіть \"Увесь вміст\""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "30 days"
+msgstr "30 днів"
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "301 Permanent"
+msgstr "301 Постійне"
+
+#: packages/admin/src/components/Redirects.tsx:156
+msgid "302 Temporary"
+msgstr "302 Тимчасове"
+
+#: packages/admin/src/components/Redirects.tsx:157
+msgid "307 Temporary (Strict)"
+msgstr "307 Тимчасове (суворе)"
+
+#: packages/admin/src/components/Redirects.tsx:158
+msgid "308 Permanent (Strict)"
+msgstr "308 Постійне (суворе)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1280
+msgid "4. Click \"Download Export File\""
+msgstr "4. Натисніть \"Завантажити файл експорту\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1525
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. Введіть \"EmDash\" і натисніть \"Додати\""
+
+#: packages/admin/src/components/Redirects.tsx:394
+msgid "404 Errors"
+msgstr "Помилки 404"
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "410 Content Deleted (Gone)"
+msgstr "410 Вміст видалено (Gone)"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "451 Unavailable for legal reasons"
+msgstr "451 Недоступно з юридичних причин"
+
+#: packages/admin/src/components/WordPressImport.tsx:1526
+msgid "5. Copy the generated password"
+msgstr "5. Скопіюйте згенерований пароль"
+
+#: packages/admin/src/components/WordPressImport.tsx:1281
+msgid "5. Upload the file here"
+msgstr "5. Завантажте файл тут"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "7 days"
+msgstr "7 днів"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "90 days"
+msgstr "90 днів"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:416
+msgid "A brief description of this content type"
+msgstr "Короткий опис цього типу вмісту"
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr "Повноширинний hero-банер із заголовком, текстом і кнопкою CTA"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:142
+msgid "A short description of your site"
+msgstr "Короткий опис вашого сайту"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:172
+msgid "Accept & Install"
+msgstr "Прийняти й встановити"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:171
+msgid "Accept & Update"
+msgstr "Прийняти й оновити"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:238
+msgid "Accept Invite"
+msgstr "Прийняти запрошення"
+
+#: packages/admin/src/routes/byline-schema.tsx:174
+msgid "Access denied"
+msgstr "Доступ заборонено"
+
+#: packages/admin/src/router.tsx:1484
+msgid "Access Denied"
+msgstr "Доступ заборонено"
+
+#: packages/admin/src/lib/api/marketplace.ts:225
+#: packages/admin/src/lib/api/marketplace.ts:233
+msgid "Access your media library"
+msgstr "Доступ до медіатеки"
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr "Обліковий запис"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:153
+msgid "Account already exists"
+msgstr "Обліковий запис уже існує"
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Account exists"
+msgstr "Обліковий запис існує"
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr "Інформація про обліковий запис"
+
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "ACF Fields"
+msgstr "Поля ACF"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:299
+#: packages/admin/src/components/ContentList.tsx:528
+#: packages/admin/src/components/ContentList.tsx:649
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/TaxonomyManager.tsx:823
+#: packages/admin/src/routes/byline-schema.tsx:249
+msgid "Actions"
+msgstr "Дії"
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr "Активний"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentSettingsPanel.tsx:801
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/TaxonomySidebar.tsx:478
+msgid "Add"
+msgstr "Додати"
+
+#. placeholder {0}: field.item_label
+#. placeholder {0}: taxonomyDef.labelSingular || t`Term`
+#: packages/admin/src/components/PortableTextEditor.tsx:1746
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Add {0}"
+msgstr "Додати {0}"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:266
+msgid "Add {label}"
+msgstr "Додати {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+msgid "Add a new passkey"
+msgstr "Додати новий passkey"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Add an allowed domain"
+msgstr "Додати дозволений домен"
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "Додайте принаймні одне підполе, щоб визначити структуру повторювача."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3191
+msgid "Add column after"
+msgstr "Додати стовпець після"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3185
+msgid "Add column before"
+msgstr "Додати стовпець перед"
+
+#: packages/admin/src/components/MenuEditor.tsx:378
+#: packages/admin/src/components/MenuEditor.tsx:493
+msgid "Add Content"
+msgstr "Додати вміст"
+
+#: packages/admin/src/components/MenuEditor.tsx:390
+#: packages/admin/src/components/MenuEditor.tsx:397
+#: packages/admin/src/components/MenuEditor.tsx:496
+msgid "Add Custom Link"
+msgstr "Додати власне посилання"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:316
+msgid "Add Domain"
+msgstr "Додати домен"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:591
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Add Field"
+msgstr "Додати поле"
+
+#: packages/admin/src/components/WordPressImport.tsx:1984
+msgid "Add fields"
+msgstr "Додати поля"
+
+#: packages/admin/src/routes/byline-schema.tsx:293
+msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+msgstr "Додайте поля на кшталт \"Посада\" або \"Займенники\", щоб доповнити кожен підпис."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:613
+msgid "Add fields to define the structure of your content"
+msgstr "Додайте поля, щоб визначити структуру вашого вмісту"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:616
+msgid "Add First Field"
+msgstr "Додати перше поле"
+
+#: packages/admin/src/components/RepeaterField.tsx:174
+msgid "Add First Item"
+msgstr "Додати перший елемент"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1746
+msgid "Add item"
+msgstr "Додати елемент"
+
+#: packages/admin/src/components/RepeaterField.tsx:158
+msgid "Add Item"
+msgstr "Додати елемент"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3121
+msgid "Add link"
+msgstr "Додати посилання"
+
+#: packages/admin/src/components/MenuEditor.tsx:486
+msgid "Add links to build your navigation menu"
+msgstr "Додайте посилання, щоб створити навігаційне меню"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr "Додати MIME-тип або розширення"
+
+#: packages/admin/src/components/ContentList.tsx:342
+msgid "Add New"
+msgstr "Додати"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:490
+msgid "Add new {0}"
+msgstr "Додати {0}"
+
+#: packages/admin/src/components/SeoPanel.tsx:227
+msgid "Add noindex meta tag"
+msgstr "Додати meta-тег noindex"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:200
+msgid "Add Passkey"
+msgstr "Додати passkey"
+
+#: packages/admin/src/components/PluginManager.tsx:206
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "Додайте плагіни до astro.config.mjs, щоб розширити можливості EmDash."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3212
+msgid "Add row after"
+msgstr "Додати рядок після"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3206
+msgid "Add row before"
+msgstr "Додати рядок перед"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr "Додати SEO-поля метаданих (заголовок, опис, зображення) та включити в sitemap"
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr "Додати підполе"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:265
+msgid "Add tags..."
+msgstr "Додати теги..."
+
+#: packages/admin/src/components/Widgets.tsx:398
+msgid "Add Widget Area"
+msgstr "Додати область віджетів"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:102
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "Додайте профілі соцмереж. Вони доступні темі сайту та можуть відображатися в шапці, підвалі або біо автора."
+
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+msgid "Adding..."
+msgstr "Додавання..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Additional data to import."
+msgstr "Додаткові дані для імпорту."
+
+#: packages/admin/src/components/WordPressImport.tsx:1483
+msgid "admin"
+msgstr "адмін"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
+#: packages/admin/src/components/Sidebar.tsx:469
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "Адмін"
+
+#: packages/admin/src/components/Sidebar.tsx:419
+msgid "Admin navigation"
+msgstr "Навігація адмін-панелі"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "Адміністратор"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:196
+msgid "After send:"
+msgstr "Після надсилання:"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3508
+msgid "Align Center"
+msgstr "По центру"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3501
+msgid "Align Left"
+msgstr "По лівому краю"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3515
+msgid "Align Right"
+msgstr "По правому краю"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
+msgid "Alignment"
+msgstr "Вирівнювання"
+
+#: packages/admin/src/components/ContentList.tsx:369
+msgid "All"
+msgstr "Усі"
+
+#: packages/admin/src/components/ContentList.tsx:773
+#: packages/admin/src/components/ContentList.tsx:777
+msgid "All authors"
+msgstr "Усі автори"
+
+#: packages/admin/src/routes/bylines.tsx:413
+msgid "All bylines"
+msgstr "Усі підписи"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr "Усі можливості"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:133
+msgid "All collections"
+msgstr "Усі колекції"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr "Усі коментарі потребують схвалення"
+
+#: packages/admin/src/components/WordPressImport.tsx:2518
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "Увесь імпортований вміст буде без автора. Пізніше ви зможете призначити авторів у редакторі вмісту."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "Усі локалі"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "Усі ролі"
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "Усі джерела"
+
+#: packages/admin/src/components/ContentList.tsx:728
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "All statuses"
+msgstr "Усі статуси"
+
+#: packages/admin/src/components/MediaLibrary.tsx:433
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "All types"
+msgstr "Усі типи"
+
+#: packages/admin/src/components/Settings.tsx:100
+msgid "Allow users from specific domains to sign up"
+msgstr "Дозволити реєстрацію користувачам із певних доменів"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr "Дозволити відвідувачам залишати коментарі до вмісту цієї колекції"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Allowed Domains"
+msgstr "Дозволені домени"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr "Дозволені типи"
+
+#: packages/admin/src/components/SignupPage.tsx:437
+msgid "Already have an account?"
+msgstr "Уже маєте обліковий запис?"
+
+#: packages/admin/src/components/PluginManager.tsx:634
+msgid "Also delete plugin storage data"
+msgstr "Також видалити дані сховища плагіна"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:231
+#: packages/admin/src/components/MediaLibrary.tsx:589
+msgid "Alt text"
+msgstr "Альтернативний текст"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
+#: packages/admin/src/components/MediaDetailPanel.tsx:354
+#: packages/admin/src/components/MediaDetailPanel.tsx:371
+msgid "Alt Text"
+msgstr "Альтернативний текст"
+
+#: packages/admin/src/components/MediaLibrary.tsx:833
+#: packages/admin/src/components/MediaLibrary.tsx:890
+msgid "Alt text set"
+msgstr "Альтернативний текст встановлено"
+
+#: packages/admin/src/components/WordPressImport.tsx:1395
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "Або експортуйте з WordPress (Інструменти → Експорт) і завантажте файл."
+
+#: packages/admin/src/components/DialogError.tsx:14
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:98
+#: packages/admin/src/components/PluginManager.tsx:117
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:71
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:95
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+#: packages/admin/src/components/settings/BackupSettings.tsx:85
+#: packages/admin/src/components/settings/BackupSettings.tsx:105
+#: packages/admin/src/components/settings/EmailSettings.tsx:51
+#: packages/admin/src/components/settings/GeneralSettings.tsx:51
+#: packages/admin/src/components/settings/SecuritySettings.tsx:54
+#: packages/admin/src/components/settings/SecuritySettings.tsx:71
+#: packages/admin/src/components/settings/SeoSettings.tsx:45
+#: packages/admin/src/components/settings/SocialSettings.tsx:43
+#: packages/admin/src/components/TaxonomySidebar.tsx:352
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:422
+#: packages/admin/src/router.tsx:437
+#: packages/admin/src/router.tsx:451
+#: packages/admin/src/router.tsx:465
+#: packages/admin/src/router.tsx:942
+#: packages/admin/src/router.tsx:995
+#: packages/admin/src/router.tsx:1013
+#: packages/admin/src/router.tsx:1031
+#: packages/admin/src/router.tsx:1052
+#: packages/admin/src/router.tsx:1073
+#: packages/admin/src/router.tsx:1094
+#: packages/admin/src/router.tsx:1125
+#: packages/admin/src/router.tsx:1145
+#: packages/admin/src/router.tsx:1429
+#: packages/admin/src/router.tsx:1445
+#: packages/admin/src/router.tsx:1470
+#: packages/admin/src/router.tsx:1959
+#: packages/admin/src/routes/byline-schema.tsx:103
+#: packages/admin/src/routes/byline-schema.tsx:123
+#: packages/admin/src/routes/byline-schema.tsx:139
+#: packages/admin/src/routes/byline-schema.tsx:153
+msgid "An error occurred"
+msgstr "Сталася помилка"
+
+#: packages/admin/src/routes/byline-schema.tsx:272
+msgid "An unexpected error occurred."
+msgstr "Сталася неочікувана помилка."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:249
+msgid "An unknown error occurred"
+msgstr "Сталася невідома помилка"
+
+#: packages/admin/src/components/WordPressImport.tsx:1575
+msgid "Analyzing export file..."
+msgstr "Аналіз файлу експорту..."
+
+#: packages/admin/src/components/WordPressImport.tsx:810
+msgid "Analyzing WordPress site..."
+msgstr "Аналіз сайту WordPress..."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr "Дозволено будь-який тип медіа (з урахуванням глобальних обмежень)."
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
+msgid "API Tokens"
+msgstr "API-токени"
+
+#: packages/admin/src/components/Widgets.tsx:435
+msgid "Appears on posts and pages"
+msgstr "З'являється в дописах і на сторінках"
+
+#: packages/admin/src/components/WordPressImport.tsx:1490
+msgid "Application Password"
+msgstr "Пароль застосунку"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3591
+msgid "Apply"
+msgstr "Застосувати"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:181
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:182
+msgid "Apply language"
+msgstr "Застосувати мову"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3061
+#: packages/admin/src/components/PortableTextEditor.tsx:3062
+msgid "Apply link"
+msgstr "Застосувати посилання"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:237
+#: packages/admin/src/components/comments/CommentInbox.tsx:489
+msgid "Approve"
+msgstr "Схвалити"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "схвалено"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:202
+msgid "Approved"
+msgstr "Схвалено"
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr "Довільні JSON-дані"
+
+#: packages/admin/src/components/ContentList.tsx:1164
+msgid "archived"
+msgstr "заархівовано"
+
+#: packages/admin/src/components/ContentList.tsx:732
+#: packages/admin/src/components/Dashboard.tsx:350
+msgid "Archived"
+msgstr "Заархівовано"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+#: packages/admin/src/components/Widgets.tsx:156
+msgid "Archives"
+msgstr "Архіви"
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:375
+msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+msgstr "Ви впевнені, що хочете видалити \"{0}\"? Жодне збережене значення не посилається на це поле."
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "Ви впевнені, що хочете видалити \"{0}\"? Це також видалить увесь вміст у цій колекції."
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:669
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr "Ви впевнені, що хочете видалити поле \"{0}\"?"
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "Ви впевнені, що хочете видалити це меню? Це також видалить усі елементи меню. Цю дію не можна скасувати."
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "Як адміністратор, ви можете запрошувати інших користувачів у розділі Користувачі."
+
+#: packages/admin/src/components/WordPressImport.tsx:2456
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "Призначте авторів WordPress користувачам EmDash. Дописи будуть приписані обраному користувачу."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:28
+msgid "Astro"
+msgstr "Astro"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+#: packages/admin/src/components/MediaLibrary.tsx:436
+msgid "Audio"
+msgstr "Аудіо"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:277
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "Помилка автентифікації: {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:195
+msgid "Authentication error: {error}"
+msgstr "Помилка автентифікації: {error}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:254
+msgid "Authentication failed"
+msgstr "Автентифікацію не вдалося"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:120
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "Автентифікацію керує зовнішній провайдер ({0}). Налаштування passkey недоступні при зовнішній автентифікації."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:261
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "Автентифікацію скасовано або час вичерпано. Спробуйте ще раз."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:287
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1011
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "Автор"
+
+#: packages/admin/src/components/WordPressImport.tsx:2471
+msgid "Author Mapping"
+msgstr "Зіставлення авторів"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "Авторизацію відхилено"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr "Авторизацію не вдалося"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "Авторизувати"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "Авторизувати пристрій"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "Авторизація..."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:672
+msgid "Authors"
+msgstr "Автори"
+
+#: packages/admin/src/components/Redirects.tsx:521
+msgid "auto"
+msgstr "авто"
+
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "Auto (slug change)"
+msgstr "Авто (зміна slug)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:539
+msgid "Auto-approve authenticated users"
+msgstr "Автосхвалення автентифікованих користувачів"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:408
+msgid "Auto-generated from name (you can edit)"
+msgstr "Автогенерація з назви (можна редагувати)"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:167
+msgid "Automatic Backups"
+msgstr "Автоматичні резервні копії"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:207
+msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
+msgstr "Автоматичні резервні копії потребують сховища (R2, S3 або локальне). Налаштуйте сховище в конфігурації EmDash, щоб увімкнути їх."
+
+#: packages/admin/src/router.tsx:994
+msgid "Autosave failed"
+msgstr "Автозбереження не вдалося"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:661
+msgid "Available media"
+msgstr "Доступні медіа"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:205
+msgid "Available Providers"
+msgstr "Доступні провайдери"
+
+#: packages/admin/src/components/Widgets.tsx:461
+msgid "Available Widgets"
+msgstr "Доступні віджети"
+
+#: packages/admin/src/components/BylineAvatarField.tsx:46
+#: packages/admin/src/components/BylineAvatarField.tsx:71
+msgid "Avatar"
+msgstr "Аватар"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:257
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/WordPressImport.tsx:1510
+#: packages/admin/src/components/WordPressImport.tsx:2527
+msgid "Back"
+msgstr "Назад"
+
+#: packages/admin/src/components/ContentEditor.tsx:634
+msgid "Back to {collectionLabel} list"
+msgstr "Назад до списку {collectionLabel}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr "Назад до типів вмісту"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:171
+#: packages/admin/src/components/LoginPage.tsx:117
+#: packages/admin/src/components/LoginPage.tsx:153
+#: packages/admin/src/components/LoginPage.tsx:311
+#: packages/admin/src/components/SignupPage.tsx:281
+msgid "Back to login"
+msgstr "Назад до входу"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:115
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:391
+msgid "Back to marketplace"
+msgstr "Назад до маркетплейсу"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:805
+msgid "Back to plugins"
+msgstr "Назад до плагінів"
+
+#: packages/admin/src/components/SectionEditor.tsx:72
+#: packages/admin/src/components/SectionEditor.tsx:173
+msgid "Back to sections"
+msgstr "Назад до секцій"
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr "Назад до налаштувань"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr "Назад до тем"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Back up now"
+msgstr "Створити резервну копію зараз"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Backing up..."
+msgstr "Резервне копіювання..."
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:97
+msgid "Backup created: {0}"
+msgstr "Резервну копію створено: {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:80
+msgid "Backup settings saved"
+msgstr "Налаштування резервного копіювання збережено"
+
+#: packages/admin/src/components/Settings.tsx:122
+#: packages/admin/src/components/settings/BackupSettings.tsx:133
+#: packages/admin/src/components/settings/BackupSettings.tsx:148
+msgid "Backups"
+msgstr "Резервні копії"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:182
+msgid "Backups to keep"
+msgstr "Резервних копій зберігати"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:29
+msgid "Bash"
+msgstr "Bash"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:191
+msgid "Before send:"
+msgstr "Перед надсиланням:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Bing Verification"
+msgstr "Верифікація Bing"
+
+#: packages/admin/src/routes/bylines.tsx:497
+msgid "Bio"
+msgstr "Біо"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
+msgid "Block actions - drag to reorder, click for menu"
+msgstr "Дії блоку — перетягніть для зміни порядку, клацніть для меню"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3085
+#: packages/admin/src/components/PortableTextEditor.tsx:3419
+msgid "Bold"
+msgstr "Жирний"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:55
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr "Логічний"
+
+#: packages/admin/src/components/SeoPanel.tsx:184
+msgid "Brief summary shown below the title in search results"
+msgstr "Короткий опис під заголовком у результатах пошуку"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr "Переглядайте та встановлюйте плагіни з децентралізованого реєстру."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr "Переглядайте та встановлюйте плагіни для розширення сайту."
+
+#: packages/admin/src/components/WordPressImport.tsx:1124
+#: packages/admin/src/components/WordPressImport.tsx:1594
+msgid "Browse Files"
+msgstr "Переглянути файли"
+
+#: packages/admin/src/components/PluginManager.tsx:199
+msgid "Browse the"
+msgstr "Переглянути"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr "Переглядайте теми та переглядайте їх із вашим вмістом."
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:102
+#: packages/admin/src/components/PortableTextEditor.tsx:1056
+#: packages/admin/src/components/PortableTextEditor.tsx:3467
+msgid "Bullet List"
+msgstr "Маркований список"
+
+#: packages/admin/src/routes/byline-schema.tsx:218
+#: packages/admin/src/routes/bylines.tsx:384
+msgid "Byline schema"
+msgstr "Схема підпису"
+
+#: packages/admin/src/components/Sidebar.tsx:347
+msgid "Byline Schema"
+msgstr "Схема підпису"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:513
+#: packages/admin/src/components/Sidebar.tsx:342
+#: packages/admin/src/routes/bylines.tsx:376
+msgid "Bylines"
+msgstr "Підписи"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:30
+msgid "C"
+msgstr "C"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:32
+msgid "C#"
+msgstr "C#"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:31
+msgid "C++"
+msgstr "C++"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "Може створювати вміст"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "Може керувати всім вмістом"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "Може публікувати власний вміст"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "Може переглядати вміст"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:315
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:163
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentList.tsx:455
+#: packages/admin/src/components/ContentList.tsx:1052
+#: packages/admin/src/components/ContentList.tsx:1123
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/ContentSettingsPanel.tsx:84
+#: packages/admin/src/components/ContentSettingsPanel.tsx:464
+#: packages/admin/src/components/ContentSettingsPanel.tsx:612
+#: packages/admin/src/components/ContentSettingsPanel.tsx:915
+#: packages/admin/src/components/ContentSettingsPanel.tsx:968
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:193
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:194
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:586
+#: packages/admin/src/components/editor/ImageNode.tsx:252
+#: packages/admin/src/components/editor/ImageNode.tsx:253
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:649
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:743
+#: packages/admin/src/components/MenuEditor.tsx:438
+#: packages/admin/src/components/MenuEditor.tsx:623
+#: packages/admin/src/components/MenuList.tsx:172
+#: packages/admin/src/components/PluginManager.tsx:640
+#: packages/admin/src/components/PortableTextEditor.tsx:3575
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:280
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:390
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:323
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:451
+#: packages/admin/src/components/settings/SecuritySettings.tsx:179
+#: packages/admin/src/components/TaxonomyManager.tsx:187
+#: packages/admin/src/components/TaxonomyManager.tsx:472
+#: packages/admin/src/components/TaxonomyManager.tsx:686
+#: packages/admin/src/components/users/InviteUserModal.tsx:198
+#: packages/admin/src/components/Widgets.tsx:446
+#: packages/admin/src/components/WordPressImport.tsx:1917
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr "Скасувати (Esc)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "Скасувати перейменування"
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr "Неможливо видалити секції теми"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:412
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr "Неможливо визначити MIME-тип з URL. Використовуйте URL із розпізнаним розширенням зображення (напр. .jpg, .png, .webp)."
+
+#: packages/admin/src/components/SeoPanel.tsx:212
+#: packages/admin/src/components/SeoPanel.tsx:216
+msgid "Canonical URL"
+msgstr "Канонічний URL"
+
+#: packages/admin/src/components/PluginManager.tsx:473
+msgid "Capabilities"
+msgstr "Можливості"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:65
+msgid "Capability consent"
+msgstr "Згода на можливості"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:352
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:541
+#: packages/admin/src/components/MediaDetailPanel.tsx:381
+msgid "Caption"
+msgstr "Підпис"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr "Підписи / Субтитри"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+#: packages/admin/src/components/Widgets.tsx:133
+msgid "Categories"
+msgstr "Категорії"
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1785
+msgid "Categories ({0})"
+msgstr "Категорії ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "Categories & Tags"
+msgstr "Категорії та теги"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
+msgid "Center"
+msgstr "По центру"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1647
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/ImageFieldRenderer.tsx:122
+#: packages/admin/src/components/ImageFieldRenderer.tsx:151
+#: packages/admin/src/components/SeoImageField.tsx:53
+msgid "Change"
+msgstr "Змінити"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr "Змінити <0>{0}</0> з <1>{1}</1> на <2>{2}</2>? Вони втратять доступ до функцій вищого рівня."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:239
+msgid "Change Favicon"
+msgstr "Змінити favicon"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:167
+msgid "Change Image"
+msgstr "Змінити зображення"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:185
+msgid "Change Logo"
+msgstr "Змінити логотип"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:793
+msgid "Changelog"
+msgstr "Журнал змін"
+
+#: packages/admin/src/router.tsx:1045
+msgid "Changes discarded"
+msgstr "Зміни скасовано"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:129
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "Символ між заголовком сторінки та назвою сайту (напр., \"Мій допис | Мій сайт\")"
+
+#: packages/admin/src/components/PluginManager.tsx:162
+msgid "Check for updates"
+msgstr "Перевірити оновлення"
+
+#: packages/admin/src/components/WordPressImport.tsx:1095
+msgid "Check Site"
+msgstr "Перевірити сайт"
+
+#: packages/admin/src/components/LoginPage.tsx:101
+#: packages/admin/src/components/SignupPage.tsx:130
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Check your email"
+msgstr "Перевірте email"
+
+#: packages/admin/src/components/WordPressImport.tsx:776
+msgid "Checking {urlInput}..."
+msgstr "Перевірка {urlInput}..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "Перевірка автентифікації..."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:362
+msgid "Checking how many stored values reference \"{0}\"…"
+msgstr "Перевірка, скільки збережених значень посилаються на \"{0}\"…"
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr "Оберіть спосіб входу"
+
+#: packages/admin/src/components/Settings.tsx:137
+msgid "Choose your preferred admin language"
+msgstr "Оберіть бажану мову адмін-панелі"
+
+#: packages/admin/src/components/ContentList.tsx:481
+msgid "Clear"
+msgstr "Очистити"
+
+#: packages/admin/src/components/ContentList.tsx:825
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr "Очистити фільтри"
+
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/MediaLibrary.tsx:521
+msgid "Clear search"
+msgstr "Очистити пошук"
+
+#: packages/admin/src/components/SignupPage.tsx:138
+msgid "Click the link in the email to continue setting up your account."
+msgstr "Перейдіть за посиланням у листі, щоб продовжити налаштування облікового запису."
+
+#: packages/admin/src/components/LoginPage.tsx:112
+msgid "Click the link in the email to sign in."
+msgstr "Перейдіть за посиланням у листі, щоб увійти."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:212
+#: packages/admin/src/components/BylineFieldEditor.tsx:218
+#: packages/admin/src/components/BylineFieldEditor.tsx:222
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:227
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:229
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:414
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:436
+#: packages/admin/src/components/MediaDetailPanel.tsx:229
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:481
+#: packages/admin/src/components/MediaPickerModal.tsx:487
+#: packages/admin/src/components/MediaPickerModal.tsx:491
+#: packages/admin/src/components/MenuEditor.tsx:400
+#: packages/admin/src/components/MenuEditor.tsx:406
+#: packages/admin/src/components/MenuEditor.tsx:410
+#: packages/admin/src/components/MenuEditor.tsx:576
+#: packages/admin/src/components/MenuEditor.tsx:582
+#: packages/admin/src/components/MenuEditor.tsx:586
+#: packages/admin/src/components/MenuList.tsx:136
+#: packages/admin/src/components/MenuList.tsx:142
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/PortableTextEditor.tsx:1530
+#: packages/admin/src/components/PortableTextEditor.tsx:1536
+#: packages/admin/src/components/PortableTextEditor.tsx:1540
+#: packages/admin/src/components/Redirects.tsx:114
+#: packages/admin/src/components/Redirects.tsx:120
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:338
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:348
+#: packages/admin/src/components/TaxonomyManager.tsx:164
+#: packages/admin/src/components/TaxonomyManager.tsx:371
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/components/TaxonomyManager.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:605
+#: packages/admin/src/components/TaxonomyManager.tsx:611
+#: packages/admin/src/components/TaxonomyManager.tsx:615
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:408
+#: packages/admin/src/components/Widgets.tsx:414
+#: packages/admin/src/components/Widgets.tsx:418
+msgid "Close"
+msgstr "Закрити"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:518
+msgid "Close comments after (days)"
+msgstr "Закрити коментарі через (днів)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr "Закрити панель"
+
+#: packages/admin/src/components/ContentEditor.tsx:1019
+msgid "Close settings"
+msgstr "Закрити налаштування"
+
+#: packages/admin/src/components/ContentTypeList.tsx:242
+#: packages/admin/src/components/PortableTextEditor.tsx:3113
+#: packages/admin/src/components/Redirects.tsx:469
+msgid "Code"
+msgstr "Код"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:94
+#: packages/admin/src/components/PortableTextEditor.tsx:1086
+#: packages/admin/src/components/PortableTextEditor.tsx:3488
+msgid "Code Block"
+msgstr "Блок коду"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Collapse"
+msgstr "Згорнути"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Collapse details"
+msgstr "Згорнути деталі"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:156
+msgid "colleague@example.com"
+msgstr "colleague@example.com"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr "Колекція"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "Колекція:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Collections"
+msgstr "Колекції"
+
+#: packages/admin/src/components/WordPressImport.tsx:2327
+msgid "Collections created:"
+msgstr "Створено колекцій:"
+
+#: packages/admin/src/components/SectionEditor.tsx:275
+msgid "Comma-separated keywords for search."
+msgstr "Ключові слова для пошуку через кому."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Comment"
+msgstr "Коментар"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "Деталі коментаря"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:146
+#: packages/admin/src/components/ContentTypeEditor.tsx:485
+#: packages/admin/src/components/Sidebar.tsx:326
+msgid "Comments"
+msgstr "Коментарі"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:542
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr "Коментарі від авторизованих користувачів CMS схвалюються автоматично"
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Complete signup"
+msgstr "Завершити реєстрацію"
+
+#: packages/admin/src/components/Widgets.tsx:914
+msgid "Component"
+msgstr "Компонент"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr "Налаштувати поле"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:313
+msgid "Confirm"
+msgstr "Підтвердити"
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+#: packages/admin/src/components/WordPressImport.tsx:1054
+msgid "Connect"
+msgstr "Підключити"
+
+#: packages/admin/src/components/WordPressImport.tsx:1507
+msgid "Connect & Analyze"
+msgstr "Підключити й проаналізувати"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1457
+msgid "Connect to {0}"
+msgstr "Підключитися до {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Connect with WordPress"
+msgstr "Підключитися до WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr "Підключено {0}"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:293
+#: packages/admin/src/components/Dashboard.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:2326
+#: packages/admin/src/components/SectionEditor.tsx:193
+#: packages/admin/src/components/Sidebar.tsx:451
+#: packages/admin/src/components/Widgets.tsx:882
+msgid "Content"
+msgstr "Вміст"
+
+#: packages/admin/src/components/Widgets.tsx:96
+msgid "Content Block"
+msgstr "Блок вмісту"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2382
+msgid "Content Errors ({0})"
+msgstr "Помилки вмісту ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1317
+msgid "Content found:"
+msgstr "Знайдено вмісту:"
+
+#: packages/admin/src/router.tsx:1067
+msgid "Content has been scheduled for publishing"
+msgstr "Вміст заплановано до публікації"
+
+#: packages/admin/src/components/RevisionHistory.tsx:123
+msgid "Content has been updated to the selected revision."
+msgstr "Вміст оновлено до обраної ревізії."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "ID вмісту:"
+
+#: packages/admin/src/router.tsx:1008
+msgid "Content is now live"
+msgstr "Вміст тепер опубліковано"
+
+#: packages/admin/src/components/WordPressImport.tsx:2371
+msgid "content items"
+msgstr "елементи вмісту"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
+msgid "Content Read"
+msgstr "Читання вмісту"
+
+#: packages/admin/src/router.tsx:1026
+msgid "Content removed from public view"
+msgstr "Вміст прибрано з публічного перегляду"
+
+#: packages/admin/src/router.tsx:1088
+msgid "Content reverted to draft"
+msgstr "Вміст повернуто до чернетки"
+
+#: packages/admin/src/components/RevisionHistory.tsx:304
+msgid "Content snapshot:"
+msgstr "Знімок вмісту:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1731
+msgid "Content to Import"
+msgstr "Вміст для імпорту"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:346
+msgid "Content Types"
+msgstr "Типи вмісту"
+
+#: packages/admin/src/components/WordPressImport.tsx:2310
+msgid "Content was skipped because it already exists"
+msgstr "Вміст пропущено, бо він уже існує"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
+msgid "Content Write"
+msgstr "Запис вмісту"
+
+#: packages/admin/src/components/SignupPage.tsx:91
+msgid "Continue"
+msgstr "Продовжити"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr "Продовжити →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2529
+msgid "Continue Import"
+msgstr "Продовжити імпорт"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "Учасник"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:224
+#: packages/admin/src/components/users/InviteUserModal.tsx:133
+msgid "Copied to clipboard"
+msgstr "Скопійовано в буфер обміну"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr "Скопіювати {0} в буфер обміну"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "Скопіювати посилання запрошення"
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr "Скопіювати slug"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
+msgid "Copy this token now — it won't be shown again."
+msgstr "Скопіюйте цей токен зараз — він більше не відображатиметься."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copy token"
+msgstr "Скопіювати токен"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+#: packages/admin/src/components/MediaDetailPanel.tsx:301
+msgid "Copy URL"
+msgstr "Скопіювати URL"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:136
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "Не вдалося скопіювати автоматично. Виділіть URL вище та скопіюйте вручну."
+
+#: packages/admin/src/components/Dashboard.tsx:84
+msgid "Could not load dashboard data"
+msgstr "Не вдалося завантажити дані панелі"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:438
+msgid "Could not load image from URL"
+msgstr "Не вдалося завантажити зображення з URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1264
+msgid "Couldn't detect WordPress"
+msgstr "Не вдалося виявити WordPress"
+
+#: packages/admin/src/routes/byline-schema.tsx:268
+msgid "Couldn't load byline fields."
+msgstr "Не вдалося завантажити поля підпису."
+
+#: packages/admin/src/routes/bylines.tsx:548
+msgid "Couldn't load custom fields."
+msgstr "Не вдалося завантажити власні поля."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr "Не вдалося визначити MIME-тип для \"{draft}\". Введіть MIME безпосередньо."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:807
+msgid "Couldn't search bylines. Please try again."
+msgstr "Не вдалося шукати підписи. Спробуйте ще раз."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:369
+msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+msgstr "Не вдалося перевірити, скільки значень посилаються на \"{0}\". Видалення все одно прибере всі збережені значення для цього поля — але кількість вище не вдалося перевірити."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:822
+msgid "Count"
+msgstr "Кількість"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:939
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:191
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:479
+#: packages/admin/src/components/Widgets.tsx:449
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Create"
+msgstr "Створити"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:292
+msgid "Create \"{trimmedInput}\""
+msgstr "Створити \"{trimmedInput}\""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1057
+msgid "Create a bullet list"
+msgstr "Створити маркований список"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:367
+msgid "Create a new {0}"
+msgstr "Створити новий {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1067
+msgid "Create a numbered list"
+msgstr "Створити нумерований список"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:83
+#: packages/admin/src/components/SignupPage.tsx:220
+msgid "Create Account"
+msgstr "Створити обліковий запис"
+
+#: packages/admin/src/components/SignupPage.tsx:399
+msgid "Create an account"
+msgstr "Створити обліковий запис"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:887
+#: packages/admin/src/routes/bylines.tsx:477
+msgid "Create byline"
+msgstr "Створити підпис"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr "Створити тип вмісту"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Create field"
+msgstr "Створити поле"
+
+#: packages/admin/src/components/MenuList.tsx:126
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "Create Menu"
+msgstr "Створити меню"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "Create New Menu"
+msgstr "Створити нове меню"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:394
+msgid "Create New Token"
+msgstr "Створити новий токен"
+
+#: packages/admin/src/components/WordPressImport.tsx:1501
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "Створіть у WordPress: Користувачі → Профіль → Паролі застосунків"
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr "Створити passkey"
+
+#: packages/admin/src/components/Settings.tsx:111
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
+msgid "Create personal access tokens for programmatic API access"
+msgstr "Створюйте персональні токени доступу для програмного доступу до API"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:247
+msgid "Create redirect for {0}"
+msgstr "Створити перенаправлення для {0}"
+
+#: packages/admin/src/components/Redirects.tsx:246
+msgid "Create redirect for this path"
+msgstr "Створити перенаправлення для цього шляху"
+
+#: packages/admin/src/components/Redirects.tsx:461
+msgid "Create redirect rules to manage URL changes."
+msgstr "Створюйте правила перенаправлення для керування змінами URL."
+
+#: packages/admin/src/components/WordPressImport.tsx:1921
+msgid "Create Schema & Import"
+msgstr "Створити схему й імпортувати"
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr "Створити секцію"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr "Створіть секції в бібліотеці секцій, щоб використовувати їх тут"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:598
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+msgid "Create Taxonomy"
+msgstr "Створити таксономію"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:256
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:448
+msgid "Create Token"
+msgstr "Створити токен"
+
+#: packages/admin/src/components/Widgets.tsx:405
+msgid "Create Widget Area"
+msgstr "Створити область віджетів"
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr "Створіть обліковий запис"
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "Create your first navigation menu to get started"
+msgstr "Створіть перше навігаційне меню, щоб почати"
+
+#: packages/admin/src/components/ContentList.tsx:556
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr "Створіть перший"
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr "Створіть першу багаторазову секцію вмісту, щоб почати."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:74
+#: packages/admin/src/components/SignupPage.tsx:211
+msgid "Create your passkey"
+msgstr "Створіть passkey"
+
+#: packages/admin/src/lib/api/marketplace.ts:223
+#: packages/admin/src/lib/api/marketplace.ts:232
+msgid "Create, update, and delete content"
+msgstr "Створювати, оновлювати та видаляти вміст"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Create, update, and delete navigation menus"
+msgstr "Створювати, оновлювати та видаляти навігаційні меню"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Create, update, and delete taxonomy terms"
+msgstr "Створювати, оновлювати та видаляти терміни таксономій"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Create, update, delete content"
+msgstr "Створювати, оновлювати, видаляти вміст"
+
+#: packages/admin/src/components/ContentList.tsx:736
+#: packages/admin/src/components/ContentSettingsPanel.tsx:486
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr "Створено"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:96
+msgid "Created \"{0}\"."
+msgstr "Створено \"{0}\"."
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:295
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr "Створено {0}"
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:1119
+msgid "Created {0} translation"
+msgstr "Створено переклад {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr "Створено"
+
+#: packages/admin/src/components/WordPressImport.tsx:887
+msgid "Creating collections and fields..."
+msgstr "Створення колекцій і полів..."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:939
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:188
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:448
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+#: packages/admin/src/components/TaxonomySidebar.tsx:292
+msgid "Creating..."
+msgstr "Створення..."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:33
+msgid "CSS"
+msgstr "CSS"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:83
+msgid "current"
+msgstr "поточний"
+
+#: packages/admin/src/components/RevisionHistory.tsx:272
+msgid "Current"
+msgstr "Поточний"
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr "Власний"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:623
+msgid "Custom Fields"
+msgstr "Власні поля"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:210
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "Власний вміст robots.txt. Залиште порожнім для значення за замовчуванням."
+
+#: packages/admin/src/components/SectionEditor.tsx:183
+msgid "Custom Section"
+msgstr "Власна секція"
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Custom Taxonomies"
+msgstr "Власні таксономії"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:176
+msgid "Daily automatic backups"
+msgstr "Щоденні автоматичні резервні копії"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "темна"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "Темна"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/Dashboard.tsx:50
+#: packages/admin/src/components/Sidebar.tsx:312
+#: packages/admin/src/components/Sidebar.tsx:442
+msgid "Dashboard"
+msgstr "Панель керування"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:296
+#: packages/admin/src/components/ContentList.tsx:525
+msgid "Date"
+msgstr "Дата"
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr "Дата й час"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr "Вибір дати й часу"
+
+#: packages/admin/src/components/ContentList.tsx:790
+msgid "Date field to filter on"
+msgstr "Поле дати для фільтрації"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:281
+msgid "Date Format"
+msgstr "Формат дати"
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr "Десяткове число"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:737
+msgid "Declared permissions"
+msgstr "Оголошені дозволи"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:294
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:356
+msgid "Default Role"
+msgstr "Роль за замовчуванням"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:233
+msgid "Default role:"
+msgstr "Роль за замовчуванням:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:147
+msgid "Default social image"
+msgstr "Зображення соцмереж за замовчуванням"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:138
+msgid "Default Social Image"
+msgstr "Зображення соцмереж за замовчуванням"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:601
+msgid "Define a new taxonomy for classifying content"
+msgstr "Визначте нову таксономію для класифікації вмісту"
+
+#: packages/admin/src/routes/byline-schema.tsx:220
+msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+msgstr "Визначте власні поля для кожного підпису — посада, займенники, соцмережі тощо."
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr "Визначте структуру вашого вмісту"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:360
+msgid "Defined in code"
+msgstr "Визначено в коді"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:267
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+#: packages/admin/src/components/ContentTypeEditor.tsx:672
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:301
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:130
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:453
+#: packages/admin/src/components/MenuEditor.tsx:549
+#: packages/admin/src/components/MenuList.tsx:255
+#: packages/admin/src/components/Redirects.tsx:582
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/settings/BackupSettings.tsx:284
+#: packages/admin/src/components/TaxonomyManager.tsx:886
+#: packages/admin/src/components/Widgets.tsx:699
+#: packages/admin/src/routes/byline-schema.tsx:378
+#: packages/admin/src/routes/bylines.tsx:589
+#: packages/admin/src/routes/bylines.tsx:625
+msgid "Delete"
+msgstr "Видалити"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:452
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "Видалити \"{0}\"? Цю дію не можна скасувати."
+
+#. placeholder {0}: archive.name
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:227
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:252
+#: packages/admin/src/components/settings/BackupSettings.tsx:245
+#: packages/admin/src/components/TaxonomyManager.tsx:97
+#: packages/admin/src/components/Widgets.tsx:800
+#: packages/admin/src/routes/byline-schema.tsx:458
+msgid "Delete {0}"
+msgstr "Видалити {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:749
+msgid "Delete {0} field"
+msgstr "Видалити поле {0}"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:237
+msgid "Delete {0} menu"
+msgstr "Видалити меню {0}"
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:647
+msgid "Delete {0} widget area"
+msgstr "Видалити область віджетів {0}"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:882
+msgid "Delete {0}?"
+msgstr "Видалити {0}?"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:282
+msgid "Delete backup?"
+msgstr "Видалити резервну копію?"
+
+#: packages/admin/src/routes/byline-schema.tsx:358
+msgid "Delete byline field?"
+msgstr "Видалити поле підпису?"
+
+#: packages/admin/src/routes/bylines.tsx:623
+msgid "Delete Byline?"
+msgstr "Видалити підпис?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3197
+msgid "Delete column"
+msgstr "Видалити стовпець"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:405
+msgid "Delete Comment?"
+msgstr "Видалити коментар?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr "Видалити тип вмісту?"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr "Видалити вбудування"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:666
+msgid "Delete Field?"
+msgstr "Видалити поле?"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
+msgid "Delete HTML block"
+msgstr "Видалити HTML-блок"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:220
+#: packages/admin/src/components/editor/ImageNode.tsx:221
+msgid "Delete image"
+msgstr "Видалити зображення"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:451
+msgid "Delete Media?"
+msgstr "Видалити медіа?"
+
+#: packages/admin/src/components/MenuList.tsx:253
+msgid "Delete Menu"
+msgstr "Видалити меню"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:525
+msgid "Delete permanently"
+msgstr "Видалити назавжди"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:1134
+msgid "Delete Permanently"
+msgstr "Видалити назавжди"
+
+#: packages/admin/src/components/ContentList.tsx:1114
+msgid "Delete Permanently?"
+msgstr "Видалити назавжди?"
+
+#: packages/admin/src/components/Redirects.tsx:535
+msgid "Delete redirect"
+msgstr "Видалити перенаправлення"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:536
+msgid "Delete redirect {0}"
+msgstr "Видалити перенаправлення {0}"
+
+#: packages/admin/src/components/Redirects.tsx:580
+msgid "Delete Redirect?"
+msgstr "Видалити перенаправлення?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3216
+msgid "Delete row"
+msgstr "Видалити рядок"
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr "Видалити секцію?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3231
+msgid "Delete table"
+msgstr "Видалити таблицю"
+
+#: packages/admin/src/components/Widgets.tsx:697
+msgid "Delete Widget Area?"
+msgstr "Видалити область віджетів?"
+
+#: packages/admin/src/components/ContentList.tsx:646
+msgid "Deleted"
+msgstr "Видалено"
+
+#. placeholder {0}: deletingField.label
+#. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
+#: packages/admin/src/routes/byline-schema.tsx:371
+msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+msgstr "Видалення \"{0}\" також прибере {1, plural, one {# збережене значення} few {# збережені значення} many {# збережених значень} other {# збережених значень}} у всіх підписах. Цю дію не можна скасувати."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:673
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:454
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:583
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/settings/BackupSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:887
+#: packages/admin/src/components/Widgets.tsx:700
+#: packages/admin/src/routes/bylines.tsx:626
+msgid "Deleting..."
+msgstr "Видалення..."
+
+#: packages/admin/src/routes/byline-schema.tsx:379
+msgid "Deleting…"
+msgstr "Видалення…"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr "Демо"
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr "Понизити користувача"
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr "Понизити користувача?"
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr "Пониження..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "Відхилити"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:238
+msgid "Describe the image..."
+msgstr "Опишіть зображення..."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
+#: packages/admin/src/components/MediaDetailPanel.tsx:374
+msgid "Describe this image for accessibility"
+msgstr "Опишіть це зображення для доступності"
+
+#: packages/admin/src/components/SectionEditor.tsx:264
+msgid "Describe what this section is for..."
+msgstr "Опишіть, для чого ця секція..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:413
+#: packages/admin/src/components/RegistryPluginDetail.tsx:790
+#: packages/admin/src/components/SectionEditor.tsx:261
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:433
+msgid "Description"
+msgstr "Опис"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:434
+msgid "Description (optional)"
+msgstr "Опис (необов'язково)"
+
+#: packages/admin/src/components/Redirects.tsx:468
+msgid "Destination"
+msgstr "Призначення"
+
+#: packages/admin/src/components/Redirects.tsx:140
+msgid "Destination path"
+msgstr "Шлях призначення"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "details"
+msgstr "деталі"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "Пристрій авторизовано"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "Код пристрою"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr "Прив'язаний до пристрою"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Passkey, прив'язаний до пристрою"
+
+#: packages/admin/src/components/SignupPage.tsx:143
+msgid "Didn't receive the email?"
+msgstr "Не отримали лист?"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:34
+msgid "Diff"
+msgstr "Різниця"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:280
+msgid "Dimensions:"
+msgstr "Розміри:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr "Вимкнути"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Disable plugin"
+msgstr "Вимкнути плагін"
+
+#: packages/admin/src/components/Redirects.tsx:504
+msgid "Disable redirect"
+msgstr "Вимкнути перенаправлення"
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr "Вимкнути користувача"
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr "Вимкнути користувача?"
+
+#: packages/admin/src/components/PluginManager.tsx:354
+#: packages/admin/src/components/Redirects.tsx:418
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: packages/admin/src/components/PluginManager.tsx:531
+msgid "Disabled:"
+msgstr "Вимкнено:"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr "Вимкнення <0>{0}</0> заборонить вхід до повторного ввімкнення. Їхній вміст буде збережено."
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr "Вимкнення..."
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:438
+msgid "Discard"
+msgstr "Скасувати"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:71
+#: packages/admin/src/components/ContentSettingsPanel.tsx:91
+msgid "Discard changes"
+msgstr "Скасувати зміни"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:436
+msgid "Discard changes?"
+msgstr "Скасувати зміни?"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:76
+msgid "Discard draft changes?"
+msgstr "Скасувати зміни чернетки?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:439
+msgid "Discarding..."
+msgstr "Скасування..."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:231
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
+msgid "Dismiss"
+msgstr "Закрити"
+
+#: packages/admin/src/components/Widgets.tsx:125
+msgid "Display a list of recent posts"
+msgstr "Показати список останніх дописів"
+
+#: packages/admin/src/components/Widgets.tsx:103
+msgid "Display a navigation menu"
+msgstr "Показати навігаційне меню"
+
+#: packages/admin/src/components/Widgets.tsx:134
+msgid "Display category list"
+msgstr "Показати список категорій"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:890
+#: packages/admin/src/components/ContentSettingsPanel.tsx:952
+#: packages/admin/src/routes/bylines.tsx:482
+msgid "Display name"
+msgstr "Відображуване ім'я"
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Display name for admin interface"
+msgstr "Відображуване ім'я в адмін-інтерфейсі"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:269
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:458
+msgid "Display Size"
+msgstr "Розмір відображення"
+
+#: packages/admin/src/components/Widgets.tsx:142
+msgid "Display tag cloud"
+msgstr "Показати хмару тегів"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
+msgid "Displayed below the image as a visible caption."
+msgstr "Відображається під зображенням як видимий підпис."
+
+#: packages/admin/src/components/ContentEditor.tsx:704
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "Режим без відволікань (⌘⇧\\)"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1111
+msgid "Divider"
+msgstr "Роздільник"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:35
+msgid "Dockerfile"
+msgstr "Dockerfile"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+#: packages/admin/src/components/MediaLibrary.tsx:437
+msgid "Documents"
+msgstr "Документи"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:286
+msgid "Domain"
+msgstr "Домен"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:66
+msgid "Domain added successfully"
+msgstr "Домен успішно додано"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain removed"
+msgstr "Домен видалено"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Domain updated"
+msgstr "Домен оновлено"
+
+#: packages/admin/src/components/LoginPage.tsx:332
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "Немає облікового запису? <0>Зареєструватися</0>"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:142
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Done"
+msgstr "Готово"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:833
+msgid "Down"
+msgstr "Вниз"
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:238
+msgid "Download {0}"
+msgstr "Завантажити {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:158
+msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
+msgstr "Завантажте повну резервну копію сайту: весь вміст (включно з чернетками та кошиком), колекції, таксономії, меню, віджети, метадані медіа та налаштування сайту. Облікові записи та секрети ніколи не включаються."
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:160
+msgid "Download backup"
+msgstr "Завантажити резервну копію"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:155
+msgid "Download Backup"
+msgstr "Завантажити резервну копію"
+
+#: packages/admin/src/components/Settings.tsx:123
+msgid "Download backups and schedule automatic backups to storage"
+msgstr "Завантажуйте резервні копії та плануйте автоматичне резервне копіювання в сховище"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:479
+msgid "Download SBOM"
+msgstr "Завантажити SBOM"
+
+#: packages/admin/src/components/WordPressImport.tsx:2126
+msgid "Downloading"
+msgstr "Завантаження"
+
+#: packages/admin/src/components/ContentList.tsx:1160
+msgid "draft"
+msgstr "чернетка"
+
+#: packages/admin/src/components/ContentList.tsx:730
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+#: packages/admin/src/components/ContentSettingsPanel.tsx:406
+#: packages/admin/src/components/Dashboard.tsx:346
+msgid "Draft"
+msgstr "Чернетка"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr "чернетка, опубліковано або заархівовано"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:251
+msgid "Drafts"
+msgstr "Чернетки"
+
+#: packages/admin/src/components/WordPressImport.tsx:1166
+msgid "Drafts & Private"
+msgstr "Чернетки та приватні"
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "Перетягніть або клацніть для вибору (.xml)"
+
+#: packages/admin/src/components/Widgets.tsx:683
+msgid "Drag here to add"
+msgstr "Перетягніть сюди, щоб додати"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1922
+msgid "Drag to reorder"
+msgstr "Перетягніть для зміни порядку"
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:716
+#: packages/admin/src/components/Widgets.tsx:785
+msgid "Drag to reorder {0}"
+msgstr "Перетягніть для зміни порядку {0}"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:338
+msgid "Drag to reorder block"
+msgstr "Перетягніть для зміни порядку блоку"
+
+#: packages/admin/src/components/Widgets.tsx:687
+msgid "Drag widgets here to add them"
+msgstr "Перетягніть віджети сюди, щоб додати"
+
+#: packages/admin/src/components/Widgets.tsx:462
+msgid "Drag widgets into an area to add them"
+msgstr "Перетягніть віджети в область, щоб додати"
+
+#: packages/admin/src/components/Widgets.tsx:683
+msgid "Drop to add widget"
+msgstr "Відпустіть, щоб додати віджет"
+
+#: packages/admin/src/components/WordPressImport.tsx:1588
+msgid "Drop your WordPress export file here"
+msgstr "Перетягніть файл експорту WordPress сюди"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:292
+msgid "Duplicate"
+msgstr "Дублювати"
+
+#: packages/admin/src/components/ContentList.tsx:1025
+msgid "Duplicate {title}"
+msgstr "Дублювати {title}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr "напр. application/zip або .pdf"
+
+#: packages/admin/src/components/Redirects.tsx:167
+msgid "e.g. import, blog"
+msgstr "напр. import, blog"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:408
+msgid "e.g., CI/CD Pipeline"
+msgstr "напр., CI/CD Pipeline"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "напр., MacBook Pro, iPhone"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:842
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:544
+#: packages/admin/src/components/MenuList.tsx:231
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TranslationsPanel.tsx:93
+msgid "Edit"
+msgstr "Редагувати"
+
+#. placeholder {0}: block?.label || ""
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:218
+#: packages/admin/src/components/PortableTextEditor.tsx:1527
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:243
+#: packages/admin/src/components/TaxonomyManager.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/routes/byline-schema.tsx:449
+#: packages/admin/src/routes/bylines.tsx:477
+msgid "Edit {0}"
+msgstr "Редагувати {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:741
+msgid "Edit {0} field"
+msgstr "Редагувати поле {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:651
+msgid "Edit {collectionLabel}"
+msgstr "Редагувати {collectionLabel}"
+
+#: packages/admin/src/components/ContentList.tsx:1017
+msgid "Edit {title}"
+msgstr "Редагувати {title}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:949
+msgid "Edit byline"
+msgstr "Редагувати підпис"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "Edit byline field"
+msgstr "Редагувати поле підпису"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:331
+msgid "Edit Domain"
+msgstr "Редагувати домен"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr "Редагувати поле"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3121
+msgid "Edit link"
+msgstr "Редагувати посилання"
+
+#: packages/admin/src/components/MenuEditor.tsx:573
+msgid "Edit Menu Item"
+msgstr "Редагувати елемент меню"
+
+#: packages/admin/src/components/MenuEditor.tsx:369
+msgid "Edit menu items"
+msgstr "Редагувати елементи меню"
+
+#: packages/admin/src/components/Redirects.tsx:527
+msgid "Edit redirect"
+msgstr "Редагувати перенаправлення"
+
+#: packages/admin/src/components/Redirects.tsx:105
+msgid "Edit Redirect"
+msgstr "Редагувати перенаправлення"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:528
+msgid "Edit redirect {0}"
+msgstr "Редагувати перенаправлення {0}"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr "Редагувати URL"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "Редактор"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid "Editor\nReporter\nPhotographer"
+msgstr "Редактор\nРепортер\nФотограф"
+
+#: packages/admin/src/components/WordPressImport.tsx:1044
+msgid "em1.…"
+msgstr "em1.…"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:61
+#: packages/admin/src/components/Settings.tsx:116
+#: packages/admin/src/components/SignupPage.tsx:197
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr "Email"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:330
+msgid "Email (optional)"
+msgstr "Email (необов'язково)"
+
+#: packages/admin/src/components/LoginPage.tsx:126
+#: packages/admin/src/components/SignupPage.tsx:66
+#: packages/admin/src/components/users/InviteUserModal.tsx:152
+msgid "Email address"
+msgstr "Адреса email"
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:49
+msgid "Email is required"
+msgstr "Email обов'язковий"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "Email Middleware"
+msgstr "Email Middleware"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:99
+msgid "Email Pipeline"
+msgstr "Email Pipeline"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:172
+msgid "Email provider active"
+msgstr "Провайдер email активний"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:77
+#: packages/admin/src/components/settings/EmailSettings.tsx:92
+msgid "Email Settings"
+msgstr "Налаштування email"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr "Email підтверджено"
+
+#: packages/admin/src/components/SignupPage.tsx:189
+msgid "Email verified!"
+msgstr "Email підтверджено!"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2340
+msgid "Embed a {0}"
+msgstr "Вбудувати {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2343
+msgid "Embeds"
+msgstr "Вбудування"
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1307
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "Виявлено плагін EmDash Exporter! Можна імпортувати напряму."
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr "Увімкнути"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:493
+msgid "Enable comments"
+msgstr "Увімкнути коментарі"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr "Увімкнути повнотекстовий пошук у цій колекції"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Enable plugin"
+msgstr "Увімкнути плагін"
+
+#: packages/admin/src/components/Redirects.tsx:504
+msgid "Enable redirect"
+msgstr "Увімкнути перенаправлення"
+
+#: packages/admin/src/components/Redirects.tsx:175
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: packages/admin/src/components/MenuEditor.tsx:423
+#: packages/admin/src/components/MenuEditor.tsx:601
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "Введіть URL (https://…) або відносний шлях (/…)"
+
+#: packages/admin/src/components/ContentEditor.tsx:1425
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr "Введіть дійсний URL (наприклад, https://example.com)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1380
+msgid "Enter credentials manually"
+msgstr "Введіть облікові дані вручну"
+
+#: packages/admin/src/components/ContentEditor.tsx:703
+msgid "Enter distraction-free mode"
+msgstr "Увійти в режим без відволікань"
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr "Введіть email"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
+msgid "Enter HTML..."
+msgstr "Введіть HTML..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1199
+msgid "Enter markdown content..."
+msgstr "Введіть вміст markdown..."
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr "Введіть ім'я"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "Введіть код із вашого терміналу"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr "Введіть URL..."
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "Enter your handle to sign in."
+msgstr "Введіть ваш handle для входу."
+
+#: packages/admin/src/components/WordPressImport.tsx:1459
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "Введіть облікові дані WordPress для прямого імпорту вмісту."
+
+#: packages/admin/src/components/WordPressImport.tsx:1082
+msgid "Enter your WordPress site URL"
+msgstr "Введіть URL сайту WordPress"
+
+#: packages/admin/src/components/MenuEditor.tsx:155
+#: packages/admin/src/components/MenuEditor.tsx:193
+#: packages/admin/src/components/MenuEditor.tsx:233
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:752
+#: packages/admin/src/router.tsx:2142
+msgid "Error"
+msgstr "Помилка"
+
+#: packages/admin/src/components/Widgets.tsx:234
+msgid "Error adding widget"
+msgstr "Помилка додавання віджета"
+
+#: packages/admin/src/components/Widgets.tsx:295
+msgid "Error reordering widgets"
+msgstr "Помилка зміни порядку віджетів"
+
+#: packages/admin/src/components/SectionEditor.tsx:51
+msgid "Error saving section"
+msgstr "Помилка збереження секції"
+
+#: packages/admin/src/components/Widgets.tsx:767
+msgid "Error updating widget"
+msgstr "Помилка оновлення віджета"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:583
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr "Усі опубліковані випуски цього плагіна були відкликані або не вдалося їх перевірити. Перевірте пізніше або зверніться до видавця."
+
+#: packages/admin/src/components/WordPressImport.tsx:2010
+msgid "Exists"
+msgstr "Існує"
+
+#: packages/admin/src/components/ContentEditor.tsx:645
+msgid "Exit distraction-free mode"
+msgstr "Вийти з режиму без відволікань"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3627
+msgid "Exit Spotlight Mode"
+msgstr "Вийти з режиму Spotlight"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Expand"
+msgstr "Розгорнути"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Expand details"
+msgstr "Розгорнути деталі"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+msgid "Expires {0}"
+msgstr "Закінчується {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:434
+msgid "Expiry"
+msgstr "Термін дії"
+
+#: packages/admin/src/components/WordPressImport.tsx:1273
+msgid "Export from WordPress manually"
+msgstr "Експорт з WordPress вручну"
+
+#: packages/admin/src/components/WordPressImport.tsx:1397
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "Експортуйте вміст з WordPress, щоб імпортувати все, включно з чернетками."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:118
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr "Невдача"
+
+#: packages/admin/src/components/WordPressImport.tsx:2130
+msgid "Failed"
+msgstr "Не вдалося"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:188
+msgid "Failed security audit"
+msgstr "Не пройшло перевірку безпеки"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:70
+msgid "Failed to add domain"
+msgstr "Не вдалося додати домен"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:188
+msgid "Failed to add passkey"
+msgstr "Не вдалося додати passkey"
+
+#: packages/admin/src/components/WordPressImport.tsx:413
+msgid "Failed to analyze WordPress site"
+msgstr "Не вдалося проаналізувати сайт WordPress"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr "Не вдалося зв'язатися з плагіном"
+
+#: packages/admin/src/lib/api/media.ts:155
+msgid "Failed to confirm upload"
+msgstr "Не вдалося підтвердити завантаження"
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr "Не вдалося створити адміністратора"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:104
+#: packages/admin/src/lib/api/backups.ts:51
+msgid "Failed to create backup"
+msgstr "Не вдалося створити резервну копію"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:933
+msgid "Failed to create byline"
+msgstr "Не вдалося створити підпис"
+
+#: packages/admin/src/lib/api/byline-fields.ts:120
+msgid "Failed to create byline field"
+msgstr "Не вдалося створити поле підпису"
+
+#: packages/admin/src/routes/byline-schema.tsx:102
+msgid "Failed to create field"
+msgstr "Не вдалося створити поле"
+
+#: packages/admin/src/lib/api/sections.ts:88
+msgid "Failed to create section"
+msgstr "Не вдалося створити секцію"
+
+#: packages/admin/src/components/WordPressImport.tsx:1714
+msgid "Failed to create some collections"
+msgstr "Не вдалося створити деякі колекції"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:497
+msgid "Failed to create term"
+msgstr "Не вдалося створити термін"
+
+#: packages/admin/src/router.tsx:1124
+msgid "Failed to create translation"
+msgstr "Не вдалося створити переклад"
+
+#: packages/admin/src/router.tsx:421
+#: packages/admin/src/router.tsx:450
+#: packages/admin/src/router.tsx:533
+#: packages/admin/src/router.tsx:1144
+msgid "Failed to delete"
+msgstr "Не вдалося видалити"
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr "Не вдалося видалити дозволений домен"
+
+#: packages/admin/src/lib/api/backups.ts:58
+msgid "Failed to delete backup"
+msgstr "Не вдалося видалити резервну копію"
+
+#: packages/admin/src/lib/api/bylines.ts:143
+msgid "Failed to delete byline"
+msgstr "Не вдалося видалити підпис"
+
+#: packages/admin/src/lib/api/byline-fields.ts:143
+msgid "Failed to delete byline field"
+msgstr "Не вдалося видалити поле підпису"
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr "Не вдалося видалити колекцію"
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1444
+msgid "Failed to delete comment"
+msgstr "Не вдалося видалити коментар"
+
+#: packages/admin/src/lib/api/content.ts:279
+msgid "Failed to delete content"
+msgstr "Не вдалося видалити вміст"
+
+#: packages/admin/src/lib/api/schema.ts:278
+#: packages/admin/src/routes/byline-schema.tsx:138
+msgid "Failed to delete field"
+msgstr "Не вдалося видалити поле"
+
+#: packages/admin/src/lib/api/media.ts:389
+msgid "Failed to delete from provider"
+msgstr "Не вдалося видалити з провайдера"
+
+#: packages/admin/src/lib/api/media.ts:259
+msgid "Failed to delete media"
+msgstr "Не вдалося видалити медіа"
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr "Не вдалося видалити меню"
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr "Не вдалося видалити пункт меню"
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr "Не вдалося видалити passkey"
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr "Не вдалося видалити перенаправлення"
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr "Не вдалося видалити секцію"
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr "Не вдалося видалити термін"
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr "Не вдалося видалити віджет"
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr "Не вдалося видалити область віджетів"
+
+#: packages/admin/src/components/PluginManager.tsx:116
+#: packages/admin/src/lib/api/plugins.ts:91
+msgid "Failed to disable plugin"
+msgstr "Не вдалося вимкнути плагін"
+
+#: packages/admin/src/lib/api/search.ts:32
+msgid "Failed to disable search"
+msgstr "Не вдалося вимкнути пошук"
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr "Не вдалося вимкнути користувача"
+
+#: packages/admin/src/router.tsx:1051
+msgid "Failed to discard changes"
+msgstr "Не вдалося скасувати зміни"
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr "Не вдалося закрити привітання"
+
+#: packages/admin/src/router.tsx:464
+msgid "Failed to duplicate"
+msgstr "Не вдалося дублювати"
+
+#: packages/admin/src/components/PluginManager.tsx:97
+#: packages/admin/src/lib/api/plugins.ts:77
+msgid "Failed to enable plugin"
+msgstr "Не вдалося увімкнути плагін"
+
+#: packages/admin/src/lib/api/search.ts:31
+msgid "Failed to enable search"
+msgstr "Не вдалося увімкнути пошук"
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr "Не вдалося увімкнути користувача"
+
+#: packages/admin/src/components/WordPressImport.tsx:340
+msgid "Failed to execute import"
+msgstr "Не вдалося виконати імпорт"
+
+#: packages/admin/src/lib/api/client.ts:227
+msgid "Failed to fetch auth mode"
+msgstr "Не вдалося отримати режим автентифікації"
+
+#: packages/admin/src/lib/api/backups.ts:37
+msgid "Failed to fetch backup settings"
+msgstr "Не вдалося отримати налаштування резервного копіювання"
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr "Не вдалося отримати колекцію"
+
+#: packages/admin/src/lib/api/dashboard.ts:42
+msgid "Failed to fetch dashboard stats"
+msgstr "Не вдалося отримати статистику панелі"
+
+#: packages/admin/src/lib/api/email-settings.ts:34
+msgid "Failed to fetch email settings"
+msgstr "Не вдалося отримати налаштування email"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:93
+msgid "Failed to fetch entry terms"
+msgstr "Не вдалося отримати терміни запису"
+
+#: packages/admin/src/lib/api/client.ts:210
+msgid "Failed to fetch manifest"
+msgstr "Не вдалося отримати маніфест"
+
+#: packages/admin/src/lib/api/media.ts:76
+msgid "Failed to fetch media"
+msgstr "Не вдалося отримати медіа"
+
+#: packages/admin/src/lib/api/media.ts:89
+msgid "Failed to fetch media item"
+msgstr "Не вдалося отримати медіа-елемент"
+
+#: packages/admin/src/lib/api/media.ts:325
+msgid "Failed to fetch media providers"
+msgstr "Не вдалося отримати медіа-провайдерів"
+
+#: packages/admin/src/lib/api/plugins.ts:59
+#: packages/admin/src/lib/api/plugins.ts:63
+msgid "Failed to fetch plugin"
+msgstr "Не вдалося отримати плагін"
+
+#: packages/admin/src/lib/api/plugins.ts:45
+msgid "Failed to fetch plugins"
+msgstr "Не вдалося отримати плагіни"
+
+#: packages/admin/src/lib/api/media.ts:355
+msgid "Failed to fetch provider media"
+msgstr "Не вдалося отримати медіа від провайдера"
+
+#: packages/admin/src/lib/api/content.ts:556
+#: packages/admin/src/lib/api/content.ts:561
+msgid "Failed to fetch revision"
+msgstr "Не вдалося отримати ревізію"
+
+#: packages/admin/src/lib/api/sections.ts:76
+msgid "Failed to fetch section"
+msgstr "Не вдалося отримати секцію"
+
+#: packages/admin/src/lib/api/sections.ts:68
+msgid "Failed to fetch sections"
+msgstr "Не вдалося отримати секції"
+
+#: packages/admin/src/lib/api/settings.ts:50
+msgid "Failed to fetch settings"
+msgstr "Не вдалося отримати налаштування"
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr "Не вдалося отримати статус налаштування"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:74
+msgid "Failed to fetch terms"
+msgstr "Не вдалося отримати терміни"
+
+#: packages/admin/src/lib/api/current-user.ts:22
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:851
+#: packages/admin/src/router.tsx:1375
+msgid "Failed to fetch user"
+msgstr "Не вдалося отримати користувача"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:263
+msgid "Failed to generate preview"
+msgstr "Не вдалося згенерувати попередній перегляд"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr "Не вдалося згенерувати URL попереднього перегляду"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr "Не вдалося отримати параметри автентифікації"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr "Не вдалося отримати параметри реєстрації"
+
+#: packages/admin/src/lib/api/media.ts:131
+msgid "Failed to get upload URL"
+msgstr "Не вдалося отримати URL завантаження"
+
+#: packages/admin/src/components/WordPressImport.tsx:436
+msgid "Failed to import from WordPress"
+msgstr "Не вдалося імпортувати з WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:365
+#: packages/admin/src/lib/api/import.ts:422
+msgid "Failed to import media"
+msgstr "Не вдалося імпортувати медіа"
+
+#: packages/admin/src/lib/api/marketplace.ts:160
+#: packages/admin/src/lib/api/registry.ts:692
+msgid "Failed to install plugin"
+msgstr "Не вдалося встановити плагін"
+
+#: packages/admin/src/lib/api/byline-fields.ts:98
+msgid "Failed to list byline fields"
+msgstr "Не вдалося отримати список полів підпису"
+
+#: packages/admin/src/router.tsx:281
+msgid "Failed to load admin"
+msgstr "Не вдалося завантажити адмін-панель"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "Failed to load allowed domains"
+msgstr "Не вдалося завантажити дозволені домени"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:135
+msgid "Failed to load backup settings"
+msgstr "Не вдалося завантажити налаштування резервного копіювання"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:366
+msgid "Failed to load bylines: {0}"
+msgstr "Не вдалося завантажити підписи: {0}"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:81
+msgid "Failed to load email settings"
+msgstr "Не вдалося завантажити налаштування email"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:421
+msgid "Failed to load image"
+msgstr "Не вдалося завантажити зображення"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:135
+msgid "Failed to load passkeys"
+msgstr "Не вдалося завантажити passkey"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:110
+msgid "Failed to load plugin"
+msgstr "Не вдалося завантажити плагін"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:145
+msgid "Failed to load plugins: {0}"
+msgstr "Не вдалося завантажити плагіни: {0}"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:95
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr "Не вдалося завантажити плагіни. Агрегатор реєстру може бути недоступним."
+
+#: packages/admin/src/components/RevisionHistory.tsx:188
+msgid "Failed to load revisions"
+msgstr "Не вдалося завантажити ревізії"
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr "Не вдалося завантажити налаштування"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr "Не вдалося завантажити тему"
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr "Не вдалося завантажити користувачів: {0}"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr "Не вдалося завантажити віджет"
+
+#: packages/admin/src/router.tsx:1469
+msgid "Failed to perform bulk action"
+msgstr "Не вдалося виконати масову дію"
+
+#: packages/admin/src/lib/api/content.ts:322
+msgid "Failed to permanently delete content"
+msgstr "Не вдалося остаточно видалити вміст"
+
+#: packages/admin/src/components/WordPressImport.tsx:321
+msgid "Failed to prepare import"
+msgstr "Не вдалося підготувати імпорт"
+
+#: packages/admin/src/router.tsx:489
+#: packages/admin/src/router.tsx:1012
+msgid "Failed to publish"
+msgstr "Не вдалося опублікувати"
+
+#: packages/admin/src/lib/api/byline-fields.ts:106
+msgid "Failed to read byline field usage"
+msgstr "Не вдалося прочитати використання поля підпису"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:112
+msgid "Failed to remove domain"
+msgstr "Не вдалося видалити домен"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:70
+msgid "Failed to remove passkey"
+msgstr "Не вдалося видалити passkey"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:53
+msgid "Failed to rename passkey"
+msgstr "Не вдалося перейменувати passkey"
+
+#: packages/admin/src/lib/api/byline-fields.ts:156
+msgid "Failed to reorder byline fields"
+msgstr "Не вдалося змінити порядок полів підпису"
+
+#: packages/admin/src/lib/api/schema.ts:293
+#: packages/admin/src/routes/byline-schema.tsx:152
+msgid "Failed to reorder fields"
+msgstr "Не вдалося змінити порядок полів"
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr "Не вдалося змінити порядок віджетів"
+
+#: packages/admin/src/router.tsx:436
+msgid "Failed to restore"
+msgstr "Не вдалося відновити"
+
+#: packages/admin/src/lib/api/content.ts:311
+msgid "Failed to restore content"
+msgstr "Не вдалося відновити вміст"
+
+#: packages/admin/src/lib/api/content.ts:578
+#: packages/admin/src/lib/api/content.ts:583
+msgid "Failed to restore revision"
+msgstr "Не вдалося відновити ревізію"
+
+#: packages/admin/src/lib/api/api-tokens.ts:98
+msgid "Failed to revoke API token"
+msgstr "Не вдалося відкликати API-токен"
+
+#: packages/admin/src/components/WordPressImport.tsx:378
+msgid "Failed to rewrite URLs"
+msgstr "Не вдалося переписати URL"
+
+#: packages/admin/src/router.tsx:941
+#: packages/admin/src/router.tsx:1958
+msgid "Failed to save"
+msgstr "Не вдалося зберегти"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:84
+msgid "Failed to save backup settings"
+msgstr "Не вдалося зберегти налаштування резервного копіювання"
+
+#: packages/admin/src/routes/byline-schema.tsx:122
+msgid "Failed to save field"
+msgstr "Не вдалося зберегти поле"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:50
+#: packages/admin/src/components/settings/SeoSettings.tsx:44
+#: packages/admin/src/components/settings/SocialSettings.tsx:42
+msgid "Failed to save settings"
+msgstr "Не вдалося зберегти налаштування"
+
+#: packages/admin/src/router.tsx:1072
+msgid "Failed to schedule"
+msgstr "Не вдалося запланувати"
+
+#: packages/admin/src/components/LoginPage.tsx:70
+#: packages/admin/src/components/LoginPage.tsx:75
+msgid "Failed to send magic link"
+msgstr "Не вдалося надіслати magic link"
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr "Не вдалося надіслати посилання для відновлення"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:50
+#: packages/admin/src/lib/api/email-settings.ts:45
+msgid "Failed to send test email"
+msgstr "Не вдалося надіслати тестовий email"
+
+#: packages/admin/src/components/SignupPage.tsx:349
+msgid "Failed to send verification email"
+msgstr "Не вдалося надіслати email для підтвердження"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:116
+msgid "Failed to set entry terms"
+msgstr "Не вдалося встановити терміни запису"
+
+#: packages/admin/src/lib/api/marketplace.ts:192
+#: packages/admin/src/lib/api/registry.ts:831
+msgid "Failed to uninstall plugin"
+msgstr "Не вдалося видалити плагін"
+
+#: packages/admin/src/router.tsx:1030
+msgid "Failed to unpublish"
+msgstr "Не вдалося зняти з публікації"
+
+#: packages/admin/src/router.tsx:1093
+msgid "Failed to unschedule"
+msgstr "Не вдалося скасувати планування"
+
+#: packages/admin/src/router.tsx:512
+msgid "Failed to update"
+msgstr "Не вдалося оновити"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:351
+msgid "Failed to update {0}"
+msgstr "Не вдалося оновити {0}"
+
+#: packages/admin/src/lib/api/backups.ts:46
+msgid "Failed to update backup settings"
+msgstr "Не вдалося оновити налаштування резервного копіювання"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:983
+msgid "Failed to update byline"
+msgstr "Не вдалося оновити підпис"
+
+#: packages/admin/src/lib/api/byline-fields.ts:135
+msgid "Failed to update byline field"
+msgstr "Не вдалося оновити поле підпису"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:94
+msgid "Failed to update domain"
+msgstr "Не вдалося оновити домен"
+
+#: packages/admin/src/lib/api/media.ts:276
+msgid "Failed to update media"
+msgstr "Не вдалося оновити медіа"
+
+#: packages/admin/src/lib/api/marketplace.ts:176
+#: packages/admin/src/lib/api/registry.ts:763
+msgid "Failed to update plugin"
+msgstr "Не вдалося оновити плагін"
+
+#: packages/admin/src/lib/api/sections.ts:100
+msgid "Failed to update section"
+msgstr "Не вдалося оновити секцію"
+
+#: packages/admin/src/lib/api/settings.ts:64
+msgid "Failed to update settings"
+msgstr "Не вдалося оновити налаштування"
+
+#: packages/admin/src/router.tsx:1428
+msgid "Failed to update status"
+msgstr "Не вдалося оновити статус"
+
+#: packages/admin/src/lib/api/media.ts:173
+msgid "Failed to upload file"
+msgstr "Не вдалося завантажити файл"
+
+#: packages/admin/src/lib/api/media.ts:218
+msgid "Failed to upload media"
+msgstr "Не вдалося завантажити медіа"
+
+#: packages/admin/src/lib/api/media.ts:377
+msgid "Failed to upload to provider"
+msgstr "Не вдалося завантажити до провайдера"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:248
+msgid "Failed to verify authentication"
+msgstr "Не вдалося підтвердити автентифікацію"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr "Не вдалося підтвердити реєстрацію"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:792
+msgid "FAQ"
+msgstr "FAQ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:213
+#: packages/admin/src/components/settings/GeneralSettings.tsx:219
+msgid "Favicon"
+msgstr "Favicon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1180
+msgid "Feature"
+msgstr "Функція"
+
+#: packages/admin/src/components/WordPressImport.tsx:1148
+msgid "Featured Images"
+msgstr "Головні зображення"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:440
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr "Функції"
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "Отримання вмісту з EmDash Exporter API."
+
+#: packages/admin/src/routes/byline-schema.tsx:95
+msgid "Field created"
+msgstr "Поле створено"
+
+#: packages/admin/src/routes/byline-schema.tsx:133
+msgid "Field deleted"
+msgstr "Поле видалено"
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr "Мітка поля"
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr "Мітка поля"
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr "Slug поля не можна змінити після створення"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:268
+msgid "Field type cannot be changed after creation."
+msgstr "Тип поля не можна змінити після створення."
+
+#: packages/admin/src/routes/byline-schema.tsx:115
+msgid "Field updated"
+msgstr "Поле оновлено"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:581
+msgid "Fields"
+msgstr "Поля"
+
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Fields created:"
+msgstr "Створено полів:"
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr "Файл"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2158
+msgid "File {0}"
+msgstr "Файл {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr "Файл з медіатеки"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:325
+#: packages/admin/src/components/MediaDetailPanel.tsx:342
+#: packages/admin/src/components/MediaLibrary.tsx:586
+msgid "Filename"
+msgstr "Ім'я файлу"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:120
+msgid "Filename cannot be changed after upload"
+msgstr "Ім'я файлу не можна змінити після завантаження"
+
+#: packages/admin/src/components/WordPressImport.tsx:2366
+msgid "files imported"
+msgstr "файлів імпортовано"
+
+#: packages/admin/src/components/ContentList.tsx:769
+msgid "Filter by author"
+msgstr "Фільтр за автором"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr "Фільтр за можливістю"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:177
+msgid "Filter by collection"
+msgstr "Фільтр за колекцією"
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr "Фільтр за роллю"
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr "Фільтр за джерелом"
+
+#: packages/admin/src/components/ContentList.tsx:754
+#: packages/admin/src/components/Redirects.tsx:419
+msgid "Filter by status"
+msgstr "Фільтр за статусом"
+
+#: packages/admin/src/components/MediaLibrary.tsx:439
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "Filter by type"
+msgstr "Фільтр за типом"
+
+#: packages/admin/src/routes/bylines.tsx:409
+msgid "Filter byline type"
+msgstr "Фільтр за типом підпису"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr "Лише нові коментатори"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr "Шрифти"
+
+#: packages/admin/src/components/WordPressImport.tsx:1398
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "Для повного імпорту, включно з чернетками та всім вмістом, експортуйте з WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1207
+msgid "For the best import experience, install the"
+msgstr "Для найкращого досвіду імпорту встановіть"
+
+#: packages/admin/src/components/ContentList.tsx:806
+msgid "From date"
+msgstr "З дати"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
+#: packages/admin/src/components/WordPressImport.tsx:1155
+msgid "Full"
+msgstr "Повний"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "Повний доступ"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Full admin access"
+msgstr "Повний доступ адміністратора"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "General"
+msgstr "Загальні"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:96
+#: packages/admin/src/components/settings/GeneralSettings.tsx:124
+msgid "General Settings"
+msgstr "Загальні налаштування"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "Genres"
+msgstr "Жанри"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "Почати"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:112
+msgid "GitHub"
+msgstr "GitHub"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "Дайте цьому passkey ім'я, щоб легше його розпізнати пізніше."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:36
+msgid "Go"
+msgstr "Перейти"
+
+#: packages/admin/src/components/WordPressImport.tsx:2418
+#: packages/admin/src/router.tsx:2162
+msgid "Go to Dashboard"
+msgstr "Перейти до панелі"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:194
+msgid "Google Verification"
+msgstr "Перевірка Google"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:37
+msgid "GraphQL"
+msgstr "GraphQL"
+
+#: packages/admin/src/components/MediaLibrary.tsx:460
+msgid "Grid view"
+msgstr "Сітка"
+
+#: packages/admin/src/components/Redirects.tsx:166
+msgid "Group (optional)"
+msgstr "Група (необов'язково)"
+
+#: packages/admin/src/components/Widgets.tsx:160
+msgid "Group by"
+msgstr "Групувати за"
+
+#: packages/admin/src/routes/bylines.tsx:556
+msgid "Guest byline"
+msgstr "Гостьовий підпис"
+
+#: packages/admin/src/routes/bylines.tsx:414
+msgid "Guest only"
+msgstr "Лише гості"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:62
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
+#: packages/admin/src/components/PortableTextEditor.tsx:1026
+msgid "Heading 1"
+msgstr "Заголовок 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:70
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:33
+#: packages/admin/src/components/PortableTextEditor.tsx:1036
+msgid "Heading 2"
+msgstr "Заголовок 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:78
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:34
+#: packages/admin/src/components/PortableTextEditor.tsx:1046
+msgid "Heading 3"
+msgstr "Заголовок 3"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
+msgid "Heading 4"
+msgstr "Заголовок 4"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
+msgid "Heading 5"
+msgstr "Заголовок 5"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
+msgid "Heading 6"
+msgstr "Заголовок 6"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:154
+msgid "Headings"
+msgstr "Заголовки"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
+msgid "Height"
+msgstr "Висота"
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr "Головний банер"
+
+#: packages/admin/src/components/SectionEditor.tsx:273
+msgid "hero, banner, cta"
+msgstr "hero, banner, cta"
+
+#: packages/admin/src/components/SeoPanel.tsx:230
+#: packages/admin/src/components/SeoPanel.tsx:233
+msgid "Hide from search engines"
+msgstr "Приховати від пошукових систем"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Hide token"
+msgstr "Приховати токен"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:649
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "Ієрархічна (як категорії, з батьківсько-дочірніми зв'язками)"
+
+#: packages/admin/src/components/Redirects.tsx:225
+#: packages/admin/src/components/Redirects.tsx:470
+msgid "Hits"
+msgstr "Переходи"
+
+#: packages/admin/src/components/MenuEditor.tsx:416
+msgid "Home"
+msgstr "Головна"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr "Домашня сторінка"
+
+#: packages/admin/src/components/PluginManager.tsx:385
+msgid "Hooks"
+msgstr "Хуки"
+
+#: packages/admin/src/components/WordPressImport.tsx:1520
+msgid "How to create an Application Password"
+msgstr "Як створити пароль додатку"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:38
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
+#: packages/admin/src/components/PortableTextEditor.tsx:1096
+msgid "HTML"
+msgstr "HTML"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
+msgid "HTML source"
+msgstr "HTML-код"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3048
+#: packages/admin/src/components/PortableTextEditor.tsx:3557
+msgid "https://..."
+msgstr "https://..."
+
+#: packages/admin/src/components/MenuEditor.tsx:424
+msgid "https://example.com or /about"
+msgstr "https://example.com або /about"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:507
+msgid "https://example.com/image.jpg"
+msgstr "https://example.com/image.jpg"
+
+#: packages/admin/src/components/WordPressImport.tsx:1089
+msgid "https://yoursite.com"
+msgstr "https://yoursite.com"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:142
+msgid "Icon blurred due to image audit"
+msgstr "Іконку розмито через перевірку зображення"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:103
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "Якщо обліковий запис для <0>{email}</0> існує, ми надіслали посилання для входу."
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/FieldEditor.tsx:587
+#: packages/admin/src/components/PortableTextEditor.tsx:2307
+msgid "Image"
+msgstr "Зображення"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr "Зображення з медіатеки"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ImageFieldRenderer.tsx:113
+msgid "Image not found"
+msgstr "Зображення не знайдено"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:208
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Image settings"
+msgstr "Налаштування зображення"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
+msgid "Image Settings"
+msgstr "Налаштування зображення"
+
+#: packages/admin/src/components/SeoImageField.tsx:43
+msgid "Image shown when this page is shared on social media"
+msgstr "Зображення, що показується при поширенні цієї сторінки в соцмережах"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:508
+msgid "Image URL"
+msgstr "URL зображення"
+
+#: packages/admin/src/components/WordPressImport.tsx:2370
+msgid "image URLs updated in"
+msgstr "URL зображень оновлено в"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+#: packages/admin/src/components/MediaLibrary.tsx:434
+msgid "Images"
+msgstr "Зображення"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:378
+#: packages/admin/src/components/WordPressImport.tsx:738
+msgid "Import"
+msgstr "Імпорт"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "Import {0}"
+msgstr "Імпорт {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1366
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "Імпортуйте весь вміст безпосередньо, включно з чернетками, користувацькими типами записів, полями ACF та SEO-даними. Завантаження файлу не потрібне."
+
+#: packages/admin/src/components/WordPressImport.tsx:2416
+msgid "Import Another File"
+msgstr "Імпортувати інший файл"
+
+#: packages/admin/src/components/WordPressImport.tsx:1174
+msgid "Import Capabilities"
+msgstr "Можливості імпорту"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Import Complete"
+msgstr "Імпорт завершено"
+
+#: packages/admin/src/components/WordPressImport.tsx:2305
+msgid "Import Completed with Errors"
+msgstr "Імпорт завершено з помилками"
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Import failed"
+msgstr "Імпорт не вдався"
+
+#: packages/admin/src/components/WordPressImport.tsx:691
+msgid "Import from WordPress"
+msgstr "Імпорт з WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "Import Media"
+msgstr "Імпорт медіа"
+
+#: packages/admin/src/components/WordPressImport.tsx:2060
+msgid "Import Media Files"
+msgstr "Імпорт медіафайлів"
+
+#: packages/admin/src/components/WordPressImport.tsx:693
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "Імпорт записів, сторінок і користувацьких типів записів з WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1814
+msgid "Import site configuration from WordPress."
+msgstr "Імпорт конфігурації сайту з WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Import via EmDash Exporter"
+msgstr "Імпорт через EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr "Імпортовано"
+
+#: packages/admin/src/components/WordPressImport.tsx:2344
+msgid "Imported by Collection"
+msgstr "Імпортовано за колекціями"
+
+#. placeholder {0}: wpImportProgress.comments
+#: packages/admin/src/components/WordPressImport.tsx:903
+msgid "Importing comments... {0}"
+msgstr "Імпорт коментарів... {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:920
+msgid "Importing content..."
+msgstr "Імпорт вмісту..."
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:901
+msgid "Importing content... {0}"
+msgstr "Імпорт вмісту... {0}"
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:900
+msgid "Importing content... {0} of {totalSelectedPosts}"
+msgstr "Імпорт вмісту... {0} з {totalSelectedPosts}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Importing Media"
+msgstr "Імпорт медіа"
+
+#: packages/admin/src/components/WordPressImport.tsx:904
+msgid "Importing menus and site settings..."
+msgstr "Імпорт меню та налаштувань сайту..."
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr "Включити зразковий вміст (рекомендовано для нових сайтів)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1980
+msgid "Incompatible"
+msgstr "Несумісний"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:493
+msgid "Indexed"
+msgstr "Проіндексовано"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3447
+msgid "Inline Code"
+msgstr "Вбудований код"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:519
+#: packages/admin/src/components/MediaPickerModal.tsx:746
+msgid "Insert"
+msgstr "Вставити"
+
+#. placeholder {0}: block?.label || ""
+#: packages/admin/src/components/PortableTextEditor.tsx:1527
+msgid "Insert {0}"
+msgstr "Вставити {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1077
+msgid "Insert a blockquote"
+msgstr "Вставити цитату"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1087
+msgid "Insert a code block"
+msgstr "Вставити блок коду"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1112
+msgid "Insert a horizontal rule"
+msgstr "Вставити горизонтальну лінію"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2323
+msgid "Insert a reusable section"
+msgstr "Вставити багаторазову секцію"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1122
+msgid "Insert a table"
+msgstr "Вставити таблицю"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2308
+msgid "Insert an image"
+msgstr "Вставити зображення"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1356
+msgid "Insert block"
+msgstr "Вставити блок"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3411
+msgid "Insert block after current block"
+msgstr "Вставити блок після поточного"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
+msgid "Insert block below"
+msgstr "Вставити блок нижче"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:501
+msgid "Insert from URL"
+msgstr "Вставити з URL"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3543
+msgid "Insert Link"
+msgstr "Вставити посилання"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1097
+msgid "Insert raw HTML"
+msgstr "Вставити HTML-код"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr "Вставити секцію"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:192
+#: packages/admin/src/components/RegistryPluginDetail.tsx:541
+msgid "Install"
+msgstr "Встановити"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:155
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "Встановіть і активуйте плагін email-провайдера, щоб увімкнути функції email: запрошення, magic links та відновлення пароля."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:186
+msgid "Install blocked"
+msgstr "Встановлення заблоковано"
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
+msgstr "Встановіть плагін EmDash Exporter на сайті WordPress і згенеруйте ключ у розділі Інструменти → EmDash Migration."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:791
+msgid "Installation"
+msgstr "Встановлення"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:173
+#: packages/admin/src/components/RegistryBrowse.tsx:198
+#: packages/admin/src/components/RegistryPluginDetail.tsx:533
+msgid "Installed"
+msgstr "Встановлено"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:500
+msgid "Installed from marketplace (v{0})"
+msgstr "Встановлено з маркетплейсу (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:519
+msgid "Installed:"
+msgstr "Встановлено:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:169
+msgid "Installing..."
+msgstr "Встановлення..."
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr "Ціле число"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:151
+msgid "Invalid invite link"
+msgstr "Недійсне посилання запрошення"
+
+#: packages/admin/src/components/ContentEditor.tsx:1494
+msgid "Invalid JSON"
+msgstr "Недійсний JSON"
+
+#: packages/admin/src/components/SignupPage.tsx:259
+msgid "Invalid link"
+msgstr "Недійсне посилання"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:239
+msgid "Invite Error"
+msgstr "Помилка запрошення"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:149
+msgid "Invite expired"
+msgstr "Запрошення прострочено"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "Посилання запрошення створено"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr "Запросити користувача"
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr "Запросіть першого учасника команди"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3092
+#: packages/admin/src/components/PortableTextEditor.tsx:3426
+msgid "Italic"
+msgstr "Курсив"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1908
+#: packages/admin/src/components/RepeaterField.tsx:239
+msgid "Item {0}"
+msgstr "Елемент {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Item added"
+msgstr "Елемент додано"
+
+#: packages/admin/src/components/MenuEditor.tsx:187
+msgid "Item deleted"
+msgstr "Елемент видалено"
+
+#: packages/admin/src/components/MenuEditor.tsx:212
+msgid "Item updated"
+msgstr "Елемент оновлено"
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:205
+msgid "Jane Doe"
+msgstr "Олена Коваленко"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:39
+msgid "Java"
+msgstr "Java"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:40
+msgid "JavaScript"
+msgstr "JavaScript"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:235
+msgid "Job title"
+msgstr "Посада"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:246
+msgid "job_title"
+msgstr "job_title"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:41
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr "JSON"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:42
+msgid "JSX"
+msgstr "JSX"
+
+#: packages/admin/src/components/WordPressImport.tsx:916
+msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
+msgstr "Тримайте цю вкладку відкритою. Імпорт виконується невеликими кроками і його можна безпечно перезапустити при перериванні."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:812
+msgid "Keep typing to narrow down more bylines."
+msgstr "Продовжуйте вводити, щоб звузити список підписів."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:293
+#: packages/admin/src/components/SectionEditor.tsx:270
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr "Ключові слова"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:43
+msgid "Kotlin"
+msgstr "Kotlin"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:232
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:416
+#: packages/admin/src/components/MenuEditor.tsx:593
+#: packages/admin/src/components/MenuList.tsx:166
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+#: packages/admin/src/components/Widgets.tsx:431
+#: packages/admin/src/routes/byline-schema.tsx:234
+msgid "Label"
+msgstr "Мітка"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:392
+msgid "Label (Plural)"
+msgstr "Мітка (множина)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:384
+msgid "Label (Singular)"
+msgstr "Мітка (однина)"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:162
+#: packages/admin/src/components/LoginPage.tsx:345
+#: packages/admin/src/components/Settings.tsx:136
+#: packages/admin/src/components/Settings.tsx:141
+msgid "Language"
+msgstr "Мова"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1027
+msgid "Large section heading"
+msgstr "Великий заголовок секції"
+
+#: packages/admin/src/components/PluginManager.tsx:525
+msgid "Last enabled:"
+msgstr "Останнє увімкнення:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr "Останній вхід"
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr "Останній вхід"
+
+#: packages/admin/src/components/Redirects.tsx:226
+msgid "Last seen"
+msgstr "Остання активність"
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr "Останнє оновлення"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:159
+msgid "Last used"
+msgstr "Останнє використання"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr "Останнє використання {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:274
+msgid "Learn more"
+msgstr "Дізнатися більше"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:339
+msgid "Leave blank to use a discoverable passkey."
+msgstr "Залиште порожнім, щоб використати discoverable passkey."
+
+#: packages/admin/src/components/WordPressImport.tsx:2497
+msgid "Leave unassigned"
+msgstr "Залишити без призначення"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
+msgid "Left"
+msgstr "Ліворуч"
+
+#: packages/admin/src/components/MediaLibrary.tsx:136
+#: packages/admin/src/components/MediaLibrary.tsx:273
+#: packages/admin/src/components/MediaLibrary.tsx:356
+#: packages/admin/src/components/MediaPickerModal.tsx:202
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Library"
+msgstr "Бібліотека"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr "Ліцензія"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "світла"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "Світла"
+
+#: packages/admin/src/components/Widgets.tsx:163
+msgid "Limit"
+msgstr "Ліміт"
+
+#: packages/admin/src/components/SignupPage.tsx:257
+msgid "Link expired"
+msgstr "Посилання прострочено"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr "Посилання на інший елемент вмісту"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr "Пов'язані облікові записи ({0})"
+
+#: packages/admin/src/routes/bylines.tsx:415
+msgid "Linked only"
+msgstr "Лише пов'язані"
+
+#: packages/admin/src/routes/bylines.tsx:507
+msgid "Linked user"
+msgstr "Пов'язаний користувач"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:130
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr "Посилання"
+
+#: packages/admin/src/components/MediaLibrary.tsx:469
+msgid "List view"
+msgstr "Список"
+
+#: packages/admin/src/components/ContentEditor.tsx:685
+#: packages/admin/src/components/ContentEditor.tsx:732
+#: packages/admin/src/components/ContentSettingsPanel.tsx:234
+msgid "Live View"
+msgstr "Перегляд наживо"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:469
+msgid "Load more"
+msgstr "Завантажити ще"
+
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:722
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr "Завантажити ще"
+
+#: packages/admin/src/routes/byline-schema.tsx:257
+msgid "Loading byline fields…"
+msgstr "Завантаження полів підпису…"
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr "Завантаження колекцій..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:307
+msgid "Loading comments..."
+msgstr "Завантаження коментарів..."
+
+#: packages/admin/src/router.tsx:2131
+msgid "Loading configuration..."
+msgstr "Завантаження конфігурації..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr "Завантаження вмісту..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2856
+msgid "Loading editor..."
+msgstr "Завантаження редактора..."
+
+#: packages/admin/src/components/MenuEditor.tsx:342
+msgid "Loading menu..."
+msgstr "Завантаження меню..."
+
+#: packages/admin/src/components/MenuList.tsx:94
+msgid "Loading menus..."
+msgstr "Завантаження меню..."
+
+#: packages/admin/src/components/PluginManager.tsx:136
+msgid "Loading plugins..."
+msgstr "Завантаження плагінів..."
+
+#: packages/admin/src/components/Redirects.tsx:456
+msgid "Loading redirects..."
+msgstr "Завантаження перенаправлень..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr "Завантаження секцій..."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:99
+#: packages/admin/src/components/settings/SeoSettings.tsx:93
+#: packages/admin/src/components/settings/SocialSettings.tsx:73
+msgid "Loading settings..."
+msgstr "Завантаження налаштувань..."
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr "Завантаження налаштування..."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:827
+msgid "Loading terms..."
+msgstr "Завантаження термінів..."
+
+#: packages/admin/src/components/Widgets.tsx:370
+msgid "Loading widgets..."
+msgstr "Завантаження віджетів..."
+
+#: packages/admin/src/components/ContentList.tsx:538
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:659
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:722
+#: packages/admin/src/components/PortableTextEditor.tsx:2035
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:161
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/TaxonomyManager.tsx:779
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:469
+msgid "Loading..."
+msgstr "Завантаження..."
+
+#: packages/admin/src/components/ContentList.tsx:518
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "Локаль"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Lock aspect ratio"
+msgstr "Заблокувати співвідношення сторін"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:291
+msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
+msgstr "Заблоковано, оскільки це поле має збережені значення. Видаліть значення (або поле), щоб змінити це."
+
+#: packages/admin/src/components/Header.tsx:109
+msgid "Log out"
+msgstr "Вийти"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "Logo"
+msgstr "Логотип"
+
+#: packages/admin/src/components/WordPressImport.tsx:1832
+msgid "Logo & favicon"
+msgstr "Логотип і favicon"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:53
+msgid "Long text"
+msgstr "Довгий текст"
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr "Довгий текст"
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "Лише малі літери, цифри та дефіси"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:641
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "Лише малі літери, цифри та підкреслення, починаючи з літери"
+
+#: packages/admin/src/components/Widgets.tsx:431
+msgid "Main Sidebar"
+msgstr "Головна бічна панель"
+
+#: packages/admin/src/lib/api/marketplace.ts:228
+#: packages/admin/src/lib/api/marketplace.ts:236
+msgid "Make network requests"
+msgstr "Виконувати мережеві запити"
+
+#: packages/admin/src/lib/api/marketplace.ts:229
+#: packages/admin/src/lib/api/marketplace.ts:237
+msgid "Make network requests to any host (unrestricted)"
+msgstr "Виконувати мережеві запити до будь-якого хоста (без обмежень)"
+
+#: packages/admin/src/components/Sidebar.tsx:461
+msgid "Manage"
+msgstr "Керувати"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:798
+msgid "Manage {0} for {1}"
+msgstr "Керувати {0} для {1}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:774
+msgid "Manage bylines in {entryLocale}"
+msgstr "Керувати підписами в {entryLocale}"
+
+#: packages/admin/src/components/Widgets.tsx:386
+msgid "Manage content widgets in your widget areas"
+msgstr "Керувати віджетами вмісту в областях віджетів"
+
+#: packages/admin/src/components/PluginManager.tsx:175
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "Керуйте встановленими плагінами. Увімкніть або вимкніть плагіни для керування їх функціональністю."
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Manage navigation menus for your site"
+msgstr "Керуйте навігаційними меню вашого сайту"
+
+#: packages/admin/src/components/Redirects.tsx:359
+msgid "Manage URL redirects and view 404 errors."
+msgstr "Керуйте URL-перенаправленнями та переглядайте помилки 404."
+
+#: packages/admin/src/components/Settings.tsx:94
+msgid "Manage your passkeys and authentication"
+msgstr "Керуйте passkey та автентифікацією"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:317
+msgid "Managed by {providerName}"
+msgstr "Керується {providerName}"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:318
+msgid "Managed by an external media provider"
+msgstr "Керується зовнішнім медіа-провайдером"
+
+#: packages/admin/src/components/Redirects.tsx:424
+msgid "Manual"
+msgstr "Вручну"
+
+#: packages/admin/src/components/WordPressImport.tsx:2454
+msgid "Map Authors"
+msgstr "Зіставити авторів"
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2502
+msgid "Map WordPress user {0} to EmDash user"
+msgstr "Зіставити користувача WordPress {0} з користувачем EmDash"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:255
+msgid "Mark {0} as Gone (410)"
+msgstr "Позначити {0} як видалено (410)"
+
+#: packages/admin/src/components/Redirects.tsx:254
+msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
+msgstr "Позначити як видалено (410) — повідомляє пошуковим системам, що сторінку остаточно видалено"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:501
+msgid "Mark as spam"
+msgstr "Позначити як спам"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:44
+msgid "Markdown"
+msgstr "Markdown"
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "marketplace"
+msgstr "маркетплейс"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:167
+#: packages/admin/src/components/PluginManager.tsx:355
+#: packages/admin/src/components/Sidebar.tsx:362
+msgid "Marketplace"
+msgstr "Маркетплейс"
+
+#: packages/admin/src/components/FieldEditor.tsx:627
+msgid "Max Items"
+msgstr "Макс. елементів"
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr "Макс. довжина"
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr "Макс. значення"
+
+#: packages/admin/src/components/Widgets.tsx:145
+msgid "Maximum tags"
+msgstr "Максимум тегів"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:45
+msgid "MDX"
+msgstr "MDX"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2311
+#: packages/admin/src/components/Sidebar.tsx:321
+#: packages/admin/src/components/WordPressImport.tsx:752
+#: packages/admin/src/components/WordPressImport.tsx:1145
+#: packages/admin/src/components/WordPressImport.tsx:1334
+msgid "Media"
+msgstr "Медіа"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:222
+msgid "Media Details"
+msgstr "Деталі медіа"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2400
+msgid "Media Errors ({0})"
+msgstr "Помилки медіа ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Media Import"
+msgstr "Імпорт медіа"
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Media Import Complete"
+msgstr "Імпорт медіа завершено"
+
+#: packages/admin/src/components/WordPressImport.tsx:2314
+msgid "Media import was skipped"
+msgstr "Імпорт медіа пропущено"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:322
+msgid "Media Library"
+msgstr "Медіатека"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Media Read"
+msgstr "Читання медіа"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Media Write"
+msgstr "Запис медіа"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1037
+msgid "Medium section heading"
+msgstr "Середній заголовок секції"
+
+#: packages/admin/src/components/Widgets.tsx:102
+#: packages/admin/src/components/Widgets.tsx:897
+msgid "Menu"
+msgstr "Меню"
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:144
+msgid "Menu \"{0}\" ({1}) created."
+msgstr "Меню \"{0}\" ({1}) створено."
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu \"{0}\" has been created."
+msgstr "Меню \"{0}\" створено."
+
+#: packages/admin/src/components/MenuList.tsx:54
+msgid "Menu created"
+msgstr "Меню створено"
+
+#: packages/admin/src/components/MenuList.tsx:74
+msgid "Menu deleted"
+msgstr "Меню видалено"
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Menu item has been added."
+msgstr "Пункт меню додано."
+
+#: packages/admin/src/components/MenuEditor.tsx:188
+msgid "Menu item has been deleted."
+msgstr "Пункт меню видалено."
+
+#: packages/admin/src/components/MenuEditor.tsx:213
+msgid "Menu item has been updated."
+msgstr "Пункт меню оновлено."
+
+#: packages/admin/src/components/MenuEditor.tsx:350
+msgid "Menu not found"
+msgstr "Меню не знайдено"
+
+#: packages/admin/src/components/MenuEditor.tsx:228
+msgid "Menu order has been updated."
+msgstr "Порядок меню оновлено."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:103
+#: packages/admin/src/components/Sidebar.tsx:331
+#: packages/admin/src/components/WordPressImport.tsx:1149
+msgid "Menus"
+msgstr "Меню"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1767
+msgid "Menus ({0})"
+msgstr "Меню ({0})"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Menus Manage"
+msgstr "Керування меню"
+
+#: packages/admin/src/components/SeoPanel.tsx:188
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Meta Description"
+msgstr "Метаопис"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:203
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "Вміст meta-тегу для перевірки Bing Webmaster Tools"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:197
+msgid "Meta tag content for Google Search Console verification"
+msgstr "Вміст meta-тегу для перевірки Google Search Console"
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "Meta titles, descriptions, and social images"
+msgstr "Мета-заголовки, описи та зображення для соцмереж"
+
+#: packages/admin/src/components/WordPressImport.tsx:1051
+msgid "Migration key"
+msgstr "Ключ міграції"
+
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Min Items"
+msgstr "Мін. елементів"
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr "Мін. довжина"
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr "Мін. значення"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:504
+msgid "Moderation"
+msgstr "Модерація"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "Сигнали модерації"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr "Змінено"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Modify collection schemas"
+msgstr "Змінювати схеми колекцій"
+
+#: packages/admin/src/components/Widgets.tsx:161
+msgid "Monthly"
+msgstr "Щомісяця"
+
+#: packages/admin/src/components/Widgets.tsx:157
+msgid "Monthly/yearly archives"
+msgstr "Щомісячні/річні архіви"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr "Найпопулярніші"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:439
+msgid "Move \"{0}\" down"
+msgstr "Перемістити \"{0}\" вниз"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:429
+msgid "Move \"{0}\" up"
+msgstr "Перемістити \"{0}\" вгору"
+
+#: packages/admin/src/components/ContentList.tsx:1046
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "Перемістити \"{title}\" до кошика? Пізніше можна відновити."
+
+#: packages/admin/src/components/ContentList.tsx:1037
+msgid "Move {title} to trash"
+msgstr "Перемістити {title} у кошик"
+
+#: packages/admin/src/components/MenuEditor.tsx:537
+msgid "Move down"
+msgstr "Перемістити вниз"
+
+#: packages/admin/src/components/ContentList.tsx:439
+msgid "Move to trash"
+msgstr "Перемістити в кошик"
+
+#: packages/admin/src/components/ContentList.tsx:466
+#: packages/admin/src/components/ContentList.tsx:1059
+#: packages/admin/src/components/ContentSettingsPanel.tsx:599
+#: packages/admin/src/components/ContentSettingsPanel.tsx:619
+msgid "Move to Trash"
+msgstr "Перемістити в кошик"
+
+#: packages/admin/src/components/ContentList.tsx:444
+#: packages/admin/src/components/ContentList.tsx:1044
+#: packages/admin/src/components/ContentSettingsPanel.tsx:604
+msgid "Move to Trash?"
+msgstr "Перемістити в кошик?"
+
+#: packages/admin/src/components/MenuEditor.tsx:528
+msgid "Move up"
+msgstr "Перемістити вгору"
+
+#: packages/admin/src/router.tsx:509
+msgid "Moved {total} items to draft"
+msgstr "Переміщено {total} елементів у чернетки"
+
+#: packages/admin/src/router.tsx:530
+msgid "Moved {total} items to trash"
+msgstr "Переміщено {total} елементів у кошик"
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr "Множинний вибір"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr "Багаторядковий простий текст"
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr "Множинний вибір із варіантів"
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr "Мій чудовий блог"
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:154
+#: packages/admin/src/components/TaxonomyManager.tsx:389
+#: packages/admin/src/components/TaxonomyManager.tsx:632
+#: packages/admin/src/components/TaxonomyManager.tsx:821
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:425
+msgid "Name"
+msgstr "Ім'я"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:558
+msgid "Name and label are required"
+msgstr "Ім'я та мітка обов'язкові"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "Ім'я має починатися з літери і містити лише малі літери, цифри та підкреслення"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "Навігація"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr "Ніколи"
+
+#: packages/admin/src/router.tsx:1119
+msgid "new"
+msgstr "новий"
+
+#: packages/admin/src/routes/bylines.tsx:427
+msgid "New"
+msgstr "Новий"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:107
+msgid "NEW"
+msgstr "НОВИЙ"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:466
+msgid "New {0}"
+msgstr "Новий {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:651
+msgid "New {collectionLabel}"
+msgstr "Новий {collectionLabel}"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "New byline field"
+msgstr "Нове поле підпису"
+
+#: packages/admin/src/components/WordPressImport.tsx:1982
+msgid "New collection"
+msgstr "Нова колекція"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr "Новий тип вмісту"
+
+#: packages/admin/src/routes/byline-schema.tsx:224
+msgid "New field"
+msgstr "Нове поле"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:118
+msgid "New public routes"
+msgstr "Нові публічні маршрути"
+
+#: packages/admin/src/components/Redirects.tsx:105
+#: packages/admin/src/components/Redirects.tsx:362
+msgid "New Redirect"
+msgstr "Нове перенаправлення"
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr "Нова секція"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "нова вкладка"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:811
+msgid "New Taxonomy"
+msgstr "Нова таксономія"
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:433
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:612
+msgid "New window"
+msgstr "Нове вікно"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr "Найновіші"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:392
+msgid "News"
+msgstr "Новини"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr "Далі"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:371
+#: packages/admin/src/components/ContentList.tsx:618
+msgid "Next page"
+msgstr "Наступна сторінка"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:463
+msgid "Next screenshot"
+msgstr "Наступний скріншот"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "No"
+msgstr "Ні"
+
+#: packages/admin/src/routes/byline-schema.tsx:420
+msgid "No (shared across translations)"
+msgstr "Ні (спільне для всіх перекладів)"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:436
+msgid "No {0} available."
+msgstr "Немає доступних {0}."
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:549
+msgid "No {0} yet."
+msgstr "Ще немає {0}."
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:830
+msgid "No {0} yet. Create one to get started."
+msgstr "Ще немає {0}. Створіть, щоб почати."
+
+#: packages/admin/src/components/Redirects.tsx:217
+msgid "No 404 errors recorded yet."
+msgstr "Ще не зафіксовано помилок 404."
+
+#: packages/admin/src/components/MediaLibrary.tsx:833
+#: packages/admin/src/components/MediaLibrary.tsx:890
+msgid "No alt text"
+msgstr "Немає alt-тексту"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:268
+msgid "No API tokens yet. Create one to get started."
+msgstr "Ще немає API-токенів. Створіть, щоб почати."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No approved comments yet."
+msgstr "Ще немає схвалених коментарів."
+
+#: packages/admin/src/routes/byline-schema.tsx:291
+msgid "No byline fields yet."
+msgstr "Ще немає полів підпису."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:766
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr "Немає доступних підписів у {entryLocale}. Створіть варіант на сторінці Підписи, перш ніж вказати його в цьому записі."
+
+#: packages/admin/src/routes/bylines.tsx:453
+msgid "No bylines found"
+msgstr "Підписи не знайдено"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:874
+msgid "No bylines selected."
+msgstr "Підписи не вибрано."
+
+#: packages/admin/src/components/Dashboard.tsx:226
+msgid "No collections configured"
+msgstr "Колекції не налаштовано"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:546
+msgid "No comments awaiting moderation."
+msgstr "Немає коментарів на модерації."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:542
+msgid "No comments match your search."
+msgstr "Жоден коментар не відповідає вашому пошуку."
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:82
+msgid "No content"
+msgstr "Немає вмісту"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr "Вміст не знайдено"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr "Немає вмісту в цій колекції"
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr "Ще немає типів вмісту."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:612
+msgid "No custom fields yet"
+msgstr "Ще немає користувацьких полів"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:264
+msgid "No detailed description available."
+msgstr "Детальний опис недоступний."
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:262
+msgid "No domains configured. Users must be invited individually."
+msgstr "Домени не налаштовано. Користувачів потрібно запрошувати індивідуально."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:152
+msgid "No email provider configured"
+msgstr "Email-провайдер не налаштовано"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "Email-провайдер не налаштовано. Поділіться цим посиланням вручну."
+
+#: packages/admin/src/components/WordPressImport.tsx:2516
+msgid "No EmDash users found"
+msgstr "Користувачів EmDash не знайдено"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
+msgid "No expiry"
+msgstr "Без терміну дії"
+
+#: packages/admin/src/components/RevisionHistory.tsx:335
+msgid "No fields to compare"
+msgstr "Немає полів для порівняння"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:204
+msgid "No headings in document"
+msgstr "У документі немає заголовків"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:581
+msgid "No installable releases"
+msgstr "Немає встановлюваних випусків"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:191
+msgid "No invite token provided"
+msgstr "Токен запрошення не надано"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1831
+#: packages/admin/src/components/RepeaterField.tsx:165
+msgid "No items yet"
+msgstr "Ще немає елементів"
+
+#: packages/admin/src/components/FieldEditor.tsx:631
+msgid "No limit"
+msgstr "Без ліміту"
+
+#: packages/admin/src/routes/bylines.tsx:518
+msgid "No linked user"
+msgstr "Немає пов'язаного користувача"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "No matches"
+msgstr "Немає збігів"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:809
+msgid "No matching bylines."
+msgstr "Немає відповідних підписів."
+
+#: packages/admin/src/components/MediaLibrary.tsx:489
+#: packages/admin/src/components/MediaLibrary.tsx:517
+msgid "No matching media"
+msgstr "Немає відповідних медіа"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:264
+msgid "No matching passkey found for this account."
+msgstr "Для цього облікового запису не знайдено відповідного passkey."
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr "Без максимуму"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:645
+msgid "No media available from this provider"
+msgstr "Немає медіа від цього провайдера"
+
+#: packages/admin/src/components/MediaLibrary.tsx:540
+msgid "No media available from this provider."
+msgstr "Немає медіа від цього провайдера."
+
+#: packages/admin/src/components/MediaLibrary.tsx:539
+#: packages/admin/src/components/MediaPickerModal.tsx:639
+msgid "No media found"
+msgstr "Медіа не знайдено"
+
+#: packages/admin/src/components/MenuEditor.tsx:485
+msgid "No menu items yet"
+msgstr "Ще немає пунктів меню"
+
+#: packages/admin/src/components/MenuList.tsx:186
+msgid "No menus yet"
+msgstr "Ще немає меню"
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr "Без мінімуму"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr "Без модерації (автосхвалення всіх)"
+
+#: packages/admin/src/components/MenuEditor.tsx:329
+msgid "No parent (top level)"
+msgstr "Без батьківського (верхній рівень)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr "Passkey не зареєстровано"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:168
+msgid "No passkeys registered yet."
+msgstr "Ще не зареєстровано жодного passkey."
+
+#: packages/admin/src/components/PluginManager.tsx:195
+msgid "No plugins configured"
+msgstr "Плагіни не налаштовано"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "Плагіни не знайдено"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:117
+msgid "No plugins have been published to this registry yet."
+msgstr "У цьому реєстрі ще не опубліковано жодного плагіна."
+
+#: packages/admin/src/components/RegistryBrowse.tsx:116
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr "Немає плагінів, що відповідають \"{debouncedQuery}\"."
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr "Немає попереднього перегляду"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:304
+msgid "No public URL available"
+msgstr "Публічний URL недоступний"
+
+#: packages/admin/src/components/Dashboard.tsx:304
+msgid "No recent activity"
+msgstr "Немає недавньої активності"
+
+#: packages/admin/src/components/Redirects.tsx:460
+msgid "No redirects yet"
+msgstr "Ще немає перенаправлень"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1381
+#: packages/admin/src/components/RepeaterField.tsx:374
+msgid "No results"
+msgstr "Немає результатів"
+
+#: packages/admin/src/components/ContentList.tsx:546
+#: packages/admin/src/components/ContentList.tsx:565
+msgid "No results for \"{activeSearch}\""
+msgstr "Немає результатів для \"{activeSearch}\""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "Немає результатів для \"{debouncedQuery}\". Спробуйте інший пошуковий запит."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "Результатів не знайдено"
+
+#: packages/admin/src/components/RevisionHistory.tsx:191
+msgid "No revisions yet"
+msgstr "Ще немає ревізій"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr "Немає доступних секцій"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr "Секції не знайдено"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr "Ще немає секцій"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No spam comments."
+msgstr "Немає спам-коментарів."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr "Теми не знайдено"
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr "Користувачів за вашими фільтрами не знайдено."
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr "Ще немає користувачів."
+
+#: packages/admin/src/components/Widgets.tsx:499
+msgid "No widget areas yet. Create one to get started."
+msgstr "Ще немає областей віджетів. Створіть, щоб почати."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
+msgid "None"
+msgstr "Немає"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:418
+#: packages/admin/src/components/TaxonomyManager.tsx:424
+msgid "None (top level)"
+msgstr "Немає (верхній рівень)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:616
+msgid "Not compatible with this environment"
+msgstr "Несумісний з цим середовищем"
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr "Число"
+
+#: packages/admin/src/components/Widgets.tsx:127
+msgid "Number of posts"
+msgstr "Кількість записів"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:278
+msgid "Number of posts to show per page on list views"
+msgstr "Кількість записів на сторінці в спискових поданнях"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:110
+#: packages/admin/src/components/PortableTextEditor.tsx:1066
+#: packages/admin/src/components/PortableTextEditor.tsx:3474
+msgid "Numbered List"
+msgstr "Нумерований список"
+
+#: packages/admin/src/components/WordPressImport.tsx:494
+msgid "OAuth authorization requires HTTPS. Please use manual credentials."
+msgstr "Авторизація OAuth потребує HTTPS. Використовуйте облікові дані вручну."
+
+#: packages/admin/src/components/SeoImageField.tsx:46
+msgid "OG Image"
+msgstr "OG-зображення"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "на користувацькому hostname не вважається безпечним, навіть на loopback."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "Авторизуйте лише коди, які ви впізнаєте."
+
+#: packages/admin/src/components/SignupPage.tsx:96
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "Реєструватися можуть лише email-адреси з дозволених доменів."
+
+#: packages/admin/src/components/MenuList.tsx:159
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "Лише малі літери, цифри та дефіси"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr "Для цього поля прийматимуться лише вказані MIME-типи."
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Oops!"
+msgstr "Ой!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:379
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:380
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:568
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:569
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr "Відкрити в новій вкладці"
+
+#: packages/admin/src/components/WordPressImport.tsx:1534
+msgid "Open WordPress Profile"
+msgstr "Відкрити профіль WordPress"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Option 1\nOption 2\nOption 3"
+msgstr "Варіант 1\nВаріант 2\nВаріант 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
+msgid "Optional caption displayed below the image"
+msgstr "Необов'язковий підпис під зображенням"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:384
+msgid "Optional caption for display"
+msgstr "Необов'язковий підпис для відображення"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+msgid "Optional description"
+msgstr "Необов'язковий опис"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:553
+msgid "Optional tooltip on hover"
+msgstr "Необов'язкова підказка при наведенні"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:302
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr "Варіанти (по одному на рядок)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:531
+msgid "or choose from library"
+msgstr "або вибрати з бібліотеки"
+
+#: packages/admin/src/components/WordPressImport.tsx:1590
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "Або натисніть для вибору. Приймаються .xml файли, експортовані з WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1071
+msgid "or connect by URL"
+msgstr "або підключити за URL"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:96
+#: packages/admin/src/components/LoginPage.tsx:261
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr "Або продовжити з"
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Or upload an export file"
+msgstr "Або завантажити файл експорту"
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "or upload directly"
+msgstr "або завантажити безпосередньо"
+
+#: packages/admin/src/components/MenuEditor.tsx:227
+msgid "Order saved"
+msgstr "Порядок збережено"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
+msgid "Original:"
+msgstr "Оригінал:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:182
+msgid "Outline"
+msgstr "Структура"
+
+#: packages/admin/src/components/SeoPanel.tsx:164
+msgid "Overrides the page title in search engine results"
+msgstr "Замінює заголовок сторінки в результатах пошуку"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:500
+msgid "Ownership"
+msgstr "Власність"
+
+#: packages/admin/src/components/PluginManager.tsx:509
+msgid "Package"
+msgstr "Пакет"
+
+#: packages/admin/src/router.tsx:2157
+msgid "Page Not Found"
+msgstr "Сторінку не знайдено"
+
+#: packages/admin/src/components/PluginManager.tsx:373
+#: packages/admin/src/components/WordPressImport.tsx:1328
+msgid "Pages"
+msgstr "Сторінки"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:54
+msgid "Paragraph"
+msgstr "Абзац"
+
+#: packages/admin/src/components/MenuEditor.tsx:615
+#: packages/admin/src/components/TaxonomyManager.tsx:414
+msgid "Parent"
+msgstr "Батьківський"
+
+#: packages/admin/src/components/Redirects.tsx:509
+#: packages/admin/src/components/Redirects.tsx:515
+msgid "Part of a redirect loop"
+msgstr "Частина циклу перенаправлення"
+
+#: packages/admin/src/components/WordPressImport.tsx:1153
+msgid "Partial"
+msgstr "Частково"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr "Пройдено"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:89
+msgid "Passkey added successfully"
+msgstr "Passkey успішно додано"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "Назва passkey"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "Назва passkey (необов'язково)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "Passkey успішно зареєстровано!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Passkey removed"
+msgstr "Passkey видалено"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:49
+msgid "Passkey renamed"
+msgstr "Passkey перейменовано"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:150
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr "Passkeys"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr "Passkeys ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:154
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Passkeys — це безпечний спосіб входу без пароля до вашого облікового запису. Ви можете зареєструвати кілька passkeys для різних пристроїв."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:76
+#: packages/admin/src/components/SignupPage.tsx:213
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Passkeys — це безпечний спосіб входу без пароля за допомогою біометрії, PIN-коду або ключа безпеки вашого пристрою."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:301
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "Passkeys недоступні тут"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:305
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Passkeys потребують"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Passkeys потребують HTTPS або http://localhost (з вашим портом); це ім'я хоста не є безпечним контекстом браузера."
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "Paste your migration key"
+msgstr "Вставте ключ міграції"
+
+#: packages/admin/src/components/Redirects.tsx:224
+msgid "Path"
+msgstr "Шлях"
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr "Шаблон (Regex)"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:435
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr "Шаблон для генерації URL, напр. /blog/{0}"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:431
+msgid "Pattern must include a {0} placeholder"
+msgstr "Шаблон має містити заповнювач {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr "PDF"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:1183
+msgid "pending"
+msgstr "очікує"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:197
+#: packages/admin/src/components/Dashboard.tsx:348
+msgid "Pending"
+msgstr "Очікує"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:405
+msgid "Pending changes"
+msgstr "Незбережені зміни"
+
+#: packages/admin/src/components/ContentList.tsx:1117
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "Назавжди видалити \"{title}\"? Цю дію не можна скасувати."
+
+#: packages/admin/src/components/ContentList.tsx:1106
+msgid "Permanently delete {title}"
+msgstr "Остаточно видалити {title}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:273
+msgid "Permissions"
+msgstr "Дозволи"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:46
+msgid "PHP"
+msgstr "PHP"
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr "Оберіть будь-який спосіб створення облікового запису адміністратора."
+
+#: packages/admin/src/components/Widgets.tsx:152
+msgid "Placeholder text"
+msgstr "Текст-заповнювач"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:311
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "Звичайний"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:27
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:120
+msgid "Plain text"
+msgstr "Звичайний текст"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:165
+msgid "Please ask your administrator to send a new invite."
+msgstr "Попросіть адміністратора надіслати нове запрошення."
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr "Введіть дійсну адресу електронної пошти"
+
+#: packages/admin/src/components/SignupPage.tsx:54
+msgid "Please enter a valid email address"
+msgstr "Введіть дійсну адресу електронної пошти"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:398
+msgid "Please enter a valid URL"
+msgstr "Введіть дійсну URL-адресу"
+
+#: packages/admin/src/components/WordPressImport.tsx:1182
+msgid "Plugin"
+msgstr "Плагін"
+
+#: packages/admin/src/lib/api/plugins.ts:57
+msgid "Plugin \"{pluginId}\" not found"
+msgstr "Плагін \"{pluginId}\" не знайдено"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:749
+msgid "Plugin details"
+msgstr "Деталі плагіна"
+
+#: packages/admin/src/components/PluginManager.tsx:110
+msgid "Plugin disabled"
+msgstr "Плагін вимкнено"
+
+#: packages/admin/src/components/PluginManager.tsx:91
+msgid "Plugin enabled"
+msgstr "Плагін увімкнено"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr "Помилка плагіна"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr "Помилка плагіна ({0})"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:112
+msgid "Plugin not found"
+msgstr "Плагін не знайдено"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:398
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr "Плагін не знайдено. Ідентифікатор видавця або slug можуть бути неправильними."
+
+#: packages/admin/src/components/WordPressImport.tsx:1209
+msgid "plugin on your WordPress site."
+msgstr "плагін на вашому сайті WordPress."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Plugin Permissions"
+msgstr "Дозволи плагіна"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:70
+msgid "Plugin Registry"
+msgstr "Реєстр плагінів"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr "Плагін відповів з кодом {0}: {text}"
+
+#: packages/admin/src/components/PluginManager.tsx:305
+msgid "Plugin uninstalled"
+msgstr "Плагін видалено"
+
+#: packages/admin/src/lib/api/registry.ts:783
+msgid "Plugin update requires re-consent"
+msgstr "Оновлення плагіна потребує повторної згоди"
+
+#: packages/admin/src/components/PluginManager.tsx:258
+msgid "Plugin updated"
+msgstr "Плагін оновлено"
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
+msgid "Plugin widget error"
+msgstr "Помилка віджета плагіна"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:135
+#: packages/admin/src/components/PluginManager.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:153
+#: packages/admin/src/components/Sidebar.tsx:349
+#: packages/admin/src/components/Sidebar.tsx:477
+msgid "Plugins"
+msgstr "Плагіни"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:264
+msgid "Point-in-Time Restore"
+msgstr "Відновлення на момент часу"
+
+#: packages/admin/src/components/SeoPanel.tsx:208
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "Вказує пошуковим системам на оригінальну версію цієї сторінки, якщо вона дублюється з іншої URL-адреси"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:387
+msgid "Post"
+msgstr "Запис"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:395
+#: packages/admin/src/components/WordPressImport.tsx:1322
+msgid "Posts"
+msgstr "Записи"
+
+#: packages/admin/src/components/WordPressImport.tsx:1144
+msgid "Posts & Pages"
+msgstr "Записи та сторінки"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:272
+msgid "Posts Per Page"
+msgstr "Записів на сторінку"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:465
+msgid "Pre-release"
+msgstr "Передрелізна версія"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "Підготовка реєстрації..."
+
+#: packages/admin/src/components/WordPressImport.tsx:2179
+msgid "Preparing to download files from WordPress..."
+msgstr "Підготовка до завантаження файлів з WordPress..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr "Підготовка..."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:143
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:585
+msgid "Preview"
+msgstr "Попередній перегляд"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr "Переглянути вміст перед публікацією"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:143
+msgid "Preview draft"
+msgstr "Переглянути чернетку"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr "Попередній"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:352
+#: packages/admin/src/components/ContentList.tsx:606
+msgid "Previous page"
+msgstr "Попередня сторінка"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:445
+msgid "Previous screenshot"
+msgstr "Попередній знімок екрана"
+
+#: packages/admin/src/components/MenuList.tsx:166
+msgid "Primary Navigation"
+msgstr "Головна навігація"
+
+#: packages/admin/src/components/Dashboard.tsx:349
+msgid "Private"
+msgstr "Приватний"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:174
+msgid "Provider:"
+msgstr "Провайдер:"
+
+#: packages/admin/src/components/ContentList.tsx:415
+#: packages/admin/src/components/ContentSettingsPanel.tsx:171
+#: packages/admin/src/components/ContentSettingsPanel.tsx:390
+msgid "Publish"
+msgstr "Опублікувати"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:178
+msgid "Publish changes"
+msgstr "Опублікувати зміни"
+
+#: packages/admin/src/components/ContentList.tsx:1158
+msgid "published"
+msgstr "опубліковано"
+
+#: packages/admin/src/components/ContentList.tsx:729
+#: packages/admin/src/components/ContentList.tsx:738
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/ContentSettingsPanel.tsx:404
+#: packages/admin/src/components/Dashboard.tsx:245
+#: packages/admin/src/components/Dashboard.tsx:345
+#: packages/admin/src/router.tsx:1008
+msgid "Published"
+msgstr "Опубліковано"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:326
+msgid "Published {0}"
+msgstr "Опубліковано {0}"
+
+#: packages/admin/src/router.tsx:486
+msgid "Published {total} items"
+msgstr "Опубліковано елементів: {total}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr "Дата публікації"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:459
+msgid "Published by"
+msgstr "Опубліковано"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:47
+msgid "Python"
+msgstr "Python"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:882
+msgid "Quick create byline"
+msgstr "Швидко створити авторський рядок"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:196
+#: packages/admin/src/components/editor/ImageNode.tsx:197
+msgid "Quick edit alt text"
+msgstr "Швидко редагувати alt-текст"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:86
+#: packages/admin/src/components/PortableTextEditor.tsx:1076
+#: packages/admin/src/components/PortableTextEditor.tsx:3481
+msgid "Quote"
+msgstr "Цитата"
+
+#: packages/admin/src/components/WordPressImport.tsx:1162
+msgid "Raw meta"
+msgstr "Необроблені метадані"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Read collection schemas"
+msgstr "Читати схеми колекцій"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Read content entries"
+msgstr "Читати записи вмісту"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Read media files"
+msgstr "Читати медіафайли"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Read site settings"
+msgstr "Читати налаштування сайту"
+
+#: packages/admin/src/lib/api/marketplace.ts:227
+#: packages/admin/src/lib/api/marketplace.ts:235
+msgid "Read user accounts"
+msgstr "Читати облікові записи користувачів"
+
+#: packages/admin/src/lib/api/marketplace.ts:222
+#: packages/admin/src/lib/api/marketplace.ts:231
+msgid "Read your content"
+msgstr "Читати ваш вміст"
+
+#: packages/admin/src/lib/api/marketplace.ts:224
+msgid "Read your taxonomies and terms"
+msgstr "Читати ваші таксономії та терміни"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:269
+msgid "Reading"
+msgstr "Читання"
+
+#: packages/admin/src/components/WordPressImport.tsx:1986
+msgid "Ready"
+msgstr "Готово"
+
+#: packages/admin/src/components/Dashboard.tsx:298
+msgid "Recent Activity"
+msgstr "Остання активність"
+
+#: packages/admin/src/components/Widgets.tsx:124
+msgid "Recent Posts"
+msgstr "Останні записи"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr "Нещодавно оновлено"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:118
+msgid "Recipient email"
+msgstr "Email одержувача"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr "Посилання для відновлення надіслано на {0}"
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Redirect loop detected"
+msgstr "Виявлено цикл перенаправлення"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "Перенаправлення на вхід..."
+
+#: packages/admin/src/components/Redirects.tsx:358
+#: packages/admin/src/components/Redirects.tsx:377
+#: packages/admin/src/components/Sidebar.tsx:332
+msgid "Redirects"
+msgstr "Перенаправлення"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3614
+msgid "Redo"
+msgstr "Повторити"
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr "Посилання"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:228
+msgid "Referenced favicon unavailable."
+msgstr "Посилання на favicon недоступне."
+
+#: packages/admin/src/components/Dashboard.tsx:85
+msgid "Refresh the page or try again."
+msgstr "Оновіть сторінку або спробуйте ще раз."
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr "Зареєструвати"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "Register Passkey"
+msgstr "Зареєструвати Passkey"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "Зареєстрований користувач"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr "Реєстрація не вдалася"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "Реєстрацію скасовано або час очікування минув. Спробуйте ще раз."
+
+#: packages/admin/src/components/Sidebar.tsx:355
+msgid "Registry"
+msgstr "Реєстр"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:597
+msgid "Release is too new to install"
+msgstr "Реліз занадто новий для встановлення"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentSettingsPanel.tsx:851
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:199
+#: packages/admin/src/components/PortableTextEditor.tsx:3587
+#: packages/admin/src/components/settings/GeneralSettings.tsx:194
+#: packages/admin/src/components/settings/GeneralSettings.tsx:248
+#: packages/admin/src/components/settings/PasskeyItem.tsx:185
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+#: packages/admin/src/components/settings/SeoSettings.tsx:176
+msgid "Remove"
+msgstr "Видалити"
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+#: packages/admin/src/components/TaxonomySidebar.tsx:246
+msgid "Remove {0}"
+msgstr "Видалити {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr "Видалити {entry}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1655
+msgid "Remove {label}"
+msgstr "Видалити {label}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:397
+msgid "Remove Domain"
+msgstr "Видалити домен"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+msgid "Remove Domain?"
+msgstr "Видалити домен?"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:130
+#: packages/admin/src/components/ImageFieldRenderer.tsx:159
+#: packages/admin/src/components/SeoImageField.tsx:61
+msgid "Remove image"
+msgstr "Видалити зображення"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:392
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:582
+msgid "Remove Image"
+msgstr "Видалити зображення"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
+msgid "Remove Image?"
+msgstr "Видалити зображення?"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1947
+#: packages/admin/src/components/RepeaterField.tsx:275
+msgid "Remove item {0}"
+msgstr "Видалити елемент {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3073
+#: packages/admin/src/components/PortableTextEditor.tsx:3074
+msgid "Remove link"
+msgstr "Видалити посилання"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+msgid "Remove passkey"
+msgstr "Видалити passkey"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:201
+msgid "Remove passkey?"
+msgstr "Видалити passkey?"
+
+#: packages/admin/src/components/FieldEditor.tsx:611
+msgid "Remove sub-field"
+msgstr "Видалити підполе"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:198
+msgid "Remove this image from the document?"
+msgstr "Видалити це зображення з документа?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:200
+#: packages/admin/src/components/settings/PasskeyItem.tsx:208
+msgid "Removing..."
+msgstr "Видалення..."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:174
+msgid "Rename"
+msgstr "Перейменувати"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename {0}"
+msgstr "Перейменувати {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename passkey"
+msgstr "Перейменувати passkey"
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr "Повторювач"
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr "Група полів, що повторюється"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:435
+msgid "Replace Image"
+msgstr "Замінити зображення"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "Відповідь на:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr "Репозиторій"
+
+#: packages/admin/src/components/SignupPage.tsx:273
+msgid "Request a new link"
+msgstr "Запросити нове посилання"
+
+#: packages/admin/src/lib/api/client.ts:198
+msgid "Request failed"
+msgstr "Запит не вдався"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:280
+#: packages/admin/src/components/ContentTypeEditor.tsx:730
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:593
+#: packages/admin/src/routes/byline-schema.tsx:246
+msgid "Required"
+msgstr "Обов'язкове"
+
+#: packages/admin/src/components/WordPressImport.tsx:1999
+msgid "Required fields:"
+msgstr "Обов'язкові поля:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "Обов'язково для доступності. Описує зображення для програм зчитування з екрана."
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:324
+msgid "Requires EmDash {0}"
+msgstr "Потребує EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend email"
+msgstr "Надіслати email повторно"
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend in {resendCooldown}s"
+msgstr "Надіслати повторно через {resendCooldown} с"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:277
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+msgid "Reset to original"
+msgstr "Скинути до оригіналу"
+
+#: packages/admin/src/components/RevisionHistory.tsx:228
+msgid "Restore"
+msgstr "Відновити"
+
+#: packages/admin/src/components/ContentList.tsx:1094
+msgid "Restore {title}"
+msgstr "Відновити {title}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:128
+msgid "Restore failed"
+msgstr "Відновлення не вдалося"
+
+#: packages/admin/src/components/RevisionHistory.tsx:222
+msgid "Restore Revision?"
+msgstr "Відновити ревізію?"
+
+#: packages/admin/src/components/RevisionHistory.tsx:289
+#: packages/admin/src/components/RevisionHistory.tsx:290
+msgid "Restore this version"
+msgstr "Відновити цю версію"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:225
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "Відновити цю версію від {0}? Поточний вміст буде оновлено даними цієї ревізії."
+
+#: packages/admin/src/components/RevisionHistory.tsx:229
+msgid "Restoring..."
+msgstr "Відновлення..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:2145
+#: packages/admin/src/routes/byline-schema.tsx:280
+msgid "Retry"
+msgstr "Повторити"
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr "Багаторазові блоки вмісту, які можна вставляти в будь-який вміст"
+
+#: packages/admin/src/router.tsx:1046
+msgid "Reverted to published version"
+msgstr "Повернуто до опублікованої версії"
+
+#: packages/admin/src/components/WordPressImport.tsx:724
+msgid "Review"
+msgstr "Переглянути"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Review New Permissions"
+msgstr "Переглянути нові дозволи"
+
+#: packages/admin/src/components/RevisionHistory.tsx:122
+msgid "Revision restored"
+msgstr "Ревізію відновлено"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:158
+msgid "Revisions"
+msgstr "Ревізії"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:331
+msgid "Revoke token"
+msgstr "Відкликати токен"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:306
+msgid "Revoke?"
+msgstr "Відкликати?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:313
+msgid "Revoking..."
+msgstr "Відкликання..."
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr "Форматований текст"
+
+#: packages/admin/src/components/Widgets.tsx:97
+msgid "Rich text content"
+msgstr "Форматований текстовий вміст"
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr "Редактор форматованого тексту"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
+msgid "Right"
+msgstr "Праворуч"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:311
+msgid "Risk score: {0}/100"
+msgstr "Оцінка ризику: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:164
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr "Роль"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "Роль {role}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:856
+msgid "Role label"
+msgstr "Мітка ролі"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:48
+msgid "Ruby"
+msgstr "Ruby"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:49
+msgid "Rust"
+msgstr "Rust"
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:432
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:611
+msgid "Same window"
+msgstr "Те саме вікно"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:989
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:395
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:589
+#: packages/admin/src/components/editor/ImageNode.tsx:264
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/Redirects.tsx:190
+#: packages/admin/src/components/SaveButton.tsx:32
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/Widgets.tsx:966
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Save"
+msgstr "Зберегти"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr "Зберегти (Enter)"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:265
+msgid "Save alt text"
+msgstr "Зберегти alt-текст"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Save changes"
+msgstr "Зберегти зміни"
+
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr "Зберегти зміни"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr "Зберегти вміст як чернетку перед публікацією"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "Зберегти назву"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+msgid "Save SEO Settings"
+msgstr "Зберегти SEO-налаштування"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+msgid "Save Settings"
+msgstr "Зберегти налаштування"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Save Social Links"
+msgstr "Зберегти соціальні посилання"
+
+#: packages/admin/src/components/SaveButton.tsx:34
+msgid "Saved"
+msgstr "Збережено"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:116
+msgid "Saved \"{0}\"."
+msgstr "Збережено \"{0}\"."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:989
+#: packages/admin/src/components/FieldEditor.tsx:660
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/Redirects.tsx:187
+#: packages/admin/src/components/SaveButton.tsx:33
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:966
+#: packages/admin/src/routes/bylines.tsx:580
+msgid "Saving..."
+msgstr "Збереження..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Saving…"
+msgstr "Збереження…"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:469
+msgid "SBOM"
+msgstr "SBOM"
+
+#. placeholder {0}: sbom.format
+#: packages/admin/src/components/RegistryPluginDetail.tsx:467
+msgid "SBOM · {0}"
+msgstr "SBOM · {0}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:453
+msgid "Schedule"
+msgstr "Запланувати"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:439
+msgid "Schedule for"
+msgstr "Запланувати на"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:476
+msgid "Schedule for later"
+msgstr "Запланувати на пізніше"
+
+#: packages/admin/src/components/ContentList.tsx:1162
+msgid "scheduled"
+msgstr "заплановано"
+
+#: packages/admin/src/components/ContentList.tsx:731
+#: packages/admin/src/components/ContentSettingsPanel.tsx:407
+#: packages/admin/src/components/Dashboard.tsx:347
+#: packages/admin/src/router.tsx:1066
+msgid "Scheduled"
+msgstr "Заплановано"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentSettingsPanel.tsx:427
+msgid "Scheduled for: {0}"
+msgstr "Заплановано на: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "Schema Changes"
+msgstr "Зміни схеми"
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Schema preparation failed"
+msgstr "Підготовка схеми не вдалася"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Schema Read"
+msgstr "Читання схеми"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Schema Write"
+msgstr "Запис схеми"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:414
+msgid "Scopes"
+msgstr "Області доступу"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:282
+msgid "Scopes: {0}"
+msgstr "Області доступу: {0}"
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:243
+#: packages/admin/src/components/RegistryPluginDetail.tsx:642
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr "Знімок екрана {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:453
+msgid "Screenshot {0} of {1}"
+msgstr "Знімок екрана {0} з {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:246
+msgid "Screenshot blurred due to image audit"
+msgstr "Знімок екрана розмито через аудит зображення"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:431
+msgid "Screenshot viewer"
+msgstr "Переглядач знімків екрана"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:233
+#: packages/admin/src/components/RegistryPluginDetail.tsx:636
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr "Знімки екрана"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:50
+msgid "SCSS"
+msgstr "SCSS"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+#: packages/admin/src/components/Widgets.tsx:149
+msgid "Search"
+msgstr "Пошук"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:353
+msgid "Search {0}"
+msgstr "Шукати {0}"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:352
+msgid "Search {0}..."
+msgstr "Шукати {0}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:577
+msgid "Search by filename..."
+msgstr "Шукати за іменем файлу..."
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr "Шукати за іменем або email..."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:783
+#: packages/admin/src/routes/bylines.tsx:402
+msgid "Search bylines"
+msgstr "Шукати авторські рядки"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:782
+msgid "Search bylines to add..."
+msgstr "Шукати авторські рядки для додавання..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments"
+msgstr "Шукати коментарі"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:162
+msgid "Search comments..."
+msgstr "Шукати коментарі..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "Шукати вміст..."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:122
+msgid "Search Engine Optimization"
+msgstr "Пошукова оптимізація"
+
+#: packages/admin/src/components/Settings.tsx:83
+msgid "Search engine optimization and verification"
+msgstr "Пошукова оптимізація та верифікація"
+
+#: packages/admin/src/components/Widgets.tsx:150
+msgid "Search form"
+msgstr "Форма пошуку"
+
+#: packages/admin/src/components/MediaLibrary.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:578
+msgid "Search media"
+msgstr "Шукати медіа"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "Шукати сторінки та вміст..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+#: packages/admin/src/components/RegistryBrowse.tsx:84
+msgid "Search plugins"
+msgstr "Шукати плагіни"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+#: packages/admin/src/components/RegistryBrowse.tsx:80
+msgid "Search plugins..."
+msgstr "Шукати плагіни..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr "Шукати секції..."
+
+#: packages/admin/src/components/Redirects.tsx:409
+msgid "Search source or destination..."
+msgstr "Шукати джерело або призначення..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr "Шукати теми"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr "Шукати теми..."
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr "Шукати користувачів"
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:577
+msgid "Search..."
+msgstr "Пошук..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr "Доступно для пошуку"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:787
+msgid "Searching..."
+msgstr "Пошук..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2322
+msgid "Section"
+msgstr "Секція"
+
+#: packages/admin/src/components/SectionEditor.tsx:81
+msgid "Section \"{slug}\" could not be found."
+msgstr "Розділ \"{slug}\" не знайдено."
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr "Секцію створено"
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr "Секцію видалено"
+
+#: packages/admin/src/components/SectionEditor.tsx:235
+msgid "Section Details"
+msgstr "Деталі секції"
+
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section Not Found"
+msgstr "Секцію не знайдено"
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "Section title"
+msgstr "Назва секції"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:334
+msgid "Sections"
+msgstr "Секції"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:306
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "безпечний контекст"
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr "Захистіть свій обліковий запис"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:794
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Security"
+msgstr "Безпека"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:307
+msgid "Security Audit"
+msgstr "Аудит безпеки"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr "Аудит безпеки не пройдено"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr "Аудит безпеки виявив проблеми"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:150
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "Аудит безпеки виявив потенційні проблеми з цим плагіном."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:151
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "Аудит безпеки позначив цей плагін як потенційно небезпечний."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr "Аудит безпеки пройдено"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:705
+msgid "Security contacts"
+msgstr "Контакти з питань безпеки"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:270
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "Помилка безпеки. Переконайтеся, що ви використовуєте безпечне з'єднання."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/settings/SecuritySettings.tsx:95
+msgid "Security Settings"
+msgstr "Налаштування безпеки"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:56
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr "Обрати"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1667
+#: packages/admin/src/components/ContentEditor.tsx:1683
+#: packages/admin/src/components/ImageFieldRenderer.tsx:187
+msgid "Select {label}"
+msgstr "Обрати {label}"
+
+#: packages/admin/src/components/ContentList.tsx:973
+msgid "Select {title}"
+msgstr "Обрати {title}"
+
+#: packages/admin/src/components/Widgets.tsx:939
+msgid "Select a component..."
+msgstr "Оберіть компонент..."
+
+#: packages/admin/src/components/Widgets.tsx:902
+msgid "Select a menu..."
+msgstr "Оберіть меню..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:283
+msgid "Select all"
+msgstr "Обрати все"
+
+#: packages/admin/src/components/ContentList.tsx:497
+msgid "Select all on this page"
+msgstr "Обрати все на цій сторінці"
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:456
+msgid "Select comment by {0}"
+msgstr "Обрати коментар від {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "Обрати вміст"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:235
+msgid "Select Default Social Image"
+msgstr "Обрати зображення для соцмереж за замовчуванням"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:260
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Select Favicon"
+msgstr "Обрати favicon"
+
+#: packages/admin/src/components/ContentEditor.tsx:1671
+msgid "Select file"
+msgstr "Обрати файл"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+msgid "Select File"
+msgstr "Обрати файл"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:175
+msgid "Select image"
+msgstr "Обрати зображення"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+#: packages/admin/src/components/PortableTextEditor.tsx:2917
+#: packages/admin/src/components/settings/SeoSettings.tsx:188
+msgid "Select Image"
+msgstr "Обрати зображення"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:206
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Select Logo"
+msgstr "Обрати логотип"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr "Обрати медіа"
+
+#: packages/admin/src/components/SeoImageField.tsx:76
+msgid "Select OG image"
+msgstr "Обрати OG-зображення"
+
+#: packages/admin/src/components/SeoImageField.tsx:85
+msgid "Select OG Image"
+msgstr "Обрати OG-зображення"
+
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "Select which content types to import."
+msgstr "Оберіть типи вмісту для імпорту."
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:2042
+#: packages/admin/src/components/RepeaterField.tsx:372
+msgid "Select..."
+msgstr "Обрати..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1372
+msgid "Selected {selectedItemTitle}"
+msgstr "Обрано {selectedItemTitle}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:733
+msgid "Selected:"
+msgstr "Обрано:"
+
+#: packages/admin/src/components/Settings.tsx:99
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:152
+msgid "Self-Signup Domains"
+msgstr "Домени для самостійної реєстрації"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:113
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "Надішліть тестовий email через повний ланцюжок, щоб перевірити налаштування пошти."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "Надішліть запрошення електронною поштою новому учаснику команди."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+msgid "Send Invite"
+msgstr "Надіслати запрошення"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+msgid "Send magic link"
+msgstr "Надіслати magic link"
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr "Надіслати посилання для відновлення"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+msgid "Send Test"
+msgstr "Надіслати тест"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:110
+msgid "Send Test Email"
+msgstr "Надіслати тестовий email"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+#: packages/admin/src/components/SignupPage.tsx:88
+#: packages/admin/src/components/SignupPage.tsx:151
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr "Надсилання..."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:564
+#: packages/admin/src/components/ContentTypeEditor.tsx:472
+#: packages/admin/src/components/Settings.tsx:82
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SeoSettings.tsx:115
+msgid "SEO Settings"
+msgstr "SEO-налаштування"
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "SEO settings (Yoast)"
+msgstr "SEO-налаштування (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:40
+msgid "SEO settings saved"
+msgstr "SEO-налаштування збережено"
+
+#: packages/admin/src/components/SeoPanel.tsx:168
+#: packages/admin/src/components/SeoPanel.tsx:172
+msgid "SEO Title"
+msgstr "SEO-заголовок"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
+msgid "Set a custom display size for this image instance."
+msgstr "Встановіть власний розмір відображення для цього зображення."
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:146
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:150
+msgid "Set language"
+msgstr "Встановити мову"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:147
+msgid "Set language (current: {label})"
+msgstr "Встановити мову (поточна: {label})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:529
+msgid "Set to 0 to never close comments automatically."
+msgstr "Встановіть 0, щоб ніколи не закривати коментарі автоматично."
+
+#: packages/admin/src/components/ContentList.tsx:425
+msgid "Set to draft"
+msgstr "Перевести в чернетку"
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr "Налаштуйте свій сайт"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr "Налаштування..."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/ContentEditor.tsx:799
+#: packages/admin/src/components/ContentEditor.tsx:1005
+#: packages/admin/src/components/ContentTypeEditor.tsx:381
+#: packages/admin/src/components/Header.tsx:101
+#: packages/admin/src/components/PluginManager.tsx:437
+#: packages/admin/src/components/Settings.tsx:63
+#: packages/admin/src/components/Sidebar.tsx:379
+#: packages/admin/src/components/WordPressImport.tsx:1811
+msgid "Settings"
+msgstr "Налаштування"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
+msgid "Settings Manage"
+msgstr "Керування налаштуваннями"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Settings Read"
+msgstr "Читання налаштувань"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:43
+msgid "Settings saved successfully"
+msgstr "Налаштування успішно збережено"
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr "Налаштування не вдалося"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "Поділіться цим посиланням із запрошеним користувачем"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:294
+msgid "Shared across all translations of the same byline."
+msgstr "Спільне для всіх перекладів одного авторського рядка."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:52
+msgid "Short text"
+msgstr "Короткий текст"
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr "Короткий текст"
+
+#: packages/admin/src/components/Widgets.tsx:144
+msgid "Show count"
+msgstr "Показувати кількість"
+
+#: packages/admin/src/components/Widgets.tsx:129
+msgid "Show date"
+msgstr "Показувати дату"
+
+#: packages/admin/src/components/Widgets.tsx:137
+msgid "Show hierarchy"
+msgstr "Показувати ієрархію"
+
+#: packages/admin/src/components/Widgets.tsx:136
+msgid "Show post count"
+msgstr "Показувати кількість записів"
+
+#: packages/admin/src/components/Widgets.tsx:128
+msgid "Show thumbnails"
+msgstr "Показувати мініатюри"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Show token"
+msgstr "Показати токен"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:365
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:554
+msgid "Shown when hovering over the image."
+msgstr "Показується при наведенні на зображення."
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Sign in"
+msgstr "Увійти"
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr "Увійти"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:161
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr "Увійти замість цього"
+
+#: packages/admin/src/components/LoginPage.tsx:232
+msgid "Sign in to your site"
+msgstr "Увійдіть на свій сайт"
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:231
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr "Увійти через {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:229
+msgid "Sign in with email"
+msgstr "Увійти через email"
+
+#: packages/admin/src/components/LoginPage.tsx:290
+msgid "Sign in with email link"
+msgstr "Увійти через посилання на email"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:252
+msgid "Sign in with Passkey"
+msgstr "Увійти через Passkey"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "Увійшли як {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr "Один варіант із списку"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr "Однорядкове текстове поле"
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr "Сайт"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:130
+msgid "Site Identity"
+msgstr "Ідентичність сайту"
+
+#: packages/admin/src/components/WordPressImport.tsx:2270
+msgid "site identity applied (title, tagline, logo)"
+msgstr "ідентичність сайту застосовано (назва, слоган, логотип)"
+
+#: packages/admin/src/components/Settings.tsx:71
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "Ідентичність сайту, логотип, favicon та налаштування читання"
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+#: packages/admin/src/components/WordPressImport.tsx:1151
+msgid "Site Settings"
+msgstr "Налаштування сайту"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:133
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr "Назва сайту"
+
+#: packages/admin/src/components/WordPressImport.tsx:1823
+msgid "Site title & tagline"
+msgstr "Назва сайту та слоган"
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr "Назва сайту обов'язкова"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:145
+msgid "Site URL"
+msgstr "URL сайту"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:267
+msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
+msgstr "Сайти на Cloudflare D1 можуть також відновлювати базу даних на будь-яку хвилину за останні 30 днів за допомогою D1 Time Travel — завжди увімкнено, налаштування не потрібне."
+
+#: packages/admin/src/components/MediaLibrary.tsx:588
+msgid "Size"
+msgstr "Розмір"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:274
+msgid "Size:"
+msgstr "Розмір:"
+
+#: packages/admin/src/components/WordPressImport.tsx:2104
+msgid "Skip Media Import"
+msgstr "Пропустити імпорт медіа"
+
+#: packages/admin/src/components/WordPressImport.tsx:2129
+msgid "Skipped"
+msgstr "Пропущено"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:239
+#: packages/admin/src/components/ContentSettingsPanel.tsx:394
+#: packages/admin/src/components/ContentSettingsPanel.tsx:898
+#: packages/admin/src/components/ContentSettingsPanel.tsx:960
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:402
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:246
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:398
+#: packages/admin/src/routes/byline-schema.tsx:237
+#: packages/admin/src/routes/bylines.tsx:487
+msgid "Slug"
+msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr "Slug скопійовано в буфер обміну"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:251
+msgid "Slugs cannot be changed after the field is created."
+msgstr "Slug не можна змінити після створення поля."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1047
+msgid "Small section heading"
+msgstr "Малий заголовок секції"
+
+#: packages/admin/src/components/Settings.tsx:76
+#: packages/admin/src/components/settings/SocialSettings.tsx:70
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
+msgid "Social Links"
+msgstr "Соціальні посилання"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:38
+msgid "Social links saved"
+msgstr "Соціальні посилання збережено"
+
+#: packages/admin/src/components/Settings.tsx:77
+msgid "Social media profile links"
+msgstr "Посилання на профілі в соцмережах"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:100
+msgid "Social Profiles"
+msgstr "Соціальні профілі"
+
+#: packages/admin/src/components/WordPressImport.tsx:1860
+msgid "Some content types cannot be imported"
+msgstr "Деякі типи вмісту не можна імпортувати"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:154
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Something went wrong"
+msgstr "Щось пішло не так"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr "Сортувати плагіни"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr "Сортувати теми"
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:560
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:214
+#: packages/admin/src/components/PluginManager.tsx:497
+#: packages/admin/src/components/Redirects.tsx:466
+#: packages/admin/src/components/SectionEditor.tsx:281
+msgid "Source"
+msgstr "Джерело"
+
+#: packages/admin/src/components/Redirects.tsx:131
+msgid "Source path"
+msgstr "Шлях джерела"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "спам"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:207
+#: packages/admin/src/components/comments/CommentInbox.tsx:247
+msgid "Spam"
+msgstr "Спам"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3627
+msgid "Spotlight Mode"
+msgstr "Режим фокусу"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr "Таблиці"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:51
+msgid "SQL"
+msgstr "SQL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1922
+msgid "Start Import"
+msgstr "Почати імпорт"
+
+#: packages/admin/src/components/ContentEditor.tsx:1177
+#: packages/admin/src/components/PortableTextEditor.tsx:2201
+#: packages/admin/src/components/PortableTextEditor.tsx:2202
+msgid "Start writing, or type '/' for commands"
+msgstr "Почніть писати або введіть «/» для команд"
+
+#: packages/admin/src/components/ContentList.tsx:511
+#: packages/admin/src/components/ContentSettingsPanel.tsx:401
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:471
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr "Статус"
+
+#: packages/admin/src/components/Redirects.tsx:151
+msgid "Status code"
+msgstr "Код статусу"
+
+#: packages/admin/src/components/Dashboard.tsx:357
+msgid "Status: {status}"
+msgstr "Статус: {status}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:173
+msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
+msgstr "Зберігайте щоденну резервну копію у сховищі сайту. Старі копії видаляються автоматично."
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:218
+msgid "Stored Backups"
+msgstr "Збережені резервні копії"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:293
+msgid "Stored per locale — each translation of a byline gets its own value."
+msgstr "Зберігається для кожної локалі — кожен переклад авторського рядка має власне значення."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3106
+#: packages/admin/src/components/PortableTextEditor.tsx:3440
+msgid "Strikethrough"
+msgstr "Закреслення"
+
+#: packages/admin/src/components/WordPressImport.tsx:1752
+msgid "Structure"
+msgstr "Структура"
+
+#: packages/admin/src/components/WordPressImport.tsx:1164
+msgid "Structured"
+msgstr "Структурований"
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr "Підполя"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "Підписник"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:52
+msgid "Svelte"
+msgstr "Svelte"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:53
+msgid "Swift"
+msgstr "Swift"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr "Синхронізовано"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Синхронізований passkey"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:777
+msgid "System"
+msgstr "Система"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "Система ({resolvedLabel})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:599
+msgid "System Fields"
+msgstr "Системні поля"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1121
+msgid "Table"
+msgstr "Таблиця"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3180
+msgid "Table controls"
+msgstr "Елементи керування таблицею"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:139
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr "Слоган"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+#: packages/admin/src/components/Widgets.tsx:141
+msgid "Tags"
+msgstr "Теги"
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1797
+msgid "Tags ({0})"
+msgstr "Теги ({0})"
+
+#: packages/admin/src/components/MenuEditor.tsx:427
+#: packages/admin/src/components/MenuEditor.tsx:606
+msgid "Target"
+msgstr "Ціль"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:172
+msgid "Target locale"
+msgstr "Цільова локаль"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:543
+msgid "Taxonomies"
+msgstr "Таксономії"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Taxonomies Manage"
+msgstr "Керування таксономіями"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:898
+msgid "Taxonomy created"
+msgstr "Таксономію створено"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:785
+msgid "Taxonomy not found:"
+msgstr "Таксономію не знайдено:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:159
+msgid "Taxonomy: {taxonomyName}"
+msgstr "Таксономія: {taxonomyName}"
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr "Шаблон:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Term"
+msgstr "Термін"
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:759
+msgid "Term \"{0}\" created in {1}."
+msgstr "Термін \"{0}\" створено в {1}."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:741
+msgid "Term deleted"
+msgstr "Термін видалено"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:122
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3397
+msgid "Text formatting"
+msgstr "Форматування тексту"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "Доступ пристрою не буде надано."
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "The existing collection has fields with incompatible types."
+msgstr "Існуюча колекція містить поля з несумісними типами."
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "Наступні таблиці містять контент, але не зареєстровані як колекції. Зареєструйте їх, щоб керувати цим контентом в адмін-панелі."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:179
+msgid "The invited user will have this role once they complete registration."
+msgstr "Запрошений користувач отримає цю роль після завершення реєстрації."
+
+#: packages/admin/src/components/LoginPage.tsx:113
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "The link will expire in 15 minutes."
+msgstr "Посилання діє 15 хвилин."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "Маркетплейс порожній. Завітайте пізніше — можуть з’явитися нові плагіни."
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "The menu has been deleted."
+msgstr "Меню видалено."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:136
+msgid "The name of your site, used in the header and metadata"
+msgstr "Назва вашого сайту, що використовується в заголовку та метаданих"
+
+#: packages/admin/src/router.tsx:2159
+msgid "The page you're looking for doesn't exist."
+msgstr "Сторінку, яку ви шукаєте, не знайдено."
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
+msgid "The plugin field widget failed to render."
+msgstr "Не вдалося відобразити віджет поля плагіна."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:149
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "Публічна URL-адреса вашого сайту (для канонічних посилань і мап сайту)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr "Зазначене зображення більше недоступне. Виберіть інше або приберіть посилання."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:174
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr "Зазначений логотип більше недоступний. Виберіть інший або приберіть посилання."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr "Маркетплейс тем порожній. Завітайте пізніше."
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr "Тема"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:294
+msgid "Theme ID: {0}"
+msgstr "ID теми: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr "Тему не знайдено"
+
+#: packages/admin/src/components/SectionEditor.tsx:183
+msgid "Theme Section"
+msgstr "Розділ теми"
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "Розділи від теми не можна видалити. Відредагуйте розділ, щоб створити власну копію, потім видаліть її."
+
+#: packages/admin/src/components/ThemeToggle.tsx:33
+msgid "Theme: {label}"
+msgstr "Тема: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:371
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr "Теми"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:370
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr "Цю колекцію визначено в коді. Деякі налаштування тут змінити не можна. Редагуйте файл live.config.ts, щоб змінити схему."
+
+#: packages/admin/src/components/WordPressImport.tsx:1059
+msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
+msgstr "Це не схоже на дійсний ключ міграції. Згенеруйте новий у плагіні та вставте повний рядок, що починається з \"em1.\"."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:417
+msgid "This field does not accept {sniffedMime} files."
+msgstr "Це поле не приймає файли {sniffedMime}."
+
+#: packages/admin/src/components/ContentEditor.tsx:1686
+#: packages/admin/src/components/ImageFieldRenderer.tsx:191
+msgid "This field is required"
+msgstr "Це поле обов’язкове"
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "This is a custom section."
+msgstr "Це власний розділ."
+
+#: packages/admin/src/components/WordPressImport.tsx:1308
+msgid "This is a WordPress site."
+msgstr "Це сайт WordPress."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "Посилання діє 7 днів і може бути використане лише один раз."
+
+#: packages/admin/src/components/WordPressImport.tsx:921
+msgid "This may take a while for large exports."
+msgstr "Для великих експортів це може зайняти деякий час."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "Цей passkey уже зареєстровано на цьому пристрої."
+
+#. placeholder {0}: archiveToDelete?.name ?? ""
+#: packages/admin/src/components/settings/BackupSettings.tsx:283
+msgid "This permanently deletes {0} from storage."
+msgstr "Це остаточно видалить {0} із сховища."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:276
+msgid "This plugin requires no special permissions."
+msgstr "Цей плагін не потребує спеціальних дозволів."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:566
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr "Цей видавець стверджує право на ім’я, яке не зміг підтвердити — можливо, видає себе за іншу особу. Встановлення вимкнено. Якщо ви знаєте видавця і довіряєте йому, попросіть виправити налаштування ідентичності перед повторною спробою."
+
+#: packages/admin/src/components/Redirects.tsx:581
+msgid "This redirect rule will be permanently removed."
+msgstr "Це правило перенаправлення буде остаточно видалено."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:618
+msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
+msgstr "Цей випуск потребує новішого середовища, ніж зараз на вашому сайті. Оновіть середовище перед встановленням."
+
+#: packages/admin/src/routes/bylines.tsx:624
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr "Це видалить профіль підпису автора. Посилання на авторські рядки в контенті буде прибрано, а вказівники lead очищено."
+
+#: packages/admin/src/components/SectionEditor.tsx:285
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "Цей розділ надано темою. Редагування створить власну копію, яка замінить версію з теми."
+
+#: packages/admin/src/components/SectionEditor.tsx:290
+msgid "This section was imported from another system."
+msgstr "Цей розділ імпортовано з іншої системи."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:121
+msgid "This update exposes the following routes without authentication:"
+msgstr "Це оновлення відкриває такі маршрути без автентифікації:"
+
+#: packages/admin/src/components/Widgets.tsx:698
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr "Це видалить область віджетів і всі віджети в ній. Цю дію не можна скасувати."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "Це надасть доступ до CLI з вашими дозволами."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:606
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "Елемент буде переміщено в кошик. Пізніше його можна відновити з кошика."
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:884
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "Це назавжди видалить \"{0}\" і прибере його з усього вмісту."
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "Це назавжди видалить \"{0}\". Цю дію не можна скасувати."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "Це остаточно видалить цей коментар. Цю дію не можна скасувати."
+
+#: packages/admin/src/components/PluginManager.tsx:629
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "Це прибере плагін і його пакет із вашого сайту."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:78
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "Буде відновлено опубліковану версію. Зміни в чернетці буде втрачено."
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr "Думки, навчальні матеріали та інше"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:287
+msgid "Timezone"
+msgstr "Часовий пояс"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:290
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "Часовий пояс для відображення дат (наприклад, Europe/Kyiv)"
+
+#: packages/admin/src/components/ContentList.tsx:505
+#: packages/admin/src/components/ContentList.tsx:643
+#: packages/admin/src/components/SectionEditor.tsx:238
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:874
+msgid "Title"
+msgstr "Заголовок"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:361
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:550
+msgid "Title (Tooltip)"
+msgstr "Заголовок (підказка)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+msgid "Title Separator"
+msgstr "Роздільник заголовка"
+
+#: packages/admin/src/components/ContentList.tsx:811
+msgid "to"
+msgstr "до"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "щоб закрити"
+
+#: packages/admin/src/components/ContentList.tsx:815
+msgid "To date"
+msgstr "До дати"
+
+#: packages/admin/src/components/PluginManager.tsx:203
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "для встановлення плагінів або додайте їх у astro.config.mjs."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "щоб вибрати"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3225
+msgid "Toggle header row"
+msgstr "Перемкнути рядок заголовка"
+
+#: packages/admin/src/components/ThemeToggle.tsx:31
+#: packages/admin/src/components/ThemeToggle.tsx:42
+msgid "Toggle theme (current: {label})"
+msgstr "Перемкнути тему (зараз: {label})"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
+msgid "Token created: {0}"
+msgstr "Токен створено: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:405
+msgid "Token Name"
+msgstr "Назва токена"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:54
+msgid "TOML"
+msgstr "TOML"
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "Tools → Export"
+msgstr "Інструменти → Експорт"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr "Відстежувати історію контенту"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:287
+#: packages/admin/src/routes/byline-schema.tsx:243
+msgid "Translatable"
+msgstr "Перекладний"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:83
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translate"
+msgstr "Перекласти"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:156
+msgid "Translate \"{0}\""
+msgstr "Перекласти \"{0}\""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:80
+msgid "Translate {0}"
+msgstr "Перекласти {0}"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translating..."
+msgstr "Переклад..."
+
+#: packages/admin/src/components/MenuEditor.tsx:143
+#: packages/admin/src/components/TaxonomyManager.tsx:758
+#: packages/admin/src/router.tsx:1118
+msgid "Translation created"
+msgstr "Переклад створено"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:60
+msgid "Translations"
+msgstr "Переклади"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "кошик"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:216
+#: packages/admin/src/components/comments/CommentInbox.tsx:257
+#: packages/admin/src/components/comments/CommentInbox.tsx:513
+#: packages/admin/src/components/ContentList.tsx:375
+msgid "Trash"
+msgstr "Кошик"
+
+#: packages/admin/src/components/ContentList.tsx:666
+msgid "Trash is empty"
+msgstr "Кошик порожній"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "Trash is empty."
+msgstr "Кошик порожній."
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr "Перемикач так/ні"
+
+#: packages/admin/src/components/MediaLibrary.tsx:493
+msgid "Try a broader media type or clear your filters."
+msgstr "Спробуйте ширший тип медіа або скиньте фільтри."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:642
+msgid "Try a different search term"
+msgstr "Спробуйте інший пошуковий запит"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr "Спробуйте змінити пошук"
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr "Спробуйте змінити пошук або фільтри."
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr "Спробувати ще раз"
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Try Again"
+msgstr "Спробувати ще раз"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "Спробуйте інший код"
+
+#: packages/admin/src/components/MediaLibrary.tsx:518
+msgid "Try another filename or clear your search."
+msgstr "Спробуйте іншу назву файлу або скиньте пошук."
+
+#: packages/admin/src/components/MediaLibrary.tsx:492
+msgid "Try another filename, or clear your search and filters."
+msgstr "Спробуйте іншу назву файлу або скиньте пошук і фільтри."
+
+#: packages/admin/src/components/WordPressImport.tsx:1286
+#: packages/admin/src/components/WordPressImport.tsx:1408
+msgid "Try Another URL"
+msgstr "Спробувати іншу URL-адресу"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr "Спробувати з моїми даними"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:55
+msgid "TSX"
+msgstr "TSX"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:282
+msgid "Turn into"
+msgstr "Перетворити на"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:106
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:260
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:587
+#: packages/admin/src/routes/byline-schema.tsx:240
+msgid "Type"
+msgstr "Тип"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:2018
+msgid "Type mismatch ({0})"
+msgstr "Невідповідність типу ({0})"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:56
+msgid "TypeScript"
+msgstr "TypeScript"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr "Не вдалося підключитися до маркетплейсу"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1003
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1020
+msgid "Unassigned"
+msgstr "Не призначено"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3099
+#: packages/admin/src/components/PortableTextEditor.tsx:3433
+msgid "Underline"
+msgstr "Підкреслення"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3607
+msgid "Undo"
+msgstr "Скасувати"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:180
+#: packages/admin/src/components/PluginManager.tsx:547
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstall"
+msgstr "Видалити"
+
+#: packages/admin/src/components/PluginManager.tsx:627
+msgid "Uninstall {pluginName}?"
+msgstr "Видалити {pluginName}?"
+
+#: packages/admin/src/components/PluginManager.tsx:622
+msgid "Uninstall confirmation"
+msgstr "Підтвердження видалення"
+
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstalling..."
+msgstr "Видалення..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:731
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr "Унікальний"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr "Унікальний ідентифікатор (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "Невідомо"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "Невідома роль"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Unlock aspect ratio"
+msgstr "Розблокувати пропорції"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr "Passkey без назви"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:184
+msgid "Unpublish"
+msgstr "Зняти з публікації"
+
+#: packages/admin/src/router.tsx:1026
+msgid "Unpublished"
+msgstr "Неопубліковано"
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr "Знайдено незареєстровані таблиці контенту"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:429
+msgid "Unschedule"
+msgstr "Скасувати публікацію за розкладом"
+
+#: packages/admin/src/router.tsx:1087
+msgid "Unscheduled"
+msgstr "Без розкладу"
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr "Непідтримуваний тип елемента віджета: {0}"
+
+#: packages/admin/src/components/Dashboard.tsx:317
+msgid "Untitled"
+msgstr "Без назви"
+
+#: packages/admin/src/components/ContentEditor.tsx:1589
+msgid "Untitled file"
+msgstr "Файл без назви"
+
+#: packages/admin/src/components/Widgets.tsx:531
+#: packages/admin/src/components/Widgets.tsx:792
+msgid "Untitled Widget"
+msgstr "Віджет без назви"
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr "Неперевірений видавець"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:830
+msgid "Up"
+msgstr "Вгору"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:478
+msgid "Update"
+msgstr "Оновити"
+
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Update Field"
+msgstr "Оновити поле"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:334
+msgid "Update settings for {0}"
+msgstr "Оновити налаштування для {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Update site settings"
+msgstr "Оновити налаштування сайту"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:366
+msgid "Update the {0} details"
+msgstr "Оновити дані {0}"
+
+#: packages/admin/src/components/Redirects.tsx:109
+msgid "Update this redirect rule."
+msgstr "Оновіть це правило перенаправлення."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Update to v{0}"
+msgstr "Оновити до v{0}"
+
+#: packages/admin/src/components/ContentList.tsx:737
+#: packages/admin/src/components/ContentSettingsPanel.tsx:490
+#: packages/admin/src/components/RegistryPluginDetail.tsx:488
+msgid "Updated"
+msgstr "Оновлено"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr "Оновлено о"
+
+#: packages/admin/src/components/WordPressImport.tsx:946
+msgid "Updating content URLs..."
+msgstr "Оновлення URL-адрес контенту..."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:168
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Updating..."
+msgstr "Оновлення..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:600
+msgid "Upload"
+msgstr "Завантажити"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:146
+msgid "Upload a file to get started"
+msgstr "Завантажте файл, щоб почати"
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Upload an export file"
+msgstr "Завантажте файл експорту"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:147
+msgid "Upload an image to get started"
+msgstr "Завантажте зображення, щоб почати"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Upload and delete media"
+msgstr "Завантаження та видалення медіа"
+
+#: packages/admin/src/lib/api/marketplace.ts:226
+#: packages/admin/src/lib/api/marketplace.ts:234
+msgid "Upload and manage media"
+msgstr "Завантаження та керування медіа"
+
+#: packages/admin/src/components/WordPressImport.tsx:1284
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Upload Export File"
+msgstr "Завантажити файл експорту"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:620
+msgid "Upload failed: {uploadError}"
+msgstr "Завантаження не вдалося: {uploadError}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:612
+msgid "Upload file"
+msgstr "Завантажити файл"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:148
+msgid "Upload File"
+msgstr "Завантажити файл"
+
+#: packages/admin/src/components/MediaLibrary.tsx:365
+msgid "Upload files"
+msgstr "Завантажити файли"
+
+#: packages/admin/src/components/MediaLibrary.tsx:508
+#: packages/admin/src/components/MediaLibrary.tsx:532
+msgid "Upload Files"
+msgstr "Завантажити файли"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:148
+msgid "Upload Image"
+msgstr "Завантажити зображення"
+
+#: packages/admin/src/components/MediaLibrary.tsx:505
+msgid "Upload images, videos, and documents to keep reusable assets in one place."
+msgstr "Завантажуйте зображення, відео та документи, щоб тримати багаторазові ресурси в одному місці."
+
+#: packages/admin/src/components/Dashboard.tsx:111
+msgid "Upload Media"
+msgstr "Завантажити медіа"
+
+#: packages/admin/src/components/MediaLibrary.tsx:529
+msgid "Upload media to keep reusable assets in one place."
+msgstr "Завантажуйте медіа, щоб тримати багаторазові ресурси в одному місці."
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:356
+msgid "Upload to {0}"
+msgstr "Завантажити в {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "Upload WordPress export file"
+msgstr "Завантажити файл експорту WordPress"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:289
+msgid "Uploaded:"
+msgstr "Завантажено:"
+
+#: packages/admin/src/components/WordPressImport.tsx:2127
+msgid "Uploading"
+msgstr "Завантаження"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:331
+msgid "Uploading {0}/{1}..."
+msgstr "Завантаження {0}/{1}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:332
+#: packages/admin/src/components/MediaPickerModal.tsx:600
+msgid "Uploading..."
+msgstr "Завантаження..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:54
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:418
+#: packages/admin/src/components/MenuEditor.tsx:596
+#: packages/admin/src/components/PortableTextEditor.tsx:3053
+#: packages/admin/src/components/PortableTextEditor.tsx:3552
+#: packages/admin/src/components/PortableTextEditor.tsx:3562
+msgid "URL"
+msgstr "URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:423
+msgid "URL Pattern"
+msgstr "Шаблон URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr "Ідентифікатор, зручний для URL"
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "Ідентифікатор для URL (напр., \"primary\", \"footer\")"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:295
+msgid "URL:"
+msgstr "URL:"
+
+#: packages/admin/src/components/Redirects.tsx:110
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "Використовуйте [param] або [...rest] у шляхах для зіставлення з шаблоном."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:364
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "Увійдіть за допомогою біометрії, ключа безпеки або PIN-коду на пристрої."
+
+#: packages/admin/src/components/LoginPage.tsx:326
+msgid "Use your registered passkey to sign in securely."
+msgstr "Увійдіть безпечно за допомогою зареєстрованого passkey."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr "Використовується як резервне зображення Open Graph, якщо на сторінці його немає. Рекомендований розмір: 1200×630."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:644
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "Використовується як ідентифікатор. Лише малі літери, цифри та підкреслення."
+
+#: packages/admin/src/components/ContentEditor.tsx:1276
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "Головне зображення допису в списках і на початку допису"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:122
+msgid "Used by screen readers and when image fails to load"
+msgstr "Для зчитувачів екрана та коли зображення не завантажилося"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:408
+msgid "Used in URLs and API endpoints"
+msgstr "Використовується в URL і кінцевих точках API"
+
+#: packages/admin/src/components/SectionEditor.tsx:256
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "Ідентифікатор цього розділу. Лише малі літери, цифри та дефіси."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:43
+#: packages/admin/src/components/Header.tsx:83
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr "Користувач"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:177
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "Доступ користувачів керується зовнішнім провайдером ({0}). Налаштування доменів для самостійної реєстрації недоступні при зовнішній автентифікації."
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr "Дані користувача"
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr "Користувача не знайдено"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:348
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr "Користувачі"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:383
+msgid "Users from"
+msgstr "Користувачі з"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:211
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "Користувачі з адресами e-mail цих доменів можуть зареєструватися без запрошення. Їм автоматично буде призначено вказану роль."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:358
+msgid "v{0} available"
+msgstr "Доступно v{0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr "Валідація"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:186
+#: packages/admin/src/components/RegistryPluginDetail.tsx:449
+msgid "Verified publisher"
+msgstr "Перевірений видавець"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:448
+msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
+msgstr "Перевірений видавець, підтверджено маркувальником {verifiedLabeller}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:439
+msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+msgstr "Перевірений видавець. Маркувальник ({verifiedLabeller}) підтвердив ідентичність цього видавця."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:440
+msgid "Verified publisher. A labeller has confirmed this publisher's identity."
+msgstr "Перевірений видавець. Маркувальник підтвердив ідентичність цього видавця."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:226
+msgid "Verifying your invite..."
+msgstr "Перевірка запрошення..."
+
+#: packages/admin/src/components/SignupPage.tsx:386
+msgid "Verifying your link..."
+msgstr "Перевірка посилання..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:211
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "Перевірка..."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:320
+#: packages/admin/src/components/RegistryPluginDetail.tsx:502
+msgid "Version"
+msgstr "Версія"
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:464
+msgid "Version {0}"
+msgstr "Версія {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+#: packages/admin/src/components/MediaLibrary.tsx:435
+msgid "Video"
+msgstr "Відео"
+
+#: packages/admin/src/components/Settings.tsx:117
+msgid "View email provider status and send test emails"
+msgstr "Статус поштового провайдера та тестові листи"
+
+#: packages/admin/src/components/PluginManager.tsx:429
+msgid "View in Marketplace"
+msgstr "Переглянути в маркетплейсі"
+
+#: packages/admin/src/components/MediaLibrary.tsx:447
+msgid "View mode"
+msgstr "Режим перегляду"
+
+#: packages/admin/src/components/ContentList.tsx:1009
+msgid "View published {title}"
+msgstr "Переглянути опублікований {title}"
+
+#: packages/admin/src/components/Header.tsx:59
+msgid "View Site"
+msgstr "Переглянути сайт"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:663
+msgid "View source"
+msgstr "Переглянути код"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:916
+msgid "View the {license} license on spdx.org"
+msgstr "Переглянути ліцензію {license} на spdx.org"
+
+#: packages/admin/src/components/Redirects.tsx:448
+msgid "Visitors hitting these paths will see an error."
+msgstr "Відвідувачі за цими шляхами побачать помилку."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:57
+msgid "Vue"
+msgstr "Vue"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "Очікування passkey..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr "Попередження"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1266
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "Не вдалося підключитися до сайту WordPress за адресою {0}. Можливо, це не WordPress, REST API вимкнено або сайт недоступний."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:564
+msgid "We couldn't verify this publisher's identity"
+msgstr "Не вдалося перевірити ідентичність цього видавця"
+
+#: packages/admin/src/components/WordPressImport.tsx:1084
+msgid "We'll check what import options are available for your site."
+msgstr "Перевіримо, які варіанти імпорту доступні для вашого сайту."
+
+#: packages/admin/src/components/LoginPage.tsx:323
+msgid "We'll send you a link to sign in without a password."
+msgstr "Ми надішлемо посилання для входу без пароля."
+
+#: packages/admin/src/components/SignupPage.tsx:132
+msgid "We've sent a verification link to"
+msgstr "Ми надіслали посилання для підтвердження на"
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr "Веб-адреса"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "WebAuthn не підтримується в цьому браузері"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/RegistryPluginDetail.tsx:688
+msgid "Website"
+msgstr "Вебсайт"
+
+#: packages/admin/src/routes/bylines.tsx:492
+msgid "Website URL"
+msgstr "URL вебсайту"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "Ласкаво просимо до EmDash, {firstName}!"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "Ласкаво просимо до EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "What happens when you import:"
+msgstr "Що відбувається під час імпорту:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1874
+msgid "What will happen when you import"
+msgstr "Що станеться під час імпорту"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr "Коли запис створено"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr "Коли запис востаннє змінено"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr "Коли запис опубліковано"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:658
+msgid "Which content types can use this taxonomy"
+msgstr "Які типи контенту можуть використовувати цю таксономію"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr "Ціле число"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:121
+msgid "Why can't this be changed?"
+msgstr "Чому це не можна змінити?"
+
+#: packages/admin/src/components/SeoPanel.tsx:209
+msgid "Why is this important for duplicate pages?"
+msgstr "Чому це важливо для дублікатів сторінок?"
+
+#: packages/admin/src/components/SeoPanel.tsx:185
+msgid "Why is this important for search result summaries?"
+msgstr "Чому це важливо для описів у результатах пошуку?"
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Why is this important for search result titles?"
+msgstr "Чому це важливо для заголовків у результатах пошуку?"
+
+#: packages/admin/src/components/SeoPanel.tsx:228
+msgid "Why is this important for search visibility?"
+msgstr "Чому це важливо для видимості в пошуку?"
+
+#: packages/admin/src/components/SeoImageField.tsx:44
+msgid "Why is this important for social sharing?"
+msgstr "Чому це важливо для поширення в соцмережах?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:123
+msgid "Why is this important?"
+msgstr "Чому це важливо?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
+msgid "Wide"
+msgstr "Широкий"
+
+#: packages/admin/src/components/Widgets.tsx:785
+#: packages/admin/src/components/Widgets.tsx:800
+msgid "widget"
+msgstr "віджет"
+
+#: packages/admin/src/components/Widgets.tsx:230
+msgid "Widget added"
+msgstr "Віджет додано"
+
+#: packages/admin/src/components/Widgets.tsx:218
+msgid "Widget area created"
+msgstr "Область віджетів створено"
+
+#: packages/admin/src/components/Widgets.tsx:628
+msgid "Widget area deleted"
+msgstr "Область віджетів видалено"
+
+#: packages/admin/src/components/Widgets.tsx:748
+msgid "Widget deleted"
+msgstr "Віджет видалено"
+
+#: packages/admin/src/components/Widgets.tsx:877
+msgid "Widget title"
+msgstr "Заголовок віджета"
+
+#: packages/admin/src/components/Widgets.tsx:763
+msgid "Widget updated"
+msgstr "Віджет оновлено"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:379
+#: packages/admin/src/components/Sidebar.tsx:333
+#: packages/admin/src/components/Widgets.tsx:385
+#: packages/admin/src/components/WordPressImport.tsx:1157
+msgid "Widgets"
+msgstr "Віджети"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:284
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:473
+msgid "Width"
+msgstr "Ширина"
+
+#: packages/admin/src/components/WordPressImport.tsx:2014
+msgid "Will create"
+msgstr "Буде створено"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:384
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "більше не зможуть зареєструватися без запрошення. Існуючі користувачі не зачіпаються."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:158
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "Без поштового провайдера посилання-запрошення треба надсилати вручну."
+
+#: packages/admin/src/components/WordPressImport.tsx:210
+msgid "WordPress authorization was rejected"
+msgstr "Авторизацію WordPress відхилено"
+
+#: packages/admin/src/components/WordPressImport.tsx:1476
+msgid "WordPress Username"
+msgstr "Ім’я користувача WordPress"
+
+#: packages/admin/src/components/ContentList.tsx:404
+msgid "Working on {selectedCount} items…"
+msgstr "Обробка {selectedCount} елементів…"
+
+#: packages/admin/src/components/Widgets.tsx:887
+msgid "Write widget content..."
+msgstr "Введіть вміст віджета..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1181
+msgid "WXR File"
+msgstr "Файл WXR"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:58
+msgid "XML"
+msgstr "XML"
+
+#: packages/admin/src/components/WordPressImport.tsx:1497
+msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
+msgstr "xxxx xxxx xxxx xxxx xxxx xxxx"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:59
+msgid "YAML"
+msgstr "YAML"
+
+#: packages/admin/src/components/Widgets.tsx:161
+msgid "Yearly"
+msgstr "Щорічно"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:420
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "Yes"
+msgstr "Так"
+
+#: packages/admin/src/components/WordPressImport.tsx:1160
+msgid "Yoast/RankMath"
+msgstr "Yoast/RankMath"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "Можете закрити цю сторінку й повернутися до термінала."
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "Ви можете створювати та редагувати власний контент."
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "Ви можете керувати контентом, медіа, меню та таксономіями."
+
+#: packages/admin/src/routes/bylines.tsx:550
+msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+msgstr "Ви ще можете редагувати поля вище. Збереження не змінить збережені значення власних полів."
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "Ви можете переглядати сайт і долучатися до роботи з ним."
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr "Ви не можете змінити власну роль"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "У вас повний доступ до керування сайтом, включно з користувачами, налаштуваннями та всім контентом."
+
+#: packages/admin/src/routes/byline-schema.tsx:175
+msgid "You need admin permissions to manage byline schema."
+msgstr "Для керування схемою підписів авторів потрібні права адміністратора."
+
+#: packages/admin/src/router.tsx:1485
+msgid "You need Editor permissions to moderate comments."
+msgstr "Для модерації коментарів потрібні права редактора."
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "Ви більше не зможете входити за допомогою \"{0}\". Цю дію не можна скасувати."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "Ви більше не зможете входити цим passkey. Цю дію не можна скасувати."
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:54
+msgid "You'll be joining as <0>{0}</0>"
+msgstr "Ви приєднаєтеся як <0>{0}</0>"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "Вас попросять увійти біометрією, ключем безпеки або PIN-кодом на пристрої."
+
+#: packages/admin/src/components/WordPressImport.tsx:1369
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "Вас перенаправлять до WordPress для авторизації з’єднання."
+
+#: packages/admin/src/components/SignupPage.tsx:191
+msgid "You'll be signing up as"
+msgstr "Ви реєструєтеся як"
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr "Ви ввійшли через Cloudflare Access"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:52
+msgid "You've been invited!"
+msgstr "Вас запрошено!"
+
+#: packages/admin/src/components/SignupPage.tsx:70
+msgid "you@company.com"
+msgstr "ви@company.com"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:334
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr "ви@example.com"
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "Ваш обліковий запис успішно створено."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:316
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "Ваш браузер не підтримує passkey. Використайте сучасний браузер, наприклад Chrome, Safari, Firefox або Edge."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:267
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "Ваш пристрій не підтримує потрібні функції безпеки."
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr "Ваша електронна пошта"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:121
+msgid "Your Facebook page or profile username"
+msgstr "Ім’я сторінки або профілю Facebook"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:115
+msgid "Your GitHub username"
+msgstr "Ваше ім’я користувача GitHub"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:127
+msgid "Your Instagram username"
+msgstr "Ваше ім’я користувача Instagram"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:133
+msgid "Your LinkedIn profile username"
+msgstr "Ім’я профілю LinkedIn"
+
+#: packages/admin/src/components/MediaLibrary.tsx:504
+#: packages/admin/src/components/MediaLibrary.tsx:528
+msgid "Your media library is empty"
+msgstr "Ваша медіатека порожня"
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr "Ваше ім’я"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:64
+#: packages/admin/src/components/SignupPage.tsx:201
+msgid "Your name (optional)"
+msgstr "Ваше ім’я (необов’язково)"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "Ваша роль"
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:599
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr "На вашому сайті випуски можна встановлювати лише після {0} з моменту публікації. Цей випуск стане доступним для встановлення пізніше."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:109
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "Ваш нік у Twitter/X (наприклад, @username)"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:437
+msgid "Your unsaved media changes will be lost."
+msgstr "Незбережені зміни медіа буде втрачено."
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:2062
+msgid "Your WordPress export contains {0} media files."
+msgstr "Ваш експорт WordPress містить {0} медіафайлів."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:139
+msgid "Your YouTube channel ID or handle"
+msgstr "ID каналу YouTube або ваш нік"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:136
+msgid "YouTube"
+msgstr "YouTube"

--- a/packages/admin/src/locales/uk/messages.po
+++ b/packages/admin/src/locales/uk/messages.po
@@ -7,6 +7,11 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: uk\n"
 "Plural-Forms: nplurals=4; plural=((n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) ? 1 : ((n % 10 == 0 || (n % 10 >= 5 && n % 10 <= 9) || (n % 100 >= 11 && n % 100 <= 14)) ? 2 : 3)));\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 
 #: packages/admin/src/routes/bylines.tsx:447
 msgid " - Guest"
@@ -2797,8 +2802,14 @@ msgid "Editor"
 msgstr "Редактор"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:305
-msgid "Editor\nReporter\nPhotographer"
-msgstr "Редактор\nРепортер\nФотограф"
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr ""
+"Редактор\n"
+"Репортер\n"
+"Фотограф"
 
 #: packages/admin/src/components/WordPressImport.tsx:1044
 msgid "em1.…"
@@ -5425,8 +5436,14 @@ msgid "Open WordPress Profile"
 msgstr "Відкрити профіль WordPress"
 
 #: packages/admin/src/components/FieldEditor.tsx:515
-msgid "Option 1\nOption 2\nOption 3"
-msgstr "Варіант 1\nВаріант 2\nВаріант 3"
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr ""
+"Варіант 1\n"
+"Варіант 2\n"
+"Варіант 3"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:544


### PR DESCRIPTION
## What does this PR do?

Add uk/messages.po catalog with full admin UI translations and enable the Ukrainian locale in the admin language switcher.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include messages.po changes except in translation PRs — a workflow extracts catalogs on merge to main. — This is a translation PR; only the uk catalog changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Composer 2.5
- [x] Manualy checked translation

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
