### PR TITLE
i18n(zh-TW): complete Traditional Chinese translations

### DIFF
--- a/.changeset/complete-traditional-chinese.md
+++ b/.changeset/complete-traditional-chinese.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Completes the Traditional Chinese (zh-TW) translation of the admin interface.

--- a/packages/admin/src/locales/zh-TW/messages.po
+++ b/packages/admin/src/locales/zh-TW/messages.po
@@ -15,61 +15,61 @@ msgstr ""
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Guest"
-msgstr ""
+msgstr " - 訪客"
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Linked"
-msgstr ""
+msgstr " - 已連結"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:72
 #: packages/admin/src/components/TranslationsPanel.tsx:81
 msgid " (default)"
-msgstr "（預設）"
+msgstr " (預設)"
 
 #: packages/admin/src/components/MenuEditor.tsx:521
 msgid " (opens in new window)"
-msgstr "（在新視窗中開啟）"
+msgstr " (在新視窗中開啟)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:867
 #: packages/admin/src/components/MediaPickerModal.tsx:950
 msgid " (selected)"
-msgstr "（已選擇）"
+msgstr " (已選取)"
 
 #: packages/admin/src/routes/bylines.tsx:706
 msgid "-- Select --"
-msgstr ""
+msgstr "-- 選取 --"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
 msgid ", or open the admin at"
-msgstr "，或者開啟管理後台"
+msgstr "，或在下列位置開啟管理後台"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
 msgid ": use"
-msgstr "：使用"
+msgstr ": 使用"
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
 #: packages/admin/src/components/MediaPickerModal.tsx:798
 msgid "(from {0})"
-msgstr "（來自 {0}）"
+msgstr "(來自 {0})"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:533
 msgid "(pre-release)"
-msgstr ""
+msgstr "(發佈前版本)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:156
 msgid "(synced)"
-msgstr "（已同步）"
+msgstr "(已同步)"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:536
 msgid "(too new)"
-msgstr ""
+msgstr "(太新)"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:310
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
-msgstr "（使用您的開發埠）。"
+msgstr "(使用您的開發通訊埠)。"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: orphan.rowCount
@@ -81,22 +81,22 @@ msgstr "{0, plural, one {(# 個項目)} other {(# 個項目)}}"
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
 msgid "{0, plural, one {# collection} other {# collections}}"
-msgstr "{0, plural, one {# 個合集} other {# 個合集}}"
+msgstr "{0, plural, one {# 個內容集合} other {# 個內容集合}}"
 
 #. placeholder {0}: result.comments.imported
 #: packages/admin/src/components/WordPressImport.tsx:2263
 msgid "{0, plural, one {# comment imported} other {# comments imported}}"
-msgstr ""
+msgstr "{0, plural, one {# 則留言已匯入} other {# 則留言已匯入}}"
 
 #. placeholder {0}: result.affected
 #: packages/admin/src/router.tsx:1465
 msgid "{0, plural, one {# comment updated} other {# comments updated}}"
-msgstr ""
+msgstr "{0, plural, one {# 則留言已更新} other {# 則留言已更新}}"
 
 #. placeholder {0}: comments.length
 #: packages/admin/src/components/comments/CommentInbox.tsx:345
 msgid "{0, plural, one {# comment} other {# comments}}"
-msgstr "{0, plural, one {# 條評論} other {# 條評論}}"
+msgstr "{0, plural, one {# 則留言} other {# 則留言}}"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2274
@@ -106,12 +106,12 @@ msgstr "{0, plural, one {# 個內容錯誤} other {# 個內容錯誤}}"
 #. placeholder {0}: result.imported
 #: packages/admin/src/components/WordPressImport.tsx:2215
 msgid "{0, plural, one {# content item imported} other {# content items imported}}"
-msgstr "{0, plural, one {# 個內容項已導入} other {# 個內容項已導入}}"
+msgstr "{0, plural, one {已匯入 # 個內容項目} other {已匯入 # 個內容項目}}"
 
 #. placeholder {0}: selectedItems.length
 #: packages/admin/src/components/MediaPickerModal.tsx:787
 msgid "{0, plural, one {# item selected} other {# items selected}}"
-msgstr ""
+msgstr "{0, plural, one {# 個項目已選取} other {# 個項目已選取}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
@@ -123,7 +123,7 @@ msgstr "{0, plural, one {# 個項目} other {# 個項目}}"
 #. placeholder {0}: mcpTools.length
 #: packages/admin/src/components/PluginManager.tsx:419
 msgid "{0, plural, one {# MCP tool} other {# MCP tools}}"
-msgstr ""
+msgstr "{0, plural, one {# 個 MCP 工具} other {# 個 MCP 工具}}"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2279
@@ -133,23 +133,23 @@ msgstr "{0, plural, one {# 個媒體錯誤} other {# 個媒體錯誤}}"
 #. placeholder {0}: mediaResult.imported.length
 #: packages/admin/src/components/WordPressImport.tsx:2231
 msgid "{0, plural, one {# media file imported} other {# media files imported}}"
-msgstr "{0, plural, one {# 個媒體文件已導入} other {# 個媒體文件已導入}}"
+msgstr "{0, plural, one {已匯入 # 個媒體檔案} other {已匯入 # 個媒體檔案}}"
 
 #. placeholder {0}: result.menus.created
 #: packages/admin/src/components/WordPressImport.tsx:2255
 msgid "{0, plural, one {# menu imported} other {# menus imported}}"
-msgstr ""
+msgstr "{0, plural, one {已匯入 # 個選單} other {已匯入 # 個選單}}"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1903
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
-msgstr "{0, plural, one {# 個菜單將導入} other {# 個菜單將導入}}"
+msgstr "{0, plural, one {將匯入 # 個選單} other {將匯入 # 個選單}}"
 
 #. placeholder {0}: plugin.capabilities.length
 #: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:433
 msgid "{0, plural, one {# permission} other {# permissions}}"
-msgstr "{0, plural, one {# 個權限} other {# 個權限}}"
+msgstr "{0, plural, one {# 項權限} other {# 項權限}}"
 
 #. placeholder {0}: mapping.postCount
 #: packages/admin/src/components/WordPressImport.tsx:2486
@@ -159,65 +159,65 @@ msgstr "{0, plural, one {# 篇文章} other {# 篇文章}}"
 #. placeholder {0}: loopRedirectIds.size
 #: packages/admin/src/components/Redirects.tsx:445
 msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
-msgstr "{0, plural, one {# 個重定向是循環的一部分。} other {# 個重定向是循環的一部分。}}"
+msgstr "{0, plural, one {# 個重新導向屬於迴圈的一部分。} other {# 個重新導向屬於迴圈的一部分。}}"
 
 #. placeholder {0}: selected.size
 #: packages/admin/src/components/comments/CommentInbox.tsx:229
 msgid "{0, plural, one {# selected} other {# selected}}"
-msgstr "{0, plural, one {# 個已選擇} other {# 個已選擇}}"
+msgstr "{0, plural, one {# 個已選取} other {# 個已選取}}"
 
 #. placeholder {0}: result.skipped
 #: packages/admin/src/components/WordPressImport.tsx:2223
 msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
-msgstr "{0, plural, one {# 個已跳過（已存在）} other {# 個已跳過（已存在）}}"
+msgstr "{0, plural, one {# 個已略過 (已存在)} other {# 個已略過 (已存在)}}"
 
 #. placeholder {0}: result.taxonomyAssignments
 #: packages/admin/src/components/WordPressImport.tsx:2247
 msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
-msgstr ""
+msgstr "{0, plural, one {# 個分類法指派} other {# 個分類法指派}}"
 
 #. placeholder {0}: result.taxonomiesCreated.length
 #: packages/admin/src/components/WordPressImport.tsx:2239
 msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
-msgstr ""
+msgstr "{0, plural, one {已建立 # 個分類法} other {已建立 # 個分類法}}"
 
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:585
 msgid "{0, plural, one {field} other {fields}}"
-msgstr ""
+msgstr "{0, plural, one {欄位} other {欄位}}"
 
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:160
 msgid "{0, plural, one {Media file} other {Media files}}"
-msgstr ""
+msgstr "{0, plural, one {媒體檔案} other {媒體檔案}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:165
 msgid "{0, plural, one {User} other {Users}}"
-msgstr ""
+msgstr "{0, plural, one {使用者} other {使用者}}"
 
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
 #. placeholder {2}: m.host
 #: packages/admin/src/components/RegistryPluginDetail.tsx:636
 msgid "{0} {1} required — you have {2}."
-msgstr ""
+msgstr "需要 {0} {1} — 您有 {2}。"
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
 #: packages/admin/src/components/MenuList.tsx:216
 msgid "{0} • {1}"
-msgstr ""
+msgstr "{0} • {1}"
 
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:425
 msgid "{0} banner"
-msgstr ""
+msgstr "{0} 橫幅"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1303
 msgid "{0} detected"
-msgstr "檢測到 {0}"
+msgstr "偵測到 {0}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:115
@@ -232,7 +232,7 @@ msgstr "{0} 已移除"
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:437
 msgid "{0} icon"
-msgstr ""
+msgstr "{0} 圖示"
 
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:213
@@ -242,7 +242,7 @@ msgstr "{0} 次安裝"
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:96
 msgid "{0} is now active"
-msgstr "{0} 現已激活"
+msgstr "{0} 現已啟用"
 
 #. placeholder {0}: postType.count
 #. placeholder {1}: postType.suggestedCollection
@@ -253,27 +253,27 @@ msgstr "{0} 個項目 → {1}"
 #. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
 #: packages/admin/src/components/WordPressImport.tsx:1896
 msgid "{0} items will be imported"
-msgstr "將導入 {0} 個項目"
+msgstr "將匯入 {0} 個項目"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:535
 msgid "{0} of {total} could not be deleted"
-msgstr ""
+msgstr "{total} 個項目中有 {0} 個無法刪除"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:491
 msgid "{0} of {total} could not be published"
-msgstr ""
+msgstr "{total} 個項目中有 {0} 個無法發佈"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:514
 msgid "{0} of {total} could not be updated"
-msgstr ""
+msgstr "{total} 個項目中有 {0} 個無法更新"
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:174
 msgid "{0} plugins"
-msgstr "{0} 個插件"
+msgstr "{0} 個外掛"
 
 #. placeholder {0}: theme.name
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:206
@@ -285,7 +285,7 @@ msgstr "{0} 預覽"
 #. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
 #: packages/admin/src/components/ContentTypeEditor.tsx:583
 msgid "{0} system + {1} custom {2}"
-msgstr ""
+msgstr "{0} 個系統欄位 + {1} 個自訂{2}"
 
 #. placeholder {0}: taxonomy.label
 #: packages/admin/src/components/TaxonomySidebar.tsx:347
@@ -308,20 +308,20 @@ msgstr "{0}{1}"
 #. placeholder {0}: draft.description.length
 #: packages/admin/src/components/SeoPanel.tsx:195
 msgid "{0}/160 characters"
-msgstr "{0}/160 個字符"
+msgstr "{0}/160 個字元"
 
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:313
 msgid "{base} to: {0}"
-msgstr ""
+msgstr "{base} 至: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:345
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
-msgstr "{changedCount, plural, one {# 個變更來自下一個修訂版本} other {# 個變更來自下一個修訂版本}}"
+msgstr "{changedCount, plural, one {與下一個修訂版本有 # 項變更} other {與下一個修訂版本有 # 項變更}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2072
 msgid "{count, plural, one {# file} other {# files}}"
-msgstr "{count, plural, one {# 個文件} other {# 個文件}}"
+msgstr "{count, plural, one {# 個檔案} other {# 個檔案}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2351
 msgid "{count, plural, one {# item} other {# items}}"
@@ -335,120 +335,120 @@ msgstr "{current} / {total}"
 #. placeholder {1}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:933
 msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
