### PR TITLE
fix(aggregator): wrap syncGetRecord errors in the CORS + no-store envelope

### DIFF
--- a/apps/aggregator/src/routes/xrpc/router.ts
+++ b/apps/aggregator/src/routes/xrpc/router.ts
@@ -128,9 +128,6 @@ export async function handleXrpc(env: Env, request: Request): Promise<Response |
 		try {
 			response = await syncGetRecord(env, request);
 		} catch (err) {
-			// The success path serves a cacheable 200; an unexpected throw (e.g. a
-			// D1 error fetching the CAR blob) must fail closed with `no-store` so
-			// the error never inherits that public cache header.
 			return wrapDispatchError(err, "sync.getRecord");
 		}
 		const headers = new Headers(response.headers);

--- a/apps/aggregator/src/routes/xrpc/router.ts
+++ b/apps/aggregator/src/routes/xrpc/router.ts
@@ -76,18 +76,34 @@ function applyCorsHeaders(headers: Headers): void {
 }
 
 /**
- * Generic 500 for an unexpected pre-dispatch failure (e.g. a D1 error resolving
- * the labeler policy). Logs the internal error for operators but returns the
- * router's own opaque envelope, so no internal detail (SQL text, stack) reaches
- * the client. Matches the body the router itself produces for a handler throw.
+ * Generic 500 for an unexpected failure (e.g. a D1 error). Logs the internal
+ * error under `context` for operators but returns the router's own opaque
+ * envelope, so no internal detail (SQL text, stack) reaches the client.
+ * Matches the body the router itself produces for a handler throw.
  */
