### PR TITLE
test: add visual regression suite for the admin UI

### DIFF
--- a/.changeset/tame-visual-regression.md
+++ b/.changeset/tame-visual-regression.md
@@ -1,0 +1,4 @@
+---
+---
+
+Adds a Playwright visual-regression suite for the admin UI and its CI workflows. No runtime or user-visible change; the only published-package edit is inert `data-testid` test hooks.

--- a/.github/workflows/visual-apply.yml
+++ b/.github/workflows/visual-apply.yml
@@ -1,0 +1,263 @@
+name: Visual Regression — Apply
+
+# Commits accepted visual baselines when a maintainer reacts 👍 to the sticky
+# comment posted by "Visual Regression — Report".
+#
+# GitHub has no "reaction" event, so this polls on a schedule (and can be run
+# on demand via workflow_dispatch). Each run processes at most one eligible PR:
+# it finds the sticky comment, confirms a 👍 from a user with write access,
+# downloads the inert candidate-baseline artifact produced by the measure job,
+# and commits those PNGs to the PR branch. It never executes PR-authored code.
+#
+# Idempotency:
+#   - The sticky comment carries an `<!-- applied:<sha> -->` marker; a head that
+#     already matches is skipped.
+#   - The measure artifact records has-drift; a green (no-drift) artifact is
+#     skipped, so a re-poll in the window before the comment is cleared is inert.
+#   - After copying candidates, an empty git diff short-circuits the push.
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read # find + download the measure artifact
+  contents: read # app token handles the write/push
+  pull-requests: write # read reactions, update the sticky comment
+
+jobs:
+  apply:
+    name: Apply
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Find an accepted PR
+        id: scan
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- visual-regression -->';
+            const { owner, repo } = context.repo;
+            const ALLOWED = new Set(['admin', 'write', 'maintain']);
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', base: 'main', per_page: 100,
+            });
+
+            for (const pr of prs) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const sticky = comments.find(
+                (c) => typeof c.body === 'string' && c.body.includes(marker),
+              );
+              if (!sticky) continue;
+
+              // Already applied for this head?
+              const applied = sticky.body.match(/<!-- applied:([0-9a-f]{7,40}) -->/);
+              if (applied && applied[1] === pr.head.sha) continue;
+
+              // Authorized 👍?
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssueComment,
+                { owner, repo, comment_id: sticky.id, per_page: 100 },
+              );
+              let reactor = null;
+              for (const r of reactions.filter((x) => x.content === '+1')) {
+                if (!r.user) continue;
+                try {
+                  const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner, repo, username: r.user.login,
+                  });
+                  if (ALLOWED.has(perm.permission)) { reactor = r.user.login; break; }
+                } catch { /* not a collaborator */ }
+              }
+              if (!reactor) continue;
+
+              // Locate the measure run (with the candidate artifact) for this head.
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'visual.yml', head_sha: pr.head.sha, per_page: 20,
+              });
+              const run = runs.data.workflow_runs?.[0];
+              if (!run) continue;
+
+              core.setOutput('eligible', 'true');
+              core.setOutput('number', String(pr.number));
+              core.setOutput('head_sha', pr.head.sha);
+              core.setOutput('ref', pr.head.ref);
+              core.setOutput('full_name', pr.head.repo.full_name);
+              core.setOutput('is_fork', String(
+                pr.head.repo.fork || pr.head.repo.full_name !== `${owner}/${repo}`,
+              ));
+              core.setOutput('comment_id', String(sticky.id));
+              core.setOutput('run_id', String(run.id));
+              core.setOutput('reactor', reactor);
+              core.info(`Eligible: PR #${pr.number} accepted by @${reactor} (run ${run.id}).`);
+              return;
+            }
+            core.setOutput('eligible', 'false');
+            core.info('No PR with an authorized 👍 awaiting baseline apply.');
+
+      - name: Download candidate baselines
+        id: download
+        if: steps.scan.outputs.eligible == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_ID: ${{ steps.scan.outputs.run_id }}
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const runId = Number(process.env.RUN_ID);
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner, repo: context.repo.repo, run_id: runId,
+            });
+            const artifact = data.artifacts.find((a) => a.name === 'visual-regression');
+            if (!artifact) {
+              core.setOutput('found', 'false');
+              core.info('Candidate artifact missing or expired (>7d). Push a new commit to regenerate.');
+              return;
+            }
+            const dl = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner, repo: context.repo.repo,
+              artifact_id: artifact.id, archive_format: 'zip',
+            });
+            const outDir = path.join(process.env.RUNNER_TEMP, 'va');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.writeFileSync(path.join(outDir, 'artifact.zip'), Buffer.from(dl.data));
+            core.setOutput('found', 'true');
+
+      - name: Unpack and validate
+        id: validate
+        if: steps.scan.outputs.eligible == 'true' && steps.download.outputs.found == 'true'
+        env:
+          HEAD_SHA: ${{ steps.scan.outputs.head_sha }}
+        run: |
+          cd "$RUNNER_TEMP/va"
+          unzip -o artifact.zip
+          drift=$(cat has-drift 2>/dev/null || echo false)
+          measured=$(cat head-sha 2>/dev/null || echo "")
+          if [ "$drift" != "true" ]; then
+            echo "Artifact reports no drift — nothing to apply."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          elif [ "$measured" != "$HEAD_SHA" ]; then
+            echo "Artifact head ($measured) != PR head ($HEAD_SHA) — skipping."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$(ls -A candidates 2>/dev/null)" ]; then
+            echo "No candidate baselines in artifact."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate app token
+        id: app-token
+        if: steps.validate.outputs.ok == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout (same-repo)
+        if: steps.validate.outputs.ok == 'true' && steps.scan.outputs.is_fork == 'false'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.scan.outputs.head_sha }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Checkout (fork)
+        if: steps.validate.outputs.ok == 'true' && steps.scan.outputs.is_fork == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ steps.scan.outputs.full_name }}
+          ref: ${{ steps.scan.outputs.head_sha }}
+          persist-credentials: false
+          # Reviewed opt-in: no code from the fork tree is executed. The steps
+          # below only copy inert PNGs from the trusted measure artifact and run
+          # git add/commit/push -- no scripts, hooks, or tooling from the tree.
+          allow-unsafe-pr-checkout: true
+
+      - name: Stage baselines
+        id: stage
+        if: steps.validate.outputs.ok == 'true'
+        run: |
+          set -e
+          dest="e2e/tests/visual-regression.spec.ts-snapshots"
+          mkdir -p "$dest"
+          cp -r "$RUNNER_TEMP/va/candidates/." "$dest/"
+          git add "$dest"
+          if git diff --staged --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Baselines already match candidates — nothing to commit."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push (same-repo)
+        if: steps.stage.outputs.changed == 'true' && steps.scan.outputs.is_fork == 'false'
+        env:
+          HEAD_REF: ${{ steps.scan.outputs.ref }}
+          REACTOR: ${{ steps.scan.outputs.reactor }}
+        run: |
+          set -e
+          git config user.name "emdashbot[bot]"
+          git config user.email "emdashbot[bot]@users.noreply.github.com"
+          git commit -m "ci: accept visual baselines (👍 @$REACTOR)"
+          if ! git push origin "HEAD:$HEAD_REF"; then
+            echo "::error::Non-fast-forward push — the PR branch moved. A fresh measure+apply will run for the new head." >&2
+            exit 1
+          fi
+
+      - name: Commit and push (fork)
+        if: steps.stage.outputs.changed == 'true' && steps.scan.outputs.is_fork == 'true'
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ steps.scan.outputs.ref }}
+          FULL_NAME: ${{ steps.scan.outputs.full_name }}
+          REACTOR: ${{ steps.scan.outputs.reactor }}
+        run: |
+          set -e
+          git config user.name "emdashbot[bot]"
+          git config user.email "emdashbot[bot]@users.noreply.github.com"
+          git commit -m "ci: accept visual baselines (👍 @$REACTOR)"
+          export GIT_ASKPASS="$RUNNER_TEMP/git-askpass.sh"
+          printf '#!/bin/sh\necho "%s"\n' "$APP_TOKEN" > "$GIT_ASKPASS"
+          chmod +x "$GIT_ASKPASS"
+          git remote add fork "https://x-access-token@github.com/$FULL_NAME.git"
+          if ! git push fork "HEAD:$HEAD_REF"; then
+            rm -f "$GIT_ASKPASS"
+            echo "::error::Failed to push to fork. The contributor likely has 'Allow edits by maintainers' disabled; they must regenerate baselines in the pinned Playwright Docker image and commit." >&2
+            exit 1
+          fi
+          rm -f "$GIT_ASKPASS"
+
+      - name: Mark comment applied
+        if: steps.validate.outputs.ok == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_ID: ${{ steps.scan.outputs.comment_id }}
+          HEAD_SHA: ${{ steps.scan.outputs.head_sha }}
+          REACTOR: ${{ steps.scan.outputs.reactor }}
+          CHANGED: ${{ steps.stage.outputs.changed }}
+        with:
+          script: |
+            const commentId = Number(process.env.COMMENT_ID);
+            const headSha = process.env.HEAD_SHA;
+            const reactor = process.env.REACTOR;
+            const changed = process.env.CHANGED === 'true';
+            const { data: comment } = await github.rest.issues.getComment({
+              owner: context.repo.owner, repo: context.repo.repo, comment_id: commentId,
+            });
+            // Strip any prior applied marker, then append the current one so a
+            // re-poll for the same head is skipped.
+            const base = comment.body.replace(/\n*<!-- applied:[0-9a-f]{7,40} -->/g, '');
+            const note = changed
+              ? `\n\n✅ Baselines accepted by @${reactor} and committed to this PR.`
+              : `\n\nℹ️ Baselines already matched the accepted candidates; nothing to commit.`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner, repo: context.repo.repo, comment_id: commentId,
+              body: `${base}${note}\n<!-- applied:${headSha} -->`,
+            });

