### PR TITLE
fix(core): restore hreflang links in bundled SSR

### DIFF
--- a/.changeset/fix-bundled-hreflang.md
+++ b/.changeset/fix-bundled-hreflang.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes missing hreflang links when EmDash UI components are used in bundled Astro deployments.

--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -12,14 +12,18 @@ export interface I18nConfig {
 	prefixDefaultLocale?: boolean;
 }
 
-let _config: I18nConfig | null | undefined;
+const I18N_CONFIG_KEY = Symbol.for("emdash:i18n-config");
+
+function configStore(): Record<symbol, I18nConfig | null | undefined> {
+	return globalThis;
+}
 
 /**
  * Initialize i18n config from virtual module data.
  * Called during runtime initialization.
  */
 export function setI18nConfig(config: I18nConfig | null): void {
-	_config = config;
+	configStore()[I18N_CONFIG_KEY] = config;
 }
 
 /**
@@ -27,13 +31,14 @@ export function setI18nConfig(config: I18nConfig | null): void {
  * Returns null if i18n is not configured.
  */
 export function getI18nConfig(): I18nConfig | null {
-	return _config ?? null;
+	return configStore()[I18N_CONFIG_KEY] ?? null;
 }
 
 /** Match a locale to the exact casing used by the site configuration. */
 export function resolveConfiguredLocale(locale: string): string {
+	const config = getI18nConfig();
 	return (
-		_config?.locales.find((configured) => configured.toLowerCase() === locale.toLowerCase()) ??
+		config?.locales.find((configured) => configured.toLowerCase() === locale.toLowerCase()) ??
 		locale
 	);
 }
@@ -43,7 +48,8 @@ export function resolveConfiguredLocale(locale: string): string {
  * Returns true when multiple locales are configured.
  */
 export function isI18nEnabled(): boolean {
-	return _config != null && _config.locales.length > 1;
+	const config = getI18nConfig();
+	return config != null && config.locales.length > 1;
 }
 
 /**
@@ -52,15 +58,16 @@ export function isI18nEnabled(): boolean {
  * Always ends with defaultLocale.
  */
 export function getFallbackChain(locale: string): string[] {
-	if (!_config) return [locale];
+	const config = getI18nConfig();
+	if (!config) return [locale];
 
 	const chain: string[] = [locale];
 	let current = locale;
 	const visited = new Set<string>([locale]);
 
-	while (_config.fallback?.[current]) {
+	while (config.fallback?.[current]) {
 		// eslint-disable-next-line typescript/no-unnecessary-type-assertion -- noUncheckedIndexedAccess
-		const next = _config.fallback[current]!;
+		const next = config.fallback[current]!;
 		if (visited.has(next)) break; // prevent cycles
 		chain.push(next);
 		visited.add(next);
@@ -68,8 +75,8 @@ export function getFallbackChain(locale: string): string[] {
 	}
 
 	// Always end with defaultLocale if not already in chain
-	if (!visited.has(_config.defaultLocale)) {
-		chain.push(_config.defaultLocale);
+	if (!visited.has(config.defaultLocale)) {
+		chain.push(config.defaultLocale);
 	}
 
 	return chain;

--- a/packages/core/tests/unit/i18n/config.test.ts
+++ b/packages/core/tests/unit/i18n/config.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(async () => {
+	const { setI18nConfig } = await import("../../../src/i18n/config.js");
+	setI18nConfig(null);
+	vi.resetModules();
+});
+
+describe("i18n config", () => {
+	it("shares config across duplicated module instances", async () => {
+		const writer = await import("../../../src/i18n/config.js");
+		writer.setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
+
+		vi.resetModules();
+		const reader = await import("../../../src/i18n/config.js");
+
+		expect(reader.getI18nConfig()).toEqual({
+			defaultLocale: "en",
+			locales: ["en", "fr"],
+		});
+		expect(reader.isI18nEnabled()).toBe(true);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Keeps the configured locale list available when Vite loads EmDash through more than one SSR module chunk. This restores the hreflang links that were skipped when the UI and middleware read separate module instances, and adds a regression test that recreates that boundary.

Closes #2061

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: Not applicable; this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter emdash exec vitest run tests/unit/i18n/config.test.ts` (1 test passed)
- Full core run: 5,014 tests passed; the only failure is the pre-existing macOS `/var` vs `/private/var` path assertion in `virtual-modules.test.ts`.
- No admin UI strings or screenshots are involved.
