### PR TITLE
fix(admin): echo _rev from content reads into editor saves so stale saves 409

### DIFF
--- a/.changeset/admin-editor-rev-echo.md
+++ b/.changeset/admin-editor-rev-echo.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+The admin content editor now echoes the `_rev` token from content API reads into its update requests, so the server's optimistic concurrency check can refuse a stale save with a 409 instead of silently overwriting a newer draft revision. On a conflict the stale token is dropped so the editor's refetch re-arms the check. Saves made before any read (no known token) still behave as before.

--- a/packages/admin/src/lib/api/content.ts
+++ b/packages/admin/src/lib/api/content.ts
@@ -203,6 +203,23 @@ export async function fetchContentAuthors(collection: string): Promise<ContentAu
 }
 
 /**
+ * Latest known `_rev` token per content id, captured from GET/PUT responses.
+ * `updateContent` echoes it into PUT bodies so the server's optimistic
+ * concurrency check (`validateRev`) can refuse stale saves instead of
+ * blind-writing over a newer draft revision (#2121). Centralized here so
+ * callers don't have to thread the token through.
+ */
+const knownRevs = new Map<string, string>();
+
+/** Test-only helpers for the `_rev` cache. */
+export function _getKnownRev(id: string): string | undefined {
+	return knownRevs.get(id);
+}
+export function _clearKnownRevs(): void {
+	knownRevs.clear();
+}
+
+/**
  * Fetch single content item
  */
 export async function fetchContent(
@@ -214,7 +231,11 @@ export async function fetchContent(
 	if (options?.locale) params.set("locale", options.locale);
 	const query = params.toString() ? `?${params}` : "";
 	const response = await apiFetch(`${API_BASE}/content/${collection}/${id}${query}`);
-	const data = await parseApiResponse<{ item: ContentItem }>(response, "Failed to fetch content");
+	const data = await parseApiResponse<{ item: ContentItem; _rev?: string }>(
+		response,
+		"Failed to fetch content",
+	);
+	if (data._rev) knownRevs.set(data.item.id, data._rev);
 	return data.item;
 }
 
@@ -253,12 +274,20 @@ export async function updateContent(
 	const params = new URLSearchParams();
 	if (options?.locale) params.set("locale", options.locale);
 	const query = params.toString() ? `?${params}` : "";
+	const rev = knownRevs.get(id);
 	const response = await apiFetch(`${API_BASE}/content/${collection}/${id}${query}`, {
 		method: "PUT",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(input),
+		body: JSON.stringify(rev ? { ...input, _rev: rev } : input),
 	});
-	const data = await parseApiResponse<{ item: ContentItem }>(response, "Failed to update content");
+	// A conflict means our token is stale; drop it so the editor's refetch
+	// re-arms concurrency checking instead of failing every later save.
+	if (response.status === 409) knownRevs.delete(id);
+	const data = await parseApiResponse<{ item: ContentItem; _rev?: string }>(
+		response,
+		"Failed to update content",
+	);
+	if (data._rev) knownRevs.set(data.item.id, data._rev);
 	return data.item;
 }
 

--- a/packages/admin/tests/lib/content-rev-echo.test.ts
+++ b/packages/admin/tests/lib/content-rev-echo.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+	_clearKnownRevs,
+	_getKnownRev,
+	fetchContent,
+	updateContent,
+} from "../../src/lib/api/content";
+
+const ITEM = {
+	id: "content-1",
+	type: "pages",
+	slug: "home",
+	status: "draft",
+	locale: "en",
+	translationGroup: null,
+	data: { title: "Hello" },
+	authorId: null,
+	primaryBylineId: null,
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-02T00:00:00Z",
+	publishedAt: null,
+	scheduledAt: null,
+	liveRevisionId: null,
+	draftRevisionId: "rev-9",
+};
+
+function jsonResponse(data: unknown, status = 200): Response {
+	return new Response(JSON.stringify({ data }), { status });
+}
+
+describe("admin content client _rev echo (#2121)", () => {
+	let fetchSpy: ReturnType<typeof vi.fn>;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		_clearKnownRevs();
+		fetchSpy = vi.fn();
+		globalThis.fetch = fetchSpy;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		_clearKnownRevs();
+	});
+
+	it("captures _rev from a GET and echoes it into the next PUT body", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ item: ITEM, _rev: "cmV2LWE=" }));
+		await fetchContent("pages", "content-1");
+		expect(_getKnownRev("content-1")).toBe("cmV2LWE=");
+
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ item: ITEM, _rev: "cmV2LWI=" }));
+		await updateContent("pages", "content-1", { data: { title: "Edited" } });
+
+		const [, init] = fetchSpy.mock.calls[1]!;
+		expect(init.method).toBe("PUT");
+		expect(JSON.parse(init.body)).toEqual({ data: { title: "Edited" }, _rev: "cmV2LWE=" });
+		// The PUT response's fresh token replaces the old one for the next save.
+		expect(_getKnownRev("content-1")).toBe("cmV2LWI=");
+	});
+
+	it("sends no _rev when none is known (backwards-compatible blind write)", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ item: ITEM, _rev: "cmV2LWM=" }));
+		await updateContent("pages", "content-1", { data: { title: "First" } });
+
+		const [, init] = fetchSpy.mock.calls[0]!;
+		expect(JSON.parse(init.body)).toEqual({ data: { title: "First" } });
+	});
+
+	it("drops the stale token on a 409 so a refetch can re-arm", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ item: ITEM, _rev: "cmV2LWQ=" }));
+		await fetchContent("pages", "content-1");
+
+		fetchSpy.mockResolvedValueOnce(
+			new Response(JSON.stringify({ error: { message: "version conflict" } }), { status: 409 }),
+		);
+		await expect(
+			updateContent("pages", "content-1", { data: { title: "Stale edit" } }),
+		).rejects.toThrow();
+		expect(_getKnownRev("content-1")).toBeUndefined();
+
+		// The refetch re-arms concurrency checking for the next save.
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ item: ITEM, _rev: "cmV2LWU=" }));
+		await fetchContent("pages", "content-1");
+		expect(_getKnownRev("content-1")).toBe("cmV2LWU=");
+	});
+
+	it("keeps autosave-style updates concurrency-checked too", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ item: ITEM, _rev: "cmV2LWY=" }));
+		await fetchContent("pages", "content-1");
+
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ item: ITEM, _rev: "cmV2LWc=" }));
+		await updateContent("pages", "content-1", {
+			data: { title: "Autosaved" },
+			skipRevision: true,
+		});
+		const [, init] = fetchSpy.mock.calls[1]!;
+		expect(JSON.parse(init.body)._rev).toBe("cmV2LWY=");
+		expect(JSON.parse(init.body).skipRevision).toBe(true);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The admin editor can silently overwrite a newer draft revision (#2121): its content PUTs never send `_rev`, so the server-side optimistic concurrency check (`validateRev`) never engages — "No `_rev` = blind write". Combined with the stale-read window described in the issue, a reload inside that window shows old content, and saving repoints `draft_revision_id` at a revision built from stale state, orphaning the newer draft.

This implements the issue's first suggested fix at the API-client level, so no caller has to thread tokens around:

- `fetchContent` captures the `_rev` the server already returns alongside `item`
- `updateContent` echoes the latest known token for that id into the PUT body — including `skipRevision` autosaves, so autosave can't stomp a newer draft either — and refreshes the token from the PUT response, keeping sequential saves valid
- on a **409** the stale token is dropped, so the editor's refetch re-arms the check instead of failing every later save
- a save with no known token (no prior read in this session) keeps today's blind-write behavior, per the server's backwards-compatibility rule

The issue's second suggestion (atomic draft hydration in `ContentRepository`) is intentionally left for a follow-up — this change makes the stale window harmless (the save is refused) rather than closing the window itself.

Closes #2121

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (for the changed files — `pnpm lint` currently fails on my machine in `packages/registry-verification/src/records.ts`, which fails identically on a clean `main` checkout)
- [x] `pnpm test` passes (targeted: `packages/admin tests/lib/content-rev-echo.test.ts`, 4/4 in the browser-mode harness)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no UI strings)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`@emdash-cms/admin` patch)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Tests

`packages/admin/tests/lib/content-rev-echo.test.ts`:
- GET captures `_rev`; the next PUT body carries it; the PUT response's fresh token replaces it
- no known token → PUT body unchanged (backwards-compatible)
- 409 drops the stale token; a refetch re-arms
- autosave-style (`skipRevision`) updates carry the token too