--- a/.github/workflows/visual-report.yml
+++ b/.github/workflows/visual-report.yml
@@ -151,7 +151,17 @@ jobs:
             git rm -rfq --cached . 2>/dev/null || true
           fi
           rm -rf "$DEST"; mkdir -p "$DEST"
+          # Normal drift: publish the diff/expected/actual triptychs.
           cp "$RUNNER_TEMP/va/diff/"*.png "$DEST/" 2>/dev/null || true
+          # Bootstrap (no committed baselines yet): Playwright writes only the
+          # new baselines, no triptych. Publish the candidate baselines so the
+          # comment has something to show. Strip the -chromium-<platform> suffix
+          # so the screen name matches the diff naming (e.g. dashboard-ltr).
+          for f in "$RUNNER_TEMP/va/candidates/"*.png; do
+            [ -e "$f" ] || continue
+            screen=$(basename "$f" | sed -E 's/-chromium-(linux|darwin|win32)\.png$//')
+            cp "$f" "$DEST/${screen}-baseline.png"
+          done
           git add "$DEST"
           if git diff --staged --quiet; then
             echo "No images to publish."
@@ -178,27 +188,50 @@ jobs:
             const prNumber = Number(process.env.PR_NUMBER);
             const headSha = process.env.HEAD_SHA;
 
