### PR TITLE
feat(admin): make content settings sections reorderable

### DIFF
--- a/.changeset/content-settings-sortable-sections.md
+++ b/.changeset/content-settings-sortable-sections.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": minor
 ---
 
-Allows editors to reorder the built-in content settings sections with accessible drag handles and stores the preferred order per user and collection in the browser.
+Adds accessible drag handles for reordering the built-in content settings sections and stores each editor's preferred order per collection in the browser.

--- a/.changeset/content-settings-sortable-sections.md
+++ b/.changeset/content-settings-sortable-sections.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Allows editors to reorder the built-in content settings sections with accessible drag handles and stores the preferred order per user and collection in the browser.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -964,7 +964,19 @@ function MobileSidebarPortalGuard() {
 		const handleFocusOut = (event: FocusEvent) => {
 			const source = event.target;
 			const destination = event.relatedTarget;
-			if (!(source instanceof Element) || !(destination instanceof Element)) return;
+			if (!(source instanceof Element)) return;
+
+			// dnd-kit briefly blurs and then restores the activator after a
+			// pointer drop. Kumo interprets the null relatedTarget as leaving the
+			// sheet and closes it before focus is restored. Keep this transient
+			// sortable-handle blur inside the mobile settings interaction.
+			if (source.closest("[data-sortable-handle]") && destination === null) {
+				event.stopPropagation();
+				keepSheetOpen();
+				return;
+			}
+
+			if (!(destination instanceof Element)) return;
 
 			const sheet = source.closest('nav[data-sidebar="sidebar"][data-mobile="true"]');
 			if (!sheet || sheet.contains(destination)) return;

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -952,6 +952,7 @@ function MobileSidebarPortalGuard() {
 		const nestedOverlaySelector =
 			'[role="dialog"], [role="listbox"], [role="menu"], .kumo-tooltip-popup';
 		const keepSheetOpen = () => queueMicrotask(() => setOpenMobile(true));
+		const reopenSheetAfterDismiss = () => setTimeout(setOpenMobile, 0, true);
 		const promotePortal = (element: Element) => {
 			const overlay =
 				element.closest(nestedOverlaySelector) ?? element.querySelector(nestedOverlaySelector);
@@ -989,7 +990,17 @@ function MobileSidebarPortalGuard() {
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (event.key !== "Escape") return;
 			const target = event.target;
-			if (!(target instanceof Element) || !target.closest(nestedOverlaySelector)) return;
+			if (!(target instanceof Element)) return;
+
+			// Escape cancels a keyboard drag, but Kumo also treats it as a request
+			// to dismiss the mobile sheet. Let dnd-kit receive the key while
+			// restoring the sheet after its dismissal handler runs.
+			if (target.closest('[data-sortable-handle][data-sorting="true"]')) {
+				reopenSheetAfterDismiss();
+				return;
+			}
+
+			if (!target.closest(nestedOverlaySelector)) return;
 			keepSheetOpen();
 		};
 

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -630,7 +630,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 				{portableTextEditor && (
 					<SortableContentSettingsSection id="outline" label={t`Outline`} disclosure>
 						<div className="p-4">
-							<DocumentOutline editor={portableTextEditor} />
+							<DocumentOutline editor={portableTextEditor} reserveHeaderEnd />
 						</div>
 					</SortableContentSettingsSection>
 				)}
@@ -638,7 +638,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 				{!isNew && item && supportsRevisions && (
 					<SortableContentSettingsSection id="revisions" label={t`Revisions`} disclosure>
 						<div className="p-4">
-							<RevisionHistory collection={collection} entryId={item.id} />
+							<RevisionHistory collection={collection} entryId={item.id} reserveHeaderEnd />
 						</div>
 					</SortableContentSettingsSection>
 				)}

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -38,7 +38,11 @@ import { RevisionHistory } from "./RevisionHistory";
 import { RouterLinkButton } from "./RouterLinkButton.js";
 import { SaveButton } from "./SaveButton";
 import { SeoPanel } from "./SeoPanel";
-import { TaxonomySidebar } from "./TaxonomySidebar";
+import {
+	SortableContentSettingsSection,
+	SortableContentSettingsSections,
+} from "./SortableContentSettingsSections.js";
+import { TaxonomySidebar, useHasApplicableTaxonomies } from "./TaxonomySidebar";
 import { TranslationsPanel } from "./TranslationsPanel.js";
 
 // Editor role level (40) from @emdash-cms/auth
@@ -379,6 +383,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 	const [scheduleDate, setScheduleDate] = React.useState<string>("");
 	const [showScheduler, setShowScheduler] = React.useState(false);
 	const showDiscard = !isNew && supportsDrafts && hasPendingChanges && !!onDiscardDraft;
+	const hasApplicableTaxonomies = useHasApplicableTaxonomies(collection);
 
 	const handleScheduleSubmit = () => {
 		if (scheduleDate && onSchedule) {
@@ -421,206 +426,223 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 		// The Kumo Sidebar wrapper sets `whitespace-nowrap` for its collapse
 		// animation, which would stop long field descriptions from wrapping.
 		<div className="flex flex-col whitespace-normal">
-			<div className="p-4">
-				<Text bold as="h3" DANGEROUS_className="mb-4">
-					{t`Publish`}
-				</Text>
-				<div className="space-y-4">
-					<Input
-						label={t`Slug`}
-						value={slug}
-						onChange={(e) => onSlugChange(e.target.value)}
-						placeholder="my-post-slug"
-					/>
-					<div>
-						<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
-							<Label>{t`Status`}</Label>
-							{supportsDrafts ? (
-								<>
-									{isLive && <Badge variant="success">{t`Published`}</Badge>}
-									{hasPendingChanges && <Badge variant="secondary">{t`Pending changes`}</Badge>}
-									{!isLive && !hasSchedule && <Badge variant="secondary">{t`Draft`}</Badge>}
-									{hasSchedule && <Badge variant="outline">{t`Scheduled`}</Badge>}
-								</>
-							) : (
-								<Badge variant="secondary">
-									{status.charAt(0).toUpperCase() + status.slice(1)}
-								</Badge>
-							)}
-						</div>
-						{showDiscard && (
-							<div className="mt-2">
-								<DiscardDraftDialog
-									onDiscard={onDiscardDraft}
-									triggerVariant="outline"
-									triggerSize="sm"
-								/>
+			<SortableContentSettingsSections collection={collection} userId={currentUser?.id}>
+				<SortableContentSettingsSection id="publish" label={t`Publish`}>
+					<div className="p-4">
+						<Text bold as="h3" DANGEROUS_className="mb-4">
+							{t`Publish`}
+						</Text>
+						<div className="space-y-4">
+							<Input
+								label={t`Slug`}
+								value={slug}
+								onChange={(e) => onSlugChange(e.target.value)}
+								placeholder="my-post-slug"
+							/>
+							<div>
+								<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+									<Label>{t`Status`}</Label>
+									{supportsDrafts ? (
+										<>
+											{isLive && <Badge variant="success">{t`Published`}</Badge>}
+											{hasPendingChanges && <Badge variant="secondary">{t`Pending changes`}</Badge>}
+											{!isLive && !hasSchedule && <Badge variant="secondary">{t`Draft`}</Badge>}
+											{hasSchedule && <Badge variant="outline">{t`Scheduled`}</Badge>}
+										</>
+									) : (
+										<Badge variant="secondary">
+											{status.charAt(0).toUpperCase() + status.slice(1)}
+										</Badge>
+									)}
+								</div>
+								{showDiscard && (
+									<div className="mt-2">
+										<DiscardDraftDialog
+											onDiscard={onDiscardDraft}
+											triggerVariant="outline"
+											triggerSize="sm"
+										/>
+									</div>
+								)}
 							</div>
-						)}
-					</div>
-					{item?.scheduledAt && (
-						<div className="flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
-							<p className="text-xs text-kumo-subtle">{t`Scheduled for: ${formatScheduledDate(item.scheduledAt)}`}</p>
-							<Button type="button" variant="outline" size="sm" onClick={onUnschedule}>
-								{t`Unschedule`}
-							</Button>
-						</div>
-					)}
+							{item?.scheduledAt && (
+								<div className="flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
+									<p className="text-xs text-kumo-subtle">{t`Scheduled for: ${formatScheduledDate(item.scheduledAt)}`}</p>
+									<Button type="button" variant="outline" size="sm" onClick={onUnschedule}>
+										{t`Unschedule`}
+									</Button>
+								</div>
+							)}
 
-					{canSchedule && (
-						<div className="pt-2">
-							{showScheduler ? (
-								<div className="space-y-2">
-									<Input
-										label={t`Schedule for`}
-										type="datetime-local"
-										value={scheduleDate}
-										onChange={(e) => setScheduleDate(e.target.value)}
-										min={new Date().toISOString().slice(0, 16)}
-									/>
-									<div className="flex gap-2">
-										<Button
-											type="button"
-											size="sm"
-											onClick={handleScheduleSubmit}
-											disabled={!scheduleDate || isScheduling}
-											icon={isScheduling ? <Loader size="sm" /> : undefined}
-										>
-											{t`Schedule`}
-										</Button>
+							{canSchedule && (
+								<div className="pt-2">
+									{showScheduler ? (
+										<div className="space-y-2">
+											<Input
+												label={t`Schedule for`}
+												type="datetime-local"
+												value={scheduleDate}
+												onChange={(e) => setScheduleDate(e.target.value)}
+												min={new Date().toISOString().slice(0, 16)}
+											/>
+											<div className="flex gap-2">
+												<Button
+													type="button"
+													size="sm"
+													onClick={handleScheduleSubmit}
+													disabled={!scheduleDate || isScheduling}
+													icon={isScheduling ? <Loader size="sm" /> : undefined}
+												>
+													{t`Schedule`}
+												</Button>
+												<Button
+													type="button"
+													variant="outline"
+													size="sm"
+													onClick={() => {
+														setShowScheduler(false);
+														setScheduleDate("");
+													}}
+												>
+													{t`Cancel`}
+												</Button>
+											</div>
+										</div>
+									) : (
 										<Button
 											type="button"
 											variant="outline"
 											size="sm"
-											onClick={() => {
-												setShowScheduler(false);
-												setScheduleDate("");
-											}}
+											className="w-full"
+											onClick={() => setShowScheduler(true)}
 										>
-											{t`Cancel`}
+											{t`Schedule for later`}
 										</Button>
-									</div>
+									)}
 								</div>
-							) : (
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									className="w-full"
-									onClick={() => setShowScheduler(true)}
-								>
-									{t`Schedule for later`}
-								</Button>
 							)}
 						</div>
-					)}
-				</div>
 
-				{item && (
-					<dl
-						data-testid="content-timestamps"
-						className="mt-4 border-t pt-4 space-y-1 text-xs text-kumo-subtle"
-					>
-						<div className="flex items-center justify-between gap-2">
-							<dt>{t`Created`}</dt>
-							<dd>{new Date(item.createdAt).toLocaleString()}</dd>
+						{item && (
+							<dl
+								data-testid="content-timestamps"
+								className="mt-4 border-t pt-4 space-y-1 text-xs text-kumo-subtle"
+							>
+								<div className="flex items-center justify-between gap-2">
+									<dt>{t`Created`}</dt>
+									<dd>{new Date(item.createdAt).toLocaleString()}</dd>
+								</div>
+								<div className="flex items-center justify-between gap-2">
+									<dt>{t`Updated`}</dt>
+									<dd>{new Date(item.updatedAt).toLocaleString()}</dd>
+								</div>
+							</dl>
+						)}
+					</div>
+				</SortableContentSettingsSection>
+
+				{currentUser && currentUser.role >= ROLE_EDITOR && users && users.length > 0 && (
+					<SortableContentSettingsSection id="ownership" label={t`Ownership`}>
+						<div className="p-4">
+							<Text bold as="h3" DANGEROUS_className="mb-4">
+								{t`Ownership`}
+							</Text>
+							<AuthorSelector
+								authorId={item?.authorId || null}
+								users={users}
+								onChange={onAuthorChange}
+							/>
 						</div>
-						<div className="flex items-center justify-between gap-2">
-							<dt>{t`Updated`}</dt>
-							<dd>{new Date(item.updatedAt).toLocaleString()}</dd>
-						</div>
-					</dl>
+					</SortableContentSettingsSection>
 				)}
-			</div>
 
-			{currentUser && currentUser.role >= ROLE_EDITOR && users && users.length > 0 && (
-				<div className="p-4 border-t">
-					<Text bold as="h3" DANGEROUS_className="mb-4">
-						{t`Ownership`}
-					</Text>
-					<AuthorSelector
-						authorId={item?.authorId || null}
-						users={users}
-						onChange={onAuthorChange}
-					/>
-				</div>
-			)}
+				{currentUser && currentUser.role >= ROLE_EDITOR && (
+					<SortableContentSettingsSection id="bylines" label={t`Bylines`}>
+						<div className="p-4">
+							<Text bold as="h3" DANGEROUS_className="mb-4">
+								{t`Bylines`}
+							</Text>
+							<BylineCreditsEditor
+								credits={activeBylines}
+								bylines={availableBylines ?? []}
+								selectedBylineDetails={item?.bylines?.map((entry) => entry.byline)}
+								bylinesLoaded={availableBylinesLoaded}
+								onChange={onBylinesChange}
+								onQuickCreate={onQuickCreateByline}
+								onQuickEdit={onQuickEditByline}
+								// Existing entry: use its own locale. New entry: use the
+								// URL `?locale=` (passed in via `entryLocale`).
+								entryLocale={item?.locale ?? entryLocale}
+								i18n={i18n}
+							/>
+						</div>
+					</SortableContentSettingsSection>
+				)}
 
-			{currentUser && currentUser.role >= ROLE_EDITOR && (
-				<div className="p-4 border-t">
-					<Text bold as="h3" DANGEROUS_className="mb-4">
-						{t`Bylines`}
-					</Text>
-					<BylineCreditsEditor
-						credits={activeBylines}
-						bylines={availableBylines ?? []}
-						selectedBylineDetails={item?.bylines?.map((entry) => entry.byline)}
-						bylinesLoaded={availableBylinesLoaded}
-						onChange={onBylinesChange}
-						onQuickCreate={onQuickCreateByline}
-						onQuickEdit={onQuickEditByline}
-						// Existing entry: use its own locale. New entry: use the
-						// URL `?locale=` (passed in via `entryLocale`).
-						entryLocale={item?.locale ?? entryLocale}
-						i18n={i18n}
-					/>
-				</div>
-			)}
+				{i18n && item && !isNew && (
+					<SortableContentSettingsSection id="translations" label={t`Translations`}>
+						<div className="p-4">
+							<TranslationsPanel
+								locales={i18n.locales}
+								defaultLocale={i18n.defaultLocale}
+								currentLocale={item.locale ?? undefined}
+								translations={translations ?? []}
+								onOpen={(tr) =>
+									navigate({
+										to: "/content/$collection/$id",
+										params: { collection, id: tr.id },
+										search: { locale: tr.locale },
+									})
+								}
+								onCreate={onTranslate}
+							/>
+						</div>
+					</SortableContentSettingsSection>
+				)}
 
-			{i18n && item && !isNew && (
-				<div className="p-4 border-t">
-					<TranslationsPanel
-						locales={i18n.locales}
-						defaultLocale={i18n.defaultLocale}
-						currentLocale={item.locale ?? undefined}
-						translations={translations ?? []}
-						onOpen={(tr) =>
-							navigate({
-								to: "/content/$collection/$id",
-								params: { collection, id: tr.id },
-								search: { locale: tr.locale },
-							})
-						}
-						onCreate={onTranslate}
-					/>
-				</div>
-			)}
+				{/* Do not register an empty sortable row when this collection has no taxonomies. */}
+				{item && hasApplicableTaxonomies && (
+					<SortableContentSettingsSection id="taxonomies" label={t`Taxonomies`}>
+						<TaxonomySidebar
+							className="p-4"
+							collection={collection}
+							entryId={item.id}
+							entryLocale={item.locale ?? entryLocale}
+						/>
+					</SortableContentSettingsSection>
+				)}
 
-			{/* Taxonomy selector — renders nothing (no chrome) when no taxonomies
-			    apply to this collection, so it owns its own section border. */}
-			{item && (
-				<TaxonomySidebar
-					className="p-4 border-t"
-					collection={collection}
-					entryId={item.id}
-					entryLocale={item.locale ?? entryLocale}
-				/>
-			)}
+				{hasSeo && !isNew && onSeoChange && (
+					<SortableContentSettingsSection id="seo" label={t`SEO`}>
+						<div className="p-4">
+							<Text bold as="h3" DANGEROUS_className="mb-4">
+								{t`SEO`}
+							</Text>
+							<SeoPanel
+								contentKey={item?.id ?? `new:${collection}`}
+								seo={item?.seo}
+								onChange={onSeoChange}
+							/>
+						</div>
+					</SortableContentSettingsSection>
+				)}
 
-			{hasSeo && !isNew && onSeoChange && (
-				<div className="p-4 border-t">
-					<Text bold as="h3" DANGEROUS_className="mb-4">
-						{t`SEO`}
-					</Text>
-					<SeoPanel
-						contentKey={item?.id ?? `new:${collection}`}
-						seo={item?.seo}
-						onChange={onSeoChange}
-					/>
-				</div>
-			)}
+				{portableTextEditor && (
+					<SortableContentSettingsSection id="outline" label={t`Outline`} disclosure>
+						<div className="p-4">
+							<DocumentOutline editor={portableTextEditor} />
+						</div>
+					</SortableContentSettingsSection>
+				)}
 
-			{portableTextEditor && (
-				<div className="p-4 border-t">
-					<DocumentOutline editor={portableTextEditor} />
-				</div>
-			)}
-
-			{!isNew && item && supportsRevisions && (
-				<div className="p-4 border-t">
-					<RevisionHistory collection={collection} entryId={item.id} />
-				</div>
-			)}
+				{!isNew && item && supportsRevisions && (
+					<SortableContentSettingsSection id="revisions" label={t`Revisions`} disclosure>
+						<div className="p-4">
+							<RevisionHistory collection={collection} entryId={item.id} />
+						</div>
+					</SortableContentSettingsSection>
+				)}
+			</SortableContentSettingsSections>
 
 			{!isNew && onDelete && (
 				<div className="border-t p-4">

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -26,7 +26,7 @@ import type {
 } from "../lib/api";
 import { fetchBylines } from "../lib/api";
 import { useDebouncedValue } from "../lib/hooks.js";
-import { slugify } from "../lib/utils";
+import { cn, slugify } from "../lib/utils";
 import type { CurrentUserInfo } from "./ContentEditor.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { GalleryDetailPanel } from "./editor/GalleryDetailPanel";
@@ -382,6 +382,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 
 	const [scheduleDate, setScheduleDate] = React.useState<string>("");
 	const [showScheduler, setShowScheduler] = React.useState(false);
+	const [isReorderingSections, setIsReorderingSections] = React.useState(false);
 	const showDiscard = !isNew && supportsDrafts && hasPendingChanges && !!onDiscardDraft;
 	const hasApplicableTaxonomies = useHasApplicableTaxonomies(collection);
 
@@ -426,7 +427,11 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 		// The Kumo Sidebar wrapper sets `whitespace-nowrap` for its collapse
 		// animation, which would stop long field descriptions from wrapping.
 		<div className="flex flex-col whitespace-normal">
-			<SortableContentSettingsSections collection={collection} userId={currentUser?.id}>
+			<SortableContentSettingsSections
+				collection={collection}
+				userId={currentUser?.id}
+				onSortingChange={setIsReorderingSections}
+			>
 				<SortableContentSettingsSection id="publish" label={t`Publish`}>
 					<div className="p-4">
 						<Text bold as="h3" DANGEROUS_className="mb-4">
@@ -645,7 +650,11 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 			</SortableContentSettingsSections>
 
 			{!isNew && onDelete && (
-				<div className="border-t p-4">
+				<div
+					data-testid="content-trash-actions"
+					aria-hidden={isReorderingSections || undefined}
+					className={cn("border-t p-4", isReorderingSections && "invisible pointer-events-none")}
+				>
 					<Dialog.Root disablePointerDismissal>
 						<Dialog.Trigger
 							render={(p) => (

--- a/packages/admin/src/components/RevisionHistory.tsx
+++ b/packages/admin/src/components/RevisionHistory.tsx
@@ -71,6 +71,8 @@ interface RevisionHistoryProps {
 	entryId: string;
 	/** Called when a revision is successfully restored */
 	onRestored?: () => void;
+	/** Reserve the inline end of the disclosure header for an external control. */
+	reserveHeaderEnd?: boolean;
 }
 
 /**
@@ -91,7 +93,12 @@ function formatFullDate(dateString: string): string {
  * RevisionHistory component - displays revision history for a content item
  * with ability to restore previous versions.
  */
-export function RevisionHistory({ collection, entryId, onRestored }: RevisionHistoryProps) {
+export function RevisionHistory({
+	collection,
+	entryId,
+	onRestored,
+	reserveHeaderEnd = false,
+}: RevisionHistoryProps) {
 	const { t } = useLingui();
 	const [isExpanded, setIsExpanded] = React.useState(false);
 	const [selectedRevision, setSelectedRevision] = React.useState<Revision | null>(null);
@@ -148,7 +155,7 @@ export function RevisionHistory({ collection, entryId, onRestored }: RevisionHis
 						<Button
 							type="button"
 							variant="ghost"
-							className="relative justify-between"
+							className={cn("relative justify-between", reserveHeaderEnd && "pe-10")}
 							style={{ width: "calc(100% + 1.5rem)", insetInlineStart: "-0.75rem" }}
 						/>
 					}

--- a/packages/admin/src/components/RevisionHistory.tsx
+++ b/packages/admin/src/components/RevisionHistory.tsx
@@ -155,8 +155,11 @@ export function RevisionHistory({
 						<Button
 							type="button"
 							variant="ghost"
-							className={cn("relative justify-between", reserveHeaderEnd && "pe-10")}
-							style={{ width: "calc(100% + 1.5rem)", insetInlineStart: "-0.75rem" }}
+							className="relative justify-between"
+							style={{
+								width: reserveHeaderEnd ? "calc(100% - 1.5rem)" : "calc(100% + 1.5rem)",
+								insetInlineStart: "-0.75rem",
+							}}
 						/>
 					}
 				>

--- a/packages/admin/src/components/SortableContentSettingsSections.tsx
+++ b/packages/admin/src/components/SortableContentSettingsSections.tsx
@@ -1,0 +1,202 @@
+import {
+	closestCenter,
+	DndContext,
+	type DragEndEvent,
+	type DragStartEvent,
+	KeyboardSensor,
+	MeasuringStrategy,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	sortableKeyboardCoordinates,
+	SortableContext,
+	useSortable,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useLingui } from "@lingui/react/macro";
+import { DotsSixVertical } from "@phosphor-icons/react";
+import * as React from "react";
+
+import {
+	parseContentSettingsLayout,
+	reorderContentSettingsLayout,
+	resolveContentSettingsLayout,
+	type ContentSettingsLayout,
+	type ContentSettingsSectionId,
+} from "../lib/content-settings-layout.js";
+import { cn } from "../lib/utils.js";
+
+const STORAGE_PREFIX = "emdash:content-settings-layout:v1";
+
+export interface SortableContentSettingsSectionProps {
+	id: ContentSettingsSectionId;
+	label: string;
+	/** Leaves room for an existing disclosure chevron at the inline end. */
+	disclosure?: boolean;
+	children: React.ReactNode;
+	/** Internal state supplied by the sortable group while any section is moving. */
+	isSorting?: boolean;
+}
+
+interface SortableContentSettingsSectionsProps {
+	collection: string;
+	userId?: string;
+	children: React.ReactNode;
+}
+
+function readStoredLayout(storageKey: string | null): ContentSettingsLayout | null {
+	if (!storageKey || typeof window === "undefined") return null;
+	try {
+		return parseContentSettingsLayout(window.localStorage.getItem(storageKey));
+	} catch {
+		return null;
+	}
+}
+
+function writeStoredLayout(storageKey: string | null, layout: ContentSettingsLayout): void {
+	if (!storageKey || typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(storageKey, JSON.stringify(layout));
+	} catch {
+		// Browser storage is optional; the reordered in-memory layout still works.
+	}
+}
+
+export function SortableContentSettingsSections({
+	collection,
+	userId,
+	children,
+}: SortableContentSettingsSectionsProps) {
+	const storageKey = userId
+		? `${STORAGE_PREFIX}:${encodeURIComponent(userId)}:${encodeURIComponent(collection)}`
+		: null;
+	// Keep the server and first client render identical. Browser preferences
+	// are restored after hydration so a saved order cannot cause a mismatch.
+	const [storedLayout, setStoredLayout] = React.useState<ContentSettingsLayout | null>(null);
+	const [activeId, setActiveId] = React.useState<ContentSettingsSectionId | null>(null);
+
+	React.useEffect(() => {
+		setStoredLayout(readStoredLayout(storageKey));
+	}, [storageKey]);
+
+	const layout = React.useMemo(() => resolveContentSettingsLayout(storedLayout), [storedLayout]);
+	const sectionsById = React.useMemo(() => {
+		const sections = React.Children.toArray(children).filter(
+			(child): child is React.ReactElement<SortableContentSettingsSectionProps> =>
+				React.isValidElement<SortableContentSettingsSectionProps>(child),
+		);
+		return new Map(sections.map((section) => [section.props.id, section]));
+	}, [children]);
+	const visibleIds = React.useMemo(
+		() => layout.order.filter((id) => sectionsById.has(id)),
+		[layout.order, sectionsById],
+	);
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+	);
+	const handleDragStart = React.useCallback((event: DragStartEvent) => {
+		setActiveId(String(event.active.id) as ContentSettingsSectionId);
+	}, []);
+
+	const handleDragEnd = React.useCallback(
+		(event: DragEndEvent) => {
+			setActiveId(null);
+			if (event.over && event.active.id !== event.over.id) {
+				const movedId = String(event.active.id) as ContentSettingsSectionId;
+				const overId = String(event.over.id) as ContentSettingsSectionId;
+				setStoredLayout((current) => {
+					const next = reorderContentSettingsLayout(
+						resolveContentSettingsLayout(current),
+						movedId,
+						overId,
+					);
+					writeStoredLayout(storageKey, next);
+					return next;
+				});
+			}
+		},
+		[storageKey],
+	);
+
+	return (
+		<DndContext
+			sensors={sensors}
+			collisionDetection={closestCenter}
+			measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+			onDragStart={handleDragStart}
+			onDragCancel={() => setActiveId(null)}
+			onDragEnd={handleDragEnd}
+		>
+			<SortableContext items={visibleIds} strategy={verticalListSortingStrategy}>
+				{visibleIds.map((id) => {
+					const section = sectionsById.get(id);
+					return section
+						? React.cloneElement(section, { key: id, isSorting: activeId !== null })
+						: null;
+				})}
+			</SortableContext>
+		</DndContext>
+	);
+}
+
+export function SortableContentSettingsSection({
+	id,
+	label,
+	disclosure = false,
+	children,
+	isSorting = false,
+}: SortableContentSettingsSectionProps) {
+	const { t } = useLingui();
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+		id,
+	});
+	const style: React.CSSProperties = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+		zIndex: isDragging ? 10 : undefined,
+	};
+
+	return (
+		<section
+			ref={setNodeRef}
+			style={style}
+			data-sorting={isSorting ? "true" : "false"}
+			className={cn(
+				"relative min-w-0 border-t bg-kumo-base first:border-t-0",
+				isSorting &&
+					"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
+				isDragging && "bg-kumo-tint opacity-60",
+			)}
+		>
+			{isSorting && (
+				<div
+					data-sortable-heading
+					className="flex items-center px-4 pe-12"
+					style={{ minHeight: 48 }}
+				>
+					<span className="text-[15px] font-semibold">{label}</span>
+				</div>
+			)}
+			{children}
+			<button
+				type="button"
+				data-sortable-handle
+				{...attributes}
+				{...listeners}
+				className={cn(
+					"absolute z-10 grid size-7 touch-none cursor-grab place-items-center rounded-md text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-accent active:cursor-grabbing",
+					isSorting ? "end-3 top-1/2 -translate-y-1/2" : "top-3",
+					!isSorting && (disclosure ? "end-10" : "end-3"),
+				)}
+				aria-label={t`Drag to reorder ${label}`}
+				title={t`Drag to reorder ${label}`}
+			>
+				<DotsSixVertical size={16} aria-hidden="true" />
+			</button>
+		</section>
+	);
+}

--- a/packages/admin/src/components/SortableContentSettingsSections.tsx
+++ b/packages/admin/src/components/SortableContentSettingsSections.tsx
@@ -50,6 +50,7 @@ export interface SortableContentSettingsSectionProps {
 interface SortableContentSettingsSectionsProps {
 	collection: string;
 	userId?: string;
+	onSortingChange?: (isSorting: boolean) => void;
 	children: React.ReactNode;
 }
 
@@ -74,6 +75,7 @@ function writeStoredLayout(storageKey: string | null, layout: ContentSettingsLay
 export function SortableContentSettingsSections({
 	collection,
 	userId,
+	onSortingChange,
 	children,
 }: SortableContentSettingsSectionsProps) {
 	const storageKey = userId
@@ -104,13 +106,22 @@ export function SortableContentSettingsSections({
 		useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
 		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
 	);
-	const handleDragStart = React.useCallback((event: DragStartEvent) => {
-		setActiveId(String(event.active.id) as ContentSettingsSectionId);
-	}, []);
+	const handleDragStart = React.useCallback(
+		(event: DragStartEvent) => {
+			setActiveId(String(event.active.id) as ContentSettingsSectionId);
+			onSortingChange?.(true);
+		},
+		[onSortingChange],
+	);
+	const handleDragCancel = React.useCallback(() => {
+		setActiveId(null);
+		onSortingChange?.(false);
+	}, [onSortingChange]);
 
 	const handleDragEnd = React.useCallback(
 		(event: DragEndEvent) => {
 			setActiveId(null);
+			onSortingChange?.(false);
 			if (event.over && event.active.id !== event.over.id) {
 				const movedId = String(event.active.id) as ContentSettingsSectionId;
 				const overId = String(event.over.id) as ContentSettingsSectionId;
@@ -125,7 +136,7 @@ export function SortableContentSettingsSections({
 				});
 			}
 		},
-		[storageKey],
+		[onSortingChange, storageKey],
 	);
 
 	return (
@@ -135,7 +146,7 @@ export function SortableContentSettingsSections({
 			modifiers={[restrictToVerticalAxis]}
 			measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
 			onDragStart={handleDragStart}
-			onDragCancel={() => setActiveId(null)}
+			onDragCancel={handleDragCancel}
 			onDragEnd={handleDragEnd}
 		>
 			<SortableContext items={visibleIds} strategy={verticalListSortingStrategy}>
@@ -193,6 +204,7 @@ export function SortableContentSettingsSection({
 			<button
 				type="button"
 				data-sortable-handle
+				data-sorting={isSorting ? "true" : "false"}
 				{...attributes}
 				{...listeners}
 				className={cn(

--- a/packages/admin/src/components/SortableContentSettingsSections.tsx
+++ b/packages/admin/src/components/SortableContentSettingsSections.tsx
@@ -5,6 +5,7 @@ import {
 	type DragStartEvent,
 	KeyboardSensor,
 	MeasuringStrategy,
+	type Modifier,
 	PointerSensor,
 	useSensor,
 	useSensors,
@@ -30,6 +31,11 @@ import {
 import { cn } from "../lib/utils.js";
 
 const STORAGE_PREFIX = "emdash:content-settings-layout:v1";
+
+const restrictToVerticalAxis: Modifier = ({ transform }) => ({
+	...transform,
+	x: 0,
+});
 
 export interface SortableContentSettingsSectionProps {
 	id: ContentSettingsSectionId;
@@ -126,6 +132,7 @@ export function SortableContentSettingsSections({
 		<DndContext
 			sensors={sensors}
 			collisionDetection={closestCenter}
+			modifiers={[restrictToVerticalAxis]}
 			measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
 			onDragStart={handleDragStart}
 			onDragCancel={() => setActiveId(null)}
@@ -155,9 +162,10 @@ export function SortableContentSettingsSection({
 		id,
 	});
 	const style: React.CSSProperties = {
-		transform: CSS.Transform.toString(transform),
+		transform: transform ? CSS.Transform.toString({ ...transform, x: 0 }) : undefined,
 		transition,
 		zIndex: isDragging ? 10 : undefined,
+		inlineSize: "100%",
 	};
 
 	return (
@@ -165,10 +173,10 @@ export function SortableContentSettingsSection({
 			ref={setNodeRef}
 			style={style}
 			data-sorting={isSorting ? "true" : "false"}
+			data-disclosure={disclosure ? "true" : "false"}
 			className={cn(
 				"relative min-w-0 border-t bg-kumo-base first:border-t-0",
-				isSorting &&
-					"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
+				isSorting && "[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
 				isDragging && "bg-kumo-tint opacity-60",
 			)}
 		>
@@ -190,7 +198,7 @@ export function SortableContentSettingsSection({
 				className={cn(
 					"absolute z-10 grid size-7 touch-none cursor-grab place-items-center rounded-md text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-accent active:cursor-grabbing",
 					isSorting ? "end-3 top-1/2 -translate-y-1/2" : "top-3",
-					!isSorting && (disclosure ? "end-10" : "end-3"),
+					!isSorting && "end-3",
 				)}
 				aria-label={t`Drag to reorder ${label}`}
 				title={t`Drag to reorder ${label}`}

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -63,6 +63,19 @@ async function fetchTaxonomyDefs(): Promise<TaxonomyDef[]> {
 	return data.taxonomies;
 }
 
+function useApplicableTaxonomies(collection: string): TaxonomyDef[] {
+	const { data: taxonomies = [] } = useQuery({
+		queryKey: ["taxonomy-defs"],
+		queryFn: fetchTaxonomyDefs,
+	});
+	return taxonomies.filter((taxonomy) => taxonomy.collections.includes(collection));
+}
+
+/** Whether the editor should include a taxonomy settings section. */
+export function useHasApplicableTaxonomies(collection: string): boolean {
+	return useApplicableTaxonomies(collection).length > 0;
+}
+
 /**
  * Fetch terms for a taxonomy, scoped to the entry's locale so only the matching
  * translation variants are offered.
@@ -524,13 +537,7 @@ export function TaxonomySidebar({
 	className,
 }: TaxonomySidebarProps) {
 	const { t } = useLingui();
-	const { data: taxonomies = [] } = useQuery({
-		queryKey: ["taxonomy-defs"],
-		queryFn: fetchTaxonomyDefs,
-	});
-
-	// Filter to taxonomies that apply to this collection
-	const applicableTaxonomies = taxonomies.filter((tax) => tax.collections.includes(collection));
+	const applicableTaxonomies = useApplicableTaxonomies(collection);
 
 	if (applicableTaxonomies.length === 0) {
 		return null;

--- a/packages/admin/src/components/editor/DocumentOutline.tsx
+++ b/packages/admin/src/components/editor/DocumentOutline.tsx
@@ -108,12 +108,18 @@ export interface DocumentOutlineProps {
 	editor: Editor | null;
 	/** Additional CSS classes */
 	className?: string;
+	/** Reserve the inline end of the disclosure header for an external control. */
+	reserveHeaderEnd?: boolean;
 }
 
 /**
  * Document outline component showing heading tree structure
  */
-export function DocumentOutline({ editor, className }: DocumentOutlineProps) {
+export function DocumentOutline({
+	editor,
+	className,
+	reserveHeaderEnd = false,
+}: DocumentOutlineProps) {
 	const { t } = useLingui();
 	const [isExpanded, setIsExpanded] = React.useState(true);
 	const [headings, setHeadings] = React.useState<HeadingItem[]>([]);
@@ -173,7 +179,7 @@ export function DocumentOutline({ editor, className }: DocumentOutlineProps) {
 				render={
 					<Button
 						variant="ghost"
-						className="relative justify-between"
+						className={cn("relative justify-between", reserveHeaderEnd && "pe-10")}
 						style={{ width: "calc(100% + 1.5rem)", insetInlineStart: "-0.75rem" }}
 					/>
 				}

--- a/packages/admin/src/components/editor/DocumentOutline.tsx
+++ b/packages/admin/src/components/editor/DocumentOutline.tsx
@@ -179,8 +179,11 @@ export function DocumentOutline({
 				render={
 					<Button
 						variant="ghost"
-						className={cn("relative justify-between", reserveHeaderEnd && "pe-10")}
-						style={{ width: "calc(100% + 1.5rem)", insetInlineStart: "-0.75rem" }}
+						className="relative justify-between"
+						style={{
+							width: reserveHeaderEnd ? "calc(100% - 1.5rem)" : "calc(100% + 1.5rem)",
+							insetInlineStart: "-0.75rem",
+						}}
 					/>
 				}
 			>

--- a/packages/admin/src/lib/content-settings-layout.ts
+++ b/packages/admin/src/lib/content-settings-layout.ts
@@ -1,0 +1,93 @@
+export const CONTENT_SETTINGS_LAYOUT_VERSION = 1 as const;
+
+export const DEFAULT_CONTENT_SETTINGS_SECTION_ORDER = [
+	"publish",
+	"ownership",
+	"bylines",
+	"translations",
+	"taxonomies",
+	"seo",
+	"outline",
+	"revisions",
+] as const;
+
+export type ContentSettingsSectionId = (typeof DEFAULT_CONTENT_SETTINGS_SECTION_ORDER)[number];
+
+export interface ContentSettingsLayout {
+	version: typeof CONTENT_SETTINGS_LAYOUT_VERSION;
+	order: ContentSettingsSectionId[];
+}
+
+const KNOWN_SECTION_IDS = new Set<string>(DEFAULT_CONTENT_SETTINGS_SECTION_ORDER);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isKnownSectionId(value: unknown): value is ContentSettingsSectionId {
+	return typeof value === "string" && KNOWN_SECTION_IDS.has(value);
+}
+
+/** Parse a browser preference without allowing malformed state to break the editor. */
+export function parseContentSettingsLayout(raw: string | null): ContentSettingsLayout | null {
+	if (!raw) return null;
+
+	try {
+		const value: unknown = JSON.parse(raw);
+		if (
+			!isRecord(value) ||
+			value.version !== CONTENT_SETTINGS_LAYOUT_VERSION ||
+			!Array.isArray(value.order)
+		) {
+			return null;
+		}
+
+		return {
+			version: CONTENT_SETTINGS_LAYOUT_VERSION,
+			order: value.order.filter(isKnownSectionId),
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Reconcile saved order with the current defaults. Duplicate and unknown ids
+ * disappear, while sections introduced by a later EmDash version append.
+ */
+export function resolveContentSettingsLayout(
+	stored: ContentSettingsLayout | null,
+): ContentSettingsLayout {
+	const seen = new Set<ContentSettingsSectionId>();
+	const order = (stored?.order ?? []).filter((id) => {
+		if (seen.has(id)) return false;
+		seen.add(id);
+		return true;
+	});
+
+	for (const id of DEFAULT_CONTENT_SETTINGS_SECTION_ORDER) {
+		if (seen.has(id)) continue;
+		order.push(id);
+		seen.add(id);
+	}
+
+	return { version: CONTENT_SETTINGS_LAYOUT_VERSION, order };
+}
+
+export function reorderContentSettingsLayout(
+	layout: ContentSettingsLayout,
+	activeId: ContentSettingsSectionId,
+	overId: ContentSettingsSectionId,
+): ContentSettingsLayout {
+	if (activeId === overId) return layout;
+
+	const from = layout.order.indexOf(activeId);
+	const to = layout.order.indexOf(overId);
+	if (from < 0 || to < 0) return layout;
+
+	const order = [...layout.order];
+	const [moved] = order.splice(from, 1);
+	if (!moved) return layout;
+	order.splice(to, 0, moved);
+	return { ...layout, order };
+}

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -85,6 +85,7 @@ vi.mock("../../src/components/RevisionHistory", () => ({
 
 vi.mock("../../src/components/TaxonomySidebar", () => ({
 	TaxonomySidebar: () => <div data-testid="taxonomy-sidebar">Taxonomy</div>,
+	useHasApplicableTaxonomies: () => true,
 }));
 
 vi.mock("../../src/components/MediaPickerModal", () => ({
@@ -450,7 +451,7 @@ describe("ContentEditor", () => {
 			const screen = await renderEditor({
 				fields: { order: { kind: "number", label: "Order" } },
 			});
-			const input = screen.getByLabelText("Order");
+			const input = screen.getByLabelText("Order", { exact: true });
 			await expect.element(input).toHaveAttribute("type", "number");
 		});
 
@@ -926,7 +927,7 @@ describe("ContentEditor", () => {
 			const screen = await renderEditor({ isNew: false, item });
 			const saveBtn = screen.getByRole("button", { name: "Saved" }).first();
 			await expect.element(saveBtn).toBeDisabled();
-			expect(screen.getByRole("status").element().textContent).toBe("Saved");
+			expect(saveBtn.getByRole("status").element().textContent).toBe("Saved");
 		});
 
 		// Strict per-locale hydration (migration 040) can return

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -1172,6 +1172,25 @@ describe("ContentEditor", () => {
 			}
 		});
 
+		it("keeps the settings sheet open when a sortable handle restores focus after drop", async () => {
+			const media = installMatchMedia(true);
+			try {
+				const screen = await renderEditor({ isNew: false, item: makeItem() });
+
+				await screen.getByRole("button", { name: "Settings" }).click();
+				const handle = screen.getByRole("button", { name: "Drag to reorder Publish" }).element();
+				handle.focus();
+				handle.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: null }));
+
+				await vi.waitFor(() => {
+					const sheet = document.querySelector('nav[data-sidebar="sidebar"][data-mobile="true"]');
+					expect(sheet?.getAttribute("data-state")).toBe("expanded");
+				});
+			} finally {
+				media.restore();
+			}
+		});
+
 		it("keeps nested dialogs above the settings sheet and dismisses only the dialog", async () => {
 			const media = installMatchMedia(true);
 			try {

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -1191,6 +1191,48 @@ describe("ContentEditor", () => {
 			}
 		});
 
+		it("keeps the settings sheet open when keyboard sorting is cancelled", async () => {
+			const media = installMatchMedia(true);
+			try {
+				const screen = await renderEditor({ isNew: false, item: makeItem() });
+
+				await screen.getByRole("button", { name: "Settings" }).click();
+				const handle = screen.getByRole("button", { name: "Drag to reorder Publish" }).element();
+				handle.focus();
+				await userEvent.keyboard(" ");
+
+				await vi.waitFor(() => expect(handle.dataset.sorting).toBe("true"));
+				await userEvent.keyboard("{Escape}");
+
+				await vi.waitFor(() => {
+					const sheet = document.querySelector('nav[data-sidebar="sidebar"][data-mobile="true"]');
+					expect(sheet?.getAttribute("data-state")).toBe("expanded");
+					expect(handle.dataset.sorting).toBe("false");
+				});
+			} finally {
+				media.restore();
+			}
+		});
+
+		it("lets Escape close the settings sheet when sorting is idle", async () => {
+			const media = installMatchMedia(true);
+			try {
+				const screen = await renderEditor({ isNew: false, item: makeItem() });
+
+				await screen.getByRole("button", { name: "Settings" }).click();
+				const handle = screen.getByRole("button", { name: "Drag to reorder Publish" }).element();
+				handle.focus();
+				await userEvent.keyboard("{Escape}");
+
+				await vi.waitFor(() => {
+					const sheet = document.querySelector('nav[data-sidebar="sidebar"][data-mobile="true"]');
+					expect(sheet?.getAttribute("data-state")).toBe("collapsed");
+				});
+			} finally {
+				media.restore();
+			}
+		});
+
 		it("keeps nested dialogs above the settings sheet and dismisses only the dialog", async () => {
 			const media = installMatchMedia(true);
 			try {

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../../src/components/RevisionHistory", () => ({
 
 vi.mock("../../src/components/TaxonomySidebar", () => ({
 	TaxonomySidebar: () => <div data-testid="taxonomy-sidebar">Taxonomy</div>,
+	useHasApplicableTaxonomies: () => true,
 }));
 
 vi.mock("../../src/components/editor/DocumentOutline", () => ({

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -1,3 +1,4 @@
+import { act, fireEvent } from "@testing-library/react";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -199,6 +200,30 @@ describe("ContentSettingsPanel", () => {
 		const root = screen.container.firstElementChild;
 		const lastSection = root?.lastElementChild;
 		expect(lastSection?.textContent).toContain("Move to Trash");
+	});
+
+	it("hides destructive actions without collapsing their space while reordering", async () => {
+		const screen = await render(<ContentSettingsPanel {...makePanelProps()} />);
+		const trashActions = screen.getByTestId("content-trash-actions").element();
+		const handle = screen.getByRole("button", { name: "Drag to reorder Publish" }).element();
+
+		expect(trashActions).not.toHaveClass("invisible", "pointer-events-none");
+		expect(trashActions).not.toHaveAttribute("aria-hidden");
+
+		handle.focus();
+		await act(async () => {
+			fireEvent.keyDown(handle, { key: " ", code: "Space" });
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		expect(trashActions).toHaveClass("invisible", "pointer-events-none");
+		expect(trashActions).toHaveAttribute("aria-hidden", "true");
+
+		await act(async () => {
+			fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		expect(trashActions).not.toHaveClass("invisible", "pointer-events-none");
+		expect(trashActions).not.toHaveAttribute("aria-hidden");
 	});
 });
 

--- a/packages/admin/tests/components/RevisionHistory.test.tsx
+++ b/packages/admin/tests/components/RevisionHistory.test.tsx
@@ -76,6 +76,17 @@ describe("RevisionHistory", () => {
 		await expect.element(noRevisionsText).not.toBeInTheDocument();
 	});
 
+	it("reserves a separate trailing area for an external header control", async () => {
+		const screen = await render(
+			<QueryWrapper>
+				<RevisionHistory collection="posts" entryId="entry-1" reserveHeaderEnd />
+			</QueryWrapper>,
+		);
+
+		const trigger = screen.getByRole("button", { name: REVISIONS_BUTTON_REGEX }).element();
+		expect(trigger.style.width).toBe("calc(100% - 1.5rem)");
+	});
+
 	// ---- Query only fires when expanded ----
 
 	it("does not fetch revisions until expanded", async () => {

--- a/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
+++ b/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
@@ -1,0 +1,132 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	SortableContentSettingsSection,
+	SortableContentSettingsSections,
+} from "../../src/components/SortableContentSettingsSections";
+
+const STORAGE_KEY = "emdash:content-settings-layout:v1:user-1:posts";
+
+function TestSections() {
+	return (
+		<SortableContentSettingsSections collection="posts" userId="user-1">
+			<SortableContentSettingsSection id="publish" label="Publish">
+				<div data-testid="publish-section">Publish</div>
+			</SortableContentSettingsSection>
+			<SortableContentSettingsSection id="seo" label="SEO">
+				<div data-testid="seo-section">SEO</div>
+			</SortableContentSettingsSection>
+		</SortableContentSettingsSections>
+	);
+}
+
+function renderSections() {
+	return render(
+		<I18nProvider i18n={i18n}>
+			<TestSections />
+		</I18nProvider>,
+	);
+}
+
+async function pressKey(target: Document | HTMLElement, key: string, code: string) {
+	await act(async () => {
+		fireEvent.keyDown(target, { key, code });
+		// dnd-kit schedules keyboard sensor listeners and state updates on the next task.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+}
+
+describe("SortableContentSettingsSections", () => {
+	beforeEach(() => {
+		i18n.load("en", {});
+		i18n.activate("en");
+		window.localStorage.clear();
+	});
+	afterEach(cleanup);
+
+	it("restores a saved section order and exposes accessible drag handles", () => {
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ version: 1, order: ["seo", "publish"] }),
+		);
+
+		const { container } = renderSections();
+		const visibleSections = [...container.querySelectorAll("section")];
+
+		expect(visibleSections.map((section) => section.textContent)).toEqual(["SEO", "Publish"]);
+		expect(screen.getByRole("button", { name: "Drag to reorder SEO" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Drag to reorder Publish" })).toBeTruthy();
+	});
+
+	it("falls back to the default order when browser state is malformed", () => {
+		window.localStorage.setItem(STORAGE_KEY, "not-json");
+
+		const { container } = renderSections();
+		const visibleSections = [...container.querySelectorAll("section")];
+
+		expect(visibleSections.map((section) => section.textContent)).toEqual(["Publish", "SEO"]);
+	});
+
+	it("collapses every section to its heading while keyboard sorting is active", async () => {
+		const { container } = renderSections();
+		const handle = screen.getByRole("button", { name: "Drag to reorder Publish" });
+
+		handle.focus();
+		await pressKey(handle, " ", "Space");
+
+		const sections = [...container.querySelectorAll("section")];
+		expect(sections.every((section) => section.dataset.sorting === "true")).toBe(true);
+		expect(screen.getByTestId("publish-section").parentElement).toBe(sections[0]);
+		expect(screen.getByTestId("seo-section").parentElement).toBe(sections[1]);
+		for (const section of sections) {
+			const heading = section.querySelector<HTMLElement>("[data-sortable-heading]");
+			const handle = section.querySelector<HTMLElement>("[data-sortable-handle]");
+
+			expect(heading?.style.minHeight).toBe("48px");
+			expect(section.className).toContain(
+				"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
+			);
+			expect(handle?.classList.contains("top-1/2")).toBe(true);
+			expect(handle?.classList.contains("-translate-y-1/2")).toBe(true);
+		}
+
+		await pressKey(document, "Escape", "Escape");
+
+		await waitFor(() => {
+			expect(sections.every((section) => section.dataset.sorting === "false")).toBe(true);
+		});
+		expect(container.querySelector("[data-sortable-heading]")).toBeNull();
+		expect(sections[0]?.className).not.toContain(
+			"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
+		);
+		expect(screen.getByTestId("publish-section").parentElement).toBe(sections[0]);
+		expect(screen.getByTestId("seo-section").parentElement).toBe(sections[1]);
+	});
+
+	it("persists a keyboard reorder and restores expanded section content", async () => {
+		const { container } = renderSections();
+		const handle = screen.getByRole("button", { name: "Drag to reorder Publish" });
+
+		handle.focus();
+		await pressKey(handle, " ", "Space");
+		await pressKey(document, "ArrowDown", "ArrowDown");
+		await pressKey(document, " ", "Space");
+
+		await waitFor(() => {
+			const sections = [...container.querySelectorAll("section")];
+			expect(sections.map((section) => section.textContent)).toEqual(["SEO", "Publish"]);
+			expect(sections.every((section) => section.dataset.sorting === "false")).toBe(true);
+		});
+
+		const saved = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "null") as {
+			order: string[];
+		};
+		expect(saved.order.indexOf("seo")).toBeLessThan(saved.order.indexOf("publish"));
+		expect(screen.getByTestId("publish-section").parentElement?.tagName).toBe("SECTION");
+		expect(screen.getByTestId("seo-section").parentElement?.tagName).toBe("SECTION");
+	});
+});

--- a/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
+++ b/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
@@ -104,14 +104,14 @@ describe("SortableContentSettingsSections", () => {
 		expect(screen.getByTestId("seo-section").parentElement).toBe(sections[1]);
 		for (const section of sections) {
 			const heading = section.querySelector<HTMLElement>("[data-sortable-heading]");
-			const handle = section.querySelector<HTMLElement>("[data-sortable-handle]");
+			const sectionHandle = section.querySelector<HTMLElement>("[data-sortable-handle]");
 
 			expect(heading?.style.minHeight).toBe("48px");
 			expect(section.className).toContain(
 				"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
 			);
-			expect(handle?.classList.contains("top-1/2")).toBe(true);
-			expect(handle?.classList.contains("-translate-y-1/2")).toBe(true);
+			expect(sectionHandle?.classList.contains("top-1/2")).toBe(true);
+			expect(sectionHandle?.classList.contains("-translate-y-1/2")).toBe(true);
 		}
 
 		await pressKey(document, "Escape", "Escape");

--- a/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
+++ b/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
@@ -71,6 +71,26 @@ describe("SortableContentSettingsSections", () => {
 		expect(visibleSections.map((section) => section.textContent)).toEqual(["Publish", "SEO"]);
 	});
 
+	it("keeps sortable rows full-width and exposes disclosure spacing", () => {
+		const { container } = render(
+			<I18nProvider i18n={i18n}>
+				<SortableContentSettingsSections collection="posts" userId="user-1">
+					<SortableContentSettingsSection id="outline" label="Outline" disclosure>
+						<div>Outline</div>
+					</SortableContentSettingsSection>
+				</SortableContentSettingsSections>
+			</I18nProvider>,
+		);
+
+		const section = container.querySelector<HTMLElement>("section");
+		const handle = screen.getByRole("button", { name: "Drag to reorder Outline" });
+
+		expect(section?.style.inlineSize).toBe("100%");
+		expect(section?.dataset.disclosure).toBe("true");
+		expect(handle.classList.contains("end-3")).toBe(true);
+		expect(handle.classList.contains("end-10")).toBe(false);
+	});
+
 	it("collapses every section to its heading while keyboard sorting is active", async () => {
 		const { container } = renderSections();
 		const handle = screen.getByRole("button", { name: "Drag to reorder Publish" });

--- a/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
+++ b/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
@@ -2,7 +2,7 @@ import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as React from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
 	SortableContentSettingsSection,
@@ -148,5 +148,32 @@ describe("SortableContentSettingsSections", () => {
 		expect(saved.order.indexOf("seo")).toBeLessThan(saved.order.indexOf("publish"));
 		expect(screen.getByTestId("publish-section").parentElement?.tagName).toBe("SECTION");
 		expect(screen.getByTestId("seo-section").parentElement?.tagName).toBe("SECTION");
+	});
+
+	it("reports keyboard sorting start and cancellation to surrounding controls", async () => {
+		const onSortingChange = vi.fn();
+		const { container } = render(
+			<I18nProvider i18n={i18n}>
+				<SortableContentSettingsSections
+					collection="posts"
+					userId="user-1"
+					onSortingChange={onSortingChange}
+				>
+					<SortableContentSettingsSection id="publish" label="Publish">
+						<div>Publish</div>
+					</SortableContentSettingsSection>
+				</SortableContentSettingsSections>
+			</I18nProvider>,
+		);
+		const handle = screen.getByRole("button", { name: "Drag to reorder Publish" });
+
+		handle.focus();
+		await pressKey(handle, " ", "Space");
+		expect(onSortingChange).toHaveBeenLastCalledWith(true);
+		expect(container.querySelector("section")?.dataset.sorting).toBe("true");
+
+		await pressKey(document, "Escape", "Escape");
+		await waitFor(() => expect(onSortingChange).toHaveBeenLastCalledWith(false));
+		expect(container.querySelector("section")?.dataset.sorting).toBe("false");
 	});
 });

--- a/packages/admin/tests/lib/content-settings-layout.test.ts
+++ b/packages/admin/tests/lib/content-settings-layout.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_CONTENT_SETTINGS_SECTION_ORDER,
+	parseContentSettingsLayout,
+	reorderContentSettingsLayout,
+	resolveContentSettingsLayout,
+} from "../../src/lib/content-settings-layout";
+
+describe("content settings layout", () => {
+	it("ignores malformed browser state", () => {
+		expect(parseContentSettingsLayout(null)).toBeNull();
+		expect(parseContentSettingsLayout("not-json")).toBeNull();
+		expect(parseContentSettingsLayout('{"version":2,"order":[]}')).toBeNull();
+	});
+
+	it("removes unknown and duplicate ids, then appends missing defaults", () => {
+		const stored = parseContentSettingsLayout(
+			JSON.stringify({
+				version: 1,
+				order: ["seo", "unknown", "ownership", "seo"],
+			}),
+		);
+
+		expect(resolveContentSettingsLayout(stored).order).toEqual([
+			"seo",
+			"ownership",
+			...DEFAULT_CONTENT_SETTINGS_SECTION_ORDER.filter((id) => id !== "seo" && id !== "ownership"),
+		]);
+	});
+
+	it("moves a section relative to another section", () => {
+		const layout = resolveContentSettingsLayout(null);
+		const next = reorderContentSettingsLayout(layout, "seo", "ownership");
+
+		expect(next.order.indexOf("seo")).toBe(next.order.indexOf("ownership") - 1);
+		expect(layout.order).toEqual(DEFAULT_CONTENT_SETTINGS_SECTION_ORDER);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Makes the built-in content editor settings sections reorderable from dedicated drag handles.

Editors can arrange Publish, Ownership, Bylines, Translations, Taxonomies, SEO, Outline, and Revisions around their workflow. The order is stored per user and collection in browser storage, so an arrangement made on one entry remains consistent when another entry in the same collection is opened.

The implementation also:

- supports pointer and keyboard sorting;
- constrains movement to the vertical axis and settings-panel width;
- keeps disclosure controls separate from drag handles;
- collapses section bodies while sorting;
- reconciles malformed, stale, and newly extended saved layouts safely;
- preserves the default order when no preference exists;
- keeps the mobile settings sheet open after keyboard reordering;
- keeps destructive footer actions outside the sortable section list.

Discussion: https://github.com/emdash-cms/emdash/discussions/2184

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs - a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/2184

## Screenshots / test output

Validated against current `main` / EmDash 0.30:

- focused browser coverage: 5 files, 119 tests passed;
- complete admin browser suite: 104 files, 1,236 tests passed;
- root typecheck passed across 31 package projects;
- root lint passed with 0 warnings and 0 errors across 2,220 files;
- formatting checks passed;
- `@emdash-cms/admin` production build passed;
- desktop and mobile interaction checks passed in light and dark themes;
- pointer and keyboard ordering, saved-order restoration, and horizontal-drift constraints were visually verified.
