### PR TITLE
fix(secrets): read site secrets from process.env only, never import.meta.env

### DIFF
--- a/.changeset/secrets-no-buildtime-inlining.md
+++ b/.changeset/secrets-no-buildtime-inlining.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Security: site secrets (`EMDASH_ENCRYPTION_KEY`, `EMDASH_PREVIEW_SECRET`, `EMDASH_IP_SALT`, and their legacy aliases) are no longer read through `import.meta.env`. In production builds Vite statically replaced that expression with the env loaded at build time, which embedded any secret present in `.env` on the build machine into the server bundle and made the stale build-time value silently shadow the real runtime secret (e.g. one set with `wrangler secret put`). The secrets module now reads only the runtime `process.env`. If you previously relied on a secret being baked in at build time, set it as a runtime secret/env var on your deployment platform instead — and rotate any key that shipped inside a bundle.

--- a/packages/core/src/config/secrets.ts
+++ b/packages/core/src/config/secrets.ts
@@ -108,8 +108,9 @@ export interface ResolveSecretsOptions {
 	db: Kysely<Database>;
 	/**
 	 * Optional explicit env override map. When omitted, falls back to
-	 * `import.meta.env` via the global accessor below. Tests pass an
-	 * explicit map to avoid leaking process state.
+	 * `process.env` via `readDefaultEnv` below (never `import.meta.env` —
+	 * see that function's docstring). Tests pass an explicit map to avoid
+	 * leaking process state.
 	 */
 	env?: SecretsEnv;
 	/**
@@ -514,29 +515,34 @@ function decodeBase64urlStrict(input: string): Uint8Array | null {
 /**
  * Default env reader.
  *
- * Note: this is the **only** code path in core that reads both
- * `import.meta.env` and `process.env`. Route handlers should not — they
- * always run inside the Astro/Vite bundle where `import.meta.env` is
- * the correct source. This resolver is shared with the CLI surface (via
- * `cli/commands/secrets.ts`) which runs outside the bundle, so we
- * deliberately consult both. `import.meta.env` wins so build-time
- * substitutions are honored when present.
+ * Reads **only** `process.env`. This module must never reference
+ * `import.meta.env`: in an Astro/Vite production build the bare
+ * `import.meta.env` expression is statically replaced with an object
+ * literal built from the env loaded at build time, which (a) embeds any
+ * secret present in `.env` on the build machine into the shipped server
+ * bundle, and (b) makes that stale build-time value silently shadow the
+ * real runtime secret configured on the deployment platform (e.g. via
+ * `wrangler secret put`). See #2139.
+ *
+ * `process.env` is the runtime source on Node/container deployments and
+ * on Cloudflare Workers with Node compatibility (the same source
+ * `resolveS3Config` in `../storage/s3.ts` uses). The CLI surface
+ * (`cli/commands/secrets.ts`) runs outside the bundle where
+ * `process.env` is native.
  *
  * The convention documented in AGENTS.md ("import.meta.env.EMDASH_X ||
- * import.meta.env.X") is the route-handler convention; this is the
- * shared-with-CLI exception.
+ * import.meta.env.X") is for public, build-time config in route
+ * handlers; secrets are deliberately excluded from it.
  */
 function readDefaultEnv(): SecretsEnv {
-	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- import.meta.env is loose by design
-	const meta = (import.meta.env ?? {}) as Record<string, string | undefined>;
 	const proc = typeof process !== "undefined" && process.env ? process.env : {};
 
 	return {
-		EMDASH_ENCRYPTION_KEY: meta.EMDASH_ENCRYPTION_KEY ?? proc.EMDASH_ENCRYPTION_KEY,
-		EMDASH_PREVIEW_SECRET: meta.EMDASH_PREVIEW_SECRET ?? proc.EMDASH_PREVIEW_SECRET,
-		PREVIEW_SECRET: meta.PREVIEW_SECRET ?? proc.PREVIEW_SECRET,
-		EMDASH_IP_SALT: meta.EMDASH_IP_SALT ?? proc.EMDASH_IP_SALT,
-		EMDASH_AUTH_SECRET: meta.EMDASH_AUTH_SECRET ?? proc.EMDASH_AUTH_SECRET,
-		AUTH_SECRET: meta.AUTH_SECRET ?? proc.AUTH_SECRET,
+		EMDASH_ENCRYPTION_KEY: proc.EMDASH_ENCRYPTION_KEY,
+		EMDASH_PREVIEW_SECRET: proc.EMDASH_PREVIEW_SECRET,
+		PREVIEW_SECRET: proc.PREVIEW_SECRET,
+		EMDASH_IP_SALT: proc.EMDASH_IP_SALT,
+		EMDASH_AUTH_SECRET: proc.EMDASH_AUTH_SECRET,
+		AUTH_SECRET: proc.AUTH_SECRET,
 	};
 }

--- a/packages/core/tests/unit/config/secrets.test.ts
+++ b/packages/core/tests/unit/config/secrets.test.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
 import type { Kysely } from "kysely";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
@@ -301,6 +304,26 @@ describe("config/secrets", () => {
 				/SECRET_PERSIST_FAILED|Failed to persist/,
 			);
 		});
