### PR TITLE
fix(admin): support heading levels 4 through 6

### DIFF
--- a/.changeset/add-editor-heading-levels.md
+++ b/.changeset/add-editor-heading-levels.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds heading levels 4 through 6 to the content editor menus and stored content.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -52,6 +52,9 @@ import {
 	TextHOne,
 	TextHTwo,
 	TextHThree,
+	TextHFour,
+	TextHFive,
+	TextHSix,
 	List,
 	ListNumbers,
 	Quotes,
@@ -1132,6 +1135,36 @@ const defaultSlashCommands: SlashCommandItem[] = [
 		aliases: ["h3"],
 		command: ({ editor, range }) => {
 			editor.chain().focus().deleteRange(range).setNode("heading", { level: 3 }).run();
+		},
+	},
+	{
+		id: "heading4",
+		title: msg`Heading 4`,
+		description: msg`Smaller section heading`,
+		icon: TextHFour,
+		aliases: ["h4"],
+		command: ({ editor, range }) => {
+			editor.chain().focus().deleteRange(range).setNode("heading", { level: 4 }).run();
+		},
+	},
+	{
+		id: "heading5",
+		title: msg`Heading 5`,
+		description: msg`Minor section heading`,
+		icon: TextHFive,
+		aliases: ["h5"],
+		command: ({ editor, range }) => {
+			editor.chain().focus().deleteRange(range).setNode("heading", { level: 5 }).run();
+		},
+	},
+	{
+		id: "heading6",
+		title: msg`Heading 6`,
+		description: msg`Smallest section heading`,
+		icon: TextHSix,
+		aliases: ["h6"],
+		command: ({ editor, range }) => {
+			editor.chain().focus().deleteRange(range).setNode("heading", { level: 6 }).run();
 		},
 	},
 	{
@@ -2493,7 +2526,7 @@ export function PortableTextEditor({
 		() => [
 			StarterKit.configure({
 				heading: {
-					levels: [1, 2, 3],
+					levels: [1, 2, 3, 4, 5, 6],
 				},
 				dropcursor: {
 					color: "#3b82f6",
@@ -3651,7 +3684,7 @@ function EditorToolbar({
 
 			{/* Headings */}
 			<ToolbarGroup>
-				<HeadingDropdownMenu editor={editor} levels={[1, 2, 3]} />
+				<HeadingDropdownMenu editor={editor} />
 			</ToolbarGroup>
 
 			<ToolbarSeparator />

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -21,6 +21,9 @@ import {
 	TextHOne,
 	TextHTwo,
 	TextHThree,
+	TextHFour,
+	TextHFive,
+	TextHSix,
 	Quotes,
 	Code,
 	List,
@@ -79,6 +82,30 @@ const blockTransforms: BlockTransform[] = [
 		icon: TextHThree,
 		transform: (editor) => {
 			editor.chain().focus().setNode("heading", { level: 3 }).run();
+		},
+	},
+	{
+		id: "heading4",
+		label: msg`Heading 4`,
+		icon: TextHFour,
+		transform: (editor) => {
+			editor.chain().focus().setNode("heading", { level: 4 }).run();
+		},
+	},
+	{
+		id: "heading5",
+		label: msg`Heading 5`,
+		icon: TextHFive,
+		transform: (editor) => {
+			editor.chain().focus().setNode("heading", { level: 5 }).run();
+		},
+	},
+	{
+		id: "heading6",
+		label: msg`Heading 6`,
+		icon: TextHSix,
+		transform: (editor) => {
+			editor.chain().focus().setNode("heading", { level: 6 }).run();
 		},
 	},
 	{

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -307,7 +307,10 @@ body {
 	margin-bottom: 0.4em !important;
 }
 
-.ProseMirror.prose > h3 {
+.ProseMirror.prose > h3,
+.ProseMirror.prose > h4,
+.ProseMirror.prose > h5,
+.ProseMirror.prose > h6 {
 	margin-top: 0.3em !important;
 	margin-bottom: 0.3em !important;
 }

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -152,7 +152,7 @@ function typeIntoEditor(editor: Editor, text: string) {
 function textBlock(
 	text: string,
 	opts: {
-		style?: "normal" | "h1" | "h2" | "h3" | "blockquote";
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
 		marks?: string[];
 		listItem?: "bullet" | "number";
 		level?: number;
@@ -311,6 +311,14 @@ describe("Portable Text ↔ ProseMirror conversion", () => {
 		const h1 = pm.querySelector("h1");
 		expect(h1).toBeTruthy();
 		expect(h1!.textContent).toBe("Title");
+	});
+
+	it("renders an h6 heading", async () => {
+		await render(<PortableTextEditor value={[textBlock("Detail", { style: "h6" })]} />);
+		const pm = await waitForEditor();
+		const h6 = pm.querySelector("h6");
+		expect(h6).toBeTruthy();
+		expect(h6!.textContent).toBe("Detail");
 	});
 
 	it("renders bold text", async () => {
@@ -691,6 +699,9 @@ describe("Toolbar", () => {
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 1" })).toBeInTheDocument();
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 2" })).toBeInTheDocument();
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 3" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 4" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 5" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 6" })).toBeInTheDocument();
 	});
 
 	it("has list buttons", async () => {

--- a/packages/admin/tests/editor/block-menu.test.tsx
+++ b/packages/admin/tests/editor/block-menu.test.tsx
@@ -243,6 +243,9 @@ describe("BlockMenu", () => {
 			expect(findButtonByText(updatedMenu, "Heading 1")).toBeTruthy();
 			expect(findButtonByText(updatedMenu, "Heading 2")).toBeTruthy();
 			expect(findButtonByText(updatedMenu, "Heading 3")).toBeTruthy();
+			expect(findButtonByText(updatedMenu, "Heading 4")).toBeTruthy();
+			expect(findButtonByText(updatedMenu, "Heading 5")).toBeTruthy();
+			expect(findButtonByText(updatedMenu, "Heading 6")).toBeTruthy();
 			expect(findButtonByText(updatedMenu, "Quote")).toBeTruthy();
 			expect(findButtonByText(updatedMenu, "Code Block")).toBeTruthy();
 			expect(findButtonByText(updatedMenu, "Bullet List")).toBeTruthy();

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -455,7 +455,7 @@ describe("Slash Command Menu", () => {
 		const menu = await waitForSlashMenu();
 		const items = getSlashMenuItems(menu);
 
-		// Default commands: heading1-3, bullet/numbered list, quote, code block, divider, image, section
+		// Default commands: heading1-6, bullet/numbered list, quote, code block, divider, image, section
 		expect(items.length).toBeGreaterThanOrEqual(8);
 	});
 
@@ -471,6 +471,9 @@ describe("Slash Command Menu", () => {
 		expect(titles).toContain("Heading 1");
 		expect(titles).toContain("Heading 2");
 		expect(titles).toContain("Heading 3");
+		expect(titles).toContain("Heading 4");
+		expect(titles).toContain("Heading 5");
+		expect(titles).toContain("Heading 6");
 		expect(titles).toContain("Bullet List");
 		expect(titles).toContain("Numbered List");
 		expect(titles).toContain("Quote");

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -177,7 +177,7 @@ function expectAlignmentState(
 
 async function getHeadingMenuItem(
 	screen: Awaited<ReturnType<typeof render>>,
-	name: "Heading 1" | "Heading 2" | "Heading 3",
+	name: "Heading 1" | "Heading 2" | "Heading 3" | "Heading 4" | "Heading 5" | "Heading 6",
 ) {
 	const trigger = getToolbarButton(screen, "Headings");
 	trigger.element().click();
@@ -224,6 +224,9 @@ describe("Toolbar Presence and Structure", () => {
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 1" })).toBeVisible();
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 2" })).toBeVisible();
 		await expect.element(screen.getByRole("menuitem", { name: "Heading 3" })).toBeVisible();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 4" })).toBeVisible();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 5" })).toBeVisible();
+		await expect.element(screen.getByRole("menuitem", { name: "Heading 6" })).toBeVisible();
 		expect(
 			screen
 				.getByRole("menuitem", { name: "Heading 1" })
@@ -235,7 +238,16 @@ describe("Toolbar Presence and Structure", () => {
 			document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
 			(item) => item.textContent?.trim(),
 		);
-		expect(headingLabels).not.toContain("Heading 4");
+		expect(headingLabels).toEqual(
+			expect.arrayContaining([
+				"Heading 1",
+				"Heading 2",
+				"Heading 3",
+				"Heading 4",
+				"Heading 5",
+				"Heading 6",
+			]),
+		);
 	});
 
 	it("has all list buttons", async () => {
@@ -496,6 +508,19 @@ describe("Formatting Button Toggle States", () => {
 		await vi.waitFor(() => {
 			expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
 			expect(editor.isActive("heading", { level: 3 })).toBe(true);
+		});
+	});
+
+	it("Heading 6: click changes to h6", async () => {
+		const { screen, editor } = await renderEditor();
+		editor.commands.focus();
+
+		const { trigger, item } = await getHeadingMenuItem(screen, "Heading 6");
+		item.element().click();
+
+		await vi.waitFor(() => {
+			expect(trigger.element().hasAttribute("aria-pressed")).toBe(false);
+			expect(editor.isActive("heading", { level: 6 })).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

Enables heading levels 4 through 6 throughout the admin content editor. Stored H4–H6 blocks now load correctly, and authors can create them from the heading dropdown, slash commands, or the block transform menu with matching editor spacing.

Closes #2172

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: Not applicable; this is a maintainer-approved bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @emdash-cms/admin exec vitest run` (104 files, 1,238 tests passed)
- `pnpm format`
- New labels and descriptions use Lingui, logical alignment remains RTL-safe, and no catalog files are included.
