### PR TITLE
ci: skip changeset validation when a PR adds no changeset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Validate changesets
-        # Only validate when this PR actually adds/edits a changeset. Gate on the
-        # same git-diff-since-merge-base notion `changeset status --since` uses
-        # internally, not on working-tree presence: on a pull_request merge commit
-        # the tree also contains changesets already accumulated on main, so a
-        # working-tree check runs `status`, which then reports zero *new*
-        # changesets and fails a PR that legitimately needs none.
+        # GitHub tests pull_request events as a merge commit, so the working tree
+        # can contain changesets already on main. Diff against the merge base.
         run: |
           base=$(git merge-base origin/main HEAD)
           added=$(git diff --name-only --diff-filter=d "$base" -- '.changeset/*.md' ':(exclude).changeset/README.md')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,19 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Validate changesets
+        # Only validate when this PR actually adds/edits a changeset. Gate on the
+        # same git-diff-since-merge-base notion `changeset status --since` uses
+        # internally, not on working-tree presence: on a pull_request merge commit
+        # the tree also contains changesets already accumulated on main, so a
+        # working-tree check runs `status`, which then reports zero *new*
+        # changesets and fails a PR that legitimately needs none.
         run: |
-          shopt -s extglob
-          if compgen -G ".changeset/!(README).md" > /dev/null; then
+          base=$(git merge-base origin/main HEAD)
+          added=$(git diff --name-only --diff-filter=d "$base" -- '.changeset/*.md' ':(exclude).changeset/README.md')
+          if [ -n "$added" ]; then
             pnpm changeset status --since=origin/main
           else
-            echo "No changesets present; skipping validation."
+            echo "No changesets added since origin/main; skipping validation."
           fi
 
   test:


### PR DESCRIPTION
## What does this PR do?

Changes changeset validation to detect changeset files added or edited since the PR's merge base rather than checking whether any changeset exists in the merged working tree.

`pull_request` CI tests a merge commit, so changesets already accumulated on `main` caused the old guard to run `changeset status --since=origin/main`. That command filters those existing changesets out, then fails when the PR changes a package but adds no changeset. The guard now uses the same merge-base diff semantics as Changesets itself.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

This is a CI-only change, so package typechecking, tests, i18n, changesets, and feature Discussion requirements are not applicable. `git diff --check origin/main...HEAD` passes. The guard was exercised locally for PRs with and without added changeset files.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6 Sol

## Screenshots / test output

Not applicable.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-changeset-validate-no-changeset-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/changeset-validate-no-changeset`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
