### PR TITLE
ci: accept visual baselines via /accept-baselines comment

### DIFF
--- a/.github/workflows/visual-apply.yml
+++ b/.github/workflows/visual-apply.yml
@@ -19,15 +19,17 @@ permissions:
   actions: read # find + download the measure artifact
   contents: read # app token handles the write/push
   pull-requests: write # comment back with the result
+  issues: write # react to the triggering comment (issues-scoped API)
 
 jobs:
   apply:
     name: Apply
-    # Only on PR comments, from a non-bot with write access, containing the command.
+    # Only on PR comments, from a non-bot with write access. Exact match (as in
+    # format-command.yml) so quoted or suffixed text can't trigger a write.
     if: >-
       github.event.issue.pull_request != null
       && github.event.sender.type != 'Bot'
-      && contains(github.event.comment.body, '/accept-baselines')
+      && github.event.comment.body == '/accept-baselines'
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     concurrency:
       group: visual-apply-${{ github.event.issue.number }}
@@ -36,6 +38,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Acknowledge
+        continue-on-error: true # a missing 👀 must not block the apply
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -56,14 +59,20 @@ jobs:
             });
 
             // Find the measure run (with the candidate artifact) for this head.
+            // The run "fails" red on drift, so match on completion, not
+            // conclusion. listWorkflowRuns returns newest first.
+            const sha7 = pr.head.sha.slice(0, 7);
             const runs = await github.rest.actions.listWorkflowRuns({
               owner, repo, workflow_id: 'visual.yml', head_sha: pr.head.sha, per_page: 20,
             });
-            const run = runs.data.workflow_runs?.[0];
+            const all = runs.data.workflow_runs ?? [];
+            const run = all.find((r) => r.status === 'completed');
             if (!run) {
               await github.rest.issues.createComment({
                 owner, repo, issue_number: number,
-                body: `No \`Visual Regression\` run found for the current head (\`${pr.head.sha.slice(0, 7)}\`). Wait for the measure job to finish (or push a commit to trigger it), then comment \`/accept-baselines\` again.`,
+                body: all.length > 0
+                  ? `The \`Visual Regression\` run for the current head (\`${sha7}\`) is still in progress. Wait for it to finish, then comment \`/accept-baselines\` again.`
+                  : `No \`Visual Regression\` run found for the current head (\`${sha7}\`). Push a commit to trigger it (or wait for the measure job), then comment \`/accept-baselines\` again.`,
               });
               core.setOutput('eligible', 'false');
               return;
@@ -99,7 +108,7 @@ jobs:
             if (!artifact) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner, repo: context.repo.repo, issue_number: number,
-                body: 'The candidate baselines have expired (artifacts are kept 7 days). Push a commit to regenerate them, then comment `/accept-baselines` again.',
+                body: "Couldn't find the candidate-baseline artifact for the completed measure run (it may have expired after 7 days, or the run failed before uploading). Push a commit to regenerate it, then comment `/accept-baselines` again.",
               });
               core.setOutput('found', 'false');
               return;
@@ -256,15 +265,14 @@ jobs:
             });
 
       - name: Report failure
-        if: failure() && steps.validate.outputs.ok == 'true'
+        if: failure()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ steps.resolve.outputs.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: Number(process.env.PR_NUMBER),
-              body: `❌ Failed to commit the accepted baselines. See the [run log](${process.env.RUN_URL}). If this is a fork PR, the contributor may have "Allow edits by maintainers" disabled.`,
+              issue_number: context.issue.number,
+              body: `❌ \`/accept-baselines\` failed. See the [run log](${process.env.RUN_URL}). If this is a fork PR, the contributor may have "Allow edits by maintainers" disabled.`,
             });

--- a/.github/workflows/visual-apply.yml
+++ b/.github/workflows/visual-apply.yml
@@ -1,122 +1,107 @@
 name: Visual Regression — Apply
 
