### PR TITLE
test(core): plugin-storage numeric filters/order compare lexically on Postgres

### DIFF
--- a/packages/core/tests/integration/plugins/storage-postgres-numeric-regression.test.ts
+++ b/packages/core/tests/integration/plugins/storage-postgres-numeric-regression.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Plugin storage: numeric comparisons/ordering are lexical on Postgres.
+ *
+ * `_plugin_storage.data` is a plain `text` column, and plugin storage was only
+ * ever exercised on SQLite. #1898 (fix for #920) added the `(data)::jsonb->>'…'`
+ * cast, so the JSON accessor no longer raises "operator does not exist:
+ * text ->> unknown" and boolean/equality filters work. But `->>` still yields
+ * **text**, and the query/count/order paths compare that text directly — so on
+ * Postgres a numeric guard compares lexically:
+ *
+ *   '9' >= '10'   →  TRUE   (lexical)   but  9 >= 10  →  false (numeric)
+ *
+ * The consequences are a silent over-count / oversell and mis-ordering:
+ *
+ *   (a) a RangeFilter `{ stock: { gte: 10 } }` over 9 / 10 / 100 returns 9 too
+ *   (b) count() of the same guard returns 3 instead of 2
+ *   (c) createStorageIndexes' UNIQUE expression index — already fixed by #1898,
+ *       kept here as a passing guard that the `->>` parse path stays healthy
+ *   (d) orderBy on a numeric field returns [10, 100, 9] instead of [9, 10, 100]
+ *
+ * These run on SQLite (always) and Postgres (when EMDASH_TEST_PG is set).
+ * SQLite's json_extract returns a typed value, so it is green throughout — which
+ * is exactly why the bug went unnoticed. The Postgres dialect FAILS on (a),(b),
+ * (d) on current main. The fix is a type-guarded numeric cast on the extracted
+ * value for numeric comparisons/order (mirroring how json_extract is already
+ * typed on SQLite).
+ */
+
+import type { Kysely } from "kysely";
+import { it, expect, beforeEach, afterEach } from "vitest";
+
+import { PluginStorageRepository } from "../../../src/database/repositories/plugin-storage.js";
+import type { Database } from "../../../src/database/types.js";
+import { createStorageIndexes } from "../../../src/plugins/storage-indexes.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+interface Product {
+	sku: string;
+	stock: number;
+}
+
+describeEachDialect("Plugin storage numeric comparison on Postgres", (dialect) => {
+	let ctx: DialectTestContext;
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		db = ctx.db;
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	function productsRepo(): PluginStorageRepository<Product> {
+		// `stock` is declared indexed so it may be used in orderBy.
+		return new PluginStorageRepository<Product>(db, "shop", "products", ["sku", "stock"]);
+	}
+
+	/** Stock values chosen so lexical and numeric ordering disagree: '9' > '10'. */
+	async function seedProducts(): Promise<PluginStorageRepository<Product>> {
+		const repo = productsRepo();
+		await repo.putMany([
+			{ id: "p9", data: { sku: "A9", stock: 9 } },
+			{ id: "p10", data: { sku: "B10", stock: 10 } },
+			{ id: "p100", data: { sku: "C100", stock: 100 } },
+		]);
+		return repo;
+	}
+
+	// (a) The load-bearing case: a lexical `>=` includes stock 9 in a `>= 10`
+	// filter — a silent over-count / oversell.
+	it("numeric RangeFilter { gte: 10 } returns exactly {10, 100}, never 9", async () => {
+		const repo = await seedProducts();
+		const result = await repo.query({ where: { stock: { gte: 10 } } });
+		expect(result.items.map((i) => i.id).toSorted()).toEqual(["p10", "p100"]);
+		expect(result.items.map((i) => i.data.stock).toSorted((a, b) => a - b)).toEqual([10, 100]);
+	});
+
+	// (b) Same lexical bug via the aggregate path.
+	it("count({ stock: { gte: 10 } }) is numerically correct (2, not 3)", async () => {
+		const repo = await seedProducts();
+		expect(await repo.count({ stock: { gte: 10 } })).toBe(2);
+	});
+
+	// (c) Already fixed by #1898 (the ::jsonb cast). Kept as a guard that the
+	// `->>` expression-index path parses and enforces uniqueness on Postgres.
+	it("creates and enforces a UNIQUE expression index (regression guard for #1898)", async () => {
+		const result = await createStorageIndexes(db, "shop", "products", [], {
+			uniqueIndexes: ["sku"],
+		});
+		expect(result.errors).toEqual([]);
+		expect(result.created).toContain("uidx_plugin_shop_products_sku");
+
+		const repo = productsRepo();
+		await repo.put("first", { sku: "DUP", stock: 1 });
+		await expect(repo.put("second", { sku: "DUP", stock: 2 })).rejects.toThrow();
+	});
+
+	// (d) Lexical ORDER BY on the text extraction.
+	it("orderBy { stock: 'asc' } sorts numerically [9, 10, 100], not lexically [10, 100, 9]", async () => {
+		const repo = await seedProducts();
+		const asc = await repo.query({ orderBy: { stock: "asc" } });
+		expect(asc.items.map((i) => i.data.stock)).toEqual([9, 10, 100]);
+		expect(asc.items.map((i) => i.id)).toEqual(["p9", "p10", "p100"]);
+
+		const desc = await repo.query({ orderBy: { stock: "desc" } });
+		expect(desc.items.map((i) => i.data.stock)).toEqual([100, 10, 9]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

> **Draft — failing test that reproduces a live bug.** Opening this as a runnable repro to confirm the diagnosis before proposing a fix. The Postgres assertions fail on `main` **by design** — that is the bug — so the `pnpm test` checkbox below is intentionally left unchecked. SQLite passes.

This adds failing tests that will be fixed by #2152 

Plugin storage still compares **numeric** field values **lexically** on Postgres. `_plugin_storage.data` is a plain `text` column. #1898 (fixing #920) added the `(data)::jsonb->>'field'` cast, which correctly resolved the `operator does not exist: text ->> unknown` parse error and the boolean/equality filters — but `->>` still returns **text**, and the query / count / order paths compare that text directly. So a numeric guard is evaluated lexically:

```
'9' >= '10'   →  TRUE   (lexical)     9 >= 10   →  false (numeric)
```

The user-visible consequences are a silent **over-count / oversell** and wrong ordering.

**Reproduction** — this PR adds a dialect-parametric integration suite (via the existing `describeEachDialect` harness) at `packages/core/tests/integration/plugins/storage-postgres-numeric-regression.test.ts`. It seeds `stock` values `9 / 10 / 100` (chosen so lexical and numeric order disagree):

| Case | Assertion | SQLite | Postgres (`main`) |
|---|---|:--:|:--:|
| (a) `query({ where: { stock: { gte: 10 } } })` | returns exactly `{10, 100}` | ✅ | ❌ returns `{9, 10, 100}` |
| (b) `count({ stock: { gte: 10 } })` | `2` | ✅ | ❌ `3` |
| (c) UNIQUE expression index via `createStorageIndexes` | created & enforced | ✅ | ✅ (already fixed by #1898 — kept as a guard) |
| (d) `query({ orderBy: { stock: 'asc' } })` | `[9, 10, 100]` | ✅ | ❌ `[10, 100, 9]` |

SQLite passes throughout because `json_extract` already returns a typed value — which is why this went unnoticed.

```bash
EMDASH_TEST_PG=postgres://… pnpm --filter emdash exec vitest run \
  tests/integration/plugins/storage-postgres-numeric-regression.test.ts
```

**Suggested fix direction:** apply a type-guarded numeric cast to the extracted value in the numeric comparison and `ORDER BY` paths on Postgres (cast to `numeric` only when the `jsonb` value is a number, so non-numeric/`null` rows are excluded rather than erroring) — mirroring the typed value SQLite's `json_extract` already returns. Happy to follow up with the fix if the diagnosis looks right.

Related: #920 (closed by #1898). No existing issue tracks the remaining numeric case.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) — intentionally unchecked: the Postgres assertions fail on `main`, which is the bug this PR demonstrates; SQLite passes
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — N/A, no admin UI strings
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — N/A, test-only, no published behavior change
- [ ] New features link to an approved Discussion — N/A, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

Postgres dialect on current `main` (RED on a/b/d, GREEN on c; all SQLite green):

```
× [postgres] numeric RangeFilter { gte: 10 } ...   expected [ 'p10','p100','p9' ] to deeply equal [ 'p10','p100' ]
× [postgres] count({ stock: { gte: 10 } }) ...      expected 3 to be 2
✓ [postgres] UNIQUE expression index (guard) ...
× [postgres] orderBy { stock: 'asc' } ...           expected [ 10,100,9 ] to deeply equal [ 9,10,100 ]
  Tests  3 failed | 5 passed (8)
```
