### PR TITLE
fix(admin): deduplicate taxonomy parent options

### DIFF
--- a/.changeset/calm-trees-list-once.md
+++ b/.changeset/calm-trees-list-once.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes duplicate terms in hierarchical taxonomy parent selectors and prevents moving a term beneath its own descendants.

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -46,6 +46,26 @@ function flattenTerms(terms: TaxonomyTerm[]): TaxonomyTerm[] {
 }
 
 /**
+ * Return valid parent candidates in tree order.
+ *
+ * The current term and its complete subtree are excluded while editing so a
+ * parent change cannot create a taxonomy cycle.
+ */
+export function getAvailableParentTerms(
+	terms: TaxonomyTerm[],
+	currentTerm?: TaxonomyTerm,
+): TaxonomyTerm[] {
+	const flatTerms = flattenTerms(terms);
+	if (!currentTerm) return flatTerms;
+
+	const excludedIds = new Set([
+		currentTerm.id,
+		...flattenTerms(currentTerm.children).map((term) => term.id),
+	]);
+	return flatTerms.filter((term) => !excludedIds.has(term.id));
+}
+
+/**
  * Term row component (recursive for hierarchy)
  */
 function TermRow({
@@ -336,11 +356,7 @@ function TermFormDialog({
 		}
 	};
 
-	// Flatten terms for parent selector (exclude current term and its children)
-	const flatTerms = flattenTerms(allTerms);
-	const availableParents = term
-		? flatTerms.filter((item) => item.id !== term.id && item.parentId !== term.id)
-		: flatTerms;
+	const availableParents = getAvailableParentTerms(allTerms, term);
 
 	return (
 		<Dialog.Root
@@ -787,8 +803,6 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 		);
 	}
 
-	const flatTerms = flattenTerms(terms);
-
 	return (
 		<div className="space-y-6">
 			<div className="flex items-center justify-between gap-4 flex-wrap">
@@ -851,7 +865,7 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 				taxonomyName={taxonomyName}
 				taxonomyDef={taxonomyDef}
 				term={editingTerm}
-				allTerms={flatTerms}
+				allTerms={terms}
 				locale={activeLocale}
 				i18n={i18n}
 				onOpenTranslation={(tr) => setActiveLocale(tr.locale)}

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -433,13 +433,19 @@ function TermFormDialog({
 								items={{
 									"": t`None (top level)`,
 									...Object.fromEntries(
-										availableParents.map((parentTerm) => [parentTerm.id, parentTerm.label]),
+										availableParents.map((parentTerm) => [
+											parentTerm.translationGroup ?? parentTerm.id,
+											parentTerm.label,
+										]),
 									),
 								}}
 							>
 								<Select.Option value="">{t`None (top level)`}</Select.Option>
 								{availableParents.map((parentTerm) => (
-									<Select.Option key={parentTerm.id} value={parentTerm.id}>
+									<Select.Option
+										key={parentTerm.id}
+										value={parentTerm.translationGroup ?? parentTerm.id}
+									>
 										{parentTerm.label}
 									</Select.Option>
 								))}

--- a/packages/admin/tests/components/TaxonomyManager.test.tsx
+++ b/packages/admin/tests/components/TaxonomyManager.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { TaxonomyManager } from "../../src/components/TaxonomyManager";
+import { getAvailableParentTerms, TaxonomyManager } from "../../src/components/TaxonomyManager";
 import { render } from "../utils/render.tsx";
 
 const taxonomyResponse = JSON.stringify({
@@ -41,6 +41,55 @@ const termsResponse = JSON.stringify({
 				parentId: null,
 				children: [],
 				count: 3,
+			},
+		],
+	},
+});
+
+const hierarchicalTermsResponse = JSON.stringify({
+	data: {
+		terms: [
+			{
+				id: "design",
+				name: "design",
+				slug: "design",
+				label: "Design",
+				parentId: null,
+				translationGroup: "design-group",
+				children: [
+					{
+						id: "test",
+						name: "test",
+						slug: "test",
+						label: "Test",
+						parentId: "design-group",
+						translationGroup: "test-group",
+						children: [
+							{
+								id: "test-child",
+								name: "test-child",
+								slug: "test-child",
+								label: "Test child",
+								parentId: "test-group",
+								translationGroup: "test-child-group",
+								children: [],
+								count: 0,
+							},
+						],
+						count: 0,
+					},
+				],
+				count: 1,
+			},
+			{
+				id: "development",
+				name: "development",
+				slug: "development",
+				label: "Development",
+				parentId: null,
+				translationGroup: "development-group",
+				children: [],
+				count: 4,
 			},
 		],
 	},
@@ -178,6 +227,20 @@ describe("TaxonomyManager", () => {
 		await screen.getByRole("button", { name: ADD_CATEGORY_BUTTON_REGEX }).click();
 
 		await expect.element(screen.getByLabelText(PARENT_SELECTOR_REGEX)).toBeInTheDocument();
+	});
+
+	it("lists each nested term once in the parent selector", () => {
+		const terms = JSON.parse(hierarchicalTermsResponse).data.terms;
+		const labels = getAvailableParentTerms(terms).map((term) => term.label);
+
+		expect(labels).toEqual(["Design", "Test", "Test child", "Development"]);
+	});
+
+	it("excludes the edited term and all descendants from parent choices", () => {
+		const terms = JSON.parse(hierarchicalTermsResponse).data.terms;
+		const labels = getAvailableParentTerms(terms, terms[0]).map((term) => term.label);
+
+		expect(labels).toEqual(["Development"]);
 	});
 
 	it("edit button opens dialog", async () => {

--- a/packages/admin/tests/components/TaxonomyManager.test.tsx
+++ b/packages/admin/tests/components/TaxonomyManager.test.tsx
@@ -243,6 +243,18 @@ describe("TaxonomyManager", () => {
 		expect(labels).toEqual(["Development"]);
 	});
 
+	it("selects the current parent by translation group when editing a nested term", async () => {
+		mockApiFetch(hierarchicalTermsResponse);
+		const screen = await render(<TaxonomyManager taxonomyName="categories" />, {
+			wrapper: Wrapper,
+		});
+
+		await expect.element(screen.getByText("Test", { exact: true })).toBeInTheDocument();
+		await screen.getByRole("button", { name: "Edit Test", exact: true }).click();
+
+		await expect.element(screen.getByLabelText(PARENT_SELECTOR_REGEX)).toHaveTextContent("Design");
+	});
+
 	it("edit button opens dialog", async () => {
 		const screen = await render(<TaxonomyManager taxonomyName="categories" />, {
 			wrapper: Wrapper,


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate entries in the Parent selector for hierarchical taxonomy terms.

The taxonomy endpoint already returns a nested tree. `TaxonomyManager` flattened that tree before passing it to `TermFormDialog`, which flattened it a second time. Because the flattened entries still retained their children, descendants appeared repeatedly.

The dialog now receives the original tree and builds the parent options in one pass. When editing a term, the current term and its complete descendant subtree are excluded so users cannot create hierarchy cycles.

No linked issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs - a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## Screenshots / test output

- `TaxonomyManager.test.tsx`: 12/12 tests passed in Chromium
- `@emdash-cms/admin` typecheck passed
- Changed admin files passed lint and format checks
- `git diff --check` passed

