### PR TITLE
feat(admin): allow trusted plugins to add content list columns

### DIFF
--- a/.changeset/trusted-content-list-columns.md
+++ b/.changeset/trusted-content-list-columns.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": minor
+"emdash": minor
+---
+
+Allow trusted React plugins to add manifest-aware, role-filtered content-list columns without taking ownership of the host table, pagination, or row actions.

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -5,7 +5,7 @@ description: Ship custom React components for plugin admin pages and dashboard w
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Native plugins can extend the admin panel with custom React pages and dashboard widgets — sandboxed plugins describe their UI as [Block Kit](/plugins/creating-plugins/block-kit/) instead, because shipping plugin JavaScript into the admin would break sandbox isolation.
+Native plugins can extend the admin panel with custom React pages, dashboard widgets, field widgets, and content-list columns — sandboxed plugins describe their UI as [Block Kit](/plugins/creating-plugins/block-kit/) instead, because shipping plugin JavaScript into the admin would break sandbox isolation.
 
 If your plugin only needs a settings form, the auto-generated `admin.settingsSchema` form (see [Your first native plugin](/plugins/creating-native-plugins/your-first-native-plugin/#settings-ui)) covers most cases without writing any React. Reach for custom components when you need richer UI than `settingsSchema` provides.
 
@@ -261,15 +261,53 @@ Panel IDs must be unique within the plugin. Keep panel content responsive to the
 	This extension point is available only to trusted React plugins. Sandboxed plugins cannot execute React components inside the host admin.
 </Aside>
 
+## Content-list columns
+
+Trusted React plugins can add read-only columns to active content collection lists. EmDash keeps ownership of the table, pagination, row actions, and loading and empty states; the plugin supplies only the header metadata and cell content.
+
+```typescript title="src/admin.tsx"
+import type {
+	ContentListColumnCellContext,
+	ContentListColumnExtension,
+} from "@emdash-cms/admin";
+
+function ScoreCell({ item }: ContentListColumnCellContext) {
+	const score = item.data.seoScore;
+	return typeof score === "number" ? <span>{score}</span> : <span>—</span>;
+}
+
+export const contentListColumns = [
+	{
+		id: "score",
+		label: "SEO score",
+		collections: ["posts", "pages"],
+		order: 10,
+		align: "end",
+		cell: ScoreCell,
+	},
+] satisfies readonly ContentListColumnExtension[];
+```
+
+Column ids only need to be unique within the plugin. Contributions are ordered by `order`, then plugin id and column id. A plugin can also provide:
+
+- `header`: a custom header component; `label` remains the host-rendered fallback.
+- `collections`: an array or predicate restricting where the column appears.
+- `minRole`: a visibility filter for the admin UI. This is not authorization; plugin API routes must still enforce access.
+
+Disabled or missing plugins are omitted. Invalid definitions, collection predicates that throw, and render failures are isolated so the host content list remains usable. Columns are not shown in Trash.
+
+Content-list columns are display-only. Server-backed sorting and filtering require a separate host data-provider contract; a browser comparator would only sort the currently loaded cursor pages and is therefore not supported by this API.
+
 ## Export structure
 
-The admin entry point exports the objects used by the features it implements:
+The admin entry point exports each contribution directly:
 
 ```typescript title="src/admin.tsx"
 import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 import { OverviewWidget } from "./components/OverviewWidget";
+import { ScoreCell } from "./components/ScoreCell";
 
 export const pages = {
 	"/settings": SettingsPage,
@@ -280,10 +318,14 @@ export const widgets = {
 	status: StatusWidget,
 	overview: OverviewWidget,
 };
+
+export const contentListColumns = [
+	{ id: "score", label: "Score", collections: ["posts"], cell: ScoreCell },
+];
 ```
 
 <Aside type="caution">
-	Page paths in `pages` should match the `path` values in `admin.pages`. A trailing slash is treated as equivalent, so `/settings` and `/settings/` resolve to the same page. Opening a plugin at its root resolves to the first registered page. Widget keys must match the `id` values in `admin.widgets`.
+	Page paths in `pages` should match the `path` values in `admin.pages`. A trailing slash is treated as equivalent, so `/settings` and `/settings/` resolve to the same page. Opening a plugin at its root resolves to the first registered page. Widget keys must match the `id` values in `admin.widgets`. Content-list columns are discovered directly from the trusted admin entry point and do not need a separate descriptor entry.
 </Aside>
 
 ## Using admin components
@@ -381,6 +423,7 @@ When a plugin is disabled in the admin:
 
 - Sidebar links are hidden.
 - Dashboard widgets are not rendered.
+- Content-list columns are not rendered.
 - Admin pages return 404.
 - Backend hooks still execute (for data safety).
 

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -270,9 +270,29 @@ import type {
 	ContentListColumnCellContext,
 	ContentListColumnExtension,
 } from "@emdash-cms/admin";
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch, parseApiResponse } from "emdash/plugin-utils";
 
-function ScoreCell({ item }: ContentListColumnCellContext) {
-	const score = item.data.seoScore;
+async function fetchScores(
+	collection: string,
+	locale: string | undefined,
+	ids: readonly string[],
+) {
+	const response = await apiFetch("/_emdash/api/plugins/my-seo-plugin/scores/batch", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ collection, locale, ids }),
+	});
+	return parseApiResponse<Record<string, number>>(response, "Failed to load SEO scores");
+}
+
+function ScoreCell({ item, visibleItems, collection, locale }: ContentListColumnCellContext) {
+	const itemIds = visibleItems.map((visibleItem) => visibleItem.id);
+	const { data: scores } = useQuery({
+		queryKey: ["my-seo-plugin", "scores", collection, locale ?? null, itemIds],
+		queryFn: () => fetchScores(collection, locale, itemIds),
+	});
+	const score = scores?.[item.id];
 	return typeof score === "number" ? <span>{score}</span> : <span>-</span>;
 }
 
@@ -287,6 +307,12 @@ export const contentListColumns = [
 	},
 ] satisfies readonly ContentListColumnExtension[];
 ```
+
+Every cell component mounts once per visible row. When a column needs data that is not already on `item`, use `visibleItems` to request the whole page in one batch. All cells in the example share the same React Query key, so they reuse one request instead of issuing one request per item.
+
+<Aside type="caution">
+	Do not fetch metadata using only `item.id` from inside a cell. A 20-row page would issue 20 requests. Add a batch plugin route and key the shared query by the visible item ids, collection, and locale.
+</Aside>
 
 Column ids only need to be unique within the plugin. Contributions are ordered by `order`, then plugin id and column id. A plugin can also provide:
 

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -273,7 +273,7 @@ import type {
 
 function ScoreCell({ item }: ContentListColumnCellContext) {
 	const score = item.data.seoScore;
-	return typeof score === "number" ? <span>{score}</span> : <span>—</span>;
+	return typeof score === "number" ? <span>{score}</span> : <span>-</span>;
 }
 
 export const contentListColumns = [

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -273,37 +273,45 @@ import type {
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch, parseApiResponse } from "emdash/plugin-utils";
 
-async function fetchScores(
+async function fetchReviewStatuses(
 	collection: string,
 	locale: string | undefined,
 	ids: readonly string[],
 ) {
-	const response = await apiFetch("/_emdash/api/plugins/my-seo-plugin/scores/batch", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ collection, locale, ids }),
-	});
-	return parseApiResponse<Record<string, number>>(response, "Failed to load SEO scores");
+	const response = await apiFetch(
+		"/_emdash/api/plugins/editorial-workflow/review-statuses/batch",
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ collection, locale, ids }),
+		},
+	);
+	return parseApiResponse<Record<string, string>>(response, "Failed to load review statuses");
 }
 
-function ScoreCell({ item, visibleItems, collection, locale }: ContentListColumnCellContext) {
+function ReviewStatusCell({
+	item,
+	visibleItems,
+	collection,
+	locale,
+}: ContentListColumnCellContext) {
 	const itemIds = visibleItems.map((visibleItem) => visibleItem.id);
-	const { data: scores } = useQuery({
-		queryKey: ["my-seo-plugin", "scores", collection, locale ?? null, itemIds],
-		queryFn: () => fetchScores(collection, locale, itemIds),
+	const { data: reviewStatuses } = useQuery({
+		queryKey: ["editorial-workflow", "review-statuses", collection, locale ?? null, itemIds],
+		queryFn: () => fetchReviewStatuses(collection, locale, itemIds),
 	});
-	const score = scores?.[item.id];
-	return typeof score === "number" ? <span>{score}</span> : <span>-</span>;
+	const reviewStatus = reviewStatuses?.[item.id];
+	return reviewStatus ? <span>{reviewStatus}</span> : <span>-</span>;
 }
 
 export const contentListColumns = [
 	{
-		id: "score",
-		label: "SEO score",
+		id: "review-status",
+		label: "Review status",
 		collections: ["posts", "pages"],
 		order: 10,
 		align: "end",
-		cell: ScoreCell,
+		cell: ReviewStatusCell,
 	},
 ] satisfies readonly ContentListColumnExtension[];
 ```
