### PR TITLE
fix(core): compare plugin-storage numeric filters/order numerically on Postgres

### DIFF
--- a/.changeset/plugin-storage-postgres-numeric.md
+++ b/.changeset/plugin-storage-postgres-numeric.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+fix(core): compare plugin-storage numeric filters and ordering numerically on Postgres. `_plugin_storage.data` is a `text` column, so after the `::jsonb` cast (#1898) the extracted value is still text and numeric guards compared lexically — `{ stock: { gte: 10 } }` over 9/10/100 matched 9 (over-count/oversell) and numeric `orderBy` sorted `[10, 100, 9]`. Numeric comparisons now use a type-guarded `::numeric` cast and ordering uses the jsonb-native value, so results are numeric and parity-correct with SQLite. Non-numeric stored values yield no match instead of erroring.

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -235,3 +235,71 @@ export function jsonExtractExpr(db: Kysely<any>, column: string, path: string): 
 	}
 	return `json_extract(${column}, '$.${path}')`;
 }
+
+/**
+ * SQL expression for extracting a queryable field from the plugin-storage
+ * `data` column.
+ *
+ * `_plugin_storage.data` is `text`, so Postgres extraction goes through the
+ * `(data)::jsonb->>'field'` cast (#1898) — otherwise `text ->> unknown` is not
+ * an operator. But the extracted value is still `text`, so a numeric comparison
+ * (`stock >= 10`) compares lexically (`'9' >= '10'` is TRUE) and silently
+ * over-counts / oversells; pass `{ numeric: true }` for a numeric comparison.
+ *
+ * The numeric form is a **type-guarded** cast, not a bare `::numeric`. A bare
+ * cast throws `invalid input syntax for type numeric` the moment a single
+ * scanned row stores a non-number in that field (documents are schemaless),
+ * aborting the whole query — and it would diverge from SQLite, which silently
+ * coerces. Guarding with `jsonb_typeof`/`json_type` makes the comparison total
+ * and parity-correct on both dialects: a non-number stored value yields `NULL`
+ * (no match) instead of an error.
+ *
+ * The field name is validated before interpolation, so the casts wrap only a
+ * safe identifier and add no injection surface.
+ *
+ * sqlite text:      json_extract(data, '$.field')
+ * sqlite numeric:   CASE WHEN json_type(data, '$.field') IN ('integer', 'real')
+ *                     THEN json_extract(data, '$.field') END
+ * postgres text:    (data)::jsonb->>'field'
+ * postgres numeric: CASE WHEN jsonb_typeof((data)::jsonb->'field') = 'number'
+ *                     THEN ((data)::jsonb->>'field')::numeric END
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export function pluginDataExtractExpr(
+	db: Kysely<any>,
+	field: string,
+	options?: { numeric?: boolean },
+): string {
+	validateJsonFieldName(field, "plugin storage field name");
+	if (isPostgres(db)) {
+		const text = `(data)::jsonb->>'${field}'`;
+		if (!options?.numeric) return text;
+		return `CASE WHEN jsonb_typeof((data)::jsonb->'${field}') = 'number' THEN (${text})::numeric END`;
+	}
+	const extract = `json_extract(data, '$.${field}')`;
+	if (!options?.numeric) return extract;
+	return `CASE WHEN json_type(data, '$.${field}') IN ('integer', 'real') THEN ${extract} END`;
+}
+
+/**
+ * SQL expression for ordering plugin-storage rows by a `data` field.
+ *
+ * `ORDER BY` has no bound operand to infer numeric-vs-text from, so extracting
+ * as text (`->>'field'`) would sort a numeric field lexically on Postgres
+ * (`[10, 100, 9]`) while SQLite's `json_extract` sorts it numerically — a
+ * cross-dialect divergence. Ordering over the jsonb-native value (`->'field'`,
+ * single arrow) fixes this: jsonb btree ordering is numeric among numbers,
+ * lexical among strings, and total across heterogeneous values (never throws).
+ * SQLite's `json_extract` already orders numerically, so it is unchanged.
+ *
+ * sqlite:   json_extract(data, '$.field')
+ * postgres: (data)::jsonb->'field'
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export function pluginDataOrderExpr(db: Kysely<any>, field: string): string {
+	validateJsonFieldName(field, "plugin storage order field name");
+	if (isPostgres(db)) {
+		return `(data)::jsonb->'${field}'`;
+	}
+	return `json_extract(data, '$.${field}')`;
+}

--- a/packages/core/src/database/repositories/plugin-storage.ts
+++ b/packages/core/src/database/repositories/plugin-storage.ts
@@ -15,7 +15,7 @@ import {
 	validateWhereClause,
 	validateOrderByClause,
 	getIndexedFields,
-	jsonExtract,
+	jsonOrderExtract,
 } from "../../plugins/storage-query.js";
 import type {
 	StorageCollection,
@@ -245,7 +245,9 @@ export class PluginStorageRepository<T = unknown> implements StorageCollection<T
 		// Build ORDER BY using sql template
 		if (Object.keys(orderBy).length > 0) {
 			for (const [field, direction] of Object.entries(orderBy)) {
-				const extract = jsonExtract(this.db, field);
+				// Order over the jsonb-native value on Postgres so numeric fields sort
+				// numerically, not lexically. See pluginDataOrderExpr.
+				const extract = jsonOrderExtract(this.db, field);
 				const orderExpr =
 					direction === "desc" ? sql`${sql.raw(extract)} desc` : sql`${sql.raw(extract)} asc`;
 				query = query.orderBy(orderExpr);

--- a/packages/core/src/plugins/storage-query.ts
+++ b/packages/core/src/plugins/storage-query.ts
@@ -8,8 +8,7 @@
 
 import type { Kysely } from "kysely";
 
-import { jsonExtractExpr } from "../database/dialect-helpers.js";
-import { validateJsonFieldName } from "../database/validate.js";
+import { pluginDataExtractExpr, pluginDataOrderExpr } from "../database/dialect-helpers.js";
 import type { WhereClause, WhereValue, RangeFilter, InFilter, StartsWithFilter } from "./types.js";
 
 /**
@@ -117,15 +116,34 @@ export function validateOrderByClause(
 }
 
 /**
- * SQL expression for extracting JSON field.
+ * SQL expression for extracting a queryable field from the `_plugin_storage.data`
+ * column.
  *
- * Validates the field name before interpolation to prevent SQL injection
- * via crafted JSON path expressions.
+ * Delegates to `pluginDataExtractExpr`, which validates the field name before
+ * interpolation and applies the dialect-correct extraction: a `::jsonb` cast on
+ * Postgres (the `data` column is `text`) plus an optional type-guarded
+ * `::numeric` cast so numeric comparisons don't fall back to lexical text
+ * ordering.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
-export function jsonExtract(db: Kysely<any>, field: string): string {
-	validateJsonFieldName(field, "query field name");
-	return jsonExtractExpr(db, "data", field);
+export function jsonExtract(
+	db: Kysely<any>,
+	field: string,
+	options?: { numeric?: boolean },
+): string {
+	return pluginDataExtractExpr(db, field, options);
+}
+
+/**
+ * SQL expression for ordering by a `_plugin_storage.data` field.
+ *
+ * Delegates to `pluginDataOrderExpr`, which orders over the jsonb-native value
+ * on Postgres so numeric fields sort numerically (not lexically) while staying
+ * total across heterogeneous data. SQLite keeps `json_extract` (already numeric).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export function jsonOrderExtract(db: Kysely<any>, field: string): string {
+	return pluginDataOrderExpr(db, field);
 }
 
 /**
@@ -137,33 +155,44 @@ export function buildCondition(
 	field: string,
 	value: WhereValue,
 ): { sql: string; params: unknown[] } {
-	const extract = jsonExtract(db, field);
+	// Numeric-vs-text is decided per condition from the JS type of the bound
+	// value. On Postgres a text extract compared to a bound number would sort
+	// lexically (`'9' >= '10'` is TRUE); a type-guarded `::numeric` cast on the
+	// extract fixes it. String/boolean operands keep text comparison. SQLite is
+	// unaffected — `json_extract` already returns a typed value.
+	const extractFor = (numeric: boolean): string => jsonExtract(db, field, { numeric });
 
 	if (value === null) {
-		return { sql: `${extract} IS NULL`, params: [] };
+		return { sql: `${extractFor(false)} IS NULL`, params: [] };
 	}
 
-	if (typeof value === "string" || typeof value === "number") {
-		return { sql: `${extract} = ?`, params: [value] };
+	if (typeof value === "number") {
+		return { sql: `${extractFor(true)} = ?`, params: [value] };
+	}
+
+	if (typeof value === "string") {
+		return { sql: `${extractFor(false)} = ?`, params: [value] };
 	}
 
 	if (typeof value === "boolean") {
 		// JSON booleans are stored as true/false strings
-		return { sql: `${extract} = ?`, params: [value] };
+		return { sql: `${extractFor(false)} = ?`, params: [value] };
 	}
 
 	if (isInFilter(value)) {
+		const numeric = value.in.length > 0 && value.in.every((v) => typeof v === "number");
 		const placeholders = value.in.map(() => "?").join(", ");
 		return {
-			sql: `${extract} IN (${placeholders})`,
+			sql: `${extractFor(numeric)} IN (${placeholders})`,
 			params: value.in,
 		};
 	}
 
 	if (isStartsWithFilter(value)) {
-		// ESCAPE '\' works on both SQLite and PostgreSQL.
+		// ESCAPE '\' works on both SQLite and PostgreSQL. startsWith is a string
+		// operation, so always compare as text.
 		return {
-			sql: `${extract} LIKE ? ESCAPE '\\'`,
+			sql: `${extractFor(false)} LIKE ? ESCAPE '\\'`,
 			params: [`${escapeLikePattern(value.startsWith)}%`],
 		};
 	}
@@ -172,22 +201,17 @@ export function buildCondition(
 		const conditions: string[] = [];
 		const params: unknown[] = [];
 
-		if (value.gt !== undefined) {
-			conditions.push(`${extract} > ?`);
-			params.push(value.gt);
-		}
-		if (value.gte !== undefined) {
-			conditions.push(`${extract} >= ?`);
-			params.push(value.gte);
-		}
-		if (value.lt !== undefined) {
-			conditions.push(`${extract} < ?`);
-			params.push(value.lt);
-		}
-		if (value.lte !== undefined) {
-			conditions.push(`${extract} <= ?`);
-			params.push(value.lte);
-		}
+		// Each bound is cast to numeric only when its own operand is a number, so
+		// a mixed range (e.g. a string lower bound) stays correct per side.
+		const pushBound = (op: string, bound: string | number): void => {
+			conditions.push(`${extractFor(typeof bound === "number")} ${op} ?`);
+			params.push(bound);
+		};
+
+		if (value.gt !== undefined) pushBound(">", value.gt);
+		if (value.gte !== undefined) pushBound(">=", value.gte);
+		if (value.lt !== undefined) pushBound("<", value.lt);
+		if (value.lte !== undefined) pushBound("<=", value.lte);
 
 		return {
 			sql: conditions.join(" AND "),
@@ -239,7 +263,7 @@ export function buildOrderByClause(
 	const clauses: string[] = [];
 
 	for (const [field, direction] of Object.entries(orderBy)) {
-		clauses.push(`${jsonExtract(db, field)} ${direction.toUpperCase()}`);
+		clauses.push(`${jsonOrderExtract(db, field)} ${direction.toUpperCase()}`);
 	}
 
 	if (clauses.length === 0) {

--- a/packages/core/tests/integration/plugins/storage-postgres-numeric-regression.test.ts
+++ b/packages/core/tests/integration/plugins/storage-postgres-numeric-regression.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Plugin storage: numeric comparisons/ordering are lexical on Postgres.
+ *
+ * `_plugin_storage.data` is a plain `text` column, and plugin storage was only
+ * ever exercised on SQLite. #1898 (fix for #920) added the `(data)::jsonb->>'…'`
+ * cast, so the JSON accessor no longer raises "operator does not exist:
+ * text ->> unknown" and boolean/equality filters work. But `->>` still yields
+ * **text**, and the query/count/order paths compare that text directly — so on
+ * Postgres a numeric guard compares lexically:
+ *
+ *   '9' >= '10'   →  TRUE   (lexical)   but  9 >= 10  →  false (numeric)
+ *
+ * The consequences are a silent over-count / oversell and mis-ordering:
+ *
+ *   (a) a RangeFilter `{ stock: { gte: 10 } }` over 9 / 10 / 100 returns 9 too
+ *   (b) count() of the same guard returns 3 instead of 2
+ *   (c) createStorageIndexes' UNIQUE expression index — already fixed by #1898,
+ *       kept here as a passing guard that the `->>` parse path stays healthy
+ *   (d) orderBy on a numeric field returns [10, 100, 9] instead of [9, 10, 100]
+ *
+ * These run on SQLite (always) and Postgres (when EMDASH_TEST_PG is set).
+ * SQLite's json_extract returns a typed value, so it is green throughout — which
+ * is exactly why the bug went unnoticed. The Postgres dialect FAILS on (a),(b),
+ * (d) on current main. The fix is a type-guarded numeric cast on the extracted
+ * value for numeric comparisons/order (mirroring how json_extract is already
+ * typed on SQLite).
+ */
+
+import type { Kysely } from "kysely";
+import { it, expect, beforeEach, afterEach } from "vitest";
+
+import { PluginStorageRepository } from "../../../src/database/repositories/plugin-storage.js";
+import type { Database } from "../../../src/database/types.js";
+import { createStorageIndexes } from "../../../src/plugins/storage-indexes.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+interface Product {
+	sku: string;
+	stock: number;
+}
+
+describeEachDialect("Plugin storage numeric comparison on Postgres", (dialect) => {
+	let ctx: DialectTestContext;
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		db = ctx.db;
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	function productsRepo(): PluginStorageRepository<Product> {
+		// `stock` is declared indexed so it may be used in orderBy.
+		return new PluginStorageRepository<Product>(db, "shop", "products", ["sku", "stock"]);
+	}
+
+	/** Stock values chosen so lexical and numeric ordering disagree: '9' > '10'. */
+	async function seedProducts(): Promise<PluginStorageRepository<Product>> {
+		const repo = productsRepo();
+		await repo.putMany([
+			{ id: "p9", data: { sku: "A9", stock: 9 } },
+			{ id: "p10", data: { sku: "B10", stock: 10 } },
+			{ id: "p100", data: { sku: "C100", stock: 100 } },
+		]);
+		return repo;
+	}
+
+	// (a) The load-bearing case: a lexical `>=` includes stock 9 in a `>= 10`
+	// filter — a silent over-count / oversell.
+	it("numeric RangeFilter { gte: 10 } returns exactly {10, 100}, never 9", async () => {
+		const repo = await seedProducts();
+		const result = await repo.query({ where: { stock: { gte: 10 } } });
+		expect(result.items.map((i) => i.id).toSorted()).toEqual(["p10", "p100"]);
+		expect(result.items.map((i) => i.data.stock).toSorted((a, b) => a - b)).toEqual([10, 100]);
+	});
+
+	// (b) Same lexical bug via the aggregate path.
+	it("count({ stock: { gte: 10 } }) is numerically correct (2, not 3)", async () => {
+		const repo = await seedProducts();
+		expect(await repo.count({ stock: { gte: 10 } })).toBe(2);
+	});
+
+	// (c) Already fixed by #1898 (the ::jsonb cast). Kept as a guard that the
+	// `->>` expression-index path parses and enforces uniqueness on Postgres.
+	it("creates and enforces a UNIQUE expression index (regression guard for #1898)", async () => {
+		const result = await createStorageIndexes(db, "shop", "products", [], {
+			uniqueIndexes: ["sku"],
+		});
+		expect(result.errors).toEqual([]);
+		expect(result.created).toContain("uidx_plugin_shop_products_sku");
+
+		const repo = productsRepo();
+		await repo.put("first", { sku: "DUP", stock: 1 });
+		await expect(repo.put("second", { sku: "DUP", stock: 2 })).rejects.toThrow();
+	});
+
+	// (d) Lexical ORDER BY on the text extraction.
+	it("orderBy { stock: 'asc' } sorts numerically [9, 10, 100], not lexically [10, 100, 9]", async () => {
+		const repo = await seedProducts();
+		const asc = await repo.query({ orderBy: { stock: "asc" } });
+		expect(asc.items.map((i) => i.data.stock)).toEqual([9, 10, 100]);
+		expect(asc.items.map((i) => i.id)).toEqual(["p9", "p10", "p100"]);
+
+		const desc = await repo.query({ orderBy: { stock: "desc" } });
+		expect(desc.items.map((i) => i.data.stock)).toEqual([100, 10, 9]);
+	});
+});

