### PR TITLE
chore: rename EmDash bot Worker

### DIFF
--- a/infra/emdash-bot/wrangler.jsonc
+++ b/infra/emdash-bot/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "emdash-bot",
+	"name": "flue-cloudflare-agent",
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-07-17",
 	"compatibility_flags": ["nodejs_compat"],


### PR DESCRIPTION
## What does this PR do?

Renames the deployed Worker from `emdash-bot` to `flue-cloudflare-agent` so it can be linked to the intended Workers Builds project.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: infrastructure configuration only)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (not applicable: no published package changes)
- [x] New features link to an approved Discussion: not applicable, this is a deployment configuration rename

## AI-generated code disclosure

- [x] This PR includes AI-generated code, model/tool: GPT-5.6 Sol

## Screenshots / test output

`pnpm lint:quick` passes. `pnpm --filter @emdash-cms/emdash-bot build` succeeds and emits `dist/flue_cloudflare_agent/wrangler.json`. No test suite was run for the one-line configuration change.