### PR TITLE
fix(db): detect Postgres dialect reliably under minification

### DIFF
--- a/.changeset/postgres-dialect-detection.md
+++ b/.changeset/postgres-dialect-detection.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix Postgres dialect misdetection under minification. When emdash is bundled and minified by the consuming app (for example an Astro SSR production build), the `PostgresAdapter` class name is mangled, so `detectDialect` fell back to SQLite and emitted SQLite-only SQL such as `datetime('now')` — failing the first migration on Postgres with `function datetime(unknown) does not exist`. Detection now also checks the adapter's `supportsMultipleConnections` capability, which survives minification.

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -36,7 +36,10 @@ export type { DatabaseDialectType };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function detectDialect(db: Kysely<any>): DatabaseDialectType {
 	const adapter = db.getExecutor().adapter;
-	if (adapter.constructor.name === "PostgresAdapter" || adapter.supportsMultipleConnections === true) {
+	if (
+		adapter.constructor.name === "PostgresAdapter" ||
+		adapter.supportsMultipleConnections === true
+	) {
 		return "postgres";
 	}
 	return "sqlite";

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -19,12 +19,26 @@ import { validateIdentifier, validateJsonFieldName } from "./validate.js";
 export type { DatabaseDialectType };
 
 /**
- * Detect dialect type from a Kysely instance via the adapter class name.
+ * Detect dialect type from a Kysely instance.
+ *
+ * Primary signal is the adapter class name, but that is unreliable: when the
+ * consuming app bundles and minifies emdash (e.g. an Astro SSR build), the
+ * `PostgresAdapter` class name gets mangled, so the string check fails and a
+ * real Postgres connection is misdetected as SQLite. The dialect helpers then
+ * emit SQLite-only SQL such as `datetime('now')`, which makes the very first
+ * migration fail on Postgres with `function datetime(unknown) does not exist`.
+ *
+ * As a minification-proof fallback we use a behavioral capability of the
+ * adapter: `supportsMultipleConnections` — the same signal this codebase already
+ * uses to tell SQLite from Postgres (see `emdash-runtime.ts`). Kysely reports it
+ * `true` for `PostgresAdapter` and `false` for the SQLite/libSQL/D1 adapters.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function detectDialect(db: Kysely<any>): DatabaseDialectType {
-	const name = db.getExecutor().adapter.constructor.name;
-	if (name === "PostgresAdapter") return "postgres";
+	const adapter = db.getExecutor().adapter;
+	if (adapter.constructor.name === "PostgresAdapter" || adapter.supportsMultipleConnections === true) {
+		return "postgres";
+	}
 	return "sqlite";
 }
 

--- a/packages/core/tests/unit/database/dialect-helpers.test.ts
+++ b/packages/core/tests/unit/database/dialect-helpers.test.ts
@@ -1,0 +1,53 @@
+import Database from "better-sqlite3";
+import { Kysely, PostgresDialect, SqliteDialect } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { detectDialect } from "../../../src/database/dialect-helpers.js";
+
+/**
+ * Regression tests for dialect misdetection under minification.
+ *
+ * The consuming app can bundle + minify emdash (e.g. an Astro SSR build), which
+ * mangles the `PostgresAdapter` class name. Relying only on `constructor.name`
+ * then misdetects Postgres as SQLite and emits SQLite-only SQL like
+ * `datetime('now')`, failing the first migration on Postgres.
+ *
+ * The first two cases exercise the *real* Kysely adapters so the fallback signal
+ * (`supportsMultipleConnections`) is validated against actual runtime behavior,
+ * not a hand-rolled stub.
+ */
+describe("detectDialect", () => {
+	let dbs: Array<Kysely<Record<string, never>>> = [];
+
+	afterEach(async () => {
+		await Promise.all(dbs.map((db) => db.destroy()));
+		dbs = [];
+	});
+
+	it("detects a real Kysely Postgres adapter", () => {
+		// createAdapter() is synchronous and makes no connection.
+		const db = new Kysely<Record<string, never>>({
+			dialect: new PostgresDialect({ pool: {} as never }),
+		});
+		dbs.push(db);
+		expect(detectDialect(db)).toBe("postgres");
+	});
+
+	it("detects a real Kysely SQLite adapter", () => {
+		const db = new Kysely<Record<string, never>>({
+			dialect: new SqliteDialect({ database: new Database(":memory:") }),
+		});
+		dbs.push(db);
+		expect(detectDialect(db)).toBe("sqlite");
+	});
+
+	it("still detects Postgres when the adapter class name is minified", () => {
+		// A bundled/minified build renames `PostgresAdapter`, so only the
+		// behavioral capability survives to distinguish the dialect.
+		const adapter = { supportsMultipleConnections: true };
+		const db = {
+			getExecutor: () => ({ adapter }),
+		} as unknown as Kysely<Record<string, never>>;
+		expect(detectDialect(db)).toBe("postgres");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes Postgres dialect **misdetection under minification**, which makes the documented Postgres setup fail on the very first migration.

With the documented config:

```js
import { postgres } from "emdash/db";
emdash({ database: postgres({ connectionString: process.env.DATABASE_URL }) })
```

an Astro SSR production build fails at startup:

```
Migration failed: function datetime(unknown) does not exist (migration: 001_initial)
```

**Root cause:** `detectDialect` (`packages/core/src/database/dialect-helpers.ts`) identifies the dialect solely by the adapter class name:

```ts
if (db.getExecutor().adapter.constructor.name === "PostgresAdapter") return "postgres";
return "sqlite";
```

When the consuming app bundles + **minifies** emdash, the `PostgresAdapter` class name is mangled, so a real Postgres connection is misdetected as SQLite and the timestamp helpers emit SQLite-only SQL (`datetime('now')`), which PostgreSQL rejects. (The build also surfaces the related warning `Import "createCoalescingDialect" will always be undefined … emdash/dist/db/sqlite.mjs`.) The helpers themselves branch correctly — only the detection is unreliable.

**Fix:** fall back to the adapter's `supportsMultipleConnections` capability — the same signal this codebase already uses to distinguish SQLite from Postgres (see `emdash-runtime.ts`). Confirmed against the real Kysely adapters: `PostgresAdapter` reports `true`, `SqliteAdapter` reports `false`.

Closes # <!-- no prior issue; this PR reports and fixes the bug -->

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — see note below
- [ ] `pnpm lint` passes — see note below
- [ ] `pnpm test` passes — see note below
- [ ] `pnpm format` has been run — see note below
- [x] I have added/updated tests for my changes
- [ ] User-visible strings wrapped for translation (n/a — no admin UI strings)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash` patch)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8**

## Screenshots / test output

**Transparency:** I did not run the full monorepo suite (`pnpm typecheck/lint/test/format`) in my fork; the maintainer CI will. What I did verify:

- **End-to-end against a real managed PostgreSQL backend** (isolated schema via `search_path`): with this change emdash's migrations apply cleanly and the CMS boots and serves on Postgres; without it, the same setup fails at `001_initial` as shown above.
- **Adapter capability ground truth**, instantiating the real Kysely dialects:

  ```
  postgres | name: PostgresAdapter | supportsMultipleConnections: true
  sqlite   | name: SqliteAdapter   | supportsMultipleConnections: false
  ```

- New tests (`packages/core/tests/unit/database/dialect-helpers.test.ts`) instantiate the real `PostgresDialect` and `SqliteDialect` adapters (plus a minified-name stub), so the fallback is validated against actual runtime behavior rather than hand-rolled stubs.

emdash version reproduced on: 0.29.0.
