### PR TITLE
fix(admin): keep rich-text toolbar states visible and accurate

### DIFF
--- a/.changeset/visible-editor-toolbar-states.md
+++ b/.changeset/visible-editor-toolbar-states.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Fixes the rich-text toolbar so active formatting and editor modes remain visibly selected while editing, and floating formatting controls keep their rounded corners.
+Fixes the rich-text toolbar so active and hovered controls remain visible, icon buttons show tooltips, and floating formatting controls keep their rounded corners while editing.

--- a/.changeset/visible-editor-toolbar-states.md
+++ b/.changeset/visible-editor-toolbar-states.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the rich-text toolbar so active formatting and editor modes remain visibly selected while editing, and floating formatting controls keep their rounded corners.

--- a/.changeset/visible-editor-toolbar-states.md
+++ b/.changeset/visible-editor-toolbar-states.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Fixes the rich-text toolbar so active and hovered controls remain visible, icon buttons show tooltips, and floating formatting controls keep their rounded corners while editing.
+Fixes the rich-text toolbar so alignment always reflects the selected blocks and active or hovered controls remain visible. Adds icon tooltips and preserves rounded corners on floating formatting controls.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -11,7 +11,16 @@
  * - Floating menu on empty lines
  */
 
-import { Button, Dialog, Input, Popover, Select, Switch } from "@cloudflare/kumo";
+import {
+	Button,
+	Dialog,
+	Input,
+	Popover,
+	Select,
+	Switch,
+	Tooltip,
+	TooltipProvider,
+} from "@cloudflare/kumo";
 import { Popover as PopoverPrimitive } from "@cloudflare/kumo/primitives/popover";
 import {
 	DndContext,
@@ -3394,7 +3403,7 @@ function EditorToolbar({
 		}
 	}, []);
 
