### PR TITLE
fix(docker): install node-gyp toolchain in build stage so native deps survive blocked prebuilt downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,16 @@ WORKDIR /app
 # ---- Install dependencies ----
 FROM base AS deps
 
+# Toolchain for the node-gyp fallback of native deps. better-sqlite3 installs
+# via `prebuild-install || node-gyp rebuild`; the prebuilt binary comes from
+# GitHub Releases, which corporate proxies and offline mirrors commonly block.
+# The fallback then compiles from source and needs python3/make/g++, which
+# node:22-slim doesn't ship. Build stages only -- the runtime image below
+# starts from a fresh node:22-slim and is unaffected.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 # pnpm-workspace.yaml declares patchedDependencies -> patches/, which pnpm
 # reads during install. It must be in the deps stage or --frozen-lockfile

--- a/docs/src/content/docs/deployment/nodejs.mdx
+++ b/docs/src/content/docs/deployment/nodejs.mdx
@@ -117,6 +117,30 @@ CMD ["node", "./dist/server/entry.mjs"]
 
 The seed file is read at build time and inlined into the bundle, so it does not need to be copied into the runtime image. Migrations run on the first request after a deploy; the seed applies only when the database has no collections and setup hasn't been completed — existing data is never overwritten.
 
+<Aside>
+	This Dockerfile builds **your own EmDash site** — a project that has `emdash` as a dependency. It is
+	not interchangeable with the `Dockerfile` in the root of the EmDash repository, which builds the whole
+	pnpm monorepo and packages the blog template from source.
+</Aside>
+
+<Aside type="caution" title="Native dependencies behind restrictive networks">
+	EmDash's SQLite driver (`better-sqlite3`) installs a prebuilt binary downloaded from GitHub Releases.
+	If your build environment blocks that download (corporate proxy, offline mirror), the install falls
+	back to compiling from source and fails with a `gyp ERR! find Python` error, because slim/alpine Node
+	images ship no compiler toolchain.
+</Aside>
+
+If you hit that error, install the toolchain in the builder stage before `npm ci`:
+
+```dockerfile
+# Alpine-based images (node:22-alpine)
+RUN apk add --no-cache python3 make g++
+
+# Debian-based images (node:22-slim)
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+```
+
 Build the image and run the container:
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2132 / #2118, prompted by [the report that the Docker build still fails after the patches fix](https://github.com/emdash-cms/emdash/pull/2132#issuecomment-5018614830).

The root `Dockerfile` relies on prebuilt binaries for its native dependencies. `better-sqlite3` installs via `prebuild-install || node-gyp rebuild`: the prebuilt binary is downloaded from **GitHub Releases**, which corporate proxies and offline registry mirrors commonly block. When that download fails, the fallback compiles from source — and dies, because `node:22-slim` ships no compiler toolchain:

```
npm error gyp ERR! find Python
npm error gyp ERR! stack Error: Could not find any Python installation to use
```

This PR:

- installs `python3 make g++` in the `deps` build stage only (the runtime image starts from a fresh `node:22-slim` and is unaffected — no size or attack-surface change to the shipped image)
- documents the same failure mode in the Node.js deployment guide, and clarifies that the guide's Dockerfile (builds **your own site** with npm) and the repo-root Dockerfile (builds the **monorepo blog template** with pnpm) are different scenarios that are not interchangeable

**Verification** (reproduced in `node:22-slim` containers):

1. GitHub Releases blocked via `/etc/hosts` + no toolchain → `npm install better-sqlite3@12.8.0` fails with the exact `gyp ERR! find Python` error above.
2. Same blocked network + `python3 make g++` installed → install compiles from source successfully and `require("better-sqlite3")` round-trips a query.
3. On an unrestricted network nothing changes: all native deps in the lockfile (better-sqlite3, sharp, lightningcss) ship prebuilts for Node 22 on glibc arm64/x64, so the toolchain sits idle and the prebuilt path is used.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes: no changeset — Dockerfile and docs only, no published package changes. No tests — infra/docs change; verification steps documented above.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude (Fable 5)

## Screenshots / test output

Repro without toolchain (GitHub blocked):

```
npm error gyp ERR! find Python
npm error gyp ERR! stack Error: Could not find any Python installation to use
npm error gyp ERR! not ok
```

With toolchain (GitHub still blocked):

```
NPM_EXIT=0
SQLITE WORKS: 42
```