### PR TITLE
fix(docker): copy patches/ into deps stage so pnpm install succeeds (#2118)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ WORKDIR /app
 FROM base AS deps
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# pnpm-workspace.yaml declares patchedDependencies -> patches/, which pnpm
+# reads during install. It must be in the deps stage or --frozen-lockfile
+# fails with ENOENT on the patch file (#2118).
+COPY patches/ patches/
 COPY packages/ packages/
 COPY templates/ templates/
 COPY demos/ demos/


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

`docker compose up` failed at the `deps` stage with:

```
pnpm: ENOENT: no such file or directory, open '/app/patches/@sigstore__core@4.0.1.patch'
```

`pnpm-workspace.yaml` declares `patchedDependencies` pointing at `patches/@sigstore__core@4.0.1.patch`, which pnpm reads during `pnpm install --frozen-lockfile`. The `deps` stage copied the lockfile and workspace manifests but never the `patches/` directory, so the install couldn't find the patch file.

This PR copies `patches/` into the `deps` stage (before `pnpm install`), alongside the other install inputs.

Closes #2118

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Kimi K3

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->

No behavior change to a published package (Dockerfile only), so no changeset. I could not run `docker compose` locally (Docker Desktop isn't installed on this machine), but the fix is verified statically: the patch file exists at `patches/@sigstore__core@4.0.1.patch`, is not excluded by `.dockerignore`, and the new `COPY patches/ patches/` lands in the `deps` stage before `RUN pnpm install --frozen-lockfile`.