### PR TITLE
fix(core): allow reducing OAuth consent scopes

### DIFF
--- a/.changeset/selective-oauth-grants.md
+++ b/.changeset/selective-oauth-grants.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes OAuth authorization so users can remove unnecessary requested permissions before granting an MCP client access.

--- a/docs/src/content/docs/guides/ai-tools.mdx
+++ b/docs/src/content/docs/guides/ai-tools.mdx
@@ -156,7 +156,7 @@ Once connected, you can ask the AI assistant to perform any of these operations 
 
 ## Permissions
 
-What you can do through an AI tool depends on your EmDash role. The AI assistant operates with the same permissions you have in the admin panel:
+When an MCP client opens the OAuth consent page, every permission it requested is selected by default. Clear any permission the client does not need before approving access. The resulting token is limited to the permissions you keep selected and the permissions allowed by your EmDash role, so granting fewer permissions never increases what the client can do.
 
 | Role | What the AI can do |
 | --- | --- |

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -27,7 +27,7 @@ Session cookies (from the admin UI) also work but aren't practical for external 
 
 ### Scopes
 
-Tokens are scoped to limit what operations a client can perform. Scopes are requested during OAuth authorization and enforced on every tool call.
+Tokens are scoped to limit what operations a client can perform. Scopes are requested during OAuth authorization and enforced on every tool call. On the authorization-code consent page, all requested scopes are selected by default for compatibility; the user can remove scopes before approval but cannot add scopes the client did not request. The effective grant is also restricted by the client's registered scopes and the user's role, and EmDash rejects an empty grant.
 
 | Scope | Grants access to |
 | --- | --- |

