### PR TITLE
fix(core): draft-only saves no longer bump updated_at on published entries

### DIFF
--- a/.changeset/draft-save-updated-at.md
+++ b/.changeset/draft-save-updated-at.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Stops draft-only saves and autosaves on published entries from advancing `updatedAt`. On revision-supporting collections, staging or discarding a pending draft leaves live content untouched, so sitemap `<lastmod>` and JSON-LD `dateModified` no longer register a modification until Publish actually changes the live entry.

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -590,11 +590,16 @@ export class ContentRepository {
 		const tableName = getTableName(type);
 		const now = new Date().toISOString();
 
-		// Build update object with parameterized values
-		const updates: Record<string, unknown> = {
-			updated_at: now,
-			version: sql`version + 1`,
-		};
+		// Build update object with parameterized values. `version` bumps on
+		// every update so the _rev optimistic-concurrency token
+		// (version:updated_at) always moves — concurrent editors still get a
+		// 409 on stale saves. `updated_at` is stamped only when the request
+		// actually carries column writes: a draft-only save on a
+		// revision-supporting collection resolves to a column no-op here (all
+		// data went into draft storage), and stamping it anyway would register
+		// a phantom modification for public "last modified" consumers like
+		// sitemap <lastmod> and JSON-LD dateModified (#2143).
+		const updates: Record<string, unknown> = {};
 
 		if (input.status !== undefined) {
 			updates.status = input.status;
@@ -629,6 +634,12 @@ export class ContentRepository {
 				}
 			}
 		}
+
+		const hasColumnWrites = Object.keys(updates).length > 0;
+		if (hasColumnWrites) {
+			updates.updated_at = now;
+		}
+		updates.version = sql`version + 1`;
 
 		await this.db
 			.updateTable(tableName as keyof Database)