+
+		it("reads the default env from process.env when no env map is passed", async () => {
+			// Regression test for #2139: secrets must come from the runtime
+			// process env, never from build-time `import.meta.env`
+			// substitution (which would embed the secret in the server
+			// bundle and shadow the platform-configured value).
+			const previous = process.env.EMDASH_PREVIEW_SECRET;
+			process.env.EMDASH_PREVIEW_SECRET = "proc-preview-secret";
+			try {
+				const result = await resolveSecrets({ db });
+				expect(result.previewSecret).toBe("proc-preview-secret");
+				expect(result.previewSecretSource).toBe("env");
+			} finally {
+				if (previous === undefined) {
+					delete process.env.EMDASH_PREVIEW_SECRET;
+				} else {
+					process.env.EMDASH_PREVIEW_SECRET = previous;
+				}
+			}
+		});
 	});
 
 	describe("validateEncryptionKeyAtStartup", () => {
@@ -370,6 +393,23 @@ describe("config/secrets", () => {
 			expect(c).not.toBe(a);
 			expect(c.ipSalt).toBe(a.ipSalt);
 			expect(c.previewSecret).toBe(a.previewSecret);
+		});
+	});
+
+	describe("source hygiene", () => {
+		it("never references import.meta.env in code (would be inlined into the server bundle at build time)", async () => {
+			// Regression guard for #2139. Vite statically replaces the bare
+			// `import.meta.env` expression with an object literal built from
+			// the build-time env, embedding secrets from `.env` into
+			// `dist/server` and shadowing platform-configured runtime values.
+			const source = await readFile(
+				fileURLToPath(new URL("../../../src/config/secrets.ts", import.meta.url)),
+				"utf8",
+			);
+			const withoutComments = source
+				.replace(/\/\*[\s\S]*?\*\//g, "")
+				.replace(/^[ \t]*\/\/.*$/gm, "");
+			expect(withoutComments).not.toContain("import.meta.env");
 		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

In an Astro production build, Vite statically replaces the bare `import.meta.env` expression in `readDefaultEnv()` (`packages/core/src/config/secrets.ts`) with an object literal built from the env loaded at build time. If `EMDASH_ENCRYPTION_KEY` (or any of the other five secrets the module reads) is present in `.env` when the operator builds:

1. the secret is **embedded in plaintext** in `dist/server/chunks/secrets-*.mjs` and ships inside the Worker bundle, and
2. because the chain was `meta.X ?? proc.X`, the inlined build-time value **silently shadowed** the real runtime secret set via `wrangler secret put` — the deployed Worker encrypted plugin secrets under the developer's local dev key.

This PR makes the secrets module read **only** `process.env` (the same runtime source `resolveS3Config` already uses, available on Node/container deployments and on Cloudflare Workers with Node compatibility). With no `import.meta.env` reference left in the module, Vite has nothing to substitute, so no secret can be embedded in build output, and runtime-configured secrets are always the values actually used.

Also included:

- a regression test that `resolveSecrets({ db })` picks up `process.env` when no explicit env map is passed
- a source-hygiene test asserting the module never references `import.meta.env` in code (comments stripped), so the inlining vector can't be silently reintroduced
- updated docstrings (`readDefaultEnv`, `ResolveSecretsOptions.env`) documenting why secrets are excluded from the `import.meta.env` convention
- a changeset (patch, `emdash`) with operator guidance to rotate any key that shipped inside a bundle

Closes #2139

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (not applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion (not applicable)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code

## Screenshots / test output

```
Test Files  1 passed (1)
     Tests  33 passed (33)
```

(`packages/core/tests/unit/config/secrets.test.ts` — 31 existing + 2 new; `tsc --noEmit` and `oxlint` clean on the touched files.)