--- a/packages/core/src/astro/routes/api/oauth/authorize.ts
+++ b/packages/core/src/astro/routes/api/oauth/authorize.ts
@@ -69,11 +69,16 @@ function getCsrfCookie(request: Request): string | null {
 
 const SCOPE_LABELS: Record<string, string> = {
 	"content:read": "Read content (posts, pages, etc.)",
-	"content:write": "Create, edit, and delete content",
+	"content:write": "Create, edit, and delete content; manage menus and taxonomies",
 	"media:read": "View media files",
 	"media:write": "Upload and manage media files",
 	"schema:read": "View collection schemas",
 	"schema:write": "Create and modify collection schemas",
+	"taxonomies:manage": "Manage taxonomies",
+	"menus:manage": "Manage navigation menus",
+	"settings:read": "View site settings",
+	"settings:manage": "Modify site settings",
+	"mcp:tools": "Use MCP tools from all enabled plugins",
 	admin: "Full administrative access",
 };
 
@@ -141,7 +146,9 @@ export const GET: APIRoute = async ({ url, request, locals }) => {
 	}
 
 	// Parse and validate scopes
-	const requestedScopes = (scope ?? "").split(" ").filter(Boolean).filter(isValidScope);
+	const requestedScopes = [
+		...new Set((scope ?? "").split(" ").filter(Boolean).filter(isValidScope)),
+	];
 
 	if (requestedScopes.length === 0) {
 		return new Response(renderErrorPage("No valid scopes requested."), {
@@ -201,6 +208,21 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const v = formData.get(name);
 		return typeof v === "string" ? v : fallback;
 	};
+	const requestedScopes = new Set(
+		(new URL(request.url).searchParams.get("scope") ?? "")
+			.split(" ")
+			.filter(Boolean)
+			.filter(isValidScope),
+	);
+	const selectedScopes = [
+		...new Set(
+			formData
+				.getAll("scope")
+				.filter((value): value is string => typeof value === "string")
+				.filter(isValidScope)
+				.filter((scope) => requestedScopes.has(scope)),
+		),
+	];
 
 	// SEC-18: Validate CSRF token (double-submit cookie pattern).
 	// The form includes a hidden csrf_token field; the cookie has the same value.
@@ -285,7 +307,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		response_type: field("response_type", "code"),
 		client_id: field("client_id"),
 		redirect_uri: redirectUri,
-		scope: field("scope"),
+		scope: selectedScopes.join(" "),
 		state,
 		code_challenge: field("code_challenge"),
 		code_challenge_method: field("code_challenge_method", "S256"),
@@ -294,12 +316,16 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
 	if (!result.success) {
 		const errMsg = result.error?.message ?? "Authorization failed";
+		const invalidScope = result.error?.code === "INVALID_SCOPE";
 		// On error, redirect back with error params — use generic description to avoid
 		// leaking internal error details to the (already-validated) redirect target
 		try {
 			const errorUrl = new URL(redirectUri);
-			errorUrl.searchParams.set("error", "server_error");
-			errorUrl.searchParams.set("error_description", "Authorization failed");
+			errorUrl.searchParams.set("error", invalidScope ? "invalid_scope" : "server_error");
+			errorUrl.searchParams.set(
+				"error_description",
+				invalidScope ? "No selected permission can be granted" : "Authorization failed",
+			);
 			if (state) errorUrl.searchParams.set("state", state);
 			return Response.redirect(errorUrl.toString(), 302);
 		} catch {
@@ -331,8 +357,8 @@ function renderConsentPage(params: {
 }): string {
 	const scopeList = params.scopes
 		.map((s) => {
-			const label = SCOPE_LABELS[s] ?? s;
-			return `<li>${escapeHtml(label)}</li>`;
+			const label = SCOPE_LABELS[s] ?? getPluginScopeLabel(s) ?? s;
+			return `<li><label><input type="checkbox" name="scope" value="${escapeHtml(s)}" checked><span>${escapeHtml(label)}</span></label></li>`;
 		})
 		.join("\n");
 
@@ -353,6 +379,8 @@ function renderConsentPage(params: {
   ul { list-style: none; margin-bottom: 1.5rem; }
   li { padding: 0.5rem 0; border-bottom: 1px solid #262626; font-size: 0.875rem; }
   li:last-child { border-bottom: none; }
+  label { display: flex; align-items: flex-start; gap: 0.625rem; cursor: pointer; }
+  input[type="checkbox"] { margin-top: 0.125rem; accent-color: #2563eb; }
   .actions { display: flex; gap: 0.75rem; }
   button { flex: 1; padding: 0.625rem 1rem; border-radius: 8px; border: none; font-size: 0.875rem; font-weight: 500; cursor: pointer; }
   .approve { background: #2563eb; color: white; }
@@ -366,14 +394,13 @@ function renderConsentPage(params: {
   <h1>Authorize Application</h1>
   <p class="client-id">${escapeHtml(params.clientId)}</p>
   <p class="user">Signed in as <strong>${escapeHtml(params.userName)}</strong></p>
-  <h2>Permissions requested</h2>
-  <ul>${scopeList}</ul>
   <form method="POST">
+    <h2>Permissions requested</h2>
+    <ul>${scopeList}</ul>
     <input type="hidden" name="csrf_token" value="${escapeHtml(params.csrfToken)}">
     <input type="hidden" name="response_type" value="${escapeHtml(params.responseType)}">
     <input type="hidden" name="client_id" value="${escapeHtml(params.clientId)}">
     <input type="hidden" name="redirect_uri" value="${escapeHtml(params.redirectUri)}">
-    <input type="hidden" name="scope" value="${escapeHtml(params.scopes.join(" "))}">
     <input type="hidden" name="state" value="${escapeHtml(params.state)}">
     <input type="hidden" name="code_challenge" value="${escapeHtml(params.codeChallenge)}">
     <input type="hidden" name="code_challenge_method" value="${escapeHtml(params.codeChallengeMethod)}">
@@ -386,6 +413,11 @@ function renderConsentPage(params: {
 </div>
 </body>
 </html>`;
+}
+
+function getPluginScopeLabel(scope: string): string | null {
+	const pluginId = scope.startsWith("mcp:tools:") ? scope.slice("mcp:tools:".length) : "";
+	return pluginId ? `Use MCP tools from ${pluginId}` : null;
 }
 
 function renderErrorPage(message: string): string {

--- a/packages/core/tests/unit/auth/oauth-authorize-route.test.ts
+++ b/packages/core/tests/unit/auth/oauth-authorize-route.test.ts
@@ -1,0 +1,205 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleOAuthClientCreate } from "../../../src/api/handlers/oauth-clients.js";
+import {
+	GET as getAuthorizationConsent,
+	POST as postAuthorizationConsent,
+} from "../../../src/astro/routes/api/oauth/authorize.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+const REDIRECT_URI = "http://127.0.0.1:8080/callback";
+
+describe("OAuth authorization consent", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+
+		await db
+			.insertInto("users")
+			.values({
+				id: "user-1",
+				email: "test@example.com",
+				name: "Test User",
+				role: 50,
+				email_verified: 1,
+			})
+			.execute();
+
+		await handleOAuthClientCreate(db, {
+			id: "test-client",
+			name: "Test Client",
+			redirectUris: [REDIRECT_URI],
+		});
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("renders every requested scope as a checked choice with accurate grant copy", async () => {
+		const { response } = await renderConsent([
+			"content:read",
+			"content:write",
+			"schema:write",
+			"mcp:tools:calendar",
+		]);
+
+		expect(response.status).toBe(200);
+		const html = await response.text();
+		expect(html).toContain('<input type="checkbox" name="scope" value="content:read" checked>');
+		expect(html).toContain('<input type="checkbox" name="scope" value="schema:write" checked>');
+		expect(html).toContain(
+			'<input type="checkbox" name="scope" value="mcp:tools:calendar" checked>',
+		);
+		expect(html).toContain("Create, edit, and delete content; manage menus and taxonomies");
+		expect(html).not.toContain('<input type="hidden" name="scope"');
+		const form = html.slice(html.indexOf("<form"), html.indexOf("</form>"));
+		expect(form).toContain('<input type="checkbox" name="scope" value="content:read"');
+	});
+
+	it("grants only selected scopes from the original request", async () => {
+		const consent = await renderConsent(["content:read", "schema:write"]);
+		const response = await submitConsent(consent, ["admin", "content:read"]);
+
+		expect(response.status).toBe(302);
+		expect(new URL(response.headers.get("Location")!).searchParams.get("code")).toBeTruthy();
+
+		const authorizationCode = await db
+			.selectFrom("_emdash_authorization_codes")
+			.select("scopes")
+			.executeTakeFirstOrThrow();
+		expect(JSON.parse(authorizationCode.scopes)).toEqual(["content:read"]);
+	});
+
+	it("renders duplicate requests once so clearing a scope removes it", async () => {
+		const consent = await renderConsent(["admin", "admin", "content:read"]);
+		const html = await consent.response.clone().text();
+		expect(html.match(/name="scope" value="admin"/g)).toHaveLength(1);
+
+		const response = await submitConsent(consent, ["content:read"]);
+		expect(response.status).toBe(302);
+
+		const authorizationCode = await db
+			.selectFrom("_emdash_authorization_codes")
+			.select("scopes")
+			.executeTakeFirstOrThrow();
+		expect(JSON.parse(authorizationCode.scopes)).toEqual(["content:read"]);
+	});
+
+	it("preserves client and role scope clamps after selection", async () => {
+		await db
+			.updateTable("_emdash_oauth_clients")
+			.set({ scopes: JSON.stringify(["content:read", "schema:write"]) })
+			.where("id", "=", "test-client")
+			.execute();
+
+		const consent = await renderConsent(["content:read", "media:read", "schema:write"]);
+		const response = await submitConsent(
+			consent,
+			["content:read", "media:read", "schema:write"],
+			20,
+		);
+
+		expect(response.status).toBe(302);
+		const authorizationCode = await db
+			.selectFrom("_emdash_authorization_codes")
+			.select("scopes")
+			.executeTakeFirstOrThrow();
+		expect(JSON.parse(authorizationCode.scopes)).toEqual(["content:read"]);
+	});
+
+	it("rejects approval when no requested scope is selected", async () => {
+		const consent = await renderConsent(["content:read", "schema:write"]);
+		const response = await submitConsent(consent, []);
+
+		expect(response.status).toBe(302);
+		const redirect = new URL(response.headers.get("Location")!);
+		expect(redirect.searchParams.get("error")).toBe("invalid_scope");
+		expect(redirect.searchParams.get("error_description")).toBe(
+			"No selected permission can be granted",
+		);
+
+		const authorizationCodes = await db
+			.selectFrom("_emdash_authorization_codes")
+			.select("code_hash")
+			.execute();
+		expect(authorizationCodes).toHaveLength(0);
+	});
+
+	async function renderConsent(scopes: string[]): Promise<{
+		response: Response;
+		url: URL;
+		csrfToken: string;
+		cookie: string;
+	}> {
+		const url = new URL("http://localhost:4321/_emdash/oauth/authorize");
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("client_id", "test-client");
+		url.searchParams.set("redirect_uri", REDIRECT_URI);
+		url.searchParams.set("scope", scopes.join(" "));
+		url.searchParams.set("state", "state-1");
+		url.searchParams.set("code_challenge", "challenge");
+		url.searchParams.set("code_challenge_method", "S256");
+
+		const response = await getAuthorizationConsent({
+			url,
+			request: new Request(url),
+			locals: {
+				emdash: { db, config: {} },
+				user: {
+					id: "user-1",
+					email: "test@example.com",
+					name: "Test User",
+					role: 50,
+				},
+			},
+		} as Parameters<typeof getAuthorizationConsent>[0]);
+
+		const html = response.clone();
+		const csrfToken = (await html.text()).match(/name="csrf_token" value="([^"]+)"/)?.[1];
+		const cookie = response.headers.get("Set-Cookie")?.split(";")[0];
+		if (!csrfToken || !cookie) throw new Error("Consent response omitted CSRF state");
+
+		return { response, url, csrfToken, cookie };
+	}
+
+	async function submitConsent(
+		consent: Awaited<ReturnType<typeof renderConsent>>,
+		selectedScopes: string[],
+		role = 50,
+	): Promise<Response> {
+		const body = new URLSearchParams({
+			csrf_token: consent.csrfToken,
+			response_type: "code",
+			client_id: "test-client",
+			redirect_uri: REDIRECT_URI,
+			state: "state-1",
+			code_challenge: "challenge",
+			code_challenge_method: "S256",
+			action: "approve",
+		});
+		for (const scope of selectedScopes) body.append("scope", scope);
+
+		const request = new Request(consent.url, {
+			method: "POST",
+			headers: { Cookie: consent.cookie },
+			body,
+		});
+
+		return postAuthorizationConsent({
+			request,
+			locals: {
+				emdash: { db, config: {} },
+				user: {
+					id: "user-1",
+					email: "test@example.com",
+					name: "Test User",
+					role,
+				},
+			},
+		} as Parameters<typeof postAuthorizationConsent>[0]);
+	}
+});


### PR DESCRIPTION
## What does this PR do?

Makes authorization-code consent scopes individually selectable so users can remove permissions an MCP client does not need before approving access. Requested scopes remain selected by default for compatibility, while submitted selections are constrained to the original request and continue through existing client- and role-based clamps.

Empty effective grants now return `invalid_scope`, duplicate requested scopes render once, plugin-specific MCP scopes remain selectable, and the consent copy reflects `content:write` compatibility grants.

Closes #2093

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (N/A: this extends the existing standalone server-rendered OAuth consent surface, not the Lingui admin SPA.)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: N/A — bug fix for #2093

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + GPT-5.6 Sol

## Screenshots / test output

Exact source identity:

- Base: `7d28ce940a7bc05043bd01c79cae07c7a1d00898`
- Head: `6179d69f1e3536bd922eaed7db75ab30d41612be`

Verification:

- Focused OAuth/MCP regression suite: 4 files, 87 tests passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed with warnings denied
- `pnpm format:check`: passed
- Source-blind `demos/simple` Node/SQLite behavior: passed
- Source-blind `demos/cloudflare` local workerd/D1 behavior: passed
- Reduced grants, unrequested-scope injection, restricted clients, empty grants, and refresh non-broadening passed in both runtimes
- Full package suite reached 4,984 passing core tests and 3 skipped; one unrelated macOS `/var` vs `/private/var` path assertion failed in `virtual-modules.test.ts`
- Exact-head Spark-2 OpenClaw review: completed clean, no accepted/actionable findings, confidence 0.95

Internal proof root: `/Users/cp-1/Developer/_machine-runs/emdash-upstream-2093-scoped-grants-20260721/`

Made with [Cursor](https://cursor.com)