### PR TITLE
fix(core): CAS-guard the draft-revision pointer flip on concurrent saves

### DIFF
--- a/.changeset/draft-revision-save-race.md
+++ b/.changeset/draft-revision-save-race.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes a race where two saves to the same draft (e.g. an autosave firing just before or after a manual save) could silently discard one of the edits. The losing save now retries against the latest draft instead of overwriting it.

--- a/.changeset/draft-revision-save-race.md
+++ b/.changeset/draft-revision-save-race.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes a race where two saves to the same draft (e.g. an autosave firing just before or after a manual save) could silently discard one of the edits. The losing save now retries against the latest draft instead of overwriting it.
+Fixes a race where two saves to the same draft (e.g. an autosave firing just before or after a manual save) could silently discard one of the edits. The losing save now retries against the latest draft instead of overwriting it; if the draft is still contested after retrying, the save now fails with a conflict error instead of silently dropping the edit.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2906,7 +2906,7 @@ export class EmDashRuntime {
 						// comparison NULL-safe across both SQLite/D1 and Postgres without
 						// relying on dialect-specific NULL operators. No updated_at stamp:
 						// draft staging leaves live content untouched, so public "last
-						// modified" consumers must not see a change (#2143).
+						// modified" consumers must not see a change.
 						const pointerUpdate = await sql`
 							UPDATE ${sql.ref(tableName)}
 							SET draft_revision_id = ${revision.id}
@@ -2927,7 +2927,12 @@ export class EmDashRuntime {
 						// instead of silently discarding this save.
 						lostEveryCasAttempt = true;
 					}
-					if (lostEveryCasAttempt && !draftStorageChanged) {
+					if (
+						lostEveryCasAttempt &&
+						!draftStorageChanged &&
+						processedData &&
+						Object.keys(processedData).length > 0
+					) {
 						return {
 							success: false as const,
 							error: {
@@ -3333,7 +3338,7 @@ export class EmDashRuntime {
 		// (only `draft_revision_id` changes — no `updated_at` stamp, since
 		// restoring to draft is the same kind of draft-only staging as
 		// Save/Autosave and must not register a phantom modification for
-		// sitemap <lastmod> / JSON-LD dateModified, #2143). The caller
+		// sitemap <lastmod> / JSON-LD dateModified). The caller
 		// must then `content_publish` to promote the restored draft to
 		// live, matching the documented tool contract.
 		try {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2845,10 +2845,25 @@ export class EmDashRuntime {
 				if (collectionInfo?.supports?.includes("revisions")) {
 					usesDraftRevisions = true;
 					const revisionRepo = new RevisionRepository(this.db);
-					// Re-fetch to get latest state (resolvedItem may be stale after _rev check)
-					const existing = await repo.findById(collection, resolvedId);
+					validateIdentifier(collection, "collection");
+					const tableName = `ec_${collection}`;
 
-					if (existing) {
+					// Concurrent saves (autosave vs. explicit save, or two explicit
+					// saves) can both read the same draft pointer before either
+					// writes. Without a guard, the pointer-flip below is a blind
+					// last-writer-wins UPDATE, so the slower save can silently
+					// clobber the faster one's edit even though its own data is
+					// stale. D1 has no multi-statement transactions, so we can't
+					// wrap read+write in one; instead the pointer-flip UPDATE is a
+					// CAS keyed on the draft_revision_id we just read, and we retry
+					// against the fresh pointer if we lose the race.
+					const MAX_ATTEMPTS = 3;
+					for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+						// Re-fetch to get latest state (resolvedItem may be stale after
+						// the _rev check, or after a lost race on a prior attempt)
+						const existing = await repo.findById(collection, resolvedId);
+						if (!existing) break;
+
 						// Build the draft data: merge with existing draft revision if one exists,
 						// otherwise merge with the published data from the content table
 						let baseData: Record<string, unknown>;
@@ -2869,30 +2884,41 @@ export class EmDashRuntime {
 							// Autosave: update existing draft revision in place
 							await revisionRepo.updateData(existing.draftRevisionId, mergedData);
 							draftStorageChanged = true;
-						} else {
-							// Create new draft revision
-							const revision = await revisionRepo.create({
-								collection,
-								entryId: resolvedId,
-								data: mergedData,
-								authorId: bodyWithoutRev.authorId ?? undefined,
-							});
+							break;
+						}
 
-							// Update entry to point to new draft (metadata only, not data columns).
-							// No updated_at stamp: draft staging leaves live content untouched,
-							// so public "last modified" consumers must not see a change (#2143).
-							validateIdentifier(collection, "collection");
-							const tableName = `ec_${collection}`;
-							await sql`
-								UPDATE ${sql.ref(tableName)}
-								SET draft_revision_id = ${revision.id}
-								WHERE id = ${resolvedId}
-							`.execute(this.db);
+						// Create new draft revision
+						const revision = await revisionRepo.create({
+							collection,
+							entryId: resolvedId,
+							data: mergedData,
+							authorId: bodyWithoutRev.authorId ?? undefined,
+						});
+
+						// Point the entry at the new draft, but only if the pointer still
+						// matches what we read above (CAS). `COALESCE(..., '')` makes the
+						// comparison NULL-safe across both SQLite/D1 and Postgres without
+						// relying on dialect-specific NULL operators. No updated_at stamp:
+						// draft staging leaves live content untouched, so public "last
+						// modified" consumers must not see a change (#2143).
+						const pointerUpdate = await sql`
+							UPDATE ${sql.ref(tableName)}
+							SET draft_revision_id = ${revision.id}
+							WHERE id = ${resolvedId}
+							AND COALESCE(draft_revision_id, '') = ${existing.draftRevisionId ?? ""}
+						`.execute(this.db);
+
+						if ((pointerUpdate.numAffectedRows ?? 0n) > 0n) {
 							draftStorageChanged = true;
-
 							// Fire-and-forget: prune old revisions to prevent unbounded growth
 							void revisionRepo.pruneOldRevisions(collection, resolvedId, 50).catch(() => {});
+							break;
 						}
+						// Lost the race: another save moved draft_revision_id between
+						// our read and this write. The revision row we just created
+						// is orphaned (harmless — pruneOldRevisions sweeps it up on a
+						// future successful save); retry against the fresh pointer
+						// instead of silently discarding this save.
 					}
 				}
 			} catch {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2857,9 +2857,14 @@ export class EmDashRuntime {
 					// wrap read+write in one; instead the pointer-flip UPDATE is a
 					// CAS keyed on the draft_revision_id we just read, and we retry
 					// against the fresh pointer if we lose the race.
-					const MAX_ATTEMPTS = 3;
+					const MAX_ATTEMPTS = 8;
 					let lostEveryCasAttempt = false;
 					for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+						if (attempt > 0) {
+							// Jittered backoff: without it, N concurrent savers all retry
+							// in lockstep and keep re-colliding on the same tick.
+							await new Promise((resolve) => setTimeout(resolve, Math.random() * 10 * attempt));
+						}
 						// Re-fetch to get latest state (resolvedItem may be stale after
 						// the _rev check, or after a lost race on a prior attempt)
 						const existing = await repo.findById(collection, resolvedId);

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2858,6 +2858,7 @@ export class EmDashRuntime {
 					// CAS keyed on the draft_revision_id we just read, and we retry
 					// against the fresh pointer if we lose the race.
 					const MAX_ATTEMPTS = 3;
+					let lostEveryCasAttempt = false;
 					for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
 						// Re-fetch to get latest state (resolvedItem may be stale after
 						// the _rev check, or after a lost race on a prior attempt)
@@ -2919,6 +2920,16 @@ export class EmDashRuntime {
 						// is orphaned (harmless — pruneOldRevisions sweeps it up on a
 						// future successful save); retry against the fresh pointer
 						// instead of silently discarding this save.
+						lostEveryCasAttempt = true;
+					}
+					if (lostEveryCasAttempt && !draftStorageChanged) {
+						return {
+							success: false as const,
+							error: {
+								code: "DRAFT_SAVE_CONFLICT",
+								message: "Could not save draft due to concurrent edits; please retry.",
+							},
+						};
 					}
 				}
 			} catch {

--- a/packages/core/tests/integration/database/content-update-save-race.test.ts
+++ b/packages/core/tests/integration/database/content-update-save-race.test.ts
@@ -75,20 +75,18 @@ describeEachDialect("concurrent draft-revision saves (issue #1158 follow-up)", (
 			releaseFirst = resolve;
 		});
 		const originalCreate = RevisionRepository.prototype.create;
-		const spy = vi
-			.spyOn(RevisionRepository.prototype, "create")
-			.mockImplementation(async function (
-				this: RevisionRepository,
-				...args: Parameters<typeof originalCreate>
-			) {
-				arrivals++;
-				if (arrivals === 1) {
-					await gate;
-				} else {
-					releaseFirst?.();
-				}
-				return originalCreate.apply(this, args);
-			});
+		const spy = vi.spyOn(RevisionRepository.prototype, "create").mockImplementation(async function (
+			this: RevisionRepository,
+			...args: Parameters<typeof originalCreate>
+		) {
+			arrivals++;
+			if (arrivals === 1) {
+				await gate;
+			} else {
+				releaseFirst?.();
+			}
+			return originalCreate.apply(this, args);
+		});
 
 		let resultA: Awaited<ReturnType<typeof runtime.handleContentUpdate>>;
 		let resultB: Awaited<ReturnType<typeof runtime.handleContentUpdate>>;

--- a/packages/core/tests/integration/database/content-update-save-race.test.ts
+++ b/packages/core/tests/integration/database/content-update-save-race.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Concurrent draft-revision saves silently drop an edit (comment on emdash
+ * issue #1158, reported against 0.28.1/0.29.0 after #1119 fixed the original
+ * TipTap-dispatch cause of #1158 itself).
+ *
+ * `EmDashRuntime.handleContentUpdate`'s draft-revision path is a
+ * read-existing -> merge -> create-revision -> flip-pointer sequence with no
+ * wrapping transaction (D1 doesn't support multi-statement transactions) and,
+ * before this fix, an unconditional pointer-flip UPDATE. Two concurrent saves
+ * that both read `draft_revision_id: null` before either writes both create a
+ * new revision and race to flip the pointer; whichever UPDATE lands last wins
+ * regardless of which read the fresher data, so the other save's edit is
+ * silently discarded even though the API reported it as successful.
+ *
+ * This test forces that exact interleaving (both saves reach
+ * `RevisionRepository.create` before either one's create/flip completes) and
+ * asserts both edits survive.
+ */
+
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { RevisionRepository } from "../../../src/database/repositories/revision.js";
+import type { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { createTestRuntime } from "../../utils/mcp-runtime.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("concurrent draft-revision saves (issue #1158 follow-up)", (dialect) => {
+	let ctx: DialectTestContext;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		setI18nConfig(null);
+		ctx = await setupForDialect(dialect);
+		const registry = new SchemaRegistry(ctx.db);
+		// Default supports = ["drafts", "revisions"] — exercises the draft
+		// revision path under test.
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		await registry.createField("posts", { slug: "subtitle", label: "Subtitle", type: "string" });
+		runtime = createTestRuntime(ctx.db);
+	});
+
+	afterEach(async () => {
+		setI18nConfig(null);
+		await teardownForDialect(ctx);
+	});
+
+	it("does not drop an edit when two saves race to create the first draft revision", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			slug: "race-post",
+			data: { title: "Original title", subtitle: "Original subtitle" },
+			status: "published",
+		});
+		expect(created.success).toBe(true);
+		if (!created.success) throw new Error(created.error.message);
+		const contentId = created.data.item.id;
+
+		// Gate RevisionRepository.create so the first call to reach it blocks
+		// until the second call also reaches it. Both handleContentUpdate
+		// calls read `existing` (draftRevisionId: null) before calling
+		// create(), so by the time either is released, both have already
+		// computed their mergedData off the same stale base — reproducing the
+		// concurrent-PUT race from the report regardless of driver/dialect
+		// timing.
+		let arrivals = 0;
+		let releaseFirst: (() => void) | undefined;
+		const gate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const originalCreate = RevisionRepository.prototype.create;
+		const spy = vi
+			.spyOn(RevisionRepository.prototype, "create")
+			.mockImplementation(async function (
+				this: RevisionRepository,
+				...args: Parameters<typeof originalCreate>
+			) {
+				arrivals++;
+				if (arrivals === 1) {
+					await gate;
+				} else {
+					releaseFirst?.();
+				}
+				return originalCreate.apply(this, args);
+			});
+
+		let resultA: Awaited<ReturnType<typeof runtime.handleContentUpdate>>;
+		let resultB: Awaited<ReturnType<typeof runtime.handleContentUpdate>>;
+		try {
+			[resultA, resultB] = await Promise.all([
+				runtime.handleContentUpdate("posts", contentId, {
+					data: { title: "Title from save A" },
+				}),
+				runtime.handleContentUpdate("posts", contentId, {
+					data: { subtitle: "Subtitle from save B" },
+				}),
+			]);
+		} finally {
+			spy.mockRestore();
+		}
+
+		expect(resultA.success).toBe(true);
+		expect(resultB.success).toBe(true);
+		// At least the forced first collision; the fix's CAS retry adds more.
+		expect(arrivals).toBeGreaterThanOrEqual(2);
+
+		const final = await runtime.handleContentGet("posts", contentId);
+		expect(final.success).toBe(true);
+		if (!final.success) throw new Error("expected success");
+
+		// Neither edit was silently discarded by the losing side of the race.
+		expect(final.data.item.data.title).toBe("Title from save A");
+		expect(final.data.item.data.subtitle).toBe("Subtitle from save B");
+	});
+});

--- a/packages/core/tests/integration/database/content-update-save-race.test.ts
+++ b/packages/core/tests/integration/database/content-update-save-race.test.ts
@@ -157,7 +157,7 @@ describeEachDialect("concurrent draft-revision saves", (dialect) => {
 			spy.mockRestore();
 		}
 
-		expect(calls).toBe(3);
+		expect(calls).toBe(8);
 		expect(result.success).toBe(false);
 		if (result.success) throw new Error("expected failure");
 		expect(result.error.code).toBe("DRAFT_SAVE_CONFLICT");

--- a/packages/core/tests/integration/database/content-update-save-race.test.ts
+++ b/packages/core/tests/integration/database/content-update-save-race.test.ts
@@ -1,22 +1,15 @@
 /**
- * Concurrent draft-revision saves silently drop an edit (comment on emdash
- * issue #1158, reported against 0.28.1/0.29.0 after #1119 fixed the original
- * TipTap-dispatch cause of #1158 itself).
+ * Concurrent draft-revision saves should not silently drop an edit.
  *
  * `EmDashRuntime.handleContentUpdate`'s draft-revision path is a
- * read-existing -> merge -> create-revision -> flip-pointer sequence with no
- * wrapping transaction (D1 doesn't support multi-statement transactions) and,
- * before this fix, an unconditional pointer-flip UPDATE. Two concurrent saves
- * that both read `draft_revision_id: null` before either writes both create a
- * new revision and race to flip the pointer; whichever UPDATE lands last wins
- * regardless of which read the fresher data, so the other save's edit is
- * silently discarded even though the API reported it as successful.
- *
- * This test forces that exact interleaving (both saves reach
- * `RevisionRepository.create` before either one's create/flip completes) and
- * asserts both edits survive.
+ * read-existing -> merge -> create-revision -> flip-pointer sequence. Two
+ * concurrent saves that both read `draft_revision_id: null` before either
+ * writes can both create a revision and race to flip the pointer; the
+ * slower save's edit must not be silently discarded even though the API
+ * reports success.
  */
 
+import { sql } from "kysely";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 import { RevisionRepository } from "../../../src/database/repositories/revision.js";
@@ -31,7 +24,7 @@ import {
 	type DialectTestContext,
 } from "../../utils/test-db.js";
 
-describeEachDialect("concurrent draft-revision saves (issue #1158 follow-up)", (dialect) => {
+describeEachDialect("concurrent draft-revision saves", (dialect) => {
 	let ctx: DialectTestContext;
 	let runtime: EmDashRuntime;
 
@@ -115,5 +108,67 @@ describeEachDialect("concurrent draft-revision saves (issue #1158 follow-up)", (
 		// Neither edit was silently discarded by the losing side of the race.
 		expect(final.data.item.data.title).toBe("Title from save A");
 		expect(final.data.item.data.subtitle).toBe("Subtitle from save B");
+	});
+
+	it("returns a conflict instead of silently dropping the edit when every CAS retry loses", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			slug: "race-post-exhausted",
+			data: { title: "Original title", subtitle: "Original subtitle" },
+			status: "published",
+		});
+		expect(created.success).toBe(true);
+		if (!created.success) throw new Error(created.error.message);
+		const contentId = created.data.item.id;
+
+		// Simulate another save winning the pointer flip on every attempt: right
+		// after our revision is created, flip draft_revision_id out from under
+		// us so the CAS UPDATE always affects zero rows.
+		const originalCreate = RevisionRepository.prototype.create;
+		let calls = 0;
+		const spy = vi.spyOn(RevisionRepository.prototype, "create").mockImplementation(async function (
+			this: RevisionRepository,
+			...args: Parameters<typeof originalCreate>
+		) {
+			const revision = await originalCreate.apply(this, args);
+			calls++;
+			// A real revision row (FK-valid), standing in for the other save's
+			// winning pointer flip.
+			const decoy = await originalCreate.apply(this, [
+				{
+					collection: "posts",
+					entryId: contentId,
+					data: { title: `external winner ${calls}` },
+				},
+			]);
+			await sql`
+				UPDATE ec_posts
+				SET draft_revision_id = ${decoy.id}
+				WHERE id = ${contentId}
+			`.execute(ctx.db);
+			return revision;
+		});
+
+		let result: Awaited<ReturnType<typeof runtime.handleContentUpdate>>;
+		try {
+			result = await runtime.handleContentUpdate("posts", contentId, {
+				data: { title: "Title that must not be silently dropped" },
+			});
+		} finally {
+			spy.mockRestore();
+		}
+
+		expect(calls).toBe(3);
+		expect(result.success).toBe(false);
+		if (result.success) throw new Error("expected failure");
+		expect(result.error.code).toBe("DRAFT_SAVE_CONFLICT");
+
+		// The edit was rejected, not silently discarded behind a success
+		// response — the draft still reflects the last CAS winner, not our
+		// attempted edit.
+		const final = await runtime.handleContentGet("posts", contentId);
+		expect(final.success).toBe(true);
+		if (!final.success) throw new Error("expected success");
+		expect(final.data.item.data.title).not.toBe("Title that must not be silently dropped");
+		expect(final.data.item.data.title).toBe(`external winner ${calls}`);
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,40 @@ importers:
         specifier: 'catalog:'
         version: 4.100.0(@cloudflare/workers-types@4.20260305.1)
 
+  demos/emdash-dev-main:
+    dependencies:
+      '@astrojs/cloudflare':
+        specifier: 'catalog:'
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+      '@astrojs/react':
+        specifier: 'catalog:'
+        version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
+      '@emdash-cms/cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/cloudflare
+      astro:
+        specifier: 'catalog:'
+        version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
+      emdash:
+        specifier: workspace:*
+        version: link:../../packages/core
+      react:
+        specifier: 'catalog:'
+        version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@astrojs/check':
+        specifier: 'catalog:'
+        version: 0.9.7(prettier-plugin-astro@0.14.1)(prettier@3.9.5)(typescript@6.0.0-beta)
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260305.1
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.100.0(@cloudflare/workers-types@4.20260305.1)
+
   demos/playground:
     dependencies:
       '@astrojs/cloudflare':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,40 +477,6 @@ importers:
         specifier: 'catalog:'
         version: 4.100.0(@cloudflare/workers-types@4.20260305.1)
 
-  demos/emdash-dev-main:
-    dependencies:
-      '@astrojs/cloudflare':
-        specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(workerd@1.20260611.1)(wrangler@4.100.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
-      '@astrojs/react':
-        specifier: 'catalog:'
-        version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
-      '@emdash-cms/cloudflare':
-        specifier: workspace:*
-        version: link:../../packages/cloudflare
-      astro:
-        specifier: 'catalog:'
-        version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      emdash:
-        specifier: workspace:*
-        version: link:../../packages/core
-      react:
-        specifier: 'catalog:'
-        version: 19.2.4
-      react-dom:
-        specifier: 'catalog:'
-        version: 19.2.4(react@19.2.4)
-    devDependencies:
-      '@astrojs/check':
-        specifier: 'catalog:'
-        version: 0.9.7(prettier-plugin-astro@0.14.1)(prettier@3.9.5)(typescript@6.0.0-beta)
-      '@cloudflare/workers-types':
-        specifier: 'catalog:'
-        version: 4.20260305.1
-      wrangler:
-        specifier: 'catalog:'
-        version: 4.100.0(@cloudflare/workers-types@4.20260305.1)
-
   demos/playground:
     dependencies:
       '@astrojs/cloudflare':


### PR DESCRIPTION
## What does this PR do?

Fixes a save race reported as a follow-up comment on closed issue #1158. `EmDashRuntime.handleContentUpdate`'s draft-revision path does read-existing → merge → create-revision → flip-pointer with no wrapping transaction (D1 has no multi-statement transactions) and an unconditional pointer-flip `UPDATE`. Two concurrent saves (autosave racing an explicit save, or two explicit saves) that both read `draft_revision_id: null` before either writes both create a new revision and race to flip the pointer — whichever `UPDATE` lands last wins regardless of which read the fresher data, so the other save's edit is silently discarded even though the API reports success. This matches the DCathal repro in the #1158 thread (two revisions created in the same second, the stale one becomes `draft_revision_id`).

Note: the *original* #1158 report (TipTap `editor.view.dispatch` bypassing `onUpdate`) was already fixed by #1119 and is unaffected here — this addresses the separate, still-reproducing save race described in the newest comment on that thread (0.28.1/0.29.0).

Fix: the pointer-flip `UPDATE` is now a compare-and-set keyed on the `draft_revision_id` read at the start of the attempt (`COALESCE(draft_revision_id, '') = <value read>`, NULL-safe across SQLite/D1 and Postgres). If the CAS fails, the losing save retries — re-reading the now-current draft, re-merging its own edit on top, and retrying the create+CAS — instead of silently overwriting. Bounded to 3 attempts. The orphaned revision row from a lost race is harmless; `pruneOldRevisions` sweeps it up on a later successful save since it's keyed by `entry_id`, not by pointer.

Known residual, out of scope for this PR: the autosave-only "update existing draft revision in place" path (`skipRevision` when a draft already exists) still isn't CAS-guarded — two concurrent autosaves (no explicit save involved) can still last-write-wins on that single row's `data` column. Closing that fully would need a version column on `revisions`, which felt like more surface than this fix needs; flagging in case a maintainer disagrees.

Closes (comment thread on) #1158

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes (pre-existing unrelated errors in `oauth-state-store.ts` / `plugins/context.ts` confirmed present without this change)
- [x] `pnpm lint` passes (oxlint, scoped to changed files)
- [x] `pnpm test` passes (targeted: new race test + adjacent content/revision/media-usage integration suites, both sqlite and postgres dialects)
- [ ] `pnpm format` has been run (skipped locally — CRLF checkout makes `format:check` unreliable on Windows; will check CI)
- [x] I have added/updated tests for my changes
- [x] I have added a changeset (patch, `emdash`)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5

## Test plan

Added `packages/core/tests/integration/database/content-update-save-race.test.ts`: creates a published entry, then fires two concurrent `handleContentUpdate` calls editing different fields, with a `RevisionRepository.create` spy that gates the first call until the second also arrives — forcing both to read `draft_revision_id: null` before either writes, regardless of driver timing. Verified the test fails against the pre-fix code (save B's edit silently dropped, matching the report) and passes with the fix (both edits survive).