-# Commits accepted visual baselines when a maintainer reacts 👍 to the sticky
-# comment posted by "Visual Regression — Report".
+# Commits accepted visual baselines when a maintainer comments
+# `/accept-baselines` on a PR. The command is the human gate: only users with
+# write access (author association OWNER/MEMBER/COLLABORATOR) can trigger it.
 #
-# GitHub has no "reaction" event, so this polls on a schedule (and can be run
-# on demand via workflow_dispatch). Each run processes at most one eligible PR:
-# it finds the sticky comment, confirms a 👍 from a user with write access,
-# downloads the inert candidate-baseline artifact produced by the measure job,
-# and commits those PNGs to the PR branch. It never executes PR-authored code.
+# It downloads the inert candidate-baseline artifact produced by the measure
+# job for the PR's current head and commits those PNGs to the PR branch. It
+# never checks out or executes PR-authored code.
 #
-# Idempotency:
-#   - The sticky comment carries an `<!-- applied:<sha> -->` marker; a head that
-#     already matches is skipped.
-#   - The measure artifact records has-drift; a green (no-drift) artifact is
-#     skipped, so a re-poll in the window before the comment is cleared is inert.
-#   - After copying candidates, an empty git diff short-circuits the push.
+# Like all issue_comment workflows, this runs from the default branch, so it
+# only takes effect once merged to main.
 
 on:
-  schedule:
-    - cron: "*/10 * * * *"
-  workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 permissions:
   actions: read # find + download the measure artifact
   contents: read # app token handles the write/push
-  pull-requests: write # read reactions, update the sticky comment
+  pull-requests: write # comment back with the result
 
 jobs:
   apply:
     name: Apply
+    # Only on PR comments, from a non-bot with write access, containing the command.
+    if: >-
+      github.event.issue.pull_request != null
+      && github.event.sender.type != 'Bot'
+      && contains(github.event.comment.body, '/accept-baselines')
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    concurrency:
+      group: visual-apply-${{ github.event.issue.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Find an accepted PR
-        id: scan
+      - name: Acknowledge
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const marker = '<!-- visual-regression -->';
-            const { owner, repo } = context.repo;
-            const ALLOWED = new Set(['admin', 'write', 'maintain']);
-
-            const prs = await github.paginate(github.rest.pulls.list, {
-              owner, repo, state: 'open', base: 'main', per_page: 100,
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: context.payload.comment.id, content: 'eyes',
             });
 
-            for (const pr of prs) {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner, repo, issue_number: pr.number, per_page: 100,
+      - name: Resolve PR and measure run
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: number,
+            });
+
+            // Find the measure run (with the candidate artifact) for this head.
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner, repo, workflow_id: 'visual.yml', head_sha: pr.head.sha, per_page: 20,
+            });
+            const run = runs.data.workflow_runs?.[0];
+            if (!run) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: number,
+                body: `No \`Visual Regression\` run found for the current head (\`${pr.head.sha.slice(0, 7)}\`). Wait for the measure job to finish (or push a commit to trigger it), then comment \`/accept-baselines\` again.`,
               });
-              const sticky = comments.find(
-                (c) => typeof c.body === 'string' && c.body.includes(marker),
-              );
-              if (!sticky) continue;
-
-              // Already applied for this head?
-              const applied = sticky.body.match(/<!-- applied:([0-9a-f]{7,40}) -->/);
-              if (applied && applied[1] === pr.head.sha) continue;
-
-              // Authorized 👍?
-              const reactions = await github.paginate(
-                github.rest.reactions.listForIssueComment,
-                { owner, repo, comment_id: sticky.id, per_page: 100 },
-              );
-              let reactor = null;
-              for (const r of reactions.filter((x) => x.content === '+1')) {
-                if (!r.user) continue;
-                try {
-                  const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
-                    owner, repo, username: r.user.login,
-                  });
-                  if (ALLOWED.has(perm.permission)) { reactor = r.user.login; break; }
-                } catch { /* not a collaborator */ }
-              }
-              if (!reactor) continue;
-
-              // Locate the measure run (with the candidate artifact) for this head.
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner, repo, workflow_id: 'visual.yml', head_sha: pr.head.sha, per_page: 20,
-              });
-              const run = runs.data.workflow_runs?.[0];
-              if (!run) continue;
-
-              core.setOutput('eligible', 'true');
-              core.setOutput('number', String(pr.number));
-              core.setOutput('head_sha', pr.head.sha);
-              core.setOutput('ref', pr.head.ref);
-              core.setOutput('full_name', pr.head.repo.full_name);
-              core.setOutput('is_fork', String(
-                pr.head.repo.fork || pr.head.repo.full_name !== `${owner}/${repo}`,
-              ));
-              core.setOutput('comment_id', String(sticky.id));
-              core.setOutput('run_id', String(run.id));
-              core.setOutput('reactor', reactor);
-              core.info(`Eligible: PR #${pr.number} accepted by @${reactor} (run ${run.id}).`);
+              core.setOutput('eligible', 'false');
               return;
             }
