### PR TITLE
fix(content): search searchable custom fields

### DIFF
--- a/.changeset/content-list-searchable-fields.md
+++ b/.changeset/content-list-searchable-fields.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Include schema fields marked searchable in admin content-list search, using the collection FTS index when available and a cross-dialect substring fallback otherwise.

--- a/packages/admin/src/lib/api/content.ts
+++ b/packages/admin/src/lib/api/content.ts
@@ -147,7 +147,7 @@ export async function fetchContentList(
 		orderBy?: string;
 		/** Sort direction; defaults to "desc" on the server. */
 		order?: "asc" | "desc";
-		/** Case-insensitive substring search across title/name/slug. */
+		/** Search across display fields, slug, and searchable custom fields. */
 		search?: string;
 		/** Filter to entries authored by this user (the `author_id` column). */
 		authorId?: string;

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -314,30 +314,33 @@ export interface TrashedContentItem {
 
 /**
  * Resolve the columns a content-list search should match against. Always
- * includes `slug` (a standard column) and adds the `title`/`name` display
- * fields when the collection actually defines them, mirroring the admin's
- * item-title resolution (title -> name -> slug). Returning only existing
- * columns avoids "no such column" errors on collections without them.
+ * includes `slug` (a standard column), adds the `title`/`name` display fields
+ * when they exist, and includes every field explicitly marked searchable.
+ * Returning only schema-backed columns avoids "no such column" errors.
  */
 async function resolveSearchColumns(db: Kysely<Database>, collection: string): Promise<string[]> {
-	const columns = ["slug"];
 	const row = await db
 		.selectFrom("_emdash_collections")
 		.select("id")
 		.where("slug", "=", collection)
 		.executeTakeFirst();
-	if (!row) return columns;
+	if (!row) return ["slug"];
 
 	const fields = await db
 		.selectFrom("_emdash_fields")
-		.select("slug")
+		.select(["slug", "searchable"])
 		.where("collection_id", "=", row.id)
+		.orderBy("sort_order", "asc")
 		.execute();
+	const columns = new Set(["slug"]);
 	const fieldSlugs = new Set(fields.map((f) => f.slug));
 	for (const candidate of ["title", "name"]) {
-		if (fieldSlugs.has(candidate)) columns.push(candidate);
+		if (fieldSlugs.has(candidate)) columns.add(candidate);
 	}
-	return columns;
+	for (const field of fields) {
+		if (field.searchable === 1) columns.add(field.slug);
+	}
+	return [...columns];
 }
 
 /**

--- a/packages/core/src/api/schemas/content.ts
+++ b/packages/core/src/api/schemas/content.ts
@@ -32,7 +32,7 @@ export const contentListQuery = cursorPaginationQuery
 		orderBy: z.string().optional(),
 		order: z.enum(["asc", "desc"]).optional(),
 		locale: localeCode.optional(),
-		/** Case-insensitive substring search across the collection's title/name/slug. */
+		/** Search across the collection's display fields, slug, and searchable custom fields. */
 		q: z.string().trim().min(1).max(200).optional(),
 		/** Filter to entries authored by this user (the `author_id` column). */
 		authorId: z.string().min(1).max(64).optional(),

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -953,7 +953,7 @@ export class ContentRepository {
 			eb.or(
 				columns.map((col) => {
 					validateIdentifier(col, "search column");
-					return eb(sql`lower(${sql.ref(col)})`, "like", sql`lower(${pattern}) escape '\\'`);
+					return sql<boolean>`lower(CAST(${sql.ref(col)} AS TEXT)) LIKE lower(${pattern}) ESCAPE '\\'`;
 				}),
 			),
 		);

--- a/packages/core/src/database/repositories/types.ts
+++ b/packages/core/src/database/repositories/types.ts
@@ -154,8 +154,9 @@ export interface FindManyOptions {
 		q?: string;
 		/**
 		 * Columns the `q` substring filter is applied to (OR'd together).
-		 * Resolved by the handler from the collection's display fields so the
-		 * repository stays generic. Each name is validated as a SQL identifier.
+		 * Resolved by the handler from the collection's display fields, slug,
+		 * and any field marked searchable. Each name is validated as a SQL
+		 * identifier.
 		 */
 		searchColumns?: string[];
 		/**

--- a/packages/core/tests/integration/content/content-list-search-fts.test.ts
+++ b/packages/core/tests/integration/content/content-list-search-fts.test.ts
@@ -27,7 +27,7 @@ async function seedPosts(db: Db) {
 	}
 	const needle = await handleContentCreate(db, "posts", {
 		slug: "the-needle-post",
-		data: { title: "zzz Needle Headline" },
+		data: { title: "zzz Needle Headline", ticket_number: "TICKET2179" },
 	});
 	if (!needle.success) throw new Error("needle seed failed");
 
@@ -59,6 +59,12 @@ describe("content list search served by FTS (#1517)", () => {
 			type: "string",
 			searchable: true,
 		});
+		await registry.createField("posts", {
+			slug: "ticket_number",
+			label: "Ticket number",
+			type: "string",
+			searchable: true,
+		});
 		await seedPosts(db);
 		await new FTSManager(db).enableSearch("posts");
 	});
@@ -87,6 +93,11 @@ describe("content list search served by FTS (#1517)", () => {
 
 	it("finds an entry by slug prefix (slug is not in the FTS index)", async () => {
 		const result = await handleContentList(db, "posts", { q: "the-needle", limit: 20 });
+		expect(titlesOf(result)).toContain("zzz Needle Headline");
+	});
+
+	it("finds an entry by a searchable custom field", async () => {
+		const result = await handleContentList(db, "posts", { q: "ticket217", limit: 20 });
 		expect(titlesOf(result)).toContain("zzz Needle Headline");
 	});
 
@@ -144,6 +155,12 @@ describe("content list search falls back to LIKE when FTS cannot serve it", () =
 			type: "text",
 			searchable: true,
 		});
+		await registry.createField("posts", {
+			slug: "ticket_number",
+			label: "Ticket number",
+			type: "string",
+			searchable: true,
+		});
 		await seedPosts(db);
 		await new FTSManager(db).enableSearch("posts");
 	});
@@ -156,6 +173,11 @@ describe("content list search falls back to LIKE when FTS cannot serve it", () =
 		// Mid-word substring — only LIKE can match this; proves the handler
 		// did not route to FTS despite search being enabled.
 		const result = await handleContentList(db, "posts", { q: "eedle", limit: 20 });
+		expect(titlesOf(result)).toContain("zzz Needle Headline");
+	});
+
+	it("searches custom fields through the LIKE fallback", async () => {
+		const result = await handleContentList(db, "posts", { q: "CKET21", limit: 20 });
 		expect(titlesOf(result)).toContain("zzz Needle Headline");
 	});
 });

--- a/packages/core/tests/integration/content/content-list-search.test.ts
+++ b/packages/core/tests/integration/content/content-list-search.test.ts
@@ -20,6 +20,12 @@ describeEachDialect("content list server-side search (#1219)", (dialect) => {
 		const registry = new SchemaRegistry(ctx.db);
 		await registry.createCollection({ slug: "posts", label: "Posts", labelSingular: "Post" });
 		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		await registry.createField("posts", {
+			slug: "ticket_number",
+			label: "Ticket number",
+			type: "integer",
+			searchable: true,
+		});
 
 		// Seed 60 ordinary posts plus a "deep" needle far past the first page.
 		for (let i = 0; i < 60; i++) {
@@ -31,7 +37,7 @@ describeEachDialect("content list server-side search (#1219)", (dialect) => {
 		}
 		const needle = await handleContentCreate(ctx.db, "posts", {
 			slug: "the-needle-post",
-			data: { title: "zzz Needle Headline" },
+			data: { title: "zzz Needle Headline", ticket_number: 2179 },
 		});
 		if (!needle.success) throw new Error("needle seed failed");
 
@@ -70,6 +76,11 @@ describeEachDialect("content list server-side search (#1219)", (dialect) => {
 
 	it("searches the slug as well as the title", async () => {
 		const result = await handleContentList(ctx.db, "posts", { q: "the-needle-post", limit: 20 });
+		expect(titlesOf(result)).toContain("zzz Needle Headline");
+	});
+
+	it("searches custom fields marked searchable", async () => {
+		const result = await handleContentList(ctx.db, "posts", { q: "2179", limit: 20 });
 		expect(titlesOf(result)).toContain("zzz Needle Headline");
 	});
 


### PR DESCRIPTION
## What does this PR do?

Content-list search now includes every schema field marked `searchable`, in addition to the collection display fields and slug.

The FTS path already indexed searchable custom fields, but the fallback path only matched `slug`, `title`, and `name`. That made custom metadata search backend-dependent and prevented values such as internal ticket numbers from being found when FTS could not serve the query.

This change keeps the existing FTS path, resolves searchable fields from the collection schema, and casts fallback values to text so scalar custom fields can be matched consistently across supported SQL dialects.

Addresses the search portion of #2179.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No user-visible strings were added.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: N/A (bug fix)

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI generated code: Claude Opus 5, GPT-5.6 (via private dev orchestra)

## Screenshots / test output

- `pnpm --filter emdash test --run tests/integration/content/content-list-search.test.ts tests/integration/content/content-list-search-fts.test.ts` (17 tests passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`