@@ -333,7 +341,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 import { OverviewWidget } from "./components/OverviewWidget";
-import { ScoreCell } from "./components/ScoreCell";
+import { ReviewStatusCell } from "./components/ReviewStatusCell";
 
 export const pages = {
 	"/settings": SettingsPage,
@@ -346,7 +354,12 @@ export const widgets = {
 };
 
 export const contentListColumns = [
-	{ id: "score", label: "Score", collections: ["posts"], cell: ScoreCell },
+	{
+		id: "review-status",
+		label: "Review status",
+		collections: ["posts"],
+		cell: ReviewStatusCell,
+	},
 ];
 ```
 

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1182,9 +1182,10 @@ function ContentListItem({
 						)}
 					>
 						<ContentListColumnBoundary
-							key={`${collection}:${item.locale}:${item.id}:${item.updatedAt}:${pluginId}:${extension.id}`}
+							key={`${collection}:${item.locale}:${item.id}:${pluginId}:${extension.id}`}
 							pluginId={pluginId}
 							columnId={extension.id}
+							resetKey={item.updatedAt}
 						>
 							<Cell
 								collection={collection}

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1023,13 +1023,15 @@ interface ExtensionColumnHeaderProps {
 }
 
 function ExtensionColumnHeader({ column, collection, locale }: ExtensionColumnHeaderProps) {
+	const { i18n } = useLingui();
 	const { pluginId, extension } = column;
 	const Header = extension.header;
+	const label = i18n._(extension.label);
 
 	return (
 		<th
 			scope="col"
-			aria-label={extension.label}
+			aria-label={label}
 			className={cn(
 				"px-4 py-3 text-sm font-medium",
 				extension.align === "end" ? "text-end" : "text-start",
@@ -1039,9 +1041,9 @@ function ExtensionColumnHeader({ column, collection, locale }: ExtensionColumnHe
 				key={`${collection}:${locale ?? ""}:${pluginId}:${extension.id}`}
 				pluginId={pluginId}
 				columnId={extension.id}
-				fallback={extension.label}
+				fallback={label}
 			>
-				{Header ? <Header collection={collection} locale={locale} /> : extension.label}
+				{Header ? <Header collection={collection} locale={locale} /> : label}
 			</ContentListColumnBoundary>
 		</th>
 	);

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -659,6 +659,7 @@ export function ContentList({
 										<ContentListItem
 											key={item.id}
 											item={item}
+											visibleItems={paginatedItems}
 											collection={collection}
 											onDelete={onDelete}
 											onDuplicate={onDuplicate}
@@ -1090,6 +1091,7 @@ function renderItemCount({
 
 interface ContentListItemProps {
 	item: ContentItem;
+	visibleItems: readonly ContentItem[];
 	collection: string;
 	onDelete?: (id: string) => void;
 	onDuplicate?: (id: string) => void;
@@ -1106,6 +1108,7 @@ interface ContentListItemProps {
 
 function ContentListItem({
 	item,
+	visibleItems,
 	collection,
 	onDelete,
 	onDuplicate,
@@ -1181,7 +1184,12 @@ function ContentListItem({
 							pluginId={pluginId}
 							columnId={extension.id}
 						>
-							<Cell collection={collection} item={item} locale={item.locale} />
+							<Cell
+								collection={collection}
+								item={item}
+								locale={item.locale}
+								visibleItems={visibleItems}
+							/>
 						</ContentListColumnBoundary>
 					</td>
 				);

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -28,9 +28,21 @@ import {
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
-import type { ContentAuthor, ContentDateField, ContentItem, TrashedContentItem } from "../lib/api";
+import type {
+	AdminManifest,
+	ContentAuthor,
+	ContentDateField,
+	ContentItem,
+	TrashedContentItem,
+} from "../lib/api.js";
+import {
+	ContentListColumnBoundary,
+	resolveContentListColumns,
+	type ResolvedContentListColumn,
+} from "../lib/content-list-columns.js";
 import { getEntryTitle } from "../lib/entryTitle.js";
 import { useDebouncedValue } from "../lib/hooks.js";
+import { usePluginAdmins } from "../lib/plugin-context.js";
 import { contentUrl } from "../lib/url.js";
 import { cn, parseTimestamp } from "../lib/utils";
 import { CaretNext, CaretPrev } from "./ArrowIcons.js";
@@ -164,6 +176,10 @@ export interface ContentListProps {
 	onBulkPublish?: BulkActionHandler;
 	onBulkUnpublish?: BulkActionHandler;
 	onBulkDelete?: BulkActionHandler;
+	/** Current role used only for contributed-column visibility, not authorization. */
+	userRole?: number;
+	/** Manifest state used to omit disabled or stale trusted-plugin contributions. */
+	pluginStates?: AdminManifest["plugins"];
 }
 
 type BulkActionHandler = (ids: string[]) => Promise<string[]>;
@@ -229,8 +245,11 @@ export function ContentList({
 	onBulkPublish,
 	onBulkUnpublish,
 	onBulkDelete,
+	userRole = 0,
+	pluginStates,
 }: ContentListProps) {
 	const { t } = useLingui();
+	const pluginAdmins = usePluginAdmins();
 	const [activeTab, setActiveTab] = React.useState<ViewTab>("all");
 	const [searchQuery, setSearchQuery] = React.useState("");
 	const [page, setPage] = React.useState(0);
@@ -337,6 +356,10 @@ export function ContentList({
 			return next;
 		});
 	const selectedCount = selectedIds.size;
+	const extensionColumns = React.useMemo(
+		() => resolveContentListColumns(pluginAdmins, collection, userRole, pluginStates),
+		[collection, pluginAdmins, pluginStates, userRole],
+	);
 	const [bulkBusy, setBulkBusy] = React.useState(false);
 	const runBulk = (fn?: BulkActionHandler) => {
 		if (!fn || selectedCount === 0 || bulkBusy) return;
@@ -357,7 +380,8 @@ export function ContentList({
 			}
 		})();
 	};
-	const colSpan = (i18n ? 5 : 4) + listColumns.length + (bulkEnabled ? 1 : 0);
+	const colSpan =
+		(i18n ? 5 : 4) + listColumns.length + extensionColumns.length + (bulkEnabled ? 1 : 0);
 
 	return (
 		<div className="space-y-4">
@@ -581,6 +605,14 @@ export function ContentList({
 										onSortChange={onSortChange}
 										label={t`Date`}
 									/>
+									{extensionColumns.map((column) => (
+										<ExtensionColumnHeader
+											key={`${column.pluginId}:${column.extension.id}`}
+											column={column}
+											collection={collection}
+											locale={activeLocale}
+										/>
+									))}
 									<th scope="col" className="px-4 py-3 text-end text-sm font-medium">
 										{t`Actions`}
 									</th>
@@ -638,6 +670,7 @@ export function ContentList({
 											selectable={bulkEnabled}
 											selected={selectedIds.has(item.id)}
 											onToggleSelect={toggleOne}
+											extensionColumns={extensionColumns}
 										/>
 									))
 								)}
@@ -982,6 +1015,37 @@ function SortableTh({ field, sort, onSortChange, label }: SortableThProps) {
 	);
 }
 
+interface ExtensionColumnHeaderProps {
+	column: ResolvedContentListColumn;
+	collection: string;
+	locale?: string;
+}
+
+function ExtensionColumnHeader({ column, collection, locale }: ExtensionColumnHeaderProps) {
+	const { pluginId, extension } = column;
+	const Header = extension.header;
+
+	return (
+		<th
+			scope="col"
+			aria-label={extension.label}
+			className={cn(
+				"px-4 py-3 text-sm font-medium",
+				extension.align === "end" ? "text-end" : "text-start",
+			)}
+		>
+			<ContentListColumnBoundary
+				key={`${collection}:${locale ?? ""}:${pluginId}:${extension.id}`}
+				pluginId={pluginId}
+				columnId={extension.id}
+				fallback={extension.label}
+			>
+				{Header ? <Header collection={collection} locale={locale} /> : extension.label}
+			</ContentListColumnBoundary>
+		</th>
+	);
+}
+
 /**
  * Render the row-count line above pagination. The rules are:
  * - A search query always wins — say how many matches there are. In
@@ -1037,6 +1101,7 @@ interface ContentListItemProps {
 	selectable?: boolean;
 	selected?: boolean;
 	onToggleSelect?: (id: string) => void;
+	extensionColumns?: ResolvedContentListColumn[];
 }
 
 function ContentListItem({
@@ -1052,6 +1117,7 @@ function ContentListItem({
 	selectable,
 	selected,
 	onToggleSelect,
+	extensionColumns,
 }: ContentListItemProps) {
 	const { t } = useLingui();
 	const title = getEntryTitle(item, titleField);
@@ -1100,6 +1166,26 @@ function ContentListItem({
 			<td data-testid="content-updated" className="px-4 py-3 text-sm text-kumo-subtle">
 				{date.toLocaleDateString()}
 			</td>
+			{extensionColumns?.map(({ pluginId, extension }) => {
+				const Cell = extension.cell;
+				return (
+					<td
+						key={`${pluginId}:${extension.id}`}
+						className={cn(
+							"px-4 py-3 text-sm",
+							extension.align === "end" ? "text-end" : "text-start",
+						)}
+					>
+						<ContentListColumnBoundary
+							key={`${collection}:${item.locale}:${item.id}:${item.updatedAt}:${pluginId}:${extension.id}`}
+							pluginId={pluginId}
+							columnId={extension.id}
+						>
+							<Cell collection={collection} item={item} locale={item.locale} />
+						</ContentListColumnBoundary>
+					</td>
+				);
+			})}
 			<td className="px-4 py-3 text-end">
 				<div className="flex items-center justify-end space-x-1">
 					{item.status === "published" && item.slug && (

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -35,7 +35,7 @@ export type {
 	ContentListColumnHeaderContext,
 	ContentListColumnCellContext,
 	ContentListColumnExtension,
-} from "./lib/content-list-columns";
+} from "./lib/content-list-columns.js";
 
 // Auth provider context (for accessing pluggable auth provider components)
 export {

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -31,6 +31,12 @@ export {
 	type PluginAdmins,
 } from "./lib/plugin-context";
 
+export type {
+	ContentListColumnHeaderContext,
+	ContentListColumnCellContext,
+	ContentListColumnExtension,
+} from "./lib/content-list-columns";
+
 // Auth provider context (for accessing pluggable auth provider components)
 export {
 	AuthProviderProvider,

--- a/packages/admin/src/lib/content-list-columns.tsx
+++ b/packages/admin/src/lib/content-list-columns.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/react/macro";
 import * as React from "react";
 
-import type { AdminManifest, ContentItem } from "./api";
+import type { AdminManifest, ContentItem } from "./api.js";
 
 /** Context passed to a trusted plugin's content-list column header. */
 export interface ContentListColumnHeaderContext {

--- a/packages/admin/src/lib/content-list-columns.tsx
+++ b/packages/admin/src/lib/content-list-columns.tsx
@@ -1,0 +1,216 @@
+import { Trans } from "@lingui/react/macro";
+import * as React from "react";
+
+import type { AdminManifest, ContentItem } from "./api";
+
+/** Context passed to a trusted plugin's content-list column header. */
+export interface ContentListColumnHeaderContext {
+	collection: string;
+	locale?: string;
+}
+
+/** Context passed to a trusted plugin's content-list column cell. */
+export interface ContentListColumnCellContext extends ContentListColumnHeaderContext {
+	item: ContentItem;
+}
+
+/** A content-list column contributed by a trusted React plugin. */
+export interface ContentListColumnExtension {
+	/** Stable identifier, unique within this plugin's list columns. */
+	id: string;
+	/** Host-rendered fallback label for the column header. */
+	label: string;
+	cell: React.ComponentType<ContentListColumnCellContext>;
+	/** Optional custom header content. The host still owns the table header. */
+	header?: React.ComponentType<ContentListColumnHeaderContext>;
+	/** Restrict this column to selected collections. Omit to support every collection. */
+	collections?: readonly string[] | ((collection: string) => boolean);
+	/** Minimum numeric admin role required to see this column. */
+	minRole?: number;
+	/** Lower values render first among contributed columns. */
+	order?: number;
+	align?: "start" | "end";
+}
+
+export interface ResolvedContentListColumn {
+	pluginId: string;
+	extension: ContentListColumnExtension;
+}
+
+type ContentListColumnRegistry = Record<
+	string,
+	{ contentListColumns?: readonly ContentListColumnExtension[] } | undefined
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function warn(pluginId: string, message: string): void {
+	console.warn(`[content-list-columns] Plugin "${pluginId}": ${message}`);
+}
+
+function isValidCollections(value: unknown): boolean {
+	return (
+		value === undefined ||
+		typeof value === "function" ||
+		(Array.isArray(value) && value.every((collection) => typeof collection === "string"))
+	);
+}
+
+function isValidColumn(value: unknown, pluginId: string): value is ContentListColumnExtension {
+	if (!isRecord(value)) {
+		warn(pluginId, "ignored a column that is not an object.");
+		return false;
+	}
+	if (typeof value.id !== "string" || value.id.trim() === "") {
+		warn(pluginId, "ignored a column without a non-empty id.");
+		return false;
+	}
+	if (typeof value.label !== "string" || value.label.trim() === "") {
+		warn(pluginId, `ignored column "${value.id}" because its label is invalid.`);
+		return false;
+	}
+	if (typeof value.cell !== "function") {
+		warn(pluginId, `ignored column "${value.id}" because its cell is invalid.`);
+		return false;
+	}
+	if (value.header !== undefined && typeof value.header !== "function") {
+		warn(pluginId, `ignored column "${value.id}" because its header is invalid.`);
+		return false;
+	}
+	if (!isValidCollections(value.collections)) {
+		warn(
+			pluginId,
+			`ignored column "${value.id}" because collections must be an array of strings or a predicate.`,
+		);
+		return false;
+	}
+	if (value.minRole !== undefined && !Number.isFinite(value.minRole)) {
+		warn(pluginId, `ignored column "${value.id}" because minRole must be finite.`);
+		return false;
+	}
+	if (value.order !== undefined && !Number.isFinite(value.order)) {
+		warn(pluginId, `ignored column "${value.id}" because order must be finite.`);
+		return false;
+	}
+	if (value.align !== undefined && value.align !== "start" && value.align !== "end") {
+		warn(pluginId, `ignored column "${value.id}" because align is invalid.`);
+		return false;
+	}
+	return true;
+}
+
+function appliesToCollection(
+	pluginId: string,
+	column: ContentListColumnExtension,
+	collection: string,
+): boolean {
+	if (column.collections === undefined) return true;
+	if (typeof column.collections !== "function") {
+		return column.collections.includes(collection);
+	}
+
+	try {
+		return column.collections(collection);
+	} catch (error) {
+		console.error(
+			`Plugin "${pluginId}" failed while checking content-list column "${column.id}".`,
+			error,
+		);
+		return false;
+	}
+}
+
+/**
+ * Select valid trusted-plugin columns for one active content collection list.
+ * Invalid, disabled, unauthorized, and inapplicable contributions are omitted
+ * so a plugin cannot make the host list unusable.
+ */
+export function resolveContentListColumns(
+	pluginAdmins: ContentListColumnRegistry,
+	collection: string,
+	userRole: number,
+	pluginStates?: AdminManifest["plugins"],
+): ResolvedContentListColumn[] {
+	const resolved: ResolvedContentListColumn[] = [];
+	const seen = new Set<string>();
+
+	for (const pluginId of Object.keys(pluginAdmins).toSorted()) {
+		const pluginState = pluginStates?.[pluginId];
+		if (pluginStates && (!pluginState || pluginState.enabled === false)) continue;
+
+		const columns: unknown = pluginAdmins[pluginId]?.contentListColumns;
+		if (columns === undefined) continue;
+		if (!Array.isArray(columns)) {
+			warn(pluginId, "ignored contentListColumns because it is not an array.");
+			continue;
+		}
+
+		for (const candidate of columns) {
+			if (!isValidColumn(candidate, pluginId)) continue;
+			const identity = `${pluginId}:${candidate.id}`;
+			if (seen.has(identity)) {
+				warn(pluginId, `ignored duplicate column id "${candidate.id}".`);
+				continue;
+			}
+			seen.add(identity);
+
+			if (!appliesToCollection(pluginId, candidate, collection)) continue;
+			if (candidate.minRole !== undefined && userRole < candidate.minRole) continue;
+			resolved.push({ pluginId, extension: candidate });
+		}
+	}
+
+	return resolved.toSorted(
+		(a, b) =>
+			(a.extension.order ?? 0) - (b.extension.order ?? 0) ||
+			a.pluginId.localeCompare(b.pluginId) ||
+			a.extension.id.localeCompare(b.extension.id),
+	);
+}
+
+interface ContentListColumnBoundaryProps {
+	pluginId: string;
+	columnId: string;
+	children: React.ReactNode;
+	fallback?: React.ReactNode;
+}
+
+interface ContentListColumnBoundaryState {
+	hasError: boolean;
+}
+
+/** Prevents one faulty trusted column from unmounting the content list. */
+export class ContentListColumnBoundary extends React.Component<
+	ContentListColumnBoundaryProps,
+	ContentListColumnBoundaryState
+> {
+	override state: ContentListColumnBoundaryState = { hasError: false };
+
+	static getDerivedStateFromError(): ContentListColumnBoundaryState {
+		return { hasError: true };
+	}
+
+	override componentDidCatch(error: Error, info: React.ErrorInfo): void {
+		console.error(
+			`Plugin "${this.props.pluginId}" failed while rendering content-list column "${this.props.columnId}".`,
+			error,
+			info,
+		);
+	}
+
+	override render(): React.ReactNode {
+		if (!this.state.hasError) return this.props.children;
+		if (this.props.fallback !== undefined) return this.props.fallback;
+
+		return (
+			<span className="text-kumo-subtle">
+				<span aria-hidden="true">—</span>
+				<span className="sr-only">
+					<Trans>Plugin column unavailable</Trans>
+				</span>
+			</span>
+		);
+	}
+}

--- a/packages/admin/src/lib/content-list-columns.tsx
+++ b/packages/admin/src/lib/content-list-columns.tsx
@@ -180,6 +180,7 @@ interface ContentListColumnBoundaryProps {
 	columnId: string;
 	children: React.ReactNode;
 	fallback?: React.ReactNode;
+	resetKey?: string;
 }
 
 interface ContentListColumnBoundaryState {
@@ -203,6 +204,12 @@ export class ContentListColumnBoundary extends React.Component<
 			error,
 			info,
 		);
+	}
+
+	override componentDidUpdate(previousProps: ContentListColumnBoundaryProps): void {
+		if (this.state.hasError && previousProps.resetKey !== this.props.resetKey) {
+			this.setState({ hasError: false });
+		}
 	}
 
 	override render(): React.ReactNode {

--- a/packages/admin/src/lib/content-list-columns.tsx
+++ b/packages/admin/src/lib/content-list-columns.tsx
@@ -47,8 +47,21 @@ type ContentListColumnRegistry = Record<
 	{ contentListColumns?: readonly ContentListColumnExtension[] } | undefined
 >;
 
+const REACT_COMPONENT_WRAPPER_TYPES = new Set<unknown>([
+	Symbol.for("react.forward_ref"),
+	Symbol.for("react.lazy"),
+	Symbol.for("react.memo"),
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isReactComponentType(value: unknown): boolean {
+	return (
+		typeof value === "function" ||
+		(isRecord(value) && REACT_COMPONENT_WRAPPER_TYPES.has(value.$$typeof))
+	);
 }
 
 function warn(pluginId: string, message: string): void {
@@ -76,11 +89,11 @@ function isValidColumn(value: unknown, pluginId: string): value is ContentListCo
 		warn(pluginId, `ignored column "${value.id}" because its label is invalid.`);
 		return false;
 	}
-	if (typeof value.cell !== "function") {
+	if (!isReactComponentType(value.cell)) {
 		warn(pluginId, `ignored column "${value.id}" because its cell is invalid.`);
 		return false;
 	}
-	if (value.header !== undefined && typeof value.header !== "function") {
+	if (value.header !== undefined && !isReactComponentType(value.header)) {
 		warn(pluginId, `ignored column "${value.id}" because its header is invalid.`);
 		return false;
 	}

--- a/packages/admin/src/lib/content-list-columns.tsx
+++ b/packages/admin/src/lib/content-list-columns.tsx
@@ -208,7 +208,7 @@ export class ContentListColumnBoundary extends React.Component<
 
 		return (
 			<span className="text-kumo-subtle">
-				<span aria-hidden="true">—</span>
+				<span aria-hidden="true">-</span>
 				<span className="sr-only">
 					<Trans>Plugin column unavailable</Trans>
 				</span>

--- a/packages/admin/src/lib/content-list-columns.tsx
+++ b/packages/admin/src/lib/content-list-columns.tsx
@@ -12,7 +12,10 @@ export interface ContentListColumnHeaderContext {
 /** Context passed to a trusted plugin's content-list column cell. */
 export interface ContentListColumnCellContext extends ContentListColumnHeaderContext {
 	item: ContentItem;
-	/** Items rendered on the current page after host filtering and pagination. */
+	/**
+	 * Items rendered on the current page after host filtering and pagination.
+	 * Batch remote data for these items under one shared query key; cells mount once per row.
+	 */
 	visibleItems: readonly ContentItem[];
 }
 
@@ -20,7 +23,7 @@ export interface ContentListColumnCellContext extends ContentListColumnHeaderCon
 export interface ContentListColumnExtension {
 	/** Stable identifier, unique within this plugin's list columns. */
 	id: string;
-	/** Host-rendered fallback label for the column header. */
+	/** Host-rendered fallback label and shared Lingui message id for the column header. */
 	label: string;
 	cell: React.ComponentType<ContentListColumnCellContext>;
 	/** Optional custom header content. The host still owns the table header. */

--- a/packages/admin/src/lib/content-list-columns.tsx
+++ b/packages/admin/src/lib/content-list-columns.tsx
@@ -12,6 +12,8 @@ export interface ContentListColumnHeaderContext {
 /** Context passed to a trusted plugin's content-list column cell. */
 export interface ContentListColumnCellContext extends ContentListColumnHeaderContext {
 	item: ContentItem;
+	/** Items rendered on the current page after host filtering and pagination. */
+	visibleItems: readonly ContentItem[];
 }
 
 /** A content-list column contributed by a trusted React plugin. */

--- a/packages/admin/src/lib/plugin-context.tsx
+++ b/packages/admin/src/lib/plugin-context.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import { createContext, useContext } from "react";
 
 import type { ContentEditorPanelExtension } from "./content-editor-panels";
+import type { ContentListColumnExtension } from "./content-list-columns.js";
 
 /** Shape of a plugin's admin exports */
 export interface PluginAdminModule {
@@ -17,6 +18,8 @@ export interface PluginAdminModule {
 	pages?: Record<string, React.ComponentType>;
 	fields?: Record<string, React.ComponentType>;
 	contentEditorPanels?: readonly ContentEditorPanelExtension[];
+	/** Columns contributed to active content collection lists by a trusted plugin. */
+	contentListColumns?: readonly ContentListColumnExtension[];
 }
 
 /** All plugin admin modules keyed by plugin ID */

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -107,6 +107,7 @@ import {
 	unpublishContent,
 	discardDraft,
 	fetchRevision,
+	useCurrentUser,
 	type CreateCollectionInput,
 	type UpdateCollectionInput,
 	type CreateFieldInput,
@@ -333,6 +334,7 @@ function ContentListPage() {
 		queryKey: ["manifest"],
 		queryFn: fetchManifest,
 	});
+	const { data: currentUser } = useCurrentUser();
 
 	const i18n = manifest?.i18n;
 
@@ -653,6 +655,8 @@ function ContentListPage() {
 			onBulkPublish={(ids) => bulkPublishMutation.mutateAsync(ids).then((r) => r.failedIds)}
 			onBulkUnpublish={(ids) => bulkUnpublishMutation.mutateAsync(ids).then((r) => r.failedIds)}
 			onBulkDelete={(ids) => bulkDeleteMutation.mutateAsync(ids).then((r) => r.failedIds)}
+			pluginStates={manifest.plugins}
+			userRole={currentUser?.role ?? 0}
 		/>
 	);
 }

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -788,13 +788,15 @@ describe("ContentList", () => {
 			columns: readonly ContentListColumnExtension[],
 			props: Partial<React.ComponentProps<typeof ContentList>> = {},
 		) {
-			const pluginAdmins: PluginAdmins = { seo: { contentListColumns: columns } };
+			const pluginAdmins: PluginAdmins = {
+				"editorial-workflow": { contentListColumns: columns },
+			};
 			return (
 				<PluginAdminProvider pluginAdmins={pluginAdmins}>
 					<ContentList
 						{...defaultProps}
-						items={[makeItem({ data: { title: "Plugin Post", score: 82 } })]}
-						pluginStates={{ seo: { enabled: true } }}
+						items={[makeItem({ data: { title: "Plugin Post", reviewStatus: "Needs review" } })]}
+						pluginStates={{ "editorial-workflow": { enabled: true } }}
 						{...props}
 					/>
 				</PluginAdminProvider>
@@ -809,30 +811,38 @@ describe("ContentList", () => {
 		}
 
 		it("renders contributed headers and cells inside the host table", async () => {
-			function ScoreCell({ item }: { item: ContentItem }) {
-				return <span>{String(item.data.score)}</span>;
+			function ReviewStatusCell({ item }: { item: ContentItem }) {
+				return <span>{String(item.data.reviewStatus)}</span>;
 			}
 
 			const screen = await renderWithColumns([
-				{ id: "score", label: "SEO score", align: "end", cell: ScoreCell },
+				{
+					id: "review-status",
+					label: "Review status",
+					cell: ReviewStatusCell,
+				},
 			]);
 
-			await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
-			await expect.element(screen.getByText("82")).toBeVisible();
+			await expect
+				.element(screen.getByRole("columnheader", { name: "Review status" }))
+				.toBeVisible();
+			await expect.element(screen.getByText("Needs review")).toBeVisible();
 			await expect.element(screen.getByText("Plugin Post")).toBeVisible();
 		});
 
 		it("updates contributed header labels when the shared catalog changes", async () => {
 			const previousLocale = i18n.locale;
-			const translatedLabel = "نتيجة تحسين محركات البحث";
+			const translatedLabel = "حالة المراجعة";
 
 			try {
 				const screen = await renderWithColumns([
-					{ id: "score", label: "SEO score", cell: () => null },
+					{ id: "review-status", label: "Review status", cell: () => null },
 				]);
-				await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
+				await expect
+					.element(screen.getByRole("columnheader", { name: "Review status" }))
+					.toBeVisible();
 
-				i18n.load("ar", { "SEO score": translatedLabel });
+				i18n.load("ar", { "Review status": translatedLabel });
 				i18n.activate("ar");
 
 				await expect
@@ -847,8 +857,8 @@ describe("ContentList", () => {
 		it("localizes a contributed header's render fallback", async () => {
 			const previousLocale = i18n.locale;
 			const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
-			const translatedLabel = "نتيجة تحسين محركات البحث";
-			i18n.load("ar", { "SEO score": translatedLabel });
+			const translatedLabel = "حالة المراجعة";
+			i18n.load("ar", { "Review status": translatedLabel });
 			i18n.activate("ar");
 
 			function BrokenHeader(): React.ReactNode {
@@ -857,7 +867,12 @@ describe("ContentList", () => {
 
 			try {
 				const screen = await renderWithColumns([
-					{ id: "score", label: "SEO score", header: BrokenHeader, cell: () => null },
+					{
+						id: "review-status",
+						label: "Review status",
+						header: BrokenHeader,
+						cell: () => null,
+					},
 				]);
 
 				await expect.element(screen.getByText(translatedLabel)).toBeVisible();
@@ -894,24 +909,36 @@ describe("ContentList", () => {
 		});
 
 		it("keeps configured and plugin columns aligned in rows and empty states", async () => {
-			function ScoreCell({ item }: { item: ContentItem }) {
-				return <span>{String(item.data.score)}</span>;
+			function ReviewStatusCell({ item }: { item: ContentItem }) {
+				return <span>{String(item.data.reviewStatus)}</span>;
 			}
-			const columns = [{ id: "score", label: "SEO score", align: "end", cell: ScoreCell }] as const;
+			const columns = [
+				{
+					id: "review-status",
+					label: "Review status",
+					cell: ReviewStatusCell,
+				},
+			] as const;
 			const listColumns = [{ slug: "ticket_number", label: "Ticket", kind: "string" }];
 			const screen = await renderWithColumns(columns, {
 				items: [
 					makeItem({
-						data: { title: "Plugin Post", ticket_number: "SUP-1042", score: 82 },
+						data: {
+							title: "Plugin Post",
+							ticket_number: "SUP-1042",
+							reviewStatus: "Needs review",
+						},
 					}),
 				],
 				listColumns,
 			});
 
 			await expect.element(screen.getByRole("columnheader", { name: "Ticket" })).toBeVisible();
-			await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
+			await expect
+				.element(screen.getByRole("columnheader", { name: "Review status" }))
+				.toBeVisible();
 			await expect.element(screen.getByText("SUP-1042")).toBeVisible();
-			await expect.element(screen.getByText("82")).toBeVisible();
+			await expect.element(screen.getByText("Needs review")).toBeVisible();
 
 			await screen.rerender(listWithColumns(columns, { items: [], isLoading: true, listColumns }));
 			await expect
@@ -970,10 +997,13 @@ describe("ContentList", () => {
 			function Cell(): React.ReactNode {
 				return null;
 			}
-			const screen = await renderWithColumns([{ id: "score", label: "Score", cell: Cell }], {
-				items: [],
-				isLoading: true,
-			});
+			const screen = await renderWithColumns(
+				[{ id: "review-status", label: "Review status", cell: Cell }],
+				{
+					items: [],
+					isLoading: true,
+				},
+			);
 
 			await expect
 				.element(screen.getByRole("cell", { name: "Loading..." }))
@@ -984,15 +1014,18 @@ describe("ContentList", () => {
 			function Cell() {
 				return <span>Plugin value</span>;
 			}
-			const screen = await renderWithColumns([{ id: "score", label: "Score", cell: Cell }], {
-				trashedItems: [makeTrashedItem({ data: { title: "Deleted" } })],
-			});
+			const screen = await renderWithColumns(
+				[{ id: "review-status", label: "Review status", cell: Cell }],
+				{
+					trashedItems: [makeTrashedItem({ data: { title: "Deleted" } })],
+				},
+			);
 
 			await screen.getByText("Trash").click();
 			await expect
 				.element(screen.getByRole("cell", { name: "Deleted", exact: true }))
 				.toBeVisible();
-			expect(screen.getByRole("columnheader", { name: "Score" }).query()).toBeNull();
+			expect(screen.getByRole("columnheader", { name: "Review status" }).query()).toBeNull();
 			expect(screen.getByText("Plugin value").query()).toBeNull();
 		});
 	});

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -888,7 +888,12 @@ describe("ContentList", () => {
 			]);
 
 			await expect.element(screen.getByText("Broken fallback")).toBeVisible();
-			await expect.element(screen.getByText("Plugin column unavailable")).toBeInTheDocument();
+			const unavailableCell = screen.getByRole("cell", {
+				name: "Plugin column unavailable",
+			});
+			await expect.element(unavailableCell).toHaveTextContent("-");
+			const visualFallback = unavailableCell.element().querySelector('[aria-hidden="true"]');
+			expect(visualFallback).toHaveTextContent("-");
 			await expect.element(screen.getByText("Healthy value")).toBeVisible();
 			await expect.element(screen.getByText("Plugin Post")).toBeVisible();
 			expect(error).toHaveBeenCalled();

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -908,6 +908,80 @@ describe("ContentList", () => {
 			expect(pages).toContainEqual(["item-20"]);
 		});
 
+		it("preserves contributed cell state when an existing row updates", async () => {
+			let mounts = 0;
+			function StatefulCell({ item }: ContentListColumnCellContext) {
+				const [mount] = React.useState(() => ++mounts);
+				return (
+					<span>
+						{String(item.data.title)}:mount-{mount}
+					</span>
+				);
+			}
+			const columns = [{ id: "stateful", label: "Stateful", cell: StatefulCell }] as const;
+			const screen = await renderWithColumns(columns, {
+				items: [
+					makeItem({
+						id: "item-1",
+						updatedAt: "2025-01-02T00:00:00Z",
+						data: { title: "Before update" },
+					}),
+				],
+			});
+
+			await expect.element(screen.getByText("Before update:mount-1")).toBeVisible();
+			await screen.rerender(
+				listWithColumns(columns, {
+					items: [
+						makeItem({
+							id: "item-1",
+							updatedAt: "2025-01-03T00:00:00Z",
+							data: { title: "After update" },
+						}),
+					],
+				}),
+			);
+
+			await expect.element(screen.getByText("After update:mount-1")).toBeVisible();
+			expect(mounts).toBe(1);
+		});
+
+		it("retries a failed cell when an existing row updates", async () => {
+			const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+			let shouldThrow = true;
+			function FlakyCell({ item }: ContentListColumnCellContext) {
+				if (shouldThrow) throw new Error("render failed");
+				return <span data-testid="flaky-cell">{String(item.data.title)}</span>;
+			}
+			const columns = [{ id: "flaky", label: "Flaky", cell: FlakyCell }] as const;
+			const screen = await renderWithColumns(columns, {
+				items: [
+					makeItem({
+						id: "item-1",
+						updatedAt: "2025-01-02T00:00:00Z",
+						data: { title: "Before update" },
+					}),
+				],
+			});
+
+			await expect.element(screen.getByText("Plugin column unavailable")).toBeInTheDocument();
+			shouldThrow = false;
+			await screen.rerender(
+				listWithColumns(columns, {
+					items: [
+						makeItem({
+							id: "item-1",
+							updatedAt: "2025-01-03T00:00:00Z",
+							data: { title: "After update" },
+						}),
+					],
+				}),
+			);
+
+			await expect.element(screen.getByTestId("flaky-cell")).toHaveTextContent("After update");
+			error.mockRestore();
+		});
+
 		it("keeps configured and plugin columns aligned in rows and empty states", async () => {
 			function ReviewStatusCell({ item }: { item: ContentItem }) {
 				return <span>{String(item.data.reviewStatus)}</span>;

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { ContentList } from "../../src/components/ContentList";
 import type { ContentItem, TrashedContentItem } from "../../src/lib/api";
+import type { ContentListColumnExtension } from "../../src/lib/content-list-columns.js";
+import { PluginAdminProvider, type PluginAdmins } from "../../src/lib/plugin-context.js";
 import { render } from "../utils/render.tsx";
 
 const NO_RESULTS_PATTERN = /No results for/;
@@ -774,6 +776,118 @@ describe("ContentList", () => {
 				.element(screen.getByRole("columnheader", { name: "Priority" }))
 				.toBeInTheDocument();
 			expect(screen.getByRole("button", { name: "Priority" }).query()).toBeNull();
+		});
+	});
+
+	describe("trusted plugin columns", () => {
+		function listWithColumns(
+			columns: readonly ContentListColumnExtension[],
+			props: Partial<React.ComponentProps<typeof ContentList>> = {},
+		) {
+			const pluginAdmins: PluginAdmins = { seo: { contentListColumns: columns } };
+			return (
+				<PluginAdminProvider pluginAdmins={pluginAdmins}>
+					<ContentList
+						{...defaultProps}
+						items={[makeItem({ data: { title: "Plugin Post", score: 82 } })]}
+						pluginStates={{ seo: { enabled: true } }}
+						{...props}
+					/>
+				</PluginAdminProvider>
+			);
+		}
+
+		function renderWithColumns(
+			columns: readonly ContentListColumnExtension[],
+			props: Partial<React.ComponentProps<typeof ContentList>> = {},
+		) {
+			return render(listWithColumns(columns, props));
+		}
+
+		it("renders contributed headers and cells inside the host table", async () => {
+			function ScoreCell({ item }: { item: ContentItem }) {
+				return <span>{String(item.data.score)}</span>;
+			}
+
+			const screen = await renderWithColumns([
+				{ id: "score", label: "SEO score", align: "end", cell: ScoreCell },
+			]);
+
+			await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
+			await expect.element(screen.getByText("82")).toBeVisible();
+			await expect.element(screen.getByText("Plugin Post")).toBeVisible();
+		});
+
+		it("isolates broken headers and cells while healthy columns and core rows remain", async () => {
+			const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+			function Broken(): React.ReactNode {
+				throw new Error("render failed");
+			}
+			function HealthyCell() {
+				return <span>Healthy value</span>;
+			}
+
+			const screen = await renderWithColumns([
+				{ id: "broken", label: "Broken fallback", header: Broken, cell: Broken },
+				{ id: "healthy", label: "Healthy", cell: HealthyCell },
+			]);
+
+			await expect.element(screen.getByText("Broken fallback")).toBeVisible();
+			await expect.element(screen.getByText("Plugin column unavailable")).toBeInTheDocument();
+			await expect.element(screen.getByText("Healthy value")).toBeVisible();
+			await expect.element(screen.getByText("Plugin Post")).toBeVisible();
+			expect(error).toHaveBeenCalled();
+			error.mockRestore();
+		});
+
+		it("retries a failed cell when the row locale changes", async () => {
+			const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+			let shouldThrow = true;
+			function LocaleCell({ item }: { item: ContentItem }) {
+				if (shouldThrow) throw new Error("render failed");
+				return <span>{item.locale}</span>;
+			}
+			const columns = [{ id: "locale", label: "Locale", cell: LocaleCell }] as const;
+			const screen = await renderWithColumns(columns, {
+				items: [makeItem({ locale: "en" })],
+			});
+
+			await expect.element(screen.getByText("Plugin column unavailable")).toBeInTheDocument();
+			shouldThrow = false;
+			await screen.rerender(listWithColumns(columns, { items: [makeItem({ locale: "fr" })] }));
+
+			await expect.element(screen.getByText("fr")).toBeVisible();
+			error.mockRestore();
+		});
+
+		it("extends loading and empty-state colspans", async () => {
+			function Cell(): React.ReactNode {
+				return null;
+			}
+			const screen = await renderWithColumns([{ id: "score", label: "Score", cell: Cell }], {
+				items: [],
+				isLoading: true,
+			});
+
+			await expect
+				.element(screen.getByRole("cell", { name: "Loading..." }))
+				.toHaveAttribute("colspan", "5");
+		});
+
+		it("does not render contributed columns in Trash", async () => {
+			function Cell() {
+				return <span>Plugin value</span>;
+			}
+			const screen = await renderWithColumns([{ id: "score", label: "Score", cell: Cell }], {
+				trashedItems: [makeTrashedItem({ data: { title: "Deleted" } })],
+			});
+
+			await screen.getByText("Trash").click();
+			await expect
+				.element(screen.getByRole("cell", { name: "Deleted", exact: true }))
+				.toBeVisible();
+			expect(screen.getByRole("columnheader", { name: "Score" }).query()).toBeNull();
+			expect(screen.getByText("Plugin value").query()).toBeNull();
 		});
 	});
 });

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -818,6 +818,32 @@ describe("ContentList", () => {
 			await expect.element(screen.getByText("Plugin Post")).toBeVisible();
 		});
 
+		it("keeps configured and plugin columns aligned in rows and empty states", async () => {
+			function ScoreCell({ item }: { item: ContentItem }) {
+				return <span>{String(item.data.score)}</span>;
+			}
+			const columns = [{ id: "score", label: "SEO score", align: "end", cell: ScoreCell }] as const;
+			const listColumns = [{ slug: "ticket_number", label: "Ticket", kind: "string" }];
+			const screen = await renderWithColumns(columns, {
+				items: [
+					makeItem({
+						data: { title: "Plugin Post", ticket_number: "SUP-1042", score: 82 },
+					}),
+				],
+				listColumns,
+			});
+
+			await expect.element(screen.getByRole("columnheader", { name: "Ticket" })).toBeVisible();
+			await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
+			await expect.element(screen.getByText("SUP-1042")).toBeVisible();
+			await expect.element(screen.getByText("82")).toBeVisible();
+
+			await screen.rerender(listWithColumns(columns, { items: [], isLoading: true, listColumns }));
+			await expect
+				.element(screen.getByRole("cell", { name: "Loading..." }))
+				.toHaveAttribute("colspan", "6");
+		});
+
 		it("isolates broken headers and cells while healthy columns and core rows remain", async () => {
 			const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
 			function Broken(): React.ReactNode {

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -819,6 +820,51 @@ describe("ContentList", () => {
 			await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
 			await expect.element(screen.getByText("82")).toBeVisible();
 			await expect.element(screen.getByText("Plugin Post")).toBeVisible();
+		});
+
+		it("updates contributed header labels when the shared catalog changes", async () => {
+			const previousLocale = i18n.locale;
+			const translatedLabel = "نتيجة تحسين محركات البحث";
+
+			try {
+				const screen = await renderWithColumns([
+					{ id: "score", label: "SEO score", cell: () => null },
+				]);
+				await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
+
+				i18n.load("ar", { "SEO score": translatedLabel });
+				i18n.activate("ar");
+
+				await expect
+					.element(screen.getByRole("columnheader", { name: translatedLabel }))
+					.toBeVisible();
+				await expect.element(screen.getByText(translatedLabel)).toBeVisible();
+			} finally {
+				i18n.activate(previousLocale);
+			}
+		});
+
+		it("localizes a contributed header's render fallback", async () => {
+			const previousLocale = i18n.locale;
+			const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+			const translatedLabel = "نتيجة تحسين محركات البحث";
+			i18n.load("ar", { "SEO score": translatedLabel });
+			i18n.activate("ar");
+
+			function BrokenHeader(): React.ReactNode {
+				throw new Error("render failed");
+			}
+
+			try {
+				const screen = await renderWithColumns([
+					{ id: "score", label: "SEO score", header: BrokenHeader, cell: () => null },
+				]);
+
+				await expect.element(screen.getByText(translatedLabel)).toBeVisible();
+			} finally {
+				i18n.activate(previousLocale);
+				error.mockRestore();
+			}
 		});
 
 		it("passes the current visible page to contributed cells", async () => {

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { ContentList } from "../../src/components/ContentList";
 import type { ContentItem, TrashedContentItem } from "../../src/lib/api";
-import type { ContentListColumnExtension } from "../../src/lib/content-list-columns.js";
+import type {
+	ContentListColumnCellContext,
+	ContentListColumnExtension,
+} from "../../src/lib/content-list-columns.js";
 import { PluginAdminProvider, type PluginAdmins } from "../../src/lib/plugin-context.js";
 import { render } from "../utils/render.tsx";
 
@@ -816,6 +819,32 @@ describe("ContentList", () => {
 			await expect.element(screen.getByRole("columnheader", { name: "SEO score" })).toBeVisible();
 			await expect.element(screen.getByText("82")).toBeVisible();
 			await expect.element(screen.getByText("Plugin Post")).toBeVisible();
+		});
+
+		it("passes the current visible page to contributed cells", async () => {
+			const pages: string[][] = [];
+			const items = Array.from({ length: 21 }, (_, index) =>
+				makeItem({
+					id: `item-${index}`,
+					data: { title: `Post ${index + 1}` },
+				}),
+			);
+			function PageCell({ item, visibleItems }: ContentListColumnCellContext) {
+				if (item.id === "item-0" || item.id === "item-20") {
+					pages.push(visibleItems.map((visibleItem) => visibleItem.id));
+				}
+				return null;
+			}
+
+			const screen = await renderWithColumns(
+				[{ id: "page", label: "Page context", cell: PageCell }],
+				{ items },
+			);
+
+			expect(pages).toContainEqual(items.slice(0, 20).map((item) => item.id));
+			await screen.getByRole("button", { name: "Next page" }).click();
+			await expect.element(screen.getByText("Post 21")).toBeVisible();
+			expect(pages).toContainEqual(["item-20"]);
 		});
 
 		it("keeps configured and plugin columns aligned in rows and empty states", async () => {

--- a/packages/admin/tests/lib/content-list-columns.test.tsx
+++ b/packages/admin/tests/lib/content-list-columns.test.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	resolveContentListColumns,
+	type ContentListColumnExtension,
+} from "../../src/lib/content-list-columns.js";
+
+function Cell(): React.ReactNode {
+	return null;
+}
+
+function column(
+	id: string,
+	overrides: Partial<ContentListColumnExtension> = {},
+): ContentListColumnExtension {
+	return { id, label: id, cell: Cell, ...overrides };
+}
+
+describe("resolveContentListColumns", () => {
+	it("filters by manifest, collection, and role and orders deterministically", () => {
+		const plugins = {
+			zeta: { contentListColumns: [column("same", { order: 1 })] },
+			alpha: {
+				contentListColumns: [
+					column("second", { order: 2 }),
+					column("same", { order: 1 }),
+					column("pages", { collections: ["pages"] }),
+					column("admin", { minRole: 100 }),
+				],
+			},
+			disabled: { contentListColumns: [column("disabled")] },
+			stale: { contentListColumns: [column("stale")] },
+		};
+
+		const result = resolveContentListColumns(plugins, "posts", 10, {
+			alpha: { enabled: true },
+			zeta: { enabled: true },
+			disabled: { enabled: false },
+		});
+
+		expect(result.map(({ pluginId, extension }) => `${pluginId}:${extension.id}`)).toEqual([
+			"alpha:same",
+			"zeta:same",
+			"alpha:second",
+		]);
+	});
+
+	it("ignores malformed exports and duplicate ids within one plugin", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const plugins = {
+			alpha: {
+				contentListColumns: [
+					column("score"),
+					column("score"),
+					["array-is-not-a-column"],
+					{ id: "broken", label: "Broken" },
+				],
+			},
+			beta: { contentListColumns: "not-an-array" },
+		};
+
+		const result = resolveContentListColumns(
+			plugins as unknown as Parameters<typeof resolveContentListColumns>[0],
+			"posts",
+			0,
+		);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.extension.id).toBe("score");
+		expect(warn).toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	it("contains collection predicate failures", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const plugins = {
+			alpha: {
+				contentListColumns: [
+					column("broken", {
+						collections: () => {
+							throw new Error("predicate failed");
+						},
+					}),
+					column("healthy"),
+				],
+			},
+		};
+
+		const result = resolveContentListColumns(plugins, "posts", 0);
+
+		expect(result.map(({ extension }) => extension.id)).toEqual(["healthy"]);
+		expect(error).toHaveBeenCalled();
+		error.mockRestore();
+	});
+});

--- a/packages/admin/tests/lib/content-list-columns.test.tsx
+++ b/packages/admin/tests/lib/content-list-columns.test.tsx
@@ -51,8 +51,8 @@ describe("resolveContentListColumns", () => {
 		const plugins = {
 			alpha: {
 				contentListColumns: [
-					column("score"),
-					column("score"),
+					column("review-status"),
+					column("review-status"),
 					["array-is-not-a-column"],
 					{ id: "broken", label: "Broken" },
 				],
@@ -67,7 +67,7 @@ describe("resolveContentListColumns", () => {
 		);
 
 		expect(result).toHaveLength(1);
-		expect(result[0]?.extension.id).toBe("score");
+		expect(result[0]?.extension.id).toBe("review-status");
 		expect(warn).toHaveBeenCalled();
 		warn.mockRestore();
 	});

--- a/packages/admin/tests/lib/content-list-columns.test.tsx
+++ b/packages/admin/tests/lib/content-list-columns.test.tsx
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
 	resolveContentListColumns,
+	type ContentListColumnCellContext,
 	type ContentListColumnExtension,
+	type ContentListColumnHeaderContext,
 } from "../../src/lib/content-list-columns.js";
 
 function Cell(): React.ReactNode {
@@ -18,6 +20,41 @@ function column(
 }
 
 describe("resolveContentListColumns", () => {
+	it("preserves memo and forwardRef components", () => {
+		const ForwardRefCell = React.forwardRef<HTMLSpanElement, ContentListColumnCellContext>(
+			function ForwardRefCell(_props, ref) {
+				return <span ref={ref} />;
+			},
+		);
+		const ForwardRefHeader = React.forwardRef<HTMLSpanElement, ContentListColumnHeaderContext>(
+			function ForwardRefHeader(_props, ref) {
+				return <span ref={ref} />;
+			},
+		);
+		const MemoCell = React.memo(function MemoCell(_props: ContentListColumnCellContext) {
+			return null;
+		});
+		const MemoHeader = React.memo(function MemoHeader(_props: ContentListColumnHeaderContext) {
+			return null;
+		});
+		const plugins = {
+			alpha: {
+				contentListColumns: [
+					column("forward-ref", { cell: ForwardRefCell, header: ForwardRefHeader }),
+					column("memo", { cell: MemoCell, header: MemoHeader }),
+				],
+			},
+		};
+
+		const result = resolveContentListColumns(plugins, "posts", 0);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]?.extension.cell).toBe(ForwardRefCell);
+		expect(result[0]?.extension.header).toBe(ForwardRefHeader);
+		expect(result[1]?.extension.cell).toBe(MemoCell);
+		expect(result[1]?.extension.header).toBe(MemoHeader);
+	});
+
 	it("filters by manifest, collection, and role and orders deterministically", () => {
 		const plugins = {
 			zeta: { contentListColumns: [column("same", { order: 1 })] },

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -210,6 +210,7 @@ declare module "virtual:emdash/admin-registry" {
 	 *   - widgets: Record<widgetId, ComponentType>
 	 *   - fields: Record<widgetName, ComponentType> (field widget renderers)
 	 *   - contentEditorPanels: Trusted content editor sidebar panels
+	 *   - contentListColumns: trusted-plugin content list column definitions
 	 */
 	export const pluginAdmins: Record<
 		string,
@@ -218,6 +219,7 @@ declare module "virtual:emdash/admin-registry" {
 			widgets?: Record<string, unknown>;
 			fields?: Record<string, unknown>;
 			contentEditorPanels?: readonly unknown[];
+			contentListColumns?: readonly unknown[];
 		}
 	>;
 }


### PR DESCRIPTION
## What does this PR do?

Adds a focused, display-only content-list column extension for trusted React plugins.

Plugins can export typed `contentListColumns` definitions for computed metadata such as review statuses, moderation outcomes, or publication readiness. EmDash retains ownership of the table, pagination, row actions, loading states, and empty states while passing each cell the current content item, collection, and locale.

The resolver:

- filters disabled or stale plugins
- supports collection and minimum-role visibility
- orders contributions deterministically
- validates malformed and duplicate definitions
- isolates failing predicates, headers, and cells so the content list remains usable
- omits plugin columns from Trash

Sorting, filtering, and search remain outside this display-only contract because they require server-backed contracts. Search is covered by https://github.com/emdash-cms/emdash/pull/2191, indexed sorting by https://github.com/emdash-cms/emdash/pull/2212, and indexed filtering by https://github.com/emdash-cms/emdash/pull/2213.

https://github.com/emdash-cms/emdash/pull/2194 has merged and supplies the shared content-list layout. This branch is now based on `main` and contains only the trusted-plugin extension commits.

Approved Discussion: https://github.com/emdash-cms/emdash/discussions/2048

Wider content-list context: https://github.com/emdash-cms/emdash/discussions/2397

Closes: N/A

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs; a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/2048

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5, GPT-5.6

## Screenshots / test output

Local validation after rebasing:

- focused admin browser tests: 2 files, 63 tests passed
- admin production build
- core and admin typechecks
- full type-aware lint
- full repository format check
- `git diff --check`

No screenshot is included because the extension renders only when a trusted plugin contributes a column.