-            core.setOutput('eligible', 'false');
-            core.info('No PR with an authorized 👍 awaiting baseline apply.');
+
+            core.setOutput('eligible', 'true');
+            core.setOutput('number', String(number));
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('ref', pr.head.ref);
+            core.setOutput('full_name', pr.head.repo.full_name);
+            core.setOutput('is_fork', String(
+              pr.head.repo.fork || pr.head.repo.full_name !== `${owner}/${repo}`,
+            ));
+            core.setOutput('run_id', String(run.id));
 
       - name: Download candidate baselines
         id: download
-        if: steps.scan.outputs.eligible == 'true'
+        if: steps.resolve.outputs.eligible == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          RUN_ID: ${{ steps.scan.outputs.run_id }}
+          RUN_ID: ${{ steps.resolve.outputs.run_id }}
+          PR_NUMBER: ${{ steps.resolve.outputs.number }}
         with:
           script: |
             const fs = require('node:fs');
             const path = require('node:path');
             const runId = Number(process.env.RUN_ID);
+            const number = Number(process.env.PR_NUMBER);
             const { data } = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner, repo: context.repo.repo, run_id: runId,
             });
             const artifact = data.artifacts.find((a) => a.name === 'visual-regression');
             if (!artifact) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: number,
+                body: 'The candidate baselines have expired (artifacts are kept 7 days). Push a commit to regenerate them, then comment `/accept-baselines` again.',
+              });
               core.setOutput('found', 'false');
-              core.info('Candidate artifact missing or expired (>7d). Push a new commit to regenerate.');
               return;
             }
             const dl = await github.rest.actions.downloadArtifact({
@@ -130,26 +115,45 @@ jobs:
 
       - name: Unpack and validate
         id: validate
-        if: steps.scan.outputs.eligible == 'true' && steps.download.outputs.found == 'true'
+        if: steps.download.outputs.found == 'true'
         env:
-          HEAD_SHA: ${{ steps.scan.outputs.head_sha }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
         run: |
           cd "$RUNNER_TEMP/va"
           unzip -o artifact.zip
           drift=$(cat has-drift 2>/dev/null || echo false)
           measured=$(cat head-sha 2>/dev/null || echo "")
           if [ "$drift" != "true" ]; then
-            echo "Artifact reports no drift — nothing to apply."
+            echo "reason=no_drift" >> "$GITHUB_OUTPUT"
             echo "ok=false" >> "$GITHUB_OUTPUT"
           elif [ "$measured" != "$HEAD_SHA" ]; then
-            echo "Artifact head ($measured) != PR head ($HEAD_SHA) — skipping."
+            echo "reason=head_mismatch" >> "$GITHUB_OUTPUT"
             echo "ok=false" >> "$GITHUB_OUTPUT"
           elif [ -z "$(ls -A candidates 2>/dev/null)" ]; then
-            echo "No candidate baselines in artifact."
+            echo "reason=no_candidates" >> "$GITHUB_OUTPUT"
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Report nothing to apply
+        if: steps.validate.outputs.ok == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.number }}
+          REASON: ${{ steps.validate.outputs.reason }}
+        with:
+          script: |
+            const messages = {
+              no_drift: 'There is no visual drift on the current head, so there are no baselines to accept.',
+              head_mismatch: 'The measured baselines are for an older commit. Wait for the `Visual Regression` run on the current head to finish, then comment `/accept-baselines` again.',
+              no_candidates: 'The measure run produced no candidate baselines (likely an infrastructure failure, not a UI change). Check the `Visual Regression` logs.',
+            };
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: messages[process.env.REASON] || 'Nothing to apply.',
+            });
 
       - name: Generate app token
         id: app-token
