### PR TITLE
fix(core): invalidate edge cache on settings/menu writes (#2042)

### DIFF
--- a/.changeset/edge-cache-invalidate-2042.md
+++ b/.changeset/edge-cache-invalidate-2042.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Closes the edge-cache gap where editing site settings or a menu never invalidated rendered HTML. Settings and menu write paths now purge reserved route-cache tags (`emdash:settings`, `emdash:menus`) on Cloudflare, and `<EmDashHead>` / menu widgets tag the pages they render so those purges reach them. Sites that call `getMenu()` directly can opt a page into the same invalidation with `Astro.cache.set({ tags: [EDGE_TAG_MENUS] })`. The Cloudflare deployment docs now explain that a publish only evicts cached pages whose tags line up, and show how to tag content, menus, and settings.

--- a/demos/cloudflare/src/layouts/Base.astro
+++ b/demos/cloudflare/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import { getMenu, getEmDashCollection, getSiteSettings } from "emdash";
+import { getMenu, getEmDashCollection, getSiteSettings, EDGE_TAG_MENUS } from "emdash";
 import {
 	WidgetArea,
 	EmDashHead,
@@ -51,6 +51,11 @@ const menu = await getMenu("primary");
 // it'll render in the footer's "Connect" column. Otherwise that column
 // just shows RSS, avoiding duplication with the "Navigate" column above.
 const socialMenu = await getMenu("social");
+
+// This layout renders menus on every page, so every page must be evicted
+// when any menu changes. Tag with the reserved menus tag so menu write
+// paths purge it (#2042). Settings are tagged by EmDashHead.
+Astro.cache.set({ tags: [EDGE_TAG_MENUS] });
 
 // Fetch pages for footer
 const { entries: pages } = await getEmDashCollection("pages");

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -154,10 +154,30 @@ Cloudflare's [Workers Cache](https://developers.cloudflare.com/workers/cache/) (
 - EmDash admin and API responses send `Cache-Control: private, no-store` and are never stored.
 - Your public pages control their own caching through the `Cache-Control` headers they return.
 
-Two things to know before enabling it:
+Three things to know before enabling it:
 
-1. **Responses without a `Cache-Control` header are still cached.** Workers Cache applies RFC 9111 heuristic freshness — a `200` without any header is cached for 2 hours. Give every custom route an explicit `Cache-Control` (use `private, no-store` for anything session-dependent).
-2. **Cached pages are shared with logged-in editors.** The cache runs before your Worker, so it cannot bypass based on request cookies. A logged-in editor may receive the cached anonymous variant of a public page — without the visual editing toolbar — until the entry expires. Editor-rendered responses themselves are never stored (they carry `private, no-store`), so nothing leaks in the other direction.
+1. **A publish does not, by itself, evict rendered HTML.** EmDash's write paths (publish, update, delete, …) call `cache.invalidate()` with the affected entry's **ULID** and its **collection slug**, and Astro's Cloudflare cache provider turns that into a tag purge. But a cached page is only purged if it was **stored with one of those tags** in the first place. Render your pages with the loader's cache hint so the tags line up:
+
+   ```astro
+   ---
+   const { entry, cacheHint } = await getEmDashEntry("pages", slug);
+   Astro.cache.set(cacheHint);
+   ---
+   ```
+
+   If you bypass the hint (or set your own `routeRules` without the content tags), a cached page is **not** invalidated on publish — it is served until its `maxAge` lapses. Treat `maxAge` as your only freshness control for any page you don't tag.
+
+   **Menus and site settings** render on every page but have no per-entry `cacheHint`. EmDash tags them automatically where it can — `<EmDashHead>` adds the reserved `emdash:settings` tag, and menu widgets add `emdash:menus` — and the settings/menu write paths purge those tags. If you call `getMenu()` / `getMenus()` directly in a layout, opt that page into the same invalidation so an edit to the navigation reaches it:
+
+   ```astro
+   ---
+   import { getMenu, EDGE_TAG_MENUS } from "emdash";
+   const menu = await getMenu("primary");
+   Astro.cache.set({ tags: [EDGE_TAG_MENUS] });
+   ---
+   ```
+2. **Responses without a `Cache-Control` header are still cached.** Workers Cache applies RFC 9111 heuristic freshness — a `200` without any header is cached for 2 hours. Give every custom route an explicit `Cache-Control` (use `private, no-store` for anything session-dependent).
+3. **Cached pages are shared with logged-in editors.** The cache runs before your Worker, so it cannot bypass based on request cookies. A logged-in editor may receive the cached anonymous variant of a public page — without the visual editing toolbar — until the entry expires. Editor-rendered responses themselves are never stored (they carry `private, no-store`), so nothing leaks in the other direction.
 
 ## Custom Domain
 

--- a/packages/core/src/astro/edge-cache-tags.ts
+++ b/packages/core/src/astro/edge-cache-tags.ts
@@ -1,0 +1,33 @@
+/**
+ * Reserved route-cache tags for EmDash-managed, non-content data that renders
+ * on many pages (site settings, menus). Content entries already tag with their
+ * ULID + collection slug via the loader's `cacheHint`; settings and menus have
+ * no per-entry identity, so they share a single reserved tag.
+ *
+ * Write paths purge the matching tag, which evicts every cached page that
+ * opted into it — closing the gap where editing the navigation or a site
+ * setting never invalidated rendered HTML (#2042). Pages opt in by adding the
+ * tag to their route cache (e.g. `Astro.cache.set({ tags: [EDGE_TAG_MENUS] })`
+ * in the layout that renders the menu).
+ */
+
+import type { APIContext } from "astro";
+
+/** Route-cache tag invalidated whenever site settings change. */
+export const EDGE_TAG_SETTINGS = "emdash:settings";
+
+/** Route-cache tag invalidated whenever any menu changes. */
+export const EDGE_TAG_MENUS = "emdash:menus";
+
+/**
+ * Purge one of the reserved edge-cache tags after a settings/menu write.
+ * No-op when no route-cache provider is configured (`cache.enabled` false) —
+ * same contract as the content write paths. Accepts the request's
+ * `APIContext["cache"]` so route handlers stay one-liners.
+ */
+export async function invalidateEdgeTag(
+	cache: APIContext["cache"] | undefined,
+	tag: string,
+): Promise<void> {
+	if (cache?.enabled) await cache.invalidate({ tags: [tag] });
+}

--- a/packages/core/src/astro/routes/api/menus/[name].ts
+++ b/packages/core/src/astro/routes/api/menus/[name].ts
@@ -13,6 +13,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuDelete, handleMenuGet, handleMenuUpdate } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery, updateMenuBody } from "#api/schemas.js";
+
 import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../edge-cache-tags.js";
 
 export const prerender = false;