@@ -1519,7 +1530,6 @@ export class ContentRepository {
 	 */
 	async setDraftRevision(type: string, id: string, revisionId: string): Promise<void> {
 		const tableName = getTableName(type);
-		const now = new Date().toISOString();
 
 		const existing = await this.findById(type, id);
 		if (!existing) {
@@ -1536,10 +1546,12 @@ export class ContentRepository {
 			throw new EmDashValidationError("Revision does not belong to the specified content item");
 		}
 
+		// Draft staging leaves live content untouched, so it must not bump
+		// updated_at — public "content last modified" consumers (sitemap
+		// <lastmod>, dateModified) would see a phantom modification (#2143).
 		await sql`
 			UPDATE ${sql.ref(tableName)}
-			SET draft_revision_id = ${revisionId},
-				updated_at = ${now}
+			SET draft_revision_id = ${revisionId}
 			WHERE id = ${id}
 			AND deleted_at IS NULL
 		`.execute(this.db);
@@ -1555,7 +1567,6 @@ export class ContentRepository {
 	 */
 	async discardDraft(type: string, id: string): Promise<ContentItem> {
 		const tableName = getTableName(type);
-		const now = new Date().toISOString();
 
 		const existing = await this.findById(type, id);
 		if (!existing) {
@@ -1567,10 +1578,12 @@ export class ContentRepository {
 			return existing;
 		}
 
+		// Discarding a draft restores the state from before the draft was
+		// staged — nothing about the live entry changed in between, so
+		// updated_at stays at its pre-draft value (#2143).
 		await sql`
 			UPDATE ${sql.ref(tableName)}
-			SET draft_revision_id = NULL,
-				updated_at = ${now}
+			SET draft_revision_id = NULL
 			WHERE id = ${id}
 			AND deleted_at IS NULL
 		`.execute(this.db);

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2798,13 +2798,14 @@ export class EmDashRuntime {
 								authorId: bodyWithoutRev.authorId ?? undefined,
 							});
 
-							// Update entry to point to new draft (metadata only, not data columns)
+							// Update entry to point to new draft (metadata only, not data columns).
+							// No updated_at stamp: draft staging leaves live content untouched,
+							// so public "last modified" consumers must not see a change (#2143).
 							validateIdentifier(collection, "collection");
 							const tableName = `ec_${collection}`;
 							await sql`
 								UPDATE ${sql.ref(tableName)}
-								SET draft_revision_id = ${revision.id},
-									updated_at = ${new Date().toISOString()}
+								SET draft_revision_id = ${revision.id}
 								WHERE id = ${resolvedId}
 							`.execute(this.db);
 							draftStorageChanged = true;
@@ -3196,7 +3197,10 @@ export class EmDashRuntime {
 
 		// Revision-capable collections: restore is "make this revision the
 		// current draft". The live row's data columns are left untouched
-		// (only `draft_revision_id` and `updated_at` change). The caller
+		// (only `draft_revision_id` changes — no `updated_at` stamp, since
+		// restoring to draft is the same kind of draft-only staging as
+		// Save/Autosave and must not register a phantom modification for
+		// sitemap <lastmod> / JSON-LD dateModified, #2143). The caller
 		// must then `content_publish` to promote the restored draft to
 		// live, matching the documented tool contract.
 		try {
@@ -3211,8 +3215,7 @@ export class EmDashRuntime {
 			const tableName = `ec_${revision.collection}`;
 			await sql`
 				UPDATE ${sql.ref(tableName)}
-				SET draft_revision_id = ${newDraft.id},
-					updated_at = ${new Date().toISOString()}
+				SET draft_revision_id = ${newDraft.id}
 				WHERE id = ${revision.entryId}
 			`.execute(this.db);
 

--- a/packages/core/tests/integration/content/draft-save-updated-at.test.ts
+++ b/packages/core/tests/integration/content/draft-save-updated-at.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Draft saves on published entries must not advance the content row's
+ * `updated_at` (#2143).
+ *
+ * On revision-supporting collections, **Save** and **Autosave** on an
+ * already-published entry store changes as a pending draft — live public
+ * content is unchanged until **Publish**. Those draft-only writes previously
+ * bumped `updated_at` anyway, which public SEO surfaces (sitemap <lastmod>,
+ * JSON-LD dateModified) treat as "content last modified" — a phantom
+ * modification for crawlers.
+ *
+ * The fix skips the `updated_at` stamp on content-row writes that touch no
+ * live columns (pure draft staging / discard), and restores the pre-save
+ * timestamp when a draft-only update request resolves to a metadata no-op.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { Database } from "../../../src/database/types.js";
+import type { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { createTestRuntime } from "../../utils/mcp-runtime.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("draft saves on published entries keep updated_at (#2143)", () => {
+	let db: Kysely<Database>;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		// Default supports: drafts + revisions.
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		// No revision support: updates land directly on the live row.
+		await registry.createCollection({
+			slug: "plain_posts",
+			label: "Plain Posts",
+			supports: [],
+		});
+		await registry.createField("plain_posts", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+		});
+		runtime = createTestRuntime(db);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("Save (draft staging) on a published entry does not bump updated_at", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live Post" },
+			slug: "live-post",
+		});
+		expect(created.success).toBe(true);
+		const id = created.data!.item.id;
+
+		const published = await runtime.handleContentPublish("posts", id);
+		expect(published.success).toBe(true);
+		const publishedUpdatedAt = published.data!.item.updatedAt;
+
+		// Manual Save: no skipRevision → creates a new draft revision and
+		// points draft_revision_id at it. Live columns are untouched.
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Live Post (edited, unpublished)" },
+		});
+		expect(saved.success).toBe(true);
+		expect(saved.data!.item.draftRevisionId).not.toBeNull();
+
+		expect(saved.data!.item.updatedAt).toBe(publishedUpdatedAt);
+	});
+
+	it("Autosave (skipRevision) on an existing draft does not bump updated_at", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live Post" },
+			slug: "live-post",
+		});
+		const id = created.data!.item.id;
+		const published = await runtime.handleContentPublish("posts", id);
+		const publishedUpdatedAt = published.data!.item.updatedAt;
+
+		const firstSave = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Draft v1" },
+		});
+		expect(firstSave.success).toBe(true);
+		expect(firstSave.data!.item.updatedAt).toBe(publishedUpdatedAt);
+
+		// Autosave: updates the existing draft revision in place.
+		const autosaved = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Draft v2" },
+			skipRevision: true,
+		});
+		expect(autosaved.success).toBe(true);
+		expect(autosaved.data!.item.updatedAt).toBe(publishedUpdatedAt);
+	});
+
+	it("Discard Draft restores updated_at from before the draft saves", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live Post" },
+			slug: "live-post",
+		});
+		const id = created.data!.item.id;
+		const published = await runtime.handleContentPublish("posts", id);
+		const publishedUpdatedAt = published.data!.item.updatedAt;
+
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Unwanted edit" },
+		});
+		expect(saved.success).toBe(true);
+
+		const discarded = await runtime.handleContentDiscardDraft("posts", id);
+		expect(discarded.success).toBe(true);
+		expect(discarded.data!.item.draftRevisionId).toBeNull();
+		expect(discarded.data!.item.updatedAt).toBe(publishedUpdatedAt);
+	});
+
+	it("a subsequent Publish advances updated_at exactly once", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live Post" },
+			slug: "live-post",
+		});
+		const id = created.data!.item.id;
+		const published = await runtime.handleContentPublish("posts", id);
+		const publishedUpdatedAt = published.data!.item.updatedAt;
+
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Ready to go live" },
+		});
+		expect(saved.data!.item.updatedAt).toBe(publishedUpdatedAt);
+
+		// The draft saves left updated_at untouched, so comparing with Date.now()
+		// proves publish moves it forward (same-millisecond collisions impossible).
+		const republished = await runtime.handleContentPublish("posts", id);
+		expect(republished.success).toBe(true);
+		expect(republished.data!.item.draftRevisionId).toBeNull();
+		expect(Date.parse(republished.data!.item.updatedAt)).toBeGreaterThan(
+			Date.parse(publishedUpdatedAt),
+		);
+	});
+
+	it("draft-only saves still bump version so _rev concurrency detection keeps working", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live Post" },
+			slug: "live-post",
+		});
+		const id = created.data!.item.id;
+		const published = await runtime.handleContentPublish("posts", id);
+		const publishedUpdatedAt = published.data!.item.updatedAt;
+		const publishedVersion = published.data!.item.version;
+
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Edited" },
+		});
+		expect(saved.success).toBe(true);
+		// updated_at frozen (no phantom modification), but version moved so a
+		// second editor holding the pre-save _rev gets a 409.
+		expect(saved.data!.item.updatedAt).toBe(publishedUpdatedAt);
+		expect(saved.data!.item.version).toBe(publishedVersion + 1);
+
+		const stale = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Conflicting edit" },
+			_rev: Buffer.from(`${publishedVersion}:${publishedUpdatedAt}`).toString("base64"),
+		});
+		expect(stale.success).toBe(false);
+		expect(stale.success === false && stale.error.code).toBe("CONFLICT");
+	});
+
+	it("Restore Revision (to draft) on a published entry does not bump updated_at", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Original" },
+			slug: "restore-post",
+		});
+		const id = created.data!.item.id;
+		const published = await runtime.handleContentPublish("posts", id);
+		const publishedUpdatedAt = published.data!.item.updatedAt;
+
+		// Find the published revision to restore from.
+		const revisions = await runtime.handleRevisionList("posts", id);
+		expect(revisions.success).toBe(true);
+		const liveRevisionId = published.data!.item.liveRevisionId;
+		const targetRevision = revisions.data!.items.find((r) => r.id === liveRevisionId);
+		expect(targetRevision).toBeDefined();
+
+		// Restore that revision as the current draft — draft-only staging,
+		// live columns untouched, so updated_at must not move.
+		const restored = await runtime.handleRevisionRestore(targetRevision!.id, "author-1");
+		expect(restored.success).toBe(true);
+		expect(restored.data!.item.updatedAt).toBe(publishedUpdatedAt);
+		expect(restored.data!.item.draftRevisionId).not.toBeNull();
+	});
+
+	it("collections without revision support keep the bump-on-write behavior", async () => {
+		const created = await runtime.handleContentCreate("plain_posts", {
+			data: { title: "Plain" },
+			slug: "plain",
+		});
+		const id = created.data!.item.id;
+		const beforeUpdate = created.data!.item.updatedAt;
+
+		const updated = await runtime.handleContentUpdate("plain_posts", id, {
+			data: { title: "Plain (edited)" },
+		});
+		expect(updated.success).toBe(true);
+		expect(Date.parse(updated.data!.item.updatedAt)).toBeGreaterThanOrEqual(
+			Date.parse(beforeUpdate),
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

On revision-supporting collections, **Save** and **Autosave** on an already-published entry stage changes as a pending draft — live public content is untouched until **Publish**. Those draft-only writes were still stamping `updated_at` on the live content row, so public SEO surfaces that read it as "content last modified" (sitemap `<lastmod>`, JSON-LD `dateModified`) registered a phantom modification every time an editor staged or discarded a draft.

The fix skips the `updated_at` stamp on content-row writes that touch no live columns (pure draft staging / discard). `version` still increments on every update, so the `_rev` optimistic-concurrency token (`version:updated_at`) continues to catch concurrent editors with a 409 — verified by a new test.

Closes #2143

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Kimi K3 (Moonshot AI)

## Screenshots / test output

New integration suite `packages/core/tests/integration/content/draft-save-updated-at.test.ts` — 6 tests covering Save, Autosave, Discard Draft, re-Publish, non-revision collections, and the `_rev` 409 path:

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Regression run over adjacent suites (ContentRepository, content/revision API handlers, revision integration):

```
Test Files  5 passed (5)
     Tests  127 passed (127)
```