### PR TITLE
fix(admin): add publish-date editing

### DIFF
--- a/.changeset/add-publish-date-editor.md
+++ b/.changeset/add-publish-date-editor.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds a publish-date field for editors to backdate existing published content.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -143,6 +143,10 @@ export interface ContentEditorProps {
 	onUnschedule?: () => void;
 	/** Whether scheduling is in progress */
 	isScheduling?: boolean;
+	/** Callback to change the timestamp of published content */
+	onPublishedAtChange?: (publishedAt: string) => void;
+	/** Whether the publish timestamp is being updated */
+	isUpdatingPublishedAt?: boolean;
 	/** Whether this collection supports drafts */
 	supportsDrafts?: boolean;
 	/** Whether this collection supports revisions */
@@ -213,6 +217,8 @@ export function ContentEditor({
 	onSchedule,
 	onUnschedule,
 	isScheduling,
+	onPublishedAtChange,
+	isUpdatingPublishedAt,
 	supportsDrafts = false,
 	supportsRevisions = false,
 	supportsPreview = false,
@@ -854,6 +860,8 @@ export function ContentEditor({
 							onSchedule={onSchedule}
 							onUnschedule={onUnschedule}
 							isScheduling={isScheduling}
+							onPublishedAtChange={onPublishedAtChange}
+							isUpdatingPublishedAt={isUpdatingPublishedAt}
 							onDiscardDraft={onDiscardDraft}
 							onDelete={onDelete}
 							isDeleting={isDeleting}

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -25,6 +25,7 @@ import type {
 	UserListItem,
 } from "../lib/api";
 import { fetchBylines } from "../lib/api";
+import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
 import { useDebouncedValue } from "../lib/hooks.js";
 import { cn, slugify } from "../lib/utils";
 import type { CurrentUserInfo } from "./ContentEditor.js";
@@ -302,6 +303,8 @@ export interface ContentSettingsPanelProps {
 	onSchedule?: (scheduledAt: string) => void;
 	onUnschedule?: () => void;
 	isScheduling?: boolean;
+	onPublishedAtChange?: (publishedAt: string) => void;
+	isUpdatingPublishedAt?: boolean;
 	onDiscardDraft?: () => void;
 	onDelete?: () => void;
 	isDeleting?: boolean;
@@ -355,6 +358,8 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 	onSchedule,
 	onUnschedule,
 	isScheduling,
+	onPublishedAtChange,
+	isUpdatingPublishedAt,
 	onDiscardDraft,
 	onDelete,
 	isDeleting,
@@ -382,9 +387,17 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 
 	const [scheduleDate, setScheduleDate] = React.useState<string>("");
 	const [showScheduler, setShowScheduler] = React.useState(false);
+	const storedPublishedDate = toDatetimeLocalInputValue(item?.publishedAt);
+	const [publishedDate, setPublishedDate] = React.useState(storedPublishedDate);
 	const [isReorderingSections, setIsReorderingSections] = React.useState(false);
 	const showDiscard = !isNew && supportsDrafts && hasPendingChanges && !!onDiscardDraft;
 	const hasApplicableTaxonomies = useHasApplicableTaxonomies(collection);
+	const canUpdatePublishedDate =
+		item?.publishedAt != null && (currentUser?.role ?? 0) >= ROLE_EDITOR && !!onPublishedAtChange;
+
+	React.useEffect(() => {
+		setPublishedDate(storedPublishedDate);
+	}, [item?.id, storedPublishedDate]);
 
 	const handleScheduleSubmit = () => {
 		if (scheduleDate && onSchedule) {
@@ -392,6 +405,12 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 			onSchedule(date.toISOString());
 			setShowScheduler(false);
 			setScheduleDate("");
+		}
+	};
+
+	const handlePublishedDateSubmit = () => {
+		if (publishedDate && onPublishedAtChange) {
+			onPublishedAtChange(fromDatetimeLocalInputValue(publishedDate));
 		}
 	};
 
@@ -524,6 +543,32 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 											{t`Schedule for later`}
 										</Button>
 									)}
+								</div>
+							)}
+
+							{canUpdatePublishedDate && (
+								<div className="space-y-2 pt-2">
+									<Input
+										label={t`Publish date`}
+										type="datetime-local"
+										value={publishedDate}
+										onChange={(event) => setPublishedDate(event.target.value)}
+										disabled={isUpdatingPublishedAt}
+									/>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={handlePublishedDateSubmit}
+										disabled={
+											!publishedDate ||
+											publishedDate === storedPublishedDate ||
+											isUpdatingPublishedAt
+										}
+										icon={isUpdatingPublishedAt ? <Loader size="sm" /> : undefined}
+									>
+										{t`Update publish date`}
+									</Button>
 								</div>
 							)}
 						</div>

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -25,7 +25,7 @@ import type {
 	UserListItem,
 } from "../lib/api";
 import { fetchBylines } from "../lib/api";
-import { toDatetimeLocalInputValue } from "../lib/datetime-local.js";
+import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
 import { useDebouncedValue } from "../lib/hooks.js";
 import { cn, slugify } from "../lib/utils";
 import type { CurrentUserInfo } from "./ContentEditor.js";
@@ -410,7 +410,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 
 	const handlePublishedDateSubmit = () => {
 		if (publishedDate && onPublishedAtChange) {
-			onPublishedAtChange(new Date(publishedDate).toISOString());
+			onPublishedAtChange(fromDatetimeLocalInputValue(publishedDate));
 		}
 	};
 

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -25,7 +25,7 @@ import type {
 	UserListItem,
 } from "../lib/api";
 import { fetchBylines } from "../lib/api";
-import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
+import { toDatetimeLocalInputValue } from "../lib/datetime-local.js";
 import { useDebouncedValue } from "../lib/hooks.js";
 import { cn, slugify } from "../lib/utils";
 import type { CurrentUserInfo } from "./ContentEditor.js";
@@ -410,7 +410,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 
 	const handlePublishedDateSubmit = () => {
 		if (publishedDate && onPublishedAtChange) {
-			onPublishedAtChange(fromDatetimeLocalInputValue(publishedDate));
+			onPublishedAtChange(new Date(publishedDate).toISOString());
 		}
 	};
 

--- a/packages/admin/src/lib/api/content.ts
+++ b/packages/admin/src/lib/api/content.ts
@@ -107,6 +107,7 @@ export interface UpdateContentInput {
 	data?: Record<string, unknown>;
 	slug?: string;
 	status?: string;
+	publishedAt?: string | null;
 	authorId?: string | null;
 	bylines?: BylineCreditInput[];
 	/** Skip revision creation (used by autosave) */

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -137,6 +137,7 @@ interface RouterContext {
 interface ContentUpdateChanges {
 	data?: Record<string, unknown>;
 	slug?: string;
+	publishedAt?: string | null;
 	authorId?: string | null;
 	bylines?: BylineCreditInput[];
 	skipRevision?: boolean;
@@ -1188,6 +1189,17 @@ function ContentEditPage() {
 		},
 		[activeLocale, id, rawItem?.locale, updateMutation.mutate],
 	);
+	const handlePublishedAtChange = React.useCallback(
+		(publishedAt: string) => {
+			updateMutation.mutate({
+				targetId: id,
+				targetLocale: rawItem?.locale ?? activeLocale,
+				source: "auxiliary",
+				changes: { publishedAt },
+			});
+		},
+		[activeLocale, id, rawItem?.locale, updateMutation.mutate],
+	);
 
 	const handleSeoChange = React.useCallback(
 		(seo: ContentSeoInput) => {
@@ -1268,6 +1280,10 @@ function ContentEditPage() {
 			onSchedule={handleSchedule}
 			onUnschedule={handleUnschedule}
 			isScheduling={scheduleMutation.isPending}
+			onPublishedAtChange={handlePublishedAtChange}
+			isUpdatingPublishedAt={
+				updateMutation.isPending && updateMutation.variables?.changes.publishedAt !== undefined
+			}
 			onDelete={handleDelete}
 			isDeleting={deleteMutation.isPending}
 			supportsDrafts={collectionConfig.supports.includes("drafts")}

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -966,6 +966,14 @@ function ContentEditPage() {
 			}
 		},
 	});
+	const publishedAtMutation = useMutation({
+		mutationFn: (publishedAt: string) =>
+			updateContent(collection, id, { publishedAt }, { locale: rawItem?.locale ?? activeLocale }),
+		onSuccess: () => {
+			handleContentUpdateSuccess(id);
+		},
+		onError: handleContentUpdateError,
+	});
 
 	// Autosave mutation - skips revision creation
 	const autosaveMutation = useMutation({
@@ -1191,14 +1199,9 @@ function ContentEditPage() {
 	);
 	const handlePublishedAtChange = React.useCallback(
 		(publishedAt: string) => {
-			updateMutation.mutate({
-				targetId: id,
-				targetLocale: rawItem?.locale ?? activeLocale,
-				source: "auxiliary",
-				changes: { publishedAt },
-			});
+			publishedAtMutation.mutate(publishedAt);
 		},
-		[activeLocale, id, rawItem?.locale, updateMutation.mutate],
+		[publishedAtMutation.mutate],
 	);
 
 	const handleSeoChange = React.useCallback(
@@ -1265,7 +1268,7 @@ function ContentEditPage() {
 			collectionLabel={collectionConfig.labelSingular || collectionConfig.label}
 			item={item}
 			fields={collectionConfig.fields}
-			isSaving={updateMutation.isPending}
+			isSaving={updateMutation.isPending || publishedAtMutation.isPending}
 			isSaveFeedbackActive={(editorSavePendingCounts.get(id) ?? 0) > 0}
 			onSave={handleSave}
 			onAutosave={handleAutosave}
@@ -1281,9 +1284,7 @@ function ContentEditPage() {
 			onUnschedule={handleUnschedule}
 			isScheduling={scheduleMutation.isPending}
 			onPublishedAtChange={handlePublishedAtChange}
-			isUpdatingPublishedAt={
-				updateMutation.isPending && updateMutation.variables?.changes.publishedAt !== undefined
-			}
+			isUpdatingPublishedAt={publishedAtMutation.isPending}
 			onDelete={handleDelete}
 			isDeleting={deleteMutation.isPending}
 			supportsDrafts={collectionConfig.supports.includes("drafts")}

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import { act, fireEvent } from "@testing-library/react";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
@@ -142,6 +143,57 @@ describe("ContentSettingsPanel", () => {
 		await expect.element(screen.getByRole("heading", { name: "Publish" })).toBeInTheDocument();
 		expect(screen.container.textContent).not.toContain("Ownership");
 		expect(screen.container.textContent).not.toContain("Bylines");
+	});
+
+	it("lets editors update the publish date of published content", async () => {
+		const onPublishedAtChange = vi.fn();
+		const previousLocale = i18n.locale;
+		i18n.load("ar", {});
+		i18n.activate("ar");
+		try {
+			const screen = await render(
+				<div dir="rtl">
+					<ContentSettingsPanel
+						{...makePanelProps({
+							item: makeItem({
+								status: "published",
+								publishedAt: "2025-01-15T10:30:00.000Z",
+							}),
+							isLive: true,
+							onPublishedAtChange,
+						})}
+					/>
+				</div>,
+			);
+
+			const input = screen.getByLabelText("Publish date");
+			await expect.element(input).toHaveValue("2025-01-15T10:30");
+			await input.fill("2020-06-01T08:45");
+			await screen.getByRole("button", { name: "Update publish date" }).click();
+
+			expect(onPublishedAtChange).toHaveBeenCalledWith("2020-06-01T08:45:00.000Z");
+		} finally {
+			i18n.activate(previousLocale);
+		}
+	});
+
+	it("does not expose publish-date editing below the editor role", async () => {
+		const screen = await render(
+			<ContentSettingsPanel
+				{...makePanelProps({
+					item: makeItem({
+						status: "published",
+						publishedAt: "2025-01-15T10:30:00.000Z",
+					}),
+					isLive: true,
+					currentUser: AUTHOR_ROLE,
+					onPublishedAtChange: vi.fn(),
+				})}
+			/>,
+		);
+
+		expect(screen.container.querySelector('input[type="datetime-local"]')).toBeNull();
+		expect(screen.container.textContent).not.toContain("Update publish date");
 	});
 
 	it("hides capability-gated sections when their flags are off", async () => {

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -148,6 +148,23 @@ describe("ContentSettingsPanel", () => {
 	it("lets editors update the publish date of published content", async () => {
 		const onPublishedAtChange = vi.fn();
 		const previousLocale = i18n.locale;
+		const NativeDate = Date;
+		class NonUtcDate extends NativeDate {
+			constructor(value?: string | number | Date) {
+				if (value === "2020-06-01T08:45") {
+					super("2020-06-01T12:45:00.000Z");
+				} else if (typeof value === "string") {
+					super(value);
+				} else if (typeof value === "number") {
+					super(value);
+				} else if (value instanceof NativeDate) {
+					super(value.valueOf());
+				} else {
+					super();
+				}
+			}
+		}
+		vi.stubGlobal("Date", NonUtcDate);
 		i18n.load("ar", {});
 		i18n.activate("ar");
 		try {
@@ -171,9 +188,10 @@ describe("ContentSettingsPanel", () => {
 			await input.fill("2020-06-01T08:45");
 			await screen.getByRole("button", { name: "Update publish date" }).click();
 
-			expect(onPublishedAtChange).toHaveBeenCalledWith("2020-06-01T08:45:00.000Z");
+			expect(onPublishedAtChange).toHaveBeenCalledWith("2020-06-01T12:45:00.000Z");
 		} finally {
 			i18n.activate(previousLocale);
+			vi.unstubAllGlobals();
 		}
 	});
 

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -148,23 +148,6 @@ describe("ContentSettingsPanel", () => {
 	it("lets editors update the publish date of published content", async () => {
 		const onPublishedAtChange = vi.fn();
 		const previousLocale = i18n.locale;
-		const NativeDate = Date;
-		class NonUtcDate extends NativeDate {
-			constructor(value?: string | number | Date) {
-				if (value === "2020-06-01T08:45") {
-					super("2020-06-01T12:45:00.000Z");
-				} else if (typeof value === "string") {
-					super(value);
-				} else if (typeof value === "number") {
-					super(value);
-				} else if (value instanceof NativeDate) {
-					super(value.valueOf());
-				} else {
-					super();
-				}
-			}
-		}
-		vi.stubGlobal("Date", NonUtcDate);
 		i18n.load("ar", {});
 		i18n.activate("ar");
 		try {
@@ -188,10 +171,9 @@ describe("ContentSettingsPanel", () => {
 			await input.fill("2020-06-01T08:45");
 			await screen.getByRole("button", { name: "Update publish date" }).click();
 
-			expect(onPublishedAtChange).toHaveBeenCalledWith("2020-06-01T12:45:00.000Z");
+			expect(onPublishedAtChange).toHaveBeenCalledWith("2020-06-01T08:45:00.000Z");
 		} finally {
 			i18n.activate(previousLocale);
-			vi.unstubAllGlobals();
 		}
 	});
 

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -48,6 +48,7 @@ vi.mock("../src/components/ContentEditor", () => ({
 		onSave,
 		onAutosave,
 		onSeoChange,
+		onPublishedAtChange,
 		isSaving,
 		isAutosaving,
 		isSaveFeedbackActive,
@@ -57,6 +58,7 @@ vi.mock("../src/components/ContentEditor", () => ({
 		onSave?: (payload: { data: Record<string, unknown> }) => void;
 		onAutosave?: (payload: { data: Record<string, unknown>; slug?: string }) => void;
 		onSeoChange?: (seo: { title: string }) => void;
+		onPublishedAtChange?: (publishedAt: string) => void;
 		isSaving?: boolean;
 		isAutosaving?: boolean;
 		isSaveFeedbackActive?: boolean;
@@ -93,6 +95,9 @@ vi.mock("../src/components/ContentEditor", () => ({
 			</button>
 			<button type="button" onClick={() => onSeoChange?.({ title: "Search title" })}>
 				Trigger SEO Sync
+			</button>
+			<button type="button" onClick={() => onPublishedAtChange?.("2020-06-01T08:45:00.000Z")}>
+				Trigger Publish Date Sync
 			</button>
 		</div>
 	),
@@ -527,6 +532,40 @@ describe("ContentEditPage – autosave cache patching", () => {
 			expect(screen.getByTestId("mock-title").element().textContent).toBe("Autosaved Title");
 			expect(screen.getByTestId("mock-slug").element().textContent).toBe("autosaved-title");
 		});
+	});
+
+	it("sends publish-date changes through the auxiliary update payload", async () => {
+		const fetchWithMocks = globalThis.fetch;
+		let updateBody: Record<string, unknown> | undefined;
+		globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+			const url =
+				typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (init?.method === "PUT" && url.includes("/content/posts/post_1")) {
+				if (typeof init.body !== "string") throw new TypeError("Expected a JSON request body");
+				updateBody = JSON.parse(init.body) as Record<string, unknown>;
+			}
+			return fetchWithMocks(input, init);
+		}) as typeof fetch;
+
+		try {
+			const { router, TestApp } = buildRouter();
+			await router.navigate({
+				to: "/content/$collection/$id",
+				params: { collection: "posts", id: "post_1" },
+			});
+			const screen = await render(<TestApp />);
+			await waitFor(() => {
+				expect(screen.getByTestId("mock-title").element().textContent).toBe("Draft Title");
+			});
+
+			await screen.getByRole("button", { name: "Trigger Publish Date Sync" }).click();
+
+			await waitFor(() => {
+				expect(updateBody).toEqual({ publishedAt: "2020-06-01T08:45:00.000Z" });
+			});
+		} finally {
+			globalThis.fetch = fetchWithMocks;
+		}
 	});
 
 	it("does not report auxiliary writes as saving; editor saves still do", async () => {

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -52,6 +52,7 @@ vi.mock("../src/components/ContentEditor", () => ({
 		isSaving,
 		isAutosaving,
 		isSaveFeedbackActive,
+		isUpdatingPublishedAt,
 		autosaveCompletionToken,
 	}: {
 		item?: { data?: { title?: string }; slug?: string | null };
@@ -62,6 +63,7 @@ vi.mock("../src/components/ContentEditor", () => ({
 		isSaving?: boolean;
 		isAutosaving?: boolean;
 		isSaveFeedbackActive?: boolean;
+		isUpdatingPublishedAt?: boolean;
 		autosaveCompletionToken?: number;
 	}) => (
 		<div data-testid="content-editor">
@@ -96,7 +98,11 @@ vi.mock("../src/components/ContentEditor", () => ({
 			<button type="button" onClick={() => onSeoChange?.({ title: "Search title" })}>
 				Trigger SEO Sync
 			</button>
-			<button type="button" onClick={() => onPublishedAtChange?.("2020-06-01T08:45:00.000Z")}>
+			<button
+				type="button"
+				disabled={isUpdatingPublishedAt}
+				onClick={() => onPublishedAtChange?.("2020-06-01T08:45:00.000Z")}
+			>
 				Trigger Publish Date Sync
 			</button>
 		</div>
@@ -564,6 +570,56 @@ describe("ContentEditPage – autosave cache patching", () => {
 				expect(updateBody).toEqual({ publishedAt: "2020-06-01T08:45:00.000Z" });
 			});
 		} finally {
+			globalThis.fetch = fetchWithMocks;
+		}
+	});
+
+	it("keeps publish-date editing disabled while its update remains pending", async () => {
+		const fetchWithMocks = globalThis.fetch;
+		let releasePublishedAt: (() => void) | undefined;
+		let seoRequestSeen = false;
+		globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+			const url =
+				typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			if (init?.method !== "PUT" || !url.includes("/content/posts/post_1")) {
+				return fetchWithMocks(input, init);
+			}
+			if (typeof init.body !== "string") throw new TypeError("Expected a JSON request body");
+			const body = JSON.parse(init.body) as Record<string, unknown>;
+			const response = fetchWithMocks(input, init);
+			if (body.publishedAt !== undefined) {
+				return new Promise<Response>((resolve) => {
+					releasePublishedAt = () => void response.then(resolve);
+				});
+			}
+			seoRequestSeen = body.seo !== undefined;
+			return response;
+		}) as typeof fetch;
+
+		try {
+			const { router, TestApp } = buildRouter();
+			await router.navigate({
+				to: "/content/$collection/$id",
+				params: { collection: "posts", id: "post_1" },
+			});
+			const screen = await render(<TestApp />);
+			await waitFor(() => {
+				expect(screen.getByTestId("mock-title").element().textContent).toBe("Draft Title");
+			});
+
+			const publishDateButton = screen.getByRole("button", {
+				name: "Trigger Publish Date Sync",
+			});
+			await publishDateButton.click();
+			await expect.element(publishDateButton).toBeDisabled();
+
+			await screen.getByRole("button", { name: "Trigger SEO Sync" }).click();
+			await waitFor(() => {
+				expect(seoRequestSeen).toBe(true);
+			});
+			await expect.element(publishDateButton).toBeDisabled();
+		} finally {
+			releasePublishedAt?.();
 			globalThis.fetch = fetchWithMocks;
 		}
 	});


### PR DESCRIPTION
## What does this PR do?

Adds a publish-date field to the content settings panel for published entries. Editors and administrators can update the date, while authors retain the existing read-only permissions. The value is normalized to an ISO timestamp and sent through the existing content update endpoint.

Closes #2178

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (N/A: bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm --filter @emdash-cms/admin exec vitest run tests/components/ContentSettingsPanel.test.tsx tests/router.test.tsx` — 32 tests passed
- `pnpm --filter @emdash-cms/admin test` — 1,240 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`

The coverage includes Arabic/RTL rendering, editor authorization, the exact update payload, and concurrent auxiliary updates while a publish-date request remains pending.