-function internalErrorResponse(err: unknown): Response {
-	console.error("[aggregator] xrpc policy resolution failed", {
+function internalErrorResponse(err: unknown, context: string): Response {
+	console.error(`[aggregator] xrpc ${context} failed`, {
 		error: err instanceof Error ? (err.stack ?? err.message) : String(err),
 	});
 	return new InternalServerError({
 		message: "an exception happened whilst processing this request",
 	}).toResponse();
+}
+
+/**
+ * Wrap an unexpected dispatch failure as an error Response carrying CORS +
+ * `no-store`. An unwrapped throw escapes to workerd's bare 500, dropping both
+ * — and on the cacheable `sync.getRecord` path it would leave a takedown-
+ * relevant error under a public cache header. `XRPCError` keeps its typed
+ * envelope (e.g. a malformed accept-labelers header); anything else is opaque.
+ */
+function wrapDispatchError(err: unknown, context: string): Response {
+	const errorResponse =
+		err instanceof XRPCError ? err.toResponse() : internalErrorResponse(err, context);
+	const headers = new Headers(errorResponse.headers);
+	headers.set("cache-control", NO_STORE);
+	applyCorsHeaders(headers);
+	return new Response(errorResponse.body, { status: errorResponse.status, headers });
 }
 
 /**
@@ -108,7 +124,15 @@ export async function handleXrpc(env: Env, request: Request): Promise<Response |
 	}
 
 	if (url.pathname === SYNC_GET_RECORD_PATH) {
-		const response = await syncGetRecord(env, request);
+		let response: Response;
+		try {
+			response = await syncGetRecord(env, request);
+		} catch (err) {
+			// The success path serves a cacheable 200; an unexpected throw (e.g. a
+			// D1 error fetching the CAR blob) must fail closed with `no-store` so
+			// the error never inherits that public cache header.
+			return wrapDispatchError(err, "sync.getRecord");
+		}
 		const headers = new Headers(response.headers);
 		applyCorsHeaders(headers);
 		return new Response(response.body, {
@@ -128,15 +152,7 @@ export async function handleXrpc(env: Env, request: Request): Promise<Response |
 	try {
 		policy = await resolveRequestLabelerPolicy(env, request);
 	} catch (err) {
-		// Both branches take the same wrapper as a normal response so the
-		// CORS + `no-store` cache invariant holds on the error path too — an
-		// unwrapped throw would escape to workerd's bare 500, dropping both
-		// and leaving a takedown-relevant response cacheable.
-		const errorResponse = err instanceof XRPCError ? err.toResponse() : internalErrorResponse(err);
-		const headers = new Headers(errorResponse.headers);
-		headers.set("cache-control", NO_STORE);
-		applyCorsHeaders(headers);
-		return new Response(errorResponse.body, { status: errorResponse.status, headers });
+		return wrapDispatchError(err, "policy resolution");
 	}
 
 	const router = getRouter(env);

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -1293,6 +1293,44 @@ describe("XRPC dispatcher — unexpected policy-resolution failure", () => {
 	});
 });
 
+describe("sync.getRecord — unexpected blob-fetch failure", () => {
+	// A D1 error inside the CAR passthrough (here: `publishers` is gone) must
+	// take the CORS + `no-store` wrapper rather than escape to workerd's bare
+	// 500 — and must NOT inherit the cacheable success header. Capture the
+	// table's schema so the shared beforeEach (`DELETE FROM publishers`) keeps
+	// working after a test drops it.
+	let publishersSchema: string;
+	beforeAll(async () => {
+		const row = await testEnv.DB.prepare(
+			"SELECT sql FROM sqlite_master WHERE type='table' AND name='publishers'",
+		).first<{ sql: string }>();
+		publishersSchema = row!.sql;
+	});
+	afterEach(async () => {
+		const exists = await testEnv.DB.prepare(
+			"SELECT 1 FROM sqlite_master WHERE type='table' AND name='publishers'",
+		).first();
+		if (!exists) await testEnv.DB.prepare(publishersSchema).run();
+	});
+
+	it("wraps a D1 failure in a 500 carrying CORS + no-store and no leaked internals", async () => {
+		// The publisher-profile blob read runs `SELECT record_blob FROM publishers`;
+		// dropping the table makes that throw a non-XRPC D1 error.
+		await testEnv.DB.prepare("DROP TABLE publishers").run();
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/com.atproto.sync.getRecord?did=${DID_A}&collection=${NSID.publisherProfile}&rkey=self`,
+		);
+		expect(res.status).toBe(500);
+		expect(res.headers.get("cache-control")).toBe("private, no-store");
+		expect(res.headers.get("access-control-allow-origin")).toBe("*");
+		const body = (await res.json()) as { error: string; message?: string };
+		expect(body.error).toBe("InternalServerError");
+		// No internal detail (SQL text, table name, stack) leaks to the client.
+		expect(JSON.stringify(body)).not.toMatch(/publishers|no such table|SQL|SELECT/i);
+	});
+});
+
 describe("getPublisherVerification", () => {
 	it("returns the verification claims naming a DID as subject, newest first", async () => {
 		await seedVerification({


### PR DESCRIPTION
## What does this PR do?

Closes a pre-existing error-handling gap in the aggregator that the review of #2117 surfaced but scoped out. In `apps/aggregator/src/routes/xrpc/router.ts`, the `syncGetRecord` branch had no try/catch, so an unexpected throw (e.g. a D1 failure in `fetchRecordBlob` → `selectBlob`) escaped `handleXrpc` and the Worker `fetch` handler unwrapped — hitting workerd's bare 500 with no CORS and no cache headers, violating the endpoint's response invariant the way #2117 fixed for the policy-resolution path.

The subtlety vs #2117: `syncGetRecord` serves immutable record bytes with a cacheable `public, max-age=300` 200. So an error must **not** be cacheable — an unexpected throw now returns an opaque 500 carrying CORS + `private, no-store` (never the cacheable header), with the internal detail logged and no `error.message`/SQL/stack leaked. The success 200 keeps its cacheable header; 404/not-found semantics (returned as JSON inside `syncGetRecord`, never thrown) are unaffected.

To keep the two error paths from drifting, this extracts #2117's inlined no-store+CORS wrapper into a shared `wrapDispatchError(err, context)` (reusing the existing `internalErrorResponse` rather than duplicating it) and threads a `context` string so operator logs read `xrpc sync.getRecord failed` vs `xrpc policy resolution failed` instead of misattributing a blob error to policy resolution. The policy path's behavior is identical; only its log string is parameterized.

Targets the `feat/plugin-registry-labelling-service` integration branch. Part of #1909; a follow-up to #2117.

## Type of change

- [x] Bug fix
- [ ] Feature (requires a Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (aggregator: clean)
- [x] `pnpm lint` passes (0 diagnostics)
- [x] `pnpm test` passes (aggregator: 342 passed / 17 files) — TDD: the new test drops a table to force a D1 error and asserts a 500 with `private, no-store` + CORS + no leaked internals; it fails pre-fix with the bare `D1_ERROR` escaping `SELF.fetch`. The existing success test covers the 200 + `public, max-age=300` path.
- [x] `pnpm format` has been run
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server-side.
- [x] I have added a changeset (if this PR changes a published package) — **n/a**: `@emdash-cms/aggregator` is private.
- [x] New features link to an approved Discussion — **n/a**: bug fix; umbrella #1909 tracks RFC #694.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation), orchestrated/reviewed by **Claude Opus 4.8**

## Screenshots / test output

```
aggregator: 342 passed (17 files)
pre-fix repro: D1_ERROR: no such table: publishers thrown from SELF.fetch
               (selectBlob → syncGetRecord → handleXrpc → Object.fetch), request rejected instead of wrapped
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-aggregator-syncgetrecord-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/aggregator-syncgetrecord`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