-msgstr ""
+msgstr "{filteredCount, plural, one {#{0} 個項目} other {#{1} 個項目}}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
-msgstr "{label} — 無翻譯"
+msgstr "{label} — 沒有翻譯"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
-msgstr "{label} — 查看翻譯"
+msgstr "{label} — 檢視翻譯"
 
 #: packages/admin/src/components/ContentList.tsx:922
 msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{matchCount, plural, one {符合「{searchQuery}」的 # 個項目} other {符合「{searchQuery}」的 # 個項目}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2473
 msgid "{matchedCount} of {totalCount} assigned"
-msgstr "已分配 {matchedCount} / {totalCount}"
+msgstr "已指派 {totalCount} 個項目中的 {matchedCount} 個"
 
 #: packages/admin/src/components/WordPressImport.tsx:2461
 msgid "{matchedCount} of {totalCount} authors matched by email"
-msgstr "通過電子郵件匹配 {matchedCount} / {totalCount} 位作者"
+msgstr "已透過電子郵件比對到 {matchedCount}/{totalCount} 位作者"
 
 #: packages/admin/src/components/WordPressImport.tsx:1879
 msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
-msgstr "{needsNewCollections, plural, one {將創建 # 個新合集} other {將創建 # 個新合集}}"
+msgstr "{needsNewCollections, plural, one {將建立 # 個新內容集合} other {將建立 # 個新內容集合}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1888
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr "{needsNewFields, plural, one {字段將添加到 # 個現有合集} other {字段將添加到 # 個現有合集}}"
+msgstr "{needsNewFields, plural, one {欄位將新增至 # 個現有內容集合} other {欄位將新增至 # 個現有內容集合}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:83
 msgid "{pluginName} is requesting additional permissions:"
-msgstr "{pluginName} 正在請求額外權限："
+msgstr "{pluginName} 要求下列額外權限:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:84
 msgid "{pluginName} requires the following permissions:"
-msgstr "{pluginName} 需要以下權限："
+msgstr "{pluginName} 需要下列權限:"
 
 #: packages/admin/src/components/PluginSettings.tsx:128
 #: packages/admin/src/components/PluginSettings.tsx:142
 #: packages/admin/src/components/PluginSettings.tsx:170
 msgid "{pluginName} Settings"
-msgstr ""
+msgstr "{pluginName} 設定"
 
 #: packages/admin/src/components/MediaLibrary.tsx:298
 msgid "{resultCount, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{resultCount, plural, one {# 個項目} other {# 個項目}}"
 
 #: packages/admin/src/components/ContentList.tsx:405
 msgid "{selectedCount, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {已選取 # 個項目} other {已選取 # 個項目}}"
 
 #: packages/admin/src/components/ContentList.tsx:446
 msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {要將 # 個項目移至回收桶嗎？之後仍可還原。} other {要將 # 個項目移至回收桶嗎？之後仍可還原。}}"
 
 #: packages/admin/src/components/ContentList.tsx:928
 msgid "{total, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{total, plural, one {# 個項目} other {# 個項目}}"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:150
 msgid "{total, plural, one {# total} other {# total}}"
-msgstr "{total, plural, one {共 # 條} other {共 # 條}}"
+msgstr "{total, plural, one {共 # 筆} other {共 # 筆}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:211
 #: packages/admin/src/components/MediaLibrary.tsx:247
 msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
-msgstr "{total, plural, one {文件已上傳} other {# 個文件已上傳}}"
+msgstr "{total, plural, one {檔案已上傳} other {已上傳 # 個檔案}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:216
 #: packages/admin/src/components/MediaLibrary.tsx:252
 msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
-msgstr "{total, plural, one {上傳失敗} other {全部 # 個上傳失敗}}"
+msgstr "{total, plural, one {上傳失敗} other {全部 # 個上傳項目均失敗}}"
 
 #: packages/admin/src/components/Dashboard.tsx:146
 msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
-msgstr ""
+msgstr "{totalDrafts, plural, one {草稿} other {草稿}}"
 
 #: packages/admin/src/components/Dashboard.tsx:153
 msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
-msgstr ""
+msgstr "{totalScheduled, plural, one {已排程} other {已排程}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:357
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
-msgstr "{unchangedCount, plural, one {隱藏 # 個未變更} other {隱藏 # 個未變更}}"
+msgstr "{unchangedCount, plural, one {隱藏 # 個未變更項目} other {隱藏 # 個未變更項目}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:358
 msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
-msgstr "{unchangedCount, plural, one {顯示 # 個未變更} other {顯示 # 個未變更}}"
+msgstr "{unchangedCount, plural, one {顯示 # 個未變更項目} other {顯示 # 個未變更項目}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:221
 #: packages/admin/src/components/MediaLibrary.tsx:257
 msgid "{uploaded} uploaded, {failed} failed"
-msgstr "{uploaded} 個已上傳，{failed} 個失敗"
+msgstr "已上傳 {uploaded} 個，{failed} 個失敗"
 
 #: packages/admin/src/components/Redirects.tsx:142
 msgid "/new-page or /articles/[slug]"
-msgstr ""
+msgstr "/new-page 或 /articles/[slug]"
 
 #: packages/admin/src/components/Redirects.tsx:133
 msgid "/old-page or /blog/[slug]"
-msgstr ""
+msgstr "/old-page 或 /blog/[slug]"
 
 #: packages/admin/src/components/WordPressImport.tsx:2093
 msgid "• Files are downloaded from your WordPress site"
-msgstr "• 文件從您的 WordPress 站點下載"
+msgstr "• 從您的 WordPress 網站下載檔案"
 
 #: packages/admin/src/components/WordPressImport.tsx:2094
 msgid "• Uploaded to your EmDash media storage"
-msgstr "• 已上傳到您的 EmDash 媒體存儲"
+msgstr "• 已上傳至您的 EmDash 媒體儲存空間"
 
 #: packages/admin/src/components/WordPressImport.tsx:2095
 msgid "• URLs in your content are updated automatically"
-msgstr "• 您內容中的 URL 將自動更新"
+msgstr "• 內容中的網址會自動更新"
 
 #: packages/admin/src/components/SetupWizard.tsx:225
 #: packages/admin/src/components/SetupWizard.tsx:277
@@ -463,11 +463,11 @@ msgstr "1 年"
 
 #: packages/admin/src/components/WordPressImport.tsx:1522
 msgid "1. Log into your WordPress admin"
-msgstr "1. 登錄您的 WordPress 管理後台"
+msgstr "1. 登入您的 WordPress 管理後台"
 
 #: packages/admin/src/components/WordPressImport.tsx:1275
 msgid "1. Log into your WordPress admin dashboard"
-msgstr "1. 登錄您的 WordPress 管理後台"
+msgstr "1. 登入您的 WordPress 管理控制台"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "2. Go to"
@@ -475,15 +475,15 @@ msgstr "2. 前往"
 
 #: packages/admin/src/components/WordPressImport.tsx:1523
 msgid "2. Go to Users → Profile"
-msgstr "2. 前往 用戶 → 個人資料"
+msgstr "2. 前往 [使用者] → [個人資料]"
 
 #: packages/admin/src/components/WordPressImport.tsx:1524
 msgid "3. Scroll to \"Application Passwords\""
-msgstr "3. 滾動到 \"應用程式密碼\""
+msgstr "3. 捲動至 [應用程式密碼]"
 
 #: packages/admin/src/components/WordPressImport.tsx:1279
 msgid "3. Select \"All content\""
-msgstr "3. 選擇 \"所有內容\""
+msgstr "3. 選取「所有內容」"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
 msgid "30 days"
@@ -491,27 +491,27 @@ msgstr "30 天"
 
 #: packages/admin/src/components/Redirects.tsx:156
 msgid "301 Permanent"
-msgstr "301 永久重定向"
+msgstr "301 永久重新導向"
 
 #: packages/admin/src/components/Redirects.tsx:157
 msgid "302 Temporary"
-msgstr "302 臨時重定向"
+msgstr "302 暫時重新導向"
 
 #: packages/admin/src/components/Redirects.tsx:158
 msgid "307 Temporary (Strict)"
-msgstr "307 臨時（嚴格）"
+msgstr "307 暫時重新導向 (嚴格)"
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "308 Permanent (Strict)"
-msgstr "308 永久（嚴格）"
+msgstr "308 永久重新導向 (嚴格)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1280
 msgid "4. Click \"Download Export File\""
-msgstr "4. 點擊 \"下載導出文件\""
+msgstr "4. 按一下「下載匯出檔案」"
 
 #: packages/admin/src/components/WordPressImport.tsx:1525
 msgid "4. Enter \"EmDash\" and click \"Add New\""
-msgstr "4. 輸入 \"EmDash\" 並點擊 \"添加新密碼\""
+msgstr "4. 輸入「EmDash」，然後按一下「新增」"
 
 #: packages/admin/src/components/Redirects.tsx:395
 msgid "404 Errors"
@@ -519,19 +519,19 @@ msgstr "404 錯誤"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "410 Content Deleted (Gone)"
-msgstr ""
+msgstr "410 內容已刪除 (已不存在)"
 
 #: packages/admin/src/components/Redirects.tsx:161
 msgid "451 Unavailable for legal reasons"
-msgstr ""
+msgstr "451 因法律原因無法提供"
 
 #: packages/admin/src/components/WordPressImport.tsx:1526
 msgid "5. Copy the generated password"
-msgstr "5. 複製生成的密碼"
+msgstr "5. 複製產生的密碼"
 
 #: packages/admin/src/components/WordPressImport.tsx:1281
 msgid "5. Upload the file here"
-msgstr "5. 在此處上傳文件"
+msgstr "5. 在這裡上傳檔案"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
 msgid "7 days"
@@ -543,15 +543,15 @@ msgstr "90 天"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:416
 msgid "A brief description of this content type"
-msgstr ""
+msgstr "這個內容類型的簡短說明"
 
 #: packages/admin/src/components/Sections.tsx:203
 msgid "A full-width hero banner with heading, text, and CTA button"
-msgstr ""
+msgstr "包含標題、文字及 CTA 按鈕的全寬主視覺橫幅"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:142
 msgid "A short description of your site"
-msgstr "您網站的簡短描述"
+msgstr "網站的簡短說明"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:201
 msgid "Accept & Install"
@@ -563,40 +563,40 @@ msgstr "接受並更新"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:240
 msgid "Accept Invite"
-msgstr ""
+msgstr "接受邀請"
 
 #: packages/admin/src/routes/byline-schema.tsx:174
 msgid "Access denied"
-msgstr ""
+msgstr "存取遭拒"
 
 #: packages/admin/src/router.tsx:1485
 msgid "Access Denied"
-msgstr ""
+msgstr "存取遭拒"
 
 #: packages/admin/src/lib/api/marketplace.ts:282
 #: packages/admin/src/lib/api/marketplace.ts:290
 msgid "Access your media library"
-msgstr ""
+msgstr "存取您的媒體庫"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
-msgstr "帳戶"
+msgstr "帳號"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:154
 msgid "Account already exists"
-msgstr ""
+msgstr "帳號已存在"
 
 #: packages/admin/src/components/SignupPage.tsx:262
 msgid "Account exists"
-msgstr "帳戶已存在"
+msgstr "帳號已存在"
 
 #: packages/admin/src/components/users/UserDetail.tsx:216
 msgid "Account Info"
-msgstr "帳戶資訊"
+msgstr "帳號資訊"
 
 #: packages/admin/src/components/WordPressImport.tsx:1158
 msgid "ACF Fields"
-msgstr ""
+msgstr "ACF 欄位"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/ContentList.tsx:528
@@ -610,14 +610,14 @@ msgstr "操作"
 #: packages/admin/src/components/users/UserDetail.tsx:206
 #: packages/admin/src/components/users/UserList.tsx:217
 msgid "Active"
-msgstr "活躍"
+msgstr "啟用"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:171
 #: packages/admin/src/components/ContentSettingsPanel.tsx:840
 #: packages/admin/src/components/MenuEditor.tsx:441
 #: packages/admin/src/components/TaxonomySidebar.tsx:478
 msgid "Add"
-msgstr "添加"
+msgstr "新增"
 
 #. placeholder {0}: field.item_label
 #. placeholder {0}: taxonomyDef.labelSingular || t`Term`
@@ -625,163 +625,163 @@ msgstr "添加"
 #: packages/admin/src/components/TaxonomyManager.tsx:378
 #: packages/admin/src/components/TaxonomyManager.tsx:834
 msgid "Add {0}"
-msgstr "添加 {0}"
+msgstr "新增 {0}"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:266
 msgid "Add {label}"
-msgstr "添加 {label}"
+msgstr "新增 {label}"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:177
 msgid "Add a new passkey"
-msgstr "添加新的通行密鑰"
+msgstr "新增通行金鑰"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
 msgid "Add an allowed domain"
-msgstr "添加允許的域名"
+msgstr "新增允許的網域"
 
 #: packages/admin/src/components/FieldEditor.tsx:544
 msgid "Add at least one sub-field to define the repeater structure."
-msgstr "添加至少一個子字段以定義重複器結構。"
+msgstr "新增至少一個子欄位，以定義重複欄位的結構。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3337
 msgid "Add column after"
-msgstr ""
+msgstr "在後方新增欄"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3331
 msgid "Add column before"
-msgstr ""
+msgstr "在前方新增欄"
 
 #: packages/admin/src/components/MenuEditor.tsx:378
 #: packages/admin/src/components/MenuEditor.tsx:493
 msgid "Add Content"
-msgstr "添加內容"
+msgstr "新增內容"
 
 #: packages/admin/src/components/MenuEditor.tsx:390
 #: packages/admin/src/components/MenuEditor.tsx:397
 #: packages/admin/src/components/MenuEditor.tsx:496
 msgid "Add Custom Link"
-msgstr "添加自定義鏈接"
+msgstr "新增自訂連結"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:316
 msgid "Add Domain"
-msgstr "添加域名"
+msgstr "新增網域"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:591
 #: packages/admin/src/components/FieldEditor.tsx:342
 #: packages/admin/src/components/FieldEditor.tsx:660
 msgid "Add Field"
-msgstr "添加字段"
+msgstr "新增欄位"
 
 #: packages/admin/src/components/WordPressImport.tsx:1984
 msgid "Add fields"
-msgstr "添加字段"
+msgstr "新增欄位"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr ""
+msgstr "新增「職稱」或「代名詞」等欄位，豐富每筆署名資料。"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:613
 msgid "Add fields to define the structure of your content"
-msgstr ""
+msgstr "新增欄位以定義內容結構"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:616
 msgid "Add First Field"
-msgstr ""
+msgstr "新增第一個欄位"
 
 #: packages/admin/src/components/RepeaterField.tsx:174
 msgid "Add First Item"
-msgstr "添加第一個項目"
+msgstr "新增第一個項目"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:200
 msgid "Add Images"
-msgstr ""
+msgstr "新增圖片"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:247
 msgid "Add images to gallery"
-msgstr ""
+msgstr "將圖片加入圖庫"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1830
 msgid "Add item"
-msgstr "添加項目"
+msgstr "新增項目"
 
 #: packages/admin/src/components/RepeaterField.tsx:158
 msgid "Add Item"
-msgstr "添加項目"
+msgstr "新增項目"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3266
 msgid "Add link"
-msgstr ""
+msgstr "新增連結"
 
 #: packages/admin/src/components/MenuEditor.tsx:486
 msgid "Add links to build your navigation menu"
-msgstr "添加鏈接以構建您的導航菜單"
+msgstr "新增連結以建立導覽選單"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:162
 msgid "Add MIME type or extension"
-msgstr ""
+msgstr "新增 MIME 類型或副檔名"
 
 #: packages/admin/src/components/ContentList.tsx:342
 msgid "Add New"
-msgstr "添加新內容"
+msgstr "新增"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:490
 msgid "Add new {0}"
-msgstr "添加新{0}"
+msgstr "新增 {0}"
 
 #: packages/admin/src/components/SeoPanel.tsx:227
 msgid "Add noindex meta tag"
-msgstr "添加 noindex 元標籤"
+msgstr "新增 noindex 中繼標籤"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:200
 msgid "Add Passkey"
-msgstr "添加通行密鑰"
+msgstr "新增通行金鑰"
 
 #: packages/admin/src/components/PluginManager.tsx:210
 msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
-msgstr "在 astro.config.mjs 中添加插件以擴展 EmDash 功能。"
+msgstr "將外掛新增至 astro.config.mjs，以擴充 EmDash 功能。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3358
 msgid "Add row after"
-msgstr ""
+msgstr "在後方新增列"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3352
 msgid "Add row before"
-msgstr ""
+msgstr "在上方新增資料列"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:474
 msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
-msgstr ""
+msgstr "新增 SEO 中繼資料欄位 (標題、說明、圖片) 並納入網站地圖"
 
 #: packages/admin/src/components/FieldEditor.tsx:538
 msgid "Add Sub-Field"
-msgstr "添加子字段"
+msgstr "新增子欄位"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:265
 msgid "Add tags..."
-msgstr "添加標籤..."
+msgstr "新增標籤..."
 
 #: packages/admin/src/components/Widgets.tsx:401
 msgid "Add Widget Area"
-msgstr ""
+msgstr "新增小工具區域"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:102
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr "添加您的社交媒體資料。這些可供您網站的主題使用，並可以顯示在頁眉、頁腳或作者簡介中。"
+msgstr "新增您的社群媒體個人檔案。網站佈景主題可以使用這些資料，並將其顯示在頁首、頁尾或作者簡介中。"
 
 #: packages/admin/src/components/MenuEditor.tsx:441
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
 msgid "Adding..."
-msgstr "添加中..."
+msgstr "正在新增…"
 
 #: packages/admin/src/components/WordPressImport.tsx:1753
 msgid "Additional data to import."
-msgstr "要導入的其他數據。"
+msgstr "要匯入的其他資料。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1483
 msgid "admin"
-msgstr ""
+msgstr "管理員"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:101
 #: packages/admin/src/components/Sidebar.tsx:383
@@ -791,7 +791,7 @@ msgstr "管理員"
 
 #: packages/admin/src/components/Sidebar.tsx:329
 msgid "Admin navigation"
-msgstr "管理員導航"
+msgstr "管理介面導覽"
 
 #: packages/admin/src/components/WelcomeModal.tsx:25
 msgid "Administrator"
@@ -799,37 +799,37 @@ msgstr "管理員"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:196
 msgid "After send:"
-msgstr "發送後："
+msgstr "傳送後:"
 
 #: packages/admin/src/components/PluginManager.tsx:542
 msgid "Agent access"
-msgstr ""
+msgstr "Agent 存取權"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:334
 msgid "Agent access for {0} has been updated"
-msgstr ""
+msgstr "已更新 {0} 的代理程式存取權"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:139
 msgid "Agent-callable MCP tools"
-msgstr ""
+msgstr "Agent 可呼叫的 MCP 工具"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3705
 msgid "Align Center"
-msgstr ""
+msgstr "置中對齊"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3698
 msgid "Align Left"
-msgstr ""
+msgstr "靠左對齊"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3712
 msgid "Align Right"
-msgstr ""
+msgstr "靠右對齊"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
 msgid "Alignment"
-msgstr ""
+msgstr "對齊"
 
 #: packages/admin/src/components/ContentList.tsx:369
 msgid "All"
@@ -838,11 +838,11 @@ msgstr "全部"
 #: packages/admin/src/components/ContentList.tsx:773
 #: packages/admin/src/components/ContentList.tsx:777
 msgid "All authors"
-msgstr ""
+msgstr "所有作者"
 
 #: packages/admin/src/routes/bylines.tsx:412
 msgid "All bylines"
-msgstr ""
+msgstr "所有署名"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
@@ -850,19 +850,19 @@ msgstr "所有權限"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:134
 msgid "All collections"
-msgstr "所有合集"
+msgstr "所有內容集合"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:63
 msgid "All comments require approval"
-msgstr ""
+msgstr "所有留言都需要審核"
 
 #: packages/admin/src/components/WordPressImport.tsx:2518
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
-msgstr "所有導入的內容將被取消分配。您可以稍後在內容編輯器中重新分配作者。"
+msgstr "所有匯入內容將不會指派給任何人。之後可在內容編輯器中重新指派作者。"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
-msgstr "所有語言"
+msgstr "所有語系"
 
 #: packages/admin/src/components/users/UserList.tsx:42
 #: packages/admin/src/components/users/UserList.tsx:46
@@ -885,53 +885,53 @@ msgstr "所有類型"
 
 #: packages/admin/src/components/PluginManager.tsx:544
 msgid "Allow MCP tokens with plugin-tool scope to invoke these routes."
-msgstr ""
+msgstr "允許具有 plugin-tool 權限範圍的 MCP 權杖呼叫這些路由。"
 
 #: packages/admin/src/components/Settings.tsx:100
 msgid "Allow users from specific domains to sign up"
-msgstr "允許來自特定域的用戶註冊"
+msgstr "允許來自特定網域的使用者註冊"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:495
 msgid "Allow visitors to leave comments on this collection's content"
-msgstr ""
+msgstr "允許訪客在這個內容集合的內容中留言"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
 msgid "Allowed Domains"
-msgstr "允許的域名"
+msgstr "允許的網域"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:102
 msgid "Allowed types"
-msgstr ""
+msgstr "允許的類型"
 
 #: packages/admin/src/components/SignupPage.tsx:439
 msgid "Already have an account?"
-msgstr "已經有帳戶了？"
+msgstr "已經有帳號了嗎？"
 
 #: packages/admin/src/components/PluginManager.tsx:718
 msgid "Also delete plugin storage data"
-msgstr "同時刪除插件存儲數據"
+msgstr "同時刪除外掛儲存資料"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:376
 #: packages/admin/src/components/editor/ImageNode.tsx:231
 #: packages/admin/src/components/MediaLibrary.tsx:589
 msgid "Alt text"
-msgstr ""
+msgstr "替代文字"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
 #: packages/admin/src/components/MediaDetailPanel.tsx:354
 #: packages/admin/src/components/MediaDetailPanel.tsx:371
 msgid "Alt Text"
-msgstr "替代文本"
+msgstr "替代文字"
 
 #: packages/admin/src/components/MediaLibrary.tsx:833
 #: packages/admin/src/components/MediaLibrary.tsx:890
 msgid "Alt text set"
-msgstr "替代文本已設置"
+msgstr "已設定替代文字"
 
 #: packages/admin/src/components/WordPressImport.tsx:1395
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
-msgstr "或者，您可以從 WordPress 導出（工具 → 導出）並上傳文件。"
+msgstr "或者，您可以從 WordPress 匯出 (工具 → 匯出)，再上傳檔案。"
 
 #: packages/admin/src/components/DialogError.tsx:14
 #: packages/admin/src/components/MarketplaceBrowse.tsx:133
@@ -977,32 +977,32 @@ msgstr "發生錯誤"
 
 #: packages/admin/src/routes/byline-schema.tsx:272
 msgid "An unexpected error occurred."
-msgstr ""
+msgstr "發生未預期的錯誤。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:251
 msgid "An unknown error occurred"
-msgstr ""
+msgstr "發生不明錯誤"
 
 #: packages/admin/src/components/WordPressImport.tsx:1575
 msgid "Analyzing export file..."
-msgstr "正在分析導出文件..."
+msgstr "正在分析匯出檔案..."
 
 #: packages/admin/src/components/WordPressImport.tsx:810
 msgid "Analyzing WordPress site..."
-msgstr "正在分析 WordPress 站點..."
+msgstr "正在分析 WordPress 網站..."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:105
 msgid "Any media type allowed (subject to global limits)."
-msgstr ""
+msgstr "允許任何媒體類型 (仍受全域限制)。"
 
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "API Tokens"
-msgstr "API 令牌"
+msgstr "API 權杖"
 
 #: packages/admin/src/components/Widgets.tsx:438
 msgid "Appears on posts and pages"
-msgstr ""
+msgstr "顯示於文章及頁面"
 
 #: packages/admin/src/components/WordPressImport.tsx:1490
 msgid "Application Password"
@@ -1010,108 +1010,108 @@ msgstr "應用程式密碼"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3794
 msgid "Apply"
-msgstr ""
+msgstr "套用"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:181
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:182
 msgid "Apply language"
-msgstr ""
+msgstr "套用語言"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3206
 #: packages/admin/src/components/PortableTextEditor.tsx:3207
 msgid "Apply link"
-msgstr ""
+msgstr "套用連結"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:148
 #: packages/admin/src/components/comments/CommentInbox.tsx:238
 #: packages/admin/src/components/comments/CommentInbox.tsx:490
 msgid "Approve"
-msgstr "批准"
+msgstr "核准"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:195
 msgid "approved"
-msgstr "已批准"
+msgstr "已核准"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:203
 msgid "Approved"
-msgstr "已批准"
+msgstr "已核准"
 
 #: packages/admin/src/components/FieldEditor.tsx:223
 msgid "Arbitrary JSON data"
-msgstr "任意 JSON 數據"
+msgstr "任意 JSON 資料"
 
 #: packages/admin/src/components/ContentList.tsx:1166
 msgid "archived"
-msgstr "已歸檔"
+msgstr "已封存"
 
 #: packages/admin/src/components/ContentList.tsx:732
 #: packages/admin/src/components/Dashboard.tsx:350
 msgid "Archived"
-msgstr ""
+msgstr "已封存"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 #: packages/admin/src/components/Widgets.tsx:158
 msgid "Archives"
-msgstr ""
+msgstr "彙整"
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:375
 msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
-msgstr ""
+msgstr "您確定要刪除「{0}」嗎？沒有任何已儲存的值參照這個欄位。"
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
-msgstr "您確定要刪除 \"{0}\" 嗎？這也將刪除該合集中的所有內容。"
+msgstr "您確定要刪除「{0}」嗎？這也會刪除這個內容集合中的所有內容。"
 
 #. placeholder {0}: deleteFieldTarget.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:669
 msgid "Are you sure you want to delete the \"{0}\" field?"
-msgstr ""
+msgstr "確定要刪除「{0}」欄位嗎？"
 
 #: packages/admin/src/components/MenuList.tsx:255
 msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
-msgstr "您確定要刪除此菜單嗎？這也將刪除所有菜單項。此操作無法撤銷。"
+msgstr "您確定要刪除這個選單嗎？這也會刪除所有選單項目。此操作無法復原。"
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
-msgstr "作爲管理員，您可以從\"用戶\"部分邀請其他用戶。"
+msgstr "身為管理員，您可以從 [使用者] 區段邀請其他使用者。"
 
 #: packages/admin/src/components/WordPressImport.tsx:2456
 msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
-msgstr "將 WordPress 作者分配給 EmDash 用戶。文章將歸屬於所選用戶。"
+msgstr "將 WordPress 作者指派給 EmDash 使用者。文章會歸屬於選取的使用者。"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:28
 msgid "Astro"
-msgstr ""
+msgstr "Astro"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 #: packages/admin/src/components/MediaLibrary.tsx:436
 msgid "Audio"
-msgstr ""
+msgstr "音訊"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:277
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
 msgid "Authentication error: {0}"
-msgstr "認證錯誤：{0}"
+msgstr "驗證錯誤: {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:197
 msgid "Authentication error: {error}"
-msgstr "認證錯誤：{error}"
+msgstr "驗證錯誤: {error}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:254
 msgid "Authentication failed"
-msgstr ""
+msgstr "驗證失敗"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/SecuritySettings.tsx:120
 msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
-msgstr "認證由外部提供商管理（{0}）。使用外部認證時，通行密鑰設置不可用。"
+msgstr "身分驗證由外部服務提供者 ({0}) 管理。使用外部驗證時，無法使用通行金鑰設定。"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:261
 msgid "Authentication was cancelled or timed out. Please try again."
-msgstr "認證已取消或超時。請重試。"
+msgstr "身分驗證已取消或逾時。請再試一次。"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:77
 #: packages/admin/src/components/comments/CommentInbox.tsx:288
@@ -1123,15 +1123,15 @@ msgstr "作者"
 
 #: packages/admin/src/components/WordPressImport.tsx:2471
 msgid "Author Mapping"
-msgstr "作者映射"
+msgstr "作者對應"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:197
 msgid "Authorization denied"
-msgstr "授權已拒絕"
+msgstr "授權遭拒"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:105
 msgid "Authorization failed"
-msgstr ""
+msgstr "授權失敗"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorize"
@@ -1139,15 +1139,15 @@ msgstr "授權"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:176
 msgid "Authorize Device"
-msgstr "授權設備"
+msgstr "授權裝置"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorizing..."
-msgstr "授權中..."
+msgstr "正在授權…"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:685
 msgid "Authors"
-msgstr ""
+msgstr "作者"
 
 #: packages/admin/src/components/Redirects.tsx:522
 msgid "auto"
@@ -1155,27 +1155,27 @@ msgstr "自動"
 
 #: packages/admin/src/components/Redirects.tsx:425
 msgid "Auto (slug change)"
-msgstr "自動（slug 變更）"
+msgstr "自動 (代稱變更)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:539
 msgid "Auto-approve authenticated users"
-msgstr ""
+msgstr "自動核准已驗證身分的使用者"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:424
 msgid "Auto-generated from name (you can edit)"
-msgstr "從名稱自動生成（您可以編輯）"
+msgstr "由名稱自動產生 (您可以編輯)"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:167
 msgid "Automatic Backups"
-msgstr ""
+msgstr "自動備份"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:207
 msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
-msgstr ""
+msgstr "自動備份需要儲存後端 (R2、S3 或本機儲存空間)。請在 EmDash 設定中設定儲存空間以啟用自動備份。"
 
 #: packages/admin/src/router.tsx:995
 msgid "Autosave failed"
-msgstr ""
+msgstr "自動儲存失敗"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:710
 msgid "Available media"
@@ -1183,16 +1183,16 @@ msgstr "可用媒體"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:205
 msgid "Available Providers"
-msgstr "可用提供商"
+msgstr "可用的服務提供者"
 
 #: packages/admin/src/components/Widgets.tsx:464
 msgid "Available Widgets"
-msgstr ""
+msgstr "可用的小工具"
 
 #: packages/admin/src/components/BylineAvatarField.tsx:46
 #: packages/admin/src/components/BylineAvatarField.tsx:71
 msgid "Avatar"
-msgstr ""
+msgstr "個人頭像"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:257
 #: packages/admin/src/components/MenuEditor.tsx:362
@@ -1203,7 +1203,7 @@ msgstr "返回"
 
 #: packages/admin/src/components/ContentEditor.tsx:636
 msgid "Back to {collectionLabel} list"
-msgstr "返回到 {collectionLabel} 列表"
+msgstr "返回 {collectionLabel} 清單"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:336
 msgid "Back to Content Types"
@@ -1215,66 +1215,66 @@ msgstr "返回內容類型"
 #: packages/admin/src/components/LoginPage.tsx:313
 #: packages/admin/src/components/SignupPage.tsx:282
 msgid "Back to login"
-msgstr "返回登錄"
+msgstr "返回登入頁面"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:126
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:404
 msgid "Back to marketplace"
-msgstr "返回市場"
+msgstr "返回市集"
 
 #: packages/admin/src/components/PluginSettings.tsx:118
 #: packages/admin/src/components/RegistryPluginDetail.tsx:820
 msgid "Back to plugins"
-msgstr ""
+msgstr "返回外掛"
 
 #: packages/admin/src/components/SectionEditor.tsx:74
 #: packages/admin/src/components/SectionEditor.tsx:175
 msgid "Back to sections"
-msgstr "返回區塊列表"
+msgstr "返回區段"
 
 #: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
 msgid "Back to settings"
-msgstr "返回設置"
+msgstr "返回設定"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
 msgid "Back to Themes"
-msgstr "返回主題列表"
+msgstr "返回佈景主題"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:199
 msgid "Back up now"
-msgstr ""
+msgstr "立即備份"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:199
 msgid "Backing up..."
-msgstr ""
+msgstr "正在備份..."
 
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:97
 msgid "Backup created: {0}"
-msgstr ""
+msgstr "已建立備份: {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:80
 msgid "Backup settings saved"
-msgstr ""
+msgstr "已儲存備份設定"
 
 #: packages/admin/src/components/Settings.tsx:122
 #: packages/admin/src/components/settings/BackupSettings.tsx:133
 #: packages/admin/src/components/settings/BackupSettings.tsx:148
 msgid "Backups"
-msgstr ""
+msgstr "備份"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:182
 msgid "Backups to keep"
-msgstr ""
+msgstr "保留的備份數量"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:29
 msgid "Bash"
-msgstr ""
+msgstr "Bash"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:191
 msgid "Before send:"
-msgstr "發送前："
+msgstr "傳送前:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:200
 msgid "Bing Verification"
@@ -1282,39 +1282,39 @@ msgstr "Bing 驗證"
 
 #: packages/admin/src/routes/bylines.tsx:496
 msgid "Bio"
-msgstr ""
+msgstr "個人簡介"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
 msgid "Block actions - drag to reorder, click for menu"
-msgstr ""
+msgstr "區塊動作 - 拖曳以重新排序，按一下以開啟選單"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3230
 #: packages/admin/src/components/PortableTextEditor.tsx:3616
 msgid "Bold"
-msgstr ""
+msgstr "粗體"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:55
 #: packages/admin/src/components/FieldEditor.tsx:174
 #: packages/admin/src/components/FieldEditor.tsx:583
 msgid "Boolean"
-msgstr "布爾值"
+msgstr "布林值"
 
 #: packages/admin/src/components/SeoPanel.tsx:184
 msgid "Brief summary shown below the title in search results"
-msgstr "在搜索結果中標題下方顯示簡短摘要"
+msgstr "搜尋結果中的標題下方會顯示簡短摘要"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:72
 msgid "Browse and install plugins published to the decentralized registry."
-msgstr ""
+msgstr "瀏覽並安裝發佈至去中心化外掛庫的外掛。"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:88
 msgid "Browse and install plugins to extend your site."
-msgstr "瀏覽並安裝插件以擴展您的網站。"
+msgstr "瀏覽並安裝外掛以擴充網站功能。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1124
 #: packages/admin/src/components/WordPressImport.tsx:1594
 msgid "Browse Files"
-msgstr "瀏覽文件"
+msgstr "瀏覽檔案"
 
 #: packages/admin/src/components/PluginManager.tsx:203
 msgid "Browse the"
@@ -1322,22 +1322,22 @@ msgstr "瀏覽"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
 msgid "Browse themes and preview them with your own content."
-msgstr "瀏覽主題並使用您自己的內容預覽。"
+msgstr "瀏覽佈景主題，並使用您自己的內容進行預覽。"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:102
 #: packages/admin/src/components/PortableTextEditor.tsx:1139
 #: packages/admin/src/components/PortableTextEditor.tsx:3664
 msgid "Bullet List"
-msgstr "無序列表"
+msgstr "項目符號清單"
 
 #: packages/admin/src/routes/byline-schema.tsx:218
 #: packages/admin/src/routes/bylines.tsx:383
 msgid "Byline schema"
-msgstr ""
+msgstr "署名結構描述"
 
 #: packages/admin/src/components/Sidebar.tsx:252
 msgid "Byline Schema"
-msgstr ""
+msgstr "署名結構描述"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:552
 #: packages/admin/src/components/Sidebar.tsx:242
@@ -1347,19 +1347,19 @@ msgstr "署名"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
-msgstr ""
+msgstr "C"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:32
 msgid "C#"
-msgstr ""
+msgstr "C#"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:31
 msgid "C++"
-msgstr ""
+msgstr "C++"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
-msgstr "可以創建內容"
+msgstr "可以建立內容"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:37
 msgid "Can manage all content"
@@ -1371,7 +1371,7 @@ msgstr "可以發佈自己的內容"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:19
 msgid "Can view content"
-msgstr "可以查看內容"
+msgstr "可以檢視內容"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:315
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:192
@@ -1418,24 +1418,24 @@ msgstr "取消"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:405
 msgid "Cancel (Esc)"
-msgstr ""
+msgstr "取消 (Esc)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:146
 msgid "Cancel rename"
-msgstr "取消重命名"
+msgstr "取消重新命名"
 
 #: packages/admin/src/components/Sections.tsx:407
 msgid "Cannot delete theme sections"
-msgstr "無法刪除主題區塊"
+msgstr "無法刪除佈景主題區段"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:456
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr ""
+msgstr "無法從 URL 判斷 MIME 類型。請使用結尾為已知圖片副檔名的 URL (例如 .jpg、.png、.webp)。"
 
 #: packages/admin/src/components/SeoPanel.tsx:212
 #: packages/admin/src/components/SeoPanel.tsx:216
 msgid "Canonical URL"
-msgstr "規範 URL"
+msgstr "標準網址"
 
 #: packages/admin/src/components/PluginManager.tsx:518
 msgid "Capabilities"
@@ -1454,7 +1454,7 @@ msgstr "說明文字"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:68
 msgid "Captions / Subtitles"
-msgstr ""
+msgstr "隱藏式字幕 / 字幕"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:192
 #: packages/admin/src/components/Widgets.tsx:135
@@ -1468,11 +1468,11 @@ msgstr "分類 ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1146
 msgid "Categories & Tags"
-msgstr ""
+msgstr "分類與標籤"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
 msgid "Center"
-msgstr ""
+msgstr "置中"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
@@ -1482,38 +1482,38 @@ msgstr ""
 #: packages/admin/src/components/ImageFieldRenderer.tsx:162
 #: packages/admin/src/components/SeoImageField.tsx:53
 msgid "Change"
-msgstr "更改"
+msgstr "變更"
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
 #. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
 #: packages/admin/src/routes/users.tsx:296
 msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
-msgstr ""
+msgstr "要將 <0>{0}</0> 從 <1>{1}</1> 變更為 <2>{2}</2> 嗎？該使用者將無法存取較高層級的功能。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:239
 msgid "Change Favicon"
-msgstr "更改網站圖標"
+msgstr "變更網站圖示"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:167
 msgid "Change Image"
-msgstr ""
+msgstr "變更圖片"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:185
 msgid "Change Logo"
-msgstr "更改標誌"
+msgstr "變更標誌"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:808
 msgid "Changelog"
-msgstr ""
+msgstr "變更記錄"
 
 #: packages/admin/src/router.tsx:1046
 msgid "Changes discarded"
-msgstr ""
+msgstr "已捨棄變更"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:129
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr "頁面標題和網站名稱之間的分隔符（例如，\"My Post | My Site\"）"
+msgstr "頁面標題與網站名稱之間的字元 (例如「我的文章 | 我的網站」)"
 
 #: packages/admin/src/components/PluginManager.tsx:166
 msgid "Check for updates"
@@ -1521,13 +1521,13 @@ msgstr "檢查更新"
 
 #: packages/admin/src/components/WordPressImport.tsx:1095
 msgid "Check Site"
-msgstr "檢查站點"
+msgstr "檢查網站"
 
 #: packages/admin/src/components/LoginPage.tsx:102
 #: packages/admin/src/components/SignupPage.tsx:131
 #: packages/admin/src/components/SignupPage.tsx:402
 msgid "Check your email"
-msgstr "查看您的郵箱"
+msgstr "請查看您的電子郵件"
 
 #: packages/admin/src/components/WordPressImport.tsx:776
 msgid "Checking {urlInput}..."
@@ -1535,51 +1535,51 @@ msgstr "正在檢查 {urlInput}..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:155
 msgid "Checking authentication..."
-msgstr "正在檢查認證..."
+msgstr "正在檢查驗證狀態..."
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:362
 msgid "Checking how many stored values reference \"{0}\"…"
-msgstr ""
+msgstr "正在檢查有多少個已儲存值參照「{0}」…"
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
-msgstr "選擇登錄方式"
+msgstr "選擇登入方式"
 
 #: packages/admin/src/components/Settings.tsx:137
 msgid "Choose your preferred admin language"
-msgstr "選擇您的首選管理語言"
+msgstr "選擇偏好的管理後台語言"
 
 #: packages/admin/src/components/ContentList.tsx:481
 msgid "Clear"
-msgstr ""
+msgstr "清除"
 
 #: packages/admin/src/components/ContentList.tsx:825
 #: packages/admin/src/components/MediaLibrary.tsx:497
 #: packages/admin/src/components/users/UserList.tsx:129
 msgid "Clear filters"
-msgstr ""
+msgstr "清除篩選條件"
 
 #: packages/admin/src/components/MediaLibrary.tsx:497
 #: packages/admin/src/components/MediaLibrary.tsx:521
 msgid "Clear search"
-msgstr ""
+msgstr "清除搜尋"
 
 #: packages/admin/src/components/PluginSettings.tsx:354
 msgid "Clear stored value"
-msgstr ""
+msgstr "清除已儲存的值"
 
 #: packages/admin/src/components/PluginSettings.tsx:352
 msgid "Clear stored value for {fieldKey}"
-msgstr ""
+msgstr "清除 {fieldKey} 的已儲存值"
 
 #: packages/admin/src/components/SignupPage.tsx:139
 msgid "Click the link in the email to continue setting up your account."
-msgstr "點擊郵件中的鏈接以繼續設置您的帳戶。"
+msgstr "按一下電子郵件中的連結，以繼續設定帳號。"
 
 #: packages/admin/src/components/LoginPage.tsx:113
 msgid "Click the link in the email to sign in."
-msgstr "點擊郵件中的鏈接即可登錄。"
+msgstr "按一下電子郵件中的連結以登入。"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:212
 #: packages/admin/src/components/BylineFieldEditor.tsx:218
@@ -1644,11 +1644,11 @@ msgstr "關閉"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:518
 msgid "Close comments after (days)"
-msgstr ""
+msgstr "幾天後關閉留言"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:178
 msgid "Close gallery settings"
-msgstr ""
+msgstr "關閉圖庫設定"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
@@ -1656,7 +1656,7 @@ msgstr "關閉面板"
 
 #: packages/admin/src/components/ContentEditor.tsx:1030
 msgid "Close settings"
-msgstr ""
+msgstr "關閉設定"
 
 #: packages/admin/src/components/ContentTypeList.tsx:242
 #: packages/admin/src/components/PortableTextEditor.tsx:3258
@@ -1668,15 +1668,15 @@ msgstr "代碼"
 #: packages/admin/src/components/PortableTextEditor.tsx:1169
 #: packages/admin/src/components/PortableTextEditor.tsx:3685
 msgid "Code Block"
-msgstr "代碼塊"
+msgstr "程式碼區塊"
 
 #: packages/admin/src/components/PluginManager.tsx:505
 msgid "Collapse"
-msgstr "收起"
+msgstr "收合"
 
 #: packages/admin/src/components/PluginManager.tsx:499
 msgid "Collapse details"
-msgstr "收起詳情"
+msgstr "收合詳細資料"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:156
 msgid "colleague@example.com"
@@ -1684,46 +1684,46 @@ msgstr "colleague@example.com"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
-msgstr ""
+msgstr "內容集合"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:106
 msgid "Collection:"
-msgstr "合集："
+msgstr "內容集合:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:678
 msgid "Collections"
-msgstr "合集"
+msgstr "內容集合"
 
 #: packages/admin/src/components/WordPressImport.tsx:2327
 msgid "Collections created:"
-msgstr "已創建的合集："
+msgstr "已建立的內容集合:"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:185
 msgid "Columns"
-msgstr ""
+msgstr "欄"
 
 #: packages/admin/src/components/SectionEditor.tsx:288
 msgid "Comma-separated keywords for search."
-msgstr "逗號分隔的搜索關鍵詞。"
+msgstr "以半形逗號分隔的搜尋關鍵字。"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:95
 #: packages/admin/src/components/comments/CommentInbox.tsx:291
 msgid "Comment"
-msgstr "評論"
+msgstr "留言"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:58
 msgid "Comment Detail"
-msgstr "評論詳情"
+msgstr "留言詳細資料"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:147
 #: packages/admin/src/components/ContentTypeEditor.tsx:485
 #: packages/admin/src/components/Sidebar.tsx:221
 msgid "Comments"
-msgstr "評論"
+msgstr "留言"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:542
 msgid "Comments from logged-in CMS users are approved automatically"
-msgstr ""
+msgstr "已登入的 CMS 使用者所發表的留言會自動核准"
 
 #: packages/admin/src/components/SignupPage.tsx:403
 msgid "Complete signup"
@@ -1731,11 +1731,11 @@ msgstr "完成註冊"
 
 #: packages/admin/src/components/Widgets.tsx:929
 msgid "Component"
-msgstr ""
+msgstr "元件"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Configure Field"
-msgstr "配置字段"
+msgstr "設定欄位"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
 msgid "Confirm"
@@ -1744,29 +1744,29 @@ msgstr "確認"
 #: packages/admin/src/components/WordPressImport.tsx:701
 #: packages/admin/src/components/WordPressImport.tsx:1054
 msgid "Connect"
-msgstr ""
+msgstr "連線"
 
 #: packages/admin/src/components/WordPressImport.tsx:1507
 msgid "Connect & Analyze"
-msgstr "連接並分析"
+msgstr "連線並分析"
 
 #. placeholder {0}: siteTitle || "WordPress"
 #: packages/admin/src/components/WordPressImport.tsx:1457
 msgid "Connect to {0}"
-msgstr "連接到 {0}"
+msgstr "連線至 {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1373
 msgid "Connect with WordPress"
-msgstr "連接 WordPress"
+msgstr "連線至 WordPress"
 
 #. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:286
 msgid "Connected {0}"
-msgstr "已連接 {0}"
+msgstr "已連線 {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:179
 msgid "content"
-msgstr ""
+msgstr "內容"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:378
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
@@ -1781,7 +1781,7 @@ msgstr "內容"
 
 #: packages/admin/src/components/Widgets.tsx:98
 msgid "Content Block"
-msgstr "內容塊"
+msgstr "內容區塊"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2382
@@ -1790,47 +1790,47 @@ msgstr "內容錯誤 ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1317
 msgid "Content found:"
-msgstr "找到的內容："
+msgstr "找到的內容:"
 
 #: packages/admin/src/router.tsx:1068
 msgid "Content has been scheduled for publishing"
-msgstr ""
+msgstr "已排程發佈內容"
 
 #: packages/admin/src/components/RevisionHistory.tsx:123
 msgid "Content has been updated to the selected revision."
-msgstr "內容已更新到所選修訂版本。"
+msgstr "內容已更新為選取的修訂版本。"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
-msgstr "內容 ID："
+msgstr "內容 ID:"
 
 #: packages/admin/src/router.tsx:1009
 msgid "Content is now live"
-msgstr ""
+msgstr "內容現已上線"
 
 #: packages/admin/src/components/WordPressImport.tsx:2371
 msgid "content items"
-msgstr "內容項"
+msgstr "內容項目"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
 msgid "Content Read"
-msgstr "內容讀取"
+msgstr "讀取內容"
 
 #: packages/admin/src/router.tsx:1027
 msgid "Content removed from public view"
-msgstr ""
+msgstr "已從公開頁面移除內容"
 
 #: packages/admin/src/router.tsx:1089
 msgid "Content reverted to draft"
-msgstr ""
+msgstr "內容已還原為草稿"
 
 #: packages/admin/src/components/RevisionHistory.tsx:304
 msgid "Content snapshot:"
-msgstr "內容快照："
+msgstr "內容快照:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1731
 msgid "Content to Import"
-msgstr "要導入的內容"
+msgstr "要匯入的內容"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:184
 #: packages/admin/src/components/ContentTypeList.tsx:40
@@ -1840,11 +1840,11 @@ msgstr "內容類型"
 
 #: packages/admin/src/components/WordPressImport.tsx:2310
 msgid "Content was skipped because it already exists"
-msgstr "內容已跳過，因爲它已存在"
+msgstr "因內容已存在而略過"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Content Write"
-msgstr "內容寫入"
+msgstr "寫入內容"
 
 #: packages/admin/src/components/SignupPage.tsx:92
 msgid "Continue"
@@ -1857,81 +1857,81 @@ msgstr "繼續 →"
 
 #: packages/admin/src/components/WordPressImport.tsx:2529
 msgid "Continue Import"
-msgstr "繼續導入"
+msgstr "繼續匯入"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
 msgid "Contributor"
-msgstr "貢獻者"
+msgstr "投稿者"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:234
 #: packages/admin/src/components/users/InviteUserModal.tsx:133
 msgid "Copied to clipboard"
-msgstr "已複製到剪貼板"
+msgstr "已複製到剪貼簿"
 
 #. placeholder {0}: section.slug
 #: packages/admin/src/components/Sections.tsx:399
 msgid "Copy {0} to clipboard"
-msgstr "複製 {0} 到剪貼板"
+msgstr "將 {0} 複製到剪貼簿"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:124
 msgid "Copy invite link"
-msgstr "複製邀請鏈接"
+msgstr "複製邀請連結"
 
 #: packages/admin/src/components/Sections.tsx:398
 msgid "Copy slug"
-msgstr "複製 slug"
+msgstr "複製代稱"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Copy this token now — it won't be shown again."
-msgstr "立即複製此令牌 — 它將不再顯示。"
+msgstr "請立即複製這個權杖 — 之後不會再次顯示。"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
 msgid "Copy token"
-msgstr "複製令牌"
+msgstr "複製權杖"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:322
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:323
 #: packages/admin/src/components/MediaDetailPanel.tsx:301
 msgid "Copy URL"
-msgstr ""
+msgstr "複製網址"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:136
 msgid "Could not copy automatically. Please select the URL above and copy manually."
-msgstr "無法自動複製。請選擇上面的 URL 並手動複製。"
+msgstr "無法自動複製。請選取上方網址並手動複製。"
 
 #: packages/admin/src/components/Dashboard.tsx:84
 msgid "Could not load dashboard data"
-msgstr ""
+msgstr "無法載入控制台資料"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:486
 msgid "Could not load image from URL"
-msgstr "無法從 URL 加載圖片"
+msgstr "無法從 URL 載入圖片"
 
 #: packages/admin/src/components/WordPressImport.tsx:1264
 msgid "Couldn't detect WordPress"
-msgstr "無法檢測到 WordPress"
+msgstr "無法偵測 WordPress"
 
 #: packages/admin/src/routes/byline-schema.tsx:268
 msgid "Couldn't load byline fields."
-msgstr ""
+msgstr "無法載入署名欄位。"
 
 #: packages/admin/src/routes/bylines.tsx:547
 msgid "Couldn't load custom fields."
-msgstr ""
+msgstr "無法載入自訂欄位。"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:88
 msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
-msgstr ""
+msgstr "無法將「{draft}」對應至 MIME 類型。請直接輸入 MIME。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:846
 msgid "Couldn't search bylines. Please try again."
-msgstr ""
+msgstr "無法搜尋署名。請再試一次。"
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
 msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
-msgstr ""
+msgstr "無法確認有多少值參照「{0}」。刪除後仍會移除這個欄位所有已儲存的值 — 但無法檢查上方的數量。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:842
 msgid "Count"
@@ -1945,182 +1945,182 @@ msgstr "數量"
 #: packages/admin/src/components/Widgets.tsx:452
 #: packages/admin/src/routes/bylines.tsx:579
 msgid "Create"
-msgstr "創建"
+msgstr "建立"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:292
 msgid "Create \"{trimmedInput}\""
-msgstr ""
+msgstr "建立「{trimmedInput}」"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1140
 msgid "Create a bullet list"
-msgstr "創建無序列表"
+msgstr "建立項目符號清單"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:383
 msgid "Create a new {0}"
-msgstr "創建新的 {0}"
+msgstr "建立新的 {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1150
 msgid "Create a numbered list"
-msgstr "創建有序列表"
+msgstr "建立編號清單"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:84
 #: packages/admin/src/components/SignupPage.tsx:221
 msgid "Create Account"
-msgstr "創建帳戶"
+msgstr "建立帳號"
 
 #: packages/admin/src/components/SignupPage.tsx:401
 msgid "Create an account"
-msgstr "創建帳戶"
+msgstr "建立帳號"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:926
 #: packages/admin/src/routes/bylines.tsx:476
 msgid "Create byline"
-msgstr "創建署名"
+msgstr "建立署名"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 msgid "Create Content Type"
-msgstr ""
+msgstr "建立內容類型"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Create field"
-msgstr ""
+msgstr "建立欄位"
 
 #: packages/admin/src/components/MenuList.tsx:127
 #: packages/admin/src/components/MenuList.tsx:190
 msgid "Create Menu"
-msgstr "創建菜單"
+msgstr "建立選單"
 
 #: packages/admin/src/components/MenuList.tsx:134
 msgid "Create New Menu"
-msgstr "創建新菜單"
+msgstr "建立新選單"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:409
 msgid "Create New Token"
-msgstr "創建新令牌"
+msgstr "建立新權杖"
 
 #: packages/admin/src/components/WordPressImport.tsx:1501
 msgid "Create one in WordPress: Users → Profile → Application Passwords"
-msgstr "在 WordPress 中創建：用戶 → 個人資料 → 應用程式密碼"
+msgstr "在 WordPress 中建立: [使用者] → [個人資料] → [應用程式密碼]"
 
 #: packages/admin/src/components/SetupWizard.tsx:298
 msgid "Create Passkey"
-msgstr "創建通行密鑰"
+msgstr "建立通行金鑰"
 
 #: packages/admin/src/components/Settings.tsx:111
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:195
 msgid "Create personal access tokens for programmatic API access"
-msgstr "創建個人訪問令牌以通過程式訪問 API"
+msgstr "建立個人存取權杖，以透過程式存取 API"
 
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:248
 msgid "Create redirect for {0}"
-msgstr "爲 {0} 創建重定向"
+msgstr "為 {0} 建立重新導向"
 
 #: packages/admin/src/components/Redirects.tsx:247
 msgid "Create redirect for this path"
-msgstr "爲此路徑創建重定向"
+msgstr "為這個路徑建立重新導向"
 
 #: packages/admin/src/components/Redirects.tsx:462
 msgid "Create redirect rules to manage URL changes."
-msgstr "創建重定向規則以管理 URL 更改。"
+msgstr "建立重新導向規則以管理網址變更。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1921
 msgid "Create Schema & Import"
-msgstr "創建架構並導入"
+msgstr "建立結構描述並匯入"
 
 #: packages/admin/src/components/Sections.tsx:150
 #: packages/admin/src/components/Sections.tsx:270
 msgid "Create Section"
-msgstr "創建區塊"
+msgstr "建立區段"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:110
 msgid "Create sections in the Sections library to use them here"
-msgstr "在區塊庫中創建區塊以便在此使用"
+msgstr "請先在區段庫中建立區段，才能在這裡使用"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:620
 #: packages/admin/src/components/TaxonomyManager.tsx:711
 msgid "Create Taxonomy"
-msgstr "創建分類"
+msgstr "建立分類法"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:269
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:477
 msgid "Create Token"
-msgstr "創建令牌"
+msgstr "建立權杖"
 
 #: packages/admin/src/components/Widgets.tsx:408
 msgid "Create Widget Area"
-msgstr ""
+msgstr "建立小工具區域"
 
 #: packages/admin/src/components/SetupWizard.tsx:560
 msgid "Create your account"
-msgstr "創建您的帳戶"
+msgstr "建立您的帳號"
 
 #: packages/admin/src/components/MenuList.tsx:188
 msgid "Create your first navigation menu to get started"
-msgstr "創建您的第一個導航菜單以開始使用"
+msgstr "建立第一個導覽選單以開始使用"
 
 #: packages/admin/src/components/ContentList.tsx:556
 #: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
-msgstr "創建第一個內容"
+msgstr "建立第一個項目"
 
 #: packages/admin/src/components/Sections.tsx:267
 msgid "Create your first reusable content section to get started."
-msgstr "創建您的第一個可重用內容區塊以開始使用。"
+msgstr "建立第一個可重複使用的內容區段即可開始。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:75
 #: packages/admin/src/components/SignupPage.tsx:212
 msgid "Create your passkey"
-msgstr "創建您的通行密鑰"
+msgstr "建立您的通行金鑰"
 
 #: packages/admin/src/lib/api/marketplace.ts:280
 #: packages/admin/src/lib/api/marketplace.ts:289
 msgid "Create, update, and delete content"
-msgstr ""
+msgstr "建立、更新及刪除內容"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:82
 msgid "Create, update, and delete navigation menus"
-msgstr "創建、更新、刪除導航菜單"
+msgstr "建立、更新及刪除導覽選單"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:77
 msgid "Create, update, and delete taxonomy terms"
-msgstr "創建、更新、刪除分類術語"
+msgstr "建立、更新及刪除分類項目"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:52
 msgid "Create, update, delete content"
-msgstr "創建、更新、刪除內容"
+msgstr "建立、更新、刪除內容"
 
 #: packages/admin/src/components/ContentList.tsx:736
 #: packages/admin/src/components/ContentSettingsPanel.tsx:525
 #: packages/admin/src/components/users/UserDetail.tsx:219
 msgid "Created"
-msgstr "已創建"
+msgstr "建立時間"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:96
 msgid "Created \"{0}\"."
-msgstr ""
+msgstr "已建立「{0}」。"
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 #: packages/admin/src/components/users/UserDetail.tsx:260
 msgid "Created {0}"
-msgstr "創建於 {0}"
+msgstr "建立於 {0}"
 
 #. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
 #: packages/admin/src/router.tsx:1120
 msgid "Created {0} translation"
-msgstr ""
+msgstr "已建立 {0} 翻譯"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "Created At"
-msgstr "創建時間"
+msgstr "建立時間"
 
 #: packages/admin/src/components/WordPressImport.tsx:887
 msgid "Creating collections and fields..."
-msgstr "正在創建合集和字段..."
+msgstr "正在建立內容集合及欄位…"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:978
 #: packages/admin/src/components/MenuList.tsx:176
@@ -2130,47 +2130,47 @@ msgstr "正在創建合集和字段..."
 #: packages/admin/src/components/TaxonomyManager.tsx:711
 #: packages/admin/src/components/TaxonomySidebar.tsx:292
 msgid "Creating..."
-msgstr "創建中..."
+msgstr "正在建立…"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:33
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:83
 msgid "current"
-msgstr "當前"
+msgstr "目前"
 
 #: packages/admin/src/components/RevisionHistory.tsx:272
 msgid "Current"
-msgstr "當前版本"
+msgstr "目前版本"
 
 #: packages/admin/src/components/PluginSettings.tsx:340
 msgid "Currently set — enter a new value to replace"
-msgstr ""
+msgstr "目前已設定 — 輸入新值即可取代"
 
 #: packages/admin/src/components/Sections.tsx:46
 msgid "Custom"
-msgstr "自定義"
+msgstr "自訂"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:623
 msgid "Custom Fields"
-msgstr ""
+msgstr "自訂欄位"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:210
 msgid "Custom robots.txt content. Leave empty to use the default."
-msgstr "自定義 robots.txt 內容。留空則使用默認值。"
+msgstr "自訂 robots.txt 內容。留空即可使用預設值。"
 
 #: packages/admin/src/components/SectionEditor.tsx:185
 msgid "Custom Section"
-msgstr "自定義區塊"
+msgstr "自訂區段"
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "Custom Taxonomies"
-msgstr ""
+msgstr "自訂分類法"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:176
 msgid "Daily automatic backups"
-msgstr ""
+msgstr "每日自動備份"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
@@ -2186,7 +2186,7 @@ msgstr "深色"
 #: packages/admin/src/components/Sidebar.tsx:206
 #: packages/admin/src/components/Sidebar.tsx:356
 msgid "Dashboard"
-msgstr "儀表板"
+msgstr "控制台"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:297
 #: packages/admin/src/components/ContentList.tsx:525
@@ -2196,15 +2196,15 @@ msgstr "日期"
 #: packages/admin/src/components/FieldEditor.tsx:180
 #: packages/admin/src/components/FieldEditor.tsx:584
 msgid "Date & Time"
-msgstr "日期和時間"
+msgstr "日期與時間"
 
 #: packages/admin/src/components/FieldEditor.tsx:181
 msgid "Date and time picker"
-msgstr "日期和時間選擇器"
+msgstr "日期與時間選擇器"
 
 #: packages/admin/src/components/ContentList.tsx:790
 msgid "Date field to filter on"
-msgstr ""
+msgstr "用來篩選的日期欄位"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:281
 msgid "Date Format"
@@ -2212,44 +2212,44 @@ msgstr "日期格式"
 
 #: packages/admin/src/components/FieldEditor.tsx:163
 msgid "Decimal number"
-msgstr "十進制數字"
+msgstr "小數"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:750
 msgid "Declared permissions"
-msgstr ""
+msgstr "宣告的權限"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:294
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:356
 msgid "Default Role"
-msgstr "默認角色"
+msgstr "預設角色"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:233
 msgid "Default role:"
-msgstr "默認角色："
+msgstr "預設角色:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:147
 msgid "Default social image"
-msgstr ""
+msgstr "預設社群圖片"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:138
 msgid "Default Social Image"
-msgstr ""
+msgstr "預設社群圖片"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:623
 msgid "Define a new taxonomy for classifying content"
-msgstr "定義新的分類以對內容進行分類"
+msgstr "定義新的分類法以分類內容"
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr ""
+msgstr "定義每筆署名資料儲存的自訂欄位，例如職稱、代名詞、社群媒體代號等。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:41
 msgid "Define the structure of your content"
-msgstr "定義您的內容結構"
+msgstr "定義內容結構"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:360
 msgid "Defined in code"
-msgstr "程式碼定義"
+msgstr "在程式碼中定義"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:268
 #: packages/admin/src/components/comments/CommentInbox.tsx:408
@@ -2277,7 +2277,7 @@ msgstr "刪除"
 #. placeholder {0}: item.filename
 #: packages/admin/src/components/MediaDetailPanel.tsx:452
 msgid "Delete \"{0}\"? This cannot be undone."
-msgstr "刪除 \"{0}\"？此操作無法撤銷。"
+msgstr "要刪除「{0}」嗎？此操作無法復原。"
 
 #. placeholder {0}: archive.name
 #. placeholder {0}: collection.label
@@ -2295,77 +2295,77 @@ msgstr "刪除 {0}"
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:749
 msgid "Delete {0} field"
-msgstr ""
+msgstr "刪除 {0} 欄位"
 
 #. placeholder {0}: menu.name
 #: packages/admin/src/components/MenuList.tsx:238
 msgid "Delete {0} menu"
-msgstr "刪除 {0} 菜單"
+msgstr "刪除 {0} 選單"
 
 #. placeholder {0}: area.label
 #: packages/admin/src/components/Widgets.tsx:662
 msgid "Delete {0} widget area"
-msgstr ""
+msgstr "刪除 {0} 小工具區域"
 
 #. placeholder {0}: taxonomyDef.labelSingular || "Term"
 #: packages/admin/src/components/TaxonomyManager.tsx:902
 msgid "Delete {0}?"
-msgstr "刪除 {0}？"
+msgstr "要刪除 {0} 嗎？"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:282
 msgid "Delete backup?"
-msgstr ""
+msgstr "要刪除備份嗎？"
 
 #: packages/admin/src/routes/byline-schema.tsx:358
 msgid "Delete byline field?"
-msgstr ""
+msgstr "要刪除署名欄位嗎？"
 
 #: packages/admin/src/routes/bylines.tsx:622
 msgid "Delete Byline?"
-msgstr ""
+msgstr "要刪除署名嗎？"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3343
 msgid "Delete column"
-msgstr ""
+msgstr "刪除欄"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:406
 msgid "Delete Comment?"
-msgstr "刪除評論？"
+msgstr "要刪除留言嗎？"
 
 #: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
-msgstr "刪除內容類型？"
+msgstr "要刪除內容類型嗎？"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:379
 msgid "Delete embed"
-msgstr ""
+msgstr "刪除嵌入內容"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:666
 msgid "Delete Field?"
-msgstr ""
+msgstr "要刪除欄位嗎？"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:237
 #: packages/admin/src/components/editor/GalleryNode.tsx:219
 #: packages/admin/src/components/editor/GalleryNode.tsx:220
 msgid "Delete gallery"
-msgstr ""
+msgstr "刪除圖庫"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
 msgid "Delete HTML block"
-msgstr ""
+msgstr "刪除 HTML 區塊"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:220
 #: packages/admin/src/components/editor/ImageNode.tsx:221
 msgid "Delete image"
-msgstr ""
+msgstr "刪除圖片"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:451
 msgid "Delete Media?"
-msgstr "刪除媒體？"
+msgstr "要刪除媒體嗎？"
 
 #: packages/admin/src/components/MenuList.tsx:254
 msgid "Delete Menu"
-msgstr "刪除菜單"
+msgstr "刪除選單"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:526
 msgid "Delete permanently"
@@ -2378,36 +2378,36 @@ msgstr "永久刪除"
 
 #: packages/admin/src/components/ContentList.tsx:1116
 msgid "Delete Permanently?"
-msgstr "永久刪除？"
+msgstr "要永久刪除嗎？"
 
 #: packages/admin/src/components/Redirects.tsx:536
 msgid "Delete redirect"
-msgstr "刪除重定向"
+msgstr "刪除重新導向"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:537
 msgid "Delete redirect {0}"
-msgstr "刪除重定向 {0}"
+msgstr "刪除重新導向 {0}"
 
 #: packages/admin/src/components/Redirects.tsx:581
 msgid "Delete Redirect?"
-msgstr "刪除重定向？"
+msgstr "要刪除重新導向嗎？"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3362
 msgid "Delete row"
-msgstr ""
+msgstr "刪除列"
 
 #: packages/admin/src/components/Sections.tsx:296
 msgid "Delete Section?"
-msgstr "刪除區塊？"
+msgstr "要刪除區段嗎？"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3377
 msgid "Delete table"
-msgstr ""
+msgstr "刪除表格"
 
 #: packages/admin/src/components/Widgets.tsx:712
 msgid "Delete Widget Area?"
-msgstr ""
+msgstr "要刪除小工具區域嗎？"
 
 #: packages/admin/src/components/ContentList.tsx:646
 msgid "Deleted"
@@ -2417,7 +2417,7 @@ msgstr "已刪除"
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr ""
+msgstr "刪除「{0}」也會移除所有署名資料中的 {1, plural, one {# 個已儲存值} other {# 個已儲存值}}。此動作無法復原。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:409
 #: packages/admin/src/components/ContentTypeEditor.tsx:673
@@ -2432,28 +2432,28 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:715
 #: packages/admin/src/routes/bylines.tsx:625
 msgid "Deleting..."
-msgstr "刪除中..."
+msgstr "正在刪除..."
 
 #: packages/admin/src/routes/byline-schema.tsx:379
 msgid "Deleting…"
-msgstr ""
+msgstr "正在刪除…"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
 msgid "Demo"
-msgstr "演示"
+msgstr "示範"
 
 #: packages/admin/src/routes/users.tsx:303
 msgid "Demote User"
-msgstr ""
+msgstr "降低使用者角色"
 
 #: packages/admin/src/routes/users.tsx:294
 msgid "Demote User?"
-msgstr ""
+msgstr "要調降使用者權限嗎？"
 
 #: packages/admin/src/routes/users.tsx:304
 msgid "Demoting..."
-msgstr ""
+msgstr "正在降低角色…"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:270
 msgid "Deny"
@@ -2462,17 +2462,17 @@ msgstr "拒絕"
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:379
 #: packages/admin/src/components/editor/ImageNode.tsx:238
 msgid "Describe the image..."
-msgstr ""
+msgstr "描述圖片…"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
 #: packages/admin/src/components/MediaDetailPanel.tsx:374
 msgid "Describe this image for accessibility"
-msgstr "描述此圖片以供無障礙訪問"
+msgstr "請提供此圖片的無障礙說明"
 
 #: packages/admin/src/components/SectionEditor.tsx:277
 msgid "Describe what this section is for..."
-msgstr "描述此區塊的用途..."
+msgstr "說明此區段的用途…"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:413
 #: packages/admin/src/components/RegistryPluginDetail.tsx:805
@@ -2480,121 +2480,121 @@ msgstr "描述此區塊的用途..."
 #: packages/admin/src/components/Sections.tsx:200
 #: packages/admin/src/components/Widgets.tsx:436
 msgid "Description"
-msgstr "描述"
+msgstr "說明"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:456
 msgid "Description (optional)"
-msgstr "描述（可選）"
+msgstr "說明 (選填)"
 
 #: packages/admin/src/components/Redirects.tsx:469
 msgid "Destination"
-msgstr "目標"
+msgstr "目的地"
 
 #: packages/admin/src/components/Redirects.tsx:141
 msgid "Destination path"
-msgstr "目標路徑"
+msgstr "目的地路徑"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:153
 #: packages/admin/src/components/PluginManager.tsx:563
 msgid "Destructive"
-msgstr ""
+msgstr "破壞性操作"
 
 #: packages/admin/src/components/PluginManager.tsx:505
 msgid "details"
-msgstr "詳情"
+msgstr "詳細資料"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:186
 msgid "Device authorized"
-msgstr "設備已授權"
+msgstr "已授權裝置"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:229
 msgid "Device code"
-msgstr "設備代碼"
+msgstr "裝置代碼"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Device-bound"
-msgstr "設備綁定"
+msgstr "裝置綁定"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Device-bound passkey"
-msgstr "設備綁定通行密鑰"
+msgstr "裝置綁定的通行金鑰"
 
 #: packages/admin/src/components/SignupPage.tsx:144
 msgid "Didn't receive the email?"
-msgstr "未收到郵件？"
+msgstr "沒有收到電子郵件嗎？"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:34
 msgid "Diff"
-msgstr ""
+msgstr "Diff"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:280
 msgid "Dimensions:"
-msgstr "尺寸："
+msgstr "尺寸:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Disable"
-msgstr "禁用"
+msgstr "停用"
 
 #: packages/admin/src/components/PluginManager.tsx:493
 msgid "Disable plugin"
-msgstr "禁用插件"
+msgstr "停用外掛"
 
 #: packages/admin/src/components/PluginManager.tsx:553
 msgid "Disable plugin MCP tools"
-msgstr ""
+msgstr "停用外掛 MCP 工具"
 
 #: packages/admin/src/components/Redirects.tsx:505
 msgid "Disable redirect"
-msgstr "禁用重定向"
+msgstr "停用重新導向"
 
 #: packages/admin/src/routes/users.tsx:279
 msgid "Disable User"
-msgstr ""
+msgstr "停用使用者"
 
 #: packages/admin/src/routes/users.tsx:272
 msgid "Disable User?"
-msgstr ""
+msgstr "要停用使用者嗎？"
 
 #: packages/admin/src/components/PluginManager.tsx:382
 #: packages/admin/src/components/Redirects.tsx:419
 #: packages/admin/src/components/users/UserDetail.tsx:201
 #: packages/admin/src/components/users/UserList.tsx:212
 msgid "Disabled"
-msgstr "已禁用"
+msgstr "已停用"
 
 #: packages/admin/src/components/PluginManager.tsx:613
 msgid "Disabled:"
-msgstr "已禁用："
+msgstr "已停用:"
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #: packages/admin/src/routes/users.tsx:274
 msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
-msgstr ""
+msgstr "停用 <0>{0}</0> 後，對方在重新啟用前將無法登入。其內容會予以保留。"
 
 #: packages/admin/src/routes/users.tsx:280
 msgid "Disabling..."
-msgstr ""
+msgstr "正在停用..."
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:438
 msgid "Discard"
-msgstr ""
+msgstr "捨棄"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:73
 #: packages/admin/src/components/ContentSettingsPanel.tsx:93
 msgid "Discard changes"
-msgstr "放棄更改"
+msgstr "捨棄變更"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:436
 msgid "Discard changes?"
-msgstr ""
+msgstr "要捨棄變更嗎？"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:78
 msgid "Discard draft changes?"
-msgstr "放棄草稿更改？"
+msgstr "要捨棄草稿變更嗎？"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:439
 msgid "Discarding..."
-msgstr ""
+msgstr "正在捨棄變更…"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:241
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:243
@@ -2603,15 +2603,15 @@ msgstr "關閉"
 
 #: packages/admin/src/components/Widgets.tsx:127
 msgid "Display a list of recent posts"
-msgstr ""
+msgstr "顯示近期文章清單"
 
 #: packages/admin/src/components/Widgets.tsx:105
 msgid "Display a navigation menu"
-msgstr "顯示導航菜單"
+msgstr "顯示導覽選單"
 
 #: packages/admin/src/components/Widgets.tsx:136
 msgid "Display category list"
-msgstr ""
+msgstr "顯示分類清單"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:929
 #: packages/admin/src/components/ContentSettingsPanel.tsx:991
@@ -2621,7 +2621,7 @@ msgstr "顯示名稱"
 
 #: packages/admin/src/components/MenuList.tsx:168
 msgid "Display name for admin interface"
-msgstr "管理界面的顯示名稱"
+msgstr "管理後台介面的顯示名稱"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:269
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:458
@@ -2630,16 +2630,16 @@ msgstr "顯示尺寸"
 
 #: packages/admin/src/components/Widgets.tsx:144
 msgid "Display tag cloud"
-msgstr ""
+msgstr "顯示標籤雲"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
 msgid "Displayed below the image as a visible caption."
-msgstr "顯示在圖片下方作爲可見說明。"
+msgstr "顯示在圖片下方的可見圖說。"
 
 #: packages/admin/src/components/ContentEditor.tsx:697
 msgid "Distraction-free mode (⌘⇧\\)"
-msgstr "無干擾模式（⌘⇧\\）"
+msgstr "專注模式 (⌘⇧\\)"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1194
 msgid "Divider"
@@ -2647,32 +2647,32 @@ msgstr "分隔線"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:35
 msgid "Dockerfile"
-msgstr ""
+msgstr "Dockerfile"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 #: packages/admin/src/components/MediaLibrary.tsx:437
 msgid "Documents"
-msgstr ""
+msgstr "文件"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:286
 msgid "Domain"
-msgstr "域名"
+msgstr "網域"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:66
 msgid "Domain added successfully"
-msgstr "域名添加成功"
+msgstr "已成功新增網域"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
 msgid "Domain removed"
-msgstr "域名已移除"
+msgstr "網域已移除"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
 msgid "Domain updated"
-msgstr "域名已更新"
+msgstr "網域已更新"
 
 #: packages/admin/src/components/LoginPage.tsx:334
 msgid "Don't have an account? <0>Sign up</0>"
-msgstr "還沒有帳號？<0>立即註冊</0>"
+msgstr "還沒有帳號嗎？<0>註冊</0>"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:142
 #: packages/admin/src/components/WordPressImport.tsx:2128
@@ -2686,31 +2686,31 @@ msgstr "下移"
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:238
 msgid "Download {0}"
-msgstr ""
+msgstr "下載 {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:158
 msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
-msgstr ""
+msgstr "下載完整網站備份: 所有內容 (包括草稿及回收桶中的內容)、內容集合、分類法、選單、小工具、媒體中繼資料及網站設定。絕不包含使用者帳號及機密資訊。"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:160
 msgid "Download backup"
-msgstr ""
+msgstr "下載備份"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:155
 msgid "Download Backup"
-msgstr ""
+msgstr "下載備份"
 
 #: packages/admin/src/components/Settings.tsx:123
 msgid "Download backups and schedule automatic backups to storage"
-msgstr ""
+msgstr "下載備份，並排程將備份自動儲存至儲存空間"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:492
 msgid "Download SBOM"
-msgstr ""
+msgstr "下載 SBOM"
 
 #: packages/admin/src/components/WordPressImport.tsx:2126
 msgid "Downloading"
-msgstr "下載中"
+msgstr "正在下載"
 
 #: packages/admin/src/components/ContentList.tsx:1162
 msgid "draft"
@@ -2725,7 +2725,7 @@ msgstr "草稿"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:119
 msgid "draft, published, or archived"
-msgstr "草稿、已發佈或已歸檔"
+msgstr "草稿、已發佈或已封存"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:71
 #: packages/admin/src/components/Dashboard.tsx:251
@@ -2734,50 +2734,50 @@ msgstr "草稿"
 
 #: packages/admin/src/components/WordPressImport.tsx:1166
 msgid "Drafts & Private"
-msgstr ""
+msgstr "草稿與私密內容"
 
 #: packages/admin/src/components/WordPressImport.tsx:1119
 msgid "Drag and drop or click to browse (.xml)"
-msgstr "拖放或點擊瀏覽 (.xml)"
+msgstr "拖放或按一下以瀏覽 (.xml)"
 
 #: packages/admin/src/components/Widgets.tsx:698
 msgid "Drag here to add"
-msgstr ""
+msgstr "拖曳至此處以新增"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2006
 msgid "Drag to reorder"
-msgstr "拖動以重新排序"
+msgstr "拖曳以重新排序"
 
 #. placeholder {0}: field.label
 #. placeholder {0}: widget.title ?? t`widget`
 #: packages/admin/src/components/ContentTypeEditor.tsx:716
 #: packages/admin/src/components/Widgets.tsx:800
 msgid "Drag to reorder {0}"
-msgstr ""
+msgstr "拖曳以重新排序 {0}"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:338
 msgid "Drag to reorder block"
-msgstr ""
+msgstr "拖曳以重新排序區塊"
 
 #: packages/admin/src/components/Widgets.tsx:702
 msgid "Drag widgets here to add them"
-msgstr ""
+msgstr "將小工具拖曳至此處即可新增"
 
 #: packages/admin/src/components/Widgets.tsx:465
 msgid "Drag widgets into an area to add them"
-msgstr ""
+msgstr "將小工具拖曳至區域即可新增"
 
 #: packages/admin/src/components/Widgets.tsx:698
 msgid "Drop to add widget"
-msgstr ""
+msgstr "放開以新增小工具"
 
 #: packages/admin/src/components/WordPressImport.tsx:1588
 msgid "Drop your WordPress export file here"
-msgstr "將 WordPress 導出文件拖放到此處"
+msgstr "將 WordPress 匯出檔案拖放到這裡"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:292
 msgid "Duplicate"
-msgstr ""
+msgstr "複製"
 
 #: packages/admin/src/components/ContentList.tsx:1027
 msgid "Duplicate {title}"
@@ -2785,19 +2785,19 @@ msgstr "複製 {title}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr ""
+msgstr "例如 application/zip 或 .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:168
 msgid "e.g. import, blog"
-msgstr ""
+msgstr "例如 import、blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:423
 msgid "e.g., CI/CD Pipeline"
-msgstr "例如：CI/CD 流水線"
+msgstr "例如 CI/CD Pipeline"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr "例如：MacBook Pro、iPhone"
+msgstr "例如 MacBook Pro、iPhone"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:881
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
@@ -2825,11 +2825,11 @@ msgstr "編輯 {0}"
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:741
 msgid "Edit {0} field"
-msgstr ""
+msgstr "編輯 {0} 欄位"
 
 #: packages/admin/src/components/ContentEditor.tsx:643
 msgid "Edit {itemLabel}"
-msgstr ""
+msgstr "編輯 {itemLabel}"
 
 #: packages/admin/src/components/ContentList.tsx:1019
 msgid "Edit {title}"
@@ -2841,113 +2841,113 @@ msgstr "編輯署名"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "Edit byline field"
-msgstr ""
+msgstr "編輯署名欄位"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:331
 msgid "Edit Domain"
-msgstr "編輯域名"
+msgstr "編輯網域"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Edit Field"
-msgstr "編輯字段"
+msgstr "編輯欄位"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryNode.tsx:178
 msgid "Edit image {0}"
-msgstr ""
+msgstr "編輯圖片 {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3266
 msgid "Edit link"
-msgstr ""
+msgstr "編輯連結"
 
 #: packages/admin/src/components/MenuEditor.tsx:573
 msgid "Edit Menu Item"
-msgstr "編輯菜單項"
+msgstr "編輯選單項目"
 
 #: packages/admin/src/components/MenuEditor.tsx:369
 msgid "Edit menu items"
-msgstr "編輯菜單項"
+msgstr "編輯選單項目"
 
 #: packages/admin/src/components/Redirects.tsx:528
 msgid "Edit redirect"
-msgstr "編輯重定向"
+msgstr "編輯重新導向"
 
 #: packages/admin/src/components/Redirects.tsx:106
 msgid "Edit Redirect"
-msgstr "編輯重定向"
+msgstr "編輯重新導向"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:529
 msgid "Edit redirect {0}"
-msgstr "編輯重定向 {0}"
+msgstr "編輯重新導向 {0}"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:368
 msgid "Edit URL"
-msgstr ""
+msgstr "編輯網址"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
-msgstr "編輯"
+msgstr "編輯者"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:305
 msgid ""
 "Editor\n"
 "Reporter\n"
 "Photographer"
-msgstr ""
+msgstr "編輯者\n記者\n攝影師"
 
 #: packages/admin/src/components/WordPressImport.tsx:1044
 msgid "em1.…"
-msgstr ""
+msgstr "em1.…"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:62
 #: packages/admin/src/components/Settings.tsx:116
 #: packages/admin/src/components/SignupPage.tsx:198
 #: packages/admin/src/components/users/UserDetail.tsx:154
 msgid "Email"
-msgstr "郵箱"
+msgstr "電子郵件"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:330
 msgid "Email (optional)"
-msgstr "郵箱（可選）"
+msgstr "電子郵件地址 (選填)"
 
 #: packages/admin/src/components/LoginPage.tsx:127
 #: packages/admin/src/components/SignupPage.tsx:67
 #: packages/admin/src/components/users/InviteUserModal.tsx:152
 msgid "Email address"
-msgstr "郵箱地址"
+msgstr "電子郵件地址"
 
 #: packages/admin/src/components/SetupWizard.tsx:179
 #: packages/admin/src/components/SignupPage.tsx:50
 msgid "Email is required"
-msgstr "郵箱爲必填項"
+msgstr "電子郵件為必填"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:187
 msgid "Email Middleware"
-msgstr "郵件中間件"
+msgstr "電子郵件中介軟體"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:99
 msgid "Email Pipeline"
-msgstr "郵件管道"
+msgstr "電子郵件處理管線"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:172
 msgid "Email provider active"
-msgstr "郵件提供商已激活"
+msgstr "電子郵件服務提供者已啟用"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:77
 #: packages/admin/src/components/settings/EmailSettings.tsx:92
 msgid "Email Settings"
-msgstr "郵件設置"
+msgstr "電子郵件設定"
 
 #: packages/admin/src/components/users/UserDetail.tsx:235
 msgid "Email verified"
-msgstr "郵箱已驗證"
+msgstr "電子郵件地址已驗證"
 
 #: packages/admin/src/components/SignupPage.tsx:190
 msgid "Email verified!"
-msgstr "郵箱已驗證！"
+msgstr "電子郵件地址已驗證。"
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:2442
@@ -2956,48 +2956,48 @@ msgstr "嵌入 {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2445
 msgid "Embeds"
-msgstr "嵌入"
+msgstr "嵌入內容"
 
 #: packages/admin/src/components/WordPressImport.tsx:1208
 msgid "EmDash Exporter"
-msgstr "EmDash 導出器"
+msgstr "EmDash Exporter"
 
 #: packages/admin/src/components/WordPressImport.tsx:1307
 msgid "EmDash Exporter plugin detected! You can import directly."
-msgstr "檢測到 EmDash 導出器插件！您可以直接導入。"
+msgstr "偵測到 EmDash Exporter 外掛。您可以直接匯入。"
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:160
 msgid "Empty gallery — open settings to add images"
-msgstr ""
+msgstr "空白圖庫 — 開啟設定以新增圖片"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
-msgstr "啓用"
+msgstr "啟用"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:493
 msgid "Enable comments"
-msgstr ""
+msgstr "啟用留言"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:87
 msgid "Enable full-text search on this collection"
-msgstr "在此合集上啓用全文搜索"
+msgstr "啟用此內容集合的全文搜尋"
 
 #: packages/admin/src/components/PluginManager.tsx:493
 msgid "Enable plugin"
-msgstr "啓用插件"
+msgstr "啟用外掛"
 
 #: packages/admin/src/components/PluginManager.tsx:554
 msgid "Enable plugin MCP tools"
-msgstr ""
+msgstr "啟用外掛 MCP 工具"
 
 #: packages/admin/src/components/Redirects.tsx:505
 msgid "Enable redirect"
-msgstr "啓用重定向"
+msgstr "啟用重新導向"
 
 #: packages/admin/src/components/Redirects.tsx:176
 #: packages/admin/src/components/Redirects.tsx:419
 msgid "Enabled"
-msgstr "已啓用"
+msgstr "已啟用"
 
 #: packages/admin/src/components/MenuEditor.tsx:423
 #: packages/admin/src/components/MenuEditor.tsx:601
@@ -3006,23 +3006,23 @@ msgstr "輸入 URL (https://…) 或相對路徑 (/…)"
 
 #: packages/admin/src/components/ContentEditor.tsx:1437
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr "輸入有效的 URL（例如 https://example.com）"
+msgstr "輸入有效的網址 (例如 https://example.com)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1380
 msgid "Enter credentials manually"
-msgstr "手動輸入憑據"
+msgstr "手動輸入認證資訊"
 
 #: packages/admin/src/components/ContentEditor.tsx:696
 msgid "Enter distraction-free mode"
-msgstr "進入無干擾模式"
+msgstr "進入專注模式"
 
 #: packages/admin/src/components/users/UserDetail.tsx:158
 msgid "Enter email"
-msgstr "輸入郵箱"
+msgstr "輸入電子郵件地址"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
 msgid "Enter HTML..."
-msgstr ""
+msgstr "輸入 HTML…"
 
 #: packages/admin/src/components/ContentEditor.tsx:1211
 msgid "Enter markdown content..."
@@ -3034,24 +3034,24 @@ msgstr "輸入名稱"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:177
 msgid "Enter the code from your terminal"
-msgstr "輸入終端中的代碼"
+msgstr "輸入終端機顯示的代碼"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:123
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:132
 msgid "Enter URL..."
-msgstr ""
+msgstr "輸入 URL…"
 
 #: packages/admin/src/components/LoginPage.tsx:327
 msgid "Enter your handle to sign in."
-msgstr "輸入您的賬號以登錄。"
+msgstr "輸入您的代號以登入。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1459
 msgid "Enter your WordPress credentials to import content directly."
-msgstr "輸入您的 WordPress 憑據以直接導入內容。"
+msgstr "輸入您的 WordPress 認證資訊，以直接匯入內容。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1082
 msgid "Enter your WordPress site URL"
-msgstr "輸入您的 WordPress 站點 URL"
+msgstr "輸入您的 WordPress 網站網址"
 
 #: packages/admin/src/components/MenuEditor.tsx:155
 #: packages/admin/src/components/MenuEditor.tsx:193
@@ -3064,23 +3064,23 @@ msgstr "錯誤"
 
 #: packages/admin/src/components/Widgets.tsx:236
 msgid "Error adding widget"
-msgstr ""
+msgstr "新增小工具時發生錯誤"
 
 #: packages/admin/src/components/Widgets.tsx:297
 msgid "Error reordering widgets"
-msgstr ""
+msgstr "重新排序小工具時發生錯誤"
 
 #: packages/admin/src/components/SectionEditor.tsx:53
 msgid "Error saving section"
-msgstr "保存區塊時出錯"
+msgstr "儲存區段時發生錯誤"
 
 #: packages/admin/src/components/Widgets.tsx:782
 msgid "Error updating widget"
-msgstr ""
+msgstr "更新小工具時發生錯誤"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:596
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
-msgstr ""
+msgstr "此外掛所有已發佈版本都已撤回或無法驗證。請稍後再回來查看，或聯絡發佈者。"
 
 #: packages/admin/src/components/WordPressImport.tsx:2010
 msgid "Exists"
@@ -3088,11 +3088,11 @@ msgstr "已存在"
 
 #: packages/admin/src/components/ContentEditor.tsx:755
 msgid "Exit distraction-free mode"
-msgstr "退出無干擾模式"
+msgstr "結束專注模式"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3830
 msgid "Exit Spotlight Mode"
-msgstr ""
+msgstr "結束焦點模式"
 
 #: packages/admin/src/components/PluginManager.tsx:505
 msgid "Expand"
@@ -3100,24 +3100,24 @@ msgstr "展開"
 
 #: packages/admin/src/components/PluginManager.tsx:499
 msgid "Expand details"
-msgstr "展開詳情"
+msgstr "展開詳細資料"
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:298
 msgid "Expires {0}"
-msgstr "過期於 {0}"
+msgstr "將於 {0} 到期"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:463
 msgid "Expiry"
-msgstr "過期時間"
+msgstr "到期日"
 
 #: packages/admin/src/components/WordPressImport.tsx:1273
 msgid "Export from WordPress manually"
-msgstr "從 WordPress 手動導出"
+msgstr "從 WordPress 手動匯出"
 
 #: packages/admin/src/components/WordPressImport.tsx:1397
 msgid "Export your content from WordPress to import everything including drafts."
-msgstr "從 WordPress 導出您的內容，以導入所有內容（包括草稿）。"
+msgstr "從 WordPress 匯出內容，即可匯入包括草稿在內的所有內容。"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:118
 msgid "Facebook"
@@ -3133,270 +3133,270 @@ msgstr "失敗"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:199
 msgid "Failed security audit"
-msgstr "安全審計失敗"
+msgstr "安全性稽核失敗"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:70
 msgid "Failed to add domain"
-msgstr "添加域名失敗"
+msgstr "新增網域失敗"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:188
 msgid "Failed to add passkey"
-msgstr ""
+msgstr "新增通行金鑰失敗"
 
 #: packages/admin/src/components/WordPressImport.tsx:413
 msgid "Failed to analyze WordPress site"
-msgstr ""
+msgstr "無法分析 WordPress 網站"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:54
 msgid "Failed to communicate with plugin"
-msgstr ""
+msgstr "無法與外掛通訊"
 
 #: packages/admin/src/lib/api/media.ts:155
 msgid "Failed to confirm upload"
-msgstr ""
+msgstr "無法確認上傳"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
-msgstr ""
+msgstr "無法建立管理員"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:104
 #: packages/admin/src/lib/api/backups.ts:51
 msgid "Failed to create backup"
-msgstr ""
+msgstr "無法建立備份"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:972
 msgid "Failed to create byline"
-msgstr "創建署名失敗"
+msgstr "無法建立署名"
 
 #: packages/admin/src/lib/api/byline-fields.ts:120
 msgid "Failed to create byline field"
-msgstr ""
+msgstr "建立署名欄位失敗"
 
 #: packages/admin/src/routes/byline-schema.tsx:102
 msgid "Failed to create field"
-msgstr ""
+msgstr "無法建立欄位"
 
 #: packages/admin/src/lib/api/sections.ts:88
 msgid "Failed to create section"
-msgstr ""
+msgstr "無法建立區段"
 
 #: packages/admin/src/components/WordPressImport.tsx:1714
 msgid "Failed to create some collections"
-msgstr "創建部分合集失敗"
+msgstr "建立部分內容集合失敗"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:497
 msgid "Failed to create term"
-msgstr "創建分類項失敗"
+msgstr "建立分類項目失敗"
 
 #: packages/admin/src/router.tsx:1125
 msgid "Failed to create translation"
-msgstr ""
+msgstr "無法建立翻譯"
 
 #: packages/admin/src/router.tsx:422
 #: packages/admin/src/router.tsx:451
 #: packages/admin/src/router.tsx:534
 #: packages/admin/src/router.tsx:1145
 msgid "Failed to delete"
-msgstr ""
+msgstr "無法刪除"
 
 #: packages/admin/src/lib/api/users.ts:345
 msgid "Failed to delete allowed domain"
-msgstr ""
+msgstr "刪除允許的網域失敗"
 
 #: packages/admin/src/lib/api/backups.ts:58
 msgid "Failed to delete backup"
-msgstr ""
+msgstr "刪除備份失敗"
 
 #: packages/admin/src/lib/api/bylines.ts:143
 msgid "Failed to delete byline"
-msgstr ""
+msgstr "刪除署名失敗"
 
 #: packages/admin/src/lib/api/byline-fields.ts:143
 msgid "Failed to delete byline field"
-msgstr ""
+msgstr "無法刪除署名欄位"
 
 #: packages/admin/src/lib/api/schema.ts:222
 msgid "Failed to delete collection"
-msgstr ""
+msgstr "無法刪除內容集合"
 
 #: packages/admin/src/lib/api/comments.ts:111
 #: packages/admin/src/router.tsx:1445
 msgid "Failed to delete comment"
-msgstr ""
+msgstr "刪除留言失敗"
 
 #: packages/admin/src/lib/api/content.ts:279
 msgid "Failed to delete content"
-msgstr ""
+msgstr "無法刪除內容"
 
 #: packages/admin/src/lib/api/schema.ts:278
 #: packages/admin/src/routes/byline-schema.tsx:138
 msgid "Failed to delete field"
-msgstr ""
+msgstr "無法刪除欄位"
 
 #: packages/admin/src/lib/api/media.ts:389
 msgid "Failed to delete from provider"
-msgstr ""
+msgstr "無法從服務提供者刪除"
 
 #: packages/admin/src/lib/api/media.ts:259
 msgid "Failed to delete media"
-msgstr ""
+msgstr "無法刪除媒體"
 
 #: packages/admin/src/lib/api/menus.ts:163
 msgid "Failed to delete menu"
-msgstr ""
+msgstr "無法刪除選單"
 
 #: packages/admin/src/lib/api/menus.ts:217
 msgid "Failed to delete menu item"
-msgstr ""
+msgstr "無法刪除選單項目"
 
 #: packages/admin/src/lib/api/users.ts:256
 msgid "Failed to delete passkey"
-msgstr ""
+msgstr "無法刪除通行金鑰"
 
 #: packages/admin/src/lib/api/redirects.ts:111
 msgid "Failed to delete redirect"
-msgstr ""
+msgstr "刪除重新導向失敗"
 
 #: packages/admin/src/lib/api/sections.ts:110
 msgid "Failed to delete section"
-msgstr ""
+msgstr "無法刪除區段"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
-msgstr ""
+msgstr "無法刪除分類項目"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
-msgstr ""
+msgstr "刪除小工具失敗"
 
 #: packages/admin/src/lib/api/widgets.ts:108
 msgid "Failed to delete widget area"
-msgstr ""
+msgstr "無法刪除小工具區域"
 
 #: packages/admin/src/components/PluginManager.tsx:120
 #: packages/admin/src/lib/api/plugins.ts:160
 msgid "Failed to disable plugin"
-msgstr "禁用插件失敗"
+msgstr "無法停用外掛"
 
 #: packages/admin/src/lib/api/search.ts:32
 msgid "Failed to disable search"
-msgstr ""
+msgstr "無法停用搜尋"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
-msgstr ""
+msgstr "無法停用使用者"
 
 #: packages/admin/src/router.tsx:1052
 msgid "Failed to discard changes"
-msgstr ""
+msgstr "捨棄變更失敗"
 
 #: packages/admin/src/components/WelcomeModal.tsx:70
 msgid "Failed to dismiss welcome"
-msgstr ""
+msgstr "關閉歡迎畫面失敗"
 
 #: packages/admin/src/router.tsx:465
 msgid "Failed to duplicate"
-msgstr ""
+msgstr "無法建立副本"
 
 #: packages/admin/src/components/PluginManager.tsx:101
 #: packages/admin/src/lib/api/plugins.ts:146
 msgid "Failed to enable plugin"
-msgstr "啓用插件失敗"
+msgstr "無法啟用外掛"
 
 #: packages/admin/src/lib/api/search.ts:31
 msgid "Failed to enable search"
-msgstr ""
+msgstr "啟用搜尋失敗"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
-msgstr ""
+msgstr "無法啟用使用者"
 
 #: packages/admin/src/components/WordPressImport.tsx:340
 msgid "Failed to execute import"
-msgstr ""
+msgstr "無法執行匯入"
 
 #: packages/admin/src/lib/api/client.ts:255
 msgid "Failed to fetch auth mode"
-msgstr ""
+msgstr "無法擷取驗證模式"
 
 #: packages/admin/src/lib/api/backups.ts:37
 msgid "Failed to fetch backup settings"
-msgstr ""
+msgstr "擷取備份設定失敗"
 
 #: packages/admin/src/lib/api/schema.ts:170
 #: packages/admin/src/lib/api/schema.ts:174
 msgid "Failed to fetch collection"
-msgstr ""
+msgstr "擷取內容集合失敗"
 
 #: packages/admin/src/lib/api/dashboard.ts:42
 msgid "Failed to fetch dashboard stats"
-msgstr ""
+msgstr "無法擷取控制台統計資料"
 
 #: packages/admin/src/lib/api/email-settings.ts:34
 msgid "Failed to fetch email settings"
-msgstr ""
+msgstr "無法擷取電子郵件設定"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:93
 msgid "Failed to fetch entry terms"
-msgstr ""
+msgstr "無法擷取內容項目的分類項目"
 
 #: packages/admin/src/lib/api/client.ts:238
 msgid "Failed to fetch manifest"
-msgstr ""
+msgstr "無法擷取資訊清單"
 
 #: packages/admin/src/lib/api/media.ts:76
 msgid "Failed to fetch media"
-msgstr ""
+msgstr "擷取媒體失敗"
 
 #: packages/admin/src/lib/api/media.ts:89
 msgid "Failed to fetch media item"
-msgstr ""
+msgstr "擷取媒體項目失敗"
 
 #: packages/admin/src/lib/api/media.ts:325
 msgid "Failed to fetch media providers"
-msgstr ""
+msgstr "無法擷取媒體服務提供者"
 
 #: packages/admin/src/lib/api/plugins.ts:70
 #: packages/admin/src/lib/api/plugins.ts:74
 msgid "Failed to fetch plugin"
-msgstr ""
+msgstr "擷取外掛失敗"
 
 #: packages/admin/src/lib/api/plugins.ts:114
 msgid "Failed to fetch plugin settings"
-msgstr ""
+msgstr "無法擷取外掛設定"
 
 #: packages/admin/src/lib/api/plugins.ts:56
 msgid "Failed to fetch plugins"
-msgstr ""
+msgstr "無法擷取外掛"
 
 #: packages/admin/src/lib/api/media.ts:355
 msgid "Failed to fetch provider media"
-msgstr ""
+msgstr "無法擷取服務提供者媒體"
 
 #: packages/admin/src/lib/api/content.ts:556
 #: packages/admin/src/lib/api/content.ts:561
 msgid "Failed to fetch revision"
-msgstr ""
+msgstr "無法取得修訂版本"
 
 #: packages/admin/src/lib/api/sections.ts:76
 msgid "Failed to fetch section"
-msgstr ""
+msgstr "無法擷取區段"
 
 #: packages/admin/src/lib/api/sections.ts:68
 msgid "Failed to fetch sections"
-msgstr ""
+msgstr "無法取得區段"
 
 #: packages/admin/src/lib/api/settings.ts:50
 msgid "Failed to fetch settings"
-msgstr ""
+msgstr "無法取得設定"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
-msgstr ""
+msgstr "擷取設定狀態失敗"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:74
 msgid "Failed to fetch terms"
-msgstr ""
+msgstr "擷取分類項目失敗"
 
 #: packages/admin/src/lib/api/current-user.ts:22
 #: packages/admin/src/lib/api/users.ts:88
@@ -3404,180 +3404,180 @@ msgstr ""
 #: packages/admin/src/router.tsx:852
 #: packages/admin/src/router.tsx:1376
 msgid "Failed to fetch user"
-msgstr ""
+msgstr "無法擷取使用者"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:263
 msgid "Failed to generate preview"
-msgstr "生成預覽失敗"
+msgstr "無法產生預覽"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
 msgid "Failed to generate preview URL"
-msgstr "生成預覽 URL 失敗"
+msgstr "產生預覽網址失敗"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:176
 msgid "Failed to get authentication options"
-msgstr ""
+msgstr "無法取得驗證選項"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
 msgid "Failed to get registration options"
-msgstr ""
+msgstr "無法取得註冊選項"
 
 #: packages/admin/src/lib/api/media.ts:131
 msgid "Failed to get upload URL"
-msgstr ""
+msgstr "無法取得上傳網址"
 
 #: packages/admin/src/components/WordPressImport.tsx:436
 msgid "Failed to import from WordPress"
-msgstr ""
+msgstr "無法從 WordPress 匯入"
 
 #: packages/admin/src/components/WordPressImport.tsx:365
 #: packages/admin/src/lib/api/import.ts:422
 msgid "Failed to import media"
-msgstr ""
+msgstr "匯入媒體失敗"
 
 #: packages/admin/src/lib/api/marketplace.ts:208
 #: packages/admin/src/lib/api/registry.ts:702
 msgid "Failed to install plugin"
-msgstr ""
+msgstr "安裝外掛失敗"
 
 #: packages/admin/src/lib/api/byline-fields.ts:98
 msgid "Failed to list byline fields"
-msgstr ""
+msgstr "列出署名欄位失敗"
 
 #: packages/admin/src/router.tsx:282
 msgid "Failed to load admin"
-msgstr ""
+msgstr "無法載入管理介面"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
 msgid "Failed to load allowed domains"
-msgstr "加載允許域名失敗"
+msgstr "載入允許的網域失敗"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:135
 msgid "Failed to load backup settings"
-msgstr ""
+msgstr "無法載入備份設定"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "Failed to load bylines: {0}"
-msgstr ""
+msgstr "無法載入署名資料: {0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:81
 msgid "Failed to load email settings"
-msgstr "加載郵件設置失敗"
+msgstr "載入電子郵件設定失敗"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:465
 msgid "Failed to load image"
-msgstr ""
+msgstr "無法載入圖片"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:135
 msgid "Failed to load passkeys"
-msgstr "加載通行密鑰失敗"
+msgstr "無法載入通行金鑰"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:121
 msgid "Failed to load plugin"
-msgstr "加載插件失敗"
+msgstr "無法載入外掛"
 
 #: packages/admin/src/components/PluginSettings.tsx:146
 msgid "Failed to load plugin settings"
-msgstr ""
+msgstr "無法載入外掛設定"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:149
 msgid "Failed to load plugins: {0}"
-msgstr "加載插件失敗：{0}"
+msgstr "無法載入外掛: {0}"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:96
 msgid "Failed to load plugins. The registry aggregator may be unreachable."
-msgstr ""
+msgstr "無法載入外掛。外掛庫彙整器可能無法連線。"
 
 #: packages/admin/src/components/RevisionHistory.tsx:188
 msgid "Failed to load revisions"
-msgstr "加載修訂歷史失敗"
+msgstr "無法載入修訂版本"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
-msgstr "加載設置失敗"
+msgstr "無法載入初始設定"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
-msgstr "加載主題失敗"
+msgstr "無法載入佈景主題"
 
 #. placeholder {0}: usersQuery.error.message
 #: packages/admin/src/routes/users.tsx:205
 msgid "Failed to load users: {0}"
-msgstr ""
+msgstr "載入使用者失敗: {0}"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:46
 msgid "Failed to load widget"
-msgstr ""
+msgstr "載入小工具失敗"
 
 #: packages/admin/src/router.tsx:1470
 msgid "Failed to perform bulk action"
-msgstr ""
+msgstr "執行批次操作失敗"
 
 #: packages/admin/src/lib/api/content.ts:322
 msgid "Failed to permanently delete content"
-msgstr ""
+msgstr "無法永久刪除內容"
 
 #: packages/admin/src/components/WordPressImport.tsx:321
 msgid "Failed to prepare import"
-msgstr ""
+msgstr "準備匯入失敗"
 
 #: packages/admin/src/router.tsx:490
 #: packages/admin/src/router.tsx:1013
 msgid "Failed to publish"
-msgstr ""
+msgstr "發佈失敗"
 
 #: packages/admin/src/lib/api/byline-fields.ts:106
 msgid "Failed to read byline field usage"
-msgstr ""
+msgstr "無法讀取署名欄位的使用情況"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:112
 msgid "Failed to remove domain"
-msgstr "移除域名失敗"
+msgstr "移除網域失敗"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:99
 #: packages/admin/src/components/settings/SecuritySettings.tsx:70
 msgid "Failed to remove passkey"
-msgstr "移除通行密鑰失敗"
+msgstr "移除通行金鑰失敗"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:53
 msgid "Failed to rename passkey"
-msgstr "重命名通行密鑰失敗"
+msgstr "無法重新命名通行金鑰"
 
 #: packages/admin/src/lib/api/byline-fields.ts:156
 msgid "Failed to reorder byline fields"
-msgstr ""
+msgstr "無法重新排序署名欄位"
 
 #: packages/admin/src/lib/api/schema.ts:293
 #: packages/admin/src/routes/byline-schema.tsx:152
 msgid "Failed to reorder fields"
-msgstr ""
+msgstr "重新排序欄位失敗"
 
 #: packages/admin/src/lib/api/widgets.ts:158
 msgid "Failed to reorder widgets"
-msgstr ""
+msgstr "無法重新排序小工具"
 
 #: packages/admin/src/router.tsx:437
 msgid "Failed to restore"
-msgstr ""
+msgstr "還原失敗"
 
 #: packages/admin/src/lib/api/content.ts:311
 msgid "Failed to restore content"
-msgstr ""
+msgstr "還原內容失敗"
 
 #: packages/admin/src/lib/api/content.ts:578
 #: packages/admin/src/lib/api/content.ts:583
 msgid "Failed to restore revision"
-msgstr ""
+msgstr "無法還原修訂版本"
 
 #: packages/admin/src/lib/api/api-tokens.ts:99
 msgid "Failed to revoke API token"
-msgstr ""
+msgstr "撤銷 API 權杖失敗"
 
 #: packages/admin/src/components/WordPressImport.tsx:378
 msgid "Failed to rewrite URLs"
-msgstr ""
+msgstr "重寫網址失敗"
 
 #: packages/admin/src/router.tsx:942
 #: packages/admin/src/router.tsx:1959
@@ -3586,61 +3586,61 @@ msgstr "儲存失敗"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:84
 msgid "Failed to save backup settings"
-msgstr ""
+msgstr "無法儲存備份設定"
 
 #: packages/admin/src/routes/byline-schema.tsx:122
 msgid "Failed to save field"
-msgstr ""
+msgstr "無法儲存欄位"
 
 #: packages/admin/src/components/PluginSettings.tsx:74
 #: packages/admin/src/components/settings/GeneralSettings.tsx:50
 #: packages/admin/src/components/settings/SeoSettings.tsx:44
 #: packages/admin/src/components/settings/SocialSettings.tsx:42
 msgid "Failed to save settings"
-msgstr "保存設置失敗"
+msgstr "無法儲存設定"
 
 #: packages/admin/src/router.tsx:1073
 msgid "Failed to schedule"
-msgstr ""
+msgstr "無法排程"
 
 #: packages/admin/src/components/LoginPage.tsx:71
 #: packages/admin/src/components/LoginPage.tsx:76
 msgid "Failed to send magic link"
-msgstr "發送免密登錄鏈接失敗"
+msgstr "無法傳送快速登入連結"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
-msgstr ""
+msgstr "無法傳送復原連結"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:50
 #: packages/admin/src/lib/api/email-settings.ts:45
 msgid "Failed to send test email"
-msgstr "發送測試郵件失敗"
+msgstr "傳送測試電子郵件失敗"
 
 #: packages/admin/src/components/SignupPage.tsx:351
 msgid "Failed to send verification email"
-msgstr ""
+msgstr "傳送驗證電子郵件失敗"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:116
 msgid "Failed to set entry terms"
-msgstr ""
+msgstr "無法設定內容項目的分類項目"
 
 #: packages/admin/src/lib/api/marketplace.ts:249
 #: packages/admin/src/lib/api/registry.ts:858
 msgid "Failed to uninstall plugin"
-msgstr ""
+msgstr "無法解除安裝外掛"
 
 #: packages/admin/src/router.tsx:1031
 msgid "Failed to unpublish"
-msgstr ""
+msgstr "取消發佈失敗"
 
 #: packages/admin/src/router.tsx:1094
 msgid "Failed to unschedule"
-msgstr ""
+msgstr "無法取消排程"
 
 #: packages/admin/src/router.tsx:513
 msgid "Failed to update"
-msgstr ""
+msgstr "更新失敗"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:351
@@ -3649,77 +3649,77 @@ msgstr "更新 {0} 失敗"
 
 #: packages/admin/src/lib/api/backups.ts:46
 msgid "Failed to update backup settings"
-msgstr ""
+msgstr "無法更新備份設定"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1022
 msgid "Failed to update byline"
-msgstr "更新署名失敗"
+msgstr "無法更新署名資料"
 
 #: packages/admin/src/lib/api/byline-fields.ts:135
 msgid "Failed to update byline field"
-msgstr ""
+msgstr "無法更新署名欄位"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:94
 msgid "Failed to update domain"
-msgstr "更新域名失敗"
+msgstr "無法更新網域"
 
 #: packages/admin/src/lib/api/media.ts:276
 msgid "Failed to update media"
-msgstr ""
+msgstr "更新媒體失敗"
 
 #: packages/admin/src/lib/api/marketplace.ts:232
 #: packages/admin/src/lib/api/registry.ts:776
 msgid "Failed to update plugin"
-msgstr ""
+msgstr "無法更新外掛"
 
 #: packages/admin/src/lib/api/plugins.ts:172
 msgid "Failed to update plugin MCP access"
-msgstr ""
+msgstr "更新外掛 MCP 存取權失敗"
 
 #: packages/admin/src/lib/api/plugins.ts:133
 msgid "Failed to update plugin settings"
-msgstr ""
+msgstr "無法更新外掛設定"
 
 #: packages/admin/src/lib/api/sections.ts:100
 msgid "Failed to update section"
-msgstr ""
+msgstr "更新區段失敗"
 
 #: packages/admin/src/lib/api/settings.ts:64
 msgid "Failed to update settings"
-msgstr ""
+msgstr "無法更新設定"
 
 #: packages/admin/src/router.tsx:1429
 msgid "Failed to update status"
-msgstr ""
+msgstr "無法更新狀態"
 
 #: packages/admin/src/lib/api/media.ts:173
 msgid "Failed to upload file"
-msgstr ""
+msgstr "上傳檔案失敗"
 
 #: packages/admin/src/lib/api/media.ts:218
 msgid "Failed to upload media"
-msgstr ""
+msgstr "上傳媒體失敗"
 
 #: packages/admin/src/lib/api/media.ts:377
 msgid "Failed to upload to provider"
-msgstr ""
+msgstr "無法上傳至服務提供者"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:248
 msgid "Failed to verify authentication"
-msgstr ""
+msgstr "無法驗證身分"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
 msgid "Failed to verify registration"
-msgstr ""
+msgstr "無法驗證註冊"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:807
 msgid "FAQ"
-msgstr ""
+msgstr "常見問題"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:213
 #: packages/admin/src/components/settings/GeneralSettings.tsx:219
 msgid "Favicon"
-msgstr "網站圖標"
+msgstr "網站圖示"
 
 #: packages/admin/src/components/WordPressImport.tsx:1180
 msgid "Feature"
@@ -3727,7 +3727,7 @@ msgstr "功能"
 
 #: packages/admin/src/components/WordPressImport.tsx:1148
 msgid "Featured Images"
-msgstr ""
+msgstr "精選圖片"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:440
 #: packages/admin/src/components/ContentTypeList.tsx:103
@@ -3736,160 +3736,160 @@ msgstr "功能"
 
 #: packages/admin/src/components/WordPressImport.tsx:811
 msgid "Fetching content from the EmDash Exporter API."
-msgstr "正在從 EmDash Exporter API 獲取內容。"
+msgstr "正在從 EmDash Exporter API 擷取內容。"
 
 #: packages/admin/src/routes/byline-schema.tsx:95
 msgid "Field created"
-msgstr ""
+msgstr "已建立欄位"
 
 #: packages/admin/src/routes/byline-schema.tsx:133
 msgid "Field deleted"
-msgstr ""
+msgstr "已刪除欄位"
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
-msgstr "字段標籤"
+msgstr "欄位標籤"
 
 #: packages/admin/src/components/FieldEditor.tsx:414
 msgid "Field Label"
-msgstr "字段標籤"
+msgstr "欄位標籤"
 
 #: packages/admin/src/components/FieldEditor.tsx:426
 msgid "Field slugs cannot be changed after creation"
-msgstr "字段別名創建後無法更改"
+msgstr "建立欄位後便無法變更其代稱"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:268
 msgid "Field type cannot be changed after creation."
-msgstr ""
+msgstr "欄位類型在建立後無法變更。"
 
 #: packages/admin/src/routes/byline-schema.tsx:115
 msgid "Field updated"
-msgstr ""
+msgstr "已更新欄位"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:581
 msgid "Fields"
-msgstr ""
+msgstr "欄位"
 
 #: packages/admin/src/components/WordPressImport.tsx:2333
 msgid "Fields created:"
-msgstr "已創建字段："
+msgstr "已建立的欄位:"
 
 #: packages/admin/src/components/FieldEditor.tsx:210
 msgid "File"
-msgstr "文件"
+msgstr "檔案"
 
 #. placeholder {0}: progress.current
 #: packages/admin/src/components/WordPressImport.tsx:2158
 msgid "File {0}"
-msgstr "文件 {0}"
+msgstr "檔案 {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:211
 msgid "File from media library"
-msgstr "來自媒體庫的文件"
+msgstr "媒體庫中的檔案"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:325
 #: packages/admin/src/components/MediaDetailPanel.tsx:342
 #: packages/admin/src/components/MediaLibrary.tsx:586
 msgid "Filename"
-msgstr "文件名"
+msgstr "檔案名稱"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:120
 msgid "Filename cannot be changed after upload"
-msgstr "文件名上傳後無法更改"
+msgstr "檔案名稱在上傳後無法變更"
 
 #: packages/admin/src/components/WordPressImport.tsx:2366
 msgid "files imported"
-msgstr "文件已導入"
+msgstr "個檔案已匯入"
 
 #: packages/admin/src/components/ContentList.tsx:769
 msgid "Filter by author"
-msgstr ""
+msgstr "依作者篩選"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
-msgstr "按功能篩選"
+msgstr "依權限篩選"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:178
 msgid "Filter by collection"
-msgstr "按合集篩選"
+msgstr "依內容集合篩選"
 
 #: packages/admin/src/components/users/UserList.tsx:82
 msgid "Filter by role"
-msgstr ""
+msgstr "依角色篩選"
 
 #: packages/admin/src/components/Sections.tsx:245
 msgid "Filter by source"
-msgstr ""
+msgstr "依來源篩選"
 
 #: packages/admin/src/components/ContentList.tsx:754
 #: packages/admin/src/components/Redirects.tsx:420
 msgid "Filter by status"
-msgstr ""
+msgstr "依狀態篩選"
 
 #: packages/admin/src/components/MediaLibrary.tsx:439
 #: packages/admin/src/components/Redirects.tsx:426
 msgid "Filter by type"
-msgstr ""
+msgstr "依類型篩選"
 
 #: packages/admin/src/routes/bylines.tsx:408
 msgid "Filter byline type"
-msgstr ""
+msgstr "依署名類型篩選"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
-msgstr ""
+msgstr "僅限首次留言者"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:69
 msgid "Fonts"
-msgstr ""
+msgstr "字型"
 
 #: packages/admin/src/components/WordPressImport.tsx:1398
 msgid "For a complete import including drafts and all content, export from WordPress."
-msgstr "如需完整導入（包括草稿和所有內容），請從 WordPress 導出。"
+msgstr "若要完整匯入草稿及所有內容，請從 WordPress 匯出。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1207
 msgid "For the best import experience, install the"
-msgstr "爲獲得最佳導入體驗，請安裝"
+msgstr "為獲得較佳的匯入體驗，請安裝"
 
 #: packages/admin/src/components/ContentList.tsx:806
 msgid "From date"
-msgstr ""
+msgstr "開始日期"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
 #: packages/admin/src/components/WordPressImport.tsx:1155
 msgid "Full"
-msgstr ""
+msgstr "完整"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
-msgstr "完全訪問權限"
+msgstr "完整存取權"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:102
 msgid "Full admin access"
-msgstr "完全管理員訪問權限"
+msgstr "完整管理員存取權"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:171
 #: packages/admin/src/components/PortableTextEditor.tsx:2409
 msgid "Gallery"
-msgstr ""
+msgstr "圖庫"
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:207
 #: packages/admin/src/components/editor/GalleryNode.tsx:208
 msgid "Gallery settings"
-msgstr ""
+msgstr "圖庫設定"
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "General"
-msgstr "常規"
+msgstr "一般"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:96
 #: packages/admin/src/components/settings/GeneralSettings.tsx:124
 msgid "General Settings"
-msgstr "常規設置"
+msgstr "一般設定"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:648
 msgid "Genres"
-msgstr ""
+msgstr "文類"
 
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
@@ -3901,16 +3901,16 @@ msgstr "GitHub"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
 msgid "Give this passkey a name to help you identify it later."
-msgstr "爲此通行密鑰命名以便日後識別。"
+msgstr "請為此通行金鑰命名，以便日後識別。"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:36
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: packages/admin/src/components/WordPressImport.tsx:2418
 #: packages/admin/src/router.tsx:2194
 msgid "Go to Dashboard"
-msgstr "前往儀表板"
+msgstr "前往控制台"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:194
 msgid "Google Verification"
@@ -3918,27 +3918,27 @@ msgstr "Google 驗證"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:37
 msgid "GraphQL"
-msgstr ""
+msgstr "GraphQL"
 
 #: packages/admin/src/components/MediaLibrary.tsx:460
 msgid "Grid view"
-msgstr "網格視圖"
+msgstr "格狀檢視"
 
 #: packages/admin/src/components/Redirects.tsx:167
 msgid "Group (optional)"
-msgstr "組（可選）"
+msgstr "群組 (選填)"
 
 #: packages/admin/src/components/Widgets.tsx:162
 msgid "Group by"
-msgstr ""
+msgstr "分組依據"
 
 #: packages/admin/src/routes/bylines.tsx:555
 msgid "Guest byline"
-msgstr ""
+msgstr "訪客署名"
 
 #: packages/admin/src/routes/bylines.tsx:413
 msgid "Guest only"
-msgstr ""
+msgstr "僅訪客"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:62
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
@@ -3960,20 +3960,20 @@ msgstr "標題 3"
 
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
 msgid "Heading 4"
-msgstr ""
+msgstr "標題 4"
 
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
 msgid "Heading 5"
-msgstr ""
+msgstr "標題 5"
 
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
 msgid "Heading 6"
-msgstr ""
+msgstr "標題 6"
 
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:142
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:158
 msgid "Headings"
-msgstr ""
+msgstr "標題"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
@@ -3982,29 +3982,29 @@ msgstr "高度"
 
 #: packages/admin/src/components/Sections.tsx:180
 msgid "Hero Banner"
-msgstr ""
+msgstr "主視覺橫幅"
 
 #: packages/admin/src/components/SectionEditor.tsx:286
 msgid "hero, banner, cta"
-msgstr ""
+msgstr "hero, banner, cta, 主視覺, 橫幅"
 
 #: packages/admin/src/components/SeoPanel.tsx:230
 #: packages/admin/src/components/SeoPanel.tsx:233
 msgid "Hide from search engines"
-msgstr "對搜索引擎隱藏"
+msgstr "對搜尋引擎隱藏"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
 msgid "Hide token"
-msgstr "隱藏令牌"
+msgstr "隱藏權杖"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:671
 msgid "Hierarchical (like categories, with parent/child relationships)"
-msgstr "層級式（類似分類，具有父子關係）"
+msgstr "階層式 (類似分類，具有上層/子層關係)"
 
 #: packages/admin/src/components/Redirects.tsx:226
 #: packages/admin/src/components/Redirects.tsx:471
 msgid "Hits"
-msgstr "點擊量"
+msgstr "命中次數"
 
 #: packages/admin/src/components/MenuEditor.tsx:416
 msgid "Home"
@@ -4012,30 +4012,30 @@ msgstr "首頁"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
 msgid "Homepage"
-msgstr "主頁"
+msgstr "首頁"
 
 #: packages/admin/src/components/PluginManager.tsx:413
 msgid "Hooks"
-msgstr "鉤子"
+msgstr "Hooks"
 
 #: packages/admin/src/components/WordPressImport.tsx:1520
 msgid "How to create an Application Password"
-msgstr "如何創建應用程式密碼"
+msgstr "如何建立應用程式密碼"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:38
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
 #: packages/admin/src/components/PortableTextEditor.tsx:1179
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
 msgid "HTML source"
-msgstr ""
+msgstr "HTML 原始碼"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3193
 #: packages/admin/src/components/PortableTextEditor.tsx:3760
 msgid "https://..."
-msgstr ""
+msgstr "https://..."
 
 #: packages/admin/src/components/MenuEditor.tsx:424
 msgid "https://example.com or /about"
@@ -4043,16 +4043,16 @@ msgstr "https://example.com 或 /about"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:555
 msgid "https://example.com/image.jpg"
-msgstr ""
+msgstr "https://example.com/image.jpg"
 
 #: packages/admin/src/components/WordPressImport.tsx:1089
 msgid "https://yoursite.com"
-msgstr ""
+msgstr "https://yoursite.com"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:241
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:153
 msgid "Icon blurred due to image audit"
-msgstr "由於圖像審計，圖標已模糊"
+msgstr "由於圖片稽核，圖示已模糊處理"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
 msgid "ID"
@@ -4060,7 +4060,7 @@ msgstr "ID"
 
 #: packages/admin/src/components/LoginPage.tsx:104
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
-msgstr "如果存在與 <0>{email}</0> 關聯的帳號，我們已發送登錄鏈接。"
+msgstr "如果 <0>{email}</0> 有對應的帳號，我們已傳送登入連結。"
 
 #: packages/admin/src/components/FieldEditor.tsx:204
 #: packages/admin/src/components/FieldEditor.tsx:587
@@ -4071,7 +4071,7 @@ msgstr "圖片"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:294
 msgid "Image {0}"
-msgstr ""
+msgstr "圖片 {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:205
 msgid "Image from media library"
@@ -4080,145 +4080,145 @@ msgstr "來自媒體庫的圖片"
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
 #: packages/admin/src/components/ImageFieldRenderer.tsx:124
 msgid "Image not found"
-msgstr ""
+msgstr "找不到圖片"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:208
 #: packages/admin/src/components/editor/ImageNode.tsx:209
 msgid "Image settings"
-msgstr ""
+msgstr "圖片設定"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
 msgid "Image Settings"
-msgstr "圖片設置"
+msgstr "圖片設定"
 
 #: packages/admin/src/components/SeoImageField.tsx:43
 msgid "Image shown when this page is shared on social media"
-msgstr "當此頁面在社交媒體上分享時顯示的圖片"
+msgstr "在社群媒體分享此頁面時顯示的圖片"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:556
 msgid "Image URL"
-msgstr "圖片 URL"
+msgstr "圖片網址"
 
 #: packages/admin/src/components/WordPressImport.tsx:2370
 msgid "image URLs updated in"
-msgstr "圖片 URL 已更新於"
+msgstr "已更新圖片網址，位置:"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:192
 #: packages/admin/src/components/MediaLibrary.tsx:434
 msgid "Images"
-msgstr ""
+msgstr "圖片"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:226
 #: packages/admin/src/components/Sidebar.tsx:290
 #: packages/admin/src/components/WordPressImport.tsx:738
 msgid "Import"
-msgstr "導入"
+msgstr "匯入"
 
 #. placeholder {0}: postType.name
 #: packages/admin/src/components/WordPressImport.tsx:1958
 msgid "Import {0}"
-msgstr "導入 {0}"
+msgstr "匯入 {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1366
 msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
-msgstr "直接導入所有內容，包括草稿、自定義文章類型、ACF 字段和 SEO 數據。無需下載文件。"
+msgstr "直接匯入所有內容，包括草稿、自訂文章類型、ACF 欄位及 SEO 資料，無需下載檔案。"
 
 #: packages/admin/src/components/WordPressImport.tsx:2416
 msgid "Import Another File"
-msgstr "導入另一個文件"
+msgstr "匯入另一個檔案"
 
 #: packages/admin/src/components/WordPressImport.tsx:1174
 msgid "Import Capabilities"
-msgstr "導入功能"
+msgstr "匯入權限"
 
 #: packages/admin/src/components/WordPressImport.tsx:2304
 msgid "Import Complete"
-msgstr "導入完成"
+msgstr "匯入完成"
 
 #: packages/admin/src/components/WordPressImport.tsx:2305
 msgid "Import Completed with Errors"
-msgstr "導入完成但有錯誤"
+msgstr "匯入完成，但發生錯誤"
 
 #: packages/admin/src/components/WordPressImport.tsx:1699
 msgid "Import failed"
-msgstr "導入失敗"
+msgstr "匯入失敗"
 
 #: packages/admin/src/components/WordPressImport.tsx:691
 msgid "Import from WordPress"
-msgstr "從 WordPress 導入"
+msgstr "從 WordPress 匯入"
 
 #: packages/admin/src/components/WordPressImport.tsx:2107
 msgid "Import Media"
-msgstr "導入媒體"
+msgstr "匯入媒體"
 
 #: packages/admin/src/components/WordPressImport.tsx:2060
 msgid "Import Media Files"
-msgstr "導入媒體文件"
+msgstr "匯入媒體檔案"
 
 #: packages/admin/src/components/WordPressImport.tsx:693
 msgid "Import posts, pages, and custom post types from WordPress."
-msgstr "從 WordPress 導入文章、頁面和自定義文章類型。"
+msgstr "從 WordPress 匯入文章、頁面及自訂文章類型。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1814
 msgid "Import site configuration from WordPress."
-msgstr "從 WordPress 導入站點配置。"
+msgstr "從 WordPress 匯入網站設定。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1364
 msgid "Import via EmDash Exporter"
-msgstr "通過 EmDash Exporter 導入"
+msgstr "使用 EmDash Exporter 匯入"
 
 #: packages/admin/src/components/Sections.tsx:47
 msgid "Imported"
-msgstr "已導入"
+msgstr "已匯入"
 
 #: packages/admin/src/components/WordPressImport.tsx:2344
 msgid "Imported by Collection"
-msgstr "按合集導入"
+msgstr "依內容集合分組的匯入內容"
 
 #. placeholder {0}: wpImportProgress.comments
 #: packages/admin/src/components/WordPressImport.tsx:903
 msgid "Importing comments... {0}"
-msgstr ""
+msgstr "正在匯入留言... {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:920
 msgid "Importing content..."
-msgstr "正在導入內容..."
+msgstr "正在匯入內容…"
 
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:901
 msgid "Importing content... {0}"
-msgstr ""
+msgstr "正在匯入內容... {0}"
 
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:900
 msgid "Importing content... {0} of {totalSelectedPosts}"
-msgstr ""
+msgstr "正在匯入內容... {0} / {totalSelectedPosts}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2139
 msgid "Importing Media"
-msgstr "正在導入媒體"
+msgstr "正在匯入媒體"
 
 #: packages/admin/src/components/WordPressImport.tsx:904
 msgid "Importing menus and site settings..."
-msgstr ""
+msgstr "正在匯入選單與網站設定..."
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
-msgstr "包含示例內容（推薦新站點使用）"
+msgstr "包含範例內容 (建議新網站使用)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1980
 msgid "Incompatible"
-msgstr "不兼容"
+msgstr "不相容"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:506
 msgid "Indexed"
-msgstr ""
+msgstr "已建立索引"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3644
 msgid "Inline Code"
-msgstr ""
+msgstr "行內程式碼"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:567
 #: packages/admin/src/components/MediaPickerModal.tsx:811
@@ -4228,15 +4228,15 @@ msgstr "插入"
 #. placeholder {0}: block?.label || ""
 #: packages/admin/src/components/PortableTextEditor.tsx:1611
 msgid "Insert {0}"
-msgstr ""
+msgstr "插入 {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1160
 msgid "Insert a blockquote"
-msgstr "插入引用塊"
+msgstr "插入引用區塊"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1170
 msgid "Insert a code block"
-msgstr "插入代碼塊"
+msgstr "插入程式碼區塊"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1195
 msgid "Insert a horizontal rule"
@@ -4244,11 +4244,11 @@ msgstr "插入水平分隔線"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2425
 msgid "Insert a reusable section"
-msgstr "插入可複用區塊"
+msgstr "插入可重複使用的區段"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1205
 msgid "Insert a table"
-msgstr ""
+msgstr "插入表格"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2395
 msgid "Insert an image"
@@ -4256,37 +4256,37 @@ msgstr "插入圖片"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2410
 msgid "Insert an image gallery"
-msgstr ""
+msgstr "插入圖片圖庫"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1439
 msgid "Insert block"
-msgstr ""
+msgstr "插入區塊"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3596
 #: packages/admin/src/components/PortableTextEditor.tsx:3606
 msgid "Insert block after current block"
-msgstr ""
+msgstr "在目前區塊後方插入區塊"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
 msgid "Insert block below"
-msgstr ""
+msgstr "在下方插入區塊"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:549
 msgid "Insert from URL"
-msgstr "從 URL 插入"
+msgstr "從網址插入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3730
 #: packages/admin/src/components/PortableTextEditor.tsx:3744
 msgid "Insert Link"
-msgstr ""
+msgstr "插入連結"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1180
 msgid "Insert raw HTML"
-msgstr ""
+msgstr "插入原始 HTML"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:58
 msgid "Insert Section"
-msgstr "插入區塊"
+msgstr "插入區段"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:124
 msgid "Instagram"
@@ -4299,19 +4299,19 @@ msgstr "安裝"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:155
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr "安裝並激活電子郵件提供商插件以啓用電子郵件功能，如邀請、免密登錄鏈接和密碼恢復。"
+msgstr "安裝並啟用電子郵件服務提供者外掛，以使用邀請、快速登入連結及密碼復原等電子郵件功能。"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:197
 msgid "Install blocked"
-msgstr "安裝被阻止"
+msgstr "安裝遭到封鎖"
 
 #: packages/admin/src/components/WordPressImport.tsx:1039
 msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
-msgstr ""
+msgstr "在您的 WordPress 網站安裝 EmDash Exporter 外掛，然後前往 [工具] → [EmDash Migration] 產生金鑰。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:806
 msgid "Installation"
-msgstr ""
+msgstr "安裝"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:261
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:184
@@ -4323,11 +4323,11 @@ msgstr "已安裝"
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:582
 msgid "Installed from marketplace (v{0})"
-msgstr "已從市場安裝 (v{0})"
+msgstr "已從市集安裝 (v{0})"
 
 #: packages/admin/src/components/PluginManager.tsx:601
 msgid "Installed:"
-msgstr "已安裝："
+msgstr "已安裝:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:198
 msgid "Installing..."
@@ -4340,7 +4340,7 @@ msgstr "整數"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:152
 msgid "Invalid invite link"
-msgstr ""
+msgstr "無效的邀請連結"
 
 #: packages/admin/src/components/ContentEditor.tsx:1506
 msgid "Invalid JSON"
@@ -4348,41 +4348,41 @@ msgstr "無效的 JSON"
 
 #: packages/admin/src/components/SignupPage.tsx:260
 msgid "Invalid link"
-msgstr "鏈接無效"
+msgstr "無效的連結"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:241
 msgid "Invite Error"
-msgstr ""
+msgstr "邀請錯誤"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:150
 msgid "Invite expired"
-msgstr ""
+msgstr "邀請已過期"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 msgid "Invite Link Created"
-msgstr "邀請鏈接已創建"
+msgstr "已建立邀請連結"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 #: packages/admin/src/components/users/UserList.tsx:56
 msgid "Invite User"
-msgstr "邀請用戶"
+msgstr "邀請使用者"
 
 #: packages/admin/src/components/users/UserList.tsx:140
 msgid "Invite your first team member"
-msgstr ""
+msgstr "邀請第一位團隊成員"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:97
 msgid "Invoke MCP tools from all enabled plugins"
-msgstr ""
+msgstr "呼叫所有已啟用外掛的 MCP 工具"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:454
 msgid "Invoke only this plugin's enabled MCP tools"
-msgstr ""
+msgstr "僅呼叫這個外掛已啟用的 MCP 工具"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3237
 #: packages/admin/src/components/PortableTextEditor.tsx:3623
 msgid "Italic"
-msgstr ""
+msgstr "斜體"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:1992
@@ -4392,7 +4392,7 @@ msgstr "項目 {0}"
 
 #: packages/admin/src/components/MenuEditor.tsx:175
 msgid "Item added"
-msgstr "項目已添加"
+msgstr "已新增項目"
 
 #: packages/admin/src/components/MenuEditor.tsx:187
 msgid "Item deleted"
@@ -4405,23 +4405,23 @@ msgstr "項目已更新"
 #: packages/admin/src/components/SetupWizard.tsx:213
 #: packages/admin/src/components/SignupPage.tsx:206
 msgid "Jane Doe"
-msgstr "張三"
+msgstr "Jane Doe"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:39
 msgid "Java"
-msgstr ""
+msgstr "Java"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:40
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:235
 msgid "Job title"
-msgstr ""
+msgstr "職稱"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:246
 msgid "job_title"
-msgstr ""
+msgstr "job_title"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:41
 #: packages/admin/src/components/FieldEditor.tsx:222
@@ -4430,25 +4430,25 @@ msgstr "JSON"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:42
 msgid "JSX"
-msgstr ""
+msgstr "JSX"
 
 #: packages/admin/src/components/WordPressImport.tsx:916
 msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
-msgstr ""
+msgstr "請保持此分頁開啟。匯入作業會分成數個小步驟執行，若中斷也能安全地重新執行。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:851
 msgid "Keep typing to narrow down more bylines."
-msgstr ""
+msgstr "繼續輸入以縮小署名資料範圍。"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
 msgid "Keywords"
-msgstr "關鍵詞"
+msgstr "關鍵字"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:43
 msgid "Kotlin"
-msgstr ""
+msgstr "Kotlin"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:232
 #: packages/admin/src/components/FieldEditor.tsx:411
@@ -4464,11 +4464,11 @@ msgstr "標籤"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:392
 msgid "Label (Plural)"
-msgstr ""
+msgstr "標籤 (複數)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:384
 msgid "Label (Singular)"
-msgstr ""
+msgstr "標籤 (單數)"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:162
 #: packages/admin/src/components/LoginPage.tsx:347
@@ -4479,54 +4479,54 @@ msgstr "語言"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1110
 msgid "Large section heading"
-msgstr "大章節標題"
+msgstr "大型區段標題"
 
 #: packages/admin/src/components/PluginManager.tsx:607
 msgid "Last enabled:"
-msgstr "最後啓用："
+msgstr "上次啟用時間:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:227
 msgid "Last login"
-msgstr "最後登錄"
+msgstr "上次登入時間"
 
 #: packages/admin/src/components/users/UserList.tsx:107
 msgid "Last Login"
-msgstr ""
+msgstr "上次登入時間"
 
 #: packages/admin/src/components/Redirects.tsx:227
 msgid "Last seen"
-msgstr "最後訪問"
+msgstr "上次出現時間"
 
 #: packages/admin/src/components/users/UserDetail.tsx:223
 msgid "Last updated"
-msgstr "最後更新"
+msgstr "上次更新時間"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:159
 msgid "Last used"
-msgstr "最後使用"
+msgstr "上次使用時間"
 
 #. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:303
 #: packages/admin/src/components/users/UserDetail.tsx:262
 msgid "Last used {0}"
-msgstr "最後使用於 {0}"
+msgstr "上次使用時間為 {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:274
 msgid "Learn more"
-msgstr ""
+msgstr "進一步瞭解"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:339
 msgid "Leave blank to use a discoverable passkey."
-msgstr "留空以使用可發現的通行密鑰。"
+msgstr "留空以使用可探索的通行金鑰。"
 
 #: packages/admin/src/components/WordPressImport.tsx:2497
 msgid "Leave unassigned"
-msgstr "不分配"
+msgstr "保留未指派狀態"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
 msgid "Left"
-msgstr ""
+msgstr "靠左"
 
 #: packages/admin/src/components/MediaLibrary.tsx:136
 #: packages/admin/src/components/MediaLibrary.tsx:273
@@ -4534,11 +4534,11 @@ msgstr ""
 #: packages/admin/src/components/MediaPickerModal.tsx:211
 #: packages/admin/src/components/MediaPickerModal.tsx:509
 msgid "Library"
-msgstr "庫"
+msgstr "媒體庫"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
 msgid "License"
-msgstr "許可證"
+msgstr "授權"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
@@ -4550,28 +4550,28 @@ msgstr "淺色"
 
 #: packages/admin/src/components/Widgets.tsx:165
 msgid "Limit"
-msgstr ""
+msgstr "限制"
 
 #: packages/admin/src/components/SignupPage.tsx:258
 msgid "Link expired"
-msgstr "鏈接已過期"
+msgstr "連結已過期"
 
 #: packages/admin/src/components/FieldEditor.tsx:217
 msgid "Link to another content item"
-msgstr "鏈接到另一個內容項"
+msgstr "連結至其他內容項目"
 
 #. placeholder {0}: user.oauthAccounts.length
 #: packages/admin/src/components/users/UserDetail.tsx:276
 msgid "Linked Accounts ({0})"
-msgstr "已關聯帳戶 ({0})"
+msgstr "已連結的帳號 ({0})"
 
 #: packages/admin/src/routes/bylines.tsx:414
 msgid "Linked only"
-msgstr ""
+msgstr "僅已連結"
 
 #: packages/admin/src/routes/bylines.tsx:506
 msgid "Linked user"
-msgstr ""
+msgstr "已連結的使用者"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:130
 msgid "LinkedIn"
@@ -4579,17 +4579,17 @@ msgstr "LinkedIn"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
 msgid "Links"
-msgstr "鏈接"
+msgstr "連結"
 
 #: packages/admin/src/components/MediaLibrary.tsx:469
 msgid "List view"
-msgstr "列表視圖"
+msgstr "清單檢視"
 
 #: packages/admin/src/components/ContentEditor.tsx:677
 #: packages/admin/src/components/ContentEditor.tsx:720
 #: packages/admin/src/components/ContentSettingsPanel.tsx:252
 msgid "Live View"
-msgstr "實時預覽"
+msgstr "即時檢視"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:236
 #: packages/admin/src/components/MarketplaceBrowse.tsx:198
@@ -4597,7 +4597,7 @@ msgstr "實時預覽"
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
 #: packages/admin/src/routes/bylines.tsx:468
 msgid "Load more"
-msgstr "加載更多"
+msgstr "載入更多"
 
 #: packages/admin/src/components/ContentList.tsx:630
 #: packages/admin/src/components/ContentList.tsx:687
@@ -4605,76 +4605,76 @@ msgstr "加載更多"
 #: packages/admin/src/components/MediaPickerModal.tsx:775
 #: packages/admin/src/components/users/UserList.tsx:169
 msgid "Load More"
-msgstr "加載更多"
+msgstr "載入更多"
 
 #: packages/admin/src/router.tsx:2149
 msgid "Loading"
-msgstr ""
+msgstr "正在載入"
 
 #: packages/admin/src/routes/byline-schema.tsx:257
 msgid "Loading byline fields…"
-msgstr ""
+msgstr "正在載入署名欄位…"
 
 #: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
-msgstr "正在加載合集..."
+msgstr "正在載入內容集合…"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:308
 msgid "Loading comments..."
-msgstr "正在加載評論..."
+msgstr "正在載入留言..."
 
 #: packages/admin/src/router.tsx:2151
 #: packages/admin/src/router.tsx:2163
 msgid "Loading configuration..."
-msgstr ""
+msgstr "正在載入設定..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:164
 msgid "Loading content..."
-msgstr "正在加載內容..."
+msgstr "正在載入內容…"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2985
 msgid "Loading editor..."
-msgstr ""
+msgstr "正在載入編輯器..."
 
 #: packages/admin/src/components/MenuEditor.tsx:342
 msgid "Loading menu..."
-msgstr "正在加載菜單..."
+msgstr "正在載入選單…"
 
 #: packages/admin/src/components/MenuList.tsx:95
 msgid "Loading menus..."
-msgstr "正在加載菜單..."
+msgstr "正在載入選單..."
 
 #: packages/admin/src/components/PluginManager.tsx:140
 msgid "Loading plugins..."
-msgstr "正在加載插件..."
+msgstr "正在載入外掛…"
 
 #: packages/admin/src/components/Redirects.tsx:457
 msgid "Loading redirects..."
-msgstr "正在加載重定向..."
+msgstr "正在載入重新導向…"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:95
 #: packages/admin/src/components/Sections.tsx:252
 msgid "Loading sections..."
-msgstr "正在加載區塊..."
+msgstr "正在載入區段..."
 
 #: packages/admin/src/components/PluginSettings.tsx:131
 #: packages/admin/src/components/settings/GeneralSettings.tsx:99
 #: packages/admin/src/components/settings/SeoSettings.tsx:93
 #: packages/admin/src/components/settings/SocialSettings.tsx:73
 msgid "Loading settings..."
-msgstr "正在加載設置..."
+msgstr "正在載入設定..."
 
 #: packages/admin/src/components/SetupWizard.tsx:528
 msgid "Loading setup..."
-msgstr "正在加載設置..."
+msgstr "正在載入設定..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:847
 msgid "Loading terms..."
-msgstr "正在加載詞條..."
+msgstr "正在載入分類項目..."
 
 #: packages/admin/src/components/Widgets.tsx:372
 msgid "Loading widgets..."
-msgstr ""
+msgstr "正在載入小工具…"
 
 #: packages/admin/src/components/ContentList.tsx:538
 #: packages/admin/src/components/ContentList.tsx:630
@@ -4696,27 +4696,27 @@ msgstr ""
 #: packages/admin/src/components/WelcomeModal.tsx:143
 #: packages/admin/src/routes/bylines.tsx:468
 msgid "Loading..."
-msgstr "加載中..."
+msgstr "正在載入…"
 
 #: packages/admin/src/components/ContentList.tsx:518
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
 msgid "Locale"
-msgstr "語言區域"
+msgstr "語系"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
 msgid "Lock aspect ratio"
-msgstr "鎖定寬高比"
+msgstr "鎖定長寬比"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:291
 msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
-msgstr ""
+msgstr "這個欄位已有儲存值，因此已鎖定。請刪除這些值 (或刪除此欄位) 後再變更。"
 
 #: packages/admin/src/components/Header.tsx:109
 msgid "Log out"
-msgstr "退出登錄"
+msgstr "登出"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:159
 #: packages/admin/src/components/settings/GeneralSettings.tsx:165
@@ -4725,38 +4725,38 @@ msgstr "標誌"
 
 #: packages/admin/src/components/WordPressImport.tsx:1832
 msgid "Logo & favicon"
-msgstr "標誌和網站圖標"
+msgstr "標誌與網站圖示"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:53
 msgid "Long text"
-msgstr ""
+msgstr "長文字"
 
 #: packages/admin/src/components/FieldEditor.tsx:156
 #: packages/admin/src/components/FieldEditor.tsx:580
 msgid "Long Text"
-msgstr "長文本"
+msgstr "長文字"
 
 #: packages/admin/src/components/Sections.tsx:193
 msgid "Lowercase letters, numbers, and hyphens only"
-msgstr "僅限小寫字母、數字和連字符"
+msgstr "僅限小寫字母、數字及連字號"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:663
 msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
-msgstr "僅限小寫字母、數字和下劃線，以字母開頭"
+msgstr "僅限小寫字母、數字和底線，且必須以字母開頭"
 
 #: packages/admin/src/components/Widgets.tsx:434
 msgid "Main Sidebar"
-msgstr ""
+msgstr "主要側邊欄"
 
 #: packages/admin/src/lib/api/marketplace.ts:285
 #: packages/admin/src/lib/api/marketplace.ts:293
 msgid "Make network requests"
-msgstr ""
+msgstr "發出網路要求"
 
 #: packages/admin/src/lib/api/marketplace.ts:286
 #: packages/admin/src/lib/api/marketplace.ts:294
 msgid "Make network requests to any host (unrestricted)"
-msgstr ""
+msgstr "向任何主機發出網路要求 (不受限制)"
 
 #: packages/admin/src/components/Sidebar.tsx:375
 msgid "Manage"
@@ -4770,35 +4770,35 @@ msgstr "管理 {1} 的 {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:813
 msgid "Manage bylines in {entryLocale}"
-msgstr ""
+msgstr "管理 {entryLocale} 的署名"
 
 #: packages/admin/src/components/Widgets.tsx:389
 msgid "Manage content widgets in your widget areas"
-msgstr ""
+msgstr "管理小工具區域中的內容小工具"
 
 #: packages/admin/src/components/PluginManager.tsx:179
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
-msgstr "管理已安裝的插件。啓用或禁用插件以控制其功能。"
+msgstr "管理已安裝的外掛。啟用或停用外掛以控制其功能。"
 
 #: packages/admin/src/components/MenuList.tsx:105
 msgid "Manage navigation menus for your site"
-msgstr "管理您站點的導航菜單"
+msgstr "管理網站導覽選單"
 
 #: packages/admin/src/components/Redirects.tsx:360
 msgid "Manage URL redirects and view 404 errors."
-msgstr "管理 URL 重定向並查看 404 錯誤。"
+msgstr "管理網址重新導向並檢視 404 錯誤。"
 
 #: packages/admin/src/components/Settings.tsx:94
 msgid "Manage your passkeys and authentication"
-msgstr "管理您的通行密鑰和認證"
+msgstr "管理您的通行金鑰與驗證方式"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:317
 msgid "Managed by {providerName}"
-msgstr ""
+msgstr "由 {providerName} 管理"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:318
 msgid "Managed by an external media provider"
-msgstr ""
+msgstr "由外部媒體服務提供者管理"
 
 #: packages/admin/src/components/Redirects.tsx:425
 msgid "Manual"
@@ -4806,44 +4806,44 @@ msgstr "手動"
 
 #: packages/admin/src/components/WordPressImport.tsx:2454
 msgid "Map Authors"
-msgstr "映射作者"
+msgstr "對應作者"
 
 #. placeholder {0}: mapping.wpLogin
 #: packages/admin/src/components/WordPressImport.tsx:2502
 msgid "Map WordPress user {0} to EmDash user"
-msgstr ""
+msgstr "將 WordPress 使用者 {0} 對應至 EmDash 使用者"
 
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:256
 msgid "Mark {0} as Gone (410)"
-msgstr ""
+msgstr "將 {0} 標示為永久移除 (410)"
 
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr ""
+msgstr "標示為已移除 (410) — 告知搜尋引擎此內容已永久刪除"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:502
 msgid "Mark as spam"
-msgstr "標記爲垃圾"
+msgstr "標示為垃圾留言"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:44
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 #: packages/admin/src/components/PluginManager.tsx:205
 msgid "marketplace"
-msgstr "市場"
+msgstr "市集"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:87
 #: packages/admin/src/components/PluginManager.tsx:171
 #: packages/admin/src/components/PluginManager.tsx:383
 #: packages/admin/src/components/Sidebar.tsx:272
 msgid "Marketplace"
-msgstr "市場"
+msgstr "市集"
 
 #: packages/admin/src/components/FieldEditor.tsx:627
 msgid "Max Items"
-msgstr "最大項目數"
+msgstr "項目數上限"
 
 #: packages/admin/src/components/FieldEditor.tsx:470
 msgid "Max Length"
@@ -4855,11 +4855,11 @@ msgstr "最大值"
 
 #: packages/admin/src/components/Widgets.tsx:147
 msgid "Maximum tags"
-msgstr ""
+msgstr "標籤數上限"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:45
 msgid "MDX"
-msgstr ""
+msgstr "MDX"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2398
 #: packages/admin/src/components/PortableTextEditor.tsx:2413
@@ -4872,7 +4872,7 @@ msgstr "媒體"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:222
 msgid "Media Details"
-msgstr "媒體詳情"
+msgstr "媒體詳細資料"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2400
@@ -4881,15 +4881,15 @@ msgstr "媒體錯誤 ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:2362
 msgid "Media Import"
-msgstr "媒體導入"
+msgstr "媒體匯入"
 
 #: packages/admin/src/components/WordPressImport.tsx:2303
 msgid "Media Import Complete"
-msgstr "媒體導入完成"
+msgstr "媒體匯入完成"
 
 #: packages/admin/src/components/WordPressImport.tsx:2314
 msgid "Media import was skipped"
-msgstr "媒體導入已跳過"
+msgstr "已略過媒體匯入"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:153
 #: packages/admin/src/components/MediaLibrary.tsx:322
@@ -4898,104 +4898,104 @@ msgstr "媒體庫"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
 msgid "Media Read"
-msgstr "媒體讀取"
+msgstr "讀取媒體"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
 msgid "Media Write"
-msgstr "媒體寫入"
+msgstr "寫入媒體"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1120
 msgid "Medium section heading"
-msgstr "中章節標題"
+msgstr "中型區段標題"
 
 #: packages/admin/src/components/Widgets.tsx:104
 #: packages/admin/src/components/Widgets.tsx:912
 msgid "Menu"
-msgstr "菜單"
+msgstr "選單"
 
 #. placeholder {0}: translated.label
 #. placeholder {1}: translated.locale.toUpperCase()
 #: packages/admin/src/components/MenuEditor.tsx:144
 msgid "Menu \"{0}\" ({1}) created."
-msgstr ""
+msgstr "已建立選單「{0}」({1})。"
 
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:56
 msgid "Menu \"{0}\" has been created."
-msgstr "菜單 \"{0}\" 已創建。"
+msgstr "已建立選單「{0}」。"
 
 #: packages/admin/src/components/MenuList.tsx:55
 msgid "Menu created"
-msgstr "菜單已創建"
+msgstr "選單已建立"
 
 #: packages/admin/src/components/MenuList.tsx:75
 msgid "Menu deleted"
-msgstr "菜單已刪除"
+msgstr "選單已刪除"
 
 #: packages/admin/src/components/MenuEditor.tsx:175
 msgid "Menu item has been added."
-msgstr "菜單項已添加。"
+msgstr "已新增選單項目。"
 
 #: packages/admin/src/components/MenuEditor.tsx:188
 msgid "Menu item has been deleted."
-msgstr "菜單項已刪除。"
+msgstr "選單項目已刪除。"
 
 #: packages/admin/src/components/MenuEditor.tsx:213
 msgid "Menu item has been updated."
-msgstr "菜單項已更新。"
+msgstr "選單項目已更新。"
 
 #: packages/admin/src/components/MenuEditor.tsx:350
 msgid "Menu not found"
-msgstr "菜單未找到"
+msgstr "找不到選單"
 
 #: packages/admin/src/components/MenuEditor.tsx:228
 msgid "Menu order has been updated."
-msgstr "菜單順序已更新。"
+msgstr "選單順序已更新。"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:160
 #: packages/admin/src/components/MenuList.tsx:104
 #: packages/admin/src/components/Sidebar.tsx:226
 #: packages/admin/src/components/WordPressImport.tsx:1149
 msgid "Menus"
-msgstr "菜單"
+msgstr "選單"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1767
 msgid "Menus ({0})"
-msgstr "菜單 ({0})"
+msgstr "選單 ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
 msgid "Menus Manage"
-msgstr "菜單管理"
+msgstr "管理選單"
 
 #: packages/admin/src/components/SeoPanel.tsx:188
 #: packages/admin/src/components/SeoPanel.tsx:192
 msgid "Meta Description"
-msgstr "Meta 描述"
+msgstr "中繼說明"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:203
 msgid "Meta tag content for Bing Webmaster Tools verification"
-msgstr "Bing 網站管理員工具驗證的元標籤內容"
+msgstr "用於 Bing Webmaster Tools 驗證的中繼標籤內容"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:197
 msgid "Meta tag content for Google Search Console verification"
-msgstr "Google Search Console 驗證的元標籤內容"
+msgstr "用於 Google Search Console 驗證的中繼標籤內容"
 
 #: packages/admin/src/components/WordPressImport.tsx:1845
 msgid "Meta titles, descriptions, and social images"
-msgstr "元標題、描述和社交圖片"
+msgstr "Meta 標題、說明及社群圖片"
 
 #: packages/admin/src/components/WordPressImport.tsx:1051
 msgid "Migration key"
-msgstr ""
+msgstr "移轉金鑰"
 
 #: packages/admin/src/components/FieldEditor.tsx:620
 msgid "Min Items"
-msgstr "最小項目數"
+msgstr "最少項目數"
 
 #: packages/admin/src/components/FieldEditor.tsx:463
 msgid "Min Length"
-msgstr "最小長度"
+msgstr "最短長度"
 
 #: packages/admin/src/components/FieldEditor.tsx:493
 msgid "Min Value"
@@ -5003,53 +5003,53 @@ msgstr "最小值"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:504
 msgid "Moderation"
-msgstr ""
+msgstr "審核"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
-msgstr "審覈信號"
+msgstr "審核訊號"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:211
 msgid "Modified"
-msgstr "已修改"
+msgstr "修改時間"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:72
 msgid "Modify collection schemas"
-msgstr "修改合集模式"
+msgstr "修改內容集合結構描述"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Monthly"
-msgstr ""
+msgstr "每月"
 
 #: packages/admin/src/components/Widgets.tsx:159
 msgid "Monthly/yearly archives"
-msgstr ""
+msgstr "每月/每年彙整"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:111
 msgid "More information about {label}"
-msgstr ""
+msgstr "{label} 的詳細資訊"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
-msgstr ""
+msgstr "熱門項目"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:439
 msgid "Move \"{0}\" down"
-msgstr ""
+msgstr "將「{0}」下移"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:429
 msgid "Move \"{0}\" up"
-msgstr ""
+msgstr "將「{0}」上移"
 
 #: packages/admin/src/components/ContentList.tsx:1048
 msgid "Move \"{title}\" to trash? You can restore it later."
-msgstr "將「{title}」移至回收站？您可以稍後恢復它。"
+msgstr "要將「{title}」移至回收桶嗎？之後仍可還原。"
 
 #: packages/admin/src/components/ContentList.tsx:1039
 msgid "Move {title} to trash"
-msgstr "將 {title} 移至回收站"
+msgstr "將 {title} 移至回收桶"
 
 #: packages/admin/src/components/MenuEditor.tsx:537
 msgid "Move down"
@@ -5057,20 +5057,20 @@ msgstr "下移"
 
 #: packages/admin/src/components/ContentList.tsx:439
 msgid "Move to trash"
-msgstr ""
+msgstr "移至回收桶"
 
 #: packages/admin/src/components/ContentList.tsx:466
 #: packages/admin/src/components/ContentList.tsx:1061
 #: packages/admin/src/components/ContentSettingsPanel.tsx:638
 #: packages/admin/src/components/ContentSettingsPanel.tsx:658
 msgid "Move to Trash"
-msgstr "移至回收站"
+msgstr "移至回收桶"
 
 #: packages/admin/src/components/ContentList.tsx:444
 #: packages/admin/src/components/ContentList.tsx:1046
 #: packages/admin/src/components/ContentSettingsPanel.tsx:643
 msgid "Move to Trash?"
-msgstr "移至回收站？"
+msgstr "要移至回收桶嗎？"
 
 #: packages/admin/src/components/MenuEditor.tsx:528
 msgid "Move up"
@@ -5078,27 +5078,27 @@ msgstr "上移"
 
 #: packages/admin/src/router.tsx:510
 msgid "Moved {total} items to draft"
-msgstr ""
+msgstr "已將 {total} 個項目移至草稿"
 
 #: packages/admin/src/router.tsx:531
 msgid "Moved {total} items to trash"
-msgstr ""
+msgstr "已將 {total} 個項目移至回收桶"
 
 #: packages/admin/src/components/FieldEditor.tsx:192
 msgid "Multi Select"
-msgstr "多選"
+msgstr "多重選取"
 
 #: packages/admin/src/components/FieldEditor.tsx:157
 msgid "Multi-line plain text"
-msgstr "多行純文本"
+msgstr "多行純文字"
 
 #: packages/admin/src/components/FieldEditor.tsx:193
 msgid "Multiple choices from options"
-msgstr "從選項中選擇多個"
+msgstr "從選項中選擇多個項目"
 
 #: packages/admin/src/components/SetupWizard.tsx:120
 msgid "My Awesome Blog"
-msgstr "我的精彩博客"
+msgstr "我的精彩網誌"
 
 #: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MarketplaceBrowse.tsx:45
@@ -5114,15 +5114,15 @@ msgstr "名稱"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:580
 msgid "Name and label are required"
-msgstr "名稱和標籤爲必填項"
+msgstr "名稱及標籤為必填"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:586
 msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
-msgstr "名稱必須以字母開頭，且僅包含小寫字母、數字和下劃線"
+msgstr "名稱必須以字母開頭，且只能包含小寫字母、數字及底線"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:340
 msgid "Navigation"
-msgstr "導航"
+msgstr "導覽"
 
 #: packages/admin/src/components/users/UserDetail.tsx:231
 #: packages/admin/src/components/users/UserList.tsx:185
@@ -5131,62 +5131,62 @@ msgstr "從未"
 
 #: packages/admin/src/router.tsx:1120
 msgid "new"
-msgstr ""
+msgstr "新增"
 
 #: packages/admin/src/routes/bylines.tsx:426
 msgid "New"
-msgstr ""
+msgstr "新增"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:111
 msgid "NEW"
-msgstr "新"
+msgstr "新增"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:466
 msgid "New {0}"
-msgstr "新{0}"
+msgstr "新增 {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:643
 msgid "New {itemLabel}"
-msgstr ""
+msgstr "新增 {itemLabel}"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
-msgstr ""
+msgstr "新增署名欄位"
 
 #: packages/admin/src/components/WordPressImport.tsx:1982
 msgid "New collection"
-msgstr "新合集"
+msgstr "新內容集合"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:355
 #: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
-msgstr "新內容類型"
+msgstr "新增內容類型"
 
 #: packages/admin/src/routes/byline-schema.tsx:224
 msgid "New field"
-msgstr ""
+msgstr "新增欄位"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:122
 msgid "New public routes"
-msgstr ""
+msgstr "新增公開路由"
 
 #: packages/admin/src/components/Redirects.tsx:106
 #: packages/admin/src/components/Redirects.tsx:363
 msgid "New Redirect"
-msgstr "新重定向"
+msgstr "新增重新導向"
 
 #: packages/admin/src/components/Sections.tsx:143
 msgid "New Section"
-msgstr "新區塊"
+msgstr "新增區段"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:479
 msgid "new tab"
-msgstr "新標籤頁"
+msgstr "新分頁"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:831
 msgid "New Taxonomy"
-msgstr "新分類"
+msgstr "新增分類法"
 
 #: packages/admin/src/components/MenuEditor.tsx:430
 #: packages/admin/src/components/MenuEditor.tsx:433
@@ -5198,15 +5198,15 @@ msgstr "新視窗"
 #: packages/admin/src/components/MarketplaceBrowse.tsx:44
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
 msgid "Newest"
-msgstr ""
+msgstr "最新項目"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:408
 msgid "News"
-msgstr ""
+msgstr "新聞"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
 msgid "Next"
-msgstr "下一步"
+msgstr "下一個"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:372
 #: packages/admin/src/components/ContentList.tsx:618
@@ -5215,7 +5215,7 @@ msgstr "下一頁"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:476
 msgid "Next screenshot"
-msgstr "下一張截圖"
+msgstr "下一張螢幕擷取畫面"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:422
@@ -5224,161 +5224,161 @@ msgstr "否"
 
 #: packages/admin/src/routes/byline-schema.tsx:420
 msgid "No (shared across translations)"
-msgstr ""
+msgstr "否 (在各翻譯間共用)"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:436
 msgid "No {0} available."
-msgstr "暫無{0}。"
+msgstr "沒有可用的 {0}。"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:549
 msgid "No {0} yet."
-msgstr "暫無 {0}。"
+msgstr "目前沒有 {0}。"
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:850
 msgid "No {0} yet. Create one to get started."
-msgstr "暫無{0}。創建一個以開始使用。"
+msgstr "尚無 {0}。請建立一個以開始使用。"
 
 #: packages/admin/src/components/Redirects.tsx:218
 msgid "No 404 errors recorded yet."
-msgstr "暫無 404 錯誤記錄。"
+msgstr "尚未記錄任何 404 錯誤。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:833
 #: packages/admin/src/components/MediaLibrary.tsx:890
 msgid "No alt text"
-msgstr "無替代文本"
+msgstr "沒有替代文字"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:281
 msgid "No API tokens yet. Create one to get started."
-msgstr "暫無 API 令牌。創建一個以開始使用。"
+msgstr "尚無 API 權杖。建立一個即可開始。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:548
 msgid "No approved comments yet."
-msgstr "暫無已審覈評論。"
+msgstr "尚無已核准的留言。"
 
 #: packages/admin/src/routes/byline-schema.tsx:291
 msgid "No byline fields yet."
-msgstr ""
+msgstr "目前沒有署名欄位。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:805
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr ""
+msgstr "在 {entryLocale} 中沒有可用的署名資料。請先從 [署名資料] 頁面建立語系版本，再為這個內容項目加入署名。"
 
 #: packages/admin/src/routes/bylines.tsx:452
 msgid "No bylines found"
-msgstr ""
+msgstr "找不到署名資料"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:913
 msgid "No bylines selected."
-msgstr "未選擇任何署名。"
+msgstr "未選取任何署名。"
 
 #: packages/admin/src/components/Dashboard.tsx:226
 msgid "No collections configured"
-msgstr "未配置任何合集"
+msgstr "尚未設定任何內容集合"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:547
 msgid "No comments awaiting moderation."
-msgstr "暫無待審覈評論。"
+msgstr "沒有待審核的留言。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:543
 msgid "No comments match your search."
-msgstr "暫無評論符合您的搜索。"
+msgstr "找不到符合搜尋條件的留言。"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:82
 msgid "No content"
-msgstr ""
+msgstr "沒有內容"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:171
 msgid "No content found"
-msgstr "未找到內容"
+msgstr "找不到內容"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:177
 msgid "No content in this collection"
-msgstr "此合集中無內容"
+msgstr "這個內容集合中沒有內容"
 
 #: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
-msgstr "暫無內容類型。"
+msgstr "尚無內容類型。"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:612
 msgid "No custom fields yet"
-msgstr ""
+msgstr "尚無自訂欄位"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:275
 msgid "No detailed description available."
-msgstr "暫無詳細描述。"
+msgstr "沒有可用的詳細說明。"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:262
 msgid "No domains configured. Users must be invited individually."
-msgstr "未配置域名。必須單獨邀請用戶。"
+msgstr "尚未設定網域。必須個別邀請使用者。"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:152
 msgid "No email provider configured"
-msgstr "未配置郵件提供商"
+msgstr "尚未設定電子郵件服務提供者"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:83
 msgid "No email provider configured. Share this link manually."
-msgstr "未配置郵件提供商。請手動分享此鏈接。"
+msgstr "尚未設定電子郵件服務提供者。請手動分享此連結。"
 
 #: packages/admin/src/components/WordPressImport.tsx:2516
 msgid "No EmDash users found"
-msgstr "未找到 EmDash 用戶"
+msgstr "找不到 EmDash 使用者"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
 msgid "No expiry"
-msgstr "永不過期"
+msgstr "永不到期"
 
 #: packages/admin/src/components/RevisionHistory.tsx:335
 msgid "No fields to compare"
-msgstr "無字段可比較"
+msgstr "沒有可比較的欄位"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:204
 msgid "No headings in document"
-msgstr "文檔中無標題"
+msgstr "內容中沒有標題"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:205
 msgid "No images in this gallery yet."
-msgstr ""
+msgstr "此圖庫中尚無圖片。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:594
 msgid "No installable releases"
-msgstr ""
+msgstr "沒有可安裝的發行版本"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:193
 msgid "No invite token provided"
-msgstr ""
+msgstr "未提供邀請權杖"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1915
 #: packages/admin/src/components/RepeaterField.tsx:165
 msgid "No items yet"
-msgstr "暫無項目"
+msgstr "尚無項目"
 
 #: packages/admin/src/components/FieldEditor.tsx:631
 msgid "No limit"
-msgstr "無限制"
+msgstr "沒有限制"
 
 #: packages/admin/src/routes/bylines.tsx:517
 msgid "No linked user"
-msgstr ""
+msgstr "沒有連結的使用者"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:171
 msgid "No matches"
-msgstr ""
+msgstr "沒有符合項目"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:848
 msgid "No matching bylines."
-msgstr ""
+msgstr "沒有符合的署名。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:489
 #: packages/admin/src/components/MediaLibrary.tsx:517
 msgid "No matching media"
-msgstr ""
+msgstr "沒有符合的媒體"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:264
 msgid "No matching passkey found for this account."
-msgstr "未找到與此帳戶匹配的通行密鑰。"
+msgstr "找不到與這個帳號相符的通行金鑰。"
 
 #: packages/admin/src/components/FieldEditor.tsx:474
 #: packages/admin/src/components/FieldEditor.tsx:504
@@ -5387,24 +5387,24 @@ msgstr "無最大值"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:694
 msgid "No media available from this provider"
-msgstr "此提供商無可用媒體"
+msgstr "此服務提供者沒有可用的媒體"
 
 #: packages/admin/src/components/MediaLibrary.tsx:540
 msgid "No media available from this provider."
-msgstr ""
+msgstr "此服務提供者沒有可用的媒體。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:539
 #: packages/admin/src/components/MediaPickerModal.tsx:688
 msgid "No media found"
-msgstr "未找到媒體"
+msgstr "找不到媒體"
 
 #: packages/admin/src/components/MenuEditor.tsx:485
 msgid "No menu items yet"
-msgstr "暫無菜單項"
+msgstr "尚無選單項目"
 
 #: packages/admin/src/components/MenuList.tsx:187
 msgid "No menus yet"
-msgstr "暫無菜單"
+msgstr "尚無選單"
 
 #: packages/admin/src/components/FieldEditor.tsx:467
 #: packages/admin/src/components/FieldEditor.tsx:497
@@ -5413,124 +5413,124 @@ msgstr "無最小值"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:65
 msgid "No moderation (auto-approve all)"
-msgstr ""
+msgstr "不進行審核 (全部自動核准)"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "No parent (top level)"
-msgstr ""
+msgstr "沒有上層項目 (最上層)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:248
 msgid "No passkeys registered"
-msgstr "未註冊通行密鑰"
+msgstr "尚未註冊通行金鑰"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:168
 msgid "No passkeys registered yet."
-msgstr "暫無已註冊的通行密鑰。"
+msgstr "尚未註冊任何通行金鑰。"
 
 #: packages/admin/src/components/PluginManager.tsx:199
 msgid "No plugins configured"
-msgstr "未配置插件"
+msgstr "尚未設定任何外掛"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:173
 msgid "No plugins found"
-msgstr "未找到插件"
+msgstr "找不到外掛"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:118
 msgid "No plugins have been published to this registry yet."
-msgstr ""
+msgstr "這個外掛庫中尚未發佈任何外掛。"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:117
 msgid "No plugins match \"{debouncedQuery}\"."
-msgstr ""
+msgstr "找不到符合「{debouncedQuery}」的外掛。"
 
 #: packages/admin/src/components/Sections.tsx:343
 msgid "No preview"
-msgstr "無預覽"
+msgstr "沒有預覽"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:304
 msgid "No public URL available"
-msgstr ""
+msgstr "沒有可用的公開網址"
 
 #: packages/admin/src/components/Dashboard.tsx:304
 msgid "No recent activity"
-msgstr "暫無最近活動"
+msgstr "沒有近期活動"
 
 #: packages/admin/src/components/Redirects.tsx:461
 msgid "No redirects yet"
-msgstr "暫無重定向"
+msgstr "目前沒有重新導向"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1464
 #: packages/admin/src/components/RepeaterField.tsx:374
 msgid "No results"
-msgstr "無結果"
+msgstr "沒有結果"
 
 #: packages/admin/src/components/ContentList.tsx:546
 #: packages/admin/src/components/ContentList.tsx:565
 msgid "No results for \"{activeSearch}\""
-msgstr ""
+msgstr "找不到符合「{activeSearch}」的結果"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:176
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
-msgstr "「{debouncedQuery}」無結果。請嘗試其他搜索詞。"
+msgstr "找不到與「{debouncedQuery}」相符的結果。請嘗試其他搜尋詞。"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:465
 msgid "No results found"
-msgstr "未找到結果"
+msgstr "找不到結果"
 
 #: packages/admin/src/components/RevisionHistory.tsx:191
 msgid "No revisions yet"
-msgstr "暫無修訂歷史"
+msgstr "尚無修訂版本"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:108
 msgid "No sections available"
-msgstr "無可用區塊"
+msgstr "沒有可用的區段"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:102
 #: packages/admin/src/components/Sections.tsx:259
 msgid "No sections found"
-msgstr "未找到區塊"
+msgstr "找不到區段"
 
 #: packages/admin/src/components/Sections.tsx:265
 msgid "No sections yet"
-msgstr "暫無區塊"
+msgstr "目前沒有區段"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:549
 msgid "No spam comments."
-msgstr "無垃圾評論。"
+msgstr "沒有垃圾留言。"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
 msgid "No themes found"
-msgstr "未找到主題"
+msgstr "找不到佈景主題"
 
 #: packages/admin/src/components/users/UserList.tsx:120
 msgid "No users found matching your filters."
-msgstr ""
+msgstr "找不到符合篩選條件的使用者。"
 
 #: packages/admin/src/components/users/UserList.tsx:134
 msgid "No users yet."
-msgstr ""
+msgstr "目前沒有使用者。"
 
 #: packages/admin/src/components/Widgets.tsx:502
 msgid "No widget areas yet. Create one to get started."
-msgstr ""
+msgstr "目前沒有小工具區域。請先建立一個。"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
 msgid "None"
-msgstr ""
+msgstr "無"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:434
 #: packages/admin/src/components/TaxonomyManager.tsx:443
 msgid "None (top level)"
-msgstr "無（頂級）"
+msgstr "無 (最上層)"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:629
 msgid "Not compatible with this environment"
-msgstr ""
+msgstr "與這個環境不相容"
 
 #: packages/admin/src/components/PluginSettings.tsx:341
 msgid "Not set"
-msgstr ""
+msgstr "未設定"
 
 #: packages/admin/src/components/FieldEditor.tsx:162
 #: packages/admin/src/components/FieldEditor.tsx:581
@@ -5539,21 +5539,21 @@ msgstr "數字"
 
 #: packages/admin/src/components/Widgets.tsx:129
 msgid "Number of posts"
-msgstr ""
+msgstr "文章數量"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:278
 msgid "Number of posts to show per page on list views"
-msgstr "列表視圖每頁顯示的文章數量"
+msgstr "清單檢視中每頁顯示的文章數"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:110
 #: packages/admin/src/components/PortableTextEditor.tsx:1149
 #: packages/admin/src/components/PortableTextEditor.tsx:3671
 msgid "Numbered List"
-msgstr "有序列表"
+msgstr "編號清單"
 
 #: packages/admin/src/components/WordPressImport.tsx:494
 msgid "OAuth authorization requires HTTPS. Please use manual credentials."
-msgstr ""
+msgstr "OAuth 授權需要 HTTPS。請使用手動認證資訊。"
 
 #: packages/admin/src/components/SeoImageField.tsx:46
 msgid "OG Image"
@@ -5562,27 +5562,27 @@ msgstr "OG 圖片"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
 msgid "on a custom hostname is not treated as secure, even on loopback."
-msgstr "在自定義主機名上不被視爲安全，即使在環回地址上。"
+msgstr "在自訂主機名稱上，即使是回送位址也不會視為安全。"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
-msgstr "僅授權您認識的代碼。"
+msgstr "只授權您能辨識的代碼。"
 
 #: packages/admin/src/components/SignupPage.tsx:97
 msgid "Only email addresses from allowed domains can sign up."
-msgstr "僅允許來自允許域名的郵箱註冊。"
+msgstr "只有允許網域的電子郵件地址可以註冊。"
 
 #: packages/admin/src/components/MenuList.tsx:160
 msgid "Only lowercase letters, numbers, and hyphens"
-msgstr "僅限小寫字母、數字和連字符"
+msgstr "僅限小寫字母、數字及連字號"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:106
 msgid "Only the listed MIME types will be accepted for this field."
-msgstr ""
+msgstr "這個欄位只接受清單中列出的 MIME 類型。"
 
 #: packages/admin/src/components/SignupPage.tsx:404
 msgid "Oops!"
-msgstr "哎呀！"
+msgstr "發生錯誤。"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:379
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:380
@@ -5591,57 +5591,57 @@ msgstr "哎呀！"
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:333
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:334
 msgid "Open in new tab"
-msgstr "在新標籤頁中開啟"
+msgstr "在新分頁開啟"
 
 #: packages/admin/src/components/WordPressImport.tsx:1534
 msgid "Open WordPress Profile"
-msgstr "開啟 WordPress 個人資料"
+msgstr "開啟 WordPress 個人檔案"
 
 #: packages/admin/src/components/FieldEditor.tsx:515
 msgid ""
 "Option 1\n"
 "Option 2\n"
 "Option 3"
-msgstr ""
+msgstr "選項 1\n選項 2\n選項 3"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:385
 msgid "Optional caption"
-msgstr ""
+msgstr "選填圖說"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
 msgid "Optional caption displayed below the image"
-msgstr "顯示在圖片下方的可選說明"
+msgstr "顯示於圖片下方的選填圖說"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:384
 msgid "Optional caption for display"
-msgstr "用於顯示的可選說明"
+msgstr "選填顯示圖說"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:459
 msgid "Optional description"
-msgstr "可選描述"
+msgstr "選填的說明"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:553
 msgid "Optional tooltip on hover"
-msgstr "懸停時的可選工具提示"
+msgstr "游標停留時顯示的選用工具提示"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:302
 #: packages/admin/src/components/FieldEditor.tsx:512
 msgid "Options (one per line)"
-msgstr "選項（每行一個）"
+msgstr "選項 (每行一個)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:579
 msgid "or choose from library"
-msgstr "或從庫中選擇"
+msgstr "或從媒體庫選取"
 
 #: packages/admin/src/components/WordPressImport.tsx:1590
 msgid "Or click to browse. Accepts .xml files exported from WordPress."
-msgstr "或點擊瀏覽。接受從 WordPress 導出的 .xml 文件。"
+msgstr "或按一下以瀏覽。接受從 WordPress 匯出的 .xml 檔案。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1071
 msgid "or connect by URL"
-msgstr ""
+msgstr "或透過網址連線"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:97
 #: packages/admin/src/components/LoginPage.tsx:263
@@ -5651,7 +5651,7 @@ msgstr "或繼續使用"
 
 #: packages/admin/src/components/WordPressImport.tsx:1391
 msgid "Or upload an export file"
-msgstr "或上傳導出文件"
+msgstr "或上傳匯出檔案"
 
 #: packages/admin/src/components/WordPressImport.tsx:1107
 msgid "or upload directly"
@@ -5659,13 +5659,13 @@ msgstr "或直接上傳"
 
 #: packages/admin/src/components/MenuEditor.tsx:227
 msgid "Order saved"
-msgstr "順序已保存"
+msgstr "順序已儲存"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:369
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
 msgid "Original:"
-msgstr "原始："
+msgstr "原始內容:"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:182
 msgid "Outline"
@@ -5673,7 +5673,7 @@ msgstr "大綱"
 
 #: packages/admin/src/components/SeoPanel.tsx:164
 msgid "Overrides the page title in search engine results"
-msgstr "覆蓋搜索引擎結果中的頁面標題"
+msgstr "取代搜尋引擎結果中的頁面標題"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:539
 msgid "Ownership"
@@ -5681,11 +5681,11 @@ msgstr "所有權"
 
 #: packages/admin/src/components/PluginManager.tsx:591
 msgid "Package"
-msgstr "包"
+msgstr "套件"
 
 #: packages/admin/src/router.tsx:2189
 msgid "Page Not Found"
-msgstr ""
+msgstr "找不到頁面"
 
 #: packages/admin/src/components/PluginManager.tsx:401
 #: packages/admin/src/components/WordPressImport.tsx:1328
@@ -5699,16 +5699,16 @@ msgstr "段落"
 #: packages/admin/src/components/MenuEditor.tsx:615
 #: packages/admin/src/components/TaxonomyManager.tsx:430
 msgid "Parent"
-msgstr "父級"
+msgstr "上層項目"
 
 #: packages/admin/src/components/Redirects.tsx:510
 #: packages/admin/src/components/Redirects.tsx:516
 msgid "Part of a redirect loop"
-msgstr "重定向循環的一部分"
+msgstr "屬於重新導向迴圈的一部分"
 
 #: packages/admin/src/components/WordPressImport.tsx:1153
 msgid "Partial"
-msgstr ""
+msgstr "部分"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:322
 msgid "Pass"
@@ -5716,64 +5716,64 @@ msgstr "通過"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:89
 msgid "Passkey added successfully"
-msgstr "通行密鑰添加成功"
+msgstr "已成功新增通行金鑰"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:129
 msgid "Passkey name"
-msgstr "通行密鑰名稱"
+msgstr "通行金鑰名稱"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
 msgid "Passkey Name (optional)"
-msgstr "通行密鑰名稱（可選）"
+msgstr "通行金鑰名稱 (選填)"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
 msgid "Passkey registered successfully!"
-msgstr "通行密鑰註冊成功！"
+msgstr "已成功註冊通行金鑰。"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:66
 msgid "Passkey removed"
-msgstr "通行密鑰已移除"
+msgstr "已移除通行金鑰"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:49
 msgid "Passkey renamed"
-msgstr "通行密鑰已重命名"
+msgstr "已重新命名通行金鑰"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:150
 #: packages/admin/src/components/users/UserList.tsx:110
 msgid "Passkeys"
-msgstr "通行密鑰"
+msgstr "通行金鑰"
 
 #. placeholder {0}: user.credentials.length
 #: packages/admin/src/components/users/UserDetail.tsx:245
 msgid "Passkeys ({0})"
-msgstr "通行密鑰 ({0})"
+msgstr "通行金鑰 ({0})"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:154
 msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
-msgstr "通行密鑰是一種安全的無密碼登錄方式。您可以爲不同設備註冊多個通行密鑰。"
+msgstr "通行金鑰是安全且無須密碼的帳號登入方式。您可以為不同裝置註冊多組通行金鑰。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:77
 #: packages/admin/src/components/SignupPage.tsx:214
 msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
-msgstr "通行密鑰是一種安全的無密碼登錄方式，使用設備的生物識別、PIN 碼或安全密鑰登錄。"
+msgstr "通行金鑰可使用裝置的生物特徵、PIN 或安全金鑰，提供安全且無須密碼的登入方式。"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:301
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
 msgid "Passkeys Not Available Here"
-msgstr "此處不提供通行密鑰"
+msgstr "此處無法使用通行金鑰"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:305
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
 msgid "Passkeys require a"
-msgstr "通行密鑰需要"
+msgstr "通行金鑰需要"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:158
 msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
-msgstr "通行密鑰需要 HTTPS 或 http://localhost（帶您的埠）；此主機名不是安全的瀏覽器上下文。"
+msgstr "通行金鑰需要 HTTPS 或 http://localhost (含您的通訊埠)；這個主機名稱不屬於安全的瀏覽器環境。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1037
 msgid "Paste your migration key"
-msgstr ""
+msgstr "貼上您的移轉金鑰"
 
 #: packages/admin/src/components/Redirects.tsx:225
 msgid "Path"
@@ -5781,21 +5781,21 @@ msgstr "路徑"
 
 #: packages/admin/src/components/FieldEditor.tsx:479
 msgid "Pattern (Regex)"
-msgstr "模式（正則表達式）"
+msgstr "模式 (Regex)"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:435
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr ""
+msgstr "產生 URL 的模式，例如 /blog/{0}"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:431
 msgid "Pattern must include a {0} placeholder"
-msgstr ""
+msgstr "模式必須包含 {0} 預留位置"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:62
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:1185
@@ -5809,11 +5809,11 @@ msgstr "待處理"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:441
 msgid "Pending changes"
-msgstr "待處理的更改"
+msgstr "待處理的變更"
 
 #: packages/admin/src/components/ContentList.tsx:1119
 msgid "Permanently delete \"{title}\"? This cannot be undone."
-msgstr "永久刪除「{title}」？此操作無法撤銷。"
+msgstr "要永久刪除「{title}」嗎？此操作無法復原。"
 
 #: packages/admin/src/components/ContentList.tsx:1108
 msgid "Permanently delete {title}"
@@ -5825,132 +5825,132 @@ msgstr "權限"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:46
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
-msgstr "選擇任意方式創建您的管理員賬戶。"
+msgstr "選擇任一方式建立管理員帳號。"
 
 #: packages/admin/src/components/Widgets.tsx:154
 msgid "Placeholder text"
-msgstr ""
+msgstr "預留位置文字"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:311
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
 msgid "Plain"
-msgstr "普通"
+msgstr "未加密的"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:27
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:120
 msgid "Plain text"
-msgstr ""
+msgstr "純文字"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:166
 msgid "Please ask your administrator to send a new invite."
-msgstr ""
+msgstr "請要求您的管理員傳送新的邀請。"
 
 #: packages/admin/src/components/SetupWizard.tsx:181
 msgid "Please enter a valid email"
-msgstr "請輸入有效的郵箱"
+msgstr "請輸入有效的電子郵件地址"
 
 #: packages/admin/src/components/SignupPage.tsx:55
 msgid "Please enter a valid email address"
-msgstr "請輸入有效的郵箱地址"
+msgstr "請輸入有效的電子郵件地址"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:442
 msgid "Please enter a valid URL"
-msgstr "請輸入有效的 URL"
+msgstr "請輸入有效的網址"
 
 #: packages/admin/src/components/WordPressImport.tsx:1182
 msgid "Plugin"
-msgstr "插件"
+msgstr "外掛"
 
 #: packages/admin/src/lib/api/plugins.ts:68
 msgid "Plugin \"{pluginId}\" not found"
-msgstr ""
+msgstr "找不到外掛「{pluginId}」"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:762
 msgid "Plugin details"
-msgstr ""
+msgstr "外掛詳細資料"
 
 #: packages/admin/src/components/PluginManager.tsx:114
 msgid "Plugin disabled"
-msgstr "插件已禁用"
+msgstr "外掛已停用"
 
 #: packages/admin/src/components/PluginManager.tsx:95
 msgid "Plugin enabled"
-msgstr "插件已啓用"
+msgstr "外掛已啟用"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:89
 msgid "Plugin Error"
-msgstr ""
+msgstr "外掛錯誤"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:37
 msgid "Plugin error ({0})"
-msgstr ""
+msgstr "外掛錯誤 ({0})"
 
 #: packages/admin/src/components/PluginManager.tsx:333
 msgid "Plugin MCP access updated"
-msgstr ""
+msgstr "外掛 MCP 存取權已更新"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
 msgid "Plugin MCP Tools"
-msgstr ""
+msgstr "外掛 MCP 工具"
 
 #: packages/admin/src/lib/api/marketplace.ts:108
 msgid "Plugin MCP tools require explicit consent"
-msgstr ""
+msgstr "外掛 MCP 工具需要明確同意"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:123
 msgid "Plugin not found"
-msgstr "未找到插件"
+msgstr "找不到外掛"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:411
 msgid "Plugin not found. The publisher handle or slug may be incorrect."
-msgstr ""
+msgstr "找不到外掛。發佈者代號或代稱可能有誤。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1209
 msgid "plugin on your WordPress site."
-msgstr "在您的 WordPress 站點上的插件。"
+msgstr "WordPress 網站上的外掛。"
 
 #: packages/admin/src/components/PluginManager.tsx:482
 msgid "Plugin pages"
-msgstr ""
+msgstr "外掛頁面"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "Plugin Permissions"
-msgstr "插件權限"
+msgstr "外掛權限"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:71
 msgid "Plugin Registry"
-msgstr ""
+msgstr "外掛庫"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginPage.tsx:40
 msgid "Plugin responded with {0}: {text}"
-msgstr ""
+msgstr "外掛回應 {0}: {text}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:452
 msgid "Plugin tools: {0}"
-msgstr ""
+msgstr "外掛工具: {0}"
 
 #: packages/admin/src/components/PluginManager.tsx:322
 msgid "Plugin uninstalled"
-msgstr "插件已卸載"
+msgstr "已解除安裝外掛"
 
 #: packages/admin/src/lib/api/registry.ts:810
 msgid "Plugin update requires re-consent"
-msgstr ""
+msgstr "外掛更新需要重新同意授權"
 
 #: packages/admin/src/components/PluginManager.tsx:268
 msgid "Plugin updated"
-msgstr "插件已更新"
+msgstr "外掛已更新"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
 msgid "Plugin widget error"
-msgstr ""
+msgstr "外掛小工具錯誤"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:218
 #: packages/admin/src/components/PluginManager.tsx:139
@@ -5959,19 +5959,19 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:256
 #: packages/admin/src/components/Sidebar.tsx:391
 msgid "Plugins"
-msgstr "插件"
+msgstr "外掛"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:264
 msgid "Point-in-Time Restore"
-msgstr ""
+msgstr "指定時間點還原"
 
 #: packages/admin/src/components/SeoPanel.tsx:208
 msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
-msgstr "如果此頁面是從另一個 URL 複製的，則引導搜索引擎到原始版本"
+msgstr "如果這個頁面重複其他網址的內容，則將搜尋引擎指向此頁面的原始版本"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:387
 msgid "Post"
-msgstr ""
+msgstr "文章"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:395
 #: packages/admin/src/components/WordPressImport.tsx:1322
@@ -5980,7 +5980,7 @@ msgstr "文章"
 
 #: packages/admin/src/components/WordPressImport.tsx:1144
 msgid "Posts & Pages"
-msgstr ""
+msgstr "文章與頁面"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:272
 msgid "Posts Per Page"
@@ -5988,7 +5988,7 @@ msgstr "每頁文章數"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:478
 msgid "Pre-release"
-msgstr ""
+msgstr "發行前版本"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
@@ -5996,12 +5996,12 @@ msgstr "正在準備註冊..."
 
 #: packages/admin/src/components/WordPressImport.tsx:2179
 msgid "Preparing to download files from WordPress..."
-msgstr "正在準備從 WordPress 下載文件..."
+msgstr "正在準備從 WordPress 下載檔案…"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:166
 #: packages/admin/src/components/SetupWizard.tsx:233
 msgid "Preparing..."
-msgstr "正在準備..."
+msgstr "正在準備…"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:154
 #: packages/admin/src/components/ContentTypeEditor.tsx:81
@@ -6019,7 +6019,7 @@ msgstr "預覽草稿"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
 msgid "Previous"
-msgstr "上一步"
+msgstr "上一個"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:353
 #: packages/admin/src/components/ContentList.tsx:606
@@ -6028,19 +6028,19 @@ msgstr "上一頁"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:458
 msgid "Previous screenshot"
-msgstr "上一張截圖"
+msgstr "上一張螢幕擷取畫面"
 
 #: packages/admin/src/components/MenuList.tsx:167
 msgid "Primary Navigation"
-msgstr "主導航"
+msgstr "主要導覽"
 
 #: packages/admin/src/components/Dashboard.tsx:349
 msgid "Private"
-msgstr ""
+msgstr "私密"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:174
 msgid "Provider:"
-msgstr "提供商："
+msgstr "服務提供者:"
 
 #: packages/admin/src/components/ContentList.tsx:415
 #: packages/admin/src/components/ContentSettingsPanel.tsx:426
@@ -6049,11 +6049,11 @@ msgstr "發佈"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:185
 msgid "Publish {itemLabel}"
-msgstr ""
+msgstr "發佈 {itemLabel}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:192
 msgid "Publish updates"
-msgstr ""
+msgstr "發佈更新"
 
 #: packages/admin/src/components/ContentList.tsx:1160
 msgid "published"
@@ -6076,7 +6076,7 @@ msgstr "發佈於 {0}"
 
 #: packages/admin/src/router.tsx:487
 msgid "Published {total} items"
-msgstr ""
+msgstr "已發佈 {total} 個項目"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
@@ -6084,20 +6084,20 @@ msgstr "發佈時間"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:472
 msgid "Published by"
-msgstr ""
+msgstr "發佈者"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
-msgstr ""
+msgstr "Python"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:921
 msgid "Quick create byline"
-msgstr "快速創建署名"
+msgstr "快速建立署名"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:196
 #: packages/admin/src/components/editor/ImageNode.tsx:197
 msgid "Quick edit alt text"
-msgstr ""
+msgstr "快速編輯替代文字"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:86
 #: packages/admin/src/components/PortableTextEditor.tsx:1159
@@ -6107,37 +6107,37 @@ msgstr "引用"
 
 #: packages/admin/src/components/WordPressImport.tsx:1162
 msgid "Raw meta"
-msgstr ""
+msgstr "原始中繼資料"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:67
 msgid "Read collection schemas"
-msgstr "讀取合集模式"
+msgstr "讀取內容集合結構描述"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:47
 msgid "Read content entries"
-msgstr "讀取內容條目"
+msgstr "讀取內容項目"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:57
 msgid "Read media files"
-msgstr "讀取媒體文件"
+msgstr "讀取媒體檔案"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:87
 msgid "Read site settings"
-msgstr "讀取網站設置"
+msgstr "讀取網站設定"
 
 #: packages/admin/src/lib/api/marketplace.ts:284
 #: packages/admin/src/lib/api/marketplace.ts:292
 msgid "Read user accounts"
-msgstr ""
+msgstr "讀取使用者帳號"
 
 #: packages/admin/src/lib/api/marketplace.ts:279
 #: packages/admin/src/lib/api/marketplace.ts:288
 msgid "Read your content"
-msgstr ""
+msgstr "讀取您的內容"
 
 #: packages/admin/src/lib/api/marketplace.ts:281
 msgid "Read your taxonomies and terms"
-msgstr ""
+msgstr "讀取您的分類法及分類項目"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:269
 msgid "Reading"
@@ -6149,55 +6149,55 @@ msgstr "就緒"
 
 #: packages/admin/src/components/Dashboard.tsx:298
 msgid "Recent Activity"
-msgstr "最近活動"
+msgstr "近期活動"
 
 #: packages/admin/src/components/Widgets.tsx:126
 msgid "Recent Posts"
-msgstr ""
+msgstr "近期文章"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:43
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
 msgid "Recently Updated"
-msgstr ""
+msgstr "最近更新"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:118
 msgid "Recipient email"
-msgstr "收件人郵箱"
+msgstr "收件者電子郵件"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/users/UserDetail.tsx:336
 msgid "Recovery link sent to {0}"
-msgstr "恢復鏈接已發送至 {0}"
+msgstr "復原連結已傳送至 {0}"
 
 #: packages/admin/src/components/Redirects.tsx:443
 msgid "Redirect loop detected"
-msgstr "檢測到重定向循環"
+msgstr "偵測到重新導向迴圈"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:163
 msgid "Redirecting to login..."
-msgstr "正在重定向到登錄..."
+msgstr "正在重新導向至登入頁面..."
 
 #: packages/admin/src/components/Redirects.tsx:359
 #: packages/admin/src/components/Redirects.tsx:378
 #: packages/admin/src/components/Sidebar.tsx:229
 msgid "Redirects"
-msgstr "重定向"
+msgstr "重新導向"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3817
 msgid "Redo"
-msgstr ""
+msgstr "重做"
 
 #: packages/admin/src/components/FieldEditor.tsx:216
 msgid "Reference"
-msgstr "引用"
+msgstr "參照"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:228
 msgid "Referenced favicon unavailable."
-msgstr ""
+msgstr "參照的網站圖示無法使用。"
 
 #: packages/admin/src/components/Dashboard.tsx:85
 msgid "Refresh the page or try again."
-msgstr ""
+msgstr "重新整理頁面或再試一次。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
@@ -6206,27 +6206,27 @@ msgstr "註冊"
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
 #: packages/admin/src/components/settings/SecuritySettings.tsx:195
 msgid "Register Passkey"
-msgstr "註冊通行密鑰"
+msgstr "註冊通行金鑰"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:83
 msgid "Registered user"
-msgstr "已註冊用戶"
+msgstr "已註冊使用者"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
 msgid "Registration failed"
-msgstr ""
+msgstr "註冊失敗"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
 msgid "Registration was cancelled or timed out. Please try again."
-msgstr "註冊已取消或超時。請重試。"
+msgstr "註冊已取消或逾時。請再試一次。"
 
 #: packages/admin/src/components/Sidebar.tsx:265
 msgid "Registry"
-msgstr ""
+msgstr "外掛庫"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:610
 msgid "Release is too new to install"
-msgstr ""
+msgstr "版本太新，無法安裝"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
@@ -6250,19 +6250,19 @@ msgstr "移除 {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:145
 msgid "Remove {entry}"
-msgstr ""
+msgstr "移除 {entry}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1667
 msgid "Remove {label}"
-msgstr ""
+msgstr "移除 {label}"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:397
 msgid "Remove Domain"
-msgstr "移除域名"
+msgstr "移除網域"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
 msgid "Remove Domain?"
-msgstr "移除域名？"
+msgstr "要移除網域嗎？"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:141
 #: packages/admin/src/components/ImageFieldRenderer.tsx:170
@@ -6278,11 +6278,11 @@ msgstr "移除圖片"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:320
 msgid "Remove image {0}"
-msgstr ""
+msgstr "移除圖片 {0}"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
 msgid "Remove Image?"
-msgstr "移除圖片？"
+msgstr "要移除圖片嗎？"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:2031
@@ -6293,23 +6293,23 @@ msgstr "移除項目 {0}"
 #: packages/admin/src/components/PortableTextEditor.tsx:3218
 #: packages/admin/src/components/PortableTextEditor.tsx:3219
 msgid "Remove link"
-msgstr ""
+msgstr "移除連結"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:186
 msgid "Remove passkey"
-msgstr "移除通行密鑰"
+msgstr "移除通行金鑰"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:201
 msgid "Remove passkey?"
-msgstr "移除通行密鑰？"
+msgstr "要移除通行金鑰嗎？"
 
 #: packages/admin/src/components/FieldEditor.tsx:611
 msgid "Remove sub-field"
-msgstr "移除子字段"
+msgstr "移除子欄位"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:198
 msgid "Remove this image from the document?"
-msgstr "從文檔中移除此圖片？"
+msgstr "要從文件中移除這張圖片嗎？"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:200
 #: packages/admin/src/components/settings/PasskeyItem.tsx:208
@@ -6318,51 +6318,51 @@ msgstr "正在移除..."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:174
 msgid "Rename"
-msgstr "重命名"
+msgstr "重新命名"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:175
 msgid "Rename {0}"
-msgstr "重命名 {0}"
+msgstr "重新命名 {0}"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:175
 msgid "Rename passkey"
-msgstr "重命名通行密鑰"
+msgstr "重新命名通行金鑰"
 
 #: packages/admin/src/components/FieldEditor.tsx:240
 msgid "Repeater"
-msgstr "重複器"
+msgstr "重複欄位"
 
 #: packages/admin/src/components/FieldEditor.tsx:241
 msgid "Repeating group of fields"
-msgstr "重複的字段組"
+msgstr "重複欄位群組"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:363
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:396
 msgid "Replace image"
-msgstr ""
+msgstr "取代圖片"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:435
 msgid "Replace Image"
-msgstr "替換圖片"
+msgstr "取代圖片"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:117
 msgid "Reply to:"
-msgstr "回覆："
+msgstr "回覆對象:"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
 msgid "Repository"
-msgstr "倉庫"
+msgstr "程式碼儲存庫"
 
 #: packages/admin/src/components/SignupPage.tsx:274
 msgid "Request a new link"
-msgstr "請求新鏈接"
+msgstr "索取新連結"
 
 #: packages/admin/src/lib/api/client.ts:226
 msgid "Request failed"
-msgstr ""
+msgstr "要求失敗"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:280
 #: packages/admin/src/components/ContentTypeEditor.tsx:730
@@ -6374,12 +6374,12 @@ msgstr "必填"
 
 #: packages/admin/src/components/WordPressImport.tsx:1999
 msgid "Required fields:"
-msgstr "必填字段："
+msgstr "必填欄位:"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
 msgid "Required for accessibility. Describes the image for screen readers."
-msgstr "無障礙訪問必需。爲屏幕閱讀器描述圖片。"
+msgstr "無障礙功能所需。用來向螢幕閱讀器描述圖片。"
 
 #. placeholder {0}: latest.minEmDashVersion
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:335
@@ -6388,46 +6388,46 @@ msgstr "需要 EmDash {0}"
 
 #: packages/admin/src/components/SignupPage.tsx:155
 msgid "Resend email"
-msgstr "重新發送郵件"
+msgstr "重新傳送電子郵件"
 
 #: packages/admin/src/components/SignupPage.tsx:154
 msgid "Resend in {resendCooldown}s"
-msgstr "{resendCooldown}秒後重發"
+msgstr "{resendCooldown} 秒後可重新傳送"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:277
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
 msgid "Reset to original"
-msgstr "重置爲原始"
+msgstr "重設為原始設定"
 
 #: packages/admin/src/components/RevisionHistory.tsx:228
 msgid "Restore"
-msgstr "恢復"
+msgstr "還原"
 
 #: packages/admin/src/components/ContentList.tsx:1096
 msgid "Restore {title}"
-msgstr "恢復 {title}"
+msgstr "還原 {title}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:128
 msgid "Restore failed"
-msgstr "恢復失敗"
+msgstr "還原失敗"
 
 #: packages/admin/src/components/RevisionHistory.tsx:222
 msgid "Restore Revision?"
-msgstr "恢復修訂版本？"
+msgstr "要還原這個修訂版本嗎？"
 
 #: packages/admin/src/components/RevisionHistory.tsx:289
 #: packages/admin/src/components/RevisionHistory.tsx:290
 msgid "Restore this version"
-msgstr "恢復此版本"
+msgstr "還原此版本"
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
 #: packages/admin/src/components/RevisionHistory.tsx:225
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
-msgstr "從 {0} 恢復此版本？這將把當前內容更新爲此修訂版本的數據。"
+msgstr "要從 {0} 還原此版本嗎？這會將目前內容更新為此修訂版本的資料。"
 
 #: packages/admin/src/components/RevisionHistory.tsx:229
 msgid "Restoring..."
-msgstr "正在恢復..."
+msgstr "正在還原..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:141
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:44
@@ -6439,23 +6439,23 @@ msgstr "重試"
 
 #: packages/admin/src/components/Sections.tsx:136
 msgid "Reusable content blocks you can insert into any content"
-msgstr "可重用的內容區塊，可插入到任何內容中"
+msgstr "可插入任何內容的可重複使用內容區塊"
 
 #: packages/admin/src/router.tsx:1047
 msgid "Reverted to published version"
-msgstr ""
+msgstr "已還原至已發佈版本"
 
 #: packages/admin/src/components/WordPressImport.tsx:724
 msgid "Review"
-msgstr ""
+msgstr "審閱"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "Review New Permissions"
-msgstr "查看新權限"
+msgstr "檢閱新權限"
 
 #: packages/admin/src/components/RevisionHistory.tsx:122
 msgid "Revision restored"
-msgstr "修訂版本已恢復"
+msgstr "已還原修訂版本"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:76
 #: packages/admin/src/components/RevisionHistory.tsx:158
@@ -6464,36 +6464,36 @@ msgstr "修訂版本"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:344
 msgid "Revoke token"
-msgstr "撤銷令牌"
+msgstr "撤銷權杖"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:319
 msgid "Revoke?"
-msgstr "撤銷？"
+msgstr "要撤銷嗎？"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
 msgid "Revoking..."
-msgstr "撤銷中..."
+msgstr "正在撤銷…"
 
 #: packages/admin/src/components/FieldEditor.tsx:198
 msgid "Rich Text"
-msgstr "富文本"
+msgstr "多格式文字"
 
 #: packages/admin/src/components/Widgets.tsx:99
 msgid "Rich text content"
-msgstr "富文本內容"
+msgstr "多格式文字內容"
 
 #: packages/admin/src/components/FieldEditor.tsx:199
 msgid "Rich text editor"
-msgstr "富文本編輯器"
+msgstr "多格式文字編輯器"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
 msgid "Right"
-msgstr ""
+msgstr "靠右"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:322
 msgid "Risk score: {0}/100"
-msgstr "風險評分：{0}/100"
+msgstr "風險分數: {0}/100"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:164
 #: packages/admin/src/components/users/UserDetail.tsx:169
@@ -6515,15 +6515,15 @@ msgstr "角色標籤"
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:149
 #: packages/admin/src/components/PluginManager.tsx:567
 msgid "Route: {0} · Permission: {1}"
-msgstr ""
+msgstr "路由: {0} · 權限: {1}"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
-msgstr ""
+msgstr "Ruby"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:49
 msgid "Rust"
-msgstr ""
+msgstr "Rust"
 
 #: packages/admin/src/components/MenuEditor.tsx:430
 #: packages/admin/src/components/MenuEditor.tsx:432
@@ -6545,57 +6545,57 @@ msgstr "同一視窗"
 #: packages/admin/src/components/Widgets.tsx:981
 #: packages/admin/src/routes/bylines.tsx:579
 msgid "Save"
-msgstr "保存"
+msgstr "儲存"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:416
 msgid "Save (Enter)"
-msgstr ""
+msgstr "儲存 (Enter)"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:265
 msgid "Save alt text"
-msgstr ""
+msgstr "儲存替代文字"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Save changes"
-msgstr ""
+msgstr "儲存變更"
 
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Save Changes"
-msgstr "保存更改"
+msgstr "儲存變更"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:72
 msgid "Save content as draft before publishing"
-msgstr "發佈前將內容保存爲草稿"
+msgstr "發佈前將內容儲存為草稿"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:137
 msgid "Save name"
-msgstr "保存名稱"
+msgstr "儲存名稱"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:111
 #: packages/admin/src/components/settings/SeoSettings.tsx:218
 msgid "Save SEO Settings"
-msgstr "保存 SEO 設置"
+msgstr "儲存 SEO 設定"
 
 #: packages/admin/src/components/PluginSettings.tsx:166
 #: packages/admin/src/components/PluginSettings.tsx:209
 #: packages/admin/src/components/settings/GeneralSettings.tsx:120
 #: packages/admin/src/components/settings/GeneralSettings.tsx:298
 msgid "Save Settings"
-msgstr "保存設置"
+msgstr "儲存設定"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:91
 #: packages/admin/src/components/settings/SocialSettings.tsx:147
 msgid "Save Social Links"
-msgstr "保存社交鏈接"
+msgstr "儲存社群連結"
 
 #: packages/admin/src/components/SaveButton.tsx:34
 msgid "Saved"
-msgstr "已保存"
+msgstr "已儲存"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:116
 msgid "Saved \"{0}\"."
-msgstr ""
+msgstr "已儲存「{0}」。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1028
 #: packages/admin/src/components/FieldEditor.tsx:660
@@ -6617,64 +6617,64 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:981
 #: packages/admin/src/routes/bylines.tsx:579
 msgid "Saving..."
-msgstr "保存中..."
+msgstr "正在儲存…"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Saving…"
-msgstr ""
+msgstr "正在儲存…"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:482
 msgid "SBOM"
-msgstr ""
+msgstr "SBOM"
 
 #. placeholder {0}: sbom.format
 #: packages/admin/src/components/RegistryPluginDetail.tsx:480
 msgid "SBOM · {0}"
-msgstr ""
+msgstr "SBOM · {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:489
 msgid "Schedule"
-msgstr "定時發佈"
+msgstr "排程"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:475
 msgid "Schedule for"
-msgstr "定時發佈於"
+msgstr "排程時間"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:512
 msgid "Schedule for later"
-msgstr "稍後定時發佈"
+msgstr "稍後排程"
 
 #: packages/admin/src/components/ContentList.tsx:1164
 msgid "scheduled"
-msgstr "已定時"
+msgstr "已排程"
 
 #: packages/admin/src/components/ContentList.tsx:731
 #: packages/admin/src/components/ContentSettingsPanel.tsx:443
 #: packages/admin/src/components/Dashboard.tsx:347
 #: packages/admin/src/router.tsx:1067
 msgid "Scheduled"
-msgstr "已定時"
+msgstr "已排程"
 
 #. placeholder {0}: formatScheduledDate(item.scheduledAt)
 #: packages/admin/src/components/ContentSettingsPanel.tsx:463
 msgid "Scheduled for: {0}"
-msgstr "計劃發佈於：{0}"
+msgstr "排定發佈時間: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2322
 msgid "Schema Changes"
-msgstr "架構更改"
+msgstr "結構描述變更"
 
 #: packages/admin/src/components/WordPressImport.tsx:1699
 msgid "Schema preparation failed"
-msgstr "架構準備失敗"
+msgstr "準備結構描述失敗"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
 msgid "Schema Read"
-msgstr "模式讀取"
+msgstr "讀取結構描述"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
 msgid "Schema Write"
-msgstr "模式寫入"
+msgstr "寫入結構描述"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:429
 msgid "Scopes"
@@ -6683,7 +6683,7 @@ msgstr "權限範圍"
 #. placeholder {0}: token.scopes.join(", ")
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:295
 msgid "Scopes: {0}"
-msgstr "權限範圍：{0}"
+msgstr "權限範圍: {0}"
 
 #. placeholder {0}: i + 1
 #. placeholder {0}: index + 1
@@ -6692,254 +6692,254 @@ msgstr "權限範圍：{0}"
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
 msgid "Screenshot {0}"
-msgstr "截圖 {0}"
+msgstr "螢幕擷取畫面 {0}"
 
 #. placeholder {0}: index + 1
 #. placeholder {1}: screenshots.length
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:466
 msgid "Screenshot {0} of {1}"
-msgstr "截圖 {0} / {1}"
+msgstr "第 {0} 張螢幕擷取畫面，共 {1} 張"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:257
 msgid "Screenshot blurred due to image audit"
-msgstr "由於圖像審計，截圖已模糊"
+msgstr "因圖片稽核而將螢幕擷取畫面模糊化"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:444
 msgid "Screenshot viewer"
-msgstr "截圖查看器"
+msgstr "螢幕擷取畫面檢視器"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:244
 #: packages/admin/src/components/RegistryPluginDetail.tsx:649
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
 msgid "Screenshots"
-msgstr "截圖"
+msgstr "螢幕擷取畫面"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:50
 msgid "SCSS"
-msgstr ""
+msgstr "SCSS"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 #: packages/admin/src/components/Widgets.tsx:151
 msgid "Search"
-msgstr "搜索"
+msgstr "搜尋"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:353
 msgid "Search {0}"
-msgstr "搜索 {0}"
+msgstr "搜尋 {0}"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:352
 msgid "Search {0}..."
-msgstr "搜索 {0}..."
+msgstr "搜尋 {0}…"
 
 #: packages/admin/src/components/MediaLibrary.tsx:415
 #: packages/admin/src/components/MediaPickerModal.tsx:626
 msgid "Search by filename..."
-msgstr ""
+msgstr "依檔名搜尋..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
-msgstr ""
+msgstr "依名稱或電子郵件地址搜尋…"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:822
 #: packages/admin/src/routes/bylines.tsx:401
 msgid "Search bylines"
-msgstr ""
+msgstr "搜尋署名"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:821
 msgid "Search bylines to add..."
-msgstr ""
+msgstr "搜尋要新增的署名…"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:164
 msgid "Search comments"
-msgstr "搜索評論"
+msgstr "搜尋留言"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:163
 msgid "Search comments..."
-msgstr "搜索評論..."
+msgstr "搜尋留言..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:141
 msgid "Search content..."
-msgstr "搜索內容..."
+msgstr "搜尋內容…"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:122
 msgid "Search Engine Optimization"
-msgstr "搜索引擎優化"
+msgstr "搜尋引擎最佳化"
 
 #: packages/admin/src/components/Settings.tsx:83
 msgid "Search engine optimization and verification"
-msgstr "搜索引擎優化和驗證"
+msgstr "搜尋引擎最佳化與驗證"
 
 #: packages/admin/src/components/Widgets.tsx:152
 msgid "Search form"
-msgstr ""
+msgstr "搜尋表單"
 
 #: packages/admin/src/components/MediaLibrary.tsx:416
 #: packages/admin/src/components/MediaPickerModal.tsx:627
 msgid "Search media"
-msgstr "搜索媒體"
+msgstr "搜尋媒體"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:438
 msgid "Search pages and content..."
-msgstr "搜索頁面和內容..."
+msgstr "搜尋頁面及內容..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:101
 #: packages/admin/src/components/RegistryBrowse.tsx:85
 msgid "Search plugins"
-msgstr ""
+msgstr "搜尋外掛"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:97
 #: packages/admin/src/components/RegistryBrowse.tsx:81
 msgid "Search plugins..."
-msgstr "搜索插件..."
+msgstr "搜尋外掛…"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:82
 #: packages/admin/src/components/Sections.tsx:226
 msgid "Search sections..."
-msgstr "搜索區塊..."
+msgstr "搜尋區段..."
 
 #: packages/admin/src/components/Redirects.tsx:410
 msgid "Search source or destination..."
-msgstr "搜索源或目標..."
+msgstr "搜尋來源或目的地..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
 msgid "Search themes"
-msgstr ""
+msgstr "搜尋佈景主題"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
 msgid "Search themes..."
-msgstr "搜索主題..."
+msgstr "搜尋佈景主題..."
 
 #: packages/admin/src/components/users/UserList.tsx:73
 msgid "Search users"
-msgstr ""
+msgstr "搜尋使用者"
 
 #: packages/admin/src/components/MediaLibrary.tsx:415
 #: packages/admin/src/components/MediaPickerModal.tsx:626
 msgid "Search..."
-msgstr "搜索..."
+msgstr "搜尋..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:732
 #: packages/admin/src/components/FieldEditor.tsx:452
 msgid "Searchable"
-msgstr "可搜索"
+msgstr "可搜尋"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:826
 msgid "Searching..."
-msgstr ""
+msgstr "正在搜尋…"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2424
 msgid "Section"
-msgstr "區塊"
+msgstr "區段"
 
 #: packages/admin/src/components/SectionEditor.tsx:83
 msgid "Section \"{slug}\" could not be found."
-msgstr "未找到區塊 \"{slug}\"。"
+msgstr "找不到區段「{slug}」。"
 
 #: packages/admin/src/components/Sections.tsx:93
 msgid "Section created"
-msgstr "區塊已創建"
+msgstr "已建立區段"
 
 #: packages/admin/src/components/Sections.tsx:107
 msgid "Section deleted"
-msgstr "區塊已刪除"
+msgstr "區段已刪除"
 
 #: packages/admin/src/components/SectionEditor.tsx:248
 msgid "Section Details"
-msgstr "區塊詳情"
+msgstr "區段詳細資料"
 
 #: packages/admin/src/components/SectionEditor.tsx:79
 msgid "Section Not Found"
-msgstr "未找到區塊"
+msgstr "找不到區段"
 
 #: packages/admin/src/components/SectionEditor.tsx:254
 msgid "Section title"
-msgstr "區塊標題"
+msgstr "區段標題"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:176
 #: packages/admin/src/components/Sections.tsx:134
 #: packages/admin/src/components/Sidebar.tsx:234
 msgid "Sections"
-msgstr "區塊"
+msgstr "區段"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:306
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
 msgid "secure context"
-msgstr "安全上下文"
+msgstr "安全環境"
 
 #: packages/admin/src/components/SetupWizard.tsx:561
 msgid "Secure your account"
-msgstr "保護您的帳戶"
+msgstr "保護您的帳號"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:809
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Security"
-msgstr "安全"
+msgstr "安全性"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:318
 msgid "Security Audit"
-msgstr "安全審計"
+msgstr "安全稽核"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:340
 msgid "Security audit failed"
-msgstr "安全審計失敗"
+msgstr "安全稽核失敗"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:330
 msgid "Security audit flagged concerns"
-msgstr "安全審計標記了問題"
+msgstr "安全性稽核發現疑慮"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:179
 msgid "Security audit flagged potential concerns with this plugin."
-msgstr "安全審計標記了此插件的潛在問題。"
+msgstr "安全稽核指出此外掛可能有疑慮。"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:180
 msgid "Security audit flagged this plugin as potentially unsafe."
-msgstr "安全審計標記此插件爲可能不安全。"
+msgstr "安全性稽核將此外掛標示為可能不安全。"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:319
 msgid "Security audit passed"
-msgstr "安全審計通過"
+msgstr "通過安全稽核"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:718
 msgid "Security contacts"
-msgstr ""
+msgstr "安全性聯絡人"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:270
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
 msgid "Security error. Make sure you're on a secure connection."
-msgstr "安全錯誤。請確保您使用的是安全連接。"
+msgstr "發生安全性錯誤。請確認您使用安全連線。"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:242
 #: packages/admin/src/components/Header.tsx:93
 #: packages/admin/src/components/settings/SecuritySettings.tsx:95
 msgid "Security Settings"
-msgstr "安全設置"
+msgstr "安全性設定"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:56
 #: packages/admin/src/components/FieldEditor.tsx:186
 #: packages/admin/src/components/FieldEditor.tsx:585
 msgid "Select"
-msgstr "選擇"
+msgstr "選取"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1695
 #: packages/admin/src/components/ImageFieldRenderer.tsx:198
 msgid "Select {label}"
-msgstr "選擇 {label}"
+msgstr "選取 {label}"
 
 #: packages/admin/src/components/ContentList.tsx:973
 msgid "Select {title}"
-msgstr ""
+msgstr "選取 {title}"
 
 #: packages/admin/src/components/Widgets.tsx:954
 msgid "Select a component..."
-msgstr ""
+msgstr "選取元件..."
 
 #: packages/admin/src/components/Widgets.tsx:917
 msgid "Select a menu..."
-msgstr ""
+msgstr "選取選單…"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:284
 msgid "Select all"
@@ -6947,115 +6947,115 @@ msgstr "全選"
 
 #: packages/admin/src/components/ContentList.tsx:497
 msgid "Select all on this page"
-msgstr ""
+msgstr "選取這個頁面上的全部項目"
 
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:457
 msgid "Select comment by {0}"
-msgstr "選擇 {0} 的評論"
+msgstr "選取 {0} 的留言"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:117
 msgid "Select Content"
-msgstr "選擇內容"
+msgstr "選取內容"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:235
 msgid "Select Default Social Image"
-msgstr ""
+msgstr "選取預設社群圖片"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:260
 #: packages/admin/src/components/settings/GeneralSettings.tsx:321
 msgid "Select Favicon"
-msgstr "選擇網站圖標"
+msgstr "選取網站圖示"
 
 #: packages/admin/src/components/ContentEditor.tsx:1683
 msgid "Select file"
-msgstr ""
+msgstr "選取檔案"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:150
 msgid "Select File"
-msgstr ""
+msgstr "選取檔案"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3061
 msgid "Select Gallery Images"
-msgstr ""
+msgstr "選取圖庫圖片"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:186
 msgid "Select image"
-msgstr "選擇圖片"
+msgstr "選取圖片"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:150
 #: packages/admin/src/components/PortableTextEditor.tsx:3047
 #: packages/admin/src/components/settings/SeoSettings.tsx:188
 msgid "Select Image"
-msgstr "選擇圖片"
+msgstr "選取圖片"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:206
 #: packages/admin/src/components/settings/GeneralSettings.tsx:313
 msgid "Select Logo"
-msgstr "選擇標誌"
+msgstr "選取標誌"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
 msgid "Select media"
-msgstr "選擇媒體"
+msgstr "選取媒體"
 
 #: packages/admin/src/components/SeoImageField.tsx:76
 msgid "Select OG image"
-msgstr "選擇 OG 圖片"
+msgstr "選取 OG 圖片"
 
 #: packages/admin/src/components/SeoImageField.tsx:85
 msgid "Select OG Image"
-msgstr "選擇 OG 圖片"
+msgstr "選取 OG 圖片"
 
 #: packages/admin/src/components/WordPressImport.tsx:1732
 msgid "Select which content types to import."
-msgstr "選擇要導入的內容類型。"
+msgstr "選取要匯入的內容類型。"
 
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:108
 #: packages/admin/src/components/PortableTextEditor.tsx:2126
 #: packages/admin/src/components/RepeaterField.tsx:372
 msgid "Select..."
-msgstr "選擇..."
+msgstr "選取..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1455
 msgid "Selected {selectedItemTitle}"
-msgstr ""
+msgstr "已選取 {selectedItemTitle}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:795
 msgid "Selected:"
-msgstr "已選擇："
+msgstr "已選取:"
 
 #: packages/admin/src/components/Settings.tsx:99
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:152
 msgid "Self-Signup Domains"
-msgstr "自助註冊域"
+msgstr "開放自行註冊的網域"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:113
 msgid "Send a test email through the full pipeline to verify your email configuration."
-msgstr "通過完整管道發送測試郵件以驗證您的郵件配置。"
+msgstr "透過完整電子郵件處理管線傳送測試郵件，以驗證電子郵件設定。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr "向新團隊成員發送邀請郵件。"
+msgstr "傳送邀請電子郵件給新的團隊成員。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:201
 msgid "Send Invite"
-msgstr "發送邀請"
+msgstr "傳送邀請"
 
 #: packages/admin/src/components/LoginPage.tsx:150
 msgid "Send magic link"
-msgstr "發送免密登錄鏈接"
+msgstr "傳送快速登入連結"
 
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Send Recovery Link"
-msgstr "發送恢復鏈接"
+msgstr "傳送復原連結"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:127
 msgid "Send Test"
-msgstr "發送測試"
+msgstr "傳送測試"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:110
 msgid "Send Test Email"
-msgstr "發送測試郵件"
+msgstr "傳送測試電子郵件"
 
 #: packages/admin/src/components/LoginPage.tsx:150
 #: packages/admin/src/components/settings/EmailSettings.tsx:127
@@ -7064,7 +7064,7 @@ msgstr "發送測試郵件"
 #: packages/admin/src/components/users/InviteUserModal.tsx:201
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Sending..."
-msgstr "發送中..."
+msgstr "正在傳送..."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:603
 #: packages/admin/src/components/ContentTypeEditor.tsx:472
@@ -7075,15 +7075,15 @@ msgstr "SEO"
 #: packages/admin/src/components/settings/SeoSettings.tsx:90
 #: packages/admin/src/components/settings/SeoSettings.tsx:115
 msgid "SEO Settings"
-msgstr "SEO 設置"
+msgstr "SEO 設定"
 
 #: packages/admin/src/components/WordPressImport.tsx:1843
 msgid "SEO settings (Yoast)"
-msgstr "SEO 設置（Yoast）"
+msgstr "SEO 設定 (Yoast)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:40
 msgid "SEO settings saved"
-msgstr "SEO 設置已保存"
+msgstr "SEO 設定已儲存"
 
 #: packages/admin/src/components/SeoPanel.tsx:168
 #: packages/admin/src/components/SeoPanel.tsx:172
@@ -7093,32 +7093,32 @@ msgstr "SEO 標題"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
 msgid "Set a custom display size for this image instance."
-msgstr "爲此圖片實例設置自定義顯示尺寸。"
+msgstr "為這張圖片設定自訂顯示大小。"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:146
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:150
 msgid "Set language"
-msgstr ""
+msgstr "設定語言"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:147
 msgid "Set language (current: {label})"
-msgstr ""
+msgstr "設定語言 (目前: {label})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:529
 msgid "Set to 0 to never close comments automatically."
-msgstr ""
+msgstr "設為 0 即永不自動關閉留言。"
 
 #: packages/admin/src/components/ContentList.tsx:425
 msgid "Set to draft"
-msgstr ""
+msgstr "設為草稿"
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
-msgstr "設置您的站點"
+msgstr "設定您的網站"
 
 #: packages/admin/src/components/SetupWizard.tsx:150
 msgid "Setting up..."
-msgstr "正在設置..."
+msgstr "正在設定…"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:234
 #: packages/admin/src/components/ContentEditor.tsx:809
@@ -7130,162 +7130,162 @@ msgstr "正在設置..."
 #: packages/admin/src/components/Sidebar.tsx:294
 #: packages/admin/src/components/WordPressImport.tsx:1811
 msgid "Settings"
-msgstr "設置"
+msgstr "設定"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
 msgid "Settings Manage"
-msgstr "設置管理"
+msgstr "管理設定"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
 msgid "Settings Read"
-msgstr "設置讀取"
+msgstr "讀取設定"
 
 #: packages/admin/src/components/PluginSettings.tsx:68
 #: packages/admin/src/components/settings/GeneralSettings.tsx:43
 msgid "Settings saved successfully"
-msgstr "設置保存成功"
+msgstr "設定已成功儲存"
 
 #: packages/admin/src/components/SetupWizard.tsx:468
 msgid "Setup failed"
-msgstr ""
+msgstr "設定失敗"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
-msgstr "與此邀請用戶分享此鏈接"
+msgstr "與受邀使用者分享此連結"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:294
 msgid "Shared across all translations of the same byline."
-msgstr ""
+msgstr "在同一署名的所有翻譯中共用。"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:52
 msgid "Short text"
-msgstr ""
+msgstr "短文字"
 
 #: packages/admin/src/components/FieldEditor.tsx:150
 #: packages/admin/src/components/FieldEditor.tsx:579
 msgid "Short Text"
-msgstr "短文本"
+msgstr "短文字"
 
 #: packages/admin/src/components/Widgets.tsx:146
 msgid "Show count"
-msgstr ""
+msgstr "顯示數量"
 
 #: packages/admin/src/components/Widgets.tsx:131
 msgid "Show date"
-msgstr ""
+msgstr "顯示日期"
 
 #: packages/admin/src/components/Widgets.tsx:139
 msgid "Show hierarchy"
-msgstr ""
+msgstr "顯示階層"
 
 #: packages/admin/src/components/Widgets.tsx:138
 msgid "Show post count"
-msgstr ""
+msgstr "顯示文章數量"
 
 #: packages/admin/src/components/Widgets.tsx:130
 msgid "Show thumbnails"
-msgstr ""
+msgstr "顯示縮圖"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
 msgid "Show token"
-msgstr "顯示令牌"
+msgstr "顯示權杖"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:365
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:554
 msgid "Shown when hovering over the image."
-msgstr "懸停在圖片上時顯示。"
+msgstr "游標停留在圖片上時顯示。"
 
 #: packages/admin/src/components/SignupPage.tsx:441
 msgid "Sign in"
-msgstr "登錄"
+msgstr "登入"
 
 #: packages/admin/src/components/SetupWizard.tsx:355
 msgid "Sign In"
-msgstr "登錄"
+msgstr "登入"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:162
 #: packages/admin/src/components/SignupPage.tsx:270
 msgid "Sign in instead"
-msgstr "改爲登錄"
+msgstr "改為登入"
 
 #: packages/admin/src/components/LoginPage.tsx:234
 msgid "Sign in to your site"
-msgstr "登錄到您的網站"
+msgstr "登入您的網站"
 
 #. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
 #. placeholder {0}: provider.label
 #: packages/admin/src/components/LoginPage.tsx:233
 #: packages/admin/src/components/SetupWizard.tsx:264
 msgid "Sign in with {0}"
-msgstr "使用 {0} 登錄"
+msgstr "使用 {0} 登入"
 
 #: packages/admin/src/components/LoginPage.tsx:231
 msgid "Sign in with email"
-msgstr "使用郵箱登錄"
+msgstr "使用電子郵件登入"
 
 #: packages/admin/src/components/LoginPage.tsx:292
 msgid "Sign in with email link"
-msgstr "使用郵箱鏈接登錄"
+msgstr "使用電子郵件連結登入"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:254
 msgid "Sign in with Passkey"
-msgstr "使用通行密鑰登錄"
+msgstr "使用通行金鑰登入"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:190
 msgid "Signed in as {0}"
-msgstr "已作爲 {0} 登錄"
+msgstr "已以 {0} 的身分登入"
 
 #: packages/admin/src/components/FieldEditor.tsx:187
 msgid "Single choice from options"
-msgstr "從選項中選擇一個"
+msgstr "從選項中選擇單一項目"
 
 #: packages/admin/src/components/FieldEditor.tsx:151
 msgid "Single line text input"
-msgstr "單行文本輸入"
+msgstr "單行文字輸入"
 
 #: packages/admin/src/components/SetupWizard.tsx:353
 msgid "Site"
-msgstr "站點"
+msgstr "網站"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:130
 msgid "Site Identity"
-msgstr "站點標識"
+msgstr "網站識別資訊"
 
 #: packages/admin/src/components/WordPressImport.tsx:2270
 msgid "site identity applied (title, tagline, logo)"
-msgstr ""
+msgstr "已套用網站識別資訊 (標題、網站標語及標誌)"
 
 #: packages/admin/src/components/Settings.tsx:71
 msgid "Site identity, logo, favicon, and reading preferences"
-msgstr "網站標識、徽標、網站圖標和閱讀偏好"
+msgstr "網站識別、標誌、網站圖示及閱讀偏好"
 
 #: packages/admin/src/components/SetupWizard.tsx:351
 #: packages/admin/src/components/WordPressImport.tsx:1151
 msgid "Site Settings"
-msgstr "站點設置"
+msgstr "網站設定"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:133
 #: packages/admin/src/components/SetupWizard.tsx:116
 msgid "Site Title"
-msgstr "站點標題"
+msgstr "網站標題"
 
 #: packages/admin/src/components/WordPressImport.tsx:1823
 msgid "Site title & tagline"
-msgstr "站點標題和副標題"
+msgstr "網站標題及標語"
 
 #: packages/admin/src/components/SetupWizard.tsx:100
 msgid "Site title is required"
-msgstr "站點標題爲必填項"
+msgstr "網站標題為必填"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:145
 msgid "Site URL"
-msgstr "站點 URL"
+msgstr "網站網址"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:267
 msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
-msgstr ""
+msgstr "使用 Cloudflare D1 的網站還可透過 D1 Time Travel，將資料庫還原至最近 30 天內的任一分鐘 — 此功能一律啟用，不需要進行設定。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:588
 msgid "Size"
@@ -7293,15 +7293,15 @@ msgstr "大小"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:274
 msgid "Size:"
-msgstr "大小："
+msgstr "大小:"
 
 #: packages/admin/src/components/WordPressImport.tsx:2104
 msgid "Skip Media Import"
-msgstr "跳過媒體導入"
+msgstr "略過媒體匯入"
 
 #: packages/admin/src/components/WordPressImport.tsx:2129
 msgid "Skipped"
-msgstr "已跳過"
+msgstr "已略過"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:239
 #: packages/admin/src/components/ContentSettingsPanel.tsx:430
@@ -7318,54 +7318,54 @@ msgstr "已跳過"
 #: packages/admin/src/routes/byline-schema.tsx:237
 #: packages/admin/src/routes/bylines.tsx:486
 msgid "Slug"
-msgstr "別名"
+msgstr "代稱"
 
 #: packages/admin/src/components/Sections.tsx:124
 msgid "Slug copied to clipboard"
-msgstr "別名已複製到剪貼板"
+msgstr "代稱已複製至剪貼簿"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:251
 msgid "Slugs cannot be changed after the field is created."
-msgstr ""
+msgstr "欄位建立後便無法變更代稱。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1130
 msgid "Small section heading"
-msgstr "小章節標題"
+msgstr "小型區段標題"
 
 #: packages/admin/src/components/Settings.tsx:76
 #: packages/admin/src/components/settings/SocialSettings.tsx:70
 #: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Social Links"
-msgstr "社交鏈接"
+msgstr "社群連結"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:38
 msgid "Social links saved"
-msgstr "社交鏈接已保存"
+msgstr "社群連結已儲存"
 
 #: packages/admin/src/components/Settings.tsx:77
 msgid "Social media profile links"
-msgstr "社交媒體個人資料鏈接"
+msgstr "社群媒體個人檔案連結"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:100
 msgid "Social Profiles"
-msgstr "社交資料"
+msgstr "社群個人檔案"
 
 #: packages/admin/src/components/WordPressImport.tsx:1860
 msgid "Some content types cannot be imported"
-msgstr "某些內容類型無法導入"
+msgstr "部分內容類型無法匯入"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:155
 #: packages/admin/src/components/SignupPage.tsx:263
 msgid "Something went wrong"
-msgstr "出現問題"
+msgstr "發生錯誤"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:123
 msgid "Sort plugins"
-msgstr "排序插件"
+msgstr "排序外掛"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
 msgid "Sort themes"
-msgstr "排序主題"
+msgstr "排序佈景主題"
 
 #: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
@@ -7379,39 +7379,39 @@ msgstr "來源"
 
 #: packages/admin/src/components/Redirects.tsx:132
 msgid "Source path"
-msgstr "源路徑"
+msgstr "來源路徑"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:197
 msgid "spam"
-msgstr "垃圾"
+msgstr "垃圾留言"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:159
 #: packages/admin/src/components/comments/CommentInbox.tsx:208
 #: packages/admin/src/components/comments/CommentInbox.tsx:248
 msgid "Spam"
-msgstr "垃圾"
+msgstr "垃圾留言"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3830
 msgid "Spotlight Mode"
-msgstr ""
+msgstr "焦點模式"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:64
 msgid "Spreadsheets"
-msgstr ""
+msgstr "試算表"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:51
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1922
 msgid "Start Import"
-msgstr "開始導入"
+msgstr "開始匯入"
 
 #: packages/admin/src/components/ContentEditor.tsx:1185
 #: packages/admin/src/components/PortableTextEditor.tsx:2285
 #: packages/admin/src/components/PortableTextEditor.tsx:2286
 msgid "Start writing, or type '/' for commands"
-msgstr ""
+msgstr "開始撰寫，或輸入「/」使用命令"
 
 #: packages/admin/src/components/ContentList.tsx:511
 #: packages/admin/src/components/ContentSettingsPanel.tsx:437
@@ -7427,24 +7427,24 @@ msgstr "狀態碼"
 
 #: packages/admin/src/components/Dashboard.tsx:357
 msgid "Status: {status}"
-msgstr ""
+msgstr "狀態: {status}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:173
 msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
-msgstr ""
+msgstr "在網站的儲存貯體中保留每日備份。系統會自動移除舊備份。"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:218
 msgid "Stored Backups"
-msgstr ""
+msgstr "已儲存的備份"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:293
 msgid "Stored per locale — each translation of a byline gets its own value."
-msgstr ""
+msgstr "依語言地區分別儲存 — 每個署名翻譯都有自己的值。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3251
 #: packages/admin/src/components/PortableTextEditor.tsx:3637
 msgid "Strikethrough"
-msgstr ""
+msgstr "刪除線"
 
 #: packages/admin/src/components/WordPressImport.tsx:1752
 msgid "Structure"
@@ -7452,11 +7452,11 @@ msgstr "結構"
 
 #: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Structured"
-msgstr ""
+msgstr "結構化"
 
 #: packages/admin/src/components/FieldEditor.tsx:523
 msgid "Sub-Fields"
-msgstr "子字段"
+msgstr "子欄位"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
@@ -7465,11 +7465,11 @@ msgstr "訂閱者"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:52
 msgid "Svelte"
-msgstr ""
+msgstr "Svelte"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:53
 msgid "Swift"
-msgstr ""
+msgstr "Swift"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
@@ -7477,32 +7477,32 @@ msgstr "已同步"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Synced passkey"
-msgstr "已同步通行密鑰"
+msgstr "已同步的通行金鑰"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:777
 msgid "System"
-msgstr ""
+msgstr "系統"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
-msgstr "跟隨系統（{resolvedLabel}）"
+msgstr "系統 ({resolvedLabel})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:599
 msgid "System Fields"
-msgstr ""
+msgstr "系統欄位"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1204
 msgid "Table"
-msgstr ""
+msgstr "表格"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3326
 msgid "Table controls"
-msgstr ""
+msgstr "表格控制項"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:139
 #: packages/admin/src/components/SetupWizard.tsx:127
 msgid "Tagline"
-msgstr "副標題"
+msgstr "網站標語"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:201
 #: packages/admin/src/components/Widgets.tsx:143
@@ -7521,47 +7521,47 @@ msgstr "目標"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:192
 msgid "Target locale"
-msgstr ""
+msgstr "目標語言地區"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:543
 msgid "Taxonomies"
-msgstr "分類"
+msgstr "分類法"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Taxonomies Manage"
-msgstr "分類管理"
+msgstr "管理分類法"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:918
 msgid "Taxonomy created"
-msgstr "分類已創建"
+msgstr "分類法已建立"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:807
 msgid "Taxonomy not found:"
-msgstr "未找到分類："
+msgstr "找不到分類法:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:179
 msgid "Taxonomy: {taxonomyName}"
-msgstr ""
+msgstr "分類法: {taxonomyName}"
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
-msgstr "模板："
+msgstr "範本:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:377
 #: packages/admin/src/components/TaxonomyManager.tsx:378
 #: packages/admin/src/components/TaxonomyManager.tsx:834
 msgid "Term"
-msgstr "詞條"
+msgstr "分類項目"
 
 #. placeholder {0}: term.label
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:781
 msgid "Term \"{0}\" created in {1}."
-msgstr ""
+msgstr "已在 {1} 中建立分類項目「{0}」。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:763
 msgid "Term deleted"
-msgstr "詞條已刪除"
+msgstr "分類項目已刪除"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:122
 msgid "test@example.com"
@@ -7569,214 +7569,214 @@ msgstr "test@example.com"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3588
 msgid "Text formatting"
-msgstr ""
+msgstr "文字格式"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:198
 msgid "The device will not be granted access."
-msgstr "設備將不會被授予訪問權限。"
+msgstr "不會授予此裝置存取權。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1862
 msgid "The existing collection has fields with incompatible types."
-msgstr "現有合集包含類型不兼容的字段。"
+msgstr "現有內容集合包含類型不相容的欄位。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
-msgstr "以下表格包含內容但未註冊爲合集。註冊它們以便在管理中管理此內容。"
+msgstr "以下表格包含內容，但尚未註冊為內容集合。請註冊這些表格，以便在管理介面管理內容。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:179
 msgid "The invited user will have this role once they complete registration."
-msgstr "被邀請的用戶完成註冊後將擁有此角色。"
+msgstr "受邀使用者完成註冊後會獲得此角色。"
 
 #: packages/admin/src/components/LoginPage.tsx:114
 #: packages/admin/src/components/SignupPage.tsx:140
 msgid "The link will expire in 15 minutes."
-msgstr "鏈接將在 15 分鐘後過期。"
+msgstr "此連結將於 15 分鐘後到期。"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:177
 msgid "The marketplace is empty. Check back later for new plugins."
-msgstr "市場爲空。請稍後查看新插件。"
+msgstr "市集目前沒有內容。請稍後再回來查看新外掛。"
 
 #: packages/admin/src/components/MenuList.tsx:76
 msgid "The menu has been deleted."
-msgstr "菜單已刪除。"
+msgstr "選單已刪除。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:136
 msgid "The name of your site, used in the header and metadata"
-msgstr "您站點的名稱，用於頁眉和元數據"
+msgstr "您的網站名稱，用於頁首及中繼資料"
 
 #: packages/admin/src/router.tsx:2191
 msgid "The page you're looking for doesn't exist."
-msgstr ""
+msgstr "您要找的頁面不存在。"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
 msgid "The plugin field widget failed to render."
-msgstr ""
+msgstr "無法轉譯外掛欄位小工具。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:149
 msgid "The public URL of your site (used for canonical links and sitemaps)"
-msgstr "您站點的公共 URL（用於規範鏈接和站點地圖）"
+msgstr "網站的公開網址 (用於標準網址與網站地圖)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:156
 msgid "The referenced image is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "參照的圖片已無法使用。請選取新圖片或移除參照。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:174
 msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "參照的標誌已無法使用。請選取新標誌或移除參照。"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
 msgid "The theme marketplace is empty. Check back later."
-msgstr "主題市場爲空。請稍後再來。"
+msgstr "佈景主題市集目前沒有內容。請稍後再回來查看。"
 
 #: packages/admin/src/components/Sections.tsx:45
 msgid "Theme"
-msgstr "主題"
+msgstr "佈景主題"
 
 #. placeholder {0}: section.themeId
 #: packages/admin/src/components/SectionEditor.tsx:307
 msgid "Theme ID: {0}"
-msgstr "主題 ID：{0}"
+msgstr "佈景主題 ID: {0}"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
 msgid "Theme not found"
-msgstr "未找到主題"
+msgstr "找不到佈景主題"
 
 #: packages/admin/src/components/SectionEditor.tsx:185
 msgid "Theme Section"
-msgstr "主題區塊"
+msgstr "佈景主題區段"
 
 #: packages/admin/src/components/Sections.tsx:300
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
-msgstr "主題提供的區塊無法刪除。編輯區塊以創建自定義副本，然後刪除該副本。"
+msgstr "無法刪除佈景主題提供的區段。請編輯該區段以建立自訂副本，再刪除該副本。"
 
 #: packages/admin/src/components/ThemeToggle.tsx:33
 msgid "Theme: {label}"
-msgstr "主題：{label}"
+msgstr "佈景主題: {label}"
 
 #: packages/admin/src/components/Sidebar.tsx:281
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
 msgid "Themes"
-msgstr "主題"
+msgstr "佈景主題"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:141
 msgid "These tools remain disabled after installation until you explicitly enable agent access."
-msgstr ""
+msgstr "安裝後這些工具會維持停用狀態，直到您明確啟用 Agent 存取權為止。"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:370
 msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
-msgstr ""
+msgstr "這個內容集合是在程式碼中定義的。部分設定無法在此變更。請編輯 live.config.ts 檔案以修改結構描述。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1059
 msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
-msgstr ""
+msgstr "這似乎不是有效的移轉金鑰。請在外掛中產生新的金鑰，並貼上以「em1.」開頭的完整字串。"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:461
 msgid "This field does not accept {sniffedMime} files."
-msgstr ""
+msgstr "此欄位不接受 {sniffedMime} 檔案。"
 
 #: packages/admin/src/components/ContentEditor.tsx:1698
 #: packages/admin/src/components/ImageFieldRenderer.tsx:201
 msgid "This field is required"
-msgstr "此字段爲必填項"
+msgstr "此欄位為必填"
 
 #: packages/admin/src/components/SectionEditor.tsx:301
 msgid "This is a custom section."
-msgstr "這是自定義區塊。"
+msgstr "這是自訂區段。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1308
 msgid "This is a WordPress site."
-msgstr "這是一個 WordPress 站點。"
+msgstr "這是 WordPress 網站。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:112
 msgid "This link expires in 7 days and can only be used once."
-msgstr "此鏈接將在 7 天後過期，且只能使用一次。"
+msgstr "此連結將於 7 天後到期，且只能使用一次。"
 
 #: packages/admin/src/components/WordPressImport.tsx:921
 msgid "This may take a while for large exports."
-msgstr "對於大型導出，這可能需要一些時間。"
+msgstr "大型匯出可能需要一些時間。"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
 msgid "This passkey is already registered on this device."
-msgstr "此通行密鑰已在此設備上註冊。"
+msgstr "此通行金鑰已在這個裝置上註冊。"
 
 #. placeholder {0}: archiveToDelete?.name ?? ""
 #: packages/admin/src/components/settings/BackupSettings.tsx:283
 msgid "This permanently deletes {0} from storage."
-msgstr ""
+msgstr "這會從儲存空間永久刪除 {0}。"
 
 #: packages/admin/src/components/PluginSettings.tsx:177
 msgid "This plugin has no configurable settings."
-msgstr ""
+msgstr "此外掛不提供可調整的設定。"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:287
 msgid "This plugin requires no special permissions."
-msgstr "此插件不需要特殊權限。"
+msgstr "此外掛不需要特殊權限。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:579
 msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
-msgstr ""
+msgstr "此發佈者聲稱擁有某個名稱，但無法證明其所有權，可能是在冒充他人。因此已停用安裝功能。如果您認識並信任此發佈者，請要求對方修正身分設定後再試一次。"
 
 #: packages/admin/src/components/Redirects.tsx:582
 msgid "This redirect rule will be permanently removed."
-msgstr "此重定向規則將被永久移除。"
+msgstr "此重新導向規則將永久移除。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:631
 msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
-msgstr ""
+msgstr "此版本需要比網站目前執行環境更新的環境。請先升級再安裝。"
 
 #: packages/admin/src/routes/bylines.tsx:623
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr ""
+msgstr "這會移除署名個人資料及內容中的署名連結，並清除主要署名參照。"
 
 #: packages/admin/src/components/SectionEditor.tsx:298
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
-msgstr "此區塊由主題提供。編輯將創建一個自定義副本以覆蓋主題版本。"
+msgstr "此區段由佈景主題提供。編輯後會建立自訂副本，並覆寫佈景主題版本。"
 
 #: packages/admin/src/components/SectionEditor.tsx:303
 msgid "This section was imported from another system."
-msgstr "此區塊是從另一個系統導入的。"
+msgstr "這個區段是從其他系統匯入的。"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:125
 msgid "This update exposes the following routes without authentication:"
-msgstr ""
+msgstr "此更新會開放下列路由，無須驗證即可存取:"
 
 #: packages/admin/src/components/Widgets.tsx:713
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
-msgstr ""
+msgstr "這會刪除小工具區域及其中的所有小工具。此動作無法復原。"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:276
 msgid "This will grant CLI access with your permissions."
-msgstr "這將授予 CLI 訪問權限以及您的權限。"
+msgstr "這會以您的權限授予 CLI 存取權。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:645
 msgid "This will move the item to trash. You can restore it later from the trash."
-msgstr "這將把項目移至回收站。您可以稍後從回收站恢復它。"
+msgstr "這會將項目移至回收桶。您稍後可以從回收桶還原。"
 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:904
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr "這將永久刪除「{0}」並將其從所有內容中移除。"
+msgstr "這會永久刪除「{0}」並將其從所有內容中移除。"
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:304
 msgid "This will permanently delete \"{0}\". This action cannot be undone."
-msgstr "這將永久刪除「{0}」。此操作無法撤銷。"
+msgstr "這會永久刪除「{0}」。此動作無法復原。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:407
 msgid "This will permanently delete this comment. This action cannot be undone."
-msgstr "這將永久刪除此評論。此操作無法撤銷。"
+msgstr "這會永久刪除這則留言。此動作無法復原。"
 
 #: packages/admin/src/components/PluginManager.tsx:713
 msgid "This will remove the plugin and its bundle from your site."
-msgstr "這將從您的站點移除插件及其包。"
+msgstr "這會從您的網站移除此外掛及其套件組合。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:80
 msgid "This will revert to the published version. Your draft changes will be lost."
-msgstr "這將恢復到已發佈的版本。您的草稿更改將會丟失。"
+msgstr "這會還原至已發佈的版本。您的草稿變更將會遺失。"
 
 #: packages/admin/src/components/SetupWizard.tsx:131
 msgid "Thoughts, tutorials, and more"
-msgstr "想法、教程等"
+msgstr "想法、教學及更多內容"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:287
 msgid "Timezone"
@@ -7784,7 +7784,7 @@ msgstr "時區"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:290
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr "用於顯示日期的時區（例如：America/New_York）"
+msgstr "用於顯示日期的時區 (例如 America/New_York)"
 
 #: packages/admin/src/components/ContentList.tsx:505
 #: packages/admin/src/components/ContentList.tsx:643
@@ -7797,15 +7797,15 @@ msgstr "標題"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:361
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:550
 msgid "Title (Tooltip)"
-msgstr "標題（工具提示）"
+msgstr "標題 (工具提示)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:126
 msgid "Title Separator"
-msgstr "標題分隔符"
+msgstr "標題分隔符號"
 
 #: packages/admin/src/components/ContentList.tsx:811
 msgid "to"
-msgstr ""
+msgstr "至"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:483
 msgid "to close"
@@ -7813,50 +7813,50 @@ msgstr "關閉"
 
 #: packages/admin/src/components/ContentList.tsx:815
 msgid "To date"
-msgstr ""
+msgstr "結束日期"
 
 #: packages/admin/src/components/PluginManager.tsx:207
 msgid "to install plugins, or add them to your astro.config.mjs."
-msgstr "以安裝插件，或將它們添加到您的 astro.config.mjs。"
+msgstr "以安裝外掛，或將外掛加入 astro.config.mjs。"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:473
 msgid "to select"
-msgstr "選擇"
+msgstr "選取"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3371
 msgid "Toggle header row"
-msgstr ""
+msgstr "切換標題列"
 
 #: packages/admin/src/components/ThemeToggle.tsx:31
 #: packages/admin/src/components/ThemeToggle.tsx:42
 msgid "Toggle theme (current: {label})"
-msgstr "切換主題（當前：{label}）"
+msgstr "切換佈景主題 (目前: {label})"
 
 #. placeholder {0}: newToken.info.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:207
 msgid "Token created: {0}"
-msgstr "令牌已創建：{0}"
+msgstr "已建立權杖: {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:420
 msgid "Token Name"
-msgstr "令牌名稱"
+msgstr "權杖名稱"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:54
 msgid "TOML"
-msgstr ""
+msgstr "TOML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "Tools → Export"
-msgstr "工具 → 導出"
+msgstr "工具 → 匯出"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:77
 msgid "Track content history"
-msgstr "跟蹤內容歷史"
+msgstr "追蹤內容歷程"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:287
 #: packages/admin/src/routes/byline-schema.tsx:243
 msgid "Translatable"
-msgstr ""
+msgstr "可翻譯"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:103
 #: packages/admin/src/components/TaxonomyManager.tsx:214
@@ -7867,23 +7867,23 @@ msgstr "翻譯"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:176
 msgid "Translate \"{0}\""
-msgstr ""
+msgstr "翻譯「{0}」"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:100
 msgid "Translate {0}"
-msgstr ""
+msgstr "翻譯 {0}"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:214
 #: packages/admin/src/components/TranslationsPanel.tsx:104
 msgid "Translating..."
-msgstr ""
+msgstr "正在翻譯..."
 
 #: packages/admin/src/components/MenuEditor.tsx:143
 #: packages/admin/src/components/TaxonomyManager.tsx:780
 #: packages/admin/src/router.tsx:1119
 msgid "Translation created"
-msgstr ""
+msgstr "翻譯已建立"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:60
 msgid "Translations"
@@ -7891,7 +7891,7 @@ msgstr "翻譯"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:198
 msgid "trash"
-msgstr "回收站"
+msgstr "回收桶"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:170
 #: packages/admin/src/components/comments/CommentInbox.tsx:217
@@ -7899,44 +7899,44 @@ msgstr "回收站"
 #: packages/admin/src/components/comments/CommentInbox.tsx:514
 #: packages/admin/src/components/ContentList.tsx:375
 msgid "Trash"
-msgstr "回收站"
+msgstr "回收桶"
 
 #: packages/admin/src/components/ContentList.tsx:666
 msgid "Trash is empty"
-msgstr "回收站爲空"
+msgstr "回收桶是空的"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:550
 msgid "Trash is empty."
-msgstr "回收站爲空。"
+msgstr "回收桶是空的。"
 
 #: packages/admin/src/components/FieldEditor.tsx:175
 msgid "True/false toggle"
-msgstr "真/假切換"
+msgstr "是/否切換開關"
 
 #: packages/admin/src/components/MediaLibrary.tsx:493
 msgid "Try a broader media type or clear your filters."
-msgstr ""
+msgstr "請嘗試更廣泛的媒體類型，或清除篩選條件。"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:691
 msgid "Try a different search term"
-msgstr "嘗試其他搜索詞"
+msgstr "嘗試其他搜尋字詞"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:172
 #: packages/admin/src/components/SectionPickerModal.tsx:103
 msgid "Try adjusting your search"
-msgstr "嘗試調整您的搜索"
+msgstr "嘗試調整搜尋條件"
 
 #: packages/admin/src/components/Sections.tsx:260
 msgid "Try adjusting your search or filters."
-msgstr "嘗試調整您的搜索或篩選條件。"
+msgstr "嘗試調整搜尋條件或篩選器。"
 
 #: packages/admin/src/routes/users.tsx:210
 msgid "Try again"
-msgstr ""
+msgstr "再試一次"
 
 #: packages/admin/src/components/WordPressImport.tsx:1582
 msgid "Try Again"
-msgstr "重試"
+msgstr "再試一次"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:207
 msgid "Try another code"
@@ -7944,29 +7944,29 @@ msgstr "嘗試其他代碼"
 
 #: packages/admin/src/components/MediaLibrary.tsx:518
 msgid "Try another filename or clear your search."
-msgstr ""
+msgstr "請嘗試其他檔案名稱，或清除搜尋。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:492
 msgid "Try another filename, or clear your search and filters."
-msgstr ""
+msgstr "請嘗試其他檔案名稱，或清除搜尋及篩選條件。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1286
 #: packages/admin/src/components/WordPressImport.tsx:1408
 msgid "Try Another URL"
-msgstr "嘗試其他 URL"
+msgstr "嘗試其他網址"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
 msgid "Try with my data"
-msgstr "使用我的數據嘗試"
+msgstr "使用我的資料試用"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:55
 msgid "TSX"
-msgstr ""
+msgstr "TSX"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:282
 msgid "Turn into"
-msgstr ""
+msgstr "轉換成"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:106
 msgid "Twitter"
@@ -7982,57 +7982,57 @@ msgstr "類型"
 #. placeholder {0}: status.existingType
 #: packages/admin/src/components/WordPressImport.tsx:2018
 msgid "Type mismatch ({0})"
-msgstr "類型不匹配 ({0})"
+msgstr "類型不符 ({0})"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:56
 msgid "TypeScript"
-msgstr ""
+msgstr "TypeScript"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:131
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
 msgid "Unable to reach marketplace"
-msgstr "無法訪問市場"
+msgstr "無法連上市集"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1042
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1059
 msgid "Unassigned"
-msgstr "未分配"
+msgstr "未指派"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3244
 #: packages/admin/src/components/PortableTextEditor.tsx:3630
 msgid "Underline"
-msgstr ""
+msgstr "底線"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3810
 msgid "Undo"
-msgstr ""
+msgstr "復原"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:191
 #: packages/admin/src/components/PluginManager.tsx:629
 #: packages/admin/src/components/PluginManager.tsx:727
 msgid "Uninstall"
-msgstr "卸載"
+msgstr "解除安裝"
 
 #: packages/admin/src/components/PluginManager.tsx:711
 msgid "Uninstall {pluginName}?"
-msgstr "卸載 {pluginName}？"
+msgstr "要解除安裝 {pluginName} 嗎？"
 
 #: packages/admin/src/components/PluginManager.tsx:706
 msgid "Uninstall confirmation"
-msgstr "卸載確認"
+msgstr "解除安裝確認"
 
 #: packages/admin/src/components/PluginManager.tsx:727
 msgid "Uninstalling..."
-msgstr "卸載中..."
+msgstr "正在解除安裝…"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:731
 #: packages/admin/src/components/FieldEditor.tsx:442
 msgid "Unique"
-msgstr "唯一"
+msgstr "不重複"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:107
 msgid "Unique identifier (ULID)"
-msgstr "唯一標識符 (ULID)"
+msgstr "唯一識別碼 (ULID)"
 
 #: packages/admin/src/components/users/useRolesConfig.ts:7
 msgid "Unknown"
@@ -8047,54 +8047,54 @@ msgstr "未知角色"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
 msgid "Unlock aspect ratio"
-msgstr "解鎖寬高比"
+msgstr "解除鎖定長寬比"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:152
 #: packages/admin/src/components/users/UserDetail.tsx:254
 msgid "Unnamed passkey"
-msgstr "未命名通行密鑰"
+msgstr "未命名的通行金鑰"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:198
 msgid "Unpublish {itemLabel}"
-msgstr ""
+msgstr "取消發佈 {itemLabel}"
 
 #: packages/admin/src/router.tsx:1027
 msgid "Unpublished"
-msgstr ""
+msgstr "未發佈"
 
 #: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
-msgstr "發現未註冊的內容表"
+msgstr "發現未註冊的內容資料表"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:465
 msgid "Unschedule"
-msgstr "取消定時發佈"
+msgstr "取消排程"
 
 #: packages/admin/src/router.tsx:1088
 msgid "Unscheduled"
-msgstr ""
+msgstr "未排程"
 
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128
 msgid "Unsupported widget element type: {0}"
-msgstr ""
+msgstr "不支援的小工具元素類型: {0}"
 
 #: packages/admin/src/components/Dashboard.tsx:317
 msgid "Untitled"
-msgstr "無標題"
+msgstr "未命名"
 
 #: packages/admin/src/components/ContentEditor.tsx:1601
 msgid "Untitled file"
-msgstr ""
+msgstr "未命名檔案"
 
 #: packages/admin/src/components/Widgets.tsx:534
 #: packages/admin/src/components/Widgets.tsx:807
 msgid "Untitled Widget"
-msgstr ""
+msgstr "未命名小工具"
 
 #: packages/admin/src/components/PublisherHandle.tsx:145
 msgid "Unverified publisher"
-msgstr ""
+msgstr "未驗證的發佈者"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:869
 msgid "Up"
@@ -8106,25 +8106,25 @@ msgstr "更新"
 
 #: packages/admin/src/components/FieldEditor.tsx:660
 msgid "Update Field"
-msgstr "更新字段"
+msgstr "更新欄位"
 
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:334
 msgid "Update settings for {0}"
-msgstr "更新 {0} 的設置"
+msgstr "更新 {0} 的設定"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:92
 msgid "Update site settings"
-msgstr "更新網站設置"
+msgstr "更新網站設定"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:382
 msgid "Update the {0} details"
-msgstr "更新 {0} 詳情"
+msgstr "更新 {0} 詳細資料"
 
 #: packages/admin/src/components/Redirects.tsx:110
 msgid "Update this redirect rule."
-msgstr "更新此重定向規則。"
+msgstr "更新此重新導向規則。"
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:451
@@ -8135,7 +8135,7 @@ msgstr "更新至 v{0}"
 #: packages/admin/src/components/ContentSettingsPanel.tsx:529
 #: packages/admin/src/components/RegistryPluginDetail.tsx:501
 msgid "Updated"
-msgstr ""
+msgstr "已更新"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:129
 msgid "Updated At"
@@ -8143,12 +8143,12 @@ msgstr "更新時間"
 
 #: packages/admin/src/components/WordPressImport.tsx:946
 msgid "Updating content URLs..."
-msgstr "正在更新內容 URL..."
+msgstr "正在更新內容網址..."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:197
 #: packages/admin/src/components/PluginManager.tsx:451
 msgid "Updating..."
-msgstr "更新中..."
+msgstr "正在更新..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:649
 msgid "Upload"
@@ -8156,50 +8156,50 @@ msgstr "上傳"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:152
 msgid "Upload a file to get started"
-msgstr ""
+msgstr "上傳檔案即可開始使用"
 
 #: packages/admin/src/components/WordPressImport.tsx:1391
 msgid "Upload an export file"
-msgstr "上傳導出文件"
+msgstr "上傳匯出檔案"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:153
 msgid "Upload an image to get started"
-msgstr "上傳圖片以開始使用"
+msgstr "上傳圖片即可開始使用"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:62
 msgid "Upload and delete media"
-msgstr "上傳和刪除媒體"
+msgstr "上傳及刪除媒體"
 
 #: packages/admin/src/lib/api/marketplace.ts:283
 #: packages/admin/src/lib/api/marketplace.ts:291
 msgid "Upload and manage media"
-msgstr ""
+msgstr "上傳及管理媒體"
 
 #: packages/admin/src/components/WordPressImport.tsx:1284
 #: packages/admin/src/components/WordPressImport.tsx:1405
 msgid "Upload Export File"
-msgstr "上傳導出文件"
+msgstr "上傳匯出檔案"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:669
 msgid "Upload failed: {uploadError}"
-msgstr "上傳失敗：{uploadError}"
+msgstr "上傳失敗: {uploadError}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:661
 msgid "Upload file"
-msgstr ""
+msgstr "上傳檔案"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:154
 msgid "Upload File"
-msgstr ""
+msgstr "上傳檔案"
 
 #: packages/admin/src/components/MediaLibrary.tsx:365
 msgid "Upload files"
-msgstr "上傳文件"
+msgstr "上傳檔案"
 
 #: packages/admin/src/components/MediaLibrary.tsx:508
 #: packages/admin/src/components/MediaLibrary.tsx:532
 msgid "Upload Files"
-msgstr "上傳文件"
+msgstr "上傳檔案"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:154
 msgid "Upload Image"
@@ -8207,7 +8207,7 @@ msgstr "上傳圖片"
 
 #: packages/admin/src/components/MediaLibrary.tsx:505
 msgid "Upload images, videos, and documents to keep reusable assets in one place."
-msgstr ""
+msgstr "上傳圖片、影片及文件，將可重複使用的素材集中存放於一處。"
 
 #: packages/admin/src/components/Dashboard.tsx:111
 msgid "Upload Media"
@@ -8215,7 +8215,7 @@ msgstr "上傳媒體"
 
 #: packages/admin/src/components/MediaLibrary.tsx:529
 msgid "Upload media to keep reusable assets in one place."
-msgstr ""
+msgstr "上傳媒體，將可重複使用的素材集中存放。"
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:356
@@ -8224,15 +8224,15 @@ msgstr "上傳至 {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1118
 msgid "Upload WordPress export file"
-msgstr "上傳 WordPress 導出文件"
+msgstr "上傳 WordPress 匯出檔案"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:289
 msgid "Uploaded:"
-msgstr "已上傳："
+msgstr "上傳時間:"
 
 #: packages/admin/src/components/WordPressImport.tsx:2127
 msgid "Uploading"
-msgstr "上傳中"
+msgstr "正在上傳"
 
 #. placeholder {0}: uploadState.progress.current
 #. placeholder {1}: uploadState.progress.total
@@ -8243,7 +8243,7 @@ msgstr "正在上傳 {0}/{1}..."
 #: packages/admin/src/components/MediaLibrary.tsx:332
 #: packages/admin/src/components/MediaPickerModal.tsx:649
 msgid "Uploading..."
-msgstr "上傳中..."
+msgstr "正在上傳..."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:54
 #: packages/admin/src/components/FieldEditor.tsx:234
@@ -8254,100 +8254,100 @@ msgstr "上傳中..."
 #: packages/admin/src/components/PortableTextEditor.tsx:3755
 #: packages/admin/src/components/PortableTextEditor.tsx:3765
 msgid "URL"
-msgstr "URL"
+msgstr "網址"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:423
 msgid "URL Pattern"
-msgstr ""
+msgstr "網址模式"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:113
 #: packages/admin/src/components/FieldEditor.tsx:229
 msgid "URL-friendly identifier"
-msgstr "URL 友好的標識符"
+msgstr "適合用於網址的識別碼"
 
 #: packages/admin/src/components/MenuList.tsx:163
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr "URL 友好的標識符（例如：\"primary\"、\"footer\"）"
+msgstr "適合用於網址的識別碼 (例如「primary」、「footer」)"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:295
 msgid "URL:"
-msgstr ""
+msgstr "URL:"
 
 #: packages/admin/src/components/Redirects.tsx:111
 msgid "Use [param] or [...rest] in paths for pattern matching."
-msgstr "在路徑中使用 [param] 或 [...rest] 進行模式匹配。"
+msgstr "在路徑中使用 [param] 或 [...rest] 進行模式比對。"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:364
 msgid "Use your device's biometric authentication, security key, or PIN to sign in."
-msgstr "使用設備的生物識別認證、安全密鑰或 PIN 碼登錄。"
+msgstr "使用裝置的生物特徵辨識、安全金鑰或 PIN 登入。"
 
 #: packages/admin/src/components/LoginPage.tsx:328
 msgid "Use your registered passkey to sign in securely."
-msgstr "使用您註冊的通行密鑰安全登錄。"
+msgstr "使用已註冊的通行金鑰安全登入。"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:140
 msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
-msgstr ""
+msgstr "當頁面沒有圖片時，用作備用 Open Graph 圖片。建議尺寸: 1200×630。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:666
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
-msgstr "用作標識符。僅限小寫字母、數字和下劃線。"
+msgstr "用作識別碼。僅限小寫字母、數字及底線。"
 
 #: packages/admin/src/components/ContentEditor.tsx:1288
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
-msgstr "用於在列表頁和文章頂部作爲主要視覺展示"
+msgstr "在清單頁面及文章頂端作為這篇文章的主要視覺"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:122
 msgid "Used by screen readers and when image fails to load"
-msgstr "供屏幕閱讀器使用，並在圖片加載失敗時顯示"
+msgstr "供螢幕閱讀器使用，並在圖片載入失敗時顯示"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:408
 msgid "Used in URLs and API endpoints"
-msgstr ""
+msgstr "用於網址與 API 端點"
 
 #: packages/admin/src/components/SectionEditor.tsx:269
 #: packages/admin/src/components/Sections.tsx:196
 msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
-msgstr "用於標識此區塊。僅限小寫字母、數字和連字符。"
+msgstr "用來識別這個區段。只能使用小寫字母、數字及連字號。"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:43
 #: packages/admin/src/components/Header.tsx:83
 #: packages/admin/src/components/users/UserList.tsx:98
 msgid "User"
-msgstr "用戶"
+msgstr "使用者"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:177
 msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
-msgstr "用戶訪問由外部提供商管理 ({0})。使用外部認證時，自助註冊域設置不可用。"
+msgstr "使用者存取權由外部服務提供者 ({0}) 管理。使用外部驗證時，無法使用自行註冊網域設定。"
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
-msgstr "用戶詳情"
+msgstr "使用者詳細資料"
 
 #: packages/admin/src/components/users/UserDetail.tsx:296
 msgid "User not found"
-msgstr "未找到用戶"
+msgstr "找不到使用者"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:210
 #: packages/admin/src/components/Sidebar.tsx:253
 #: packages/admin/src/components/users/UserList.tsx:54
 msgid "Users"
-msgstr "用戶"
+msgstr "使用者"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:383
 msgid "Users from"
-msgstr "來自以下域的用戶"
+msgstr "來自以下網域的使用者"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:211
 msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
-msgstr "來自這些域名的郵箱地址的用戶可以無需邀請即可註冊。他們將自動被分配指定的角色。"
+msgstr "電子郵件地址屬於這些網域的使用者，不需邀請即可註冊。系統會自動指派指定角色。"
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:386
 msgid "v{0} available"
-msgstr "v{0} 可用"
+msgstr "已有 v{0} 可用"
 
 #: packages/admin/src/components/FieldEditor.tsx:460
 #: packages/admin/src/components/FieldEditor.tsx:490
@@ -8357,32 +8357,32 @@ msgstr "驗證"
 #: packages/admin/src/components/RegistryBrowse.tsx:187
 #: packages/admin/src/components/RegistryPluginDetail.tsx:462
 msgid "Verified publisher"
-msgstr ""
+msgstr "已驗證的發佈者"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:461
 msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
-msgstr ""
+msgstr "已驗證的發佈者，由標記者 {verifiedLabeller} 確認"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:452
 msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
-msgstr ""
+msgstr "已驗證的發佈者。標記者 ({verifiedLabeller}) 已確認此發佈者的身分。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:453
 msgid "Verified publisher. A labeller has confirmed this publisher's identity."
-msgstr ""
+msgstr "已驗證的發佈者。標記者已確認此發佈者的身分。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:228
 msgid "Verifying your invite..."
-msgstr ""
+msgstr "正在驗證您的邀請…"
 
 #: packages/admin/src/components/SignupPage.tsx:388
 msgid "Verifying your link..."
-msgstr "正在驗證您的鏈接..."
+msgstr "正在驗證您的連結…"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:211
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
 msgid "Verifying..."
-msgstr "驗證中..."
+msgstr "正在驗證..."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:331
 #: packages/admin/src/components/RegistryPluginDetail.tsx:515
@@ -8392,53 +8392,53 @@ msgstr "版本"
 #. placeholder {0}: release.version
 #: packages/admin/src/components/RegistryPluginDetail.tsx:477
 msgid "Version {0}"
-msgstr ""
+msgstr "版本 {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:67
 #: packages/admin/src/components/MediaLibrary.tsx:435
 msgid "Video"
-msgstr ""
+msgstr "影片"
 
 #: packages/admin/src/components/Settings.tsx:117
 msgid "View email provider status and send test emails"
-msgstr "查看郵件提供商狀態並發送測試郵件"
+msgstr "檢視電子郵件服務提供者狀態並傳送測試郵件"
 
 #: packages/admin/src/components/PluginManager.tsx:463
 msgid "View in Marketplace"
-msgstr "在市場查看"
+msgstr "在市集中檢視"
 
 #: packages/admin/src/components/MediaLibrary.tsx:447
 msgid "View mode"
-msgstr "查看模式"
+msgstr "檢視模式"
 
 #: packages/admin/src/components/ContentList.tsx:1011
 msgid "View published {title}"
-msgstr "查看已發佈的 {title}"
+msgstr "檢視已發佈的 {title}"
 
 #: packages/admin/src/components/Header.tsx:59
 msgid "View Site"
-msgstr "查看站點"
+msgstr "檢視網站"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:676
 msgid "View source"
-msgstr ""
+msgstr "檢視原始碼"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:931
 msgid "View the {license} license on spdx.org"
-msgstr ""
+msgstr "在 spdx.org 檢視 {license} 授權條款"
 
 #: packages/admin/src/components/Redirects.tsx:449
 msgid "Visitors hitting these paths will see an error."
-msgstr "訪問這些路徑的訪問者將看到錯誤。"
+msgstr "瀏覽者存取這些路徑時會看到錯誤。"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:57
 msgid "Vue"
-msgstr ""
+msgstr "Vue"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
 msgid "Waiting for passkey..."
-msgstr "等待通行密鑰..."
+msgstr "正在等待通行金鑰..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:333
 msgid "Warn"
@@ -8447,23 +8447,23 @@ msgstr "警告"
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1266
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr "我們無法連接到位於 {0} 的 WordPress 站點。這可能意味着該站點不是 WordPress、REST API 被禁用或站點無法訪問。"
+msgstr "我們無法連線至位於 {0} 的 WordPress 網站。這可能表示該網站不是 WordPress 網站、REST API 已停用，或無法存取該網站。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:577
 msgid "We couldn't verify this publisher's identity"
-msgstr ""
+msgstr "我們無法驗證這個發佈者的身分"
 
 #: packages/admin/src/components/WordPressImport.tsx:1084
 msgid "We'll check what import options are available for your site."
-msgstr "我們將檢查您的站點有哪些導入選項可用。"
+msgstr "我們會檢查您的網站有哪些可用的匯入選項。"
 
 #: packages/admin/src/components/LoginPage.tsx:325
 msgid "We'll send you a link to sign in without a password."
-msgstr "我們將向您發送一個無需密碼即可登錄的鏈接。"
+msgstr "我們會傳送連結給您，讓您不必輸入密碼即可登入。"
 
 #: packages/admin/src/components/SignupPage.tsx:133
 msgid "We've sent a verification link to"
-msgstr "我們已向以下郵箱發送了驗證鏈接"
+msgstr "我們已將驗證連結傳送至"
 
 #: packages/admin/src/components/FieldEditor.tsx:235
 msgid "Web address"
@@ -8472,7 +8472,7 @@ msgstr "網址"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:159
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
 msgid "WebAuthn is not supported in this browser"
-msgstr "此瀏覽器不支持 WebAuthn"
+msgstr "此瀏覽器不支援 WebAuthn"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:236
 #: packages/admin/src/components/RegistryPluginDetail.tsx:701
@@ -8481,7 +8481,7 @@ msgstr "網站"
 
 #: packages/admin/src/routes/bylines.tsx:491
 msgid "Website URL"
-msgstr ""
+msgstr "網站網址"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -8489,31 +8489,31 @@ msgstr "歡迎使用 EmDash，{firstName}！"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
-msgstr "歡迎使用 EmDash！"
+msgstr "歡迎使用 EmDash。"
 
 #: packages/admin/src/components/WordPressImport.tsx:2091
 msgid "What happens when you import:"
-msgstr "導入時會發生什麼："
+msgstr "匯入時會進行下列作業:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1874
 msgid "What will happen when you import"
-msgstr "導入時會發生什麼"
+msgstr "匯入後將進行的作業"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:125
 msgid "When the entry was created"
-msgstr "條目創建時間"
+msgstr "內容項目的建立時間"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:131
 msgid "When the entry was last modified"
-msgstr "條目最後修改時間"
+msgstr "項目上次修改的時間"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:137
 msgid "When the entry was published"
-msgstr "條目發佈時間"
+msgstr "項目發佈的時間"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:680
 msgid "Which content types can use this taxonomy"
-msgstr "哪些內容類型可以使用此分類"
+msgstr "可使用此分類法的內容類型"
 
 #: packages/admin/src/components/FieldEditor.tsx:169
 msgid "Whole number"
@@ -8521,64 +8521,64 @@ msgstr "整數"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:121
 msgid "Why can't this be changed?"
-msgstr ""
+msgstr "為什麼無法變更？"
 
 #: packages/admin/src/components/SeoPanel.tsx:209
 msgid "Why is this important for duplicate pages?"
-msgstr ""
+msgstr "為什麼這對重複頁面很重要？"
 
 #: packages/admin/src/components/SeoPanel.tsx:185
 msgid "Why is this important for search result summaries?"
-msgstr ""
+msgstr "為什麼這對搜尋結果摘要很重要？"
 
 #: packages/admin/src/components/SeoPanel.tsx:165
 msgid "Why is this important for search result titles?"
-msgstr ""
+msgstr "為什麼這對搜尋結果標題很重要？"
 
 #: packages/admin/src/components/SeoPanel.tsx:228
 msgid "Why is this important for search visibility?"
-msgstr ""
+msgstr "為什麼這對搜尋可見度很重要？"
 
 #: packages/admin/src/components/SeoImageField.tsx:44
 msgid "Why is this important for social sharing?"
-msgstr ""
+msgstr "為什麼這對社群分享很重要？"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:123
 msgid "Why is this important?"
-msgstr ""
+msgstr "為什麼這很重要？"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
 msgid "Wide"
-msgstr ""
+msgstr "寬幅"
 
 #: packages/admin/src/components/Widgets.tsx:800
 #: packages/admin/src/components/Widgets.tsx:815
 msgid "widget"
-msgstr ""
+msgstr "小工具"
 
 #: packages/admin/src/components/Widgets.tsx:232
 msgid "Widget added"
-msgstr ""
+msgstr "小工具已新增"
 
 #: packages/admin/src/components/Widgets.tsx:220
 msgid "Widget area created"
-msgstr ""
+msgstr "小工具區域已建立"
 
 #: packages/admin/src/components/Widgets.tsx:643
 msgid "Widget area deleted"
-msgstr ""
+msgstr "已刪除小工具區域"
 
 #: packages/admin/src/components/Widgets.tsx:763
 msgid "Widget deleted"
-msgstr ""
+msgstr "小工具已刪除"
 
 #: packages/admin/src/components/Widgets.tsx:892
 msgid "Widget title"
-msgstr ""
+msgstr "小工具標題"
 
 #: packages/admin/src/components/Widgets.tsx:778
 msgid "Widget updated"
-msgstr ""
+msgstr "已更新小工具"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:168
 #: packages/admin/src/components/PluginManager.tsx:407
@@ -8586,7 +8586,7 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:388
 #: packages/admin/src/components/WordPressImport.tsx:1157
 msgid "Widgets"
-msgstr "小部件"
+msgstr "小工具"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:284
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:473
@@ -8595,55 +8595,55 @@ msgstr "寬度"
 
 #: packages/admin/src/components/PluginSettings.tsx:338
 msgid "Will be cleared on save"
-msgstr ""
+msgstr "儲存時將會清除"
 
 #: packages/admin/src/components/WordPressImport.tsx:2014
 msgid "Will create"
-msgstr "將創建"
+msgstr "將會建立"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:384
 msgid "will no longer be able to sign up without an invite. Existing users are not affected."
-msgstr "將不再能夠無需邀請即可註冊。現有用戶不受影響。"
+msgstr "將無法在未受邀的情況下註冊。現有使用者不受影響。"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:158
 msgid "Without an email provider, invite links must be shared manually."
-msgstr "如果沒有郵件提供商，必須手動分享邀請鏈接。"
+msgstr "若未設定電子郵件服務提供者，必須手動分享邀請連結。"
 
 #: packages/admin/src/components/WordPressImport.tsx:210
 msgid "WordPress authorization was rejected"
-msgstr ""
+msgstr "WordPress 授權遭拒"
 
 #: packages/admin/src/components/WordPressImport.tsx:1476
 msgid "WordPress Username"
-msgstr "WordPress 用戶名"
+msgstr "WordPress 使用者名稱"
 
 #: packages/admin/src/components/ContentList.tsx:404
 msgid "Working on {selectedCount} items…"
-msgstr ""
+msgstr "正在處理 {selectedCount} 個項目…"
 
 #: packages/admin/src/components/Widgets.tsx:902
 msgid "Write widget content..."
-msgstr ""
+msgstr "撰寫小工具內容..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1181
 msgid "WXR File"
-msgstr "WXR 文件"
+msgstr "WXR 檔案"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:58
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1497
 msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
-msgstr ""
+msgstr "xxxx xxxx xxxx xxxx xxxx xxxx"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:59
 msgid "YAML"
-msgstr ""
+msgstr "YAML"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Yearly"
-msgstr ""
+msgstr "每年"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:420
@@ -8653,77 +8653,77 @@ msgstr "是"
 
 #: packages/admin/src/components/WordPressImport.tsx:1160
 msgid "Yoast/RankMath"
-msgstr ""
+msgstr "Yoast/RankMath"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."
-msgstr "您可以關閉此頁面並返回終端。"
+msgstr "您可以關閉此頁面並返回終端機。"
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
-msgstr "您可以創建和編輯自己的內容。"
+msgstr "您可以建立及編輯自己的內容。"
 
 #: packages/admin/src/components/WelcomeModal.tsx:42
 msgid "You can manage content, media, menus, and taxonomies."
-msgstr "您可以管理內容、媒體、菜單和分類。"
+msgstr "您可以管理內容、媒體、選單及分類法。"
 
 #: packages/admin/src/routes/bylines.tsx:549
 msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
-msgstr ""
+msgstr "您仍可編輯上方的固定欄位。儲存時不會變更任何已儲存的自訂欄位值。"
 
 #: packages/admin/src/components/WelcomeModal.tsx:44
 msgid "You can view and contribute to the site."
-msgstr "您可以查看和貢獻網站內容。"
+msgstr "您可以檢視網站並參與內容編輯。"
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
-msgstr "您無法更改自己的角色"
+msgstr "您無法變更自己的角色"
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
-msgstr "您擁有完全訪問權限來管理此網站，包括用戶、設置和所有內容。"
+msgstr "您擁有管理此網站的完整存取權，包括使用者、設定及所有內容。"
 
 #: packages/admin/src/routes/byline-schema.tsx:175
 msgid "You need admin permissions to manage byline schema."
-msgstr ""
+msgstr "您需要管理員權限才能管理署名結構描述。"
 
 #: packages/admin/src/router.tsx:1486
 msgid "You need Editor permissions to moderate comments."
-msgstr ""
+msgstr "您需要編輯者權限才能審核留言。"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:204
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
-msgstr "您將無法再使用「{0}」登錄。此操作無法撤銷。"
+msgstr "您將無法再使用「{0}」登入。此動作無法復原。"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
-msgstr "您將無法再使用此通行密鑰登錄。此操作無法撤銷。"
+msgstr "您將無法再使用此通行金鑰登入。此動作無法復原。"
 
 #. placeholder {0}: inviteData.roleName
 #: packages/admin/src/components/InviteAcceptPage.tsx:55
 msgid "You'll be joining as <0>{0}</0>"
-msgstr ""
+msgstr "您將以 <0>{0}</0> 身分加入"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
-msgstr "系統將提示您使用設備的生物識別認證、安全密鑰或 PIN 碼。"
+msgstr "系統將提示您使用裝置的生物特徵驗證、安全金鑰或 PIN。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1369
 msgid "You'll be redirected to WordPress to authorize the connection."
-msgstr "您將被重定向到 WordPress 以授權連接。"
+msgstr "系統會將您重新導向至 WordPress，以授權連線。"
 
 #: packages/admin/src/components/SignupPage.tsx:192
 msgid "You'll be signing up as"
-msgstr "您將註冊爲"
+msgstr "您將註冊為"
 
 #: packages/admin/src/components/SetupWizard.tsx:564
 msgid "You're signed in via Cloudflare Access"
-msgstr "您已通過 Cloudflare Access 登錄"
+msgstr "您已透過 Cloudflare Access 登入"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:53
 msgid "You've been invited!"
-msgstr ""
+msgstr "您已收到邀請。"
 
 #: packages/admin/src/components/SignupPage.tsx:71
 msgid "you@company.com"
@@ -8736,42 +8736,42 @@ msgstr "you@example.com"
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
-msgstr "您的帳號已成功創建。"
+msgstr "您的帳號已成功建立。"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:316
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
 msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
-msgstr "您的瀏覽器不支持通行密鑰。請使用現代瀏覽器，如 Chrome、Safari、Firefox 或 Edge。"
+msgstr "您的瀏覽器不支援通行金鑰。請使用 Chrome、Safari、Firefox 或 Edge 等現代瀏覽器。"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:267
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
 msgid "Your device doesn't support the required security features."
-msgstr "您的設備不支持所需的安全功能。"
+msgstr "您的裝置不支援所需的安全性功能。"
 
 #: packages/admin/src/components/SetupWizard.tsx:197
 msgid "Your Email"
-msgstr "您的郵箱"
+msgstr "您的電子郵件"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:121
 msgid "Your Facebook page or profile username"
-msgstr "您的 Facebook 頁面或個人資料用戶名"
+msgstr "您的 Facebook 粉絲專頁或個人檔案使用者名稱"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:115
 msgid "Your GitHub username"
-msgstr "您的 GitHub 用戶名"
+msgstr "您的 GitHub 使用者名稱"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:127
 msgid "Your Instagram username"
-msgstr "您的 Instagram 用戶名"
+msgstr "您的 Instagram 使用者名稱"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:133
 msgid "Your LinkedIn profile username"
-msgstr "您的 LinkedIn 個人資料用戶名"
+msgstr "您的 LinkedIn 個人檔案使用者名稱"
 
 #: packages/admin/src/components/MediaLibrary.tsx:504
 #: packages/admin/src/components/MediaLibrary.tsx:528
 msgid "Your media library is empty"
-msgstr ""
+msgstr "您的媒體庫是空的"
 
 #: packages/admin/src/components/SetupWizard.tsx:209
 msgid "Your Name"
@@ -8780,7 +8780,7 @@ msgstr "您的姓名"
 #: packages/admin/src/components/InviteAcceptPage.tsx:65
 #: packages/admin/src/components/SignupPage.tsx:202
 msgid "Your name (optional)"
-msgstr "您的姓名（可選）"
+msgstr "您的姓名 (選填)"
 
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
@@ -8789,24 +8789,24 @@ msgstr "您的角色"
 #. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
 #: packages/admin/src/components/RegistryPluginDetail.tsx:612
 msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
-msgstr ""
+msgstr "您的網站要求發行版本至少已有 {0} 的時間才能安裝。這個版本稍後才能安裝。"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:109
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr "您的 Twitter/X 用戶名（例如：@username）"
+msgstr "您的 Twitter/X 代號 (例如 @username)"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:437
 msgid "Your unsaved media changes will be lost."
-msgstr ""
+msgstr "未儲存的媒體變更將會遺失。"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:2062
 msgid "Your WordPress export contains {0} media files."
-msgstr "您的 WordPress 導出包含 {0} 個媒體文件。"
+msgstr "您的 WordPress 匯出檔包含 {0} 個媒體檔案。"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:139
 msgid "Your YouTube channel ID or handle"
-msgstr "您的 YouTube 頻道 ID 或用戶名"
+msgstr "您的 YouTube 頻道 ID 或代號"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:136
 msgid "YouTube"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Completes the Traditional Chinese (`zh-TW`) translation of the EmDash admin interface.

This update:

- Translates all 1,932 entries in the `zh-TW` message catalog.
- Fills the remaining 710 untranslated entries.
- Uses terminology and phrasing appropriate for Traditional Chinese users in Taiwan.
- Preserves the original message IDs, source references, comments, and catalog structure.
- Leaves no untranslated or fuzzy entries.
## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (not applicable; this is a translation-only change)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable; this PR only updates the translation catalog)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [x] New features link to an approved Discussion (not applicable; this PR does not add a feature)

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-assisted translation work — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
The catalog passes GNU gettext validation:

```text
msgfmt --check --check-format packages/admin/src/locales/zh-TW/messages.po -o /dev/null

Additional validation:
Entries: 1,932
Translated: 1,932
Untranslated: 0
Fuzzy: 0

```