### PR TITLE
fix(core): content API answers 500 NOT_CONFIGURED, not 401, when the runtime failed to init

### DIFF
--- a/.changeset/content-api-init-500.md
+++ b/.changeset/content-api-init-500.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+The content API now answers 500 NOT_CONFIGURED instead of 401 UNAUTHORIZED when the EmDash runtime failed to initialize. Previously the permission check ran first, so a server fault (broken DB binding, init failure) was reported as an authentication error even for requests carrying a valid token — and retry logic correctly treating 4xx as non-retryable gave up instead of retrying. The 13 affected content routes now check initialization before permissions, matching the schema routes.

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -18,15 +18,14 @@ export const prerender = false;
 
 export const GET: APIRoute = async ({ params, url, locals }) => {
 	const { emdash, user } = locals;
+	if (!emdash?.handleContentGet) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
 	const denied = requirePerm(user, "content:read");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;
 	const locale = url.searchParams.get("locale") || undefined;
-
-	if (!emdash?.handleContentGet) {
-		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-	}
 
 	const result = await emdash.handleContentGet(collection, id, locale);
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/compare.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/compare.ts
@@ -13,14 +13,13 @@ export const prerender = false;
 
 export const GET: APIRoute = async ({ params, locals }) => {
 	const { emdash, user } = locals;
+	if (!emdash?.handleContentCompare) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
 	const denied = requirePerm(user, "content:read_drafts");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;
-
-	if (!emdash?.handleContentCompare) {
-		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-	}
 
 	const result = await emdash.handleContentCompare(collection, id);
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/duplicate.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/duplicate.ts
@@ -16,12 +16,11 @@ export const POST: APIRoute = async ({ params, locals, cache }) => {
 	const collection = params.collection!;
 	const id = params.id!;
 
-	const denied = requirePerm(user, "content:create");
-	if (denied) return denied;
-
 	if (!emdash?.handleContentDuplicate || !emdash?.handleContentGet) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
+	const denied = requirePerm(user, "content:create");
+	if (denied) return denied;
 
 	// Fetch item to check ownership — duplicating requires read access to the source
 	const existing = await emdash.handleContentGet(collection, id);

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/permanent.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/permanent.ts
@@ -16,12 +16,11 @@ export const DELETE: APIRoute = async ({ params, locals, cache }) => {
 	const collection = params.collection!;
 	const id = params.id!;
 
-	const denied = requirePerm(user, "content:delete_permanent");
-	if (denied) return denied;
-
 	if (!emdash?.handleContentPermanentDelete) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
+	const denied = requirePerm(user, "content:delete_permanent");
+	if (denied) return denied;
 
 	const result = await emdash.handleContentPermanentDelete(collection, id);
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
@@ -33,14 +33,13 @@ const DURATION_PATTERN = /^(\d+)([smhdw])$/;
 
 export const POST: APIRoute = async ({ params, request, locals }) => {
 	const { emdash, user } = locals;
+	if (!emdash?.db) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
 	const denied = requirePerm(user, "content:read_drafts");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;
-
-	if (!emdash?.db) {
-		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-	}
 
 	// Resolve the preview secret. Env override wins; otherwise a stable
 	// site-specific value is read from (or generated into) the options table.

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/references/[relation]/children.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/references/[relation]/children.ts
@@ -21,15 +21,14 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
 	const { emdash, user } = locals;
 	const { collection, id, relation } = params;
 
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
 	const denied = requirePerm(user, "content:read");
 	if (denied) return denied;
 
 	if (!collection || !id || !relation) {
 		return apiError("VALIDATION_ERROR", "Collection, id, and relation required", 400);
 	}
-
-	const dbErr = requireDb(emdash?.db);
-	if (dbErr) return dbErr;
 
 	const query = parseQuery(new URL(request.url), cursorPaginationQuery);
 	if (isParseError(query)) return query;
@@ -57,15 +56,14 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		return apiError("VALIDATION_ERROR", "Collection, id, and relation required", 400);
 	}
 
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
 	// Gate on the base edit capability BEFORE the existence lookup. Resolving the
 	// entry first would let a user with no edit permission distinguish real ids
 	// (403) from missing ids (404) — an existence oracle. Mirrors the taxonomy
 	// edge POST, which checks `content:edit_own` before fetching the entry.
 	const denied = requirePerm(user, "content:edit_own");
 	if (denied) return denied;
-
-	const dbErr = requireDb(emdash?.db);
-	if (dbErr) return dbErr;
 
 	// Resolve the parent entry to gate on its author (ownership-aware write).
 	const parent = await new ContentRepository(emdash.db).findByIdOrSlug(collection, id);

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/references/[relation]/parents.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/references/[relation]/parents.ts
@@ -19,15 +19,14 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
 	const { emdash, user } = locals;
 	const { collection, id, relation } = params;
 
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
 	const denied = requirePerm(user, "content:read");
 	if (denied) return denied;
 
 	if (!collection || !id || !relation) {
 		return apiError("VALIDATION_ERROR", "Collection, id, and relation required", 400);
 	}
-
-	const dbErr = requireDb(emdash?.db);
-	if (dbErr) return dbErr;
 
 	const query = parseQuery(new URL(request.url), cursorPaginationQuery);
 	if (isParseError(query)) return query;

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/revisions.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/revisions.ts
@@ -13,14 +13,13 @@ export const prerender = false;
 
 export const GET: APIRoute = async ({ params, url, locals }) => {
 	const { emdash, user } = locals;
+	if (!emdash?.handleRevisionList) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
 	const denied = requirePerm(user, "content:read_drafts");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;
-
-	if (!emdash?.handleRevisionList) {
-		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-	}
 
 	const limitParam = url.searchParams.get("limit");
 	const parsedLimit = limitParam ? parseInt(limitParam, 10) : undefined;

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/terms/[taxonomy].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/terms/[taxonomy].ts
@@ -24,15 +24,14 @@ export const GET: APIRoute = async ({ params, locals }) => {
 	const { emdash, user } = locals;
 	const { collection, id, taxonomy } = params;
 
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
 	const denied = requirePerm(user, "content:read");
 	if (denied) return denied;
 
 	if (!collection || !id || !taxonomy) {
 		return apiError("VALIDATION_ERROR", "Collection, id, and taxonomy required", 400);
 	}
-
-	const dbErr = requireDb(emdash?.db);
-	if (dbErr) return dbErr;
 
 	try {
 		// Terms are stored against the per-locale entry row but their
@@ -71,11 +70,10 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		return apiError("VALIDATION_ERROR", "Collection, id, and taxonomy required", 400);
 	}
 
-	const denied = requirePerm(user, "content:edit_own");
-	if (denied) return denied;
-
 	const dbErr = requireDb(emdash?.db);
 	if (dbErr) return dbErr;
+	const denied = requirePerm(user, "content:edit_own");
+	if (denied) return denied;
 
 	if (!emdash.handleContentGet) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/translations.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/translations.ts
@@ -25,14 +25,13 @@ function isPublished(t: unknown): boolean {
 
 export const GET: APIRoute = async ({ params, locals }) => {
 	const { emdash, user } = locals;
+	if (!emdash?.handleContentTranslations) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
 	const denied = requirePerm(user, "content:read");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;
-
-	if (!emdash?.handleContentTranslations) {
-		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-	}
 
 	const result = await emdash.handleContentTranslations(collection, id);
 

--- a/packages/core/src/astro/routes/api/content/[collection]/authors.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/authors.ts
@@ -21,12 +21,11 @@ export const GET: APIRoute = async ({ params, locals }) => {
 	// not be reachable by subscribers (content:read). content:read_drafts is
 	// the same tier the list route requires before it stops forcing
 	// status=published, so the visibility surfaces line up.
-	const denied = requirePerm(user, "content:read_drafts");
-	if (denied) return denied;
-
 	if (!emdash?.handleContentAuthors) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
+	const denied = requirePerm(user, "content:read_drafts");
+	if (denied) return denied;
 
 	const result = await emdash.handleContentAuthors(collection);
 

--- a/packages/core/src/astro/routes/api/content/[collection]/index.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/index.ts
@@ -17,15 +17,14 @@ export const prerender = false;
 
 export const GET: APIRoute = async ({ params, url, locals }) => {
 	const { emdash, user } = locals;
+	if (!emdash?.handleContentList) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
 	const denied = requirePerm(user, "content:read");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const query = parseQuery(url, contentListQuery);
 	if (isParseError(query)) return query;
-
-	if (!emdash?.handleContentList) {
-		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-	}
 
 	// Subscribers must only see published content; force the status filter
 	// regardless of caller-supplied value. Any user with content:read_drafts
@@ -41,15 +40,14 @@ export const GET: APIRoute = async ({ params, url, locals }) => {
 
 export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
+	if (!emdash?.handleContentCreate || !emdash?.handleContentGet) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
 	const denied = requirePerm(user, "content:create");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const body = await parseBody(request, contentCreateBody);
 	if (isParseError(body)) return body;
-
-	if (!emdash?.handleContentCreate || !emdash?.handleContentGet) {
-		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-	}
 
 	// Creating a translation requires edit permission on the source item
 	if (body.translationOf) {

--- a/packages/core/src/astro/routes/api/content/[collection]/trash.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/trash.ts
@@ -17,12 +17,11 @@ export const GET: APIRoute = async ({ params, url, locals }) => {
 	const { emdash, user } = locals;
 	const collection = params.collection!;
 
-	const denied = requirePerm(user, "content:read_drafts");
-	if (denied) return denied;
-
 	if (!emdash?.handleContentListTrashed) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
+	const denied = requirePerm(user, "content:read_drafts");
+	if (denied) return denied;
 
 	const query = parseQuery(url, contentTrashQuery);
 	if (isParseError(query)) return query;

--- a/packages/core/tests/unit/astro/content-routes-authz.test.ts
+++ b/packages/core/tests/unit/astro/content-routes-authz.test.ts
@@ -137,6 +137,9 @@ function buildEmdash(
 	}));
 
 	return {
+		// Routes treat a missing db as "runtime not initialized" (500 before any
+		// permission check), so the mock carries one to exercise the authz path.
+		db: {},
 		handleContentList,
 		handleContentGet,
 		handleContentTranslations,
@@ -426,5 +429,43 @@ describe("DELETE /content/:collection/:id/permanent", () => {
 		const res = await deletePermanent(permanentCtx(subscriber, emdash));
 		expect(res.status).toBe(403);
 		expect(emdash.handleContentPermanentDelete).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Uninitialized runtime (#2094)
+// ---------------------------------------------------------------------------
+
+describe("uninitialized runtime returns NOT_CONFIGURED, not UNAUTHORIZED", () => {
+	// When runtime init fails, the middleware never sets locals.emdash and the
+	// auth middleware never resolves a user — even for a valid token. The
+	// routes must report the server fault (500) instead of blaming the
+	// caller's credentials (401).
+	const uninitialized = undefined as unknown as ReturnType<typeof buildEmdash>;
+
+	it("GET /content/:collection → 500 NOT_CONFIGURED with no user", async () => {
+		const res = await getList(ctx({ user: null, emdash: uninitialized }));
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe("NOT_CONFIGURED");
+	});
+
+	it("GET /content/:collection → 500 even for an authenticated admin", async () => {
+		const res = await getList(ctx({ user: admin, emdash: uninitialized }));
+		expect(res.status).toBe(500);
+	});
+
+	it("GET /content/:collection/:id → 500 NOT_CONFIGURED", async () => {
+		const res = await getItem(
+			ctx({ user: null, emdash: uninitialized, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe("NOT_CONFIGURED");
+	});
+
+	it("GET /content/:collection/trash → 500 NOT_CONFIGURED", async () => {
+		const res = await getTrash(ctx({ user: null, emdash: uninitialized }));
+		expect(res.status).toBe(500);
 	});
 });

--- a/packages/core/tests/unit/astro/content-routes-authz.test.ts
+++ b/packages/core/tests/unit/astro/content-routes-authz.test.ts
@@ -22,6 +22,7 @@ import { GET as getItem } from "../../../src/astro/routes/api/content/[collectio
 import { GET as getCompare } from "../../../src/astro/routes/api/content/[collection]/[id]/compare.js";
 import { DELETE as deletePermanent } from "../../../src/astro/routes/api/content/[collection]/[id]/permanent.js";
 import { POST as postPreviewUrl } from "../../../src/astro/routes/api/content/[collection]/[id]/preview-url.js";
+import { GET as getParents } from "../../../src/astro/routes/api/content/[collection]/[id]/references/[relation]/parents.js";
 import { GET as getRevisions } from "../../../src/astro/routes/api/content/[collection]/[id]/revisions.js";
 import { GET as getTranslations } from "../../../src/astro/routes/api/content/[collection]/[id]/translations.js";
 import { GET as getList } from "../../../src/astro/routes/api/content/[collection]/index.js";
@@ -467,5 +468,41 @@ describe("uninitialized runtime returns NOT_CONFIGURED, not UNAUTHORIZED", () =>
 	it("GET /content/:collection/trash → 500 NOT_CONFIGURED", async () => {
 		const res = await getTrash(ctx({ user: null, emdash: uninitialized }));
 		expect(res.status).toBe(500);
+	});
+
+	// A requireDb-gated route (references) — the guard style differs from the
+	// handler-presence checks above, so pin it separately.
+	it("GET …/references/:relation/parents → 500 NOT_CONFIGURED", async () => {
+		const url = "http://localhost/";
+		const res = await getParents(
+			ctx({
+				user: admin,
+				emdash: uninitialized,
+				params: { collection: "post", id: "p1", relation: "rel" },
+				url,
+				request: new Request(url),
+			}),
+		);
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe("NOT_CONFIGURED");
+	});
+
+	// A handler-presence WRITE route — deletes must also blame the server, not
+	// the caller's credentials, when the runtime never came up.
+	it("DELETE …/:id/permanent → 500 NOT_CONFIGURED", async () => {
+		const url = "http://localhost/";
+		const res = await deletePermanent(
+			ctx({
+				user: null,
+				emdash: uninitialized,
+				params: { collection: "post", id: "p1" },
+				url,
+				request: new Request(url, { method: "DELETE" }),
+			}),
+		);
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe("NOT_CONFIGURED");
 	});
 });


### PR DESCRIPTION
## What does this PR do?

When the EmDash runtime fails to initialize (broken DB binding, downstream failure), `locals.emdash` is never set and the auth middleware never resolves a user — even for a valid token. The content routes ran `requirePerm(user, …)` first, so they answered **401 UNAUTHORIZED** and the `NOT_CONFIGURED` 500 a few lines below was unreachable. A server fault got blamed on the caller's credentials, and clients correctly treating 4xx as non-retryable aborted instead of retrying.

This PR moves each route's existing initialization check (handler-presence check or `requireDb`) **ahead of** the permission check in the 13 content route files that had the order inverted, mirroring the schema routes which already do this correctly (`requireDb` before `requirePerm` in `src/astro/routes/api/schema/index.ts`). Routes that already checked init first (`publish`, `unpublish`, `restore`, `schedule`, `discard-draft`) are untouched. No new concepts — each route keeps its own check, just earlier.

Tests: the authz mock runtime now carries a `db` (a configured runtime) so all existing 403 assertions still exercise the authz path, and a new describe block pins the regression — uninitialized runtime → **500 `NOT_CONFIGURED`** on list / get / trash / a `requireDb`-gated route (references/parents) / a handler-presence write route (permanent DELETE), including for an authenticated admin. A patch changeset is included.

Closes #2094

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

`vitest run` on `content-route-permissions`, `content-routes-authz` (26 tests incl. 6 new), and `content-route-locale`: all pass. Prettier clean.