@@ -161,19 +165,19 @@ jobs:
           permission-contents: write
 
       - name: Checkout (same-repo)
-        if: steps.validate.outputs.ok == 'true' && steps.scan.outputs.is_fork == 'false'
+        if: steps.validate.outputs.ok == 'true' && steps.resolve.outputs.is_fork == 'false'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.scan.outputs.head_sha }}
+          ref: ${{ steps.resolve.outputs.head_sha }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
       - name: Checkout (fork)
-        if: steps.validate.outputs.ok == 'true' && steps.scan.outputs.is_fork == 'true'
+        if: steps.validate.outputs.ok == 'true' && steps.resolve.outputs.is_fork == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ steps.scan.outputs.full_name }}
-          ref: ${{ steps.scan.outputs.head_sha }}
+          repository: ${{ steps.resolve.outputs.full_name }}
+          ref: ${{ steps.resolve.outputs.head_sha }}
           persist-credentials: false
           # Reviewed opt-in: no code from the fork tree is executed. The steps
           # below only copy inert PNGs from the trusted measure artifact and run
@@ -191,38 +195,37 @@ jobs:
           git add "$dest"
           if git diff --staged --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Baselines already match candidates — nothing to commit."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push (same-repo)
-        if: steps.stage.outputs.changed == 'true' && steps.scan.outputs.is_fork == 'false'
+        if: steps.stage.outputs.changed == 'true' && steps.resolve.outputs.is_fork == 'false'
         env:
-          HEAD_REF: ${{ steps.scan.outputs.ref }}
-          REACTOR: ${{ steps.scan.outputs.reactor }}
+          HEAD_REF: ${{ steps.resolve.outputs.ref }}
+          ACCEPTER: ${{ github.event.comment.user.login }}
         run: |
           set -e
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git commit -m "ci: accept visual baselines (👍 @$REACTOR)"
+          git commit -m "ci: accept visual baselines (requested by @$ACCEPTER)"
           if ! git push origin "HEAD:$HEAD_REF"; then
-            echo "::error::Non-fast-forward push — the PR branch moved. A fresh measure+apply will run for the new head." >&2
+            echo "::error::Non-fast-forward push — the PR branch moved. Wait for the new measure run, then comment /accept-baselines again." >&2
             exit 1
           fi
 
       - name: Commit and push (fork)
-        if: steps.stage.outputs.changed == 'true' && steps.scan.outputs.is_fork == 'true'
+        if: steps.stage.outputs.changed == 'true' && steps.resolve.outputs.is_fork == 'true'
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          HEAD_REF: ${{ steps.scan.outputs.ref }}
-          FULL_NAME: ${{ steps.scan.outputs.full_name }}
-          REACTOR: ${{ steps.scan.outputs.reactor }}
+          HEAD_REF: ${{ steps.resolve.outputs.ref }}
+          FULL_NAME: ${{ steps.resolve.outputs.full_name }}
+          ACCEPTER: ${{ github.event.comment.user.login }}
         run: |
           set -e
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git commit -m "ci: accept visual baselines (👍 @$REACTOR)"
+          git commit -m "ci: accept visual baselines (requested by @$ACCEPTER)"
           export GIT_ASKPASS="$RUNNER_TEMP/git-askpass.sh"
           printf '#!/bin/sh\necho "%s"\n' "$APP_TOKEN" > "$GIT_ASKPASS"
           chmod +x "$GIT_ASKPASS"
@@ -234,30 +237,34 @@ jobs:
           fi
           rm -f "$GIT_ASKPASS"
 
