### PR TITLE
fix(e2e): make visual-regression editor captures deterministic

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -67,15 +67,19 @@ jobs:
 
       # Always record PR metadata so the Report workflow can upsert *or* clear
       # the sticky comment. Candidate baselines + diff images are added only
-      # when the suite actually diffed (exit != 0 AND regeneration produced
-      # snapshots) -- an infra failure exits non-zero but yields no candidates,
-      # so we don't mislabel it as a visual change.
+      # when the regenerated baselines actually differ from the committed ones.
+      # A non-zero exit alone is not drift: a flaky render can fail the diff
+      # check on the first pass yet regenerate byte-identical baselines under
+      # --update-snapshots, and an infra failure exits non-zero without
+      # regenerating anything. Both leave the snapshots dir git-clean, so we
+      # decide drift from `git status`, not from the exit code.
       - name: Collect result
         id: collect
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_EXIT: ${{ steps.run.outputs.exit }}
+          SNAP_DIR: e2e/tests/visual-regression.spec.ts-snapshots
         run: |
           mkdir -p visual-out
           echo "$PR_NUMBER" > visual-out/pr-number
@@ -99,21 +103,27 @@ jobs:
           # Regenerate the accepted-state baselines (the candidates the Apply
           # workflow will commit verbatim on 👍). These are Linux/chromium PNGs.
           pnpm exec playwright test visual-regression --update-snapshots --reporter=line || true
-          mkdir -p visual-out/candidates
-          if [ -d e2e/tests/visual-regression.spec.ts-snapshots ]; then
-            cp -r e2e/tests/visual-regression.spec.ts-snapshots/. visual-out/candidates/
-          fi
 
-          if [ -z "$(ls -A visual-out/candidates 2>/dev/null)" ]; then
-            # Non-zero exit but nothing regenerated -> infra failure, not drift.
+          # Real drift == the regeneration changed tracked baselines or added
+          # new ones. Untracked new files count (bootstrap: a PR that adds a
+          # page has no committed baseline yet). A clean tree means the failure
+          # did not correspond to a stable pixel difference -- treat it as flake
+          # or infra and keep the check green with a warning.
+          if [ -z "$(git status --porcelain -- "$SNAP_DIR")" ]; then
             echo "false" > visual-out/has-drift
             echo "has_drift=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Visual suite failed without producing candidate baselines (likely an infra failure, not a UI diff)."
-          else
-            echo "true" > visual-out/has-drift
-            echo "has_drift=true" >> "$GITHUB_OUTPUT"
-            echo "Visual drift detected — candidates and diff images staged for the Report workflow."
+            echo "::warning::Visual suite exited non-zero but regenerated baselines are identical to the committed ones (flaky render or infra failure, not a UI diff)."
+            exit 0
           fi
+
+          # Stage the candidate baselines for the Report/Apply workflows.
+          mkdir -p visual-out/candidates
+          if [ -d "$SNAP_DIR" ]; then
+            cp -r "$SNAP_DIR/." visual-out/candidates/
+          fi
+          echo "true" > visual-out/has-drift
+          echo "has_drift=true" >> "$GITHUB_OUTPUT"
+          echo "Visual drift detected — candidates and diff images staged for the Report workflow."
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/e2e/tests/visual-regression.spec.ts
+++ b/e2e/tests/visual-regression.spec.ts
@@ -110,6 +110,17 @@ async function openAdmin(admin: AdminPage, path: string, dir: string): Promise<v
 /** Settle fonts and freeze animation before capturing. */
 async function stabilize(admin: AdminPage): Promise<void> {
 	await admin.page.addStyleTag({ content: FREEZE_CSS });
+	// Drop focus before capturing. The editor pages mount a TipTap toolbar
+	// whose buttons reflect the editor's focus/active state; whether the editor
+	// grabs focus during hydration is a race, so a run can capture a focused
+	// (highlighted) toolbar button or an unfocused one. Blurring makes the
+	// capture depend on the rendered page, not on who won the focus race.
+	await admin.page.evaluate(() => {
+		const active = document.activeElement;
+		if (active instanceof HTMLElement && active !== document.body) {
+			active.blur();
+		}
+	});
 	// Await font loading without returning the FontFaceSet that
 	// document.fonts.ready fulfils with -- Playwright cannot serialize it.
 	await admin.page.evaluate(async () => {


### PR DESCRIPTION
## What does this PR do?

Makes the visual-regression suite deterministic on the editor screens and stops the measure job from flagging drift on flaky/infra failures.

Two independent fixes:

1. **Spec: blur before capture.** `content-editor` and `content-new` mount a TipTap toolbar whose buttons reflect the editor's focus/active state. Whether the editor grabs focus during hydration is a race, so a run could capture a focused (highlighted) toolbar button or an unfocused one, producing spurious diffs. `stabilize()` now blurs the active element before awaiting fonts, so the capture depends on the rendered page rather than who won the focus race.

2. **Workflow: decide drift from `git status`, not the exit code.** The measure job regenerates baselines with `--update-snapshots` after a failing diff, then decided "drift" from whether the candidates directory was non-empty. But `cp -r` always copies the committed baselines (which always exist), so that check flagged drift on *any* non-zero exit, including a flaky render that regenerated byte-identical baselines. The decision is now `git status --porcelain` on the snapshots dir: a modified/untracked PNG is real drift (including the bootstrap case, where a new screen has no committed baseline yet); a clean tree after regeneration is treated as flake or infra failure, keeps the check green, and emits a warning.

Root cause was confirmed from PR #2185's measure artifact (run 29865573115, head 86d30b11): the run-1 `actual` had a highlighted toolbar button while the `--update-snapshots` candidate was byte-identical to the committed baseline.

Follow-up to #2147 (suite + CI) and #2165 (baselines).

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes <!-- n/a: change is confined to the e2e spec (Playwright transpiles, no type-check pass) and a CI workflow; no package typecheck surface touched -->
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: the visual suite is EMDASH_VISUAL-gated and platform-sensitive; Linux baselines can't be validated on macOS, so this is verified on the PR's own measure runs -->
- [x] `pnpm format` has been run <!-- scoped to the two changed files to avoid touching unrelated in-progress work -->
- [x] I have added/updated tests for my changes (if applicable) <!-- the change is itself to the test suite -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no admin UI strings -->
- [x] I have added a changeset (if this PR changes a published package) <!-- n/a: no published package changed (e2e + CI only) -->
- [x] New features link to an approved Discussion <!-- n/a: bug fix -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

The determinism fix cannot be meaningfully validated on macOS (Linux baselines differ), so verification happens on this PR's own measure runs. Residual fallback if flakiness persists on those two screens: mask the editor toolbar region for `content-editor`/`content-new`.
