### PR TITLE
fix(core): detect Postgres after adapter minification

### DIFF
--- a/.changeset/tidy-cats-detect.md
+++ b/.changeset/tidy-cats-detect.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes PostgreSQL migrations failing in production builds that rename database adapter classes.

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ColumnDataType, Kysely, RawBuilder } from "kysely";
-import { sql } from "kysely";
+import { PostgresAdapter, sql } from "kysely";
 
 import type { DatabaseDialectType } from "../db/adapters.js";
 import { validateIdentifier, validateJsonFieldName } from "./validate.js";
@@ -19,12 +19,11 @@ import { validateIdentifier, validateJsonFieldName } from "./validate.js";
 export type { DatabaseDialectType };
 
 /**
- * Detect dialect type from a Kysely instance via the adapter class name.
+ * Detect dialect type from a Kysely instance via the adapter class.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function detectDialect(db: Kysely<any>): DatabaseDialectType {
-	const name = db.getExecutor().adapter.constructor.name;
-	if (name === "PostgresAdapter") return "postgres";
+	if (db.getExecutor().adapter instanceof PostgresAdapter) return "postgres";
 	return "sqlite";
 }
 

--- a/packages/core/src/database/pg-migration-lock.ts
+++ b/packages/core/src/database/pg-migration-lock.ts
@@ -38,10 +38,7 @@ const KYSELY_PG_MIGRATION_LOCK_ID = BigInt("3853314791062309107");
 
 /**
  * Extends the stock adapter so every capability flag and `instanceof` check
- * is inherited, and keeps the class NAME `PostgresAdapter` because
- * `detectDialect()` (dialect-helpers.ts) identifies the dialect via
- * `adapter.constructor.name` — a differently-named adapter would make every
- * dialect helper fall back to SQLite SQL against a Postgres database.
+ * is inherited.
  */
 class PostgresAdapter extends KyselyPostgresAdapter {
 	// eslint-disable-next-line typescript/no-explicit-any -- matches the DialectAdapter signature

--- a/packages/core/tests/unit/database/pg-migration-lock.test.ts
+++ b/packages/core/tests/unit/database/pg-migration-lock.test.ts
@@ -1,6 +1,7 @@
-import { PostgresDialect } from "kysely";
+import { Kysely, PostgresDialect } from "kysely";
 import { describe, expect, it } from "vitest";
 
+import { detectDialect } from "../../../src/database/dialect-helpers.js";
 import { FailFastPostgresDialect } from "../../../src/database/pg-migration-lock.js";
 
 /**
@@ -22,12 +23,19 @@ describe("FailFastPostgresDialect", () => {
 		expect(adapter.supportsMultipleConnections).toBe(stock.supportsMultipleConnections ?? true);
 	});
 
-	it("still identifies as PostgresAdapter for dialect detection", () => {
-		// detectDialect() (dialect-helpers.ts) matches on the adapter's
-		// constructor name; a differently-named adapter class would make
-		// every dialect helper emit SQLite SQL against Postgres.
-		const adapter = new FailFastPostgresDialect({ pool: {} as never }).createAdapter();
-		expect(adapter.constructor.name).toBe("PostgresAdapter");
+	it("detects Postgres when a bundler renames the adapter class", () => {
+		const db = new Kysely({
+			dialect: new FailFastPostgresDialect({ pool: {} as never }),
+		});
+		const constructor = db.getExecutor().adapter.constructor;
+		const originalName = Object.getOwnPropertyDescriptor(constructor, "name");
+
+		try {
+			Object.defineProperty(constructor, "name", { value: "a", configurable: true });
+			expect(detectDialect(db)).toBe("postgres");
+		} finally {
+			if (originalName) Object.defineProperty(constructor, "name", originalName);
+		}
 	});
 
 	it("remains a PostgresDialect for the public dialect type", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes PostgreSQL migrations failing after a consuming production build renames Kysely adapter classes. `detectDialect()` now uses `PostgresAdapter` class identity, which survives minification, instead of `constructor.name`.

This addresses the failure reported by the Cloudflare Blog team on upgrade to 0.30.0:

```
Migration failed: function pragma_table_info(unknown) does not exist (migration: 051_content_taxonomies_denorm)
```

This is an alternative to #2138. It avoids that PR's `supportsMultipleConnections` fallback, which would misclassify EmDash's coalescing D1 and DO SQL adapters as PostgreSQL.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted tests for this change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable, no UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion (not applicable, bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: GPT-5.6 Sol

## Screenshots / test output

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:json | jq '.diagnostics | length'` (0)
- `EMDASH_TEST_PG=postgres://postgres:test@localhost:5432/emdash_test pnpm --filter emdash test --run tests/unit/database/pg-migration-lock.test.ts tests/integration/database/dialect-compat.test.ts` (31 passed across SQLite and PostgreSQL)

The PostgreSQL run applies every migration through `051_content_taxonomies_denorm` against the local PostgreSQL server.