-            const diffDir = path.join(process.env.RUNNER_TEMP, 'va', 'diff');
-            const files = fs.existsSync(diffDir) ? fs.readdirSync(diffDir) : [];
-            const names = files
+            const dir = path.join(process.env.RUNNER_TEMP, 'va');
+            const diffDir = path.join(dir, 'diff');
+            const candDir = path.join(dir, 'candidates');
+            const diffFiles = fs.existsSync(diffDir) ? fs.readdirSync(diffDir) : [];
+            const diffNames = diffFiles
               .filter((f) => f.endsWith('-diff.png'))
               .map((f) => f.slice(0, -'-diff.png'.length))
               .sort();
 
-            const rows = names.map((n) => {
-              const diff = `${baseUrl}/${n}-diff.png`;
-              const expected = `${baseUrl}/${n}-expected.png`;
-              const actual = `${baseUrl}/${n}-actual.png`;
-              return `| \`${n}\` | <img src="${diff}" width="320"> | [expected](${expected}) · [actual](${actual}) |`;
-            });
+            let heading;
+            let intro;
+            let rows;
+            if (diffNames.length > 0) {
+              // Normal drift: prior baselines exist, show the triptych.
+              heading = `## Visual regression: ${diffNames.length} screen${diffNames.length === 1 ? '' : 's'} changed`;
+              intro = 'These admin screens render differently on this PR. Confirm every change below is intended before accepting.';
+              rows = diffNames.map((n) => {
+                const diff = `${baseUrl}/${n}-diff.png`;
+                const expected = `${baseUrl}/${n}-expected.png`;
+                const actual = `${baseUrl}/${n}-actual.png`;
+                return `| \`${n}\` | <img src="${diff}" width="320"> | [expected](${expected}) · [actual](${actual}) |`;
+              });
+            } else {
+              // Bootstrap: no prior baselines, show the new candidate baselines.
+              const candFiles = fs.existsSync(candDir) ? fs.readdirSync(candDir) : [];
+              const newNames = candFiles
+                .filter((f) => /-chromium-(linux|darwin|win32)\.png$/.test(f))
+                .map((f) => f.replace(/-chromium-(linux|darwin|win32)\.png$/, ''))
+                .sort();
+              heading = `## Visual regression: ${newNames.length} new screen${newNames.length === 1 ? '' : 's'} (no baseline yet)`;
+              intro = 'No baselines exist for these admin screens yet. Review the proposed baselines below, then accept them to start tracking visual drift.';
+              rows = newNames.map((n) => {
+                const baseline = `${baseUrl}/${n}-baseline.png`;
+                return `| \`${n}\` | <img src="${baseline}" width="320"> | new screen (no prior baseline) |`;
+              });
+            }
 
             const body = [
               marker,
-              `## Visual regression: ${names.length} screen${names.length === 1 ? '' : 's'} changed`,
+              heading,
               '',
-              'These admin screens render differently on this PR. Confirm every change below is intended before accepting.',
+              intro,
               '',
-              '| Screen | Diff | Compare |',
+              '| Screen | Image | Compare |',
               '| --- | --- | --- |',
               ...rows,
               '',

--- a/.github/workflows/visual-report.yml
+++ b/.github/workflows/visual-report.yml
@@ -1,0 +1,234 @@
+name: Visual Regression — Report
+
+# Runs after "Visual Regression" completes. Trusted (runs from the base repo
+# with elevated permissions) but never executes PR-authored code: it only
+# consumes the inert PNG + metadata artifact produced by the measure job.
+#
+# Responsibilities:
+#   - Publish the diff images to the `visual-snapshots` branch so they can be
+#     embedded in a comment (GitHub cannot host comment images via the API).
+#   - Upsert a sticky comment with the diffs and 👍-to-accept instructions.
+#   - Delete the sticky comment when a later run shows no drift (resolved).
+
+on:
+  workflow_run:
+    workflows: ["Visual Regression"]
+    types: [completed]
+
+permissions:
+  actions: read # list/download the measure artifact
+  contents: write # push diff images to the visual-snapshots branch
+  pull-requests: write # upsert/delete the sticky comment
+
+jobs:
+  report:
+    name: Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download artifact
+        id: download
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const artifact = data.artifacts.find((a) => a.name === 'visual-regression');
+            if (!artifact) {
+              core.setOutput('found', 'false');
+              core.info('No visual-regression artifact (measure job likely failed early). Nothing to report.');
+              return;
+            }
+            const dl = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: artifact.id,
+              archive_format: 'zip',
+            });
+            // Stage outside GITHUB_WORKSPACE so nothing wipes it.
+            const outDir = path.join(process.env.RUNNER_TEMP, 'va');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.writeFileSync(path.join(outDir, 'artifact.zip'), Buffer.from(dl.data));
+            core.setOutput('found', 'true');
+
+      - name: Unpack artifact
+        if: steps.download.outputs.found == 'true'
+        run: |
+          cd "$RUNNER_TEMP/va"
+          unzip -o artifact.zip
+          ls -R .
+
+      - name: Resolve PR
+        if: steps.download.outputs.found == 'true'
+        id: pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const dir = path.join(process.env.RUNNER_TEMP, 'va');
+            const prNumber = Number(fs.readFileSync(path.join(dir, 'pr-number'), 'utf8').trim());
+            const hasDrift = fs.readFileSync(path.join(dir, 'has-drift'), 'utf8').trim() === 'true';
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number in artifact: ${prNumber}`);
+              return;
+            }
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            // If the branch moved past what was measured, skip; a fresh measure
+            // for the new head will follow.
+            if (pr.head.sha !== headSha) {
+              core.info(`PR #${prNumber} head (${pr.head.sha}) != measured (${headSha}); skipping.`);
+              core.setOutput('stale', 'true');
+              return;
+            }
+            core.setOutput('stale', 'false');
+            core.setOutput('number', String(pr.number));
+            core.setOutput('sha', headSha);
+            core.setOutput('has_drift', hasDrift ? 'true' : 'false');
+
+      # No drift on this run: remove any stale sticky comment and stop.
+      - name: Clear sticky comment (resolved)
+        if: steps.download.outputs.found == 'true' && steps.pr.outputs.stale == 'false' && steps.pr.outputs.has_drift == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const marker = '<!-- visual-regression -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const prior = comments.find((c) => typeof c.body === 'string' && c.body.includes(marker));
+            if (prior) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+              });
+              core.info('Removed stale sticky comment (no drift).');
+            }
+
+      - name: Publish diff images
+        if: steps.download.outputs.found == 'true' && steps.pr.outputs.stale == 'false' && steps.pr.outputs.has_drift == 'true'
+        id: images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          set -e
+          BRANCH=visual-snapshots
+          DEST="pr-${PR_NUMBER}/${HEAD_SHA}"
+          work="$RUNNER_TEMP/vs"
+          rm -rf "$work"; mkdir -p "$work"; cd "$work"
+          git init -q
+          git config user.name "emdashbot[bot]"
+          git config user.email "emdashbot[bot]@users.noreply.github.com"
+          export GIT_ASKPASS="$RUNNER_TEMP/git-askpass.sh"
+          printf '#!/bin/sh\necho "%s"\n' "$GH_TOKEN" > "$GIT_ASKPASS"
+          chmod +x "$GIT_ASKPASS"
+          git remote add origin "https://x-access-token@github.com/${OWNER_REPO}.git"
+          # Preserve other PRs' images: build on the existing branch if present.
+          if git fetch -q --depth=1 origin "$BRANCH"; then
+            git checkout -q -B "$BRANCH" FETCH_HEAD
+          else
+            git checkout -q --orphan "$BRANCH"
+            git rm -rfq --cached . 2>/dev/null || true
+          fi
+          rm -rf "$DEST"; mkdir -p "$DEST"
+          cp "$RUNNER_TEMP/va/diff/"*.png "$DEST/" 2>/dev/null || true
+          git add "$DEST"
+          if git diff --staged --quiet; then
+            echo "No images to publish."
+          else
+            git commit -q -m "visual diffs for PR #${PR_NUMBER} @ ${HEAD_SHA}"
+            git push -q origin "$BRANCH"
+          fi
+          rm -f "$GIT_ASKPASS"
+          echo "base_url=https://github.com/${OWNER_REPO}/raw/${BRANCH}/${DEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert sticky comment
+        if: steps.download.outputs.found == 'true' && steps.pr.outputs.stale == 'false' && steps.pr.outputs.has_drift == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BASE_URL: ${{ steps.images.outputs.base_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.sha }}
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const marker = '<!-- visual-regression -->';
+            const baseUrl = process.env.BASE_URL;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const headSha = process.env.HEAD_SHA;
+
+            const diffDir = path.join(process.env.RUNNER_TEMP, 'va', 'diff');
+            const files = fs.existsSync(diffDir) ? fs.readdirSync(diffDir) : [];
+            const names = files
+              .filter((f) => f.endsWith('-diff.png'))
+              .map((f) => f.slice(0, -'-diff.png'.length))
+              .sort();
+
+            const rows = names.map((n) => {
+              const diff = `${baseUrl}/${n}-diff.png`;
+              const expected = `${baseUrl}/${n}-expected.png`;
+              const actual = `${baseUrl}/${n}-actual.png`;
+              return `| \`${n}\` | <img src="${diff}" width="320"> | [expected](${expected}) · [actual](${actual}) |`;
+            });
+
+            const body = [
+              marker,
+              `## Visual regression: ${names.length} screen${names.length === 1 ? '' : 's'} changed`,
+              '',
+              'These admin screens render differently on this PR. Confirm every change below is intended before accepting.',
+              '',
+              '| Screen | Diff | Compare |',
+              '| --- | --- | --- |',
+              ...rows,
+              '',
+              '---',
+              '**Maintainers:** react 👍 to this comment to accept these baselines. The',
+              '"Visual Regression — Apply" job (every ~10 min, or run it manually via',
+              'workflow_dispatch) will commit the regenerated Linux baselines to this PR.',
+              '',
+              `<sub>Measured head: \`${headSha}\`. Reacting 👍 accepts the snapshots for this commit.</sub>`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const prior = comments.find((c) => typeof c.body === 'string' && c.body.includes(marker));
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -20,15 +20,9 @@ on:
     paths:
       - "packages/admin/**"
       - "packages/core/**"
-      # The whole e2e tree feeds the screenshots: the spec, the committed
-      # baselines, the fixtures/page objects, global setup, and the seed data
-      # under e2e/fixture/** all determine what renders and how it's captured.
       - "e2e/**"
       - "playwright.config.ts"
       - ".github/workflows/visual.yml"
-      # A Playwright/Chromium version bump changes font rendering and pixel
-      # output, so a lockfile/manifest change can drift baselines without
-      # touching any source path above.
       - "pnpm-lock.yaml"
       - "package.json"
 

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -26,6 +26,11 @@ on:
       - "e2e/**"
       - "playwright.config.ts"
       - ".github/workflows/visual.yml"
+      # A Playwright/Chromium version bump changes font rendering and pixel
+      # output, so a lockfile/manifest change can drift baselines without
+      # touching any source path above.
+      - "pnpm-lock.yaml"
+      - "package.json"
 
 permissions:
   contents: read

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -20,8 +20,11 @@ on:
     paths:
       - "packages/admin/**"
       - "packages/core/**"
-      - "e2e/tests/visual-regression.spec.ts"
-      - "e2e/tests/visual-regression.spec.ts-snapshots/**"
+      # The whole e2e tree feeds the screenshots: the spec, the committed
+      # baselines, the fixtures/page objects, global setup, and the seed data
+      # under e2e/fixture/** all determine what renders and how it's captured.
+      - "e2e/**"
+      - "playwright.config.ts"
       - ".github/workflows/visual.yml"
 
 permissions:

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,0 +1,131 @@
+name: Visual Regression
+
+# Untrusted measure job. Runs the visual-regression Playwright suite against the
+# committed baselines and, when snapshots differ, produces an artifact with the
+# candidate (accepted-state) baselines plus diff images. This workflow runs with
+# a read-only token and never comments or pushes. The companion workflows handle
+# that with elevated permissions, isolated from PR-authored code:
+#   - "Visual Regression — Report" (workflow_run) posts the sticky comment.
+#   - "Visual Regression — Apply" (schedule) commits accepted baselines when a
+#     maintainer reacts 👍 to the sticky comment.
+#
+# Baselines are Linux/chromium PNGs regenerated here on the CI runner, so they
+# always match the environment they're diffed in. Contributors do NOT commit
+# baselines by hand (macOS PNGs would never match); the 👍-accept flow commits
+# the correct Linux baselines for them.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/admin/**"
+      - "packages/core/**"
+      - "e2e/tests/visual-regression.spec.ts"
+      - "e2e/tests/visual-regression.spec.ts-snapshots/**"
+      - ".github/workflows/visual.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: Measure
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run --filter emdash... build
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
+      - run: pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Run visual regression
+        id: run
+        env:
+          EMDASH_VISUAL: "1"
+        run: |
+          set +e
+          pnpm exec playwright test visual-regression --reporter=line
+          code=$?
+          set -e
+          echo "exit=$code" >> "$GITHUB_OUTPUT"
+          echo "Playwright exited with $code"
+
+      # Always record PR metadata so the Report workflow can upsert *or* clear
+      # the sticky comment. Candidate baselines + diff images are added only
+      # when the suite actually diffed (exit != 0 AND regeneration produced
+      # snapshots) -- an infra failure exits non-zero but yields no candidates,
+      # so we don't mislabel it as a visual change.
+      - name: Collect result
+        id: collect
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_EXIT: ${{ steps.run.outputs.exit }}
+        run: |
+          mkdir -p visual-out
+          echo "$PR_NUMBER" > visual-out/pr-number
+          echo "$HEAD_SHA" > visual-out/head-sha
+
+          if [ "$RUN_EXIT" = "0" ]; then
+            echo "false" > visual-out/has-drift
+            echo "has_drift=false" >> "$GITHUB_OUTPUT"
+            echo "No visual drift."
+            exit 0
+          fi
+
+          # Copy the diff/actual/expected triptychs Playwright writes on failure.
+          mkdir -p visual-out/diff
+          if [ -d test-results ]; then
+            find test-results -type f \
+              \( -name '*-diff.png' -o -name '*-actual.png' -o -name '*-expected.png' \) \
+              -exec cp {} visual-out/diff/ \;
+          fi
+
+          # Regenerate the accepted-state baselines (the candidates the Apply
+          # workflow will commit verbatim on 👍). These are Linux/chromium PNGs.
+          pnpm exec playwright test visual-regression --update-snapshots --reporter=line || true
+          mkdir -p visual-out/candidates
+          if [ -d e2e/tests/visual-regression.spec.ts-snapshots ]; then
+            cp -r e2e/tests/visual-regression.spec.ts-snapshots/. visual-out/candidates/
+          fi
+
+          if [ -z "$(ls -A visual-out/candidates 2>/dev/null)" ]; then
+            # Non-zero exit but nothing regenerated -> infra failure, not drift.
+            echo "false" > visual-out/has-drift
+            echo "has_drift=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Visual suite failed without producing candidate baselines (likely an infra failure, not a UI diff)."
+          else
+            echo "true" > visual-out/has-drift
+            echo "has_drift=true" >> "$GITHUB_OUTPUT"
+            echo "Visual drift detected — candidates and diff images staged for the Report workflow."
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: visual-regression
+          path: visual-out/
+          retention-days: 7
+          if-no-files-found: error
+
+      # Make the check red so a UI PR gets a visible signal. This does not, by
+      # itself, block merge -- keep it out of required checks until the false-
+      # diff rate is near zero, then promote it.
+      - name: Fail on drift
+        if: steps.collect.outputs.has_drift == 'true'
+        run: |
+          echo "::error::Visual snapshots changed. Review the diff in the sticky comment; a maintainer 👍 on that comment accepts the new baselines."
+          exit 1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -40,6 +40,12 @@ rules:
       # query-counts-label labels PRs based on path filters; it does not
       # check out PR code.
       - query-counts-label.yml
+      # visual-report uses workflow_run to comment on PRs after the untrusted
+      # `visual` measure workflow completes. The trusted job only consumes the
+      # inert PNG + metadata artifact, verifies the PR head SHA matches the
+      # workflow_run head SHA, publishes diff images to a snapshots branch, and
+      # upserts a sticky comment. It never checks out or executes PR code.
+      - visual-report.yml
 
   # The CLA assistant action (contributor-assistant/github-action) requires
   # write access to actions, contents (cla-signatures branch), issues, PRs,

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,12 @@ playwright-report/
 test-results/
 playwright/.cache/
 
+# Visual regression baselines are platform-specific. CI (Linux) is the source
+# of truth and commits `-linux.png` via the visual-apply workflow; locally
+# generated macOS/Windows baselines must never be committed (they won't match).
+e2e/tests/*-snapshots/*-darwin.png
+e2e/tests/*-snapshots/*-win32.png
+
 # Debug screenshots
 debug-*.png
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,18 @@ pnpm test:e2e    # Playwright
 
 Tests use real in-memory SQLite -- no mocking. Each test gets a fresh database. Typecheck and lint must pass.
 
+### Visual regression tests
+
+The admin UI has a Playwright visual-regression suite (`e2e/tests/visual-regression.spec.ts`) that screenshots key screens in both LTR (English) and RTL (Arabic). It is gated behind `EMDASH_VISUAL=1` so it stays out of the default `pnpm test:e2e` run:
+
+```bash
+EMDASH_VISUAL=1 pnpm test:e2e visual-regression
+```
+
+Baselines are platform-specific. **CI (Linux) is the source of truth** -- committed baselines are `*-chromium-linux.png`. Locally generated macOS/Windows baselines (`*-darwin.png`, `*-win32.png`) are gitignored; never commit them, they won't match CI.
+
+When a PR changes how a screen renders, the `Visual Regression` check goes red and a bot posts a sticky comment with the diff images. A maintainer reviews the diffs and, if the change is intended, reacts 👍 to the comment. The `Visual Regression — Apply` job then commits the regenerated Linux baselines to the PR branch. Baselines are never updated automatically on push -- a human must accept each change.
+
 ### Building your own site in the monorepo
 
 Copy a template into `demos/`, give it a unique `name` in `package.json`, install, and run:

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -18,7 +18,7 @@ export { AdminPage } from "./admin";
 
 const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
 
-interface ServerInfo {
+export interface ServerInfo {
 	pid: number;
 	workDir: string;
 	baseUrl: string;

--- a/e2e/tests/visual-regression.spec.ts
+++ b/e2e/tests/visual-regression.spec.ts
@@ -21,7 +21,7 @@
 
 import type { Locator } from "@playwright/test";
 
-import { test, expect, type AdminPage } from "../fixtures";
+import { test, expect, type AdminPage, type ServerInfo } from "../fixtures";
 
 const VISUAL_ENABLED = process.env.EMDASH_VISUAL === "1";
 
@@ -45,10 +45,6 @@ const LOCALES = [
 	{ name: "ltr", code: "en", dir: "ltr" },
 	{ name: "rtl", code: "ar", dir: "rtl" },
 ] as const;
-
-interface ServerInfo {
-	contentIds: Record<string, string[]>;
-}
 
 /**
  * A screen to snapshot.
@@ -114,7 +110,11 @@ async function openAdmin(admin: AdminPage, path: string, dir: string): Promise<v
 /** Settle fonts and freeze animation before capturing. */
 async function stabilize(admin: AdminPage): Promise<void> {
 	await admin.page.addStyleTag({ content: FREEZE_CSS });
-	await admin.page.evaluate(() => document.fonts.ready);
+	// Await font loading without returning the FontFaceSet that
+	// document.fonts.ready fulfils with -- Playwright cannot serialize it.
+	await admin.page.evaluate(async () => {
+		await document.fonts.ready;
+	});
 }
 
 test.describe("visual regression", () => {

--- a/e2e/tests/visual-regression.spec.ts
+++ b/e2e/tests/visual-regression.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Visual regression proof-of-concept.
+ *
+ * Captures pixel snapshots of key admin screens in both LTR (English) and
+ * RTL (Arabic) and diffs them against committed baselines via Playwright's
+ * built-in `toHaveScreenshot()` assertion. This is the *local runner* approach:
+ * the browser is whatever `playwright install chromium` gave you. That makes it
+ * environment-sensitive -- baselines generated on macOS will NOT match a Linux
+ * CI runner. For stable CI, regenerate baselines inside the pinned Playwright
+ * Docker image (mcr.microsoft.com/playwright) or run this against Cloudflare
+ * Browser Rendering so the render environment is fixed. See the PR discussion.
+ *
+ * Gated behind EMDASH_VISUAL=1 so it stays out of the default e2e suite until
+ * baselines are committed (a fresh checkout has none, which would fail CI):
+ *
+ *   # first run writes baselines, reports them as "created" (non-zero exit)
+ *   EMDASH_VISUAL=1 pnpm exec playwright test visual-regression --update-snapshots
+ *   # subsequent runs diff against them
+ *   EMDASH_VISUAL=1 pnpm exec playwright test visual-regression
+ */
+
+import type { Locator } from "@playwright/test";
+
+import { test, expect, type AdminPage } from "../fixtures";
+
+const VISUAL_ENABLED = process.env.EMDASH_VISUAL === "1";
+
+// Kill the usual sources of pixel nondeterminism: animations, transitions,
+// the blinking text caret, and smooth-scroll. Re-injected after every reload
+// because a full navigation drops injected styles.
+const FREEZE_CSS = `
+	*, *::before, *::after {
+		animation-duration: 0s !important;
+		animation-delay: 0s !important;
+		transition-duration: 0s !important;
+		transition-delay: 0s !important;
+		caret-color: transparent !important;
+		scroll-behavior: auto !important;
+	}
+`;
+
+// Admin locale is driven by the `emdash-locale` cookie (path /_emdash); Arabic
+// is enabled with dir: "rtl", so this flips the whole shell to RTL.
+const LOCALES = [
+	{ name: "ltr", code: "en", dir: "ltr" },
+	{ name: "rtl", code: "ar", dir: "rtl" },
+] as const;
+
+interface ServerInfo {
+	contentIds: Record<string, string[]>;
+}
+
+/**
+ * A screen to snapshot.
+ *
+ * `path` may depend on seeded data (e.g. a post id for the editor).
+ * `extraMasks` returns page regions to paint over on top of the always-masked
+ * version footer -- use it for anything that changes every run (timestamps).
+ */
+interface PageCase {
+	name: string;
+	path: (info: ServerInfo) => string;
+	extraMasks?: (admin: AdminPage) => Locator[];
+}
+
+const PAGES: PageCase[] = [
+	{
+		name: "dashboard",
+		path: () => "/",
+		// Recent Activity prints relative times ("just now") that drift over time.
+		extraMasks: (admin) => [admin.page.getByTestId("activity-time")],
+	},
+	{
+		name: "content-list",
+		path: () => "/content/posts",
+		// The Updated column is an absolute date (the seed day) -- guaranteed to
+		// differ between a committed baseline and any later run.
+		extraMasks: (admin) => [admin.page.getByTestId("content-updated")],
+	},
+	{
+		name: "content-editor",
+		path: (info) => `/content/posts/${info.contentIds.posts[0]}`,
+		// The Publish panel prints Created/Updated timestamps seeded at test time.
+		extraMasks: (admin) => [admin.page.getByTestId("content-timestamps")],
+	},
+	{ name: "content-new", path: () => "/content/posts/new" },
+	{ name: "media", path: () => "/media" },
+	{ name: "menus", path: () => "/menus" },
+	{ name: "settings", path: () => "/settings" },
+];
+
+/** Set the admin locale cookie (SSR + client both read it). */
+async function setLocale(admin: AdminPage, code: string): Promise<void> {
+	await admin.page
+		.context()
+		.addCookies([{ name: "emdash-locale", value: code, domain: "localhost", path: "/_emdash" }]);
+}
+
+/**
+ * Navigate to an admin path and wait for it to be ready without relying on any
+ * localized selectors. The shared AdminPage.waitForShell() matches the sidebar
+ * by its aria-label, which is translated -- so it can't be used once the locale
+ * is Arabic. Here we wait on the hydration signal and the <aside> landmark
+ * (both locale-independent), then confirm the document direction flipped.
+ */
+async function openAdmin(admin: AdminPage, path: string, dir: string): Promise<void> {
+	await admin.goto(path);
+	await admin.page.waitForSelector("astro-island:not([ssr])", { timeout: 30000 });
+	await admin.page.locator("aside").first().waitFor({ state: "visible", timeout: 30000 });
+	await expect(admin.page.locator("html")).toHaveAttribute("dir", dir);
+	await admin.waitForLoading();
+}
+
+/** Settle fonts and freeze animation before capturing. */
+async function stabilize(admin: AdminPage): Promise<void> {
+	await admin.page.addStyleTag({ content: FREEZE_CSS });
+	await admin.page.evaluate(() => document.fonts.ready);
+}
+
+test.describe("visual regression", () => {
+	test.skip(!VISUAL_ENABLED, "Set EMDASH_VISUAL=1 to run visual regression snapshots");
+
+	// Freeze OS-level motion preferences as well as our CSS override.
+	test.use({ reducedMotion: "reduce" });
+
+	test.beforeEach(async ({ admin }) => {
+		await admin.devBypassAuth();
+	});
+
+	for (const locale of LOCALES) {
+		for (const pageCase of PAGES) {
+			test(`${pageCase.name} @${locale.name}`, async ({ admin, serverInfo }) => {
+				await setLocale(admin, locale.code);
+				await openAdmin(admin, pageCase.path(serverInfo), locale.dir);
+				await stabilize(admin);
+
+				await expect(admin.page).toHaveScreenshot(`${pageCase.name}-${locale.name}.png`, {
+					fullPage: true,
+					animations: "disabled",
+					// The version/commit string changes every build; always mask it.
+					mask: [admin.page.getByTestId("admin-version"), ...(pageCase.extraMasks?.(admin) ?? [])],
+				});
+			});
+		}
+	}
+});

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -997,7 +997,9 @@ function ContentListItem({
 					</span>
 				</td>
 			)}
-			<td className="px-4 py-3 text-sm text-kumo-subtle">{date.toLocaleDateString()}</td>
+			<td data-testid="content-updated" className="px-4 py-3 text-sm text-kumo-subtle">
+				{date.toLocaleDateString()}
+			</td>
 			<td className="px-4 py-3 text-end">
 				<div className="flex items-center justify-end space-x-1">
 					{item.status === "published" && item.slug && (

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -505,7 +505,10 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 				</div>
 
 				{item && (
-					<dl className="mt-4 border-t pt-4 space-y-1 text-xs text-kumo-subtle">
+					<dl
+						data-testid="content-timestamps"
+						className="mt-4 border-t pt-4 space-y-1 text-xs text-kumo-subtle"
+					>
 						<div className="flex items-center justify-between gap-2">
 							<dt>{t`Created`}</dt>
 							<dd>{new Date(item.createdAt).toLocaleString()}</dd>

--- a/packages/admin/src/components/Dashboard.tsx
+++ b/packages/admin/src/components/Dashboard.tsx
@@ -320,7 +320,7 @@ function RecentActivity({ items, loading }: { items: RecentItem[]; loading: bool
 										{item.collectionLabel}
 									</span>
 								</div>
-								<span className="shrink-0 text-xs text-kumo-subtle">
+								<span data-testid="activity-time" className="shrink-0 text-xs text-kumo-subtle">
 									{formatRelativeTime(item.updatedAt)}
 								</span>
 							</Link>

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -487,7 +487,10 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 			<KumoSidebar.Footer className="gap-0">
 				<KumoSidebar.Trigger className="rtl:rotate-180" />
 				<div className="min-w-0 flex-1 overflow-hidden">
-					<p className="w-40 overflow-hidden truncate ps-2 text-[11px] text-kumo-subtle">
+					<p
+						data-testid="admin-version"
+						className="w-40 overflow-hidden truncate ps-2 text-[11px] text-kumo-subtle"
+					>
 						{manifest.admin?.siteName || "EmDash CMS"} v{manifest.version || "0.0.0"}
 						{manifest.commit && ` (${manifest.commit})`}
 					</p>


### PR DESCRIPTION
## What does this PR do?

Adds a Playwright visual-regression suite for the admin UI plus the CI machinery to run it safely on contributor PRs.

- **Suite** (`e2e/tests/visual-regression.spec.ts`): screenshots 7 key admin screens (dashboard, content list/editor/new, media, menus, settings) in both LTR (English) and RTL (Arabic) = 14 snapshots. Config-driven `PAGES` array, `reducedMotion`, frozen CSS animations, `document.fonts.ready`, and locale-independent shell detection. Gated behind `EMDASH_VISUAL=1` so it stays out of the default `pnpm test:e2e` run until baselines are committed.
- **Drift masking**: inert `data-testid` hooks on the version/commit footer, content timestamps, the content-list date column, and dashboard relative times, so guaranteed-drift values don't cause false diffs.
- **CI trio**, mirroring the reviewed query-counts trust model:
  - `visual.yml` — untrusted `pull_request` measure job. Read-only; never pushes or comments. On drift it regenerates candidate baselines + diff triptychs and uploads them as an inert artifact, and fails the check red.
  - `visual-report.yml` — trusted `workflow_run` job. Consumes only the inert artifact, verifies the PR head SHA, publishes diff images to a `visual-snapshots` branch, and upserts (or clears) a sticky comment.
  - `visual-apply.yml` — reaction-gated apply. Scans open PRs for a 👍 from a write/admin/maintain collaborator on the sticky comment, then commits the regenerated **Linux** baselines to the PR branch. Baselines are never updated automatically on push — a human must accept each change. Polls on a schedule (no native reaction event) and supports `workflow_dispatch`.
- **Baselines are platform-specific.** Linux (CI) is the source of truth; `*-darwin.png` / `*-win32.png` are gitignored so locally generated baselines are never committed.

This PR doubles as the end-to-end validation vehicle for the workflows, which can only run on GitHub.

## Type of change

- [x] Tests

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) <!-- visual suite verified green locally; full run pending Linux baselines -->
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no new user-visible strings; only inert data-testid attributes -->
- [ ] I have added a changeset (if this PR changes a published package) <!-- n/a: the only published-package change is inert data-testid test hooks with no runtime or user-visible effect; this is test/CI infrastructure -->
- [ ] New features link to an approved Discussion <!-- n/a: not a feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

zizmor reports no findings on the three new workflows. `pnpm lint:json` is at 0 diagnostics.

Note: the workflows can only be validated on GitHub. The first measure run on this PR bootstraps baselines (no committed baselines yet), so expect a red `Visual Regression` check and a sticky comment; that's the intended 👍-to-accept bootstrap path.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-admin-visual-regression-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/admin-visual-regression`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
