### PR TITLE
fix(cloudflare): reclaim stranded coalescing flush after request cancel (#1927)

### DIFF
--- a/.changeset/coalescing-flush-cancellation.md
+++ b/.changeset/coalescing-flush-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes a hang where a request cancelled mid-query on Cloudflare D1 could wedge the query-coalescing buffer: the flush timer scheduled by the cancelled request was dropped with it, leaving the coalescing flag stuck so every later query on the connection waited on a flush that never ran. The coalescing D1 and Durable Object SQL connections now treat a flush left pending past a short deadline as stranded and reschedule it, so a cancelled request can no longer stall subsequent queries.

--- a/packages/cloudflare/src/db/coalescing-d1.ts
+++ b/packages/cloudflare/src/db/coalescing-d1.ts
@@ -69,6 +69,18 @@ export class CoalescingD1Connection implements DatabaseConnection {
 	#buffer: PendingQuery[] = [];
 	#flushScheduled = false;
 	/**
+	 * Time by which the currently-scheduled flush must have run. If it hasn't
+	 * (its timer was dropped by a cancelled owner), the next caller reclaims
+	 * the flag and reschedules. See #scheduleFlush.
+	 */
+	#flushDeadline = 0;
+	/**
+	 * How long a scheduled flush may go unfired before a later caller treats
+	 * it as stranded. Generous — a live setTimeout(0) fires within a turn —
+	 * so reclaim only ever trips on a genuinely dropped timer, never a slow one.
+	 */
+	static readonly #FLUSH_RECLAIM_MS = 1_000;
+	/**
 	 * Tail of a promise chain that serializes every physical call against the
 	 * shared D1DatabaseSession (direct-path statements and batch flushes
 	 * alike). See #enqueue.
@@ -127,19 +139,43 @@ export class CoalescingD1Connection implements DatabaseConnection {
 	/**
 	 * Schedule a flush of buffered SELECTs unless one is already pending.
 	 *
-	 * setTimeout(0) (macrotask), not queueMicrotask: Kysely awaits internally
-	 * between acquiring the connection and executing each query, so a
-	 * microtask window would close before sibling queries issued in the same
-	 * turn reach the connection. Queries that arrive after the buffer is
-	 * drained (flag already cleared) simply schedule the next window; physical
-	 * ordering against any in-flight call is handled by #enqueue.
+	 * Cancellation-safe on workerd (#1927). A request cancelled after queueing
+	 * a query drops its pending timers, so if that request owned the scheduled
+	 * flush the timer would never fire — leaving `#flushScheduled` stuck `true`
+	 * and every later query awaiting a flush that never runs. Two defences:
+	 *
+	 * 1. The scheduled timer runs `setTimeout(0)` (macrotask — a microtask
+	 *    window would close before sibling queries issued in the same turn
+	 *    reach the connection, since Kysely awaits internally between
+	 *    acquiring the connection and executing each query).
+	 * 2. The flush flag is **reclaimable**: each schedule stamps a deadline,
+	 *    and if that deadline lapses with the flag still set (the timer was
+	 *    dropped by a cancelled owner), the next caller clears the stale flag
+	 *    and reschedules instead of queueing behind a dead timer. A live flush
+	 *    fires within a turn, well under the deadline, so reclaim only ever
+	 *    trips on a genuinely stranded flush.
 	 */
 	#scheduleFlush(): void {
-		if (this.#flushScheduled) return;
+		if (this.#flushScheduled) {
+			this.#reclaimStrandedFlush();
+			if (this.#flushScheduled) return;
+		}
 		this.#flushScheduled = true;
+		this.#flushDeadline = Date.now() + CoalescingD1Connection.#FLUSH_RECLAIM_MS;
 		setTimeout(() => {
 			void this.#flush();
 		}, 0);
+	}
+
+	/**
+	 * If the pending flush is older than its deadline, its timer was dropped
+	 * by a cancelled owner — clear the flag so this caller reschedules rather
+	 * than queueing behind a flush that will never run.
+	 */
+	#reclaimStrandedFlush(): void {
+		if (this.#flushScheduled && Date.now() > this.#flushDeadline) {
+			this.#flushScheduled = false;
+		}
 	}
 
 	async #flush(): Promise<void> {

--- a/packages/cloudflare/src/db/coalescing-do-sql.ts
+++ b/packages/cloudflare/src/db/coalescing-do-sql.ts
@@ -143,7 +143,7 @@ class CoalescingDOSqlConnection implements DatabaseConnection {
 	 */
 	#scheduleFlush(): void {
 		if (this.#flushScheduled) {
-			if (Date.now() > this.#flushDeadline) this.#flushScheduled = false;
+			this.#reclaimStrandedFlush();
 			if (this.#flushScheduled) return;
 		}
 		this.#flushScheduled = true;
@@ -151,6 +151,17 @@ class CoalescingDOSqlConnection implements DatabaseConnection {
 		setTimeout(() => {
 			void this.#flush();
 		}, 0);
+	}
+
+	/**
+	 * If the pending flush is older than its deadline, its timer was dropped
+	 * by a cancelled owner — clear the flag so this caller reschedules rather
+	 * than queueing behind a flush that will never run.
+	 */
+	#reclaimStrandedFlush(): void {
+		if (this.#flushScheduled && Date.now() > this.#flushDeadline) {
+			this.#flushScheduled = false;
+		}
 	}
 
 	async #flush(): Promise<void> {

--- a/packages/cloudflare/src/db/coalescing-do-sql.ts
+++ b/packages/cloudflare/src/db/coalescing-do-sql.ts
@@ -54,6 +54,19 @@ class CoalescingDOSqlConnection implements DatabaseConnection {
 	#buffer: PendingQuery[] = [];
 	#flushScheduled = false;
 	/**
+	 * Time by which the currently-scheduled flush must have run; if it hasn't
+	 * (its timer was dropped by a cancelled owner), the next caller reclaims
+	 * the flag and reschedules. A DO connection is long-lived and its buffer
+	 * can be shared across requests, so a stranded flush would wedge every
+	 * later query — this makes it reclaimable (#1927).
+	 */
+	#flushDeadline = 0;
+	/**
+	 * How long a scheduled flush may go unfired before a later caller treats
+	 * it as stranded. Generous — a live setTimeout(0) fires within a turn.
+	 */
+	static readonly #FLUSH_RECLAIM_MS = 1_000;
+	/**
 	 * Tail of a promise chain that serializes every physical RPC against the
 	 * DO (direct-path statements and batch flushes alike), so a write and a
 	 * read batch never overlap and the bookmark advances in execution order.
@@ -122,10 +135,19 @@ class CoalescingDOSqlConnection implements DatabaseConnection {
 	 * between acquiring the connection and executing each query, so a microtask
 	 * window would close before sibling queries issued in the same turn reach
 	 * the buffer.
+	 *
+	 * Cancellation-safe on workerd (#1927): the flush flag is reclaimable. Each
+	 * schedule stamps a deadline; if it lapses with the flag still set (the
+	 * timer was dropped by a cancelled owner), the next caller clears the stale
+	 * flag and reschedules rather than queueing behind a flush that never runs.
 	 */
 	#scheduleFlush(): void {
-		if (this.#flushScheduled) return;
+		if (this.#flushScheduled) {
+			if (Date.now() > this.#flushDeadline) this.#flushScheduled = false;
+			if (this.#flushScheduled) return;
+		}
 		this.#flushScheduled = true;
+		this.#flushDeadline = Date.now() + CoalescingDOSqlConnection.#FLUSH_RECLAIM_MS;
 		setTimeout(() => {
 			void this.#flush();
 		}, 0);

--- a/packages/cloudflare/tests/db/coalescing-d1.test.ts
+++ b/packages/cloudflare/tests/db/coalescing-d1.test.ts
@@ -1,5 +1,5 @@
 import { CompiledQuery, Kysely } from "kysely";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CoalescingD1Dialect } from "../../src/db/coalescing-d1.js";
 
@@ -278,5 +278,52 @@ describe("CoalescingD1Dialect", () => {
 				// never reached
 			}),
 		).rejects.toThrow("Transactions are not supported");
+	});
+
+	describe("cancellation-safe flush (#1927)", () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("reclaims a stranded flush so a later query is not left hanging", async () => {
+			// On workerd a cancelled request drops its pending timers, so the
+			// flush it scheduled never fires and #flushScheduled stays true. The
+			// next query must clear the stale flag (past its deadline) and
+			// reschedule instead of queueing behind a flush that will never run.
+			vi.useFakeTimers();
+			const mock = createMockD1({ "select 1": { rows: [{ id: 1 }] } });
+			const db = createDb(mock);
+
+			// Queue a query, then drop its flush timer to simulate a cancelled
+			// owner: #flushScheduled is left set with no timer to clear it.
+			const first = db.executeQuery(CompiledQuery.raw("select 1"));
+			vi.clearAllTimers();
+
+			// Let the reclaim deadline lapse, then queue another query. It must
+			// reclaim the stranded flag, reschedule, and both queries resolve.
+			await vi.advanceTimersByTimeAsync(2_000);
+			const second = db.executeQuery(CompiledQuery.raw("select 1"));
+			await vi.runAllTimersAsync();
+
+			await expect(first).resolves.toMatchObject({ rows: [{ id: 1 }] });
+			await expect(second).resolves.toMatchObject({ rows: [{ id: 1 }] });
+		});
+
+		it("does not reclaim a live flush that is still within its deadline", async () => {
+			vi.useFakeTimers();
+			const mock = createMockD1();
+			const db = createDb(mock);
+
+			// Queue two queries in the same turn without advancing past the
+			// deadline: the second must coalesce onto the first's pending flush
+			// (no premature reclaim), so both land in one batch.
+			const p1 = db.executeQuery(CompiledQuery.raw("select 1"));
+			const p2 = db.executeQuery(CompiledQuery.raw("select 2"));
+			await vi.runAllTimersAsync();
+			await Promise.all([p1, p2]);
+
+			expect(mock.batchCalls).toHaveLength(1);
+			expect(mock.batchCalls[0]?.map((s) => s.sql)).toEqual(["select 1", "select 2"]);
+		});
 	});
 });

--- a/packages/cloudflare/tests/db/coalescing-do-sql.test.ts
+++ b/packages/cloudflare/tests/db/coalescing-do-sql.test.ts
@@ -1,5 +1,5 @@
 import { CompiledQuery } from "kysely";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { CoalescingDOSqlDialect } from "../../src/db/coalescing-do-sql.js";
 import type { BookmarkSink } from "../../src/db/do-sql-dialect.js";
@@ -150,5 +150,65 @@ describe("CoalescingDOSqlDialect", () => {
 
 		expect(results[0]).toMatchObject({ status: "fulfilled" });
 		expect(results[1]).toMatchObject({ status: "rejected" });
+	});
+
+	describe("cancellation-safe flush (#1927)", () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("reclaims a stranded flush so a later query is not left hanging", async () => {
+			// On workerd a cancelled request drops its pending timers, so the
+			// flush it scheduled never fires and #flushScheduled stays true. The
+			// next query must clear the stale flag (past its deadline) and
+			// reschedule instead of queueing behind a flush that will never run.
+			vi.useFakeTimers();
+			const { dialect } = setup({
+				// The stranded first query stays buffered and coalesces with the
+				// second after the reclaim, so the batch must return two results.
+				batchQuery: vi
+					.fn()
+					.mockResolvedValue([{ rows: [{ id: 1 }] }, { rows: [{ id: 1 }] }] as DOQueryResult[]),
+			});
+			const conn = await dialect.createDriver().acquireConnection();
+
+			// Queue a query, then drop its flush timer to simulate a cancelled
+			// owner: #flushScheduled is left set with no timer to clear it.
+			const first = conn.executeQuery(CompiledQuery.raw("select 1"));
+			vi.clearAllTimers();
+
+			// Let the reclaim deadline lapse, then queue another query. It must
+			// reclaim the stranded flag, reschedule, and both queries resolve.
+			await vi.advanceTimersByTimeAsync(2_000);
+			const second = conn.executeQuery(CompiledQuery.raw("select 1"));
+			await vi.runAllTimersAsync();
+
+			await expect(first).resolves.toMatchObject({ rows: [{ id: 1 }] });
+			await expect(second).resolves.toMatchObject({ rows: [{ id: 1 }] });
+		});
+
+		it("does not reclaim a live flush that is still within its deadline", async () => {
+			vi.useFakeTimers();
+			const { batchQuery, dialect } = setup({
+				batchQuery: vi
+					.fn()
+					.mockResolvedValue([{ rows: [{ id: 1 }] }, { rows: [{ id: 2 }] }] as DOQueryResult[]),
+			});
+			const conn = await dialect.createDriver().acquireConnection();
+
+			// Queue two queries in the same turn without advancing past the
+			// deadline: the second must coalesce onto the first's pending flush
+			// (no premature reclaim), so both land in one batch.
+			const p1 = conn.executeQuery(CompiledQuery.raw("select 1"));
+			const p2 = conn.executeQuery(CompiledQuery.raw("select 2"));
+			await vi.runAllTimersAsync();
+			await Promise.all([p1, p2]);
+
+			expect(batchQuery).toHaveBeenCalledTimes(1);
+			expect(batchQuery.mock.calls[0]![0]).toEqual([
+				{ sql: "select 1", params: [] },
+				{ sql: "select 2", params: [] },
+			]);
+		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a hang where a request cancelled mid-query on Cloudflare D1 could wedge the query-coalescing buffer. On workerd, a request that is cancelled after queueing a coalesced query drops its pending `setTimeout(0)`, so the flush it scheduled never fires and `#flushScheduled` stays `true` — every later query on the connection then awaits a flush that never runs. This is the same hazard class that `single-flight-cache.ts` already documents and defends against; the two coalescing connections had escaped that hardening.

The flush flag is now **reclaimable**: each schedule stamps a short deadline (1s — a live `setTimeout(0)` fires within a turn, so this only ever trips on a genuinely dropped timer), and if that deadline lapses with the flag still set, the next caller clears the stale flag and reschedules instead of queueing behind a dead timer. Applied to both the coalescing D1 connection and the Durable Object SQL connection (the latter is long-lived and its buffer can be shared across requests, so it is the more exposed of the two).

Context: this came up alongside #2040 (the default-config `ConnectionMutex` deadlock, fixed in #2125). As analysed in #1927, the coalescing connections are not the default path and are mostly short-lived/per-request, but the hazard is real and the fix is cheap defence-in-depth.

Closes #1927

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude (Kimi K3)

## Screenshots / test output

New regression tests in `packages/cloudflare/tests/db/coalescing-d1.test.ts` (`cancellation-safe flush (#1927)`): one reclaims a stranded flush so a later query is not left hanging, one confirms a live flush within its deadline is not prematurely reclaimed. Full `tests/db` suite passes (165 tests).
