### PR TITLE
feat(admin): add Italian (it) locale

### DIFF
--- a/.changeset/italian-locale.md
+++ b/.changeset/italian-locale.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds Italian (`it`) as a supported admin UI language. The admin now offers a fully translated Italian locale in the language switcher, and auto-selects it for browsers requesting Italian.

--- a/packages/admin/src/locales/it/messages.po
+++ b/packages/admin/src/locales/it/messages.po
@@ -1,0 +1,8819 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-04 12:28+0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: it\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: packages/admin/src/routes/bylines.tsx:446
+msgid " - Guest"
+msgstr " - Ospite"
+
+#: packages/admin/src/routes/bylines.tsx:446
+msgid " - Linked"
+msgstr " - Collegato"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:81
+msgid " (default)"
+msgstr " (predefinito)"
+
+#: packages/admin/src/components/MenuEditor.tsx:521
+msgid " (opens in new window)"
+msgstr " (si apre in una nuova finestra)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:867
+#: packages/admin/src/components/MediaPickerModal.tsx:950
+msgid " (selected)"
+msgstr " (selezionato)"
+
+#: packages/admin/src/routes/bylines.tsx:706
+msgid "-- Select --"
+msgstr "-- Seleziona --"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", oppure apri il pannello di amministrazione all'indirizzo"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": utilizza"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:798
+msgid "(from {0})"
+msgstr "(da {0})"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:533
+msgid "(pre-release)"
+msgstr "(pre-release)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:156
+msgid "(synced)"
+msgstr "(sincronizzata)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:536
+msgid "(too new)"
+msgstr "(troppo recente)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(con la tua porta di sviluppo)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# elemento)} other {(# elementi)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# collezione} other {# collezioni}}"
+
+#. placeholder {0}: result.comments.imported
+#: packages/admin/src/components/WordPressImport.tsx:2263
+msgid "{0, plural, one {# comment imported} other {# comments imported}}"
+msgstr "{0, plural, one {# commento importato} other {# commenti importati}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1465
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr "{0, plural, one {# commento aggiornato} other {# commenti aggiornati}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:345
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# commento} other {# commenti}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2274
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {# errore nei contenuti} other {# errori nei contenuti}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {# voce importata} other {# voci importate}}"
+
+#. placeholder {0}: selectedItems.length
+#: packages/admin/src/components/MediaPickerModal.tsx:787
+msgid "{0, plural, one {# item selected} other {# items selected}}"
+msgstr "{0, plural, one {# elemento selezionato} other {# elementi selezionati}}"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:636
+#: packages/admin/src/components/MenuList.tsx:218
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# elemento} other {# elementi}}"
+
+#. placeholder {0}: mcpTools.length
+#: packages/admin/src/components/PluginManager.tsx:419
+msgid "{0, plural, one {# MCP tool} other {# MCP tools}}"
+msgstr "{0, plural, one {# strumento MCP} other {# strumenti MCP}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {# errore media} other {# errori media}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2231
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {# file media importato} other {# file media importati}}"
+
+#. placeholder {0}: result.menus.created
+#: packages/admin/src/components/WordPressImport.tsx:2255
+msgid "{0, plural, one {# menu imported} other {# menus imported}}"
+msgstr "{0, plural, one {# menu importato} other {# menu importati}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1903
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {# menu verrà importato} other {# menu verranno importati}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:433
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# permesso} other {# permessi}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2486
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# articolo} other {# articoli}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:445
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {# redirect fa parte di un ciclo.} other {# redirect fanno parte di un ciclo.}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:229
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {# selezionato} other {# selezionati}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2223
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {# ignorato (esiste già)} other {# ignorati (esistono già)}}"
+
+#. placeholder {0}: result.taxonomyAssignments
+#: packages/admin/src/components/WordPressImport.tsx:2247
+msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
+msgstr "{0, plural, one {# assegnazione tassonomia} other {# assegnazioni tassonomia}}"
+
+#. placeholder {0}: result.taxonomiesCreated.length
+#: packages/admin/src/components/WordPressImport.tsx:2239
+msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
+msgstr "{0, plural, one {# tassonomia creata} other {# tassonomie create}}"
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:585
+msgid "{0, plural, one {field} other {fields}}"
+msgstr "{0, plural, one {campo} other {campi}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:160
+msgid "{0, plural, one {Media file} other {Media files}}"
+msgstr "{0, plural, one {File media} other {File media}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:165
+msgid "{0, plural, one {User} other {Users}}"
+msgstr "{0, plural, one {Utente} other {Utenti}}"
+
+#. placeholder {0}: envLabel(m.key)
+#. placeholder {1}: m.required
+#. placeholder {2}: m.host
+#: packages/admin/src/components/RegistryPluginDetail.tsx:636
+msgid "{0} {1} required — you have {2}."
+msgstr "{0} {1} richiesto — disponibile: {2}."
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); }
+#: packages/admin/src/components/MenuList.tsx:216
+msgid "{0} • {1}"
+msgstr "{0} • {1}"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:425
+msgid "{0} banner"
+msgstr "banner {0}"
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1303
+msgid "{0} detected"
+msgstr "{0} rilevato"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:115
+msgid "{0} has been deactivated"
+msgstr "{0} è stato disattivato"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:323
+msgid "{0} has been removed"
+msgstr "{0} è stato rimosso"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:437
+msgid "{0} icon"
+msgstr "icona {0}"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr "{0} installazioni"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:96
+msgid "{0} is now active"
+msgstr "{0} è ora attivo"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1973
+msgid "{0} items → {1}"
+msgstr "{0} elementi → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "{0} items will be imported"
+msgstr "{0} elementi verranno importati"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:535
+msgid "{0} of {total} could not be deleted"
+msgstr "{0} di {total} non è stato possibile eliminare"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:491
+msgid "{0} of {total} could not be published"
+msgstr "{0} di {total} non è stato possibile pubblicare"
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:514
+msgid "{0} of {total} could not be updated"
+msgstr "{0} di {total} non è stato possibile aggiornare"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:174
+msgid "{0} plugins"
+msgstr "{0} plugin"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:206
+msgid "{0} preview"
+msgstr "anteprima {0}"
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); }
+#: packages/admin/src/components/ContentTypeEditor.tsx:583
+msgid "{0} system + {1} custom {2}"
+msgstr "{0} di sistema + {1} personalizzati {2}"
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:347
+msgid "{0} updated"
+msgstr "{0} aggiornato"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:269
+msgid "{0} updated to v{1}"
+msgstr "{0} aggiornato alla v{1}"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:867
+#: packages/admin/src/components/MediaPickerModal.tsx:950
+msgid "{0}{1}"
+msgstr "{0}{1}"
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:195
+msgid "{0}/160 characters"
+msgstr "{0}/160 caratteri"
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:313
+msgid "{base} to: {0}"
+msgstr "{base} a: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:345
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# modifica rispetto alla revisione successiva} other {# modifiche rispetto alla revisione successiva}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# file} other {# file}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# elemento} other {# elementi}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "{current} of {total}"
+msgstr "{current} di {total}"
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:933
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr "{filteredCount, plural, one {#{0} elemento} other {#{1} elementi}}"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — nessuna traduzione"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — visualizza traduzione"
+
+#: packages/admin/src/components/ContentList.tsx:922
+msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{matchCount, plural, one {# elemento corrispondente a \"{searchQuery}\"} other {# elementi corrispondenti a \"{searchQuery}\"}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2473
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "{matchedCount} di {totalCount} assegnati"
+
+#: packages/admin/src/components/WordPressImport.tsx:2461
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "{matchedCount} di {totalCount} autori abbinati per email"
+
+#: packages/admin/src/components/WordPressImport.tsx:1879
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {# nuova collezione verrà creata} other {# nuove collezioni verranno create}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1888
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {Verranno aggiunti campi a # collezione esistente} other {Verranno aggiunti campi a # collezioni esistenti}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:83
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} sta richiedendo permessi aggiuntivi:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:84
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} richiede i seguenti permessi:"
+
+#: packages/admin/src/components/PluginSettings.tsx:128
+#: packages/admin/src/components/PluginSettings.tsx:142
+#: packages/admin/src/components/PluginSettings.tsx:170
+msgid "{pluginName} Settings"
+msgstr "Impostazioni di {pluginName}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:298
+msgid "{resultCount, plural, one {# item} other {# items}}"
+msgstr "{resultCount, plural, one {# elemento} other {# elementi}}"
+
+#: packages/admin/src/components/ContentList.tsx:405
+msgid "{selectedCount, plural, one {# selected} other {# selected}}"
+msgstr "{selectedCount, plural, one {# selezionato} other {# selezionati}}"
+
+#: packages/admin/src/components/ContentList.tsx:446
+msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
+msgstr "{selectedCount, plural, one {Spostare # elemento nel cestino? Potrai ripristinarlo in seguito.} other {Spostare # elementi nel cestino? Potrai ripristinarli in seguito.}}"
+
+#: packages/admin/src/components/ContentList.tsx:928
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr "{total, plural, one {# elemento} other {# elementi}}"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:150
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {# totale} other {# totali}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:211
+#: packages/admin/src/components/MediaLibrary.tsx:247
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {File caricato} other {# file caricati}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:216
+#: packages/admin/src/components/MediaLibrary.tsx:252
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {Caricamento non riuscito} other {Tutti i # caricamenti non riusciti}}"
+
+#: packages/admin/src/components/Dashboard.tsx:146
+msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
+msgstr "{totalDrafts, plural, one {Bozza} other {Bozze}}"
+
+#: packages/admin/src/components/Dashboard.tsx:153
+msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
+msgstr "{totalScheduled, plural, one {Pianificato} other {Pianificati}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:357
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {Nascondi # non modificato} other {Nascondi # non modificati}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:358
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {Mostra # non modificato} other {Mostra # non modificati}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:221
+#: packages/admin/src/components/MediaLibrary.tsx:257
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "{uploaded} caricati, {failed} non riusciti"
+
+#: packages/admin/src/components/Redirects.tsx:142
+msgid "/new-page or /articles/[slug]"
+msgstr "/new-page or /articles/[slug]"
+
+#: packages/admin/src/components/Redirects.tsx:133
+msgid "/old-page or /blog/[slug]"
+msgstr "/old-page or /blog/[slug]"
+
+#: packages/admin/src/components/WordPressImport.tsx:2093
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• I file vengono scaricati dal tuo sito WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:2094
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• Caricati nello spazio media di EmDash"
+
+#: packages/admin/src/components/WordPressImport.tsx:2095
+msgid "• URLs in your content are updated automatically"
+msgstr "• Gli URL nei tuoi contenuti vengono aggiornati automaticamente"
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1601
+msgid "← Back"
+msgstr "← Indietro"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:36
+msgid "1 year"
+msgstr "1 anno"
+
+#: packages/admin/src/components/WordPressImport.tsx:1522
+msgid "1. Log into your WordPress admin"
+msgstr "1. Accedi al pannello di amministrazione WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1275
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. Accedi alla dashboard di amministrazione WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "2. Go to"
+msgstr "2. Vai su"
+
+#: packages/admin/src/components/WordPressImport.tsx:1523
+msgid "2. Go to Users → Profile"
+msgstr "2. Vai su Utenti → Profilo"
+
+#: packages/admin/src/components/WordPressImport.tsx:1524
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. Scorri fino a \"Password per applicazioni\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1279
+msgid "3. Select \"All content\""
+msgstr "3. Seleziona \"Tutti i contenuti\""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "30 days"
+msgstr "30 giorni"
+
+#: packages/admin/src/components/Redirects.tsx:156
+msgid "301 Permanent"
+msgstr "301 Permanente"
+
+#: packages/admin/src/components/Redirects.tsx:157
+msgid "302 Temporary"
+msgstr "302 Temporaneo"
+
+#: packages/admin/src/components/Redirects.tsx:158
+msgid "307 Temporary (Strict)"
+msgstr "307 Temporaneo (Strict)"
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "308 Permanent (Strict)"
+msgstr "308 Permanente (Strict)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1280
+msgid "4. Click \"Download Export File\""
+msgstr "4. Clicca su \"Scarica file di esportazione\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1525
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. Inserisci \"EmDash\" e clicca su \"Aggiungi nuovo\""
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "404 Errors"
+msgstr "Errori 404"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "410 Content Deleted (Gone)"
+msgstr "410 Contenuto eliminato (Gone)"
+
+#: packages/admin/src/components/Redirects.tsx:161
+msgid "451 Unavailable for legal reasons"
+msgstr "451 Non disponibile per motivi legali"
+
+#: packages/admin/src/components/WordPressImport.tsx:1526
+msgid "5. Copy the generated password"
+msgstr "5. Copia la password generata"
+
+#: packages/admin/src/components/WordPressImport.tsx:1281
+msgid "5. Upload the file here"
+msgstr "5. Carica il file qui"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "7 days"
+msgstr "7 giorni"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "90 days"
+msgstr "90 giorni"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:416
+msgid "A brief description of this content type"
+msgstr "Una breve descrizione di questo tipo di contenuto"
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr "Un banner hero a piena larghezza con intestazione, testo e pulsante CTA"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:142
+msgid "A short description of your site"
+msgstr "Una breve descrizione del tuo sito"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:201
+msgid "Accept & Install"
+msgstr "Accetta e installa"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:200
+msgid "Accept & Update"
+msgstr "Accetta e aggiorna"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:240
+msgid "Accept Invite"
+msgstr "Accetta invito"
+
+#: packages/admin/src/routes/byline-schema.tsx:174
+msgid "Access denied"
+msgstr "Accesso negato"
+
+#: packages/admin/src/router.tsx:1485
+msgid "Access Denied"
+msgstr "Accesso negato"
+
+#: packages/admin/src/lib/api/marketplace.ts:282
+#: packages/admin/src/lib/api/marketplace.ts:290
+msgid "Access your media library"
+msgstr "Accedi alla libreria media"
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr "Account"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:154
+msgid "Account already exists"
+msgstr "L'account esiste già"
+
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Account exists"
+msgstr "Account esistente"
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr "Informazioni account"
+
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "ACF Fields"
+msgstr "Campi ACF"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
+#: packages/admin/src/components/ContentList.tsx:528
+#: packages/admin/src/components/ContentList.tsx:649
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/TaxonomyManager.tsx:843
+#: packages/admin/src/routes/byline-schema.tsx:249
+msgid "Actions"
+msgstr "Azioni"
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr "Attivo"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentSettingsPanel.tsx:840
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/TaxonomySidebar.tsx:478
+msgid "Add"
+msgstr "Aggiungi"
+
+#. placeholder {0}: field.item_label
+#. placeholder {0}: taxonomyDef.labelSingular || t`Term`
+#: packages/admin/src/components/PortableTextEditor.tsx:1830
+#: packages/admin/src/components/TaxonomyManager.tsx:378
+#: packages/admin/src/components/TaxonomyManager.tsx:834
+msgid "Add {0}"
+msgstr "Aggiungi {0}"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:266
+msgid "Add {label}"
+msgstr "Aggiungi {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+msgid "Add a new passkey"
+msgstr "Aggiungi una nuova passkey"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Add an allowed domain"
+msgstr "Aggiungi un dominio consentito"
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "Aggiungi almeno un sottocampo per definire la struttura del ripetitore."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3337
+msgid "Add column after"
+msgstr "Aggiungi colonna dopo"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3331
+msgid "Add column before"
+msgstr "Aggiungi colonna prima"
+
+#: packages/admin/src/components/MenuEditor.tsx:378
+#: packages/admin/src/components/MenuEditor.tsx:493
+msgid "Add Content"
+msgstr "Aggiungi contenuto"
+
+#: packages/admin/src/components/MenuEditor.tsx:390
+#: packages/admin/src/components/MenuEditor.tsx:397
+#: packages/admin/src/components/MenuEditor.tsx:496
+msgid "Add Custom Link"
+msgstr "Aggiungi link personalizzato"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:316
+msgid "Add Domain"
+msgstr "Aggiungi dominio"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:591
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Add Field"
+msgstr "Aggiungi campo"
+
+#: packages/admin/src/components/WordPressImport.tsx:1984
+msgid "Add fields"
+msgstr "Aggiungi campi"
+
+#: packages/admin/src/routes/byline-schema.tsx:293
+msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+msgstr "Aggiungi campi come \"Titolo professionale\" o \"Pronomi\" per arricchire ogni firma."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:613
+msgid "Add fields to define the structure of your content"
+msgstr "Aggiungi campi per definire la struttura del tuo contenuto"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:616
+msgid "Add First Field"
+msgstr "Aggiungi il primo campo"
+
+#: packages/admin/src/components/RepeaterField.tsx:174
+msgid "Add First Item"
+msgstr "Aggiungi il primo elemento"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:200
+msgid "Add Images"
+msgstr "Aggiungi immagini"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:247
+msgid "Add images to gallery"
+msgstr "Aggiungi immagini alla galleria"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1830
+msgid "Add item"
+msgstr "Aggiungi elemento"
+
+#: packages/admin/src/components/RepeaterField.tsx:158
+msgid "Add Item"
+msgstr "Aggiungi elemento"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3266
+msgid "Add link"
+msgstr "Aggiungi link"
+
+#: packages/admin/src/components/MenuEditor.tsx:486
+msgid "Add links to build your navigation menu"
+msgstr "Aggiungi link per costruire il tuo menu di navigazione"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr "Aggiungi tipo MIME o estensione"
+
+#: packages/admin/src/components/ContentList.tsx:342
+msgid "Add New"
+msgstr "Aggiungi nuovo"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:490
+msgid "Add new {0}"
+msgstr "Aggiungi nuovo {0}"
+
+#: packages/admin/src/components/SeoPanel.tsx:227
+msgid "Add noindex meta tag"
+msgstr "Aggiungi meta tag noindex"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:200
+msgid "Add Passkey"
+msgstr "Aggiungi passkey"
+
+#: packages/admin/src/components/PluginManager.tsx:210
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "Aggiungi plugin al tuo astro.config.mjs per estendere le funzionalità di EmDash."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3358
+msgid "Add row after"
+msgstr "Aggiungi riga dopo"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3352
+msgid "Add row before"
+msgstr "Aggiungi riga prima"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr "Aggiungi campi di metadati SEO (titolo, descrizione, immagine) e includi nella sitemap"
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr "Aggiungi Sotto-Campo"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:265
+msgid "Add tags..."
+msgstr "Aggiungi tag..."
+
+#: packages/admin/src/components/Widgets.tsx:401
+msgid "Add Widget Area"
+msgstr "Aggiungi Area Widget"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:102
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "Aggiungi i tuoi profili social. Sono disponibili per il tema del sito e possono essere visualizzati in intestazioni, piè di pagina o biografie degli autori."
+
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+msgid "Adding..."
+msgstr "Aggiunta in corso..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Additional data to import."
+msgstr "Dati aggiuntivi da importare."
+
+#: packages/admin/src/components/WordPressImport.tsx:1483
+msgid "admin"
+msgstr "admin"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:101
+#: packages/admin/src/components/Sidebar.tsx:383
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "Admin"
+
+#: packages/admin/src/components/Sidebar.tsx:329
+msgid "Admin navigation"
+msgstr "Navigazione amministrativa"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "Amministratore"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:196
+msgid "After send:"
+msgstr "Dopo l'invio:"
+
+#: packages/admin/src/components/PluginManager.tsx:542
+msgid "Agent access"
+msgstr "Accesso agente"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:334
+msgid "Agent access for {0} has been updated"
+msgstr "Accesso agente per {0} aggiornato"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+msgid "Agent-callable MCP tools"
+msgstr "Strumenti MCP richiamabili dall'agente"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3705
+msgid "Align Center"
+msgstr "Allinea al centro"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3698
+msgid "Align Left"
+msgstr "Allinea a sinistra"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3712
+msgid "Align Right"
+msgstr "Allinea a destra"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
+msgid "Alignment"
+msgstr "Allineamento"
+
+#: packages/admin/src/components/ContentList.tsx:369
+msgid "All"
+msgstr "Tutti"
+
+#: packages/admin/src/components/ContentList.tsx:773
+#: packages/admin/src/components/ContentList.tsx:777
+msgid "All authors"
+msgstr "Tutti gli autori"
+
+#: packages/admin/src/routes/bylines.tsx:412
+msgid "All bylines"
+msgstr "Tutte le firme"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr "Tutte le funzionalità"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:134
+msgid "All collections"
+msgstr "Tutte le collezioni"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr "Tutti i commenti richiedono approvazione"
+
+#: packages/admin/src/components/WordPressImport.tsx:2518
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "Tutto il contenuto importato sarà non assegnato. È possibile riassegnare gli autori in seguito dall'editor dei contenuti."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "Tutti i locale"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "Tutti i ruoli"
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "Tutte le sorgenti"
+
+#: packages/admin/src/components/ContentList.tsx:728
+#: packages/admin/src/components/Redirects.tsx:419
+msgid "All statuses"
+msgstr "Tutti gli stati"
+
+#: packages/admin/src/components/MediaLibrary.tsx:433
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "All types"
+msgstr "Tutti i tipi"
+
+#: packages/admin/src/components/PluginManager.tsx:544
+msgid "Allow MCP tokens with plugin-tool scope to invoke these routes."
+msgstr "Consenti ai token MCP con scope plugin-tool di richiamare queste route."
+
+#: packages/admin/src/components/Settings.tsx:100
+msgid "Allow users from specific domains to sign up"
+msgstr "Consenti agli utenti di domini specifici di registrarsi"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr "Consenti ai visitatori di lasciare commenti sui contenuti di questa collezione"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Allowed Domains"
+msgstr "Domini consentiti"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr "Tipi consentiti"
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Already have an account?"
+msgstr "Hai già un account?"
+
+#: packages/admin/src/components/PluginManager.tsx:718
+msgid "Also delete plugin storage data"
+msgstr "Elimina anche i dati di archiviazione del plugin"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:376
+#: packages/admin/src/components/editor/ImageNode.tsx:231
+#: packages/admin/src/components/MediaLibrary.tsx:589
+msgid "Alt text"
+msgstr "Testo alternativo"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
+#: packages/admin/src/components/MediaDetailPanel.tsx:354
+#: packages/admin/src/components/MediaDetailPanel.tsx:371
+msgid "Alt Text"
+msgstr "Testo alternativo"
+
+#: packages/admin/src/components/MediaLibrary.tsx:833
+#: packages/admin/src/components/MediaLibrary.tsx:890
+msgid "Alt text set"
+msgstr "Testo alternativo impostato"
+
+#: packages/admin/src/components/WordPressImport.tsx:1395
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "In alternativa, puoi esportare da WordPress (Strumenti → Esporta) e caricare il file."
+
+#: packages/admin/src/components/DialogError.tsx:14
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:102
+#: packages/admin/src/components/PluginManager.tsx:121
+#: packages/admin/src/components/PluginSettings.tsx:75
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:71
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:95
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+#: packages/admin/src/components/settings/BackupSettings.tsx:85
+#: packages/admin/src/components/settings/BackupSettings.tsx:105
+#: packages/admin/src/components/settings/EmailSettings.tsx:51
+#: packages/admin/src/components/settings/GeneralSettings.tsx:51
+#: packages/admin/src/components/settings/SecuritySettings.tsx:54
+#: packages/admin/src/components/settings/SecuritySettings.tsx:71
+#: packages/admin/src/components/settings/SeoSettings.tsx:45
+#: packages/admin/src/components/settings/SocialSettings.tsx:43
+#: packages/admin/src/components/TaxonomySidebar.tsx:352
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:423
+#: packages/admin/src/router.tsx:438
+#: packages/admin/src/router.tsx:452
+#: packages/admin/src/router.tsx:466
+#: packages/admin/src/router.tsx:943
+#: packages/admin/src/router.tsx:996
+#: packages/admin/src/router.tsx:1014
+#: packages/admin/src/router.tsx:1032
+#: packages/admin/src/router.tsx:1053
+#: packages/admin/src/router.tsx:1074
+#: packages/admin/src/router.tsx:1095
+#: packages/admin/src/router.tsx:1126
+#: packages/admin/src/router.tsx:1146
+#: packages/admin/src/router.tsx:1430
+#: packages/admin/src/router.tsx:1446
+#: packages/admin/src/router.tsx:1471
+#: packages/admin/src/router.tsx:1960
+#: packages/admin/src/routes/byline-schema.tsx:103
+#: packages/admin/src/routes/byline-schema.tsx:123
+#: packages/admin/src/routes/byline-schema.tsx:139
+#: packages/admin/src/routes/byline-schema.tsx:153
+msgid "An error occurred"
+msgstr "Si è verificato un errore"
+
+#: packages/admin/src/routes/byline-schema.tsx:272
+msgid "An unexpected error occurred."
+msgstr "Si è verificato un errore imprevisto."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:251
+msgid "An unknown error occurred"
+msgstr "Si è verificato un errore sconosciuto"
+
+#: packages/admin/src/components/WordPressImport.tsx:1575
+msgid "Analyzing export file..."
+msgstr "Analisi del file di esportazione in corso..."
+
+#: packages/admin/src/components/WordPressImport.tsx:810
+msgid "Analyzing WordPress site..."
+msgstr "Analisi del sito WordPress in corso..."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr "Qualsiasi tipo di media consentito (soggetto ai limiti globali)."
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
+msgid "API Tokens"
+msgstr "Token API"
+
+#: packages/admin/src/components/Widgets.tsx:438
+msgid "Appears on posts and pages"
+msgstr "Appare su articoli e pagine"
+
+#: packages/admin/src/components/WordPressImport.tsx:1490
+msgid "Application Password"
+msgstr "Password applicazione"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3794
+msgid "Apply"
+msgstr "Applica"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:181
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:182
+msgid "Apply language"
+msgstr "Applica linguaggio"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3206
+#: packages/admin/src/components/PortableTextEditor.tsx:3207
+msgid "Apply link"
+msgstr "Applica collegamento"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:238
+#: packages/admin/src/components/comments/CommentInbox.tsx:490
+msgid "Approve"
+msgstr "Approva"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "approvato"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:203
+msgid "Approved"
+msgstr "Approvato"
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr "Dati JSON arbitrari"
+
+#: packages/admin/src/components/ContentList.tsx:1166
+msgid "archived"
+msgstr "archiviato"
+
+#: packages/admin/src/components/ContentList.tsx:732
+#: packages/admin/src/components/Dashboard.tsx:350
+msgid "Archived"
+msgstr "Archiviato"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+#: packages/admin/src/components/Widgets.tsx:158
+msgid "Archives"
+msgstr "Archivi"
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:375
+msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+msgstr "Confermi l'eliminazione di \"{0}\"? Nessun valore memorizzato fa riferimento a questo campo."
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "Confermi l'eliminazione di \"{0}\"? Verranno eliminati anche tutti i contenuti di questa collezione."
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:669
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr "Confermi l'eliminazione del campo \"{0}\"?"
+
+#: packages/admin/src/components/MenuList.tsx:255
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "Confermi l'eliminazione di questo menu? Verranno eliminati anche tutti gli elementi del menu. Questa operazione non può essere annullata."
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "In qualità di amministratore, puoi invitare altri utenti dalla sezione Utenti."
+
+#: packages/admin/src/components/WordPressImport.tsx:2456
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "Assegna gli autori WordPress agli utenti EmDash. Gli articoli verranno attribuiti all'utente selezionato."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:28
+msgid "Astro"
+msgstr "Astro"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+#: packages/admin/src/components/MediaLibrary.tsx:436
+msgid "Audio"
+msgstr "Audio"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:277
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "Errore di autenticazione: {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:197
+msgid "Authentication error: {error}"
+msgstr "Errore di autenticazione: {error}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:254
+msgid "Authentication failed"
+msgstr "Autenticazione non riuscita"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:120
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "L'autenticazione è gestita da un provider esterno ({0}). Le impostazioni Passkey non sono disponibili con l'autenticazione esterna."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:261
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "Autenticazione annullata o scaduta. Riprova."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:288
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1050
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "Autore"
+
+#: packages/admin/src/components/WordPressImport.tsx:2471
+msgid "Author Mapping"
+msgstr "Mappatura autori"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "Autorizzazione negata"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr "Autorizzazione non riuscita"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "Autorizza"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "Autorizza dispositivo"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "Autorizzazione in corso..."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:685
+msgid "Authors"
+msgstr "Autori"
+
+#: packages/admin/src/components/Redirects.tsx:522
+msgid "auto"
+msgstr "auto"
+
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "Auto (slug change)"
+msgstr "Auto (cambio slug)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:539
+msgid "Auto-approve authenticated users"
+msgstr "Approva automaticamente gli utenti autenticati"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:424
+msgid "Auto-generated from name (you can edit)"
+msgstr "Generato automaticamente dal nome (modificabile)"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:167
+msgid "Automatic Backups"
+msgstr "Backup automatici"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:207
+msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
+msgstr "I backup automatici richiedono un backend di archiviazione (R2, S3 o archiviazione locale). Configura l'archiviazione nella configurazione di EmDash per abilitarli."
+
+#: packages/admin/src/router.tsx:995
+msgid "Autosave failed"
+msgstr "Salvataggio automatico non riuscito"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:710
+msgid "Available media"
+msgstr "Media disponibili"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:205
+msgid "Available Providers"
+msgstr "Provider disponibili"
+
+#: packages/admin/src/components/Widgets.tsx:464
+msgid "Available Widgets"
+msgstr "Widget disponibili"
+
+#: packages/admin/src/components/BylineAvatarField.tsx:46
+#: packages/admin/src/components/BylineAvatarField.tsx:71
+msgid "Avatar"
+msgstr "Avatar"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:257
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/WordPressImport.tsx:1510
+#: packages/admin/src/components/WordPressImport.tsx:2527
+msgid "Back"
+msgstr "Indietro"
+
+#: packages/admin/src/components/ContentEditor.tsx:636
+msgid "Back to {collectionLabel} list"
+msgstr "Torna all'elenco {collectionLabel}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr "Torna ai tipi di contenuto"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:172
+#: packages/admin/src/components/LoginPage.tsx:118
+#: packages/admin/src/components/LoginPage.tsx:154
+#: packages/admin/src/components/LoginPage.tsx:313
+#: packages/admin/src/components/SignupPage.tsx:282
+msgid "Back to login"
+msgstr "Torna al login"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:126
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:404
+msgid "Back to marketplace"
+msgstr "Torna al marketplace"
+
+#: packages/admin/src/components/PluginSettings.tsx:118
+#: packages/admin/src/components/RegistryPluginDetail.tsx:820
+msgid "Back to plugins"
+msgstr "Torna ai plugin"
+
+#: packages/admin/src/components/SectionEditor.tsx:74
+#: packages/admin/src/components/SectionEditor.tsx:175
+msgid "Back to sections"
+msgstr "Torna alle sezioni"
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr "Torna alle impostazioni"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr "Torna ai temi"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Back up now"
+msgstr "Esegui backup ora"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Backing up..."
+msgstr "Backup in corso..."
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:97
+msgid "Backup created: {0}"
+msgstr "Backup creato: {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:80
+msgid "Backup settings saved"
+msgstr "Impostazioni di backup salvate"
+
+#: packages/admin/src/components/Settings.tsx:122
+#: packages/admin/src/components/settings/BackupSettings.tsx:133
+#: packages/admin/src/components/settings/BackupSettings.tsx:148
+msgid "Backups"
+msgstr "Backup"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:182
+msgid "Backups to keep"
+msgstr "Backup da conservare"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:29
+msgid "Bash"
+msgstr "Bash"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:191
+msgid "Before send:"
+msgstr "Prima dell'invio:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Bing Verification"
+msgstr "Verifica Bing"
+
+#: packages/admin/src/routes/bylines.tsx:496
+msgid "Bio"
+msgstr "Bio"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
+msgid "Block actions - drag to reorder, click for menu"
+msgstr "Azioni blocco - trascina per riordinare, fai clic per il menu"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3230
+#: packages/admin/src/components/PortableTextEditor.tsx:3616
+msgid "Bold"
+msgstr "Grassetto"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:55
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr "Booleano"
+
+#: packages/admin/src/components/SeoPanel.tsx:184
+msgid "Brief summary shown below the title in search results"
+msgstr "Breve riepilogo visualizzato sotto il titolo nei risultati di ricerca"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:72
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr "Sfoglia e installa plugin pubblicati nel registro decentralizzato."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr "Sfoglia e installa plugin per estendere il tuo sito."
+
+#: packages/admin/src/components/WordPressImport.tsx:1124
+#: packages/admin/src/components/WordPressImport.tsx:1594
+msgid "Browse Files"
+msgstr "Sfoglia file"
+
+#: packages/admin/src/components/PluginManager.tsx:203
+msgid "Browse the"
+msgstr "Sfoglia il"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr "Sfoglia i temi e visualizzane l'anteprima con i tuoi contenuti."
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:102
+#: packages/admin/src/components/PortableTextEditor.tsx:1139
+#: packages/admin/src/components/PortableTextEditor.tsx:3664
+msgid "Bullet List"
+msgstr "Elenco puntato"
+
+#: packages/admin/src/routes/byline-schema.tsx:218
+#: packages/admin/src/routes/bylines.tsx:383
+msgid "Byline schema"
+msgstr "Schema firma"
+
+#: packages/admin/src/components/Sidebar.tsx:252
+msgid "Byline Schema"
+msgstr "Schema firma"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:552
+#: packages/admin/src/components/Sidebar.tsx:242
+#: packages/admin/src/routes/bylines.tsx:375
+msgid "Bylines"
+msgstr "Firme"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:30
+msgid "C"
+msgstr "C"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:32
+msgid "C#"
+msgstr "C#"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:31
+msgid "C++"
+msgstr "C++"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "Può creare contenuti"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "Può gestire tutti i contenuti"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "Può pubblicare i propri contenuti"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "Può visualizzare i contenuti"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:315
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:192
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentList.tsx:455
+#: packages/admin/src/components/ContentList.tsx:1054
+#: packages/admin/src/components/ContentList.tsx:1125
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/ContentSettingsPanel.tsx:86
+#: packages/admin/src/components/ContentSettingsPanel.tsx:500
+#: packages/admin/src/components/ContentSettingsPanel.tsx:651
+#: packages/admin/src/components/ContentSettingsPanel.tsx:954
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1007
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:193
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:194
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:586
+#: packages/admin/src/components/editor/ImageNode.tsx:252
+#: packages/admin/src/components/editor/ImageNode.tsx:253
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:649
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:805
+#: packages/admin/src/components/MenuEditor.tsx:438
+#: packages/admin/src/components/MenuEditor.tsx:623
+#: packages/admin/src/components/MenuList.tsx:173
+#: packages/admin/src/components/PluginManager.tsx:724
+#: packages/admin/src/components/PortableTextEditor.tsx:3778
+#: packages/admin/src/components/Redirects.tsx:183
+#: packages/admin/src/components/SectionPickerModal.tsx:131
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:280
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:390
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:336
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:480
+#: packages/admin/src/components/settings/SecuritySettings.tsx:179
+#: packages/admin/src/components/TaxonomyManager.tsx:207
+#: packages/admin/src/components/TaxonomyManager.tsx:494
+#: packages/admin/src/components/TaxonomyManager.tsx:708
+#: packages/admin/src/components/users/InviteUserModal.tsx:198
+#: packages/admin/src/components/Widgets.tsx:449
+#: packages/admin/src/components/WordPressImport.tsx:1917
+msgid "Cancel"
+msgstr "Annulla"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr "Annulla (Esc)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "Annulla rinomina"
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr "Impossibile eliminare le sezioni del tema"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:456
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr "Impossibile determinare il tipo MIME dall'URL. Usa un URL che termini con un'estensione immagine riconosciuta (ad es. .jpg, .png, .webp)."
+
+#: packages/admin/src/components/SeoPanel.tsx:212
+#: packages/admin/src/components/SeoPanel.tsx:216
+msgid "Canonical URL"
+msgstr "URL canonico"
+
+#: packages/admin/src/components/PluginManager.tsx:518
+msgid "Capabilities"
+msgstr "Funzionalità"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:69
+msgid "Capability consent"
+msgstr "Consenso funzionalità"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:382
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:352
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:541
+#: packages/admin/src/components/MediaDetailPanel.tsx:381
+msgid "Caption"
+msgstr "Didascalia"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr "Didascalie / Sottotitoli"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:192
+#: packages/admin/src/components/Widgets.tsx:135
+msgid "Categories"
+msgstr "Categorie"
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1785
+msgid "Categories ({0})"
+msgstr "Categorie ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "Categories & Tags"
+msgstr "Categorie e tag"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
+msgid "Center"
+msgstr "Centro"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1659
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/ImageFieldRenderer.tsx:133
+#: packages/admin/src/components/ImageFieldRenderer.tsx:162
+#: packages/admin/src/components/SeoImageField.tsx:53
+msgid "Change"
+msgstr "Cambia"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr "Modificare <0>{0}</0> da <1>{1}</1> a <2>{2}</2>? L'utente perderà l'accesso alle funzionalità di livello superiore."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:239
+msgid "Change Favicon"
+msgstr "Cambia Favicon"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:167
+msgid "Change Image"
+msgstr "Cambia immagine"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:185
+msgid "Change Logo"
+msgstr "Cambia logo"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:808
+msgid "Changelog"
+msgstr "Changelog"
+
+#: packages/admin/src/router.tsx:1046
+msgid "Changes discarded"
+msgstr "Modifiche scartate"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:129
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "Carattere tra il titolo della pagina e il nome del sito (ad es., \"Il mio articolo | Il mio sito\")"
+
+#: packages/admin/src/components/PluginManager.tsx:166
+msgid "Check for updates"
+msgstr "Controlla aggiornamenti"
+
+#: packages/admin/src/components/WordPressImport.tsx:1095
+msgid "Check Site"
+msgstr "Controlla sito"
+
+#: packages/admin/src/components/LoginPage.tsx:102
+#: packages/admin/src/components/SignupPage.tsx:131
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Check your email"
+msgstr "Controlla la tua email"
+
+#: packages/admin/src/components/WordPressImport.tsx:776
+msgid "Checking {urlInput}..."
+msgstr "Verifica di {urlInput} in corso..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "Verifica autenticazione in corso..."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:362
+msgid "Checking how many stored values reference \"{0}\"…"
+msgstr "Verifica del numero di valori memorizzati che fanno riferimento a \"{0}\"…"
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr "Scegli come accedere"
+
+#: packages/admin/src/components/Settings.tsx:137
+msgid "Choose your preferred admin language"
+msgstr "Scegli la lingua preferita per l'amministrazione"
+
+#: packages/admin/src/components/ContentList.tsx:481
+msgid "Clear"
+msgstr "Cancella"
+
+#: packages/admin/src/components/ContentList.tsx:825
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr "Cancella filtri"
+
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/MediaLibrary.tsx:521
+msgid "Clear search"
+msgstr "Cancella ricerca"
+
+#: packages/admin/src/components/PluginSettings.tsx:354
+msgid "Clear stored value"
+msgstr "Cancella valore memorizzato"
+
+#: packages/admin/src/components/PluginSettings.tsx:352
+msgid "Clear stored value for {fieldKey}"
+msgstr "Cancella valore memorizzato per {fieldKey}"
+
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "Click the link in the email to continue setting up your account."
+msgstr "Clicca il link nell'email per continuare la configurazione del tuo account."
+
+#: packages/admin/src/components/LoginPage.tsx:113
+msgid "Click the link in the email to sign in."
+msgstr "Clicca il link nell'email per accedere."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:212
+#: packages/admin/src/components/BylineFieldEditor.tsx:218
+#: packages/admin/src/components/BylineFieldEditor.tsx:222
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:227
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:229
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:414
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:449
+#: packages/admin/src/components/MediaDetailPanel.tsx:229
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:529
+#: packages/admin/src/components/MediaPickerModal.tsx:535
+#: packages/admin/src/components/MediaPickerModal.tsx:539
+#: packages/admin/src/components/MenuEditor.tsx:400
+#: packages/admin/src/components/MenuEditor.tsx:406
+#: packages/admin/src/components/MenuEditor.tsx:410
+#: packages/admin/src/components/MenuEditor.tsx:576
+#: packages/admin/src/components/MenuEditor.tsx:582
+#: packages/admin/src/components/MenuEditor.tsx:586
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/MenuList.tsx:147
+#: packages/admin/src/components/PortableTextEditor.tsx:1614
+#: packages/admin/src/components/PortableTextEditor.tsx:1620
+#: packages/admin/src/components/PortableTextEditor.tsx:1624
+#: packages/admin/src/components/Redirects.tsx:115
+#: packages/admin/src/components/Redirects.tsx:121
+#: packages/admin/src/components/SectionPickerModal.tsx:61
+#: packages/admin/src/components/SectionPickerModal.tsx:67
+#: packages/admin/src/components/SectionPickerModal.tsx:71
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:338
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:348
+#: packages/admin/src/components/TaxonomyManager.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:387
+#: packages/admin/src/components/TaxonomyManager.tsx:393
+#: packages/admin/src/components/TaxonomyManager.tsx:397
+#: packages/admin/src/components/TaxonomyManager.tsx:627
+#: packages/admin/src/components/TaxonomyManager.tsx:633
+#: packages/admin/src/components/TaxonomyManager.tsx:637
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:411
+#: packages/admin/src/components/Widgets.tsx:417
+#: packages/admin/src/components/Widgets.tsx:421
+msgid "Close"
+msgstr "Chiudi"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:518
+msgid "Close comments after (days)"
+msgstr "Chiudi commenti dopo (giorni)"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:178
+msgid "Close gallery settings"
+msgstr "Chiudi impostazioni galleria"
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr "Chiudi pannello"
+
+#: packages/admin/src/components/ContentEditor.tsx:1030
+msgid "Close settings"
+msgstr "Chiudi impostazioni"
+
+#: packages/admin/src/components/ContentTypeList.tsx:242
+#: packages/admin/src/components/PortableTextEditor.tsx:3258
+#: packages/admin/src/components/Redirects.tsx:470
+msgid "Code"
+msgstr "Codice"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:94
+#: packages/admin/src/components/PortableTextEditor.tsx:1169
+#: packages/admin/src/components/PortableTextEditor.tsx:3685
+msgid "Code Block"
+msgstr "Blocco di codice"
+
+#: packages/admin/src/components/PluginManager.tsx:505
+msgid "Collapse"
+msgstr "Comprimi"
+
+#: packages/admin/src/components/PluginManager.tsx:499
+msgid "Collapse details"
+msgstr "Comprimi dettagli"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:156
+msgid "colleague@example.com"
+msgstr "collega@example.com"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr "Collezione"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "Collezione:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:678
+msgid "Collections"
+msgstr "Collezioni"
+
+#: packages/admin/src/components/WordPressImport.tsx:2327
+msgid "Collections created:"
+msgstr "Collezioni create:"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:185
+msgid "Columns"
+msgstr "Colonne"
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "Comma-separated keywords for search."
+msgstr "Parole chiave separate da virgola per la ricerca."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:291
+msgid "Comment"
+msgstr "Commento"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "Dettaglio commento"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:147
+#: packages/admin/src/components/ContentTypeEditor.tsx:485
+#: packages/admin/src/components/Sidebar.tsx:221
+msgid "Comments"
+msgstr "Commenti"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:542
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr "I commenti degli utenti CMS autenticati vengono approvati automaticamente"
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Complete signup"
+msgstr "Completa registrazione"
+
+#: packages/admin/src/components/Widgets.tsx:929
+msgid "Component"
+msgstr "Componente"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr "Configura campo"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
+msgid "Confirm"
+msgstr "Conferma"
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+#: packages/admin/src/components/WordPressImport.tsx:1054
+msgid "Connect"
+msgstr "Connetti"
+
+#: packages/admin/src/components/WordPressImport.tsx:1507
+msgid "Connect & Analyze"
+msgstr "Connetti e analizza"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1457
+msgid "Connect to {0}"
+msgstr "Connetti a {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Connect with WordPress"
+msgstr "Connetti con WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr "Connesso il {0}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:179
+msgid "content"
+msgstr "contenuto"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:378
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
+#: packages/admin/src/components/Dashboard.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:2428
+#: packages/admin/src/components/SectionEditor.tsx:195
+#: packages/admin/src/components/Sidebar.tsx:365
+#: packages/admin/src/components/Widgets.tsx:897
+msgid "Content"
+msgstr "Contenuto"
+
+#: packages/admin/src/components/Widgets.tsx:98
+msgid "Content Block"
+msgstr "Blocco di contenuto"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2382
+msgid "Content Errors ({0})"
+msgstr "Errori contenuto ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1317
+msgid "Content found:"
+msgstr "Contenuto trovato:"
+
+#: packages/admin/src/router.tsx:1068
+msgid "Content has been scheduled for publishing"
+msgstr "Il contenuto è stato pianificato per la pubblicazione"
+
+#: packages/admin/src/components/RevisionHistory.tsx:123
+msgid "Content has been updated to the selected revision."
+msgstr "Il contenuto è stato aggiornato alla revisione selezionata."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "ID contenuto:"
+
+#: packages/admin/src/router.tsx:1009
+msgid "Content is now live"
+msgstr "Il contenuto è ora pubblicato"
+
+#: packages/admin/src/components/WordPressImport.tsx:2371
+msgid "content items"
+msgstr "voci di contenuto"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Content Read"
+msgstr "Lettura contenuto"
+
+#: packages/admin/src/router.tsx:1027
+msgid "Content removed from public view"
+msgstr "Contenuto rimosso dalla visualizzazione pubblica"
+
+#: packages/admin/src/router.tsx:1089
+msgid "Content reverted to draft"
+msgstr "Contenuto ripristinato a bozza"
+
+#: packages/admin/src/components/RevisionHistory.tsx:304
+msgid "Content snapshot:"
+msgstr "Snapshot del contenuto:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1731
+msgid "Content to Import"
+msgstr "Contenuto da importare"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:184
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:248
+msgid "Content Types"
+msgstr "Tipi di contenuto"
+
+#: packages/admin/src/components/WordPressImport.tsx:2310
+msgid "Content was skipped because it already exists"
+msgstr "Il contenuto è stato ignorato perché esiste già"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Content Write"
+msgstr "Scrittura contenuto"
+
+#: packages/admin/src/components/SignupPage.tsx:92
+msgid "Continue"
+msgstr "Continua"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr "Continua →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2529
+msgid "Continue Import"
+msgstr "Continua importazione"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "Collaboratore"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:234
+#: packages/admin/src/components/users/InviteUserModal.tsx:133
+msgid "Copied to clipboard"
+msgstr "Copiato negli appunti"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr "Copia {0} negli appunti"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "Copia link di invito"
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr "Copia slug"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Copy this token now — it won't be shown again."
+msgstr "Copia questo token ora — non verrà mostrato di nuovo."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
+msgid "Copy token"
+msgstr "Copia token"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+#: packages/admin/src/components/MediaDetailPanel.tsx:301
+msgid "Copy URL"
+msgstr "Copia URL"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:136
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "Impossibile copiare automaticamente. Seleziona l'URL qui sopra e copialo manualmente."
+
+#: packages/admin/src/components/Dashboard.tsx:84
+msgid "Could not load dashboard data"
+msgstr "Impossibile caricare i dati della dashboard"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:486
+msgid "Could not load image from URL"
+msgstr "Impossibile caricare l'immagine dall'URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1264
+msgid "Couldn't detect WordPress"
+msgstr "Impossibile rilevare WordPress"
+
+#: packages/admin/src/routes/byline-schema.tsx:268
+msgid "Couldn't load byline fields."
+msgstr "Impossibile caricare i campi firma."
+
+#: packages/admin/src/routes/bylines.tsx:547
+msgid "Couldn't load custom fields."
+msgstr "Impossibile caricare i campi personalizzati."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr "Impossibile associare \"{draft}\" a un tipo MIME. Inserisci il tipo MIME direttamente."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:846
+msgid "Couldn't search bylines. Please try again."
+msgstr "Impossibile cercare le firme. Riprova."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:369
+msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+msgstr "Impossibile verificare quanti valori fanno riferimento a \"{0}\". L'eliminazione rimuoverà comunque ogni valore memorizzato per questo campo — ma il conteggio precedente non ha potuto essere verificato."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:842
+msgid "Count"
+msgstr "Conteggio"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:978
+#: packages/admin/src/components/MenuList.tsx:176
+#: packages/admin/src/components/Redirects.tsx:192
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:501
+#: packages/admin/src/components/Widgets.tsx:452
+#: packages/admin/src/routes/bylines.tsx:579
+msgid "Create"
+msgstr "Crea"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:292
+msgid "Create \"{trimmedInput}\""
+msgstr "Crea \"{trimmedInput}\""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1140
+msgid "Create a bullet list"
+msgstr "Crea un elenco puntato"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:383
+msgid "Create a new {0}"
+msgstr "Crea nuovo {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1150
+msgid "Create a numbered list"
+msgstr "Crea un elenco numerato"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:84
+#: packages/admin/src/components/SignupPage.tsx:221
+msgid "Create Account"
+msgstr "Crea account"
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Create an account"
+msgstr "Crea un account"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:926
+#: packages/admin/src/routes/bylines.tsx:476
+msgid "Create byline"
+msgstr "Crea firma"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr "Crea tipo di contenuto"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Create field"
+msgstr "Crea campo"
+
+#: packages/admin/src/components/MenuList.tsx:127
+#: packages/admin/src/components/MenuList.tsx:190
+msgid "Create Menu"
+msgstr "Crea menu"
+
+#: packages/admin/src/components/MenuList.tsx:134
+msgid "Create New Menu"
+msgstr "Crea nuovo menu"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:409
+msgid "Create New Token"
+msgstr "Crea nuovo token"
+
+#: packages/admin/src/components/WordPressImport.tsx:1501
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "Creane uno in WordPress: Utenti → Profilo → Password applicazione"
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr "Crea passkey"
+
+#: packages/admin/src/components/Settings.tsx:111
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:195
+msgid "Create personal access tokens for programmatic API access"
+msgstr "Crea token di accesso personali per l'accesso programmatico alle API"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:248
+msgid "Create redirect for {0}"
+msgstr "Crea reindirizzamento per {0}"
+
+#: packages/admin/src/components/Redirects.tsx:247
+msgid "Create redirect for this path"
+msgstr "Crea reindirizzamento per questo percorso"
+
+#: packages/admin/src/components/Redirects.tsx:462
+msgid "Create redirect rules to manage URL changes."
+msgstr "Crea regole di reindirizzamento per gestire le modifiche agli URL."
+
+#: packages/admin/src/components/WordPressImport.tsx:1921
+msgid "Create Schema & Import"
+msgstr "Crea schema e importa"
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr "Crea sezione"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:110
+msgid "Create sections in the Sections library to use them here"
+msgstr "Crea sezioni nella libreria Sezioni per utilizzarle qui"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:620
+#: packages/admin/src/components/TaxonomyManager.tsx:711
+msgid "Create Taxonomy"
+msgstr "Crea tassonomia"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:269
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:477
+msgid "Create Token"
+msgstr "Crea token"
+
+#: packages/admin/src/components/Widgets.tsx:408
+msgid "Create Widget Area"
+msgstr "Crea area widget"
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr "Crea il tuo account"
+
+#: packages/admin/src/components/MenuList.tsx:188
+msgid "Create your first navigation menu to get started"
+msgstr "Crea il tuo primo menu di navigazione per iniziare"
+
+#: packages/admin/src/components/ContentList.tsx:556
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr "Crea il primo"
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr "Crea la tua prima sezione di contenuto riutilizzabile per iniziare."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:75
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Create your passkey"
+msgstr "Crea la tua passkey"
+
+#: packages/admin/src/lib/api/marketplace.ts:280
+#: packages/admin/src/lib/api/marketplace.ts:289
+msgid "Create, update, and delete content"
+msgstr "Crea, aggiorna ed elimina contenuto"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:82
+msgid "Create, update, and delete navigation menus"
+msgstr "Crea, aggiorna ed elimina menu di navigazione"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:77
+msgid "Create, update, and delete taxonomy terms"
+msgstr "Crea, aggiorna ed elimina termini di tassonomia"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:52
+msgid "Create, update, delete content"
+msgstr "Crea, aggiorna, elimina contenuto"
+
+#: packages/admin/src/components/ContentList.tsx:736
+#: packages/admin/src/components/ContentSettingsPanel.tsx:525
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr "Creato"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:96
+msgid "Created \"{0}\"."
+msgstr "Creato \"{0}\"."
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr "Creato il {0}"
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:1120
+msgid "Created {0} translation"
+msgstr "Traduzione {0} creata"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr "Data di creazione"
+
+#: packages/admin/src/components/WordPressImport.tsx:887
+msgid "Creating collections and fields..."
+msgstr "Creazione di collezioni e campi in corso…"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:978
+#: packages/admin/src/components/MenuList.tsx:176
+#: packages/admin/src/components/Redirects.tsx:189
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:477
+#: packages/admin/src/components/TaxonomyManager.tsx:711
+#: packages/admin/src/components/TaxonomySidebar.tsx:292
+msgid "Creating..."
+msgstr "Creazione in corso…"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:33
+msgid "CSS"
+msgstr "CSS"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:83
+msgid "current"
+msgstr "corrente"
+
+#: packages/admin/src/components/RevisionHistory.tsx:272
+msgid "Current"
+msgstr "Corrente"
+
+#: packages/admin/src/components/PluginSettings.tsx:340
+msgid "Currently set — enter a new value to replace"
+msgstr "Attualmente impostato — inserisci un nuovo valore per sostituirlo"
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr "Personalizzato"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:623
+msgid "Custom Fields"
+msgstr "Campi personalizzati"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:210
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "Contenuto personalizzato del robots.txt. Lascia vuoto per usare quello predefinito."
+
+#: packages/admin/src/components/SectionEditor.tsx:185
+msgid "Custom Section"
+msgstr "Sezione personalizzata"
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Custom Taxonomies"
+msgstr "Tassonomie personalizzate"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:176
+msgid "Daily automatic backups"
+msgstr "Backup automatici giornalieri"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "scuro"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:130
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/Dashboard.tsx:50
+#: packages/admin/src/components/Sidebar.tsx:206
+#: packages/admin/src/components/Sidebar.tsx:356
+msgid "Dashboard"
+msgstr "Dashboard"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+#: packages/admin/src/components/ContentList.tsx:525
+msgid "Date"
+msgstr "Data"
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr "Data e ora"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr "Selettore data e ora"
+
+#: packages/admin/src/components/ContentList.tsx:790
+msgid "Date field to filter on"
+msgstr "Campo data su cui filtrare"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:281
+msgid "Date Format"
+msgstr "Formato data"
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr "Numero decimale"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:750
+msgid "Declared permissions"
+msgstr "Permessi dichiarati"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:294
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:356
+msgid "Default Role"
+msgstr "Ruolo predefinito"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:233
+msgid "Default role:"
+msgstr "Ruolo predefinito:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:147
+msgid "Default social image"
+msgstr "Immagine social predefinita"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:138
+msgid "Default Social Image"
+msgstr "Immagine social predefinita"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Define a new taxonomy for classifying content"
+msgstr "Definisci una nuova tassonomia per classificare il contenuto"
+
+#: packages/admin/src/routes/byline-schema.tsx:220
+msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+msgstr "Definisci campi personalizzati memorizzati su ogni firma — titolo professionale, pronomi, handle social e altro ancora."
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr "Definisci la struttura del tuo contenuto"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:360
+msgid "Defined in code"
+msgstr "Definito nel codice"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:268
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:672
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:301
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:130
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:453
+#: packages/admin/src/components/MenuEditor.tsx:549
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:583
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/settings/BackupSettings.tsx:284
+#: packages/admin/src/components/TaxonomyManager.tsx:906
+#: packages/admin/src/components/Widgets.tsx:714
+#: packages/admin/src/routes/byline-schema.tsx:378
+#: packages/admin/src/routes/bylines.tsx:588
+#: packages/admin/src/routes/bylines.tsx:624
+msgid "Delete"
+msgstr "Elimina"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:452
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "Eliminare \"{0}\"? Questa operazione non può essere annullata."
+
+#. placeholder {0}: archive.name
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:227
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:252
+#: packages/admin/src/components/settings/BackupSettings.tsx:245
+#: packages/admin/src/components/TaxonomyManager.tsx:117
+#: packages/admin/src/components/Widgets.tsx:815
+#: packages/admin/src/routes/byline-schema.tsx:458
+msgid "Delete {0}"
+msgstr "Elimina {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:749
+msgid "Delete {0} field"
+msgstr "Elimina campo {0}"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:238
+msgid "Delete {0} menu"
+msgstr "Elimina menu {0}"
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:662
+msgid "Delete {0} widget area"
+msgstr "Elimina area widget {0}"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:902
+msgid "Delete {0}?"
+msgstr "Eliminare {0}?"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:282
+msgid "Delete backup?"
+msgstr "Eliminare il backup?"
+
+#: packages/admin/src/routes/byline-schema.tsx:358
+msgid "Delete byline field?"
+msgstr "Eliminare il campo firma?"
+
+#: packages/admin/src/routes/bylines.tsx:622
+msgid "Delete Byline?"
+msgstr "Eliminare la firma?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3343
+msgid "Delete column"
+msgstr "Elimina colonna"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "Delete Comment?"
+msgstr "Eliminare il commento?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr "Eliminare il tipo di contenuto?"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr "Elimina incorporamento"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:666
+msgid "Delete Field?"
+msgstr "Eliminare il campo?"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:237
+#: packages/admin/src/components/editor/GalleryNode.tsx:219
+#: packages/admin/src/components/editor/GalleryNode.tsx:220
+msgid "Delete gallery"
+msgstr "Elimina galleria"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
+msgid "Delete HTML block"
+msgstr "Elimina blocco HTML"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:220
+#: packages/admin/src/components/editor/ImageNode.tsx:221
+msgid "Delete image"
+msgstr "Elimina immagine"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:451
+msgid "Delete Media?"
+msgstr "Eliminare il Media?"
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Delete Menu"
+msgstr "Elimina Menu"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:526
+msgid "Delete permanently"
+msgstr "Elimina definitivamente"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:1136
+msgid "Delete Permanently"
+msgstr "Elimina definitivamente"
+
+#: packages/admin/src/components/ContentList.tsx:1116
+msgid "Delete Permanently?"
+msgstr "Eliminare definitivamente?"
+
+#: packages/admin/src/components/Redirects.tsx:536
+msgid "Delete redirect"
+msgstr "Elimina reindirizzamento"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:537
+msgid "Delete redirect {0}"
+msgstr "Elimina reindirizzamento {0}"
+
+#: packages/admin/src/components/Redirects.tsx:581
+msgid "Delete Redirect?"
+msgstr "Eliminare il reindirizzamento?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3362
+msgid "Delete row"
+msgstr "Elimina riga"
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr "Eliminare la sezione?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3377
+msgid "Delete table"
+msgstr "Elimina tabella"
+
+#: packages/admin/src/components/Widgets.tsx:712
+msgid "Delete Widget Area?"
+msgstr "Eliminare l'area widget?"
+
+#: packages/admin/src/components/ContentList.tsx:646
+msgid "Deleted"
+msgstr "Eliminato"
+
+#. placeholder {0}: deletingField.label
+#. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
+#: packages/admin/src/routes/byline-schema.tsx:371
+msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+msgstr "L'eliminazione di \"{0}\" rimuoverà anche {1, plural, one {# valore salvato} other {# valori salvati}} in tutte le firme. Questa operazione non può essere annullata."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:409
+#: packages/admin/src/components/ContentTypeEditor.tsx:673
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:454
+#: packages/admin/src/components/MenuList.tsx:257
+#: packages/admin/src/components/Redirects.tsx:584
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/settings/BackupSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:907
+#: packages/admin/src/components/Widgets.tsx:715
+#: packages/admin/src/routes/bylines.tsx:625
+msgid "Deleting..."
+msgstr "Eliminazione in corso..."
+
+#: packages/admin/src/routes/byline-schema.tsx:379
+msgid "Deleting…"
+msgstr "Eliminazione in corso…"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr "Demo"
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr "Retrocedi utente"
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr "Retrocedere l'utente?"
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr "Retrocessione in corso..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "Rifiuta"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:379
+#: packages/admin/src/components/editor/ImageNode.tsx:238
+msgid "Describe the image..."
+msgstr "Descrivi l'immagine..."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
+#: packages/admin/src/components/MediaDetailPanel.tsx:374
+msgid "Describe this image for accessibility"
+msgstr "Descrivi questa immagine per l'accessibilità"
+
+#: packages/admin/src/components/SectionEditor.tsx:277
+msgid "Describe what this section is for..."
+msgstr "Descrivi a cosa serve questa sezione..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:413
+#: packages/admin/src/components/RegistryPluginDetail.tsx:805
+#: packages/admin/src/components/SectionEditor.tsx:274
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:436
+msgid "Description"
+msgstr "Descrizione"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:456
+msgid "Description (optional)"
+msgstr "Descrizione (facoltativa)"
+
+#: packages/admin/src/components/Redirects.tsx:469
+msgid "Destination"
+msgstr "Destinazione"
+
+#: packages/admin/src/components/Redirects.tsx:141
+msgid "Destination path"
+msgstr "Percorso di destinazione"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:153
+#: packages/admin/src/components/PluginManager.tsx:563
+msgid "Destructive"
+msgstr "Distruttiva"
+
+#: packages/admin/src/components/PluginManager.tsx:505
+msgid "details"
+msgstr "dettagli"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "Dispositivo autorizzato"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "Codice dispositivo"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr "Legata al dispositivo"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Passkey legata al dispositivo"
+
+#: packages/admin/src/components/SignupPage.tsx:144
+msgid "Didn't receive the email?"
+msgstr "Non hai ricevuto l'email?"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:34
+msgid "Diff"
+msgstr "Diff"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:280
+msgid "Dimensions:"
+msgstr "Dimensioni:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr "Disabilita"
+
+#: packages/admin/src/components/PluginManager.tsx:493
+msgid "Disable plugin"
+msgstr "Disabilita plugin"
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Disable plugin MCP tools"
+msgstr "Disabilita strumenti MCP del plugin"
+
+#: packages/admin/src/components/Redirects.tsx:505
+msgid "Disable redirect"
+msgstr "Disabilita reindirizzamento"
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr "Disabilita utente"
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr "Disabilitare l'utente?"
+
+#: packages/admin/src/components/PluginManager.tsx:382
+#: packages/admin/src/components/Redirects.tsx:419
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr "Disabilitato"
+
+#: packages/admin/src/components/PluginManager.tsx:613
+msgid "Disabled:"
+msgstr "Disabilitati:"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr "Disabilitando <0>{0}</0> gli verrà impedito di accedere finché non viene riabilitato. I contenuti dell'utente verranno conservati."
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr "Disabilitazione in corso..."
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:438
+msgid "Discard"
+msgstr "Scarta"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:73
+#: packages/admin/src/components/ContentSettingsPanel.tsx:93
+msgid "Discard changes"
+msgstr "Scarta modifiche"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:436
+msgid "Discard changes?"
+msgstr "Scartare le modifiche?"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:78
+msgid "Discard draft changes?"
+msgstr "Scartare le modifiche della bozza?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:439
+msgid "Discarding..."
+msgstr "Eliminazione in corso..."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:241
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:243
+msgid "Dismiss"
+msgstr "Chiudi"
+
+#: packages/admin/src/components/Widgets.tsx:127
+msgid "Display a list of recent posts"
+msgstr "Mostra un elenco degli articoli recenti"
+
+#: packages/admin/src/components/Widgets.tsx:105
+msgid "Display a navigation menu"
+msgstr "Mostra un menu di navigazione"
+
+#: packages/admin/src/components/Widgets.tsx:136
+msgid "Display category list"
+msgstr "Mostra l'elenco delle categorie"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:929
+#: packages/admin/src/components/ContentSettingsPanel.tsx:991
+#: packages/admin/src/routes/bylines.tsx:481
+msgid "Display name"
+msgstr "Nome visualizzato"
+
+#: packages/admin/src/components/MenuList.tsx:168
+msgid "Display name for admin interface"
+msgstr "Nome visualizzato nell'interfaccia di amministrazione"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:269
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:458
+msgid "Display Size"
+msgstr "Dimensione di visualizzazione"
+
+#: packages/admin/src/components/Widgets.tsx:144
+msgid "Display tag cloud"
+msgstr "Mostra il tag cloud"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
+msgid "Displayed below the image as a visible caption."
+msgstr "Visualizzata sotto l'immagine come didascalia visibile."
+
+#: packages/admin/src/components/ContentEditor.tsx:697
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "Modalità senza distrazioni (⌘⇧\\)"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1194
+msgid "Divider"
+msgstr "Divisore"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:35
+msgid "Dockerfile"
+msgstr "Dockerfile"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+#: packages/admin/src/components/MediaLibrary.tsx:437
+msgid "Documents"
+msgstr "Documenti"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:286
+msgid "Domain"
+msgstr "Dominio"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:66
+msgid "Domain added successfully"
+msgstr "Dominio aggiunto correttamente"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain removed"
+msgstr "Dominio rimosso"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Domain updated"
+msgstr "Dominio aggiornato"
+
+#: packages/admin/src/components/LoginPage.tsx:334
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "Non hai un account? <0>Registrati</0>"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:142
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Done"
+msgstr "Fatto"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:872
+msgid "Down"
+msgstr "Giù"
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:238
+msgid "Download {0}"
+msgstr "Scarica {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:158
+msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
+msgstr "Scarica un backup completo del sito: tutti i contenuti (inclusi bozze e cestino), collezioni, tassonomie, menu, widget, metadati dei media e impostazioni del sito. Gli account utente e i dati segreti non vengono mai inclusi."
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:160
+msgid "Download backup"
+msgstr "Scarica backup"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:155
+msgid "Download Backup"
+msgstr "Scarica backup"
+
+#: packages/admin/src/components/Settings.tsx:123
+msgid "Download backups and schedule automatic backups to storage"
+msgstr "Scarica backup e pianifica backup automatici sullo storage"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:492
+msgid "Download SBOM"
+msgstr "Scarica SBOM"
+
+#: packages/admin/src/components/WordPressImport.tsx:2126
+msgid "Downloading"
+msgstr "Download in corso"
+
+#: packages/admin/src/components/ContentList.tsx:1162
+msgid "draft"
+msgstr "bozza"
+
+#: packages/admin/src/components/ContentList.tsx:730
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+#: packages/admin/src/components/ContentSettingsPanel.tsx:442
+#: packages/admin/src/components/Dashboard.tsx:346
+msgid "Draft"
+msgstr "Bozza"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr "bozza, pubblicato o archiviato"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:251
+msgid "Drafts"
+msgstr "Bozze"
+
+#: packages/admin/src/components/WordPressImport.tsx:1166
+msgid "Drafts & Private"
+msgstr "Bozze e privati"
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "Trascina o fai clic per sfogliare (.xml)"
+
+#: packages/admin/src/components/Widgets.tsx:698
+msgid "Drag here to add"
+msgstr "Trascina qui per aggiungere"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2006
+msgid "Drag to reorder"
+msgstr "Trascina per riordinare"
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:716
+#: packages/admin/src/components/Widgets.tsx:800
+msgid "Drag to reorder {0}"
+msgstr "Trascina per riordinare {0}"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:338
+msgid "Drag to reorder block"
+msgstr "Trascina per riordinare il blocco"
+
+#: packages/admin/src/components/Widgets.tsx:702
+msgid "Drag widgets here to add them"
+msgstr "Trascina i widget qui per aggiungerli"
+
+#: packages/admin/src/components/Widgets.tsx:465
+msgid "Drag widgets into an area to add them"
+msgstr "Trascina i widget in un'area per aggiungerli"
+
+#: packages/admin/src/components/Widgets.tsx:698
+msgid "Drop to add widget"
+msgstr "Rilascia per aggiungere il widget"
+
+#: packages/admin/src/components/WordPressImport.tsx:1588
+msgid "Drop your WordPress export file here"
+msgstr "Rilascia qui il file di esportazione WordPress"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:292
+msgid "Duplicate"
+msgstr "Duplica"
+
+#: packages/admin/src/components/ContentList.tsx:1027
+msgid "Duplicate {title}"
+msgstr "Duplica {title}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr "es. application/zip o .pdf"
+
+#: packages/admin/src/components/Redirects.tsx:168
+msgid "e.g. import, blog"
+msgstr "es. import, blog"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:423
+msgid "e.g., CI/CD Pipeline"
+msgstr "es., CI/CD Pipeline"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "es., MacBook Pro, iPhone"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:881
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:544
+#: packages/admin/src/components/MenuList.tsx:232
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TranslationsPanel.tsx:93
+msgid "Edit"
+msgstr "Modifica"
+
+#. placeholder {0}: block?.label || ""
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:218
+#: packages/admin/src/components/PortableTextEditor.tsx:1611
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:243
+#: packages/admin/src/components/TaxonomyManager.tsx:109
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/routes/byline-schema.tsx:449
+#: packages/admin/src/routes/bylines.tsx:476
+msgid "Edit {0}"
+msgstr "Modifica {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:741
+msgid "Edit {0} field"
+msgstr "Modifica il campo {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:643
+msgid "Edit {itemLabel}"
+msgstr "Modifica {itemLabel}"
+
+#: packages/admin/src/components/ContentList.tsx:1019
+msgid "Edit {title}"
+msgstr "Modifica {title}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:988
+msgid "Edit byline"
+msgstr "Modifica firma"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "Edit byline field"
+msgstr "Modifica campo firma"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:331
+msgid "Edit Domain"
+msgstr "Modifica dominio"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr "Modifica campo"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/editor/GalleryNode.tsx:178
+msgid "Edit image {0}"
+msgstr "Modifica immagine {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3266
+msgid "Edit link"
+msgstr "Modifica collegamento"
+
+#: packages/admin/src/components/MenuEditor.tsx:573
+msgid "Edit Menu Item"
+msgstr "Modifica voce di menu"
+
+#: packages/admin/src/components/MenuEditor.tsx:369
+msgid "Edit menu items"
+msgstr "Modifica voci di menu"
+
+#: packages/admin/src/components/Redirects.tsx:528
+msgid "Edit redirect"
+msgstr "Modifica reindirizzamento"
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Edit Redirect"
+msgstr "Modifica reindirizzamento"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:529
+msgid "Edit redirect {0}"
+msgstr "Modifica reindirizzamento {0}"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr "Modifica URL"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "Editor"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr ""
+"Editor\n"
+"Reporter\n"
+"Fotografo"
+
+#: packages/admin/src/components/WordPressImport.tsx:1044
+msgid "em1.…"
+msgstr "em1.…"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:62
+#: packages/admin/src/components/Settings.tsx:116
+#: packages/admin/src/components/SignupPage.tsx:198
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr "Email"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:330
+msgid "Email (optional)"
+msgstr "Email (facoltativa)"
+
+#: packages/admin/src/components/LoginPage.tsx:127
+#: packages/admin/src/components/SignupPage.tsx:67
+#: packages/admin/src/components/users/InviteUserModal.tsx:152
+msgid "Email address"
+msgstr "Indirizzo email"
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:50
+msgid "Email is required"
+msgstr "L'email è obbligatoria"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "Email Middleware"
+msgstr "Middleware email"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:99
+msgid "Email Pipeline"
+msgstr "Pipeline email"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:172
+msgid "Email provider active"
+msgstr "Provider email attivo"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:77
+#: packages/admin/src/components/settings/EmailSettings.tsx:92
+msgid "Email Settings"
+msgstr "Impostazioni email"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr "Email verificata"
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "Email verified!"
+msgstr "Email verificata!"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2442
+msgid "Embed a {0}"
+msgstr "Incorpora un {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2445
+msgid "Embeds"
+msgstr "Incorporamenti"
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1307
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "Plugin EmDash Exporter rilevato! Puoi importare direttamente."
+
+#: packages/admin/src/components/editor/GalleryNode.tsx:160
+msgid "Empty gallery — open settings to add images"
+msgstr "Galleria vuota — apri le impostazioni per aggiungere immagini"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr "Abilita"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:493
+msgid "Enable comments"
+msgstr "Abilita commenti"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr "Abilita la ricerca full-text su questa collezione"
+
+#: packages/admin/src/components/PluginManager.tsx:493
+msgid "Enable plugin"
+msgstr "Abilita plugin"
+
+#: packages/admin/src/components/PluginManager.tsx:554
+msgid "Enable plugin MCP tools"
+msgstr "Abilita strumenti MCP del plugin"
+
+#: packages/admin/src/components/Redirects.tsx:505
+msgid "Enable redirect"
+msgstr "Abilita reindirizzamento"
+
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/Redirects.tsx:419
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: packages/admin/src/components/MenuEditor.tsx:423
+#: packages/admin/src/components/MenuEditor.tsx:601
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "Inserisci un URL (https://…) o un percorso relativo (/…)"
+
+#: packages/admin/src/components/ContentEditor.tsx:1437
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr "Inserisci un URL valido (es. https://example.com)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1380
+msgid "Enter credentials manually"
+msgstr "Inserisci le credenziali manualmente"
+
+#: packages/admin/src/components/ContentEditor.tsx:696
+msgid "Enter distraction-free mode"
+msgstr "Entra in modalità senza distrazioni"
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr "Inserisci email"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
+msgid "Enter HTML..."
+msgstr "Inserisci HTML..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1211
+msgid "Enter markdown content..."
+msgstr "Inserisci contenuto markdown..."
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr "Inserisci nome"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "Inserisci il codice dal tuo terminale"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr "Inserisci URL..."
+
+#: packages/admin/src/components/LoginPage.tsx:327
+msgid "Enter your handle to sign in."
+msgstr "Inserisci il tuo handle per accedere."
+
+#: packages/admin/src/components/WordPressImport.tsx:1459
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "Inserisci le credenziali WordPress per importare i contenuti direttamente."
+
+#: packages/admin/src/components/WordPressImport.tsx:1082
+msgid "Enter your WordPress site URL"
+msgstr "Inserisci l'URL del tuo sito WordPress"
+
+#: packages/admin/src/components/MenuEditor.tsx:155
+#: packages/admin/src/components/MenuEditor.tsx:193
+#: packages/admin/src/components/MenuEditor.tsx:233
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:767
+#: packages/admin/src/router.tsx:2174
+msgid "Error"
+msgstr "Errore"
+
+#: packages/admin/src/components/Widgets.tsx:236
+msgid "Error adding widget"
+msgstr "Errore durante l'aggiunta del widget"
+
+#: packages/admin/src/components/Widgets.tsx:297
+msgid "Error reordering widgets"
+msgstr "Errore durante il riordinamento dei widget"
+
+#: packages/admin/src/components/SectionEditor.tsx:53
+msgid "Error saving section"
+msgstr "Errore durante il salvataggio della sezione"
+
+#: packages/admin/src/components/Widgets.tsx:782
+msgid "Error updating widget"
+msgstr "Errore durante l'aggiornamento del widget"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:596
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr "Ogni versione pubblicata di questo plugin è stata ritirata o non ha potuto essere verificata. Riprova più tardi o contatta il publisher."
+
+#: packages/admin/src/components/WordPressImport.tsx:2010
+msgid "Exists"
+msgstr "Esiste"
+
+#: packages/admin/src/components/ContentEditor.tsx:755
+msgid "Exit distraction-free mode"
+msgstr "Esci dalla modalità senza distrazioni"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3830
+msgid "Exit Spotlight Mode"
+msgstr "Esci dalla modalità Spotlight"
+
+#: packages/admin/src/components/PluginManager.tsx:505
+msgid "Expand"
+msgstr "Espandi"
+
+#: packages/admin/src/components/PluginManager.tsx:499
+msgid "Expand details"
+msgstr "Espandi dettagli"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:298
+msgid "Expires {0}"
+msgstr "Scade il {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:463
+msgid "Expiry"
+msgstr "Scadenza"
+
+#: packages/admin/src/components/WordPressImport.tsx:1273
+msgid "Export from WordPress manually"
+msgstr "Esporta da WordPress manualmente"
+
+#: packages/admin/src/components/WordPressImport.tsx:1397
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "Esporta i tuoi contenuti da WordPress per importare tutto, incluse le bozze."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:118
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr "Errore"
+
+#: packages/admin/src/components/WordPressImport.tsx:2130
+msgid "Failed"
+msgstr "Fallito"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:199
+msgid "Failed security audit"
+msgstr "Audit di sicurezza non superato"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:70
+msgid "Failed to add domain"
+msgstr "Impossibile aggiungere il dominio"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:188
+msgid "Failed to add passkey"
+msgstr "Impossibile aggiungere la passkey"
+
+#: packages/admin/src/components/WordPressImport.tsx:413
+msgid "Failed to analyze WordPress site"
+msgstr "Impossibile analizzare il sito WordPress"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr "Impossibile comunicare con il plugin"
+
+#: packages/admin/src/lib/api/media.ts:155
+msgid "Failed to confirm upload"
+msgstr "Impossibile confermare il caricamento"
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr "Impossibile creare l'amministratore"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:104
+#: packages/admin/src/lib/api/backups.ts:51
+msgid "Failed to create backup"
+msgstr "Impossibile creare il backup"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:972
+msgid "Failed to create byline"
+msgstr "Impossibile creare la firma"
+
+#: packages/admin/src/lib/api/byline-fields.ts:120
+msgid "Failed to create byline field"
+msgstr "Impossibile creare il campo firma"
+
+#: packages/admin/src/routes/byline-schema.tsx:102
+msgid "Failed to create field"
+msgstr "Impossibile creare il campo"
+
+#: packages/admin/src/lib/api/sections.ts:88
+msgid "Failed to create section"
+msgstr "Impossibile creare la sezione"
+
+#: packages/admin/src/components/WordPressImport.tsx:1714
+msgid "Failed to create some collections"
+msgstr "Impossibile creare alcune collezioni"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:497
+msgid "Failed to create term"
+msgstr "Impossibile creare il termine"
+
+#: packages/admin/src/router.tsx:1125
+msgid "Failed to create translation"
+msgstr "Impossibile creare la traduzione"
+
+#: packages/admin/src/router.tsx:422
+#: packages/admin/src/router.tsx:451
+#: packages/admin/src/router.tsx:534
+#: packages/admin/src/router.tsx:1145
+msgid "Failed to delete"
+msgstr "Impossibile eliminare"
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr "Impossibile eliminare il dominio consentito"
+
+#: packages/admin/src/lib/api/backups.ts:58
+msgid "Failed to delete backup"
+msgstr "Impossibile eliminare il backup"
+
+#: packages/admin/src/lib/api/bylines.ts:143
+msgid "Failed to delete byline"
+msgstr "Impossibile eliminare la firma"
+
+#: packages/admin/src/lib/api/byline-fields.ts:143
+msgid "Failed to delete byline field"
+msgstr "Impossibile eliminare il campo firma"
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr "Impossibile eliminare la collezione"
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1445
+msgid "Failed to delete comment"
+msgstr "Impossibile eliminare il commento"
+
+#: packages/admin/src/lib/api/content.ts:279
+msgid "Failed to delete content"
+msgstr "Impossibile eliminare il contenuto"
+
+#: packages/admin/src/lib/api/schema.ts:278
+#: packages/admin/src/routes/byline-schema.tsx:138
+msgid "Failed to delete field"
+msgstr "Impossibile eliminare il campo"
+
+#: packages/admin/src/lib/api/media.ts:389
+msgid "Failed to delete from provider"
+msgstr "Impossibile eliminare dal provider"
+
+#: packages/admin/src/lib/api/media.ts:259
+msgid "Failed to delete media"
+msgstr "Impossibile eliminare il media"
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr "Impossibile eliminare il menu"
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr "Impossibile eliminare la voce del menu"
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr "Impossibile eliminare la passkey"
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr "Impossibile eliminare il reindirizzamento"
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr "Impossibile eliminare la sezione"
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr "Impossibile eliminare il termine"
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr "Impossibile eliminare il widget"
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr "Impossibile eliminare l'area widget"
+
+#: packages/admin/src/components/PluginManager.tsx:120
+#: packages/admin/src/lib/api/plugins.ts:160
+msgid "Failed to disable plugin"
+msgstr "Impossibile disabilitare il plugin"
+
+#: packages/admin/src/lib/api/search.ts:32
+msgid "Failed to disable search"
+msgstr "Impossibile disabilitare la ricerca"
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr "Impossibile disabilitare l'utente"
+
+#: packages/admin/src/router.tsx:1052
+msgid "Failed to discard changes"
+msgstr "Impossibile scartare le modifiche"
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr "Impossibile chiudere il messaggio di benvenuto"
+
+#: packages/admin/src/router.tsx:465
+msgid "Failed to duplicate"
+msgstr "Impossibile duplicare"
+
+#: packages/admin/src/components/PluginManager.tsx:101
+#: packages/admin/src/lib/api/plugins.ts:146
+msgid "Failed to enable plugin"
+msgstr "Impossibile abilitare il plugin"
+
+#: packages/admin/src/lib/api/search.ts:31
+msgid "Failed to enable search"
+msgstr "Impossibile abilitare la ricerca"
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr "Impossibile abilitare l'utente"
+
+#: packages/admin/src/components/WordPressImport.tsx:340
+msgid "Failed to execute import"
+msgstr "Impossibile eseguire l'importazione"
+
+#: packages/admin/src/lib/api/client.ts:255
+msgid "Failed to fetch auth mode"
+msgstr "Impossibile recuperare la modalità di autenticazione"
+
+#: packages/admin/src/lib/api/backups.ts:37
+msgid "Failed to fetch backup settings"
+msgstr "Impossibile recuperare le impostazioni di backup"
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr "Impossibile recuperare la collezione"
+
+#: packages/admin/src/lib/api/dashboard.ts:42
+msgid "Failed to fetch dashboard stats"
+msgstr "Impossibile recuperare le statistiche della dashboard"
+
+#: packages/admin/src/lib/api/email-settings.ts:34
+msgid "Failed to fetch email settings"
+msgstr "Impossibile recuperare le impostazioni email"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:93
+msgid "Failed to fetch entry terms"
+msgstr "Impossibile recuperare i termini della voce"
+
+#: packages/admin/src/lib/api/client.ts:238
+msgid "Failed to fetch manifest"
+msgstr "Impossibile recuperare il manifest"
+
+#: packages/admin/src/lib/api/media.ts:76
+msgid "Failed to fetch media"
+msgstr "Impossibile recuperare i media"
+
+#: packages/admin/src/lib/api/media.ts:89
+msgid "Failed to fetch media item"
+msgstr "Impossibile recuperare l'elemento media"
+
+#: packages/admin/src/lib/api/media.ts:325
+msgid "Failed to fetch media providers"
+msgstr "Impossibile recuperare i provider media"
+
+#: packages/admin/src/lib/api/plugins.ts:70
+#: packages/admin/src/lib/api/plugins.ts:74
+msgid "Failed to fetch plugin"
+msgstr "Impossibile recuperare il plugin"
+
+#: packages/admin/src/lib/api/plugins.ts:114
+msgid "Failed to fetch plugin settings"
+msgstr "Impossibile recuperare le impostazioni del plugin"
+
+#: packages/admin/src/lib/api/plugins.ts:56
+msgid "Failed to fetch plugins"
+msgstr "Impossibile recuperare i plugin"
+
+#: packages/admin/src/lib/api/media.ts:355
+msgid "Failed to fetch provider media"
+msgstr "Impossibile recuperare i media del provider"
+
+#: packages/admin/src/lib/api/content.ts:556
+#: packages/admin/src/lib/api/content.ts:561
+msgid "Failed to fetch revision"
+msgstr "Impossibile recuperare la revisione"
+
+#: packages/admin/src/lib/api/sections.ts:76
+msgid "Failed to fetch section"
+msgstr "Impossibile recuperare la sezione"
+
+#: packages/admin/src/lib/api/sections.ts:68
+msgid "Failed to fetch sections"
+msgstr "Impossibile recuperare le sezioni"
+
+#: packages/admin/src/lib/api/settings.ts:50
+msgid "Failed to fetch settings"
+msgstr "Impossibile recuperare le impostazioni"
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr "Impossibile recuperare lo stato della configurazione"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:74
+msgid "Failed to fetch terms"
+msgstr "Impossibile recuperare i termini"
+
+#: packages/admin/src/lib/api/current-user.ts:22
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:852
+#: packages/admin/src/router.tsx:1376
+msgid "Failed to fetch user"
+msgstr "Impossibile recuperare l'utente"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:263
+msgid "Failed to generate preview"
+msgstr "Impossibile generare l'anteprima"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr "Impossibile generare l'URL di anteprima"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr "Impossibile ottenere le opzioni di autenticazione"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr "Impossibile ottenere le opzioni di registrazione"
+
+#: packages/admin/src/lib/api/media.ts:131
+msgid "Failed to get upload URL"
+msgstr "Impossibile ottenere l'URL di caricamento"
+
+#: packages/admin/src/components/WordPressImport.tsx:436
+msgid "Failed to import from WordPress"
+msgstr "Impossibile importare da WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:365
+#: packages/admin/src/lib/api/import.ts:422
+msgid "Failed to import media"
+msgstr "Impossibile importare i media"
+
+#: packages/admin/src/lib/api/marketplace.ts:208
+#: packages/admin/src/lib/api/registry.ts:702
+msgid "Failed to install plugin"
+msgstr "Impossibile installare il plugin"
+
+#: packages/admin/src/lib/api/byline-fields.ts:98
+msgid "Failed to list byline fields"
+msgstr "Impossibile elencare i campi firma"
+
+#: packages/admin/src/router.tsx:282
+msgid "Failed to load admin"
+msgstr "Impossibile caricare l'area amministrativa"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "Failed to load allowed domains"
+msgstr "Impossibile caricare i domini consentiti"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:135
+msgid "Failed to load backup settings"
+msgstr "Impossibile caricare le impostazioni di backup"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:365
+msgid "Failed to load bylines: {0}"
+msgstr "Impossibile caricare le firme: {0}"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:81
+msgid "Failed to load email settings"
+msgstr "Impossibile caricare le impostazioni email"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:465
+msgid "Failed to load image"
+msgstr "Impossibile caricare l'immagine"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:135
+msgid "Failed to load passkeys"
+msgstr "Impossibile caricare le passkey"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:121
+msgid "Failed to load plugin"
+msgstr "Impossibile caricare il plugin"
+
+#: packages/admin/src/components/PluginSettings.tsx:146
+msgid "Failed to load plugin settings"
+msgstr "Impossibile caricare le impostazioni del plugin"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:149
+msgid "Failed to load plugins: {0}"
+msgstr "Impossibile caricare i plugin: {0}"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:96
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr "Impossibile caricare i plugin. L'aggregatore del registro potrebbe non essere raggiungibile."
+
+#: packages/admin/src/components/RevisionHistory.tsx:188
+msgid "Failed to load revisions"
+msgstr "Impossibile caricare le revisioni"
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr "Impossibile caricare la configurazione"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr "Impossibile caricare il tema"
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr "Impossibile caricare gli utenti: {0}"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr "Impossibile caricare il widget"
+
+#: packages/admin/src/router.tsx:1470
+msgid "Failed to perform bulk action"
+msgstr "Impossibile eseguire l'azione in blocco"
+
+#: packages/admin/src/lib/api/content.ts:322
+msgid "Failed to permanently delete content"
+msgstr "Impossibile eliminare definitivamente il contenuto"
+
+#: packages/admin/src/components/WordPressImport.tsx:321
+msgid "Failed to prepare import"
+msgstr "Impossibile preparare l'importazione"
+
+#: packages/admin/src/router.tsx:490
+#: packages/admin/src/router.tsx:1013
+msgid "Failed to publish"
+msgstr "Impossibile pubblicare"
+
+#: packages/admin/src/lib/api/byline-fields.ts:106
+msgid "Failed to read byline field usage"
+msgstr "Impossibile leggere l'utilizzo del campo firma"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:112
+msgid "Failed to remove domain"
+msgstr "Impossibile rimuovere il dominio"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:70
+msgid "Failed to remove passkey"
+msgstr "Impossibile rimuovere la passkey"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:53
+msgid "Failed to rename passkey"
+msgstr "Impossibile rinominare la passkey"
+
+#: packages/admin/src/lib/api/byline-fields.ts:156
+msgid "Failed to reorder byline fields"
+msgstr "Impossibile riordinare i campi firma"
+
+#: packages/admin/src/lib/api/schema.ts:293
+#: packages/admin/src/routes/byline-schema.tsx:152
+msgid "Failed to reorder fields"
+msgstr "Impossibile riordinare i campi"
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr "Impossibile riordinare i widget"
+
+#: packages/admin/src/router.tsx:437
+msgid "Failed to restore"
+msgstr "Impossibile ripristinare"
+
+#: packages/admin/src/lib/api/content.ts:311
+msgid "Failed to restore content"
+msgstr "Impossibile ripristinare il contenuto"
+
+#: packages/admin/src/lib/api/content.ts:578
+#: packages/admin/src/lib/api/content.ts:583
+msgid "Failed to restore revision"
+msgstr "Impossibile ripristinare la revisione"
+
+#: packages/admin/src/lib/api/api-tokens.ts:99
+msgid "Failed to revoke API token"
+msgstr "Impossibile revocare il token API"
+
+#: packages/admin/src/components/WordPressImport.tsx:378
+msgid "Failed to rewrite URLs"
+msgstr "Impossibile riscrivere gli URL"
+
+#: packages/admin/src/router.tsx:942
+#: packages/admin/src/router.tsx:1959
+msgid "Failed to save"
+msgstr "Impossibile salvare"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:84
+msgid "Failed to save backup settings"
+msgstr "Impossibile salvare le impostazioni di backup"
+
+#: packages/admin/src/routes/byline-schema.tsx:122
+msgid "Failed to save field"
+msgstr "Impossibile salvare il campo"
+
+#: packages/admin/src/components/PluginSettings.tsx:74
+#: packages/admin/src/components/settings/GeneralSettings.tsx:50
+#: packages/admin/src/components/settings/SeoSettings.tsx:44
+#: packages/admin/src/components/settings/SocialSettings.tsx:42
+msgid "Failed to save settings"
+msgstr "Impossibile salvare le impostazioni"
+
+#: packages/admin/src/router.tsx:1073
+msgid "Failed to schedule"
+msgstr "Impossibile pianificare"
+
+#: packages/admin/src/components/LoginPage.tsx:71
+#: packages/admin/src/components/LoginPage.tsx:76
+msgid "Failed to send magic link"
+msgstr "Impossibile inviare il magic link"
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr "Impossibile inviare il link di recupero"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:50
+#: packages/admin/src/lib/api/email-settings.ts:45
+msgid "Failed to send test email"
+msgstr "Impossibile inviare l'email di prova"
+
+#: packages/admin/src/components/SignupPage.tsx:351
+msgid "Failed to send verification email"
+msgstr "Impossibile inviare l'email di verifica"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:116
+msgid "Failed to set entry terms"
+msgstr "Impossibile impostare i termini della voce"
+
+#: packages/admin/src/lib/api/marketplace.ts:249
+#: packages/admin/src/lib/api/registry.ts:858
+msgid "Failed to uninstall plugin"
+msgstr "Impossibile disinstallare il plugin"
+
+#: packages/admin/src/router.tsx:1031
+msgid "Failed to unpublish"
+msgstr "Impossibile annullare la pubblicazione"
+
+#: packages/admin/src/router.tsx:1094
+msgid "Failed to unschedule"
+msgstr "Impossibile annullare la pianificazione"
+
+#: packages/admin/src/router.tsx:513
+msgid "Failed to update"
+msgstr "Impossibile aggiornare"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:351
+msgid "Failed to update {0}"
+msgstr "Impossibile aggiornare {0}"
+
+#: packages/admin/src/lib/api/backups.ts:46
+msgid "Failed to update backup settings"
+msgstr "Impossibile aggiornare le impostazioni di backup"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1022
+msgid "Failed to update byline"
+msgstr "Impossibile aggiornare la firma"
+
+#: packages/admin/src/lib/api/byline-fields.ts:135
+msgid "Failed to update byline field"
+msgstr "Impossibile aggiornare il campo firma"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:94
+msgid "Failed to update domain"
+msgstr "Impossibile aggiornare il dominio"
+
+#: packages/admin/src/lib/api/media.ts:276
+msgid "Failed to update media"
+msgstr "Impossibile aggiornare il media"
+
+#: packages/admin/src/lib/api/marketplace.ts:232
+#: packages/admin/src/lib/api/registry.ts:776
+msgid "Failed to update plugin"
+msgstr "Impossibile aggiornare il plugin"
+
+#: packages/admin/src/lib/api/plugins.ts:172
+msgid "Failed to update plugin MCP access"
+msgstr "Impossibile aggiornare l'accesso MCP del plugin"
+
+#: packages/admin/src/lib/api/plugins.ts:133
+msgid "Failed to update plugin settings"
+msgstr "Impossibile aggiornare le impostazioni del plugin"
+
+#: packages/admin/src/lib/api/sections.ts:100
+msgid "Failed to update section"
+msgstr "Impossibile aggiornare la sezione"
+
+#: packages/admin/src/lib/api/settings.ts:64
+msgid "Failed to update settings"
+msgstr "Impossibile aggiornare le impostazioni"
+
+#: packages/admin/src/router.tsx:1429
+msgid "Failed to update status"
+msgstr "Impossibile aggiornare lo stato"
+
+#: packages/admin/src/lib/api/media.ts:173
+msgid "Failed to upload file"
+msgstr "Impossibile caricare il file"
+
+#: packages/admin/src/lib/api/media.ts:218
+msgid "Failed to upload media"
+msgstr "Impossibile caricare il media"
+
+#: packages/admin/src/lib/api/media.ts:377
+msgid "Failed to upload to provider"
+msgstr "Impossibile caricare sul provider"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:248
+msgid "Failed to verify authentication"
+msgstr "Impossibile verificare l'autenticazione"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr "Impossibile verificare la registrazione"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:807
+msgid "FAQ"
+msgstr "FAQ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:213
+#: packages/admin/src/components/settings/GeneralSettings.tsx:219
+msgid "Favicon"
+msgstr "Favicon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1180
+msgid "Feature"
+msgstr "Funzionalità"
+
+#: packages/admin/src/components/WordPressImport.tsx:1148
+msgid "Featured Images"
+msgstr "Immagini in evidenza"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:440
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr "Funzionalità"
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "Recupero dei contenuti dall'API EmDash Exporter in corso."
+
+#: packages/admin/src/routes/byline-schema.tsx:95
+msgid "Field created"
+msgstr "Campo creato"
+
+#: packages/admin/src/routes/byline-schema.tsx:133
+msgid "Field deleted"
+msgstr "Campo eliminato"
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr "Etichetta campo"
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr "Etichetta campo"
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr "Gli slug dei campi non possono essere modificati dopo la creazione"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:268
+msgid "Field type cannot be changed after creation."
+msgstr "Il tipo di campo non può essere modificato dopo la creazione."
+
+#: packages/admin/src/routes/byline-schema.tsx:115
+msgid "Field updated"
+msgstr "Campo aggiornato"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:581
+msgid "Fields"
+msgstr "Campi"
+
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Fields created:"
+msgstr "Campi creati:"
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr "File"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2158
+msgid "File {0}"
+msgstr "File {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr "File dalla libreria media"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:325
+#: packages/admin/src/components/MediaDetailPanel.tsx:342
+#: packages/admin/src/components/MediaLibrary.tsx:586
+msgid "Filename"
+msgstr "Nome file"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:120
+msgid "Filename cannot be changed after upload"
+msgstr "Il nome del file non può essere modificato dopo il caricamento"
+
+#: packages/admin/src/components/WordPressImport.tsx:2366
+msgid "files imported"
+msgstr "file importati"
+
+#: packages/admin/src/components/ContentList.tsx:769
+msgid "Filter by author"
+msgstr "Filtra per autore"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr "Filtra per funzionalità"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:178
+msgid "Filter by collection"
+msgstr "Filtra per collezione"
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr "Filtra per ruolo"
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr "Filtra per origine"
+
+#: packages/admin/src/components/ContentList.tsx:754
+#: packages/admin/src/components/Redirects.tsx:420
+msgid "Filter by status"
+msgstr "Filtra per stato"
+
+#: packages/admin/src/components/MediaLibrary.tsx:439
+#: packages/admin/src/components/Redirects.tsx:426
+msgid "Filter by type"
+msgstr "Filtra per tipo"
+
+#: packages/admin/src/routes/bylines.tsx:408
+msgid "Filter byline type"
+msgstr "Filtra per tipo di firma"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr "Solo nuovi commentatori"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr "Font"
+
+#: packages/admin/src/components/WordPressImport.tsx:1398
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "Per un'importazione completa che includa bozze e tutti i contenuti, esporta da WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1207
+msgid "For the best import experience, install the"
+msgstr "Per la migliore esperienza di importazione, installa il"
+
+#: packages/admin/src/components/ContentList.tsx:806
+msgid "From date"
+msgstr "Data inizio"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
+#: packages/admin/src/components/WordPressImport.tsx:1155
+msgid "Full"
+msgstr "Completo"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "Accesso completo"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:102
+msgid "Full admin access"
+msgstr "Accesso amministratore completo"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:171
+#: packages/admin/src/components/PortableTextEditor.tsx:2409
+msgid "Gallery"
+msgstr "Galleria"
+
+#: packages/admin/src/components/editor/GalleryNode.tsx:207
+#: packages/admin/src/components/editor/GalleryNode.tsx:208
+msgid "Gallery settings"
+msgstr "Impostazioni galleria"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "General"
+msgstr "Generale"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:96
+#: packages/admin/src/components/settings/GeneralSettings.tsx:124
+msgid "General Settings"
+msgstr "Impostazioni generali"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:648
+msgid "Genres"
+msgstr "Generi"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "Inizia"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:112
+msgid "GitHub"
+msgstr "GitHub"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "Assegna un nome a questa passkey per identificarla in seguito."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:36
+msgid "Go"
+msgstr "Go"
+
+#: packages/admin/src/components/WordPressImport.tsx:2418
+#: packages/admin/src/router.tsx:2194
+msgid "Go to Dashboard"
+msgstr "Vai alla Dashboard"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:194
+msgid "Google Verification"
+msgstr "Verifica Google"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:37
+msgid "GraphQL"
+msgstr "GraphQL"
+
+#: packages/admin/src/components/MediaLibrary.tsx:460
+msgid "Grid view"
+msgstr "Vista a griglia"
+
+#: packages/admin/src/components/Redirects.tsx:167
+msgid "Group (optional)"
+msgstr "Gruppo (facoltativo)"
+
+#: packages/admin/src/components/Widgets.tsx:162
+msgid "Group by"
+msgstr "Raggruppa per"
+
+#: packages/admin/src/routes/bylines.tsx:555
+msgid "Guest byline"
+msgstr "Firma ospite"
+
+#: packages/admin/src/routes/bylines.tsx:413
+msgid "Guest only"
+msgstr "Solo ospiti"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:62
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
+#: packages/admin/src/components/PortableTextEditor.tsx:1109
+msgid "Heading 1"
+msgstr "Titolo 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:70
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:33
+#: packages/admin/src/components/PortableTextEditor.tsx:1119
+msgid "Heading 2"
+msgstr "Titolo 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:78
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:34
+#: packages/admin/src/components/PortableTextEditor.tsx:1129
+msgid "Heading 3"
+msgstr "Titolo 3"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
+msgid "Heading 4"
+msgstr "Titolo 4"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
+msgid "Heading 5"
+msgstr "Titolo 5"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
+msgid "Heading 6"
+msgstr "Titolo 6"
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:142
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:158
+msgid "Headings"
+msgstr "Titoli"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
+msgid "Height"
+msgstr "Altezza"
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr "Hero Banner"
+
+#: packages/admin/src/components/SectionEditor.tsx:286
+msgid "hero, banner, cta"
+msgstr "hero, banner, cta"
+
+#: packages/admin/src/components/SeoPanel.tsx:230
+#: packages/admin/src/components/SeoPanel.tsx:233
+msgid "Hide from search engines"
+msgstr "Nascondi dai motori di ricerca"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
+msgid "Hide token"
+msgstr "Nascondi token"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:671
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "Gerarchica (come le categorie, con relazioni genitore/figlio)"
+
+#: packages/admin/src/components/Redirects.tsx:226
+#: packages/admin/src/components/Redirects.tsx:471
+msgid "Hits"
+msgstr "Accessi"
+
+#: packages/admin/src/components/MenuEditor.tsx:416
+msgid "Home"
+msgstr "Home"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr "Homepage"
+
+#: packages/admin/src/components/PluginManager.tsx:413
+msgid "Hooks"
+msgstr "Hook"
+
+#: packages/admin/src/components/WordPressImport.tsx:1520
+msgid "How to create an Application Password"
+msgstr "Come creare una password applicazione"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:38
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
+#: packages/admin/src/components/PortableTextEditor.tsx:1179
+msgid "HTML"
+msgstr "HTML"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
+msgid "HTML source"
+msgstr "Sorgente HTML"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3193
+#: packages/admin/src/components/PortableTextEditor.tsx:3760
+msgid "https://..."
+msgstr "https://..."
+
+#: packages/admin/src/components/MenuEditor.tsx:424
+msgid "https://example.com or /about"
+msgstr "https://example.com or /about"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:555
+msgid "https://example.com/image.jpg"
+msgstr "https://example.com/image.jpg"
+
+#: packages/admin/src/components/WordPressImport.tsx:1089
+msgid "https://yoursite.com"
+msgstr "https://yoursite.com"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:153
+msgid "Icon blurred due to image audit"
+msgstr "Icona oscurata a causa di una verifica dell'immagine"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:104
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "Se esiste un account per <0>{email}</0>, abbiamo inviato un link di accesso."
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/FieldEditor.tsx:587
+#: packages/admin/src/components/PortableTextEditor.tsx:2394
+msgid "Image"
+msgstr "Immagine"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:294
+msgid "Image {0}"
+msgstr "Immagine {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr "Immagine dalla libreria media"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ImageFieldRenderer.tsx:124
+msgid "Image not found"
+msgstr "Immagine non trovata"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:208
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Image settings"
+msgstr "Impostazioni immagine"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
+msgid "Image Settings"
+msgstr "Impostazioni immagine"
+
+#: packages/admin/src/components/SeoImageField.tsx:43
+msgid "Image shown when this page is shared on social media"
+msgstr "Immagine mostrata quando questa pagina viene condivisa sui social media"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:556
+msgid "Image URL"
+msgstr "URL immagine"
+
+#: packages/admin/src/components/WordPressImport.tsx:2370
+msgid "image URLs updated in"
+msgstr "URL immagine aggiornati in"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:192
+#: packages/admin/src/components/MediaLibrary.tsx:434
+msgid "Images"
+msgstr "Immagini"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:226
+#: packages/admin/src/components/Sidebar.tsx:290
+#: packages/admin/src/components/WordPressImport.tsx:738
+msgid "Import"
+msgstr "Importa"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "Import {0}"
+msgstr "Importa {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1366
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "Importa tutti i contenuti direttamente, incluse bozze, tipi di articolo personalizzati, campi ACF e dati SEO. Non è necessario scaricare alcun file."
+
+#: packages/admin/src/components/WordPressImport.tsx:2416
+msgid "Import Another File"
+msgstr "Importa un altro file"
+
+#: packages/admin/src/components/WordPressImport.tsx:1174
+msgid "Import Capabilities"
+msgstr "Funzionalità di importazione"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Import Complete"
+msgstr "Importazione completata"
+
+#: packages/admin/src/components/WordPressImport.tsx:2305
+msgid "Import Completed with Errors"
+msgstr "Importazione completata con errori"
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Import failed"
+msgstr "Importazione non riuscita"
+
+#: packages/admin/src/components/WordPressImport.tsx:691
+msgid "Import from WordPress"
+msgstr "Importa da WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "Import Media"
+msgstr "Importa media"
+
+#: packages/admin/src/components/WordPressImport.tsx:2060
+msgid "Import Media Files"
+msgstr "Importa file media"
+
+#: packages/admin/src/components/WordPressImport.tsx:693
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "Importa articoli, pagine e tipi di articolo personalizzati da WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1814
+msgid "Import site configuration from WordPress."
+msgstr "Importa la configurazione del sito da WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Import via EmDash Exporter"
+msgstr "Importa tramite EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr "Importato"
+
+#: packages/admin/src/components/WordPressImport.tsx:2344
+msgid "Imported by Collection"
+msgstr "Importato per collezione"
+
+#. placeholder {0}: wpImportProgress.comments
+#: packages/admin/src/components/WordPressImport.tsx:903
+msgid "Importing comments... {0}"
+msgstr "Importazione commenti in corso... {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:920
+msgid "Importing content..."
+msgstr "Importazione contenuti in corso..."
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:901
+msgid "Importing content... {0}"
+msgstr "Importazione contenuti in corso... {0}"
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:900
+msgid "Importing content... {0} of {totalSelectedPosts}"
+msgstr "Importazione contenuti in corso... {0} di {totalSelectedPosts}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Importing Media"
+msgstr "Importazione media in corso"
+
+#: packages/admin/src/components/WordPressImport.tsx:904
+msgid "Importing menus and site settings..."
+msgstr "Importazione menu e impostazioni del sito in corso..."
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr "Includi contenuti di esempio (consigliato per i nuovi siti)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1980
+msgid "Incompatible"
+msgstr "Incompatibile"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:506
+msgid "Indexed"
+msgstr "Indicizzato"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3644
+msgid "Inline Code"
+msgstr "Codice inline"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:567
+#: packages/admin/src/components/MediaPickerModal.tsx:811
+msgid "Insert"
+msgstr "Inserisci"
+
+#. placeholder {0}: block?.label || ""
+#: packages/admin/src/components/PortableTextEditor.tsx:1611
+msgid "Insert {0}"
+msgstr "Inserisci {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1160
+msgid "Insert a blockquote"
+msgstr "Inserisci una citazione"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1170
+msgid "Insert a code block"
+msgstr "Inserisci un blocco di codice"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1195
+msgid "Insert a horizontal rule"
+msgstr "Inserisci una riga orizzontale"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2425
+msgid "Insert a reusable section"
+msgstr "Inserisci una sezione riutilizzabile"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1205
+msgid "Insert a table"
+msgstr "Inserisci una tabella"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2395
+msgid "Insert an image"
+msgstr "Inserisci un'immagine"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2410
+msgid "Insert an image gallery"
+msgstr "Inserisci una galleria immagini"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1439
+msgid "Insert block"
+msgstr "Inserisci blocco"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3596
+#: packages/admin/src/components/PortableTextEditor.tsx:3606
+msgid "Insert block after current block"
+msgstr "Inserisci blocco dopo il blocco corrente"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
+msgid "Insert block below"
+msgstr "Inserisci blocco sotto"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:549
+msgid "Insert from URL"
+msgstr "Inserisci da URL"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3730
+#: packages/admin/src/components/PortableTextEditor.tsx:3744
+msgid "Insert Link"
+msgstr "Inserisci link"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1180
+msgid "Insert raw HTML"
+msgstr "Inserisci HTML grezzo"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:58
+msgid "Insert Section"
+msgstr "Inserisci sezione"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+#: packages/admin/src/components/RegistryPluginDetail.tsx:554
+msgid "Install"
+msgstr "Installa"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:155
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "Installa e attiva un plugin per provider email per abilitare funzionalità come inviti, link magici e recupero password."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:197
+msgid "Install blocked"
+msgstr "Installazione bloccata"
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
+msgstr "Installa il plugin EmDash Exporter sul tuo sito WordPress e genera una chiave in Strumenti → EmDash Migration."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:806
+msgid "Installation"
+msgstr "Installazione"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:184
+#: packages/admin/src/components/RegistryBrowse.tsx:199
+#: packages/admin/src/components/RegistryPluginDetail.tsx:546
+msgid "Installed"
+msgstr "Installato"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:582
+msgid "Installed from marketplace (v{0})"
+msgstr "Installato dal marketplace (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:601
+msgid "Installed:"
+msgstr "Installato:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:198
+msgid "Installing..."
+msgstr "Installazione in corso..."
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr "Intero"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:152
+msgid "Invalid invite link"
+msgstr "Link di invito non valido"
+
+#: packages/admin/src/components/ContentEditor.tsx:1506
+msgid "Invalid JSON"
+msgstr "JSON non valido"
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Invalid link"
+msgstr "Link non valido"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:241
+msgid "Invite Error"
+msgstr "Errore invito"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:150
+msgid "Invite expired"
+msgstr "Invito scaduto"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "Link di invito creato"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr "Invita utente"
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr "Invita il primo membro del team"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:97
+msgid "Invoke MCP tools from all enabled plugins"
+msgstr "Richiama gli strumenti MCP di tutti i plugin abilitati"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:454
+msgid "Invoke only this plugin's enabled MCP tools"
+msgstr "Richiama solo gli strumenti MCP abilitati di questo plugin"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3237
+#: packages/admin/src/components/PortableTextEditor.tsx:3623
+msgid "Italic"
+msgstr "Corsivo"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1992
+#: packages/admin/src/components/RepeaterField.tsx:239
+msgid "Item {0}"
+msgstr "Elemento {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Item added"
+msgstr "Elemento aggiunto"
+
+#: packages/admin/src/components/MenuEditor.tsx:187
+msgid "Item deleted"
+msgstr "Elemento eliminato"
+
+#: packages/admin/src/components/MenuEditor.tsx:212
+msgid "Item updated"
+msgstr "Elemento aggiornato"
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:206
+msgid "Jane Doe"
+msgstr "Jane Doe"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:39
+msgid "Java"
+msgstr "Java"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:40
+msgid "JavaScript"
+msgstr "JavaScript"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:235
+msgid "Job title"
+msgstr "Qualifica"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:246
+msgid "job_title"
+msgstr "job_title"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:41
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr "JSON"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:42
+msgid "JSX"
+msgstr "JSX"
+
+#: packages/admin/src/components/WordPressImport.tsx:916
+msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
+msgstr "Tieni questa scheda aperta. L'importazione avviene in piccoli passaggi e può essere ripetuta in sicurezza se interrotta."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:851
+msgid "Keep typing to narrow down more bylines."
+msgstr "Continua a digitare per filtrare ulteriormente le firme."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:283
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr "Parole chiave"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:43
+msgid "Kotlin"
+msgstr "Kotlin"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:232
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:416
+#: packages/admin/src/components/MenuEditor.tsx:593
+#: packages/admin/src/components/MenuList.tsx:167
+#: packages/admin/src/components/TaxonomyManager.tsx:645
+#: packages/admin/src/components/Widgets.tsx:434
+#: packages/admin/src/routes/byline-schema.tsx:234
+msgid "Label"
+msgstr "Etichetta"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:392
+msgid "Label (Plural)"
+msgstr "Etichetta (plurale)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:384
+msgid "Label (Singular)"
+msgstr "Etichetta (singolare)"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:162
+#: packages/admin/src/components/LoginPage.tsx:347
+#: packages/admin/src/components/Settings.tsx:136
+#: packages/admin/src/components/Settings.tsx:141
+msgid "Language"
+msgstr "Lingua"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1110
+msgid "Large section heading"
+msgstr "Intestazione di sezione grande"
+
+#: packages/admin/src/components/PluginManager.tsx:607
+msgid "Last enabled:"
+msgstr "Ultima abilitazione:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr "Ultimo accesso"
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr "Ultimo Accesso"
+
+#: packages/admin/src/components/Redirects.tsx:227
+msgid "Last seen"
+msgstr "Ultima visita"
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr "Ultimo aggiornamento"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:159
+msgid "Last used"
+msgstr "Ultimo utilizzo"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:303
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr "Ultimo utilizzo {0}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:274
+msgid "Learn more"
+msgstr "Scopri di più"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:339
+msgid "Leave blank to use a discoverable passkey."
+msgstr "Lascia vuoto per utilizzare una passkey rilevabile automaticamente."
+
+#: packages/admin/src/components/WordPressImport.tsx:2497
+msgid "Leave unassigned"
+msgstr "Lascia non assegnato"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
+msgid "Left"
+msgstr "Sinistra"
+
+#: packages/admin/src/components/MediaLibrary.tsx:136
+#: packages/admin/src/components/MediaLibrary.tsx:273
+#: packages/admin/src/components/MediaLibrary.tsx:356
+#: packages/admin/src/components/MediaPickerModal.tsx:211
+#: packages/admin/src/components/MediaPickerModal.tsx:509
+msgid "Library"
+msgstr "Libreria"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr "Licenza"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "chiaro"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/admin/src/components/Widgets.tsx:165
+msgid "Limit"
+msgstr "Limite"
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Link expired"
+msgstr "Link scaduto"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr "Collega a un altro elemento di contenuto"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr "Account collegati ({0})"
+
+#: packages/admin/src/routes/bylines.tsx:414
+msgid "Linked only"
+msgstr "Solo collegati"
+
+#: packages/admin/src/routes/bylines.tsx:506
+msgid "Linked user"
+msgstr "Utente collegato"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:130
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr "Link"
+
+#: packages/admin/src/components/MediaLibrary.tsx:469
+msgid "List view"
+msgstr "Vista elenco"
+
+#: packages/admin/src/components/ContentEditor.tsx:677
+#: packages/admin/src/components/ContentEditor.tsx:720
+#: packages/admin/src/components/ContentSettingsPanel.tsx:252
+msgid "Live View"
+msgstr "Vista live"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/RegistryBrowse.tsx:144
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:468
+msgid "Load more"
+msgstr "Carica altri"
+
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:775
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr "Carica altri"
+
+#: packages/admin/src/router.tsx:2149
+msgid "Loading"
+msgstr "Caricamento"
+
+#: packages/admin/src/routes/byline-schema.tsx:257
+msgid "Loading byline fields…"
+msgstr "Caricamento campi firma…"
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr "Caricamento collezioni..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:308
+msgid "Loading comments..."
+msgstr "Caricamento commenti..."
+
+#: packages/admin/src/router.tsx:2151
+#: packages/admin/src/router.tsx:2163
+msgid "Loading configuration..."
+msgstr "Caricamento configurazione..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr "Caricamento contenuto..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2985
+msgid "Loading editor..."
+msgstr "Caricamento editor..."
+
+#: packages/admin/src/components/MenuEditor.tsx:342
+msgid "Loading menu..."
+msgstr "Caricamento menu..."
+
+#: packages/admin/src/components/MenuList.tsx:95
+msgid "Loading menus..."
+msgstr "Caricamento menu..."
+
+#: packages/admin/src/components/PluginManager.tsx:140
+msgid "Loading plugins..."
+msgstr "Caricamento plugin..."
+
+#: packages/admin/src/components/Redirects.tsx:457
+msgid "Loading redirects..."
+msgstr "Caricamento reindirizzamenti..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:95
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr "Caricamento sezioni..."
+
+#: packages/admin/src/components/PluginSettings.tsx:131
+#: packages/admin/src/components/settings/GeneralSettings.tsx:99
+#: packages/admin/src/components/settings/SeoSettings.tsx:93
+#: packages/admin/src/components/settings/SocialSettings.tsx:73
+msgid "Loading settings..."
+msgstr "Caricamento impostazioni..."
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr "Caricamento configurazione..."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:847
+msgid "Loading terms..."
+msgstr "Caricamento termini..."
+
+#: packages/admin/src/components/Widgets.tsx:372
+msgid "Loading widgets..."
+msgstr "Caricamento widget..."
+
+#: packages/admin/src/components/ContentList.tsx:538
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:659
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:775
+#: packages/admin/src/components/PortableTextEditor.tsx:2119
+#: packages/admin/src/components/RegistryBrowse.tsx:144
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:161
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/TaxonomyManager.tsx:801
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:468
+msgid "Loading..."
+msgstr "Caricamento..."
+
+#: packages/admin/src/components/ContentList.tsx:518
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "locale"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Lock aspect ratio"
+msgstr "Blocca proporzioni"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:291
+msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
+msgstr "Bloccato perché questo campo contiene valori salvati. Elimina i valori (o il campo) per modificarlo."
+
+#: packages/admin/src/components/Header.tsx:109
+msgid "Log out"
+msgstr "Esci"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "Logo"
+msgstr "Logo"
+
+#: packages/admin/src/components/WordPressImport.tsx:1832
+msgid "Logo & favicon"
+msgstr "Logo e favicon"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:53
+msgid "Long text"
+msgstr "Testo lungo"
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr "Testo lungo"
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "Solo lettere minuscole, numeri e trattini"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:663
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "Solo lettere minuscole, numeri e underscore, a partire da una lettera"
+
+#: packages/admin/src/components/Widgets.tsx:434
+msgid "Main Sidebar"
+msgstr "Barra laterale principale"
+
+#: packages/admin/src/lib/api/marketplace.ts:285
+#: packages/admin/src/lib/api/marketplace.ts:293
+msgid "Make network requests"
+msgstr "Esegui richieste di rete"
+
+#: packages/admin/src/lib/api/marketplace.ts:286
+#: packages/admin/src/lib/api/marketplace.ts:294
+msgid "Make network requests to any host (unrestricted)"
+msgstr "Esegui richieste di rete verso qualsiasi host (senza restrizioni)"
+
+#: packages/admin/src/components/Sidebar.tsx:375
+msgid "Manage"
+msgstr "Gestisci"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:818
+msgid "Manage {0} for {1}"
+msgstr "Gestisci {0} per {1}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:813
+msgid "Manage bylines in {entryLocale}"
+msgstr "Gestisci le firme in {entryLocale}"
+
+#: packages/admin/src/components/Widgets.tsx:389
+msgid "Manage content widgets in your widget areas"
+msgstr "Gestisci i widget di contenuto nelle aree widget"
+
+#: packages/admin/src/components/PluginManager.tsx:179
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "Gestisci i plugin installati. Abilita o disabilita i plugin per controllarne le funzionalità."
+
+#: packages/admin/src/components/MenuList.tsx:105
+msgid "Manage navigation menus for your site"
+msgstr "Gestisci i menu di navigazione del tuo sito"
+
+#: packages/admin/src/components/Redirects.tsx:360
+msgid "Manage URL redirects and view 404 errors."
+msgstr "Gestisci i reindirizzamenti URL e visualizza gli errori 404."
+
+#: packages/admin/src/components/Settings.tsx:94
+msgid "Manage your passkeys and authentication"
+msgstr "Gestisci le tue passkey e l'autenticazione"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:317
+msgid "Managed by {providerName}"
+msgstr "Gestito da {providerName}"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:318
+msgid "Managed by an external media provider"
+msgstr "Gestito da un provider multimediale esterno"
+
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "Manual"
+msgstr "Manuale"
+
+#: packages/admin/src/components/WordPressImport.tsx:2454
+msgid "Map Authors"
+msgstr "Mappa autori"
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2502
+msgid "Map WordPress user {0} to EmDash user"
+msgstr "Mappa l'utente WordPress {0} a un utente EmDash"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:256
+msgid "Mark {0} as Gone (410)"
+msgstr "Contrassegna {0} come rimosso (410)"
+
+#: packages/admin/src/components/Redirects.tsx:255
+msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
+msgstr "Contrassegna come rimosso (410) — informa i motori di ricerca che è stato eliminato definitivamente"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:502
+msgid "Mark as spam"
+msgstr "Contrassegna come spam"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:44
+msgid "Markdown"
+msgstr "Markdown"
+
+#: packages/admin/src/components/PluginManager.tsx:205
+msgid "marketplace"
+msgstr "marketplace"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:171
+#: packages/admin/src/components/PluginManager.tsx:383
+#: packages/admin/src/components/Sidebar.tsx:272
+msgid "Marketplace"
+msgstr "Marketplace"
+
+#: packages/admin/src/components/FieldEditor.tsx:627
+msgid "Max Items"
+msgstr "Elementi massimi"
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr "Lunghezza massima"
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr "Valore massimo"
+
+#: packages/admin/src/components/Widgets.tsx:147
+msgid "Maximum tags"
+msgstr "Tag massimi"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:45
+msgid "MDX"
+msgstr "MDX"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2398
+#: packages/admin/src/components/PortableTextEditor.tsx:2413
+#: packages/admin/src/components/Sidebar.tsx:216
+#: packages/admin/src/components/WordPressImport.tsx:752
+#: packages/admin/src/components/WordPressImport.tsx:1145
+#: packages/admin/src/components/WordPressImport.tsx:1334
+msgid "Media"
+msgstr "Media"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:222
+msgid "Media Details"
+msgstr "Dettagli media"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2400
+msgid "Media Errors ({0})"
+msgstr "Errori media ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Media Import"
+msgstr "Importazione media"
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Media Import Complete"
+msgstr "Importazione media completata"
+
+#: packages/admin/src/components/WordPressImport.tsx:2314
+msgid "Media import was skipped"
+msgstr "L'importazione media è stata saltata"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:153
+#: packages/admin/src/components/MediaLibrary.tsx:322
+msgid "Media Library"
+msgstr "Libreria media"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Media Read"
+msgstr "Lettura media"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Media Write"
+msgstr "Scrittura media"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1120
+msgid "Medium section heading"
+msgstr "Intestazione di sezione media"
+
+#: packages/admin/src/components/Widgets.tsx:104
+#: packages/admin/src/components/Widgets.tsx:912
+msgid "Menu"
+msgstr "Menu"
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:144
+msgid "Menu \"{0}\" ({1}) created."
+msgstr "Menu \"{0}\" ({1}) creato."
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "Menu \"{0}\" has been created."
+msgstr "Il menu \"{0}\" è stato creato."
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu created"
+msgstr "Menu creato"
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Menu deleted"
+msgstr "Menu eliminato"
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Menu item has been added."
+msgstr "La voce di menu è stata aggiunta."
+
+#: packages/admin/src/components/MenuEditor.tsx:188
+msgid "Menu item has been deleted."
+msgstr "La voce di menu è stata eliminata."
+
+#: packages/admin/src/components/MenuEditor.tsx:213
+msgid "Menu item has been updated."
+msgstr "La voce di menu è stata aggiornata."
+
+#: packages/admin/src/components/MenuEditor.tsx:350
+msgid "Menu not found"
+msgstr "Menu non trovato"
+
+#: packages/admin/src/components/MenuEditor.tsx:228
+msgid "Menu order has been updated."
+msgstr "L'ordine del menu è stato aggiornato."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:160
+#: packages/admin/src/components/MenuList.tsx:104
+#: packages/admin/src/components/Sidebar.tsx:226
+#: packages/admin/src/components/WordPressImport.tsx:1149
+msgid "Menus"
+msgstr "Menu"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1767
+msgid "Menus ({0})"
+msgstr "Menu ({0})"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Menus Manage"
+msgstr "Gestione menu"
+
+#: packages/admin/src/components/SeoPanel.tsx:188
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Meta Description"
+msgstr "Meta descrizione"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:203
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "Contenuto del meta tag per la verifica di Bing Webmaster Tools"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:197
+msgid "Meta tag content for Google Search Console verification"
+msgstr "Contenuto del meta tag per la verifica di Google Search Console"
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "Meta titles, descriptions, and social images"
+msgstr "Titoli meta, descrizioni e immagini social"
+
+#: packages/admin/src/components/WordPressImport.tsx:1051
+msgid "Migration key"
+msgstr "Chiave di migrazione"
+
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Min Items"
+msgstr "Elementi minimi"
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr "Lunghezza minima"
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr "Valore minimo"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:504
+msgid "Moderation"
+msgstr "Moderazione"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "Segnali di moderazione"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr "Modificato"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:72
+msgid "Modify collection schemas"
+msgstr "Modifica gli schemi delle collezioni"
+
+#: packages/admin/src/components/Widgets.tsx:163
+msgid "Monthly"
+msgstr "Mensile"
+
+#: packages/admin/src/components/Widgets.tsx:159
+msgid "Monthly/yearly archives"
+msgstr "Archivi mensili/annuali"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:111
+msgid "More information about {label}"
+msgstr "Ulteriori informazioni su {label}"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr "Più popolari"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:439
+msgid "Move \"{0}\" down"
+msgstr "Sposta \"{0}\" in basso"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:429
+msgid "Move \"{0}\" up"
+msgstr "Sposta \"{0}\" in alto"
+
+#: packages/admin/src/components/ContentList.tsx:1048
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "Spostare \"{title}\" nel cestino? Sarà possibile ripristinarlo in seguito."
+
+#: packages/admin/src/components/ContentList.tsx:1039
+msgid "Move {title} to trash"
+msgstr "Sposta {title} nel cestino"
+
+#: packages/admin/src/components/MenuEditor.tsx:537
+msgid "Move down"
+msgstr "Sposta in basso"
+
+#: packages/admin/src/components/ContentList.tsx:439
+msgid "Move to trash"
+msgstr "Sposta nel cestino"
+
+#: packages/admin/src/components/ContentList.tsx:466
+#: packages/admin/src/components/ContentList.tsx:1061
+#: packages/admin/src/components/ContentSettingsPanel.tsx:638
+#: packages/admin/src/components/ContentSettingsPanel.tsx:658
+msgid "Move to Trash"
+msgstr "Sposta nel cestino"
+
+#: packages/admin/src/components/ContentList.tsx:444
+#: packages/admin/src/components/ContentList.tsx:1046
+#: packages/admin/src/components/ContentSettingsPanel.tsx:643
+msgid "Move to Trash?"
+msgstr "Spostare nel cestino?"
+
+#: packages/admin/src/components/MenuEditor.tsx:528
+msgid "Move up"
+msgstr "Sposta in alto"
+
+#: packages/admin/src/router.tsx:510
+msgid "Moved {total} items to draft"
+msgstr "{total} elementi spostati in bozza"
+
+#: packages/admin/src/router.tsx:531
+msgid "Moved {total} items to trash"
+msgstr "{total} elementi spostati nel cestino"
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr "Selezione multipla"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr "Testo normale su più righe"
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr "Scelte multiple tra le opzioni"
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr "Il mio fantastico blog"
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:155
+#: packages/admin/src/components/TaxonomyManager.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+#: packages/admin/src/components/TaxonomyManager.tsx:841
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:428
+msgid "Name"
+msgstr "Nome"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:580
+msgid "Name and label are required"
+msgstr "Nome ed etichetta sono obbligatori"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:586
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "Il nome deve iniziare con una lettera e contenere solo lettere minuscole, numeri e underscore"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:340
+msgid "Navigation"
+msgstr "Navigazione"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr "Mai"
+
+#: packages/admin/src/router.tsx:1120
+msgid "new"
+msgstr "nuovo"
+
+#: packages/admin/src/routes/bylines.tsx:426
+msgid "New"
+msgstr "Nuovo"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:111
+msgid "NEW"
+msgstr "NUOVO"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:466
+msgid "New {0}"
+msgstr "Nuovo {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:643
+msgid "New {itemLabel}"
+msgstr "Nuovo {itemLabel}"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "New byline field"
+msgstr "Nuovo campo firma"
+
+#: packages/admin/src/components/WordPressImport.tsx:1982
+msgid "New collection"
+msgstr "Nuova collezione"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr "Nuovo tipo di contenuto"
+
+#: packages/admin/src/routes/byline-schema.tsx:224
+msgid "New field"
+msgstr "Nuovo campo"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:122
+msgid "New public routes"
+msgstr "Nuove route pubbliche"
+
+#: packages/admin/src/components/Redirects.tsx:106
+#: packages/admin/src/components/Redirects.tsx:363
+msgid "New Redirect"
+msgstr "Nuovo reindirizzamento"
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr "Nuova sezione"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:479
+msgid "new tab"
+msgstr "nuova scheda"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:831
+msgid "New Taxonomy"
+msgstr "Nuova tassonomia"
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:433
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:612
+msgid "New window"
+msgstr "Nuova finestra"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr "Più recenti"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:408
+msgid "News"
+msgstr "Notizie"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr "Avanti"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:372
+#: packages/admin/src/components/ContentList.tsx:618
+msgid "Next page"
+msgstr "Pagina successiva"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:476
+msgid "Next screenshot"
+msgstr "Screenshot successivo"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "No"
+msgstr "No"
+
+#: packages/admin/src/routes/byline-schema.tsx:420
+msgid "No (shared across translations)"
+msgstr "No (condiviso tra le traduzioni)"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:436
+msgid "No {0} available."
+msgstr "Nessun {0} disponibile."
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:549
+msgid "No {0} yet."
+msgstr "Nessun {0} ancora."
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:850
+msgid "No {0} yet. Create one to get started."
+msgstr "Nessun {0} ancora. Creane uno per iniziare."
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "No 404 errors recorded yet."
+msgstr "Nessun errore 404 registrato."
+
+#: packages/admin/src/components/MediaLibrary.tsx:833
+#: packages/admin/src/components/MediaLibrary.tsx:890
+msgid "No alt text"
+msgstr "Nessun testo alternativo"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:281
+msgid "No API tokens yet. Create one to get started."
+msgstr "Nessun token API ancora. Creane uno per iniziare."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No approved comments yet."
+msgstr "Nessun commento approvato ancora."
+
+#: packages/admin/src/routes/byline-schema.tsx:291
+msgid "No byline fields yet."
+msgstr "Nessun campo firma ancora."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:805
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr "Nessuna firma disponibile in {entryLocale}. Crea una variante dalla pagina Firme prima di aggiungerne una a questa voce."
+
+#: packages/admin/src/routes/bylines.tsx:452
+msgid "No bylines found"
+msgstr "Nessuna firma trovata"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:913
+msgid "No bylines selected."
+msgstr "Nessuna firma selezionata."
+
+#: packages/admin/src/components/Dashboard.tsx:226
+msgid "No collections configured"
+msgstr "Nessuna collezione configurata"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No comments awaiting moderation."
+msgstr "Nessun commento in attesa di moderazione."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:543
+msgid "No comments match your search."
+msgstr "Nessun commento corrisponde alla ricerca."
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:82
+msgid "No content"
+msgstr "Nessun contenuto"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr "Nessun contenuto trovato"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr "Nessun contenuto in questa collezione"
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr "Nessun tipo di contenuto ancora."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:612
+msgid "No custom fields yet"
+msgstr "Nessun campo personalizzato ancora"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr "Nessuna descrizione dettagliata disponibile."
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:262
+msgid "No domains configured. Users must be invited individually."
+msgstr "Nessun dominio configurato. Gli utenti devono essere invitati singolarmente."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:152
+msgid "No email provider configured"
+msgstr "Nessun provider email configurato"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "Nessun provider email configurato. Condividi questo link manualmente."
+
+#: packages/admin/src/components/WordPressImport.tsx:2516
+msgid "No EmDash users found"
+msgstr "Nessun utente EmDash trovato"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "No expiry"
+msgstr "Nessuna scadenza"
+
+#: packages/admin/src/components/RevisionHistory.tsx:335
+msgid "No fields to compare"
+msgstr "Nessun campo da confrontare"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:204
+msgid "No headings in document"
+msgstr "Nessun titolo nel documento"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:205
+msgid "No images in this gallery yet."
+msgstr "Nessuna immagine in questa galleria ancora."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:594
+msgid "No installable releases"
+msgstr "Nessuna versione installabile"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:193
+msgid "No invite token provided"
+msgstr "Nessun token di invito fornito"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1915
+#: packages/admin/src/components/RepeaterField.tsx:165
+msgid "No items yet"
+msgstr "Nessun elemento ancora"
+
+#: packages/admin/src/components/FieldEditor.tsx:631
+msgid "No limit"
+msgstr "Nessun limite"
+
+#: packages/admin/src/routes/bylines.tsx:517
+msgid "No linked user"
+msgstr "Nessun utente collegato"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "No matches"
+msgstr "Nessuna corrispondenza"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:848
+msgid "No matching bylines."
+msgstr "Nessuna firma corrispondente."
+
+#: packages/admin/src/components/MediaLibrary.tsx:489
+#: packages/admin/src/components/MediaLibrary.tsx:517
+msgid "No matching media"
+msgstr "Nessun media corrispondente"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:264
+msgid "No matching passkey found for this account."
+msgstr "Nessuna passkey corrispondente trovata per questo account."
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr "Nessun massimo"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:694
+msgid "No media available from this provider"
+msgstr "Nessun media disponibile da questo provider"
+
+#: packages/admin/src/components/MediaLibrary.tsx:540
+msgid "No media available from this provider."
+msgstr "Nessun media disponibile da questo provider."
+
+#: packages/admin/src/components/MediaLibrary.tsx:539
+#: packages/admin/src/components/MediaPickerModal.tsx:688
+msgid "No media found"
+msgstr "Nessun media trovato"
+
+#: packages/admin/src/components/MenuEditor.tsx:485
+msgid "No menu items yet"
+msgstr "Nessuna voce di menu ancora"
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "No menus yet"
+msgstr "Nessun menu ancora"
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr "Nessun minimo"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr "Nessuna moderazione (approva tutto automaticamente)"
+
+#: packages/admin/src/components/MenuEditor.tsx:329
+msgid "No parent (top level)"
+msgstr "Nessun genitore (livello superiore)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr "Nessuna passkey registrata"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:168
+msgid "No passkeys registered yet."
+msgstr "Nessuna passkey registrata ancora."
+
+#: packages/admin/src/components/PluginManager.tsx:199
+msgid "No plugins configured"
+msgstr "Nessun plugin configurato"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "Nessun plugin trovato"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:118
+msgid "No plugins have been published to this registry yet."
+msgstr "Nessun plugin è stato ancora pubblicato in questo registro."
+
+#: packages/admin/src/components/RegistryBrowse.tsx:117
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr "Nessun plugin corrisponde a \"{debouncedQuery}\"."
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr "Nessuna anteprima"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:304
+msgid "No public URL available"
+msgstr "Nessun URL pubblico disponibile"
+
+#: packages/admin/src/components/Dashboard.tsx:304
+msgid "No recent activity"
+msgstr "Nessuna attività recente"
+
+#: packages/admin/src/components/Redirects.tsx:461
+msgid "No redirects yet"
+msgstr "Nessun reindirizzamento ancora"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1464
+#: packages/admin/src/components/RepeaterField.tsx:374
+msgid "No results"
+msgstr "Nessun risultato"
+
+#: packages/admin/src/components/ContentList.tsx:546
+#: packages/admin/src/components/ContentList.tsx:565
+msgid "No results for \"{activeSearch}\""
+msgstr "Nessun risultato per \"{activeSearch}\""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "Nessun risultato per \"{debouncedQuery}\". Prova con un termine diverso."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:465
+msgid "No results found"
+msgstr "Nessun risultato trovato"
+
+#: packages/admin/src/components/RevisionHistory.tsx:191
+msgid "No revisions yet"
+msgstr "Nessuna revisione ancora"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:108
+msgid "No sections available"
+msgstr "Nessuna sezione disponibile"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr "Nessuna sezione trovata"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr "Nessuna sezione ancora"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No spam comments."
+msgstr "Nessun commento spam."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr "Nessun tema trovato"
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr "Nessun utente trovato corrispondente ai filtri."
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr "Nessun utente ancora."
+
+#: packages/admin/src/components/Widgets.tsx:502
+msgid "No widget areas yet. Create one to get started."
+msgstr "Nessuna area widget ancora. Creane una per iniziare."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
+msgid "None"
+msgstr "Nessuno"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:434
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+msgid "None (top level)"
+msgstr "Nessuno (livello superiore)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:629
+msgid "Not compatible with this environment"
+msgstr "Non compatibile con questo ambiente"
+
+#: packages/admin/src/components/PluginSettings.tsx:341
+msgid "Not set"
+msgstr "Non impostato"
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr "Numero"
+
+#: packages/admin/src/components/Widgets.tsx:129
+msgid "Number of posts"
+msgstr "Numero di articoli"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:278
+msgid "Number of posts to show per page on list views"
+msgstr "Numero di articoli da mostrare per pagina nelle viste elenco"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:110
+#: packages/admin/src/components/PortableTextEditor.tsx:1149
+#: packages/admin/src/components/PortableTextEditor.tsx:3671
+msgid "Numbered List"
+msgstr "Elenco numerato"
+
+#: packages/admin/src/components/WordPressImport.tsx:494
+msgid "OAuth authorization requires HTTPS. Please use manual credentials."
+msgstr "L'autorizzazione OAuth richiede HTTPS. Utilizza le credenziali manuali."
+
+#: packages/admin/src/components/SeoImageField.tsx:46
+msgid "OG Image"
+msgstr "Immagine OG"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "su un hostname personalizzato non è considerato sicuro, nemmeno su loopback."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "Autorizza solo i codici che riconosci."
+
+#: packages/admin/src/components/SignupPage.tsx:97
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "Solo gli indirizzi email dei domini consentiti possono registrarsi."
+
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "Solo lettere minuscole, numeri e trattini"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr "Solo i tipi MIME elencati saranno accettati per questo campo."
+
+#: packages/admin/src/components/SignupPage.tsx:404
+msgid "Oops!"
+msgstr "Ops!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:379
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:380
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:568
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:569
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr "Apri in una nuova scheda"
+
+#: packages/admin/src/components/WordPressImport.tsx:1534
+msgid "Open WordPress Profile"
+msgstr "Apri profilo WordPress"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr ""
+"Opzione 1\n"
+"Opzione 2\n"
+"Opzione 3"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:385
+msgid "Optional caption"
+msgstr "Didascalia facoltativa"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
+msgid "Optional caption displayed below the image"
+msgstr "Didascalia facoltativa visualizzata sotto l'immagine"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:384
+msgid "Optional caption for display"
+msgstr "Didascalia facoltativa per la visualizzazione"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:459
+msgid "Optional description"
+msgstr "Descrizione facoltativa"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:553
+msgid "Optional tooltip on hover"
+msgstr "Tooltip facoltativo al passaggio del mouse"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:302
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr "Opzioni (una per riga)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:579
+msgid "or choose from library"
+msgstr "oppure scegli dalla libreria"
+
+#: packages/admin/src/components/WordPressImport.tsx:1590
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "Oppure fai clic per sfogliare. Accetta file .xml esportati da WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1071
+msgid "or connect by URL"
+msgstr "oppure connetti tramite URL"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:97
+#: packages/admin/src/components/LoginPage.tsx:263
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr "Oppure continua con"
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Or upload an export file"
+msgstr "Oppure carica un file di esportazione"
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "or upload directly"
+msgstr "oppure carica direttamente"
+
+#: packages/admin/src/components/MenuEditor.tsx:227
+msgid "Order saved"
+msgstr "Ordine salvato"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:369
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
+msgid "Original:"
+msgstr "Originale:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:182
+msgid "Outline"
+msgstr "Struttura"
+
+#: packages/admin/src/components/SeoPanel.tsx:164
+msgid "Overrides the page title in search engine results"
+msgstr "Sostituisce il titolo della pagina nei risultati dei motori di ricerca"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:539
+msgid "Ownership"
+msgstr "Proprietà"
+
+#: packages/admin/src/components/PluginManager.tsx:591
+msgid "Package"
+msgstr "Pacchetto"
+
+#: packages/admin/src/router.tsx:2189
+msgid "Page Not Found"
+msgstr "Pagina non trovata"
+
+#: packages/admin/src/components/PluginManager.tsx:401
+#: packages/admin/src/components/WordPressImport.tsx:1328
+msgid "Pages"
+msgstr "Pagine"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:54
+msgid "Paragraph"
+msgstr "Paragrafo"
+
+#: packages/admin/src/components/MenuEditor.tsx:615
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+msgid "Parent"
+msgstr "Genitore"
+
+#: packages/admin/src/components/Redirects.tsx:510
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Part of a redirect loop"
+msgstr "Parte di un ciclo di reindirizzamento"
+
+#: packages/admin/src/components/WordPressImport.tsx:1153
+msgid "Partial"
+msgstr "Parziale"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr "Superato"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:89
+msgid "Passkey added successfully"
+msgstr "Passkey aggiunta con successo"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "Nome passkey"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "Nome passkey (facoltativo)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "Passkey registrata con successo!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Passkey removed"
+msgstr "Passkey rimossa"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:49
+msgid "Passkey renamed"
+msgstr "Passkey rinominata"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:150
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr "Passkey"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr "Passkey ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:154
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Le passkey sono un metodo sicuro e senza password per accedere al tuo account. Puoi registrare più passkey per dispositivi diversi."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:77
+#: packages/admin/src/components/SignupPage.tsx:214
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Le passkey sono un metodo sicuro e senza password per accedere utilizzando la biometria del dispositivo, il PIN o la chiave di sicurezza."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:301
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "Passkey non disponibili qui"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:305
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Le passkey richiedono un"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Le passkey richiedono HTTPS o http://localhost (con la tua porta); questo hostname non è un contesto browser sicuro."
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "Paste your migration key"
+msgstr "Incolla la tua chiave di migrazione"
+
+#: packages/admin/src/components/Redirects.tsx:225
+msgid "Path"
+msgstr "Percorso"
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr "Pattern (Regex)"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:435
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr "Pattern per la generazione degli URL, ad es. /blog/{0}"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:431
+msgid "Pattern must include a {0} placeholder"
+msgstr "Il pattern deve includere un segnaposto {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr "PDF"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:1185
+msgid "pending"
+msgstr "in attesa"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:198
+#: packages/admin/src/components/Dashboard.tsx:348
+msgid "Pending"
+msgstr "In attesa"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:441
+msgid "Pending changes"
+msgstr "Modifiche in attesa"
+
+#: packages/admin/src/components/ContentList.tsx:1119
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "Eliminare definitivamente \"{title}\"? Questa operazione non può essere annullata."
+
+#: packages/admin/src/components/ContentList.tsx:1108
+msgid "Permanently delete {title}"
+msgstr "Elimina definitivamente {title}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr "Permessi"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:46
+msgid "PHP"
+msgstr "PHP"
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr "Scegli un metodo per creare il tuo account amministratore."
+
+#: packages/admin/src/components/Widgets.tsx:154
+msgid "Placeholder text"
+msgstr "Testo segnaposto"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:311
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "Semplice"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:27
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:120
+msgid "Plain text"
+msgstr "Testo normale"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:166
+msgid "Please ask your administrator to send a new invite."
+msgstr "Chiedi al tuo amministratore di inviare un nuovo invito."
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr "Inserisci un indirizzo email valido"
+
+#: packages/admin/src/components/SignupPage.tsx:55
+msgid "Please enter a valid email address"
+msgstr "Inserisci un indirizzo email valido"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:442
+msgid "Please enter a valid URL"
+msgstr "Inserisci un URL valido"
+
+#: packages/admin/src/components/WordPressImport.tsx:1182
+msgid "Plugin"
+msgstr "Plugin"
+
+#: packages/admin/src/lib/api/plugins.ts:68
+msgid "Plugin \"{pluginId}\" not found"
+msgstr "Plugin \"{pluginId}\" non trovato"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:762
+msgid "Plugin details"
+msgstr "Dettagli plugin"
+
+#: packages/admin/src/components/PluginManager.tsx:114
+msgid "Plugin disabled"
+msgstr "Plugin disabilitato"
+
+#: packages/admin/src/components/PluginManager.tsx:95
+msgid "Plugin enabled"
+msgstr "Plugin abilitato"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr "Errore plugin"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr "Errore plugin ({0})"
+
+#: packages/admin/src/components/PluginManager.tsx:333
+msgid "Plugin MCP access updated"
+msgstr "Accesso MCP del plugin aggiornato"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Plugin MCP Tools"
+msgstr "Strumenti MCP del plugin"
+
+#: packages/admin/src/lib/api/marketplace.ts:108
+msgid "Plugin MCP tools require explicit consent"
+msgstr "Gli strumenti MCP del plugin richiedono il consenso esplicito"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:123
+msgid "Plugin not found"
+msgstr "Plugin non trovato"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:411
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr "Plugin non trovato. L'handle del publisher o lo slug potrebbero essere errati."
+
+#: packages/admin/src/components/WordPressImport.tsx:1209
+msgid "plugin on your WordPress site."
+msgstr "plugin sul tuo sito WordPress."
+
+#: packages/admin/src/components/PluginManager.tsx:482
+msgid "Plugin pages"
+msgstr "Pagine del plugin"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "Plugin Permissions"
+msgstr "Permessi del plugin"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Plugin Registry"
+msgstr "Registro plugin"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr "Il plugin ha risposto con {0}: {text}"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:452
+msgid "Plugin tools: {0}"
+msgstr "Strumenti del plugin: {0}"
+
+#: packages/admin/src/components/PluginManager.tsx:322
+msgid "Plugin uninstalled"
+msgstr "Plugin disinstallato"
+
+#: packages/admin/src/lib/api/registry.ts:810
+msgid "Plugin update requires re-consent"
+msgstr "L'aggiornamento del plugin richiede un nuovo consenso"
+
+#: packages/admin/src/components/PluginManager.tsx:268
+msgid "Plugin updated"
+msgstr "Plugin aggiornato"
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
+msgid "Plugin widget error"
+msgstr "Errore widget del plugin"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:218
+#: packages/admin/src/components/PluginManager.tsx:139
+#: packages/admin/src/components/PluginManager.tsx:148
+#: packages/admin/src/components/PluginManager.tsx:157
+#: packages/admin/src/components/Sidebar.tsx:256
+#: packages/admin/src/components/Sidebar.tsx:391
+msgid "Plugins"
+msgstr "Plugin"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:264
+msgid "Point-in-Time Restore"
+msgstr "Ripristino a un momento specifico"
+
+#: packages/admin/src/components/SeoPanel.tsx:208
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "Indica ai motori di ricerca la versione originale di questa pagina, se è duplicata da un altro URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:387
+msgid "Post"
+msgstr "Articolo"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:395
+#: packages/admin/src/components/WordPressImport.tsx:1322
+msgid "Posts"
+msgstr "Articoli"
+
+#: packages/admin/src/components/WordPressImport.tsx:1144
+msgid "Posts & Pages"
+msgstr "Articoli e pagine"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:272
+msgid "Posts Per Page"
+msgstr "Articoli per pagina"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:478
+msgid "Pre-release"
+msgstr "Pre-release"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "Preparazione della registrazione in corso..."
+
+#: packages/admin/src/components/WordPressImport.tsx:2179
+msgid "Preparing to download files from WordPress..."
+msgstr "Preparazione del download dei file da WordPress in corso..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr "Preparazione in corso..."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:154
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:585
+msgid "Preview"
+msgstr "Anteprima"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr "Visualizza l'anteprima del contenuto prima della pubblicazione"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:154
+msgid "Preview draft"
+msgstr "Anteprima bozza"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr "Precedente"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:353
+#: packages/admin/src/components/ContentList.tsx:606
+msgid "Previous page"
+msgstr "Pagina precedente"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:458
+msgid "Previous screenshot"
+msgstr "Screenshot precedente"
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Primary Navigation"
+msgstr "Navigazione principale"
+
+#: packages/admin/src/components/Dashboard.tsx:349
+msgid "Private"
+msgstr "Privato"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:174
+msgid "Provider:"
+msgstr "Provider:"
+
+#: packages/admin/src/components/ContentList.tsx:415
+#: packages/admin/src/components/ContentSettingsPanel.tsx:426
+msgid "Publish"
+msgstr "Pubblica"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:185
+msgid "Publish {itemLabel}"
+msgstr "Pubblica {itemLabel}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:192
+msgid "Publish updates"
+msgstr "Pubblica aggiornamenti"
+
+#: packages/admin/src/components/ContentList.tsx:1160
+msgid "published"
+msgstr "pubblicato"
+
+#: packages/admin/src/components/ContentList.tsx:729
+#: packages/admin/src/components/ContentList.tsx:738
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/ContentSettingsPanel.tsx:440
+#: packages/admin/src/components/Dashboard.tsx:245
+#: packages/admin/src/components/Dashboard.tsx:345
+#: packages/admin/src/router.tsx:1009
+msgid "Published"
+msgstr "Pubblicato"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
+msgstr "Pubblicato {0}"
+
+#: packages/admin/src/router.tsx:487
+msgid "Published {total} items"
+msgstr "Pubblicati {total} elementi"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr "Pubblicato il"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:472
+msgid "Published by"
+msgstr "Pubblicato da"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:47
+msgid "Python"
+msgstr "Python"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:921
+msgid "Quick create byline"
+msgstr "Crea firma rapida"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:196
+#: packages/admin/src/components/editor/ImageNode.tsx:197
+msgid "Quick edit alt text"
+msgstr "Modifica rapida testo alternativo"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:86
+#: packages/admin/src/components/PortableTextEditor.tsx:1159
+#: packages/admin/src/components/PortableTextEditor.tsx:3678
+msgid "Quote"
+msgstr "Citazione"
+
+#: packages/admin/src/components/WordPressImport.tsx:1162
+msgid "Raw meta"
+msgstr "Meta non elaborati"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:67
+msgid "Read collection schemas"
+msgstr "Leggi schemi delle collezioni"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:47
+msgid "Read content entries"
+msgstr "Leggi voci di contenuto"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:57
+msgid "Read media files"
+msgstr "Leggi file media"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:87
+msgid "Read site settings"
+msgstr "Leggi impostazioni del sito"
+
+#: packages/admin/src/lib/api/marketplace.ts:284
+#: packages/admin/src/lib/api/marketplace.ts:292
+msgid "Read user accounts"
+msgstr "Leggi account utenti"
+
+#: packages/admin/src/lib/api/marketplace.ts:279
+#: packages/admin/src/lib/api/marketplace.ts:288
+msgid "Read your content"
+msgstr "Leggi il tuo contenuto"
+
+#: packages/admin/src/lib/api/marketplace.ts:281
+msgid "Read your taxonomies and terms"
+msgstr "Leggi le tue tassonomie e i termini"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:269
+msgid "Reading"
+msgstr "Lettura"
+
+#: packages/admin/src/components/WordPressImport.tsx:1986
+msgid "Ready"
+msgstr "Pronto"
+
+#: packages/admin/src/components/Dashboard.tsx:298
+msgid "Recent Activity"
+msgstr "Attività recente"
+
+#: packages/admin/src/components/Widgets.tsx:126
+msgid "Recent Posts"
+msgstr "Articoli recenti"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr "Aggiornati di recente"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:118
+msgid "Recipient email"
+msgstr "Email del destinatario"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr "Link di recupero inviato a {0}"
+
+#: packages/admin/src/components/Redirects.tsx:443
+msgid "Redirect loop detected"
+msgstr "Rilevato ciclo di reindirizzamento"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "Reindirizzamento all'accesso in corso..."
+
+#: packages/admin/src/components/Redirects.tsx:359
+#: packages/admin/src/components/Redirects.tsx:378
+#: packages/admin/src/components/Sidebar.tsx:229
+msgid "Redirects"
+msgstr "Reindirizzamenti"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3817
+msgid "Redo"
+msgstr "Ripeti"
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr "Riferimento"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:228
+msgid "Referenced favicon unavailable."
+msgstr "La favicon di riferimento non è disponibile."
+
+#: packages/admin/src/components/Dashboard.tsx:85
+msgid "Refresh the page or try again."
+msgstr "Aggiorna la pagina o riprova."
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr "Registra"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "Register Passkey"
+msgstr "Registra Passkey"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "Utente registrato"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr "Registrazione non riuscita"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "La registrazione è stata annullata o è scaduta. Riprova."
+
+#: packages/admin/src/components/Sidebar.tsx:265
+msgid "Registry"
+msgstr "Registro"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:610
+msgid "Release is too new to install"
+msgstr "La versione è troppo recente per essere installata"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentSettingsPanel.tsx:890
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:199
+#: packages/admin/src/components/PortableTextEditor.tsx:3790
+#: packages/admin/src/components/settings/GeneralSettings.tsx:194
+#: packages/admin/src/components/settings/GeneralSettings.tsx:248
+#: packages/admin/src/components/settings/PasskeyItem.tsx:185
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+#: packages/admin/src/components/settings/SeoSettings.tsx:176
+msgid "Remove"
+msgstr "Rimuovi"
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+#: packages/admin/src/components/TaxonomySidebar.tsx:246
+msgid "Remove {0}"
+msgstr "Rimuovi {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr "Rimuovi {entry}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1667
+msgid "Remove {label}"
+msgstr "Rimuovi {label}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:397
+msgid "Remove Domain"
+msgstr "Rimuovi dominio"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+msgid "Remove Domain?"
+msgstr "Rimuovere il dominio?"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:141
+#: packages/admin/src/components/ImageFieldRenderer.tsx:170
+#: packages/admin/src/components/SeoImageField.tsx:61
+msgid "Remove image"
+msgstr "Rimuovi immagine"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:392
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:582
+msgid "Remove Image"
+msgstr "Rimuovi immagine"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:320
+msgid "Remove image {0}"
+msgstr "Rimuovi immagine {0}"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
+msgid "Remove Image?"
+msgstr "Rimuovere l'immagine?"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:2031
+#: packages/admin/src/components/RepeaterField.tsx:275
+msgid "Remove item {0}"
+msgstr "Rimuovi elemento {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3218
+#: packages/admin/src/components/PortableTextEditor.tsx:3219
+msgid "Remove link"
+msgstr "Rimuovi collegamento"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+msgid "Remove passkey"
+msgstr "Rimuovi passkey"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:201
+msgid "Remove passkey?"
+msgstr "Rimuovere la passkey?"
+
+#: packages/admin/src/components/FieldEditor.tsx:611
+msgid "Remove sub-field"
+msgstr "Rimuovi sottocampo"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:198
+msgid "Remove this image from the document?"
+msgstr "Rimuovere questa immagine dal documento?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:200
+#: packages/admin/src/components/settings/PasskeyItem.tsx:208
+msgid "Removing..."
+msgstr "Rimozione in corso..."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:174
+msgid "Rename"
+msgstr "Rinomina"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename {0}"
+msgstr "Rinomina {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename passkey"
+msgstr "Rinomina passkey"
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr "Ripetitore"
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr "Gruppo di campi ripetibile"
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:363
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:396
+msgid "Replace image"
+msgstr "Sostituisci immagine"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:435
+msgid "Replace Image"
+msgstr "Sostituisci immagine"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "Risposta a:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr "Repository"
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr "Richiedi un nuovo link"
+
+#: packages/admin/src/lib/api/client.ts:226
+msgid "Request failed"
+msgstr "Richiesta non riuscita"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:280
+#: packages/admin/src/components/ContentTypeEditor.tsx:730
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:593
+#: packages/admin/src/routes/byline-schema.tsx:246
+msgid "Required"
+msgstr "Obbligatorio"
+
+#: packages/admin/src/components/WordPressImport.tsx:1999
+msgid "Required fields:"
+msgstr "Campi obbligatori:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "Obbligatorio per l'accessibilità. Descrive l'immagine per i lettori di schermo."
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr "Richiede EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:155
+msgid "Resend email"
+msgstr "Reinvia email"
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend in {resendCooldown}s"
+msgstr "Reinvia tra {resendCooldown}s"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:277
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+msgid "Reset to original"
+msgstr "Ripristina originale"
+
+#: packages/admin/src/components/RevisionHistory.tsx:228
+msgid "Restore"
+msgstr "Ripristina"
+
+#: packages/admin/src/components/ContentList.tsx:1096
+msgid "Restore {title}"
+msgstr "Ripristina {title}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:128
+msgid "Restore failed"
+msgstr "Ripristino non riuscito"
+
+#: packages/admin/src/components/RevisionHistory.tsx:222
+msgid "Restore Revision?"
+msgstr "Ripristinare la revisione?"
+
+#: packages/admin/src/components/RevisionHistory.tsx:289
+#: packages/admin/src/components/RevisionHistory.tsx:290
+msgid "Restore this version"
+msgstr "Ripristina questa versione"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:225
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "Ripristinare la versione del {0}? Il contenuto attuale verrà aggiornato con i dati di questa revisione."
+
+#: packages/admin/src/components/RevisionHistory.tsx:229
+msgid "Restoring..."
+msgstr "Ripristino in corso..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:2177
+#: packages/admin/src/routes/byline-schema.tsx:280
+msgid "Retry"
+msgstr "Riprova"
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr "Blocchi di contenuto riutilizzabili che puoi inserire in qualsiasi contenuto"
+
+#: packages/admin/src/router.tsx:1047
+msgid "Reverted to published version"
+msgstr "Ripristinata la versione pubblicata"
+
+#: packages/admin/src/components/WordPressImport.tsx:724
+msgid "Review"
+msgstr "Revisione"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "Review New Permissions"
+msgstr "Esamina nuovi permessi"
+
+#: packages/admin/src/components/RevisionHistory.tsx:122
+msgid "Revision restored"
+msgstr "Revisione ripristinata"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:158
+msgid "Revisions"
+msgstr "Revisioni"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:344
+msgid "Revoke token"
+msgstr "Revoca token"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:319
+msgid "Revoke?"
+msgstr "Revocare?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
+msgid "Revoking..."
+msgstr "Revoca in corso..."
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr "Testo ricco"
+
+#: packages/admin/src/components/Widgets.tsx:99
+msgid "Rich text content"
+msgstr "Contenuto in testo ricco"
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr "Editor di testo ricco"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
+msgid "Right"
+msgstr "Destra"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr "Punteggio di rischio: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:164
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr "Ruolo"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "Ruolo {role}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:895
+msgid "Role label"
+msgstr "Etichetta ruolo"
+
+#. placeholder {0}: tool.route
+#. placeholder {1}: tool.permission
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:149
+#: packages/admin/src/components/PluginManager.tsx:567
+msgid "Route: {0} · Permission: {1}"
+msgstr "Route: {0} · Permesso: {1}"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:48
+msgid "Ruby"
+msgstr "Ruby"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:49
+msgid "Rust"
+msgstr "Rust"
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:432
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:611
+msgid "Same window"
+msgstr "Stessa finestra"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1028
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:395
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:589
+#: packages/admin/src/components/editor/ImageNode.tsx:264
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/Redirects.tsx:191
+#: packages/admin/src/components/SaveButton.tsx:32
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/Widgets.tsx:981
+#: packages/admin/src/routes/bylines.tsx:579
+msgid "Save"
+msgstr "Salva"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr "Salva (Invio)"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:265
+msgid "Save alt text"
+msgstr "Salva testo alternativo"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Save changes"
+msgstr "Salva modifiche"
+
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr "Salva modifiche"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr "Salva il contenuto come bozza prima della pubblicazione"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "Salva nome"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+msgid "Save SEO Settings"
+msgstr "Salva impostazioni SEO"
+
+#: packages/admin/src/components/PluginSettings.tsx:166
+#: packages/admin/src/components/PluginSettings.tsx:209
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+msgid "Save Settings"
+msgstr "Salva impostazioni"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Save Social Links"
+msgstr "Salva link social"
+
+#: packages/admin/src/components/SaveButton.tsx:34
+msgid "Saved"
+msgstr "Salvato"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:116
+msgid "Saved \"{0}\"."
+msgstr "Salvato \"{0}\"."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1028
+#: packages/admin/src/components/FieldEditor.tsx:660
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/PluginSettings.tsx:166
+#: packages/admin/src/components/PluginSettings.tsx:209
+#: packages/admin/src/components/Redirects.tsx:188
+#: packages/admin/src/components/SaveButton.tsx:33
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+#: packages/admin/src/components/TaxonomyManager.tsx:498
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:981
+#: packages/admin/src/routes/bylines.tsx:579
+msgid "Saving..."
+msgstr "Salvataggio in corso..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Saving…"
+msgstr "Salvataggio in corso…"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:482
+msgid "SBOM"
+msgstr "SBOM"
+
+#. placeholder {0}: sbom.format
+#: packages/admin/src/components/RegistryPluginDetail.tsx:480
+msgid "SBOM · {0}"
+msgstr "SBOM · {0}"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:489
+msgid "Schedule"
+msgstr "Pianifica"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:475
+msgid "Schedule for"
+msgstr "Pianifica per"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:512
+msgid "Schedule for later"
+msgstr "Pianifica per dopo"
+
+#: packages/admin/src/components/ContentList.tsx:1164
+msgid "scheduled"
+msgstr "pianificato"
+
+#: packages/admin/src/components/ContentList.tsx:731
+#: packages/admin/src/components/ContentSettingsPanel.tsx:443
+#: packages/admin/src/components/Dashboard.tsx:347
+#: packages/admin/src/router.tsx:1067
+msgid "Scheduled"
+msgstr "Pianificato"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentSettingsPanel.tsx:463
+msgid "Scheduled for: {0}"
+msgstr "Pianificato per: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "Schema Changes"
+msgstr "Modifiche allo schema"
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Schema preparation failed"
+msgstr "Preparazione dello schema non riuscita"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Schema Read"
+msgstr "Lettura schema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Schema Write"
+msgstr "Scrittura schema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:429
+msgid "Scopes"
+msgstr "Ambiti"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:295
+msgid "Scopes: {0}"
+msgstr "Ambiti: {0}"
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/RegistryPluginDetail.tsx:655
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr "Screenshot {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:466
+msgid "Screenshot {0} of {1}"
+msgstr "Screenshot {0} di {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr "Screenshot offuscato per revisione immagine"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:444
+msgid "Screenshot viewer"
+msgstr "Visualizzatore screenshot"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/RegistryPluginDetail.tsx:649
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr "Screenshot"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:50
+msgid "SCSS"
+msgstr "SCSS"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+#: packages/admin/src/components/Widgets.tsx:151
+msgid "Search"
+msgstr "Cerca"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:353
+msgid "Search {0}"
+msgstr "Cerca {0}"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:352
+msgid "Search {0}..."
+msgstr "Cerca {0}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:626
+msgid "Search by filename..."
+msgstr "Cerca per nome file..."
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr "Cerca per nome o email..."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:822
+#: packages/admin/src/routes/bylines.tsx:401
+msgid "Search bylines"
+msgstr "Cerca firme"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:821
+msgid "Search bylines to add..."
+msgstr "Cerca firme da aggiungere..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:164
+msgid "Search comments"
+msgstr "Cerca commenti"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments..."
+msgstr "Cerca commenti..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "Cerca contenuto..."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:122
+msgid "Search Engine Optimization"
+msgstr "Ottimizzazione per i motori di ricerca"
+
+#: packages/admin/src/components/Settings.tsx:83
+msgid "Search engine optimization and verification"
+msgstr "Ottimizzazione e verifica per i motori di ricerca"
+
+#: packages/admin/src/components/Widgets.tsx:152
+msgid "Search form"
+msgstr "Modulo di ricerca"
+
+#: packages/admin/src/components/MediaLibrary.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:627
+msgid "Search media"
+msgstr "Cerca media"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:438
+msgid "Search pages and content..."
+msgstr "Cerca pagine e contenuto..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+#: packages/admin/src/components/RegistryBrowse.tsx:85
+msgid "Search plugins"
+msgstr "Cerca plugin"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+#: packages/admin/src/components/RegistryBrowse.tsx:81
+msgid "Search plugins..."
+msgstr "Cerca plugin..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:82
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr "Cerca sezioni..."
+
+#: packages/admin/src/components/Redirects.tsx:410
+msgid "Search source or destination..."
+msgstr "Cerca origine o destinazione..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr "Cerca temi"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr "Cerca temi..."
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr "Cerca utenti"
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:626
+msgid "Search..."
+msgstr "Cerca..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr "Ricercabile"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:826
+msgid "Searching..."
+msgstr "Ricerca in corso..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2424
+msgid "Section"
+msgstr "Sezione"
+
+#: packages/admin/src/components/SectionEditor.tsx:83
+msgid "Section \"{slug}\" could not be found."
+msgstr "Impossibile trovare la sezione \"{slug}\"."
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr "Sezione creata"
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr "Sezione eliminata"
+
+#: packages/admin/src/components/SectionEditor.tsx:248
+msgid "Section Details"
+msgstr "Dettagli sezione"
+
+#: packages/admin/src/components/SectionEditor.tsx:79
+msgid "Section Not Found"
+msgstr "Sezione non trovata"
+
+#: packages/admin/src/components/SectionEditor.tsx:254
+msgid "Section title"
+msgstr "Titolo sezione"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:176
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:234
+msgid "Sections"
+msgstr "Sezioni"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:306
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "contesto sicuro"
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr "Proteggi il tuo account"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:809
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Security"
+msgstr "Sicurezza"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr "Audit di sicurezza"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr "Audit di sicurezza non superato"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr "L'audit di sicurezza ha rilevato problemi"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:179
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "L'audit di sicurezza ha rilevato potenziali problemi con questo plugin."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:180
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "L'audit di sicurezza ha segnalato questo plugin come potenzialmente non sicuro."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr "Audit di sicurezza superato"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:718
+msgid "Security contacts"
+msgstr "Contatti per la sicurezza"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:270
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "Errore di sicurezza. Assicurati di utilizzare una connessione sicura."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:242
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/settings/SecuritySettings.tsx:95
+msgid "Security Settings"
+msgstr "Impostazioni di sicurezza"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:56
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr "Seleziona"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1679
+#: packages/admin/src/components/ContentEditor.tsx:1695
+#: packages/admin/src/components/ImageFieldRenderer.tsx:198
+msgid "Select {label}"
+msgstr "Seleziona {label}"
+
+#: packages/admin/src/components/ContentList.tsx:973
+msgid "Select {title}"
+msgstr "Seleziona {title}"
+
+#: packages/admin/src/components/Widgets.tsx:954
+msgid "Select a component..."
+msgstr "Seleziona un componente..."
+
+#: packages/admin/src/components/Widgets.tsx:917
+msgid "Select a menu..."
+msgstr "Seleziona un menu..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:284
+msgid "Select all"
+msgstr "Seleziona tutto"
+
+#: packages/admin/src/components/ContentList.tsx:497
+msgid "Select all on this page"
+msgstr "Seleziona tutti in questa pagina"
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:457
+msgid "Select comment by {0}"
+msgstr "Seleziona commento di {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "Seleziona contenuto"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:235
+msgid "Select Default Social Image"
+msgstr "Seleziona immagine social predefinita"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:260
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Select Favicon"
+msgstr "Seleziona favicon"
+
+#: packages/admin/src/components/ContentEditor.tsx:1683
+msgid "Select file"
+msgstr "Seleziona file"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:150
+msgid "Select File"
+msgstr "Seleziona file"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3061
+msgid "Select Gallery Images"
+msgstr "Seleziona immagini galleria"
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:186
+msgid "Select image"
+msgstr "Seleziona immagine"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:150
+#: packages/admin/src/components/PortableTextEditor.tsx:3047
+#: packages/admin/src/components/settings/SeoSettings.tsx:188
+msgid "Select Image"
+msgstr "Seleziona immagine"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:206
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Select Logo"
+msgstr "Seleziona logo"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr "Seleziona media"
+
+#: packages/admin/src/components/SeoImageField.tsx:76
+msgid "Select OG image"
+msgstr "Seleziona immagine OG"
+
+#: packages/admin/src/components/SeoImageField.tsx:85
+msgid "Select OG Image"
+msgstr "Seleziona immagine OG"
+
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "Select which content types to import."
+msgstr "Seleziona i tipi di contenuto da importare."
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:2126
+#: packages/admin/src/components/RepeaterField.tsx:372
+msgid "Select..."
+msgstr "Seleziona..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1455
+msgid "Selected {selectedItemTitle}"
+msgstr "Selezionato {selectedItemTitle}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:795
+msgid "Selected:"
+msgstr "Selezionato:"
+
+#: packages/admin/src/components/Settings.tsx:99
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:152
+msgid "Self-Signup Domains"
+msgstr "Domini di registrazione autonoma"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:113
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "Invia un'email di test attraverso l'intera pipeline per verificare la configurazione email."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "Invia un'email di invito a un nuovo membro del team."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+msgid "Send Invite"
+msgstr "Invia invito"
+
+#: packages/admin/src/components/LoginPage.tsx:150
+msgid "Send magic link"
+msgstr "Invia magic link"
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr "Invia link di recupero"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+msgid "Send Test"
+msgstr "Invia test"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:110
+msgid "Send Test Email"
+msgstr "Invia email di test"
+
+#: packages/admin/src/components/LoginPage.tsx:150
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+#: packages/admin/src/components/SignupPage.tsx:89
+#: packages/admin/src/components/SignupPage.tsx:152
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr "Invio in corso..."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:603
+#: packages/admin/src/components/ContentTypeEditor.tsx:472
+#: packages/admin/src/components/Settings.tsx:82
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SeoSettings.tsx:115
+msgid "SEO Settings"
+msgstr "Impostazioni SEO"
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "SEO settings (Yoast)"
+msgstr "Impostazioni SEO (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:40
+msgid "SEO settings saved"
+msgstr "Impostazioni SEO salvate"
+
+#: packages/admin/src/components/SeoPanel.tsx:168
+#: packages/admin/src/components/SeoPanel.tsx:172
+msgid "SEO Title"
+msgstr "Titolo SEO"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
+msgid "Set a custom display size for this image instance."
+msgstr "Imposta una dimensione di visualizzazione personalizzata per questa istanza dell'immagine."
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:146
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:150
+msgid "Set language"
+msgstr "Imposta lingua"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:147
+msgid "Set language (current: {label})"
+msgstr "Imposta lingua (corrente: {label})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:529
+msgid "Set to 0 to never close comments automatically."
+msgstr "Imposta a 0 per non chiudere mai i commenti automaticamente."
+
+#: packages/admin/src/components/ContentList.tsx:425
+msgid "Set to draft"
+msgstr "Imposta come bozza"
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr "Configura il tuo sito"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr "Configurazione in corso..."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:234
+#: packages/admin/src/components/ContentEditor.tsx:809
+#: packages/admin/src/components/ContentEditor.tsx:1016
+#: packages/admin/src/components/ContentTypeEditor.tsx:381
+#: packages/admin/src/components/Header.tsx:101
+#: packages/admin/src/components/PluginManager.tsx:471
+#: packages/admin/src/components/Settings.tsx:63
+#: packages/admin/src/components/Sidebar.tsx:294
+#: packages/admin/src/components/WordPressImport.tsx:1811
+msgid "Settings"
+msgstr "Impostazioni"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Settings Manage"
+msgstr "Gestione impostazioni"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Settings Read"
+msgstr "Lettura impostazioni"
+
+#: packages/admin/src/components/PluginSettings.tsx:68
+#: packages/admin/src/components/settings/GeneralSettings.tsx:43
+msgid "Settings saved successfully"
+msgstr "Impostazioni salvate correttamente"
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr "Configurazione non riuscita"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "Condividi questo link con l'utente invitato"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:294
+msgid "Shared across all translations of the same byline."
+msgstr "Condiviso tra tutte le traduzioni della stessa firma."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:52
+msgid "Short text"
+msgstr "Testo breve"
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr "Testo breve"
+
+#: packages/admin/src/components/Widgets.tsx:146
+msgid "Show count"
+msgstr "Mostra conteggio"
+
+#: packages/admin/src/components/Widgets.tsx:131
+msgid "Show date"
+msgstr "Mostra data"
+
+#: packages/admin/src/components/Widgets.tsx:139
+msgid "Show hierarchy"
+msgstr "Mostra gerarchia"
+
+#: packages/admin/src/components/Widgets.tsx:138
+msgid "Show post count"
+msgstr "Mostra conteggio articoli"
+
+#: packages/admin/src/components/Widgets.tsx:130
+msgid "Show thumbnails"
+msgstr "Mostra miniature"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
+msgid "Show token"
+msgstr "Mostra token"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:365
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:554
+msgid "Shown when hovering over the image."
+msgstr "Mostrato al passaggio del mouse sull'immagine."
+
+#: packages/admin/src/components/SignupPage.tsx:441
+msgid "Sign in"
+msgstr "Accedi"
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr "Accedi"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:270
+msgid "Sign in instead"
+msgstr "Accedi invece"
+
+#: packages/admin/src/components/LoginPage.tsx:234
+msgid "Sign in to your site"
+msgstr "Accedi al tuo sito"
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:233
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr "Accedi con {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:231
+msgid "Sign in with email"
+msgstr "Accedi con email"
+
+#: packages/admin/src/components/LoginPage.tsx:292
+msgid "Sign in with email link"
+msgstr "Accedi con link email"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:254
+msgid "Sign in with Passkey"
+msgstr "Accedi con Passkey"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "Accesso effettuato come {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr "Scelta singola tra le opzioni"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr "Campo di testo su riga singola"
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr "Sito"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:130
+msgid "Site Identity"
+msgstr "Identità del sito"
+
+#: packages/admin/src/components/WordPressImport.tsx:2270
+msgid "site identity applied (title, tagline, logo)"
+msgstr "identità del sito applicata (titolo, tagline, logo)"
+
+#: packages/admin/src/components/Settings.tsx:71
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "Identità del sito, logo, favicon e preferenze di lettura"
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+#: packages/admin/src/components/WordPressImport.tsx:1151
+msgid "Site Settings"
+msgstr "Impostazioni sito"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:133
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr "Titolo sito"
+
+#: packages/admin/src/components/WordPressImport.tsx:1823
+msgid "Site title & tagline"
+msgstr "Titolo e tagline del sito"
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr "Il titolo del sito è obbligatorio"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:145
+msgid "Site URL"
+msgstr "URL del sito"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:267
+msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
+msgstr "I siti su Cloudflare D1 possono inoltre ripristinare il database a qualsiasi minuto degli ultimi 30 giorni tramite D1 Time Travel — sempre attivo, nessuna configurazione richiesta."
+
+#: packages/admin/src/components/MediaLibrary.tsx:588
+msgid "Size"
+msgstr "Dimensione"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:274
+msgid "Size:"
+msgstr "Dimensione:"
+
+#: packages/admin/src/components/WordPressImport.tsx:2104
+msgid "Skip Media Import"
+msgstr "Salta importazione media"
+
+#: packages/admin/src/components/WordPressImport.tsx:2129
+msgid "Skipped"
+msgstr "Saltato"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:239
+#: packages/admin/src/components/ContentSettingsPanel.tsx:430
+#: packages/admin/src/components/ContentSettingsPanel.tsx:937
+#: packages/admin/src/components/ContentSettingsPanel.tsx:999
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:402
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:259
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:414
+#: packages/admin/src/routes/byline-schema.tsx:237
+#: packages/admin/src/routes/bylines.tsx:486
+msgid "Slug"
+msgstr "slug"
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr "slug copiato negli appunti"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:251
+msgid "Slugs cannot be changed after the field is created."
+msgstr "Gli slug non possono essere modificati dopo la creazione del campo."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1130
+msgid "Small section heading"
+msgstr "Intestazione di sezione piccola"
+
+#: packages/admin/src/components/Settings.tsx:76
+#: packages/admin/src/components/settings/SocialSettings.tsx:70
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
+msgid "Social Links"
+msgstr "Link social"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:38
+msgid "Social links saved"
+msgstr "Link social salvati"
+
+#: packages/admin/src/components/Settings.tsx:77
+msgid "Social media profile links"
+msgstr "Link ai profili social"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:100
+msgid "Social Profiles"
+msgstr "Profili social"
+
+#: packages/admin/src/components/WordPressImport.tsx:1860
+msgid "Some content types cannot be imported"
+msgstr "Alcuni tipi di contenuto non possono essere importati"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:155
+#: packages/admin/src/components/SignupPage.tsx:263
+msgid "Something went wrong"
+msgstr "Qualcosa è andato storto"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr "Ordina plugin"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr "Ordina temi"
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:560
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:579
+#: packages/admin/src/components/Redirects.tsx:467
+#: packages/admin/src/components/SectionEditor.tsx:294
+msgid "Source"
+msgstr "Origine"
+
+#: packages/admin/src/components/Redirects.tsx:132
+msgid "Source path"
+msgstr "Percorso origine"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "spam"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:208
+#: packages/admin/src/components/comments/CommentInbox.tsx:248
+msgid "Spam"
+msgstr "Spam"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3830
+msgid "Spotlight Mode"
+msgstr "Modalità spotlight"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr "Fogli di calcolo"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:51
+msgid "SQL"
+msgstr "SQL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1922
+msgid "Start Import"
+msgstr "Avvia importazione"
+
+#: packages/admin/src/components/ContentEditor.tsx:1185
+#: packages/admin/src/components/PortableTextEditor.tsx:2285
+#: packages/admin/src/components/PortableTextEditor.tsx:2286
+msgid "Start writing, or type '/' for commands"
+msgstr "Inizia a scrivere, o digita '/' per i comandi"
+
+#: packages/admin/src/components/ContentList.tsx:511
+#: packages/admin/src/components/ContentSettingsPanel.tsx:437
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:472
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr "Stato"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "Status code"
+msgstr "Codice di stato"
+
+#: packages/admin/src/components/Dashboard.tsx:357
+msgid "Status: {status}"
+msgstr "Stato: {status}"
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:173
+msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
+msgstr "Salva un backup giornaliero nel bucket di archiviazione del sito. I backup precedenti vengono rimossi automaticamente."
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:218
+msgid "Stored Backups"
+msgstr "Backup archiviati"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:293
+msgid "Stored per locale — each translation of a byline gets its own value."
+msgstr "Memorizzato per locale — ogni traduzione di una firma ha il proprio valore."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3251
+#: packages/admin/src/components/PortableTextEditor.tsx:3637
+msgid "Strikethrough"
+msgstr "Barrato"
+
+#: packages/admin/src/components/WordPressImport.tsx:1752
+msgid "Structure"
+msgstr "Struttura"
+
+#: packages/admin/src/components/WordPressImport.tsx:1164
+msgid "Structured"
+msgstr "Strutturato"
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr "Sottocampi"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "Abbonato"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:52
+msgid "Svelte"
+msgstr "Svelte"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:53
+msgid "Swift"
+msgstr "Swift"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr "Sincronizzato"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Passkey sincronizzata"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:777
+msgid "System"
+msgstr "Sistema"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "Sistema ({resolvedLabel})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:599
+msgid "System Fields"
+msgstr "Campi di sistema"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1204
+msgid "Table"
+msgstr "Tabella"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3326
+msgid "Table controls"
+msgstr "Controlli tabella"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:139
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr "Slogan"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:201
+#: packages/admin/src/components/Widgets.tsx:143
+msgid "Tags"
+msgstr "Tag"
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1797
+msgid "Tags ({0})"
+msgstr "Tag ({0})"
+
+#: packages/admin/src/components/MenuEditor.tsx:427
+#: packages/admin/src/components/MenuEditor.tsx:606
+msgid "Target"
+msgstr "Destinazione"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:192
+msgid "Target locale"
+msgstr "locale di destinazione"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:543
+msgid "Taxonomies"
+msgstr "Tassonomie"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Taxonomies Manage"
+msgstr "Gestione tassonomie"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:918
+msgid "Taxonomy created"
+msgstr "Tassonomia creata"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:807
+msgid "Taxonomy not found:"
+msgstr "Tassonomia non trovata:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:179
+msgid "Taxonomy: {taxonomyName}"
+msgstr "Tassonomia: {taxonomyName}"
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr "Template:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/components/TaxonomyManager.tsx:378
+#: packages/admin/src/components/TaxonomyManager.tsx:834
+msgid "Term"
+msgstr "Termine"
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:781
+msgid "Term \"{0}\" created in {1}."
+msgstr "Termine \"{0}\" creato in {1}."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:763
+msgid "Term deleted"
+msgstr "Termine eliminato"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:122
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3588
+msgid "Text formatting"
+msgstr "Formattazione testo"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "Al dispositivo non verrà concesso l'accesso."
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "The existing collection has fields with incompatible types."
+msgstr "La collezione esistente ha campi con tipi incompatibili."
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "Le seguenti tabelle contengono contenuto ma non sono registrate come collezioni. Registrale per gestire questo contenuto nell'area di amministrazione."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:179
+msgid "The invited user will have this role once they complete registration."
+msgstr "L'utente invitato avrà questo ruolo una volta completata la registrazione."
+
+#: packages/admin/src/components/LoginPage.tsx:114
+#: packages/admin/src/components/SignupPage.tsx:140
+msgid "The link will expire in 15 minutes."
+msgstr "Il link scadrà tra 15 minuti."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "Il marketplace è vuoto. Torna più tardi per nuovi plugin."
+
+#: packages/admin/src/components/MenuList.tsx:76
+msgid "The menu has been deleted."
+msgstr "Il menu è stato eliminato."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:136
+msgid "The name of your site, used in the header and metadata"
+msgstr "Il nome del sito, utilizzato nell'intestazione e nei metadati"
+
+#: packages/admin/src/router.tsx:2191
+msgid "The page you're looking for doesn't exist."
+msgstr "La pagina cercata non esiste."
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
+msgid "The plugin field widget failed to render."
+msgstr "Impossibile eseguire il rendering del widget del campo plugin."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:149
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "L'URL pubblico del sito (utilizzato per i link canonici e le sitemap)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr "L'immagine di riferimento non è più disponibile. Selezionane una nuova o rimuovi il riferimento."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:174
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr "Il logo di riferimento non è più disponibile. Selezionane uno nuovo o rimuovi il riferimento."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr "Il marketplace dei temi è vuoto. Torna più tardi."
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr "Tema"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:307
+msgid "Theme ID: {0}"
+msgstr "ID tema: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr "Tema non trovato"
+
+#: packages/admin/src/components/SectionEditor.tsx:185
+msgid "Theme Section"
+msgstr "Sezione tema"
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "Le sezioni fornite dal tema non possono essere eliminate. Modifica la sezione per creare una copia personalizzata, poi elimina quella."
+
+#: packages/admin/src/components/ThemeToggle.tsx:33
+msgid "Theme: {label}"
+msgstr "Tema: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:281
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr "Temi"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:141
+msgid "These tools remain disabled after installation until you explicitly enable agent access."
+msgstr "Questi strumenti rimangono disabilitati dopo l'installazione finché non si abilita esplicitamente l'accesso agli agenti."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:370
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr "Questa collezione è definita nel codice. Alcune impostazioni non possono essere modificate qui. Modifica il file live.config.ts per cambiare lo schema."
+
+#: packages/admin/src/components/WordPressImport.tsx:1059
+msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
+msgstr "Questa non sembra una chiave di migrazione valida. Generane una nuova nel plugin e incolla la stringa completa che inizia con \"em1.\"."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "This field does not accept {sniffedMime} files."
+msgstr "Questo campo non accetta file {sniffedMime}."
+
+#: packages/admin/src/components/ContentEditor.tsx:1698
+#: packages/admin/src/components/ImageFieldRenderer.tsx:201
+msgid "This field is required"
+msgstr "Questo campo è obbligatorio"
+
+#: packages/admin/src/components/SectionEditor.tsx:301
+msgid "This is a custom section."
+msgstr "Questa è una sezione personalizzata."
+
+#: packages/admin/src/components/WordPressImport.tsx:1308
+msgid "This is a WordPress site."
+msgstr "Questo è un sito WordPress."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "Questo link scade tra 7 giorni e può essere utilizzato una sola volta."
+
+#: packages/admin/src/components/WordPressImport.tsx:921
+msgid "This may take a while for large exports."
+msgstr "Per esportazioni di grandi dimensioni potrebbe richiedere del tempo."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "Questa passkey è già registrata su questo dispositivo."
+
+#. placeholder {0}: archiveToDelete?.name ?? ""
+#: packages/admin/src/components/settings/BackupSettings.tsx:283
+msgid "This permanently deletes {0} from storage."
+msgstr "Questa operazione elimina definitivamente {0} dall'archivio."
+
+#: packages/admin/src/components/PluginSettings.tsx:177
+msgid "This plugin has no configurable settings."
+msgstr "Questo plugin non ha impostazioni configurabili."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr "Questo plugin non richiede permessi speciali."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:579
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr "Questo publisher rivendica un nome che non ha potuto dimostrare di possedere — potrebbe trattarsi di una rappresentazione fraudolenta. L'installazione è disabilitata. Se conosci il publisher e ti fidi di lui, chiedigli di correggere la configurazione della propria identità prima di riprovare."
+
+#: packages/admin/src/components/Redirects.tsx:582
+msgid "This redirect rule will be permanently removed."
+msgstr "Questa regola di reindirizzamento verrà rimossa definitivamente."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:631
+msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
+msgstr "Questa versione richiede un ambiente più recente di quello attualmente in uso dal sito. Aggiorna prima di installare."
+
+#: packages/admin/src/routes/bylines.tsx:623
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr "Questa operazione rimuove il profilo della firma. I collegamenti alla firma nei contenuti vengono rimossi e i puntatori al lead vengono cancellati."
+
+#: packages/admin/src/components/SectionEditor.tsx:298
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "Questa sezione è fornita dal tema. La modifica creerà una copia personalizzata che sovrascrive la versione del tema."
+
+#: packages/admin/src/components/SectionEditor.tsx:303
+msgid "This section was imported from another system."
+msgstr "Questa sezione è stata importata da un altro sistema."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:125
+msgid "This update exposes the following routes without authentication:"
+msgstr "Questo aggiornamento espone le seguenti route senza autenticazione:"
+
+#: packages/admin/src/components/Widgets.tsx:713
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr "Questa operazione eliminerà l'area widget e tutti i suoi widget. L'azione non può essere annullata."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "Questa operazione concederà l'accesso CLI con i tuoi permessi."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:645
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "Questa operazione sposterà l'elemento nel cestino. Potrai ripristinarlo in seguito dal cestino."
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:904
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "Questa operazione eliminerà definitivamente \"{0}\" e lo rimuoverà da tutti i contenuti."
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "Questa operazione eliminerà definitivamente \"{0}\". L'azione non può essere annullata."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "Questa operazione eliminerà definitivamente questo commento. L'azione non può essere annullata."
+
+#: packages/admin/src/components/PluginManager.tsx:713
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "Questa operazione rimuoverà il plugin e il suo bundle dal sito."
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:80
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "Questa operazione ripristinerà la versione pubblicata. Le modifiche alla bozza andranno perse."
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr "Riflessioni, tutorial e altro ancora"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:287
+msgid "Timezone"
+msgstr "Fuso orario"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:290
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "Fuso orario per la visualizzazione delle date (es. America/New_York)"
+
+#: packages/admin/src/components/ContentList.tsx:505
+#: packages/admin/src/components/ContentList.tsx:643
+#: packages/admin/src/components/SectionEditor.tsx:251
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:889
+msgid "Title"
+msgstr "Titolo"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:361
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:550
+msgid "Title (Tooltip)"
+msgstr "Titolo (Tooltip)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+msgid "Title Separator"
+msgstr "Separatore titolo"
+
+#: packages/admin/src/components/ContentList.tsx:811
+msgid "to"
+msgstr "a"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:483
+msgid "to close"
+msgstr "per chiudere"
+
+#: packages/admin/src/components/ContentList.tsx:815
+msgid "To date"
+msgstr "Data finale"
+
+#: packages/admin/src/components/PluginManager.tsx:207
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "per installare plugin, o aggiungili al tuo astro.config.mjs."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:473
+msgid "to select"
+msgstr "per selezionare"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3371
+msgid "Toggle header row"
+msgstr "Attiva/disattiva riga di intestazione"
+
+#: packages/admin/src/components/ThemeToggle.tsx:31
+#: packages/admin/src/components/ThemeToggle.tsx:42
+msgid "Toggle theme (current: {label})"
+msgstr "Cambia tema (attuale: {label})"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:207
+msgid "Token created: {0}"
+msgstr "Token creato: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:420
+msgid "Token Name"
+msgstr "Nome token"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:54
+msgid "TOML"
+msgstr "TOML"
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "Tools → Export"
+msgstr "Strumenti → Esporta"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr "Traccia la cronologia dei contenuti"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:287
+#: packages/admin/src/routes/byline-schema.tsx:243
+msgid "Translatable"
+msgstr "Traducibile"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:103
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translate"
+msgstr "Traduci"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:176
+msgid "Translate \"{0}\""
+msgstr "Traduci \"{0}\""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:100
+msgid "Translate {0}"
+msgstr "Traduci {0}"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translating..."
+msgstr "Traduzione in corso..."
+
+#: packages/admin/src/components/MenuEditor.tsx:143
+#: packages/admin/src/components/TaxonomyManager.tsx:780
+#: packages/admin/src/router.tsx:1119
+msgid "Translation created"
+msgstr "Traduzione creata"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:60
+msgid "Translations"
+msgstr "Traduzioni"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "cestino"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:217
+#: packages/admin/src/components/comments/CommentInbox.tsx:258
+#: packages/admin/src/components/comments/CommentInbox.tsx:514
+#: packages/admin/src/components/ContentList.tsx:375
+msgid "Trash"
+msgstr "Cestino"
+
+#: packages/admin/src/components/ContentList.tsx:666
+msgid "Trash is empty"
+msgstr "Il cestino è vuoto"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:550
+msgid "Trash is empty."
+msgstr "Il cestino è vuoto."
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr "Interruttore vero/falso"
+
+#: packages/admin/src/components/MediaLibrary.tsx:493
+msgid "Try a broader media type or clear your filters."
+msgstr "Prova un tipo di media più generico o rimuovi i filtri."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:691
+msgid "Try a different search term"
+msgstr "Prova un termine di ricerca diverso"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:103
+msgid "Try adjusting your search"
+msgstr "Prova a modificare la ricerca"
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr "Prova a modificare la ricerca o i filtri."
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr "Riprova"
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Try Again"
+msgstr "Riprova"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "Prova un altro codice"
+
+#: packages/admin/src/components/MediaLibrary.tsx:518
+msgid "Try another filename or clear your search."
+msgstr "Prova un altro nome file o cancella la ricerca."
+
+#: packages/admin/src/components/MediaLibrary.tsx:492
+msgid "Try another filename, or clear your search and filters."
+msgstr "Prova un altro nome file, o cancella la ricerca e i filtri."
+
+#: packages/admin/src/components/WordPressImport.tsx:1286
+#: packages/admin/src/components/WordPressImport.tsx:1408
+msgid "Try Another URL"
+msgstr "Prova un altro URL"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr "Prova con i miei dati"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:55
+msgid "TSX"
+msgstr "TSX"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:282
+msgid "Turn into"
+msgstr "Converti in"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:106
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:260
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:587
+#: packages/admin/src/routes/byline-schema.tsx:240
+msgid "Type"
+msgstr "Tipo"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:2018
+msgid "Type mismatch ({0})"
+msgstr "Tipo non compatibile ({0})"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:56
+msgid "TypeScript"
+msgstr "TypeScript"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr "Impossibile raggiungere il marketplace"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1042
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1059
+msgid "Unassigned"
+msgstr "Non assegnato"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3244
+#: packages/admin/src/components/PortableTextEditor.tsx:3630
+msgid "Underline"
+msgstr "Sottolineato"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3810
+msgid "Undo"
+msgstr "Annulla"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:191
+#: packages/admin/src/components/PluginManager.tsx:629
+#: packages/admin/src/components/PluginManager.tsx:727
+msgid "Uninstall"
+msgstr "Disinstalla"
+
+#: packages/admin/src/components/PluginManager.tsx:711
+msgid "Uninstall {pluginName}?"
+msgstr "Disinstallare {pluginName}?"
+
+#: packages/admin/src/components/PluginManager.tsx:706
+msgid "Uninstall confirmation"
+msgstr "Conferma disinstallazione"
+
+#: packages/admin/src/components/PluginManager.tsx:727
+msgid "Uninstalling..."
+msgstr "Disinstallazione in corso..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:731
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr "Univoco"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr "Identificatore univoco (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "Ruolo sconosciuto"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Unlock aspect ratio"
+msgstr "Sblocca proporzioni"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr "Passkey senza nome"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:198
+msgid "Unpublish {itemLabel}"
+msgstr "Annulla pubblicazione {itemLabel}"
+
+#: packages/admin/src/router.tsx:1027
+msgid "Unpublished"
+msgstr "Non pubblicato"
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr "Tabelle di contenuto non registrate rilevate"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:465
+msgid "Unschedule"
+msgstr "Annulla pianificazione"
+
+#: packages/admin/src/router.tsx:1088
+msgid "Unscheduled"
+msgstr "Non pianificato"
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr "Tipo di elemento widget non supportato: {0}"
+
+#: packages/admin/src/components/Dashboard.tsx:317
+msgid "Untitled"
+msgstr "Senza titolo"
+
+#: packages/admin/src/components/ContentEditor.tsx:1601
+msgid "Untitled file"
+msgstr "File senza titolo"
+
+#: packages/admin/src/components/Widgets.tsx:534
+#: packages/admin/src/components/Widgets.tsx:807
+msgid "Untitled Widget"
+msgstr "Widget senza titolo"
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr "Publisher non verificato"
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:869
+msgid "Up"
+msgstr "Su"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:500
+msgid "Update"
+msgstr "Aggiorna"
+
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Update Field"
+msgstr "Aggiorna campo"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:334
+msgid "Update settings for {0}"
+msgstr "Aggiorna le impostazioni per {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:92
+msgid "Update site settings"
+msgstr "Aggiorna le impostazioni del sito"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:382
+msgid "Update the {0} details"
+msgstr "Aggiorna i dettagli {0}"
+
+#: packages/admin/src/components/Redirects.tsx:110
+msgid "Update this redirect rule."
+msgstr "Aggiorna questa regola di reindirizzamento."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:451
+msgid "Update to v{0}"
+msgstr "Aggiorna alla v{0}"
+
+#: packages/admin/src/components/ContentList.tsx:737
+#: packages/admin/src/components/ContentSettingsPanel.tsx:529
+#: packages/admin/src/components/RegistryPluginDetail.tsx:501
+msgid "Updated"
+msgstr "Aggiornato"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr "Aggiornato il"
+
+#: packages/admin/src/components/WordPressImport.tsx:946
+msgid "Updating content URLs..."
+msgstr "Aggiornamento URL dei contenuti in corso..."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:197
+#: packages/admin/src/components/PluginManager.tsx:451
+msgid "Updating..."
+msgstr "Aggiornamento in corso..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:649
+msgid "Upload"
+msgstr "Carica"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:152
+msgid "Upload a file to get started"
+msgstr "Carica un file per iniziare"
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Upload an export file"
+msgstr "Carica un file di esportazione"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:153
+msgid "Upload an image to get started"
+msgstr "Carica un'immagine per iniziare"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:62
+msgid "Upload and delete media"
+msgstr "Carica ed elimina media"
+
+#: packages/admin/src/lib/api/marketplace.ts:283
+#: packages/admin/src/lib/api/marketplace.ts:291
+msgid "Upload and manage media"
+msgstr "Carica e gestisci media"
+
+#: packages/admin/src/components/WordPressImport.tsx:1284
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Upload Export File"
+msgstr "Carica file di esportazione"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:669
+msgid "Upload failed: {uploadError}"
+msgstr "Caricamento non riuscito: {uploadError}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:661
+msgid "Upload file"
+msgstr "Carica file"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:154
+msgid "Upload File"
+msgstr "Carica file"
+
+#: packages/admin/src/components/MediaLibrary.tsx:365
+msgid "Upload files"
+msgstr "Carica file"
+
+#: packages/admin/src/components/MediaLibrary.tsx:508
+#: packages/admin/src/components/MediaLibrary.tsx:532
+msgid "Upload Files"
+msgstr "Carica file"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:154
+msgid "Upload Image"
+msgstr "Carica immagine"
+
+#: packages/admin/src/components/MediaLibrary.tsx:505
+msgid "Upload images, videos, and documents to keep reusable assets in one place."
+msgstr "Carica immagini, video e documenti per conservare le risorse riutilizzabili in un unico posto."
+
+#: packages/admin/src/components/Dashboard.tsx:111
+msgid "Upload Media"
+msgstr "Carica media"
+
+#: packages/admin/src/components/MediaLibrary.tsx:529
+msgid "Upload media to keep reusable assets in one place."
+msgstr "Carica media per conservare le risorse riutilizzabili in un unico posto."
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:356
+msgid "Upload to {0}"
+msgstr "Carica in {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "Upload WordPress export file"
+msgstr "Carica il file di esportazione WordPress"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:289
+msgid "Uploaded:"
+msgstr "Caricato:"
+
+#: packages/admin/src/components/WordPressImport.tsx:2127
+msgid "Uploading"
+msgstr "Caricamento in corso"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:331
+msgid "Uploading {0}/{1}..."
+msgstr "Caricamento {0}/{1}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:332
+#: packages/admin/src/components/MediaPickerModal.tsx:649
+msgid "Uploading..."
+msgstr "Caricamento in corso..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:54
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:418
+#: packages/admin/src/components/MenuEditor.tsx:596
+#: packages/admin/src/components/PortableTextEditor.tsx:3198
+#: packages/admin/src/components/PortableTextEditor.tsx:3755
+#: packages/admin/src/components/PortableTextEditor.tsx:3765
+msgid "URL"
+msgstr "URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:423
+msgid "URL Pattern"
+msgstr "Schema URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr "Identificatore compatibile con URL"
+
+#: packages/admin/src/components/MenuList.tsx:163
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "Identificatore compatibile con URL (es. \"primary\", \"footer\")"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:295
+msgid "URL:"
+msgstr "URL:"
+
+#: packages/admin/src/components/Redirects.tsx:111
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "Usa [param] o [...rest] nei percorsi per la corrispondenza dei pattern."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:364
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "Usa l'autenticazione biometrica del dispositivo, la chiave di sicurezza o il PIN per accedere."
+
+#: packages/admin/src/components/LoginPage.tsx:328
+msgid "Use your registered passkey to sign in securely."
+msgstr "Usa la tua passkey registrata per accedere in modo sicuro."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr "Utilizzata come immagine Open Graph di fallback quando una pagina non ne ha una. Dimensione consigliata: 1200×630."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:666
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "Usato come identificatore. Solo lettere minuscole, numeri e trattini bassi."
+
+#: packages/admin/src/components/ContentEditor.tsx:1288
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "Usata come immagine principale di questo articolo nelle pagine di elenco e in cima all'articolo"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:122
+msgid "Used by screen readers and when image fails to load"
+msgstr "Usato dai lettori di schermo e quando l'immagine non riesce a caricarsi"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:408
+msgid "Used in URLs and API endpoints"
+msgstr "Usato negli URL e negli endpoint API"
+
+#: packages/admin/src/components/SectionEditor.tsx:269
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "Usato per identificare questa sezione. Solo lettere minuscole, numeri e trattini."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:43
+#: packages/admin/src/components/Header.tsx:83
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr "Utente"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:177
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "L'accesso degli utenti è gestito da un provider esterno ({0}). Le impostazioni del dominio per la registrazione autonoma non sono disponibili con l'autenticazione esterna."
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr "Dettagli utente"
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr "Utente non trovato"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:210
+#: packages/admin/src/components/Sidebar.tsx:253
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr "Utenti"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:383
+msgid "Users from"
+msgstr "Utenti da"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:211
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "Gli utenti con indirizzi email di questi domini possono registrarsi senza un invito. Verrà assegnato loro automaticamente il ruolo specificato."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:386
+msgid "v{0} available"
+msgstr "v{0} disponibile"
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr "Validazione"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:187
+#: packages/admin/src/components/RegistryPluginDetail.tsx:462
+msgid "Verified publisher"
+msgstr "Editore verificato"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:461
+msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
+msgstr "Editore verificato, confermato dall'etichettatore {verifiedLabeller}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:452
+msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+msgstr "Editore verificato. Un etichettatore ({verifiedLabeller}) ha confermato l'identità di questo editore."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:453
+msgid "Verified publisher. A labeller has confirmed this publisher's identity."
+msgstr "Editore verificato. Un etichettatore ha confermato l'identità di questo editore."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:228
+msgid "Verifying your invite..."
+msgstr "Verifica dell'invito in corso..."
+
+#: packages/admin/src/components/SignupPage.tsx:388
+msgid "Verifying your link..."
+msgstr "Verifica del link in corso..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:211
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "Verifica in corso..."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+#: packages/admin/src/components/RegistryPluginDetail.tsx:515
+msgid "Version"
+msgstr "Versione"
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:477
+msgid "Version {0}"
+msgstr "Versione {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+#: packages/admin/src/components/MediaLibrary.tsx:435
+msgid "Video"
+msgstr "Video"
+
+#: packages/admin/src/components/Settings.tsx:117
+msgid "View email provider status and send test emails"
+msgstr "Visualizza lo stato del provider email e invia email di prova"
+
+#: packages/admin/src/components/PluginManager.tsx:463
+msgid "View in Marketplace"
+msgstr "Visualizza nel Marketplace"
+
+#: packages/admin/src/components/MediaLibrary.tsx:447
+msgid "View mode"
+msgstr "Modalità di visualizzazione"
+
+#: packages/admin/src/components/ContentList.tsx:1011
+msgid "View published {title}"
+msgstr "Visualizza {title} pubblicato"
+
+#: packages/admin/src/components/Header.tsx:59
+msgid "View Site"
+msgstr "Visualizza sito"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:676
+msgid "View source"
+msgstr "Visualizza sorgente"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:931
+msgid "View the {license} license on spdx.org"
+msgstr "Visualizza la licenza {license} su spdx.org"
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Visitors hitting these paths will see an error."
+msgstr "I visitatori che accedono a questi percorsi visualizzeranno un errore."
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:57
+msgid "Vue"
+msgstr "Vue"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "In attesa della passkey..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr "Avviso"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1266
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "Impossibile connettersi a un sito WordPress all'indirizzo {0}. Il sito potrebbe non essere WordPress, l'API REST potrebbe essere disabilitata oppure il sito non è raggiungibile."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:577
+msgid "We couldn't verify this publisher's identity"
+msgstr "Impossibile verificare l'identità di questo editore"
+
+#: packages/admin/src/components/WordPressImport.tsx:1084
+msgid "We'll check what import options are available for your site."
+msgstr "Verificheremo le opzioni di importazione disponibili per il tuo sito."
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "We'll send you a link to sign in without a password."
+msgstr "Ti invieremo un link per accedere senza password."
+
+#: packages/admin/src/components/SignupPage.tsx:133
+msgid "We've sent a verification link to"
+msgstr "Abbiamo inviato un link di verifica a"
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr "Indirizzo web"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "WebAuthn non è supportato in questo browser"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+#: packages/admin/src/components/RegistryPluginDetail.tsx:701
+msgid "Website"
+msgstr "Sito web"
+
+#: packages/admin/src/routes/bylines.tsx:491
+msgid "Website URL"
+msgstr "URL del sito web"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "Benvenuto in EmDash, {firstName}!"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "Benvenuto in EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "What happens when you import:"
+msgstr "Cosa succede durante l'importazione:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1874
+msgid "What will happen when you import"
+msgstr "Cosa succederà durante l'importazione"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr "Quando la voce è stata creata"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr "Quando la voce è stata modificata l'ultima volta"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr "Quando la voce è stata pubblicata"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:680
+msgid "Which content types can use this taxonomy"
+msgstr "Quali tipi di contenuto possono utilizzare questa tassonomia"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr "Numero intero"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:121
+msgid "Why can't this be changed?"
+msgstr "Perché non è possibile modificarlo?"
+
+#: packages/admin/src/components/SeoPanel.tsx:209
+msgid "Why is this important for duplicate pages?"
+msgstr "Perché è importante per le pagine duplicate?"
+
+#: packages/admin/src/components/SeoPanel.tsx:185
+msgid "Why is this important for search result summaries?"
+msgstr "Perché è importante per i riepiloghi dei risultati di ricerca?"
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Why is this important for search result titles?"
+msgstr "Perché è importante per i titoli dei risultati di ricerca?"
+
+#: packages/admin/src/components/SeoPanel.tsx:228
+msgid "Why is this important for search visibility?"
+msgstr "Perché è importante per la visibilità nei motori di ricerca?"
+
+#: packages/admin/src/components/SeoImageField.tsx:44
+msgid "Why is this important for social sharing?"
+msgstr "Perché è importante per la condivisione sui social?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:123
+msgid "Why is this important?"
+msgstr "Perché è importante?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
+msgid "Wide"
+msgstr "Largo"
+
+#: packages/admin/src/components/Widgets.tsx:800
+#: packages/admin/src/components/Widgets.tsx:815
+msgid "widget"
+msgstr "widget"
+
+#: packages/admin/src/components/Widgets.tsx:232
+msgid "Widget added"
+msgstr "Widget aggiunto"
+
+#: packages/admin/src/components/Widgets.tsx:220
+msgid "Widget area created"
+msgstr "Area widget creata"
+
+#: packages/admin/src/components/Widgets.tsx:643
+msgid "Widget area deleted"
+msgstr "Area widget eliminata"
+
+#: packages/admin/src/components/Widgets.tsx:763
+msgid "Widget deleted"
+msgstr "Widget eliminato"
+
+#: packages/admin/src/components/Widgets.tsx:892
+msgid "Widget title"
+msgstr "Titolo widget"
+
+#: packages/admin/src/components/Widgets.tsx:778
+msgid "Widget updated"
+msgstr "Widget aggiornato"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:168
+#: packages/admin/src/components/PluginManager.tsx:407
+#: packages/admin/src/components/Sidebar.tsx:233
+#: packages/admin/src/components/Widgets.tsx:388
+#: packages/admin/src/components/WordPressImport.tsx:1157
+msgid "Widgets"
+msgstr "Widget"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:284
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:473
+msgid "Width"
+msgstr "Larghezza"
+
+#: packages/admin/src/components/PluginSettings.tsx:338
+msgid "Will be cleared on save"
+msgstr "Verrà cancellato al salvataggio"
+
+#: packages/admin/src/components/WordPressImport.tsx:2014
+msgid "Will create"
+msgstr "Creerà"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:384
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "non potranno più registrarsi senza un invito. Gli utenti esistenti non sono interessati."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:158
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "Senza un provider email, i link di invito devono essere condivisi manualmente."
+
+#: packages/admin/src/components/WordPressImport.tsx:210
+msgid "WordPress authorization was rejected"
+msgstr "L'autorizzazione WordPress è stata rifiutata"
+
+#: packages/admin/src/components/WordPressImport.tsx:1476
+msgid "WordPress Username"
+msgstr "Nome utente WordPress"
+
+#: packages/admin/src/components/ContentList.tsx:404
+msgid "Working on {selectedCount} items…"
+msgstr "Elaborazione di {selectedCount} elementi in corso…"
+
+#: packages/admin/src/components/Widgets.tsx:902
+msgid "Write widget content..."
+msgstr "Scrivi il contenuto del widget..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1181
+msgid "WXR File"
+msgstr "File WXR"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:58
+msgid "XML"
+msgstr "XML"
+
+#: packages/admin/src/components/WordPressImport.tsx:1497
+msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
+msgstr "xxxx xxxx xxxx xxxx xxxx xxxx"
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:59
+msgid "YAML"
+msgstr "YAML"
+
+#: packages/admin/src/components/Widgets.tsx:163
+msgid "Yearly"
+msgstr "Annuale"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:420
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "Yes"
+msgstr "Sì"
+
+#: packages/admin/src/components/WordPressImport.tsx:1160
+msgid "Yoast/RankMath"
+msgstr "Yoast/RankMath"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "Puoi chiudere questa pagina e tornare al terminale."
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "Puoi creare e modificare i tuoi contenuti."
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "Puoi gestire contenuti, media, menu e tassonomie."
+
+#: packages/admin/src/routes/bylines.tsx:549
+msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+msgstr "Puoi ancora modificare i campi fissi qui sopra. Il salvataggio non modificherà alcun valore dei campi personalizzati memorizzati."
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "Puoi visualizzare il sito e contribuire ai suoi contenuti."
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr "Non puoi modificare il tuo ruolo"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "Hai accesso completo per gestire questo sito, inclusi utenti, impostazioni e tutti i contenuti."
+
+#: packages/admin/src/routes/byline-schema.tsx:175
+msgid "You need admin permissions to manage byline schema."
+msgstr "Sono necessari i permessi di amministratore per gestire lo schema delle firme."
+
+#: packages/admin/src/router.tsx:1486
+msgid "You need Editor permissions to moderate comments."
+msgstr "Sono necessari i permessi di Editor per moderare i commenti."
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "Non potrai più usare \"{0}\" per accedere. Questa azione non può essere annullata."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "Non potrai più usare questa passkey per accedere. Questa azione non può essere annullata."
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:55
+msgid "You'll be joining as <0>{0}</0>"
+msgstr "Accederai come <0>{0}</0>"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "Verrà richiesto di utilizzare l'autenticazione biometrica del dispositivo, la chiave di sicurezza o il PIN."
+
+#: packages/admin/src/components/WordPressImport.tsx:1369
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "Verrai reindirizzato a WordPress per autorizzare la connessione."
+
+#: packages/admin/src/components/SignupPage.tsx:192
+msgid "You'll be signing up as"
+msgstr "Ti registrerai come"
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr "Hai effettuato l'accesso tramite Cloudflare Access"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:53
+msgid "You've been invited!"
+msgstr "Sei stato invitato!"
+
+#: packages/admin/src/components/SignupPage.tsx:71
+msgid "you@company.com"
+msgstr "you@company.com"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:334
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr "you@example.com"
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "Il tuo account è stato creato con successo."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:316
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "Il tuo browser non supporta le passkey. Utilizza un browser moderno come Chrome, Safari, Firefox o Edge."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:267
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "Il tuo dispositivo non supporta le funzionalità di sicurezza richieste."
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr "La tua email"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:121
+msgid "Your Facebook page or profile username"
+msgstr "Il nome utente della tua pagina o profilo Facebook"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:115
+msgid "Your GitHub username"
+msgstr "Il tuo nome utente GitHub"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:127
+msgid "Your Instagram username"
+msgstr "Il tuo nome utente Instagram"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:133
+msgid "Your LinkedIn profile username"
+msgstr "Il tuo nome utente del profilo LinkedIn"
+
+#: packages/admin/src/components/MediaLibrary.tsx:504
+#: packages/admin/src/components/MediaLibrary.tsx:528
+msgid "Your media library is empty"
+msgstr "La tua libreria media è vuota"
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr "Il tuo nome"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:65
+#: packages/admin/src/components/SignupPage.tsx:202
+msgid "Your name (optional)"
+msgstr "Il tuo nome (facoltativo)"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "Il tuo ruolo"
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:612
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr "Il tuo sito richiede che le versioni abbiano almeno {0} di anzianità prima di poter essere installate. Questa versione diventerà installabile in seguito."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:109
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "Il tuo handle Twitter/X (es. @username)"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:437
+msgid "Your unsaved media changes will be lost."
+msgstr "Le modifiche ai media non salvate andranno perse."
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:2062
+msgid "Your WordPress export contains {0} media files."
+msgstr "L'esportazione WordPress contiene {0} file media."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:139
+msgid "Your YouTube channel ID or handle"
+msgstr "L'ID o il handle del tuo canale YouTube"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:136
+msgid "YouTube"
+msgstr "YouTube"

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -44,6 +44,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "de", label: "Deutsch", enabled: true }, // German
 	{ code: "hu", label: "Magyar", enabled: true }, // Hungarian
 	{ code: "id", label: "Bahasa Indonesia", enabled: true }, // Indonesian
+	{ code: "it", label: "Italiano", enabled: true }, // Italian
 	{ code: "ja", label: "日本語", enabled: true }, // Japanese
 	{ code: "ko", label: "한국어", enabled: false }, // Korean
 	{ code: "nb", label: "Norsk bokmål", enabled: true }, // Norwegian Bokmål


### PR DESCRIPTION
## What does this PR do?

Adds **Italian (`it`)** as a supported admin UI language.

- Registers `it` (`Italiano`) in `packages/admin/src/locales/locales.ts`, in alphabetical position between Indonesian and Japanese, with `enabled: true`.
- Adds a fully translated catalog at `packages/admin/src/locales/it/messages.po` — **all 1932 strings translated** (0 empty `msgstr`).

Translation notes:
- A shared glossary was used for term consistency (Collezione, Campo, Bozza, Pubblica/Pubblicato, Firma for "byline", Impostazioni, etc.).
- Established technical terms and brand/format names are kept as-is per Italian software convention (slug, tag, plugin, widget, media, dashboard, SQL/JSON/HTML, GitHub, etc.).
- ICU plural branches use Italian `one`/`other` with correct gender/number agreement; `#`, `{placeholders}`, `<0>…</0>` inline tags and escapes are preserved verbatim.

No linked issue — per [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md), translations are opened directly.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, this is catalog data; the existing `loadMessages` test already covers every enabled locale
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no source strings changed; this only adds a locale catalog, which is exactly what a translation PR should include
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a (translation)

> **Note on the unchecked build boxes:** I was unable to run `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm format` locally — `pnpm install` fails on my machine with filesystem errors (`ERR_PNPM_EINVAL` / `EILSEQ` / `ENOENT`) while writing the store on this volume, so the workspace never links. I did validate the catalog offline instead: 1932/1932 entries parse with valid gettext escaping, 0 unbalanced braces, ICU plural shape matches the English source for every plural entry, and `{placeholder}`/tag parity holds against `en/messages.po`. The `locales.ts` change is a single line matching the 20+ sibling entries. Please let CI run the authoritative checks.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8** (translation of the catalog and the locale registration)

## Screenshots / test output

Offline catalog validation:

```
enEntries: 1932
itEntries: 1932
emptyMsgstr: 0
ICU/brace issues: 0
placeholder-parity problems: 0 (real)
```