-	return (
+	const toolbar = (
 		<div
 			ref={toolbarRef}
 			role="toolbar"
@@ -3405,18 +3414,24 @@ function EditorToolbar({
 		>
 			{/* Text formatting */}
 			<ToolbarGroup>
-				<Button
-					type="button"
-					variant="ghost"
-					shape="square"
-					className="hidden h-8 w-8 flex-none pointer-coarse:flex"
-					onMouseDown={(event) => event.preventDefault()}
-					onClick={onInsertBlock}
-					aria-label={t`Insert block after current block`}
-					data-touch-block-insert
+				<Tooltip
+					content={t`Insert block after current block`}
+					side="bottom"
+					render={
+						<Button
+							type="button"
+							variant="ghost"
+							shape="square"
+							className="hidden h-8 w-8 flex-none hover:bg-kumo-interact/50 pointer-coarse:flex"
+							onMouseDown={(event) => event.preventDefault()}
+							onClick={onInsertBlock}
+							aria-label={t`Insert block after current block`}
+							data-touch-block-insert
+						/>
+					}
 				>
 					<Plus className="h-4 w-4" aria-hidden="true" />
-				</Button>
+				</Tooltip>
 				<ToolbarButton
 					onClick={() => editor.chain().focus().toggleBold().run()}
 					active={editorState.isBold}
@@ -3533,25 +3548,30 @@ function EditorToolbar({
 						if (!open) setLinkUrl("");
 					}}
 				>
-					<Popover.Trigger
+					<Tooltip
+						content={t`Insert Link`}
+						side="bottom"
 						render={
-							<Button
-								type="button"
-								variant="ghost"
-								shape="square"
-								className={cn(
-									"h-8 w-8 flex-none",
-									editorState.isLink &&
-										"bg-kumo-interact/50 text-kumo-default hover:bg-kumo-interact/50",
-								)}
-								onMouseDown={(event) => event.preventDefault()}
-								aria-label={t`Insert Link`}
-								aria-pressed={editorState.isLink}
-							>
-								<LinkIcon className="h-4 w-4" aria-hidden="true" />
-							</Button>
+							<Popover.Trigger
+								render={
+									<Button
+										type="button"
+										variant="ghost"
+										shape="square"
+										className={cn(
+											"h-8 w-8 flex-none hover:bg-kumo-interact/50",
+											editorState.isLink && "bg-kumo-interact/50 text-kumo-default",
+										)}
+										onMouseDown={(event) => event.preventDefault()}
+										aria-label={t`Insert Link`}
+										aria-pressed={editorState.isLink}
+									/>
+								}
+							/>
 						}
-					/>
+					>
+						<LinkIcon className="h-4 w-4" aria-hidden="true" />
+					</Tooltip>
 					<Popover.Content side="bottom" align="start" className="w-auto p-3">
 						<div className="flex flex-col gap-2">
 							<label className="text-xs font-medium text-kumo-subtle">{t`URL`}</label>
@@ -3636,6 +3656,8 @@ function EditorToolbar({
 			</ToolbarGroup>
 		</div>
 	);
+
+	return <TooltipProvider>{toolbar}</TooltipProvider>;
 }
 
 function ToolbarGroup({ children }: { children: React.ReactNode }) {
@@ -3656,23 +3678,29 @@ interface ToolbarButtonProps {
 
 function ToolbarButton({ onClick, active, disabled, title, children }: ToolbarButtonProps) {
 	return (
-		<Button
-			type="button"
-			variant="ghost"
-			shape="square"
-			className={cn(
-				"h-8 w-8 flex-none",
-				active && "bg-kumo-interact/50 text-kumo-default hover:bg-kumo-interact/50",
-			)}
-			onMouseDown={(e) => e.preventDefault()}
-			onClick={onClick}
-			disabled={disabled}
-			aria-label={title}
-			aria-pressed={active}
-			tabIndex={0}
+		<Tooltip
+			content={title}
+			side="bottom"
+			render={
+				<Button
+					type="button"
+					variant="ghost"
+					shape="square"
+					className={cn(
+						"h-8 w-8 flex-none hover:bg-kumo-interact/50",
+						active && "bg-kumo-interact/50 text-kumo-default",
+					)}
+					onMouseDown={(e) => e.preventDefault()}
+					onClick={onClick}
+					disabled={disabled}
+					aria-label={title}
+					aria-pressed={active}
+					tabIndex={0}
+				/>
+			}
 		>
 			{children}
-		</Button>
+		</Tooltip>
 	);
 }
 

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -3027,6 +3027,7 @@ function EditorBubbleMenu({
 					apply: ({ availableWidth, elements }) => {
 						elements.floating.style.maxWidth = `${Math.max(0, availableWidth)}px`;
 						elements.floating.style.overflowX = "auto";
+						elements.floating.style.borderRadius = "var(--radius-lg)";
 					},
 				}),
 			}}
@@ -3165,6 +3166,7 @@ function TableBubbleMenu({
 					apply: ({ availableWidth, elements }) => {
 						elements.floating.style.maxWidth = `${Math.max(0, availableWidth)}px`;
 						elements.floating.style.overflowX = "auto";
+						elements.floating.style.borderRadius = "var(--radius-lg)";
 					},
 				}),
 			}}
@@ -3539,7 +3541,8 @@ function EditorToolbar({
 								shape="square"
 								className={cn(
 									"h-8 w-8 flex-none",
-									editorState.isLink && "bg-kumo-tint text-kumo-default",
+									editorState.isLink &&
+										"bg-kumo-interact/50 text-kumo-default hover:bg-kumo-interact/50",
 								)}
 								onMouseDown={(event) => event.preventDefault()}
 								aria-label={t`Insert Link`}
@@ -3657,7 +3660,10 @@ function ToolbarButton({ onClick, active, disabled, title, children }: ToolbarBu
 			type="button"
 			variant="ghost"
 			shape="square"
-			className={cn("h-8 w-8 flex-none", active && "bg-kumo-tint text-kumo-default")}
+			className={cn(
+				"h-8 w-8 flex-none",
+				active && "bg-kumo-interact/50 text-kumo-default hover:bg-kumo-interact/50",
+			)}
 			onMouseDown={(e) => e.preventDefault()}
 			onClick={onClick}
 			disabled={disabled}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -93,6 +93,7 @@ import { TableHeader } from "@tiptap/extension-table-header";
 import { TableRow } from "@tiptap/extension-table-row";
 import TextAlign from "@tiptap/extension-text-align";
 import Typography from "@tiptap/extension-typography";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { AllSelection, TextSelection } from "@tiptap/pm/state";
 import { CellSelection } from "@tiptap/pm/tables";
 import { useEditor, EditorContent, useEditorState, type Editor } from "@tiptap/react";
@@ -3276,6 +3277,48 @@ function BubbleButton({
 	);
 }
 
+type TextAlignment = "left" | "center" | "right" | "justify";
+
+function getSelectionTextAlignment(editor: Editor): TextAlignment | null {
+	const window = editor.view.dom.ownerDocument.defaultView;
+	const defaultAlignment: TextAlignment =
+		window?.getComputedStyle(editor.view.dom).direction === "rtl" ? "right" : "left";
+	const alignments = new Set<TextAlignment>();
+
+	const collectAlignment = (node: ProseMirrorNode) => {
+		if (node.type.name !== "paragraph" && node.type.name !== "heading") return;
+		const textAlign = node.attrs.textAlign;
+		alignments.add(
+			textAlign === "left" ||
+				textAlign === "center" ||
+				textAlign === "right" ||
+				textAlign === "justify"
+				? textAlign
+				: defaultAlignment,
+		);
+	};
+
+	for (const { $from, $to } of editor.state.selection.ranges) {
+		if ($from.pos === $to.pos) {
+			for (let depth = $from.depth; depth >= 0; depth -= 1) {
+				const node = $from.node(depth);
+				if (node.type.name === "paragraph" || node.type.name === "heading") {
+					collectAlignment(node);
+					break;
+				}
+			}
+			continue;
+		}
+
+		editor.state.doc.nodesBetween($from.pos, $to.pos, (node) => {
+			collectAlignment(node);
+			return node.type.name !== "paragraph" && node.type.name !== "heading";
+		});
+	}
+
+	return alignments.size === 1 ? (alignments.values().next().value ?? null) : null;
+}
+
 /**
  * Editor Toolbar
  *
@@ -3303,23 +3346,26 @@ function EditorToolbar({
 	// Subscribe to editor state changes for reactive button states
 	const editorState = useEditorState({
 		editor,
-		selector: (ctx) => ({
-			isBold: ctx.editor.isActive("bold"),
-			isItalic: ctx.editor.isActive("italic"),
-			isUnderline: ctx.editor.isActive("underline"),
-			isStrike: ctx.editor.isActive("strike"),
-			isCode: ctx.editor.isActive("code"),
-			isBulletList: ctx.editor.isActive("bulletList"),
-			isOrderedList: ctx.editor.isActive("orderedList"),
-			isBlockquote: ctx.editor.isActive("blockquote"),
-			isCodeBlock: ctx.editor.isActive("codeBlock"),
-			isAlignLeft: ctx.editor.isActive({ textAlign: "left" }),
-			isAlignCenter: ctx.editor.isActive({ textAlign: "center" }),
-			isAlignRight: ctx.editor.isActive({ textAlign: "right" }),
-			isLink: ctx.editor.isActive("link"),
-			canUndo: ctx.editor.can().undo(),
-			canRedo: ctx.editor.can().redo(),
-		}),
+		selector: (ctx) => {
+			const textAlignment = getSelectionTextAlignment(ctx.editor);
+			return {
+				isBold: ctx.editor.isActive("bold"),
+				isItalic: ctx.editor.isActive("italic"),
+				isUnderline: ctx.editor.isActive("underline"),
+				isStrike: ctx.editor.isActive("strike"),
+				isCode: ctx.editor.isActive("code"),
+				isBulletList: ctx.editor.isActive("bulletList"),
+				isOrderedList: ctx.editor.isActive("orderedList"),
+				isBlockquote: ctx.editor.isActive("blockquote"),
+				isCodeBlock: ctx.editor.isActive("codeBlock"),
+				isAlignLeft: textAlignment === "left",
+				isAlignCenter: textAlignment === "center",
+				isAlignRight: textAlignment === "right",
+				isLink: ctx.editor.isActive("link"),
+				canUndo: ctx.editor.can().undo(),
+				canRedo: ctx.editor.can().redo(),
+			};
+		},
 	});
 
 	// Populate link URL when opening popover

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -3280,9 +3280,9 @@ function BubbleButton({
 type TextAlignment = "left" | "center" | "right" | "justify";
 
 function getSelectionTextAlignment(editor: Editor): TextAlignment | null {
-	const window = editor.view.dom.ownerDocument.defaultView;
+	const ownerWindow = editor.view.dom.ownerDocument.defaultView;
 	const defaultAlignment: TextAlignment =
-		window?.getComputedStyle(editor.view.dom).direction === "rtl" ? "right" : "left";
+		ownerWindow?.getComputedStyle(editor.view.dom).direction === "rtl" ? "right" : "left";
 	const alignments = new Set<TextAlignment>();
 
 	const collectAlignment = (node: ProseMirrorNode) => {
@@ -3473,11 +3473,11 @@ function EditorToolbar({
 							onClick={onInsertBlock}
 							aria-label={t`Insert block after current block`}
 							data-touch-block-insert
-						/>
+						>
+							<Plus className="h-4 w-4" aria-hidden="true" />
+						</Button>
 					}
-				>
-					<Plus className="h-4 w-4" aria-hidden="true" />
-				</Tooltip>
+				/>
 				<ToolbarButton
 					onClick={() => editor.chain().focus().toggleBold().run()}
 					active={editorState.isBold}
@@ -3611,13 +3611,13 @@ function EditorToolbar({
 										onMouseDown={(event) => event.preventDefault()}
 										aria-label={t`Insert Link`}
 										aria-pressed={editorState.isLink}
-									/>
+									>
+										<LinkIcon className="h-4 w-4" aria-hidden="true" />
+									</Button>
 								}
 							/>
 						}
-					>
-						<LinkIcon className="h-4 w-4" aria-hidden="true" />
-					</Tooltip>
+					/>
 					<Popover.Content side="bottom" align="start" className="w-auto p-3">
 						<div className="flex flex-col gap-2">
 							<label className="text-xs font-medium text-kumo-subtle">{t`URL`}</label>
@@ -3742,11 +3742,11 @@ function ToolbarButton({ onClick, active, disabled, title, children }: ToolbarBu
 					aria-label={title}
 					aria-pressed={active}
 					tabIndex={0}
-				/>
+				>
+					{children}
+				</Button>
 			}
-		>
-			{children}
-		</Tooltip>
+		/>
 	);
 }
 

--- a/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
+++ b/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, DropdownMenu } from "@cloudflare/kumo";
+import { Button, DropdownMenu, Tooltip } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
@@ -138,28 +138,34 @@ export const HeadingDropdownMenu = React.forwardRef<HTMLButtonElement, HeadingDr
 
 		return (
 			<DropdownMenu open={open} onOpenChange={handleOpenChange}>
-				<DropdownMenu.Trigger
+				<Tooltip
+					content={t`Headings`}
+					side="bottom"
 					render={
-						<Button
-							ref={ref}
-							type="button"
-							variant="ghost"
-							className={cn(
-								"h-8 min-w-11 flex-none gap-0.5 px-2",
-								isActive && "bg-kumo-interact/50 text-kumo-default hover:bg-kumo-interact/50",
-								className,
-							)}
-							disabled={!canToggle}
-							onMouseDown={(event) => event.preventDefault()}
-							aria-label={t`Headings`}
-							aria-haspopup="menu"
-							aria-expanded={open}
-						>
-							<Icon className="h-4 w-4" aria-hidden="true" />
-							<CaretDown className="h-3 w-3" aria-hidden="true" />
-						</Button>
+						<DropdownMenu.Trigger
+							render={
+								<Button
+									ref={ref}
+									type="button"
+									variant="ghost"
+									className={cn(
+										"h-8 min-w-11 flex-none gap-0.5 px-2 hover:bg-kumo-interact/50",
+										isActive && "bg-kumo-interact/50 text-kumo-default",
+										className,
+									)}
+									disabled={!canToggle}
+									onMouseDown={(event) => event.preventDefault()}
+									aria-label={t`Headings`}
+									aria-haspopup="menu"
+									aria-expanded={open}
+								/>
+							}
+						/>
 					}
-				/>
+				>
+					<Icon className="h-4 w-4" aria-hidden="true" />
+					<CaretDown className="h-3 w-3" aria-hidden="true" />
+				</Tooltip>
 				<DropdownMenu.Content align="start" className="min-w-44">
 					{levels.map((level) => {
 						const HeadingIcon = HEADING_ICONS[level];

--- a/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
+++ b/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
@@ -158,14 +158,14 @@ export const HeadingDropdownMenu = React.forwardRef<HTMLButtonElement, HeadingDr
 									aria-label={t`Headings`}
 									aria-haspopup="menu"
 									aria-expanded={open}
-								/>
+								>
+									<Icon className="h-4 w-4" aria-hidden="true" />
+									<CaretDown className="h-3 w-3" aria-hidden="true" />
+								</Button>
 							}
 						/>
 					}
-				>
-					<Icon className="h-4 w-4" aria-hidden="true" />
-					<CaretDown className="h-3 w-3" aria-hidden="true" />
-				</Tooltip>
+				/>
 				<DropdownMenu.Content align="start" className="min-w-44">
 					{levels.map((level) => {
 						const HeadingIcon = HEADING_ICONS[level];

--- a/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
+++ b/packages/admin/src/components/editor/HeadingDropdownMenu.tsx
@@ -146,7 +146,7 @@ export const HeadingDropdownMenu = React.forwardRef<HTMLButtonElement, HeadingDr
 							variant="ghost"
 							className={cn(
 								"h-8 min-w-11 flex-none gap-0.5 px-2",
-								isActive && "bg-kumo-tint text-kumo-default",
+								isActive && "bg-kumo-interact/50 text-kumo-default hover:bg-kumo-interact/50",
 								className,
 							)}
 							disabled={!canToggle}

--- a/packages/admin/tests/editor/bubble-menu.test.tsx
+++ b/packages/admin/tests/editor/bubble-menu.test.tsx
@@ -242,11 +242,33 @@ async function waitForBubbleMenu(): Promise<HTMLElement> {
 	return menu!;
 }
 
+function findScrollableAncestor(element: HTMLElement): HTMLElement | null {
+	let ancestor = element.parentElement;
+	while (ancestor) {
+		if (["auto", "scroll"].includes(getComputedStyle(ancestor).overflowX)) return ancestor;
+		ancestor = ancestor.parentElement;
+	}
+	return null;
+}
+
+function hasNonZeroRadius(element: HTMLElement): boolean {
+	const computedRadius = getComputedStyle(element).borderRadius;
+	const computedValues = computedRadius.match(/\d*\.?\d+/g)?.map(Number) ?? [];
+	if (computedValues.some((value) => value > 0)) return true;
+
+	// The component harness does not resolve admin-only Tailwind variables, so
+	// fall back to validating a semantic inline declaration when necessary.
+	const declaredRadius = element.style.borderRadius.trim();
+	if (!declaredRadius || !CSS.supports("border-radius", declaredRadius)) return false;
+	if (declaredRadius.includes("var(")) return true;
+	const declaredValues = declaredRadius.match(/\d*\.?\d+/g)?.map(Number) ?? [];
+	return declaredValues.some((value) => value > 0);
+}
+
 function expectRoundedFloatingWrapper(menu: HTMLElement) {
-	const wrapper = menu.parentElement;
+	const wrapper = findScrollableAncestor(menu);
 	expect(wrapper).toBeTruthy();
-	expect(wrapper!.style.overflowX).toBe("auto");
-	expect(wrapper!.style.borderRadius).toBe("var(--radius-lg)");
+	expect(hasNonZeroRadius(wrapper!)).toBe(true);
 }
 
 /** Get a bubble menu button by aria-label */

--- a/packages/admin/tests/editor/bubble-menu.test.tsx
+++ b/packages/admin/tests/editor/bubble-menu.test.tsx
@@ -242,6 +242,13 @@ async function waitForBubbleMenu(): Promise<HTMLElement> {
 	return menu!;
 }
 
+function expectRoundedFloatingWrapper(menu: HTMLElement) {
+	const wrapper = menu.parentElement;
+	expect(wrapper).toBeTruthy();
+	expect(wrapper!.style.overflowX).toBe("auto");
+	expect(wrapper!.style.borderRadius).toBe("var(--radius-lg)");
+}
+
 /** Get a bubble menu button by aria-label */
 function getBubbleButton(menu: HTMLElement, label: string): HTMLButtonElement | null {
 	return menu.querySelector(`[aria-label="${label}"]`);
@@ -282,6 +289,14 @@ describe("Bubble Menu", () => {
 
 		const menu = await waitForBubbleMenu();
 		expect(menu).toBeTruthy();
+	});
+
+	it("rounds the scrollable positioning wrapper to preserve every menu corner", async () => {
+		const { editor, pm } = await renderEditor();
+		await focusAndSelectAll(editor, pm);
+
+		const menu = await waitForBubbleMenu();
+		await vi.waitFor(() => expectRoundedFloatingWrapper(menu));
 	});
 
 	it("flips below a top-line selection when the sticky toolbar blocks the preferred position", async () => {
@@ -361,6 +376,7 @@ describe("Bubble Menu", () => {
 			expect(menuRect.top).toBeGreaterThanOrEqual(
 				formattingToolbar!.getBoundingClientRect().bottom,
 			);
+			expectRoundedFloatingWrapper(tableToolbar);
 		});
 	});
 

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -1,4 +1,5 @@
 import type { Editor } from "@tiptap/core";
+import { CellSelection } from "@tiptap/pm/tables";
 import { userEvent } from "@vitest/browser/context";
 import { describe, it, expect, vi } from "vitest";
 
@@ -143,6 +144,35 @@ function expectVisibleActiveState(element: HTMLElement) {
 
 function expectNoVisibleActiveState(element: HTMLElement) {
 	expect(element.classList.contains("bg-kumo-interact/50")).toBe(false);
+}
+
+function getTextPosition(editor: Editor, text: string): number {
+	let position: number | undefined;
+	editor.state.doc.descendants((node, pos) => {
+		if (position !== undefined) return false;
+		if (node.isTextblock && node.textContent.includes(text)) {
+			position = pos + 1;
+			return false;
+		}
+		return true;
+	});
+	if (position === undefined) throw new Error(`Could not find text: ${text}`);
+	return position;
+}
+
+function expectAlignmentState(
+	screen: Awaited<ReturnType<typeof render>>,
+	active: "left" | "center" | "right" | null,
+) {
+	const buttons = {
+		left: getToolbarButton(screen, "Align Left").element(),
+		center: getToolbarButton(screen, "Align Center").element(),
+		right: getToolbarButton(screen, "Align Right").element(),
+	};
+
+	for (const [alignment, button] of Object.entries(buttons)) {
+		expect(button.getAttribute("aria-pressed")).toBe(String(alignment === active));
+	}
 }
 
 async function getHeadingMenuItem(
@@ -548,6 +578,235 @@ describe("Formatting Button Toggle States", () => {
 // =============================================================================
 
 describe("Text Alignment", () => {
+	it("tracks default and explicit alignment whenever the cursor changes paragraphs", async () => {
+		const { screen, editor } = await renderEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "1",
+					style: "normal",
+					children: [{ _type: "span", _key: "s1", text: "Default left" }],
+				},
+				{
+					_type: "block",
+					_key: "2",
+					style: "normal",
+					textAlign: "center",
+					children: [{ _type: "span", _key: "s2", text: "Centered" }],
+				},
+				{
+					_type: "block",
+					_key: "3",
+					style: "normal",
+					textAlign: "right",
+					children: [{ _type: "span", _key: "s3", text: "Right aligned" }],
+				},
+			],
+		});
+
+		for (const [text, alignment] of [
+			["Default left", "left"],
+			["Centered", "center"],
+			["Right aligned", "right"],
+			["Default left", "left"],
+		] as const) {
+			editor.chain().focus().setTextSelection(getTextPosition(editor, text)).run();
+			await vi.waitFor(() => expectAlignmentState(screen, alignment));
+		}
+	});
+
+	it("treats unannotated headings, list paragraphs, and newly split empty blocks as left aligned", async () => {
+		const { screen, editor } = await renderEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "1",
+					style: "h2",
+					children: [{ _type: "span", _key: "s1", text: "A heading" }],
+				},
+				{
+					_type: "block",
+					_key: "2",
+					style: "normal",
+					listItem: "bullet",
+					level: 1,
+					children: [{ _type: "span", _key: "s2", text: "A list item" }],
+				},
+			],
+		});
+
+		for (const text of ["A heading", "A list item"]) {
+			editor.chain().focus().setTextSelection(getTextPosition(editor, text)).run();
+			await vi.waitFor(() => expectAlignmentState(screen, "left"));
+		}
+
+		const listPosition = getTextPosition(editor, "A list item") + "A list item".length;
+		editor.chain().focus().setTextSelection(listPosition).splitBlock().run();
+		await vi.waitFor(() => expectAlignmentState(screen, "left"));
+	});
+
+	it("reports a shared alignment for uniform multi-block selections and none for mixed selections", async () => {
+		const { screen, editor } = await renderEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "1",
+					style: "normal",
+					children: [{ _type: "span", _key: "s1", text: "Left one" }],
+				},
+				{
+					_type: "block",
+					_key: "2",
+					style: "normal",
+					children: [{ _type: "span", _key: "s2", text: "Left two" }],
+				},
+				{
+					_type: "block",
+					_key: "3",
+					style: "normal",
+					textAlign: "center",
+					children: [{ _type: "span", _key: "s3", text: "Center three" }],
+				},
+			],
+		});
+
+		editor
+			.chain()
+			.focus()
+			.setTextSelection({
+				from: getTextPosition(editor, "Left one"),
+				to: getTextPosition(editor, "Left two") + "Left two".length,
+			})
+			.run();
+		await vi.waitFor(() => expectAlignmentState(screen, "left"));
+
+		editor
+			.chain()
+			.focus()
+			.setTextSelection({
+				from: getTextPosition(editor, "Left two"),
+				to: getTextPosition(editor, "Center three") + "Center three".length,
+			})
+			.run();
+		await vi.waitFor(() => expectAlignmentState(screen, null));
+	});
+
+	it("updates an entire mixed selection and follows alignment undo and redo history", async () => {
+		const { screen, editor } = await renderEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "1",
+					style: "normal",
+					children: [{ _type: "span", _key: "s1", text: "Default block" }],
+				},
+				{
+					_type: "block",
+					_key: "2",
+					style: "normal",
+					textAlign: "center",
+					children: [{ _type: "span", _key: "s2", text: "Centered block" }],
+				},
+			],
+		});
+		editor
+			.chain()
+			.focus()
+			.setTextSelection({
+				from: getTextPosition(editor, "Default block"),
+				to: getTextPosition(editor, "Centered block") + "Centered block".length,
+			})
+			.run();
+		await vi.waitFor(() => expectAlignmentState(screen, null));
+
+		getToolbarButton(screen, "Align Right").element().click();
+		await vi.waitFor(() => expectAlignmentState(screen, "right"));
+
+		editor.commands.undo();
+		await vi.waitFor(() => expectAlignmentState(screen, null));
+
+		editor.commands.redo();
+		await vi.waitFor(() => expectAlignmentState(screen, "right"));
+
+		getToolbarButton(screen, "Align Left").element().click();
+		await vi.waitFor(() => expectAlignmentState(screen, "left"));
+	});
+
+	it("shows no alignment for a selection containing no alignable text block", async () => {
+		const { screen, editor } = await renderEditor();
+		editor.chain().focus().setTextSelection(1).toggleCodeBlock().run();
+
+		await vi.waitFor(() => expectAlignmentState(screen, null));
+	});
+
+	it("resolves uniform and mixed table cell selections from their selected ranges", async () => {
+		const { screen, editor } = await renderEditor();
+		editor.chain().focus().insertTable({ rows: 2, cols: 2, withHeaderRow: false }).run();
+
+		const cellPositions: number[] = [];
+		editor.state.doc.descendants((node, pos) => {
+			if (node.type.name === "tableCell") cellPositions.push(pos);
+		});
+		expect(cellPositions).toHaveLength(4);
+
+		editor
+			.chain()
+			.focus()
+			.setTextSelection(cellPositions[0]! + 2)
+			.setTextAlign("center")
+			.run();
+		editor.view.dispatch(
+			editor.state.tr.setSelection(
+				CellSelection.create(editor.state.doc, cellPositions[0]!, cellPositions[1]!),
+			),
+		);
+		await vi.waitFor(() => expectAlignmentState(screen, null));
+
+		editor.view.dispatch(
+			editor.state.tr.setSelection(
+				CellSelection.create(editor.state.doc, cellPositions[2]!, cellPositions[3]!),
+			),
+		);
+		await vi.waitFor(() => expectAlignmentState(screen, "left"));
+	});
+
+	it("uses the writing direction for unannotated text without masking explicit or unsupported alignment", async () => {
+		const { screen, editor } = await renderEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "1",
+					style: "normal",
+					children: [{ _type: "span", _key: "s1", text: "مرحبا بالعالم" }],
+				},
+				{
+					_type: "block",
+					_key: "2",
+					style: "normal",
+					textAlign: "left",
+					children: [{ _type: "span", _key: "s2", text: "Explicit left" }],
+				},
+				{
+					_type: "block",
+					_key: "3",
+					style: "normal",
+					textAlign: "justify",
+					children: [{ _type: "span", _key: "s3", text: "Justified" }],
+				},
+			],
+		});
+		expect(getComputedStyle(editor.view.dom).direction).toBe("rtl");
+
+		editor.chain().focus().setTextSelection(getTextPosition(editor, "مرحبا بالعالم")).run();
+		await vi.waitFor(() => expectAlignmentState(screen, "right"));
+
+		editor.chain().focus().setTextSelection(getTextPosition(editor, "Explicit left")).run();
+		await vi.waitFor(() => expectAlignmentState(screen, "left"));
+
+		editor.chain().focus().setTextSelection(getTextPosition(editor, "Justified")).run();
+		await vi.waitFor(() => expectAlignmentState(screen, null));
+	});
+
 	it("Align Center becomes pressed, Align Left becomes unpressed", async () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -136,6 +136,16 @@ function getToolbarButton(screen: Awaited<ReturnType<typeof render>>, name: stri
 	return screen.getByRole("toolbar", { name: "Text formatting" }).getByRole("button", { name });
 }
 
+function expectVisibleActiveState(element: HTMLElement) {
+	expect(element.classList.contains("bg-kumo-interact/50")).toBe(true);
+	expect(element.classList.contains("hover:bg-kumo-interact/50")).toBe(true);
+}
+
+function expectNoVisibleActiveState(element: HTMLElement) {
+	expect(element.classList.contains("bg-kumo-interact/50")).toBe(false);
+	expect(element.classList.contains("hover:bg-kumo-interact/50")).toBe(false);
+}
+
 async function getHeadingMenuItem(
 	screen: Awaited<ReturnType<typeof render>>,
 	name: "Heading 1" | "Heading 2" | "Heading 3",
@@ -291,6 +301,41 @@ describe("Toolbar Presence and Structure", () => {
 // =============================================================================
 
 describe("Formatting Button Toggle States", () => {
+	it("shows existing bold formatting and clears the state for mixed or plain selections", async () => {
+		const { screen, editor } = await renderEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "1",
+					style: "normal",
+					children: [
+						{ _type: "span", _key: "s1", text: "Bold", marks: ["strong"] },
+						{ _type: "span", _key: "s2", text: " plain" },
+					],
+				},
+			],
+		});
+		const bold = getToolbarButton(screen, "Bold").element();
+
+		editor.chain().focus().setTextSelection({ from: 1, to: 5 }).run();
+		await vi.waitFor(() => {
+			expect(bold.getAttribute("aria-pressed")).toBe("true");
+			expectVisibleActiveState(bold);
+		});
+
+		editor.chain().focus().setTextSelection({ from: 1, to: 11 }).run();
+		await vi.waitFor(() => {
+			expect(bold.getAttribute("aria-pressed")).toBe("false");
+			expectNoVisibleActiveState(bold);
+		});
+
+		editor.chain().focus().setTextSelection({ from: 5, to: 11 }).run();
+		await vi.waitFor(() => {
+			expect(bold.getAttribute("aria-pressed")).toBe("false");
+			expectNoVisibleActiveState(bold);
+		});
+	});
+
 	it("Bold: click toggles aria-pressed to true", async () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
@@ -369,6 +414,7 @@ describe("Formatting Button Toggle States", () => {
 		await vi.waitFor(() => {
 			expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
 			expect(editor.isActive("heading", { level: 1 })).toBe(true);
+			expectVisibleActiveState(trigger.element());
 		});
 	});
 
@@ -677,6 +723,9 @@ describe("Link Insertion", () => {
 
 		await vi.waitFor(() => {
 			expect(editor.isActive("link")).toBe(true);
+			const link = getToolbarButton(screen, "Insert Link").element();
+			expect(link.getAttribute("aria-pressed")).toBe("true");
+			expectVisibleActiveState(link);
 		});
 	});
 

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -143,7 +143,6 @@ function expectVisibleActiveState(element: HTMLElement) {
 
 function expectNoVisibleActiveState(element: HTMLElement) {
 	expect(element.classList.contains("bg-kumo-interact/50")).toBe(false);
-	expect(element.classList.contains("hover:bg-kumo-interact/50")).toBe(false);
 }
 
 async function getHeadingMenuItem(
@@ -287,6 +286,38 @@ describe("Toolbar Presence and Structure", () => {
 	it("has Spotlight Mode button", async () => {
 		const { screen } = await renderEditor();
 		await expect.element(screen.getByRole("button", { name: "Spotlight Mode" })).toBeVisible();
+	});
+
+	it("gives every fixed-toolbar control visible pointer-hover feedback", async () => {
+		const { screen } = await renderEditor();
+		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
+		const buttons = [...toolbar.querySelectorAll<HTMLButtonElement>("button")];
+
+		expect(buttons.length).toBeGreaterThan(0);
+		for (const button of buttons) {
+			expect(button.classList.contains("hover:bg-kumo-interact/50")).toBe(true);
+		}
+	});
+
+	it("shows Kumo tooltips on pointer hover and keyboard focus", async () => {
+		const { screen } = await renderEditor();
+		const bold = getToolbarButton(screen, "Bold");
+
+		await userEvent.hover(bold.element());
+		await vi.waitFor(
+			() => expect(document.querySelector(".kumo-tooltip-popup")?.textContent).toBe("Bold"),
+			{ timeout: 2000 },
+		);
+
+		await userEvent.hover(document.body);
+		await vi.waitFor(() => expect(document.querySelector(".kumo-tooltip-popup")).toBeNull());
+
+		const headings = getToolbarButton(screen, "Headings");
+		headings.element().focus();
+		await vi.waitFor(
+			() => expect(document.querySelector(".kumo-tooltip-popup")?.textContent).toBe("Headings"),
+			{ timeout: 2000 },
+		);
 	});
 
 	it("hides toolbar when minimal={true}", async () => {

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -334,20 +334,14 @@ describe("Toolbar Presence and Structure", () => {
 		const bold = getToolbarButton(screen, "Bold");
 
 		await userEvent.hover(bold.element());
-		await vi.waitFor(
-			() => expect(document.querySelector(".kumo-tooltip-popup")?.textContent).toBe("Bold"),
-			{ timeout: 2000 },
-		);
+		await expect.element(screen.getByText("Bold")).toBeVisible();
 
 		await userEvent.hover(document.body);
-		await vi.waitFor(() => expect(document.querySelector(".kumo-tooltip-popup")).toBeNull());
+		await vi.waitFor(() => expect(screen.getByText("Bold").query()).toBeNull());
 
 		const headings = getToolbarButton(screen, "Headings");
 		headings.element().focus();
-		await vi.waitFor(
-			() => expect(document.querySelector(".kumo-tooltip-popup")?.textContent).toBe("Headings"),
-			{ timeout: 2000 },
-		);
+		await expect.element(screen.getByText("Headings")).toBeVisible();
 	});
 
 	it("hides toolbar when minimal={true}", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes the fixed rich-text toolbar so its controls visibly and accurately reflect the current editor selection.

- Gives active and hovered toolbar controls a contrasting Kumo interaction state across marks, headings, lists, blocks, alignment, links, and Spotlight mode.
- Resolves alignment from the selected blocks, including default LTR and RTL alignment, uniform and mixed multi-block selections, table cells, empty blocks, and unsupported block types.
- Adds Kumo hover and keyboard-focus tooltips to the icon-only fixed-toolbar controls while preserving their accessible names and keyboard behavior.
- Preserves the rounded corners of scrollable inline and table formatting menus.

Editor commands, history behavior, Portable Text persistence, schemas, and public APIs are unchanged.

Closes #2154

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — the admin package passes, but the repository-level command reaches an existing unrelated error in `packages/core/src/cli/commands/bundle-utils.ts:173` because `ManifestRouteEntry.cacheControl` is absent.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — N/A: this is a bug fix tied to #2154 and adds no API or schema capability.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

The before state is shown in #2154. The updated toolbar was manually verified in light and dark themes using pointer and keyboard interactions. LTR and RTL alignment behavior is covered by browser tests.

Passed:

- `pnpm --filter @emdash-cms/admin typecheck`
- `pnpm lint`
- `pnpm --filter @emdash-cms/admin exec vitest run tests/editor/toolbar.test.tsx tests/editor/bubble-menu.test.tsx` (88 tests)
- `pnpm --filter @emdash-cms/admin build`
- Formatting and diff checks for every changed file

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-editor-formatting-toolbar-polish-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/editor-formatting-toolbar-polish`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