-      - name: Mark comment applied
+      - name: Report result
         if: steps.validate.outputs.ok == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          COMMENT_ID: ${{ steps.scan.outputs.comment_id }}
-          HEAD_SHA: ${{ steps.scan.outputs.head_sha }}
-          REACTOR: ${{ steps.scan.outputs.reactor }}
+          PR_NUMBER: ${{ steps.resolve.outputs.number }}
+          ACCEPTER: ${{ github.event.comment.user.login }}
           CHANGED: ${{ steps.stage.outputs.changed }}
         with:
           script: |
-            const commentId = Number(process.env.COMMENT_ID);
-            const headSha = process.env.HEAD_SHA;
-            const reactor = process.env.REACTOR;
             const changed = process.env.CHANGED === 'true';
-            const { data: comment } = await github.rest.issues.getComment({
-              owner: context.repo.owner, repo: context.repo.repo, comment_id: commentId,
+            const body = changed
+              ? `✅ Baselines accepted by @${process.env.ACCEPTER} and committed to this PR.`
+              : 'ℹ️ The committed baselines already match the candidates; nothing to commit.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER), body,
             });
-            // Strip any prior applied marker, then append the current one so a
-            // re-poll for the same head is skipped.
-            const base = comment.body.replace(/\n*<!-- applied:[0-9a-f]{7,40} -->/g, '');
-            const note = changed
-              ? `\n\n✅ Baselines accepted by @${reactor} and committed to this PR.`
-              : `\n\nℹ️ Baselines already matched the accepted candidates; nothing to commit.`;
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner, repo: context.repo.repo, comment_id: commentId,
-              body: `${base}${note}\n<!-- applied:${headSha} -->`,
+
+      - name: Report failure
+        if: failure() && steps.validate.outputs.ok == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: `❌ Failed to commit the accepted baselines. See the [run log](${process.env.RUN_URL}). If this is a fork PR, the contributor may have "Allow edits by maintainers" disabled.`,
             });

--- a/.github/workflows/visual-report.yml
+++ b/.github/workflows/visual-report.yml
@@ -7,7 +7,7 @@ name: Visual Regression — Report
 # Responsibilities:
 #   - Publish the diff images to the `visual-snapshots` branch so they can be
 #     embedded in a comment (GitHub cannot host comment images via the API).
-#   - Upsert a sticky comment with the diffs and 👍-to-accept instructions.
+#   - Upsert a sticky comment with the diffs and /accept-baselines instructions.
 #   - Delete the sticky comment when a later run shows no drift (resolved).
 
 on:
@@ -236,11 +236,10 @@ jobs:
               ...rows,
               '',
               '---',
-              '**Maintainers:** react 👍 to this comment to accept these baselines. The',
-              '"Visual Regression — Apply" job (every ~10 min, or run it manually via',
-              'workflow_dispatch) will commit the regenerated Linux baselines to this PR.',
+              '**Maintainers:** if every change above is intended, comment `/accept-baselines`',
+              'to commit the regenerated Linux baselines to this PR.',
               '',
-              `<sub>Measured head: \`${headSha}\`. Reacting 👍 accepts the snapshots for this commit.</sub>`,
+              `<sub>Measured head: \`${headSha}\`. \`/accept-baselines\` accepts the snapshots for this commit.</sub>`,
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -6,13 +6,13 @@ name: Visual Regression
 # a read-only token and never comments or pushes. The companion workflows handle
 # that with elevated permissions, isolated from PR-authored code:
 #   - "Visual Regression — Report" (workflow_run) posts the sticky comment.
-#   - "Visual Regression — Apply" (schedule) commits accepted baselines when a
-#     maintainer reacts 👍 to the sticky comment.
+#   - "Visual Regression — Apply" commits accepted baselines when a maintainer
+#     comments /accept-baselines on the PR.
 #
 # Baselines are Linux/chromium PNGs regenerated here on the CI runner, so they
 # always match the environment they're diffed in. Contributors do NOT commit
