### PR TITLE
fix(admin): isolate plugin block modal saves

### DIFF
--- a/.changeset/quiet-blocks-save.md
+++ b/.changeset/quiet-blocks-save.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes plugin block edits being overwritten when saving from the block modal.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1485,6 +1485,7 @@ function PluginBlockModal({
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
+		e.stopPropagation();
 		if (block?.fields && block.fields.length > 0) {
 			onInsert(formValues);
 		} else {

--- a/packages/admin/tests/editor/plugin-block-modal.test.tsx
+++ b/packages/admin/tests/editor/plugin-block-modal.test.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	PortableTextEditor,
+	type PortableTextEditorProps,
+} from "../../src/components/PortableTextEditor";
+import { render } from "../utils/render";
+
+vi.mock("../../src/components/MediaPickerModal", () => ({
+	MediaPickerModal: () => null,
+}));
+
+vi.mock("../../src/components/SectionPickerModal", () => ({
+	SectionPickerModal: () => null,
+}));
+
+vi.mock("../../src/components/editor/DragHandleWrapper", () => ({
+	DragHandleWrapper: () => null,
+}));
+
+const pluginBlocks: NonNullable<PortableTextEditorProps["pluginBlocks"]> = [
+	{
+		type: "test.hero",
+		pluginId: "test-blocks",
+		label: "Test Hero",
+		fields: [
+			{
+				type: "text_input",
+				action_id: "heading",
+				label: "Heading",
+			},
+		],
+	},
+];
+
+describe("plugin block modal", () => {
+	it("saves an edited block without submitting the surrounding content form", async () => {
+		const onPageSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+		const onChange = vi.fn<NonNullable<PortableTextEditorProps["onChange"]>>();
+		const screen = await render(
+			<form onSubmit={onPageSubmit}>
+				<PortableTextEditor
+					value={[
+						{
+							_type: "test.hero",
+							_key: "hero-1",
+							heading: "Before",
+						},
+					]}
+					onChange={onChange}
+					pluginBlocks={pluginBlocks}
+				/>
+			</form>,
+		);
+
+		const editButton = screen.getByRole("button", { name: "Edit" });
+		await expect.element(editButton).toBeVisible();
+		await editButton.click();
+
+		const heading = screen.getByRole("textbox");
+		await expect.element(heading).toHaveValue("Before");
+		await heading.fill("After");
+		screen.getByRole("button", { name: "Save", exact: true }).element().click();
+
+		expect(onPageSubmit).not.toHaveBeenCalled();
+		await vi.waitFor(() => {
+			const savedBlocks = onChange.mock.lastCall?.[0];
+			expect(savedBlocks).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						_type: "test.hero",
+						heading: "After",
+					}),
+				]),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Prevents the Block Kit modal's submit event from reaching the surrounding content form. Because the modal is a React descendant of the page form even when its DOM is portaled, one Save click could invoke the page submit handler twice and race stale content against the intended block update.

The fix stops propagation in the modal submit handler while preserving native form and Enter-key behavior. A browser regression renders a real editable plugin block inside a host form, saves the edited field, verifies the block update, and proves the host form is not submitted.

Related to #1118 and #727.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#localization-i18n) (N/A — no user-visible strings changed)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6 Sol via Cursor

## Screenshots / test output

```text
pnpm lint
# passed with warnings denied

pnpm typecheck
# 30 package typechecks passed

pnpm --filter @emdash-cms/admin test --run tests/editor/plugin-block-modal.test.tsx
# 1 file, 1 test passed in Chromium
```

Before the fix, the regression observed the surrounding submit handler twice for one trusted modal submit. An isolated Cloudflare/workerd reproduction also captured competing manual PUT payloads carrying the pre-edit and post-edit block values. After the fix, the modal edit persisted through hard reload with no competing manual save. The workerd fixture was kept out of this diff so the contribution remains scoped to the fix, regression, and required changeset.

Made with [Cursor](https://cursor.com)