--- a/packages/core/tests/unit/plugins/storage-query.test.ts
+++ b/packages/core/tests/unit/plugins/storage-query.test.ts
@@ -210,8 +210,12 @@ describe("storage-query", () => {
 		});
 
 		it("should handle number values", () => {
+			// Numeric operands use a type-guarded extract so the comparison is
+			// numeric (not lexical text) and total across schemaless documents.
 			const result = buildCondition(db, "count", 42);
-			expect(result.sql).toBe("json_extract(data, '$.count') = ?");
+			expect(result.sql).toBe(
+				"CASE WHEN json_type(data, '$.count') IN ('integer', 'real') THEN json_extract(data, '$.count') END = ?",
+			);
 			expect(result.params).toEqual([42]);
 		});
 
@@ -239,35 +243,38 @@ describe("storage-query", () => {
 			expect(buildCondition(db, "name", { startsWith: "c:\\dir" }).params).toEqual(["c:\\\\dir%"]);
 		});
 
+		// Numeric range bounds are type-guarded so `'9' >= '10'` can't sneak in
+		// via lexical text comparison.
+		const ageNum =
+			"CASE WHEN json_type(data, '$.age') IN ('integer', 'real') THEN json_extract(data, '$.age') END";
+
 		it("should handle range filters with gt", () => {
 			const result = buildCondition(db, "age", { gt: 18 });
-			expect(result.sql).toBe("json_extract(data, '$.age') > ?");
+			expect(result.sql).toBe(`${ageNum} > ?`);
 			expect(result.params).toEqual([18]);
 		});
 
 		it("should handle range filters with gte", () => {
 			const result = buildCondition(db, "age", { gte: 18 });
-			expect(result.sql).toBe("json_extract(data, '$.age') >= ?");
+			expect(result.sql).toBe(`${ageNum} >= ?`);
 			expect(result.params).toEqual([18]);
 		});
 
 		it("should handle range filters with lt", () => {
 			const result = buildCondition(db, "age", { lt: 65 });
-			expect(result.sql).toBe("json_extract(data, '$.age') < ?");
+			expect(result.sql).toBe(`${ageNum} < ?`);
 			expect(result.params).toEqual([65]);
 		});
 
 		it("should handle range filters with lte", () => {
 			const result = buildCondition(db, "age", { lte: 65 });
-			expect(result.sql).toBe("json_extract(data, '$.age') <= ?");
+			expect(result.sql).toBe(`${ageNum} <= ?`);
 			expect(result.params).toEqual([65]);
 		});
 
 		it("should handle combined range filters", () => {
 			const result = buildCondition(db, "age", { gte: 18, lt: 65 });
-			expect(result.sql).toBe(
-				"json_extract(data, '$.age') >= ? AND json_extract(data, '$.age') < ?",
-			);
+			expect(result.sql).toBe(`${ageNum} >= ? AND ${ageNum} < ?`);
 			expect(result.params).toEqual([18, 65]);
 		});
 	});


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining Postgres numeric bug in plugin storage. `_plugin_storage.data` is a `text` column. #1898 (fixing #920) added the `(data)::jsonb->>'field'` cast, which resolved the `text ->> unknown` parse error and boolean/`= 1` filters — but the extracted value is still **text**, so numeric guards compared **lexically**:

```
'9' >= '10'   →  TRUE (lexical)     9 >= 10   →  false (numeric)
```

Consequences on Postgres (green on SQLite, whose `json_extract` is typed):
- `query({ where: { stock: { gte: 10 } } })` over `9 / 10 / 100` matched **9** too — a silent over-count / **oversell**.
- `count({ stock: { gte: 10 } })` returned `3` instead of `2`.
- `orderBy({ stock: 'asc' })` returned `[10, 100, 9]` instead of `[9, 10, 100]`.

### The fix
- `pluginDataExtractExpr(field, { numeric })` — adds an optional **type-guarded** `::numeric` cast (guarded by `jsonb_typeof` / `json_type`). Not a bare `::numeric`: a bare cast throws `invalid input syntax for type numeric` the moment one scanned row stores a non-number in that field (documents are schemaless). Guarded, a non-number yields `NULL` (no match) — total and parity-correct with SQLite.
- `pluginDataOrderExpr(field)` — orders over the **jsonb-native** value (`->`), whose btree ordering is numeric among numbers and total across heterogeneous data.
- `buildCondition` chooses numeric-vs-text per operand from its JS type; `orderBy` uses the jsonb-native expression. SQLite is unchanged.

The index path (text `->>`, already fixed by #1898) is intentionally untouched — see the note in `generateCreateIndexSql`.

### Tests
Adds a dialect-parametric regression suite (`storage-postgres-numeric-regression.test.ts`) and updates the `buildCondition` unit assertions to the type-guarded SQL. Full run on both dialects:

```bash
EMDASH_TEST_PG=postgres://… pnpm --filter emdash exec vitest run tests/unit/plugins tests/integration/plugins
# storage-query (unit) + storage / storage-indexes / storage-dialect / numeric-regression (integration): all green
```

Related: #2150 (failing-test companion), #1898, #920.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — plugin-storage unit + integration suites, both dialects
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — N/A
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

```
tests/integration/plugins/storage-postgres-numeric-regression.test.ts  Tests  8 passed (8)   # [sqlite] ×4 + [postgres] ×4
tests/unit/plugins/storage-query.test.ts                                Tests  46 passed
```