-# baselines by hand (macOS PNGs would never match); the 👍-accept flow commits
-# the correct Linux baselines for them.
+# baselines by hand (macOS PNGs would never match); the /accept-baselines flow
+# commits the correct Linux baselines for them.
 
 on:
   pull_request:
@@ -97,7 +97,7 @@ jobs:
           fi
 
           # Regenerate the accepted-state baselines (the candidates the Apply
-          # workflow will commit verbatim on 👍). These are Linux/chromium PNGs.
+          # workflow commits verbatim on accept). These are Linux/chromium PNGs.
           pnpm exec playwright test visual-regression --update-snapshots --reporter=line || true
           mkdir -p visual-out/candidates
           if [ -d e2e/tests/visual-regression.spec.ts-snapshots ]; then
@@ -129,5 +129,5 @@ jobs:
       - name: Fail on drift
         if: steps.collect.outputs.has_drift == 'true'
         run: |
-          echo "::error::Visual snapshots changed. Review the diff in the sticky comment; a maintainer 👍 on that comment accepts the new baselines."
+          echo "::error::Visual snapshots changed. Review the diff in the sticky comment; a maintainer comments /accept-baselines to accept the new baselines."
           exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ EMDASH_VISUAL=1 pnpm test:e2e visual-regression
 
 Baselines are platform-specific. **CI (Linux) is the source of truth** -- committed baselines are `*-chromium-linux.png`. Locally generated macOS/Windows baselines (`*-darwin.png`, `*-win32.png`) are gitignored; never commit them, they won't match CI.
 
-When a PR changes how a screen renders, the `Visual Regression` check goes red and a bot posts a sticky comment with the diff images. A maintainer reviews the diffs and, if the change is intended, reacts 👍 to the comment. The `Visual Regression — Apply` job then commits the regenerated Linux baselines to the PR branch. Baselines are never updated automatically on push -- a human must accept each change.
+When a PR changes how a screen renders, the `Visual Regression` check goes red and a bot posts a sticky comment with the diff images. A maintainer reviews the diffs and, if the change is intended, comments `/accept-baselines`. The `Visual Regression — Apply` job then commits the regenerated Linux baselines to the PR branch. Baselines are never updated automatically on push -- a maintainer must accept each change.
 
 ### Building your own site in the monorepo
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2147 (merged). Replaces the reaction-poll apply mechanism with a comment command.

Previously the `Visual Regression — Apply` job ran on a `schedule` (every ~10 min) and scanned every open PR for a 👍 reaction on the sticky comment, because GitHub emits no event for reactions. That meant polling, an all-PR scan, the reactions API, and a per-user `getCollaboratorPermissionLevel` lookup.

Now a maintainer comments `/accept-baselines` on the PR. The `issue_comment` event carries the author association, so the job:

- gates on `OWNER`/`MEMBER`/`COLLABORATOR` (same trusted-command model as `review.yml`), reacting 👀 to acknowledge;
- resolves the PR head and finds the `Visual Regression` measure run for it;
- downloads the inert candidate-baseline artifact and commits the Linux baselines to the PR branch (same-repo and fork paths unchanged);
- posts an explicit result comment for every outcome (accepted, nothing to commit, no drift, stale head, expired artifact, failure).

No poller, no cross-PR scan, no reactions/collaborator API calls. The sticky-comment copy and CONTRIBUTING note now say "comment `/accept-baselines`" instead of "react 👍".

Like the old job (and `review.yml`), `issue_comment` workflows run from the default branch, so this only takes effect on `main`.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes <!-- n/a: no source changes; workflows + docs only -->
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) <!-- n/a: CI/docs only -->
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a: GitHub Actions workflows can only be exercised on the default branch -->
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no admin UI strings -->
- [ ] I have added a changeset (if this PR changes a published package) <!-- n/a: no published package changed -->
- [ ] New features link to an approved Discussion <!-- n/a: not a feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

zizmor reports no findings on the three visual workflows; `pnpm lint:json` is at 0 diagnostics.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://ci-visual-accept-command-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `ci/visual-accept-command`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