--- a/packages/core/src/astro/routes/api/menus/[name].ts
+++ b/packages/core/src/astro/routes/api/menus/[name].ts
@@ -13,6 +13,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuDelete, handleMenuGet, handleMenuUpdate } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery, updateMenuBody } from "#api/schemas.js";
+import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../edge-cache-tags.js";
 
 export const prerender = false;
 
@@ -34,7 +35,7 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
 	}
 };
 
-export const PUT: APIRoute = async ({ params, request, locals }) => {
+export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const name = params.name!;
 
@@ -49,13 +50,14 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		if (isParseError(body)) return body;
 
 		const result = await handleMenuUpdate(emdash.db, name, { ...body, locale: query.locale });
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to update menu", "MENU_UPDATE_ERROR");
 	}
 };
 
-export const DELETE: APIRoute = async ({ params, request, locals }) => {
+export const DELETE: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const name = params.name!;
 
@@ -67,6 +69,7 @@ export const DELETE: APIRoute = async ({ params, request, locals }) => {
 
 	try {
 		const result = await handleMenuDelete(emdash.db, name, { locale: query.locale });
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to delete menu", "MENU_DELETE_ERROR");

--- a/packages/core/src/astro/routes/api/menus/[name]/items.ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/items.ts
@@ -11,10 +11,11 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuItemCreate } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { createMenuItemBody, localeFilterQuery } from "#api/schemas.js";
+import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../edge-cache-tags.js";
 
 export const prerender = false;
 
-export const POST: APIRoute = async ({ params, request, locals }) => {
+export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const name = params.name!;
 
@@ -29,6 +30,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		if (isParseError(body)) return body;
 
 		const result = await handleMenuItemCreate(emdash.db, name, body, { locale: localeQ.locale });
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result, 201);
 	} catch (error) {
 		return handleError(error, "Failed to create menu item", "MENU_ITEM_CREATE_ERROR");

--- a/packages/core/src/astro/routes/api/menus/[name]/items.ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/items.ts
@@ -11,6 +11,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuItemCreate } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { createMenuItemBody, localeFilterQuery } from "#api/schemas.js";
+
 import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../edge-cache-tags.js";
 
 export const prerender = false;

--- a/packages/core/src/astro/routes/api/menus/[name]/items/[id].ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/items/[id].ts
@@ -12,6 +12,7 @@ import { apiError, handleError, unwrapResult } from "#api/error.js";
 import { handleMenuItemDelete, handleMenuItemUpdate } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery, updateMenuItemBody } from "#api/schemas.js";
