### PR TITLE
fix(cloudflare): remove D1 ConnectionMutex on the raw-binding singleton (#2040)

### DIFF
--- a/.changeset/d1-default-deadlock-fix.md
+++ b/.changeset/d1-default-deadlock-fix.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes a site-wide hang on Cloudflare Workers with the default D1 config (`d1({ binding: "DB" })`, sessions disabled). Previously, a single request canceled while a D1 query was in flight could deadlock every subsequent D1 query on that Worker isolate — including EmDash's own per-request middleware — so all SSR pages hung until the isolate was recycled. Concurrent D1 queries on the default raw binding now run independently instead of being serialized behind a connection mutex, removing the deadlock.

--- a/packages/cloudflare/src/db/d1-dialect.ts
+++ b/packages/cloudflare/src/db/d1-dialect.ts
@@ -7,9 +7,42 @@
  */
 
 import type { DatabaseIntrospector, Kysely } from "kysely";
+import { SqliteAdapter } from "kysely";
 import { D1Dialect } from "kysely-d1";
 
 import { D1Introspector } from "./d1-introspector.js";
+
+/**
+ * Adapter for the raw-binding (non-session) D1 dialect only.
+ *
+ * The stock SqliteAdapter reports `supportsMultipleConnections: false`, which
+ * makes Kysely's RuntimeDriver serialize every query behind a ConnectionMutex
+ * (acquire → execute → release). On Workers a request canceled mid-query
+ * leaves the pending I/O promise unsettled, so `releaseLock()` never runs and
+ * every later `obtainLock()` waits forever — a single canceled request then
+ * deadlocks the whole isolate (#2040).
+ *
+ * The mutex protects nothing on the raw binding: kysely-d1's D1Connection
+ * rejects transactions outright, releaseConnection is a no-op, and concurrent
+ * `prepare().all()` calls are independent subrequests. Reporting `true`
+ * removes the deadlock class with no read-your-writes implications — there is
+ * no session bookmark to protect on this path.
+ *
+ * This is deliberately a SEPARATE dialect (RawBindingD1Dialect) rather than a
+ * change to EmDashD1Dialect: the session-backed non-coalesce path in
+ * createRequestScopedDb also builds an EmDashD1Dialect, and there the mutex
+ * IS load-bearing. A D1DatabaseSession advances its bookmark per executed
+ * query; concurrent physical calls on one session could interleave the
+ * bookmark and persist a stale one at commit(), breaking read-your-writes.
+ * (The coalescing session path removes the mutex safely by adding its own
+ * single-in-flight op chain — see CoalescingD1Connection — but the plain
+ * session path has no such replacement, so it must keep the mutex.)
+ */
+class RawBindingD1Adapter extends SqliteAdapter {
+	override get supportsMultipleConnections(): boolean {
+		return true;
+	}
+}
 
 /**
  * Custom D1 Dialect that uses our D1-compatible introspector
@@ -20,5 +53,18 @@ import { D1Introspector } from "./d1-introspector.js";
 export class EmDashD1Dialect extends D1Dialect {
 	override createIntrospector(db: Kysely<any>): DatabaseIntrospector {
 		return new D1Introspector(db);
+	}
+}
+
+/**
+ * Dialect for the raw-binding singleton (no D1 session). Identical to
+ * EmDashD1Dialect except it reports `supportsMultipleConnections: true` so
+ * Kysely skips the ConnectionMutex that turns one canceled request into an
+ * isolate-wide deadlock (#2040). Use ONLY for the raw binding — never for a
+ * session-backed Kysely (see RawBindingD1Adapter above).
+ */
+export class RawBindingD1Dialect extends EmDashD1Dialect {
+	override createAdapter(): SqliteAdapter {
+		return new RawBindingD1Adapter();
 	}
 }

--- a/packages/cloudflare/src/db/d1.ts
+++ b/packages/cloudflare/src/db/d1.ts
@@ -13,7 +13,7 @@ import { kyselyLogOption } from "emdash/database/instrumentation";
 import { type Dialect, Kysely } from "kysely";
 
 import { CoalescingD1Dialect } from "./coalescing-d1.js";
-import { EmDashD1Dialect } from "./d1-dialect.js";
+import { EmDashD1Dialect, RawBindingD1Dialect } from "./d1-dialect.js";
 
 /**
  * D1 configuration (runtime type — matches the config-time type in index.ts)
@@ -84,7 +84,11 @@ export function createDialect(config: D1Config): Dialect {
 			'[emdash] d1({ coalesce: true }) has no effect without sessions — set session: "auto" (or "primary-first") to enable query coalescing.',
 		);
 	}
-	return new EmDashD1Dialect({ database: db });
+	// The raw-binding singleton skips the ConnectionMutex: on Workers a
+	// canceled request would otherwise never release the lock, deadlocking the
+	// isolate (#2040). The session-backed dialects below keep their
+	// serialization (see RawBindingD1Dialect for why).
+	return new RawBindingD1Dialect({ database: db });
 }
 
 /**

--- a/packages/cloudflare/tests/db/d1-dialect.test.ts
+++ b/packages/cloudflare/tests/db/d1-dialect.test.ts
@@ -1,0 +1,111 @@
+import { CompiledQuery, Kysely } from "kysely";
+import { describe, expect, it } from "vitest";
+
+import { EmDashD1Dialect, RawBindingD1Dialect } from "../../src/db/d1-dialect.js";
+
+/**
+ * Regression tests for #2040: with the default D1 config the singleton
+ * Kysely serializes every query behind a ConnectionMutex (because
+ * SqliteAdapter reports supportsMultipleConnections: false). When a request
+ * is canceled mid-query on Workers the pending I/O promise never settles, so
+ * releaseLock() never runs and every later obtainLock() waits forever — an
+ * isolate-wide deadlock from a single canceled request.
+ *
+ * The fix scopes `supportsMultipleConnections: true` to the raw-binding
+ * dialect (RawBindingD1Dialect) ONLY. The session-backed non-coalesce path
+ * keeps the stock adapter (mutex), because a D1DatabaseSession advances its
+ * bookmark per query and concurrent physical calls could interleave it.
+ */
+
+interface MockStatement {
+	sql: string;
+	params: unknown[];
+	bind: (...params: unknown[]) => MockStatement;
+	all: () => Promise<unknown>;
+}
+
+function createMockD1() {
+	const allCalls: string[] = [];
+	let inFlight = 0;
+	let maxInFlight = 0;
+	const database = {
+		prepare(sql: string): MockStatement {
+			const stmt: MockStatement = {
+				sql,
+				params: [],
+				bind(...params: unknown[]) {
+					stmt.params = params;
+					return stmt;
+				},
+				async all() {
+					inFlight++;
+					maxInFlight = Math.max(maxInFlight, inFlight);
+					// Yield so a concurrent query can enter all() before this one
+					// resolves — this is what lets maxInFlight measure overlap.
+					await new Promise((resolve) => setTimeout(resolve, 5));
+					inFlight--;
+					allCalls.push(sql);
+					return { success: true, results: [], meta: { changes: 0, last_row_id: 0 } };
+				},
+			};
+			return stmt;
+		},
+	};
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- mock implements the prepare/batch subset the dialect uses
+	const db = database as unknown as D1Database;
+	return {
+		database: db,
+		allCalls,
+		maxInFlight: () => maxInFlight,
+	};
+}
+
+describe("RawBindingD1Dialect (#2040)", () => {
+	it("reports supportsMultipleConnections: true so no ConnectionMutex serializes queries", () => {
+		const { database } = createMockD1();
+		const dialect = new RawBindingD1Dialect({ database });
+		expect(dialect.createAdapter().supportsMultipleConnections).toBe(true);
+	});
+
+	it("lets concurrent queries overlap instead of serializing behind a mutex", async () => {
+		const { database, allCalls, maxInFlight } = createMockD1();
+		const db = new Kysely<any>({ dialect: new RawBindingD1Dialect({ database }) });
+
+		// With the mutex (supportsMultipleConnections: false) the second query
+		// cannot reach the binding until the first resolves: maxInFlight would
+		// stay 1. Without it, both overlap: maxInFlight reaches 2. This is what
+		// actually proves the deadlock class is gone (a canceled first query no
+		// longer blocks a later one).
+		await Promise.all([
+			db.executeQuery(CompiledQuery.raw("select 1")),
+			db.executeQuery(CompiledQuery.raw("select 2")),
+		]);
+
+		expect(maxInFlight()).toBe(2);
+		expect(allCalls).toHaveLength(2);
+	});
+});
+
+describe("EmDashD1Dialect (session path keeps the mutex)", () => {
+	it("still reports supportsMultipleConnections: false", () => {
+		const { database } = createMockD1();
+		const dialect = new EmDashD1Dialect({ database });
+		// The session-backed non-coalesce path must keep Kysely's serialization:
+		// a D1DatabaseSession advances its bookmark per executed query, and
+		// concurrent physical calls could interleave it and persist a stale
+		// bookmark at commit(), breaking read-your-writes.
+		expect(dialect.createAdapter().supportsMultipleConnections).toBe(false);
+	});
+
+	it("serializes concurrent queries (maxInFlight stays 1)", async () => {
+		const { database, maxInFlight } = createMockD1();
+		const db = new Kysely<any>({ dialect: new EmDashD1Dialect({ database }) });
+
+		await Promise.all([
+			db.executeQuery(CompiledQuery.raw("select 1")),
+			db.executeQuery(CompiledQuery.raw("select 2")),
+		]);
+
+		expect(maxInFlight()).toBe(1);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

With the default D1 config (`d1({ binding: "DB" })`, sessions disabled) all runtime queries go through one module-scope Kysely singleton. Its dialect (`EmDashD1Dialect` → kysely-d1) uses Kysely's `SqliteAdapter`, which reports `supportsMultipleConnections: false`, so Kysely's `RuntimeDriver` serializes every query behind a `ConnectionMutex` (acquire → execute → release). On Workers, when a request is canceled while its query is in flight, the pending I/O promise never settles, so `releaseLock()` never runs — and every later `obtainLock()` waits forever. One canceled request (a visitor clicking away on a slow cold page is enough) permanently deadlocks the whole isolate.

The mutex protects nothing on the raw binding: kysely-d1's `D1Connection` rejects transactions outright, `releaseConnection` is a no-op, and concurrent `prepare().all()` calls are independent subrequests. This PR adds `RawBindingD1Dialect` — identical to `EmDashD1Dialect` except its adapter reports `supportsMultipleConnections: true` — and uses it for the raw-binding singleton in `createDialect`. This is the same override the existing `CoalescingD1Adapter` already applies, scoped to the path where it's safe.

The fix is deliberately scoped to the raw-binding path. The session-backed non-coalesce path in `createRequestScopedDb` also builds an `EmDashD1Dialect`, and there the mutex **is** load-bearing: a `D1DatabaseSession` advances its bookmark per executed query, and concurrent physical calls on one session could interleave the bookmark and persist a stale one at `commit()`, breaking read-your-writes. That path keeps the stock adapter (mutex) — verified by a dedicated test.

Closes #2040

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Kimi K3

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->

```
Test Files  17 passed (17)
     Tests  228 passed (228)
```

New regression tests prove (via an in-flight overlap counter) that concurrent queries on the raw-binding dialect overlap (`maxInFlight === 2`) instead of serializing, while the session-backed `EmDashD1Dialect` still reports `supportsMultipleConnections: false` and still serializes (`maxInFlight === 1`), preserving the session bookmark invariant.