### PR TITLE
fix(labeler): keep assessment-pending live until the last concurrent run resolves (held review finding #13)

### DIFF
--- a/apps/labeler/src/assessment-orchestrator.ts
+++ b/apps/labeler/src/assessment-orchestrator.ts
@@ -32,6 +32,7 @@ import type { ModerationPolicy } from "./policy.js";
 import {
 	buildIssuanceStatements,
 	markPublicationAccepted,
+	readIssuedLabelByActionKey,
 	type AutomatedIssuanceAction,
 	type AutomatedLabelProposal,
 	type IssuedLabel,
@@ -347,8 +348,40 @@ export class AssessmentOrchestrator {
 		if (toState === "error") {
 			await issue("assessment-error", false);
 		}
-		// Spec §9.9 point 9: always negate this run's own assessment-pending.
-		await issue("assessment-pending", true);
+		// Spec §9.9 point 9: negate this run's own assessment-pending — but only when
+		// this is the last run in flight for the subject. `requireNoOtherActiveRun`
+		// no-ops the negation while a sibling run for the same (uri, cid) is still
+		// non-terminal, so the positive assessment-pending stays the stream head and
+		// the release stays gated; the last run to finalize clears it.
+		const pendingNegationKey = automatedIdempotencyKey(
+			assessment.runKey,
+			"assessment-pending",
+			true,
+		);
+		const pendingNegation = await buildIssuanceStatements(
+			this.db,
+			this.config,
+			this.signer,
+			{
+				actor: this.config.labelerDid,
+				type: "automated-assessment",
+				assessmentId: assessment.id,
+				reason: `assessment ${toState}`,
+				idempotencyKey: pendingNegationKey,
+			},
+			{ uri: assessment.uri, cid: assessment.cid, val: "assessment-pending", neg: true },
+			now,
+			this.publisher !== undefined,
+			{
+				requireAssessmentState: toState,
+				requireNoOtherActiveRun: {
+					uri: assessment.uri,
+					cid: assessment.cid,
+					assessmentId: assessment.id,
+				},
+			},
+		);
+		statements.push(...pendingNegation.statements);
 
 		// Spec §9.9 point 8 / §10: negate prior active automated labels this
 		// outcome no longer supports.
@@ -424,6 +457,12 @@ export class AssessmentOrchestrator {
 		}
 		const issued: IssuedLabel[] = [];
 		for (const postCommit of postCommits) issued.push(await postCommit());
+		// The pending negation is suppressed (writes no row) while a sibling run is
+		// still in flight; broadcast it only when it committed. It is the only label
+		// here that can legitimately be absent after the CAS succeeded — the CAS shares
+		// its signing guard — so its absence needs no signing diagnosis.
+		const pendingNegated = await readIssuedLabelByActionKey(this.db, pendingNegationKey);
+		if (pendingNegated) issued.push(pendingNegated);
 		await this.publishLabels(issued);
 
 		const finalised = await getAssessment(this.db, assessment.id);

--- a/apps/labeler/src/assessment-store.ts
+++ b/apps/labeler/src/assessment-store.ts
@@ -387,25 +387,14 @@ export async function listNonTerminalAssessmentsForUri(
 	return (rows.results ?? []).map(rowToAssessment);
 }
 
-/** States a run can be in and still carry a live, un-negated positive
- * `assessment-pending`: every non-terminal state, plus terminal `stale` (which,
- * unlike the other terminals, does not negate its own pending on transition).
- * `cancelled` is excluded — the delete negates before cancelling; the decision
- * outcomes negate their own pending at finalization. */
-const PENDING_BEARING_STATES: readonly AssessmentState[] = [
-	"observed",
-	"verifying",
-	"pending",
-	"running",
-	"stale",
-];
-
 /**
- * Runs for a URI that could still carry a live positive `assessment-pending`
- * label — the delete cleanup's scan set (spec §9.1). Widens
- * `listNonTerminalAssessmentsForUri` to include terminal `stale` runs: a run that
- * self-transitioned to `stale` on detecting a deleted/superseded subject keeps
- * its committed positive, so the delete must still reach it to negate.
+ * Runs for a URI the delete cleanup must reach (spec §9.1): every non-terminal
+ * run (to cancel it and negate any pending it issued) plus any run — of ANY state,
+ * terminal included — still holding a committed, un-negated positive
+ * `assessment-pending`. A run that self-stales on a deleted/superseded subject, or
+ * a decision run that suppressed its own pending-negation while a sibling was still
+ * in flight (`requireNoOtherActiveRun`), stays terminal yet keeps its positive, so
+ * its state alone does not identify it — the label stream does.
  */
 export async function listPendingBearingAssessmentsForUri(
 	db: D1Database,
@@ -416,10 +405,19 @@ export async function listPendingBearingAssessmentsForUri(
 			`SELECT id, run_key, uri, cid, artifact_id, artifact_checksum, state, trigger, trigger_id,
 			 policy_version, model_id, prompt_hash, public_summary, coverage_json,
 			 supersedes_assessment_id, started_at, completed_at, created_at
-			 FROM assessments
-			 WHERE uri = ? AND state IN (${PENDING_BEARING_STATES.map(() => "?").join(", ")})`,
+			 FROM assessments a
+			 WHERE a.uri = ?
+			   AND (
+				 a.state NOT IN (${Array.from(TERMINAL_STATES, () => "?").join(", ")})
+				 OR (
+				   EXISTS (SELECT 1 FROM issued_labels l JOIN issuance_actions act ON act.id = l.action_id
+				           WHERE act.assessment_id = a.id AND l.val = 'assessment-pending' AND l.neg = 0)
+				   AND NOT EXISTS (SELECT 1 FROM issued_labels l JOIN issuance_actions act ON act.id = l.action_id
+				           WHERE act.assessment_id = a.id AND l.val = 'assessment-pending' AND l.neg = 1)
+				 )
+			   )`,
 		)
-		.bind(uri, ...PENDING_BEARING_STATES)
+		.bind(uri, ...TERMINAL_STATES)
 		.all<AssessmentRow>();
 	return (rows.results ?? []).map(rowToAssessment);
 }

--- a/apps/labeler/src/discovery-consumer.ts
+++ b/apps/labeler/src/discovery-consumer.ts
@@ -45,6 +45,7 @@ import {
 	automatedIdempotencyKey,
 	computeRunKey,
 	initialTriggerId,
+	TERMINAL_STATES,
 } from "./assessment-lifecycle.js";
 import {
 	buildAssessmentRunStatement,
@@ -596,22 +597,23 @@ async function transitionOrObserve(
 
 /**
  * Tombstones the subject (advancing its `delete_generation`) and retires every
- * run that could still carry a live positive `assessment-pending` — including
- * terminal `stale` runs, which self-transition on detecting a deleted subject and
- * do NOT negate their own pending. For each such run the negation is issued
- * BEFORE any cancellation, so a failed or paused negation (signing mid-rotation)
- * leaves a non-terminal run non-terminal and re-discoverable on redelivery;
- * cancelling first would drop it from the scan set, stranding the pending live
- * once the message acks.
+ * run that could still carry a live positive `assessment-pending` — including any
+ * terminal run still holding a committed, un-negated positive (a `stale` run that
+ * self-transitioned on a deleted/superseded subject, or a decision run that
+ * suppressed its own pending-negation while a sibling was in flight). For each such
+ * run the negation is issued BEFORE any cancellation, so a failed or paused
+ * negation (signing mid-rotation) leaves a non-terminal run non-terminal and
+ * re-discoverable on redelivery; cancelling first would drop it from the scan set,
+ * stranding the pending live once the message acks.
  *
  * The negation is keyed on the run having committed a live positive — NOT on its
  * lifecycle state — because an operator rerun issues its positive while the run is
- * still `observed`, and a stale run keeps its positive after going terminal.
- * Cancellation applies only to non-terminal runs (a stale run is already
- * terminal). The invariant: a run is cancelled only after any positive it
- * committed has been negated, and the message cannot ack while a negation is still
- * owed (a throw propagates to the delete handler's mutation-phase catch, which
- * always retries), so no active `assessment-pending` survives an acked delete.
+ * still `observed`, and a terminal run keeps its positive after finalizing.
+ * Cancellation applies only to non-terminal runs (a terminal run needs none). The
+ * invariant: a run is cancelled only after any positive it committed has been
+ * negated, and the message cannot ack while a negation is still owed (a throw
+ * propagates to the delete handler's mutation-phase catch, which always retries),
+ * so no active `assessment-pending` survives an acked delete.
  */
 async function applyDiscoveryDelete(
 	deps: DiscoveryConsumerDeps,
@@ -634,7 +636,7 @@ async function applyDiscoveryDelete(
 			);
 			if (!negated) await negateRunPendingLabel(deps, run, now);
 		}
-		if (run.state === "stale") continue; // already terminal — negated, nothing to cancel
+		if (TERMINAL_STATES.has(run.state)) continue; // already terminal — negated, nothing to cancel
 		try {
 			await transitionAssessmentState(deps.db, {
 				id: run.id,

--- a/apps/labeler/src/service.ts
+++ b/apps/labeler/src/service.ts
@@ -1,6 +1,6 @@
 import type { LabelSigner, SignedLabel } from "@emdash-cms/registry-moderation";
 
-import { ASSESSMENT_ID, type AssessmentState } from "./assessment-lifecycle.js";
+import { ASSESSMENT_ID, TERMINAL_STATES, type AssessmentState } from "./assessment-lifecycle.js";
 import { getNegatableAutomatedLabels } from "./assessment-store.js";
 import type { LabelerConfig } from "./config.js";
 import type { FindingSeverity } from "./evidence.js";
@@ -132,6 +132,18 @@ export interface BuildIssuanceOptions {
 	 * action (not the label) leaves no orphan label, same as the state guard.
 	 */
 	requireSubjectNotDeleted?: { uri: string; cid: string; generation: number };
+	/**
+	 * Gate the action insert (and thus its label) on NO OTHER assessment run for the
+	 * same subject `(uri, cid)` being non-terminal at commit time. Finalization pairs
+	 * this with `requireAssessmentState` on the `assessment-pending` negation so the
+	 * shared pending gate clears only when the LAST run resolves: while any sibling
+	 * run is still in flight, this run's negation no-ops and the positive
+	 * `assessment-pending` stays the stream head, holding the release gated.
+	 * `assessmentId` excludes this run itself from the sibling scan (by id), so
+	 * self-exclusion holds regardless of batch ordering; siblings are read as their
+	 * committed terminal state. Requires an automated-assessment action.
+	 */
+	requireNoOtherActiveRun?: { uri: string; cid: string; assessmentId: string };
 }
 
 /**
@@ -232,6 +244,15 @@ export async function buildIssuanceStatements(
 			? ""
 			: `\n\t\t\t\t AND EXISTS (SELECT 1 FROM subjects
 				 WHERE uri = ? AND cid = ? AND deleted_at IS NULL AND delete_generation = ?)`;
+	const requireNoOtherActiveRun = options.requireNoOtherActiveRun;
+	if (requireNoOtherActiveRun !== undefined && action.type !== "automated-assessment")
+		throw new TypeError("requireNoOtherActiveRun requires an automated-assessment action");
+	const activeRunGuardSql =
+		requireNoOtherActiveRun === undefined
+			? ""
+			: `\n\t\t\t\t AND NOT EXISTS (SELECT 1 FROM assessments
+				 WHERE uri = ? AND cid = ? AND id != ?
+				   AND state NOT IN (${Array.from(TERMINAL_STATES, () => "?").join(", ")}))`;
 	const actionBinds: unknown[] = [
 		action.actor,
 		action.type,
@@ -253,6 +274,13 @@ export async function buildIssuanceStatements(
 	if (requireState !== undefined) actionBinds.push(assessmentId, requireState);
 	if (requireSubject !== undefined)
 		actionBinds.push(requireSubject.uri, requireSubject.cid, requireSubject.generation);
+	if (requireNoOtherActiveRun !== undefined)
+		actionBinds.push(
+			requireNoOtherActiveRun.uri,
+			requireNoOtherActiveRun.cid,
+			requireNoOtherActiveRun.assessmentId,
+			...TERMINAL_STATES,
+		);
 
 	const statements: D1PreparedStatement[] = [
 		db
@@ -277,7 +305,7 @@ export async function buildIssuanceStatements(
 						  )
 						  AND l2.neg = 0 AND a2.type <> 'automated-assessment'
 					)
-				 )${stateGuardSql}${subjectGuardSql}
+				 )${stateGuardSql}${subjectGuardSql}${activeRunGuardSql}
 				 ON CONFLICT(idempotency_key) DO NOTHING`,
 			)
 			.bind(...actionBinds),

--- a/apps/labeler/test/assessment-orchestrator.test.ts
+++ b/apps/labeler/test/assessment-orchestrator.test.ts
@@ -12,7 +12,12 @@ import {
 	type AcquisitionHolder,
 	type AcquisitionTarget,
 } from "../src/artifact-acquisition.js";
-import { computeRunKey, initialTriggerId, operatorTriggerId } from "../src/assessment-lifecycle.js";
+import {
+	automatedIdempotencyKey,
+	computeRunKey,
+	initialTriggerId,
+	operatorTriggerId,
+} from "../src/assessment-lifecycle.js";
 import {
 	AssessmentFinalizationConflictError,
 	AssessmentOrchestrator,
@@ -26,6 +31,7 @@ import {
 	createAssessmentRun,
 	createSubject,
 	deleteSubject,
+	getActiveLabelState,
 	getAssessment,
 	getCurrentAssessment,
 	transitionAssessmentState,
@@ -33,7 +39,12 @@ import {
 import { FindingValidationError, HISTORY_FINDING_CATEGORIES } from "../src/findings.js";
 import { analyzeHistory } from "../src/history-context.js";
 import { MODERATION_POLICY } from "../src/policy.js";
-import { issueManualLabel, type IssuedLabel } from "../src/service.js";
+import {
+	issueAutomatedAssessmentLabel,
+	issueManualLabel,
+	readIssuedLabelByActionKey,
+	type IssuedLabel,
+} from "../src/service.js";
 import {
 	abortRoutineKeyRotation,
 	beginRoutineKeyRotation,
@@ -1385,5 +1396,83 @@ describe("AssessmentOrchestrator: delete racing finalization (Blocker 1)", () =>
 			.bind(run.id)
 			.first<{ n: number }>();
 		expect(labelsAfter?.n).toBe(0);
+	});
+});
+
+/** Issues a run's initial positive `assessment-pending`, the way the discovery
+ * consumer does, so the subject carries a live pending gate before a run finalizes. */
+async function issuePendingPositive(run: {
+	id: string;
+	uri: string;
+	cid: string;
+	runKey: string;
+}): Promise<void> {
+	await issueAutomatedAssessmentLabel(
+		testEnv.DB,
+		config,
+		await signer(),
+		{
+			actor: LABELER_DID,
+			type: "automated-assessment",
+			assessmentId: run.id,
+			reason: "initial discovery",
+			idempotencyKey: automatedIdempotencyKey(run.runKey, "assessment-pending", false),
+		},
+		{ uri: run.uri, cid: run.cid, val: "assessment-pending" },
+	);
+}
+
+describe("AssessmentOrchestrator: concurrent runs share one pending gate", () => {
+	it("keeps assessment-pending live while a sibling run for the same subject is in flight, clearing it only when the last run finalizes", async () => {
+		const cidValue = await cid("shared-pending");
+		const runA = await pendingRun({
+			name: "shared-pending",
+			cidValue,
+			triggerId: initialTriggerId(cidValue),
+		});
+		const runB = await pendingRun({
+			name: "shared-pending",
+			cidValue,
+			triggerId: operatorTriggerId("op-shared-pending"),
+		});
+		await issuePendingPositive(runA);
+		await issuePendingPositive(runB);
+
+		const orchestrator = await buildOrchestrator();
+
+		// A finalizes while B is still `pending`. Its own pending-negation is
+		// suppressed, so the gate B also depends on stays live.
+		const a = await orchestrator.runAssessment(runA.id);
+		expect(a.state).toBe("passed");
+
+		const aNegation = await readIssuedLabelByActionKey(
+			testEnv.DB,
+			automatedIdempotencyKey(runA.runKey, "assessment-pending", true),
+		);
+		expect(aNegation).toBeNull();
+
+		const gateWhileBActive = await getActiveLabelState(testEnv.DB, {
+			src: LABELER_DID,
+			uri: runA.uri,
+			cid: cidValue,
+		});
+		expect(gateWhileBActive.get("assessment-pending")?.active).toBe(true);
+
+		// B is the last run in flight; finalizing it clears the shared gate.
+		const b = await orchestrator.runAssessment(runB.id);
+		expect(b.state).toBe("passed");
+
+		const bNegation = await readIssuedLabelByActionKey(
+			testEnv.DB,
+			automatedIdempotencyKey(runB.runKey, "assessment-pending", true),
+		);
+		expect(bNegation).not.toBeNull();
+
+		const gateAfterLast = await getActiveLabelState(testEnv.DB, {
+			src: LABELER_DID,
+			uri: runB.uri,
+			cid: cidValue,
+		});
+		expect(gateAfterLast.get("assessment-pending")?.active).toBe(false);
 	});
 });

--- a/apps/labeler/test/discovery-consumer.test.ts
+++ b/apps/labeler/test/discovery-consumer.test.ts
@@ -900,6 +900,45 @@ describe("processDiscoveryMessage: delete", () => {
 		expect((await latestPending())?.neg).toBe(1);
 	});
 
+	it("negates a live pending positive still held by a terminal decision run on delete", async () => {
+		const job = await jobFor({ rkey: rkey() });
+		const deps = await buildDeps();
+		await processDiscoveryMessage(job, new FakeMessage(), { ...deps, verify: verifiedFor(job) });
+		const runKey = await runKeyFor(job);
+		const run = await getAssessmentByRunKey(testEnv.DB, runKey);
+
+		// A finalization that suppressed its own pending-negation (a sibling run was
+		// still in flight) leaves a terminal `passed` run that still holds a live
+		// positive assessment-pending — the orchestrator produces exactly this state.
+		await testEnv.DB.prepare(
+			`UPDATE assessments SET state = 'passed', completed_at = ?, completed_at_epoch_ms = ? WHERE id = ?`,
+		)
+			.bind(new Date().toISOString(), Date.now(), run!.id)
+			.run();
+
+		const latestPending = () =>
+			testEnv.DB.prepare(
+				`SELECT neg FROM issued_labels WHERE uri = ? AND val = 'assessment-pending'
+				 ORDER BY sequence DESC LIMIT 1`,
+			)
+				.bind(uriFor(job))
+				.first<{ neg: number }>();
+		expect((await latestPending())?.neg).toBe(0);
+
+		const deleteJob: DiscoveryJob = { ...job, operation: "delete", cid: "" };
+		const msg = new FakeMessage();
+		await processDiscoveryMessage(deleteJob, msg, {
+			...deps,
+			confirmDeleted: () => Promise.resolve(true),
+		});
+
+		expect(msg.acked).toBe(1);
+		expect(msg.retried).toBe(0);
+		// The delete cleanup reaches the terminal run's un-negated positive and clears
+		// it, so no active assessment-pending survives the delete.
+		expect((await latestPending())?.neg).toBe(1);
+	});
+
 	it("dead-letters a forged/premature delete whose record still resolves, suppressing nothing", async () => {
 		const job = await jobFor({ rkey: rkey() });
 		const deps = await buildDeps();


### PR DESCRIPTION
## What does this PR do?

Closes held finding #13 from the adversarial review of the labeler (RFC #694, umbrella #1909) — parked during the earlier fix PRs, now addressed off the merged tip. TDD'd and independently adversary-reviewed (PASS, no #2115 regression). Targets the `feat/plugin-registry-labelling-service` integration branch.

**The race.** `assessment-pending` is a real atproto label whose subject state is the highest-`sequence` op per `(src,uri,val)`. Concurrent assessment runs for the same `(uri,cid)` (different run keys → separate Workflow instances, by design so an operator rerun mints a fresh run) each issue their own positive/negation, but all target the same `val` — so **any** run's negation becomes the stream head and clears the gate for the whole subject. If run A finalizes `passed` while run B is still active, A's negation clears the pending gate, briefly flipping the release from `pending` to eligible (exposing A's stale pass) until B finalizes and re-blocks.

**The fix — a pending projection via last-run-clears.** The `assessment-pending` negation is now gated, in the same `db.batch`, on *no other non-terminal run existing for the same `(uri,cid)`* (a new `requireNoOtherActiveRun` guard on `buildIssuanceStatements`, alongside the existing signing / `requireAssessmentState` / subject-not-deleted guards). D1 serializes batch transactions and each run's `running→terminal` CAS commits in the same batch, so the *last* run to resolve is the only one that sees no non-terminal sibling and negates — the gate clears exactly once, when the last run finishes. Self-exclusion is by run id, so it holds regardless of batch ordering. Keyed on `(uri,cid)`, so distinct CID versions never entangle. Serialization was rejected in favor of the projection because it would regress the deliberate rerun-mints-a-fresh-run semantics.

Because a run can now finalize `passed`/`blocked` while still holding a live positive (its own negation suppressed), the delete cleanup's pending scan (`listPendingBearingAssessmentsForUri`) is made **label-driven** — it now negates any run of any state that holds a committed, un-negated positive, plus all non-terminal runs — so the #2115 delete-vs-issuance closure is preserved (the adversary confirmed it's a strict superset of the old state-based scan). The cleanup's cancel-skip widens from `state==="stale"` to all terminal states (a terminal run is negated but not fed an illegal `→cancelled` transition).

**Known follow-up (deferred, not a regression):** the pure CID-supersession case — a run self-`stale`d because its CID was superseded (no delete event) — leaves an old-CID positive that this fix doesn't negate. Negating it would clobber the *new* CID's legitimate pending (the negation would be the CID-mismatched stream head). Both real consumers (enforcement and `getActiveLabelState`) are CID-scoped, and the new-CID run's own pending is the stream winner, so the lingering old-CID positive is a stale audit signal on a superseded CID, not a false-eligibility signal. Tracked as a CID-aware pending-reduction follow-up if the audit-view wart matters.

## Type of change

- [x] Bug fix
- [ ] Feature (requires a Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all three labeler projects)
- [x] `pnpm lint` passes (0 diagnostics)
- [x] `pnpm test` passes (labeler: 904 + 136 + 39) — TDD: the pending-gate test asserts A's negation is suppressed while a sibling is active (fails pre-fix, where finalize unconditionally negated); the delete test asserts a terminal decision run's live positive is negated on delete (fails pre-fix, where the state-based scan excluded `passed`)
- [x] `pnpm format` has been run
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**: server-side.
- [x] I have added a changeset (if this PR changes a published package) — **n/a**: `@emdash-cms/labeler` is private.
- [x] New features link to an approved Discussion — **n/a**: bug fix; umbrella #1909 tracks RFC #694.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (implementation + independent adversarial review), orchestrated by **Claude Opus 4.8**

## Screenshots / test output

```
labeler: 904 (workerd) + 136 (console) + 39 (calibration) passed
adversary: PASS — no stranding/both-skip; label-driven scan is a strict superset (no #2115 regression); read-back can't drop a signing-paused negation; supersession deferral verified CID-safe
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-labeler-sol-13-concurrency-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/labeler-sol-13-concurrency`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