+
 import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../../edge-cache-tags.js";
 
 export const prerender = false;

--- a/packages/core/src/astro/routes/api/menus/[name]/items/[id].ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/items/[id].ts
@@ -12,10 +12,11 @@ import { apiError, handleError, unwrapResult } from "#api/error.js";
 import { handleMenuItemDelete, handleMenuItemUpdate } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery, updateMenuItemBody } from "#api/schemas.js";
+import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../../edge-cache-tags.js";
 
 export const prerender = false;
 
-export const PUT: APIRoute = async ({ params, request, locals }) => {
+export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const name = params.name!;
 	const itemId = params.id;
@@ -37,13 +38,14 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		const result = await handleMenuItemUpdate(emdash.db, name, itemId, body, {
 			locale: localeQ.locale,
 		});
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to update menu item", "MENU_ITEM_UPDATE_ERROR");
 	}
 };
 
-export const DELETE: APIRoute = async ({ params, request, locals }) => {
+export const DELETE: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const name = params.name!;
 	const itemId = params.id;
@@ -62,6 +64,7 @@ export const DELETE: APIRoute = async ({ params, request, locals }) => {
 		const result = await handleMenuItemDelete(emdash.db, name, itemId, {
 			locale: localeQ.locale,
 		});
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to delete menu item", "MENU_ITEM_DELETE_ERROR");

--- a/packages/core/src/astro/routes/api/menus/[name]/reorder.ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/reorder.ts
@@ -11,10 +11,11 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuItemReorder } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery, reorderMenuItemsBody } from "#api/schemas.js";
+import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../edge-cache-tags.js";
 
 export const prerender = false;
 
-export const POST: APIRoute = async ({ params, request, locals }) => {
+export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const name = params.name!;
 
@@ -31,6 +32,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		const result = await handleMenuItemReorder(emdash.db, name, body.items, {
 			locale: localeQ.locale,
 		});
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to reorder menu items", "MENU_REORDER_ERROR");

--- a/packages/core/src/astro/routes/api/menus/[name]/reorder.ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/reorder.ts
@@ -11,6 +11,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuItemReorder } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery, reorderMenuItemsBody } from "#api/schemas.js";
+
 import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../edge-cache-tags.js";
 
 export const prerender = false;

--- a/packages/core/src/astro/routes/api/menus/[name]/translations.ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/translations.ts
@@ -13,6 +13,7 @@ import { handleError, requireDb, unwrapResult } from "#api/error.js";
 import { handleMenuCreate, handleMenuGet, handleMenuTranslations } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery } from "#api/schemas.js";
