### PR TITLE
fix(emdash-bot): persist agent results and authorize pushes

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -19,13 +19,14 @@ import { cloudflareSandbox } from "@flue/runtime/cloudflare";
 import { env as workerEnv } from "cloudflare:workers";
 import * as v from "valibot";
 
+import { createPushCapability, PUSH_CAPABILITY_HEADER } from "../lib/github-proxy.js";
 import {
 	getBranchSha,
 	mintInstallationToken,
 	readAppCreds,
 	readRepoContext,
 } from "../lib/github.js";
-import type { AgentResult } from "../lib/orchestrator.js";
+import { applyInvestigationResult } from "../lib/investigation-result.js";
 import { withSandboxDeadlines } from "../lib/sandbox-deadline.js";
 import investigateDocument from "../skills/investigate/instructions.md?raw";
 
@@ -94,7 +95,7 @@ export function Investigate({ id }: AgentProps) {
 			const result = failedResult(
 				`I couldn't prepare the investigation sandbox: ${errorMessage(error)}`,
 			);
-			await applyResult(input, result, false, false);
+			await applyInvestigationResult(input, result, false, false);
 			writeResult({ result, ok: false, pushed: false });
 			setReported(true);
 			log.error("sandbox setup failed", { error: errorMessage(error) });
@@ -112,7 +113,9 @@ export function Investigate({ id }: AgentProps) {
 				const pushed = await step.do("detect-push", () =>
 					detectPush(input.issueNumber, input.previousBranchSha),
 				);
-				await step.do("apply-agent-result", () => applyResult(input, data, true, pushed));
+				await step.do("apply-agent-result", () =>
+					applyInvestigationResult(input, data, true, pushed),
+				);
 				const reportedResult = { result: data, ok: true, pushed };
 				writeResult(reportedResult);
 				setReported(true);
@@ -144,7 +147,7 @@ export function Investigate({ id }: AgentProps) {
 		const result = failedResult(
 			"I couldn't complete this run because the agent stopped without reporting a result.",
 		);
-		await applyResult(input, result, false, false);
+		await applyInvestigationResult(input, result, false, false);
 		writeResult({ result, ok: false, pushed: false });
 		setReported(true);
 		log.warn("agent stopped without reporting", { runId: input.runId });
@@ -170,6 +173,10 @@ async function setupSandbox(
 	if (!repo) throw new Error("repository context is not configured");
 	const cloneUrl = `https://github.com/${repo.owner}/${repo.repo}.git`;
 	const branch = input.mode === "revise" ? `bot/fix-${input.issueNumber}` : "main";
+	const pushCapability = await createPushCapability(
+		workerEnv.GITHUB_WEBHOOK_SECRET,
+		input.issueNumber,
+	);
 	const steps: Array<{ name: string; command: string; timeoutMs?: number; nonFatal?: boolean }> = [
 		{
 			name: "git-identity-email",
@@ -191,6 +198,10 @@ async function setupSandbox(
 					name: "checkout-main",
 					command: `cd ${REPO_DIR} && git checkout main && git reset --hard origin/main`,
 				},
+		{
+			name: "git-push-capability",
+			command: `cd ${REPO_DIR} && git config http.https://github.com/.extraHeader '${PUSH_CAPABILITY_HEADER}: ${pushCapability}'`,
+		},
 		{
 			name: "pnpm-install",
 			command: `cd ${REPO_DIR} && pnpm install --frozen-lockfile --prefer-offline`,
@@ -225,16 +236,6 @@ async function setupSandbox(
 			throw error;
 		}
 	}
-}
-
-async function applyResult(
-	input: InvestigateData,
-	result: AgentResult,
-	ok: boolean,
-	pushed: boolean,
-): Promise<void> {
-	const stub = workerEnv.Orchestrator.getByName(`issue-${input.issueNumber}`);
-	await stub.applyAgentResult({ runId: input.runId, result, ok, pushed });
 }
 
 function failedResult(summary: string): InvestigationResult {

--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -175,6 +175,8 @@ async function setupSandbox(
 	const branch = input.mode === "revise" ? `bot/fix-${input.issueNumber}` : "main";
 	const pushCapability = await createPushCapability(
 		workerEnv.GITHUB_WEBHOOK_SECRET,
+		repo.owner,
+		repo.repo,
 		input.issueNumber,
 	);
 	const steps: Array<{ name: string; command: string; timeoutMs?: number; nonFatal?: boolean }> = [

--- a/infra/emdash-bot/.flue/cloudflare.ts
+++ b/infra/emdash-bot/.flue/cloudflare.ts
@@ -65,6 +65,8 @@ async function handleAuthenticatedGithub(request: Request, env: Env): Promise<Re
 	const issueNumber = await verifyPushCapability(
 		forwarded.headers.get(PUSH_CAPABILITY_HEADER),
 		env.GITHUB_WEBHOOK_SECRET,
+		owner,
+		repo,
 	);
 	forwarded.headers.delete(PUSH_CAPABILITY_HEADER);
 	const denial = await gateGithubRequest(forwarded, url, owner, repo, issueNumber ?? undefined);

--- a/infra/emdash-bot/.flue/cloudflare.ts
+++ b/infra/emdash-bot/.flue/cloudflare.ts
@@ -3,10 +3,13 @@
 
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 
-import { gateGithubRequest, githubAuthHeader } from "./lib/github-proxy.js";
+import {
+	gateGithubRequest,
+	githubAuthHeader,
+	PUSH_CAPABILITY_HEADER,
+	verifyPushCapability,
+} from "./lib/github-proxy.js";
 import { mintInstallationToken, readAppCreds } from "./lib/github.js";
-
-const INVESTIGATE_CONTAINER_ID = /^investigate-(\d+)-/;
 
 // Subclass so we can attach an outbound proxy to github.com. The handler runs
 // in the Worker runtime (outside the sandbox) with full env access; the
@@ -37,9 +40,8 @@ export class Sandbox extends BaseSandbox {
 
 // Static, always-on handler for github hosts. Bound at module load via
 // `outboundByHost` so it survives sandbox restarts / runtime override drops.
-// Gates by host + repo (from env); does NOT gate by anchor issue number --
-// the per-anchor scoping was unreliable because runtime overrides could be
-// dropped mid-run, leaving subsequent requests with no handler.
+// Gates by host + repo (from env). Pushes additionally require an issue-scoped
+// capability supplied by the investigation sandbox.
 Sandbox.outboundByHost = {
 	"github.com": handleAuthenticatedGithub,
 	"api.github.com": handleAuthenticatedGithub,
@@ -50,11 +52,7 @@ console.log("[sandbox/outbound] module loaded; outboundByHost set", {
 	hosts: Object.keys(Sandbox.outboundByHost ?? {}),
 });
 
-async function handleAuthenticatedGithub(
-	request: Request,
-	env: Env,
-	context: { containerId: string },
-): Promise<Response> {
+async function handleAuthenticatedGithub(request: Request, env: Env): Promise<Response> {
 	const url = new URL(request.url);
 	const owner = env.GITHUB_OWNER;
 	const repo = env.GITHUB_REPO;
@@ -63,8 +61,13 @@ async function handleAuthenticatedGithub(
 		return new Response("github proxy not configured", { status: 403 });
 	}
 
-	const issueNumber = issueNumberFromContainerId(context.containerId);
-	const denial = await gateGithubRequest(request, url, owner, repo, issueNumber);
+	const forwarded = new Request(request);
+	const issueNumber = await verifyPushCapability(
+		forwarded.headers.get(PUSH_CAPABILITY_HEADER),
+		env.GITHUB_WEBHOOK_SECRET,
+	);
+	forwarded.headers.delete(PUSH_CAPABILITY_HEADER);
+	const denial = await gateGithubRequest(forwarded, url, owner, repo, issueNumber ?? undefined);
 	if (denial) {
 		console.warn("[sandbox/outbound] denying", {
 			method: request.method,
@@ -90,7 +93,7 @@ async function handleAuthenticatedGithub(
 		console.error("[sandbox/outbound] token mint failed", { error: errorMessage(err) });
 		return new Response("token mint failed", { status: 502 });
 	}
-	const authed = new Request(request);
+	const authed = new Request(forwarded);
 	authed.headers.set("authorization", githubAuthHeader(url.host, token));
 	authed.headers.set("user-agent", "emdash-bot");
 	try {
@@ -108,13 +111,6 @@ async function handleAuthenticatedGithub(
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
-}
-
-function issueNumberFromContainerId(containerId: string): number | undefined {
-	const match = INVESTIGATE_CONTAINER_ID.exec(containerId);
-	if (!match?.[1]) return undefined;
-	const issueNumber = Number(match[1]);
-	return Number.isSafeInteger(issueNumber) ? issueNumber : undefined;
 }
 
 export { ContainerProxy } from "@cloudflare/sandbox";

--- a/infra/emdash-bot/.flue/lib/github-proxy.ts
+++ b/infra/emdash-bot/.flue/lib/github-proxy.ts
@@ -3,16 +3,24 @@ const PKT_LINE_HEADER = /^[0-9a-fA-F]{4}$/;
 const MAX_RECEIVE_PACK_COMMAND_BYTES = 64 * 1024;
 export const PUSH_CAPABILITY_HEADER = "X-EmDash-Push-Capability";
 
-export async function createPushCapability(secret: string, issueNumber: number): Promise<string> {
+export async function createPushCapability(
+	secret: string,
+	owner: string,
+	repo: string,
+	issueNumber: number,
+): Promise<string> {
+	if (!secret) throw new Error("push capability secret is not configured");
 	const payload = String(issueNumber);
-	return `${payload}.${await signPushCapability(secret, payload)}`;
+	return `${payload}.${await signPushCapability(secret, `${owner}/${repo}/${payload}`)}`;
 }
 
 export async function verifyPushCapability(
 	capability: string | null,
 	secret: string,
+	owner: string,
+	repo: string,
 ): Promise<number | null> {
-	if (!capability) return null;
+	if (!capability || !secret) return null;
 	const separator = capability.indexOf(".");
 	if (separator <= 0) return null;
 	const payload = capability.slice(0, separator);
@@ -26,7 +34,7 @@ export async function verifyPushCapability(
 			"HMAC",
 			key,
 			decodeBase64Url(signature),
-			new TextEncoder().encode(payload),
+			new TextEncoder().encode(`${owner}/${repo}/${payload}`),
 		);
 		return valid ? issueNumber : null;
 	} catch {

--- a/infra/emdash-bot/.flue/lib/github-proxy.ts
+++ b/infra/emdash-bot/.flue/lib/github-proxy.ts
@@ -1,6 +1,70 @@
 const GIT_REF = /refs\/(?:heads|tags)\/\S+/g;
 const PKT_LINE_HEADER = /^[0-9a-fA-F]{4}$/;
 const MAX_RECEIVE_PACK_COMMAND_BYTES = 64 * 1024;
+export const PUSH_CAPABILITY_HEADER = "X-EmDash-Push-Capability";
+
+export async function createPushCapability(secret: string, issueNumber: number): Promise<string> {
+	const payload = String(issueNumber);
+	return `${payload}.${await signPushCapability(secret, payload)}`;
+}
+
+export async function verifyPushCapability(
+	capability: string | null,
+	secret: string,
+): Promise<number | null> {
+	if (!capability) return null;
+	const separator = capability.indexOf(".");
+	if (separator <= 0) return null;
+	const payload = capability.slice(0, separator);
+	const signature = capability.slice(separator + 1);
+	const issueNumber = Number(payload);
+	if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0 || !signature) return null;
+
+	try {
+		const key = await importPushCapabilityKey(secret, ["verify"]);
+		const valid = await crypto.subtle.verify(
+			"HMAC",
+			key,
+			decodeBase64Url(signature),
+			new TextEncoder().encode(payload),
+		);
+		return valid ? issueNumber : null;
+	} catch {
+		return null;
+	}
+}
+
+async function signPushCapability(secret: string, payload: string): Promise<string> {
+	const key = await importPushCapabilityKey(secret, ["sign"]);
+	const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+	return encodeBase64Url(new Uint8Array(signature));
+}
+
+function importPushCapabilityKey(
+	secret: string,
+	usages: Array<"sign" | "verify">,
+): Promise<CryptoKey> {
+	return crypto.subtle.importKey(
+		"raw",
+		new TextEncoder().encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		usages,
+	);
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+	return btoa(String.fromCharCode(...bytes))
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replaceAll("=", "");
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+	const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+	const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+	return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+}
 
 /**
  * Auth scheme for the sandbox outbound GitHub proxy.

--- a/infra/emdash-bot/.flue/lib/investigation-result.ts
+++ b/infra/emdash-bot/.flue/lib/investigation-result.ts
@@ -2,14 +2,19 @@ import { env as workerEnv } from "cloudflare:workers";
 
 import type { AgentResult, OrchestratorDO } from "./orchestrator.js";
 
+interface InvestigationEnv {
+	Orchestrator: DurableObjectNamespace<OrchestratorDO>;
+}
+
 export async function applyInvestigationResult(
 	input: { issueNumber: number; runId: string },
 	result: AgentResult,
 	ok: boolean,
 	pushed: boolean,
 ): Promise<true> {
-	const orchestrator = workerEnv.Orchestrator as DurableObjectNamespace<OrchestratorDO>;
-	const stub = orchestrator.getByName(`issue-${input.issueNumber}`);
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Wrangler cannot infer Flue-generated RPC class types.
+	const { Orchestrator } = workerEnv as unknown as InvestigationEnv;
+	const stub = Orchestrator.getByName(`issue-${input.issueNumber}`);
 	await stub.applyAgentResult({ runId: input.runId, result, ok, pushed });
 	return true;
 }

--- a/infra/emdash-bot/.flue/lib/investigation-result.ts
+++ b/infra/emdash-bot/.flue/lib/investigation-result.ts
@@ -1,0 +1,15 @@
+import { env as workerEnv } from "cloudflare:workers";
+
+import type { AgentResult, OrchestratorDO } from "./orchestrator.js";
+
+export async function applyInvestigationResult(
+	input: { issueNumber: number; runId: string },
+	result: AgentResult,
+	ok: boolean,
+	pushed: boolean,
+): Promise<true> {
+	const orchestrator = workerEnv.Orchestrator as DurableObjectNamespace<OrchestratorDO>;
+	const stub = orchestrator.getByName(`issue-${input.issueNumber}`);
+	await stub.applyAgentResult({ runId: input.runId, result, ok, pushed });
+	return true;
+}

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -20,6 +20,7 @@
 import { env } from "cloudflare:workers";
 import { describe, expect, test } from "vitest";
 
+import { applyInvestigationResult } from "../../.flue/lib/investigation-result.js";
 import type { NormalizedEvent } from "../../.flue/lib/orchestrator.js";
 
 interface TestEnv {
@@ -128,6 +129,17 @@ describe("OrchestratorDO (workers-pool)", () => {
 			expect(outcome.runId).toBe("ghost-run");
 			expect(outcome.currentRunId).toBe(null);
 		}
+	});
+
+	test("investigation result handoff returns a durable step value", async () => {
+		await expect(
+			applyInvestigationResult(
+				{ issueNumber: 987_654_321, runId: "ghost-run" },
+				{ summary: "The investigation completed." },
+				true,
+				false,
+			),
+		).resolves.toBe(true);
 	});
 
 	test("applyAgentResult commits the transition before clearing run markers", async () => {

--- a/infra/emdash-bot/tests/unit/github-proxy.test.ts
+++ b/infra/emdash-bot/tests/unit/github-proxy.test.ts
@@ -35,14 +35,28 @@ describe("githubAuthHeader", () => {
 
 describe("push capabilities", () => {
 	test("round-trips only with the signing secret", async () => {
-		const capability = await createPushCapability("webhook-secret", 123);
+		const capability = await createPushCapability("webhook-secret", OWNER, REPO, 123);
 
-		await expect(verifyPushCapability(capability, "webhook-secret")).resolves.toBe(123);
-		await expect(verifyPushCapability(capability, "different-secret")).resolves.toBeNull();
+		await expect(verifyPushCapability(capability, "webhook-secret", OWNER, REPO)).resolves.toBe(
+			123,
+		);
 		await expect(
-			verifyPushCapability(`456.${capability.split(".")[1]}`, "webhook-secret"),
+			verifyPushCapability(capability, "different-secret", OWNER, REPO),
 		).resolves.toBeNull();
-		await expect(verifyPushCapability("123.!", "webhook-secret")).resolves.toBeNull();
+		await expect(
+			verifyPushCapability(`456.${capability.split(".")[1]}`, "webhook-secret", OWNER, REPO),
+		).resolves.toBeNull();
+		await expect(verifyPushCapability("123.!", "webhook-secret", OWNER, REPO)).resolves.toBeNull();
+	});
+
+	test("fails closed without a secret or for another repository", async () => {
+		const capability = await createPushCapability("webhook-secret", OWNER, REPO, 123);
+
+		await expect(createPushCapability("", OWNER, REPO, 123)).rejects.toThrow(/secret/);
+		await expect(verifyPushCapability(capability, "", OWNER, REPO)).resolves.toBeNull();
+		await expect(
+			verifyPushCapability(capability, "webhook-secret", OWNER, "another-repo"),
+		).resolves.toBeNull();
 	});
 });
 

--- a/infra/emdash-bot/tests/unit/github-proxy.test.ts
+++ b/infra/emdash-bot/tests/unit/github-proxy.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { gateGithubRequest, githubAuthHeader } from "../../.flue/lib/github-proxy.js";
+import {
+	createPushCapability,
+	gateGithubRequest,
+	githubAuthHeader,
+	verifyPushCapability,
+} from "../../.flue/lib/github-proxy.js";
 
 const OWNER = "emdash-cms";
 const REPO = "emdash";
@@ -25,6 +30,19 @@ describe("githubAuthHeader", () => {
 		expect(githubAuthHeader("raw.githubusercontent.com", "tok_abc")).toBe(
 			`Basic ${btoa("x-access-token:tok_abc")}`,
 		);
+	});
+});
+
+describe("push capabilities", () => {
+	test("round-trips only with the signing secret", async () => {
+		const capability = await createPushCapability("webhook-secret", 123);
+
+		await expect(verifyPushCapability(capability, "webhook-secret")).resolves.toBe(123);
+		await expect(verifyPushCapability(capability, "different-secret")).resolves.toBeNull();
+		await expect(
+			verifyPushCapability(`456.${capability.split(".")[1]}`, "webhook-secret"),
+		).resolves.toBeNull();
+		await expect(verifyPushCapability("123.!", "webhook-secret")).resolves.toBeNull();
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes the two runtime failures exposed by the first deployed Flue 2 investigation:

- Returns a serializable value from the durable agent-result handoff instead of `undefined`.
- Replaces unreliable container-ID branch scoping with an HMAC-signed issue capability. The outbound proxy verifies and strips the capability before allowing pushes only to the current issue `bot/fix-*` branch.

Discovered while emdashbot was investigating #2172.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

The admin i18n, changeset, and Discussion items are not applicable to this private infrastructure bug fix. Bot typechecking is currently blocked by pre-existing Wrangler-generated binding errors; the new changed-file errors were resolved, and the production bundle builds successfully.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6 Sol

## Screenshots / test output

- `pnpm build`
- `pnpm --dir infra/emdash-bot build`
- `pnpm lint`
- `pnpm --dir infra/emdash-bot test:unit` (83 passed)
- `pnpm exec vitest run --config vitest.workers.config.ts --testTimeout 15000` (29 passed; default 5-second cold-start timeout remains flaky)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-emdash-bot-runtime-results-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/emdash-bot-runtime-results`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
