### PR TITLE
docs: strengthen agent guidance on logged-out query counts, comments, and test quality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ For human-facing contributor info (setup, repo layout, PR policy, changesets, i1
 
 **Scope discipline.** No drive-by refactors, no bulk lint/type cleanups, no "while I'm here" edits in unrelated files. If you see a systemic issue, open a Discussion. See [CONTRIBUTING.md § Contribution Policy](CONTRIBUTING.md#contribution-policy).
 
+**Never add queries to the logged-out hot path.** Any change that increases the query count of a logged-out route needs a _really_ good reason -- and that includes cold-start or first-request-only queries, not just steady state. See [Performance](#performance-caching-and-query-patterns).
+
+**Comments are for code readers, not reviewers.** Write a comment only when the code can't be made clearer, or to give a non-obvious "why". Never justification, narrative, or issue/PR references. See [Comments](#comments).
+
 ## Workflow
 
 Run `pnpm lint:json | jq '.diagnostics | length'` before starting and confirm it's clean -- if it's failing after your edits, your changes caused it.
@@ -177,6 +181,8 @@ When adding content-table features, ask: per-locale (display fields) or per-tran
 
 EmDash runs on D1 with the Sessions API. Anonymous reads go to the nearest replica; writes and authenticated reads route to the primary. Every round-trip matters.
 
+**The logged-out hot path only ratchets down.** Anonymous page renders are what visitors actually hit; their query count is the product's performance envelope. Any change that adds a query to a logged-out route needs a _really_ good reason -- including queries that only run on cold start or first request. Before accepting a new round-trip, look for a way to piggyback on an existing query, batch, defer with `after()`, or cache.
+
 **Wrap query helpers in `requestCached`.** Per-request cache (`src/request-cache.ts`) dedupes identical calls within a render. If a helper takes stable args (slug, key, id) and may be called from multiple components, wrap it. The cache key must include every argument that changes the result. The promise is cached, so concurrent callers share the in-flight query.
 
 ```typescript
@@ -208,7 +214,7 @@ after(async () => {
 
 **One query beats two.** Use `LEFT JOIN` for parent+children. Batch with `WHERE id IN (...)`, chunked at `SQL_BATCH_SIZE` (from `utils/chunks.ts`) for D1's bind-parameter limit.
 
-**Query-count snapshots.** `pnpm query-counts` (see `scripts/query-counts.mjs`) records per-route query counts in `scripts/query-counts.snapshot.{sqlite,d1}.json`. CI auto-updates on PRs -- review the diff. Fewer is always right; more needs a conversation.
+**Query-count snapshots.** `pnpm query-counts` (see `scripts/query-counts.mjs`) records per-route query counts in `scripts/query-counts.snapshot.{sqlite,d1}.json`. CI auto-updates on PRs -- review the diff. Fewer is always right; more needs a conversation. An increase on a logged-out route is presumed wrong: the snapshot diff makes it visible, it does not make it acceptable.
 
 # Admin UI
 
@@ -315,6 +321,23 @@ For directional icons (chevrons, arrows), flip them with `rtl:-scale-x-100` or u
 
 # Conventions
 
+## Comments
+
+Comments are evergreen and addressed to a future reader of the code -- not to whoever reviews the PR. Most comments agents write should not exist. A comment earns its place only when:
+
+- the code is unclear and genuinely can't be made clearer (first try making it clearer), or
+- there's a non-obvious reason for something the reader would otherwise get wrong (an ordering constraint, a footgun, an invariant).
+
+Comments are **not**:
+
+- PR descriptions or summaries of the change
+- messages to the reviewer
+- justification for a decision ("intentionally", "for safety", "we accept", "unlike X")
+- narrative about what you tried and rejected
+- restatements of what the code plainly does
+
+Never reference issues, PRs, or review threads in comments -- they're stale narrative the moment the change merges; that context belongs in the commit message and PR description. Never number comments.
+
 ## Imports
 
 - **Internal imports** use `.js` extensions (ESM): `import { X } from "../foo.js"`.
@@ -345,6 +368,15 @@ In libraries used in a Worker but not themselves Workers, install `@cloudflare/w
 - **No mocks for the DB.** SQLite (`better-sqlite3`) by default. PostgreSQL parity tests via a real `pg` connection with per-test schema isolation (set `PG_CONNECTION_STRING` to opt in).
 - **Utilities:** `tests/utils/test-db.ts` exposes `setupTestDatabase()`, `setupTestDatabaseWithCollections()`, `teardownTestDatabase()` for SQLite and `setupTestPostgresDatabase()` etc. for Postgres. Dialect-agnostic: `setupForDialect`, `setupForDialectWithCollections`, `teardownForDialect`, plus `describeEachDialect(name, fn)`. Use the dialect wrapper for query-builder code -- regressions tend to be dialect-specific.
 - **Structure:** `tests/unit/`, `tests/integration/`, `tests/e2e/` (Playwright). Test files mirror source structure. Each test gets a fresh DB.
+
+**A test must be able to fail on a real regression.** If it can't, it's not a test -- delete it. The common offenders:
+
+- **Config-pin tests**: asserting a config literal, constant, or schema shape back at itself. It re-states the source file and fails only when someone makes an intentional change.
+- **Tautological tests**: asserting the implementation detail you just wrote straight back -- add a CSS class to a component, then test the component has that class; call a function with arguments, then assert it was called with those arguments. This re-states the diff, not the behavior. Test what the change does for the user (the element is hidden, the query is filtered), not that the code you wrote is the code you wrote.
+- **Mocking the unit under test**, or a mock that returns the very value the assertion checks. The test then verifies the mock, not the code.
+- **Tests that only exercise third-party code**: Kysely, Zod, and Lingui have their own test suites. Test your behavior, not theirs.
+
+**Never change a test just to make it pass.** Understand why it's failing first -- the test may be the only thing that's right. If you can't work out why, stop and say so.
 
 # Toolchain
 

--- a/infra/flue-review/.flue/skills/review/SKILL.md
+++ b/infra/flue-review/.flue/skills/review/SKILL.md
@@ -9,7 +9,7 @@ You are reviewing a pull request on **emdash-cms/emdash**. Find real bugs, regre
 
 Review **statically**. Do not run the test suite, linter, builds, or install anything (you have no shell anyway). Read code, trace with searches, and reason. If confirming something would require running tooling, say it's unverified rather than guessing.
 
-The repo's AGENTS.md is at the repo root in your context. Check the PR against its conventions (Lingui localization, RTL-safe Tailwind, SQL safety, API envelope shape, authorization, locale filtering on content tables, index discipline, changesets). A violation is a real finding, not a nit.
+The repo's AGENTS.md is at the repo root in your context. Check the PR against its conventions (Lingui localization, RTL-safe Tailwind, SQL safety, API envelope shape, authorization, locale filtering on content tables, index discipline, changesets, query counts on logged-out routes, comment discipline). A violation is a real finding, not a nit.
 
 ## Your only tool: `code`
 
@@ -54,7 +54,9 @@ Breadth first, depth second. The two most common ways to fail are to grade the i
 - **Security**: unsanitized input reaching SQL/HTML/shell/paths, missing/wrong authorization, secret/info leakage, open redirect, path traversal.
 - **Data integrity**: validation at boundaries, partial writes without transactions, cascading deletes that orphan rows, schema/code mismatch, a missing `locale` filter on a content-table query.
 - **Resources**: leaked handles/timers/listeners, unbounded growth, missing timeouts, retry without backoff.
-- **Tests**: a fix without a reproducing test is not fixed; a mock that returns the thing the test claims to verify is false confidence.
+- **Tests**: a fix without a reproducing test is not fixed; a mock that returns the thing the test claims to verify is false confidence. A test that cannot fail on a real regression -- a config literal asserted back at itself, an implementation detail asserted straight back (adding a CSS class and testing the class is present), a mocked unit under test, a test exercising only third-party code -- is worse than no test: it inflates coverage and pins intentional changes. Flag it for deletion, or for rewriting against observable behavior.
+- **Logged-out query counts**: any new query on a route an anonymous visitor can hit -- including cold-start or first-request-only queries -- needs a _really_ good reason. Check whether it could piggyback on an existing query, batch, defer with `after()`, or use `requestCached`. A query-count snapshot diff that increases a logged-out route is a finding, not bookkeeping.
+- **Comments**: comments that restate what the code does, justify the decision ("intentionally", "for safety"), address the reviewer, narrate rejected alternatives, or reference issues/PRs/review threads. Comments are evergreen and for future readers of the code; almost all of these should be deleted (or the code made clearer instead). Numbered comments are always wrong.
 - **AGENTS.md conventions** (see above).
 
 ## Severity and verdict


### PR DESCRIPTION
## What does this PR do?

Strengthens the guidance agents work from (`AGENTS.md`) and the conventions the flue-review reviewer checks against (`infra/flue-review/.flue/skills/review/SKILL.md`) in three areas where agent-authored PRs keep slipping:

- **Logged-out query counts.** New headline rule plus Performance-section detail: any change that adds a query to a logged-out route needs a really good reason — including cold-start/first-request-only queries. A query-count snapshot increase on a logged-out route is presumed wrong, and the reviewer now treats it as a finding rather than bookkeeping.
- **Comment discipline.** New Comments section: comments are evergreen and addressed to future readers of the code — not PR descriptions, not messages to reviewers, not justification for decisions, not narrative about rejected alternatives, and never references to issues/PRs/review threads or numbered lists. The reviewer enumerates these as candidates.
- **Test quality.** Tests must be able to fail on a real regression. Named offenders: config-pin tests, tautological tests (add a CSS class, then assert the class is present), mocking the unit under test, and tests that only exercise third-party code. Plus: never change a test just to make it pass. The reviewer flags such tests for deletion or rewriting against observable behavior.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a, Markdown-only change
- [ ] `pnpm lint` passes — n/a, Markdown-only change
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a, Markdown-only change
- [ ] `pnpm format` has been run — n/a, Markdown-only change
- [ ] I have added/updated tests for my changes (if applicable) — n/a, docs
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no UI change
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — n/a, no published package touched
- [ ] New features link to an approved Discussion — n/a, docs

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

n/a

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://docs-agent-guidance-queries-comments-tests-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `docs/agent-guidance-queries-comments-tests`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