+
 import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../edge-cache-tags.js";
 
 export const prerender = false;

--- a/packages/core/src/astro/routes/api/menus/[name]/translations.ts
+++ b/packages/core/src/astro/routes/api/menus/[name]/translations.ts
@@ -13,6 +13,7 @@ import { handleError, requireDb, unwrapResult } from "#api/error.js";
 import { handleMenuCreate, handleMenuGet, handleMenuTranslations } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { localeFilterQuery } from "#api/schemas.js";
+import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../../edge-cache-tags.js";
 
 export const prerender = false;
 
@@ -47,7 +48,7 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
 	}
 };
 
-export const POST: APIRoute = async ({ params, request, locals }) => {
+export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const name = params.name!;
 
@@ -75,6 +76,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 			locale: body.locale,
 			translationOf: source.data.id,
 		});
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result, 201);
 	} catch (error) {
 		return handleError(error, "Failed to create menu translation", "MENU_TRANSLATION_CREATE_ERROR");

--- a/packages/core/src/astro/routes/api/menus/index.ts
+++ b/packages/core/src/astro/routes/api/menus/index.ts
@@ -12,6 +12,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuCreate, handleMenuList } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { createMenuBody, localeFilterQuery } from "#api/schemas.js";
+
 import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../edge-cache-tags.js";
 
 export const prerender = false;

--- a/packages/core/src/astro/routes/api/menus/index.ts
+++ b/packages/core/src/astro/routes/api/menus/index.ts
@@ -12,6 +12,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleMenuCreate, handleMenuList } from "#api/handlers/menus.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { createMenuBody, localeFilterQuery } from "#api/schemas.js";
+import { EDGE_TAG_MENUS, invalidateEdgeTag } from "../../../edge-cache-tags.js";
 
 export const prerender = false;
 
@@ -32,7 +33,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
 	}
 };
 
-export const POST: APIRoute = async ({ request, locals }) => {
+export const POST: APIRoute = async ({ request, locals, cache }) => {
 	const { emdash, user } = locals;
 
 	const denied = requirePerm(user, "menus:manage");
@@ -43,6 +44,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		const result = await handleMenuCreate(emdash.db, body);
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_MENUS);
 		return unwrapResult(result, 201);
 	} catch (error) {
 		return handleError(error, "Failed to create menu", "MENU_CREATE_ERROR");

--- a/packages/core/src/astro/routes/api/settings.ts
+++ b/packages/core/src/astro/routes/api/settings.ts
@@ -12,6 +12,7 @@ import { apiError, handleError, unwrapResult } from "#api/error.js";
 import { handleSettingsGet, handleSettingsUpdate } from "#api/handlers/settings.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { settingsUpdateBody } from "#api/schemas.js";
+import { EDGE_TAG_SETTINGS, invalidateEdgeTag } from "../../edge-cache-tags.js";
 
 export const prerender = false;
 
@@ -45,7 +46,7 @@ export const GET: APIRoute = async ({ locals }) => {
  * Updates site settings. Accepts a partial settings object.
  * Merges with existing settings and returns the updated settings.
  */
-export const POST: APIRoute = async ({ request, locals }) => {
+export const POST: APIRoute = async ({ request, locals, cache }) => {
 	const { emdash, user } = locals;
 
 	if (!emdash?.db) {
@@ -60,6 +61,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		const result = await handleSettingsUpdate(emdash.db, emdash.storage, body);
+		// Purge the edge cache for every page that renders site settings
+		// (typically all of them). No-op without a cache provider (#2042).
+		if (result.success) await invalidateEdgeTag(cache, EDGE_TAG_SETTINGS);
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to update settings", "SETTINGS_UPDATE_ERROR");

--- a/packages/core/src/astro/routes/api/settings.ts
+++ b/packages/core/src/astro/routes/api/settings.ts
@@ -12,6 +12,7 @@ import { apiError, handleError, unwrapResult } from "#api/error.js";
 import { handleSettingsGet, handleSettingsUpdate } from "#api/handlers/settings.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { settingsUpdateBody } from "#api/schemas.js";
+
 import { EDGE_TAG_SETTINGS, invalidateEdgeTag } from "../../edge-cache-tags.js";
 
 export const prerender = false;

--- a/packages/core/src/components/EmDashHead.astro
+++ b/packages/core/src/components/EmDashHead.astro
@@ -34,6 +34,7 @@ import {
 import { renderSiteIdentity } from "../page/site-identity.js";
 import { getPageRuntime } from "../page/index.js";
 import { getSiteSettings } from "../settings/index.js";
+import { EDGE_TAG_SETTINGS } from "../astro/edge-cache-tags.js";
 import { absolutizeMediaUrl } from "../page/absolute-url.js";
 import { getHreflangAlternates } from "../seo/hreflang.js";
 import { isI18nEnabled } from "../i18n/config.js";
@@ -67,6 +68,11 @@ if (runtime) {
 		runtime.collectPageMetadata(page),
 		runtime.collectPageFragments(page),
 	]);
+
+	// This page renders site settings, so it must be evicted when they change.
+	// Tag it with the reserved settings tag so the settings write path's purge
+	// reaches it (#2042). Merges with any tags the route already set.
+	Astro.cache.set({ tags: [EDGE_TAG_SETTINGS] });
 
 	// Site-level default OG image: applied per-page in base contributions
 	// rather than emitted unconditionally, so per-content images still win.

--- a/packages/core/src/components/WidgetRenderer.astro
+++ b/packages/core/src/components/WidgetRenderer.astro
@@ -1,6 +1,7 @@
 ---
 import type { Widget } from "../widgets/types.js";
 import { getMenu } from "../menus/index.js";
+import { EDGE_TAG_MENUS } from "../astro/edge-cache-tags.js";
 import { sanitizeHref } from "../utils/url.js";
 import PortableText from "./PortableText.astro";
 import RecentPosts from "./widgets/RecentPosts.astro";
@@ -28,6 +29,9 @@ const componentMap = {
 let menuData = null;
 if (widget.type === "menu" && widget.menuName) {
 	menuData = await getMenu(widget.menuName);
+	// This page renders a menu, so it must be evicted when any menu changes.
+	// Tag it with the reserved menus tag so menu write paths purge it (#2042).
+	Astro.cache.set({ tags: [EDGE_TAG_MENUS] });
 }
 
 // For component widgets, get the component

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -430,6 +430,7 @@ export type { GetCommentsOptions, GetCommentsResult } from "./comments/query.js"
 
 // Menus
 export { getMenu, getMenus } from "./menus/index.js";
+export { EDGE_TAG_MENUS, EDGE_TAG_SETTINGS } from "./astro/edge-cache-tags.js";
 export type {
 	Menu,
 	MenuItem,


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Editing site settings or a menu never evicted rendered HTML from the Cloudflare Workers route cache. Pages went stale until their `maxAge` lapsed, even though the in-memory object cache was invalidated.

This PR closes the gap:

- Adds reserved route-cache tags `emdash:settings` and `emdash:menus` plus an `invalidateEdgeTag()` helper (`packages/core/src/astro/edge-cache-tags.ts`).
- The settings `POST` route and every state-changing menu route (create / update / delete / reorder / translate / item update / item delete) now purge their reserved tag on success — no-op when no cache provider is configured, same contract as the content write paths.
- Pages that render settings or menus are tagged so the purges reach them: `<EmDashHead>` adds `emdash:settings`, and menu widgets (`WidgetRenderer`) add `emdash:menus`.
- Sites calling `getMenu()` directly can opt a page into the same invalidation with `Astro.cache.set({ tags: [EDGE_TAG_MENUS] })` (both tags are now exported from `emdash`).
- The Cloudflare deployment docs now explain that a publish only evicts cached pages whose tags line up, and show how to tag content, menus, and settings.

Closes #2042

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Kimi K3

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->