### PR TITLE
fix(core): populate route/hook metadata for config-declared sandboxed plugins

### DIFF
--- a/.changeset/sandboxed-config-plugin-route-meta.md
+++ b/.changeset/sandboxed-config-plugin-route-meta.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes public routes on `sandboxed: []` (config-declared) plugins requiring authentication regardless of the plugin's own `public: true` declaration. Declare `routes` (and optionally `hooks`) on the plugin's descriptor to have them honored, the same way `adminPages`/`capabilities` already are.

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -7,6 +7,8 @@
  * DO NOT import Node.js-only modules here (fs, path, module, etc.)
  */
 
+import type { ManifestHookEntry, ManifestRouteEntry } from "@emdash-cms/plugin-types";
+
 import type { AuthDescriptor, AuthProviderDescriptor } from "../../auth/types.js";
 import type { DatabaseDescriptor } from "../../db/adapters.js";
 import type { MediaProviderDescriptor } from "../../media/types.js";
@@ -137,6 +139,20 @@ export interface PluginDescriptor<TOptions = Record<string, unknown>> {
 	storage?: Record<string, StorageCollectionDeclaration>;
 	/** Serialized MCP declarations emitted by the plugin build. */
 	mcp?: PluginMcpManifestConfig;
+	/**
+	 * Route declarations (name + `public`/`permission`/`cacheControl`), mirroring
+	 * the plugin's own `definePlugin({ routes })`. Required for `sandboxed: []`
+	 * registration -- unlike marketplace/registry installs, there is no bundled
+	 * `manifest.json` to read at build time, so route auth metadata can only come
+	 * from here. Omitted routes default to non-public.
+	 */
+	routes?: Array<ManifestRouteEntry | string>;
+	/**
+	 * Hook declarations this plugin implements, mirroring `definePlugin({ hooks })`.
+	 * Same rationale as `routes` -- needed for `sandboxed: []` since there's no
+	 * bundle manifest to read it from.
+	 */
+	hooks?: Array<ManifestHookEntry | string>;
 }
 
 /**

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -140,17 +140,14 @@ export interface PluginDescriptor<TOptions = Record<string, unknown>> {
 	/** Serialized MCP declarations emitted by the plugin build. */
 	mcp?: PluginMcpManifestConfig;
 	/**
-	 * Route declarations (name + `public`/`permission`/`cacheControl`), mirroring
-	 * the plugin's own `definePlugin({ routes })`. Required for `sandboxed: []`
-	 * registration -- unlike marketplace/registry installs, there is no bundled
-	 * `manifest.json` to read at build time, so route auth metadata can only come
-	 * from here. Omitted routes default to non-public.
+	 * Route declarations for sandboxed config-declared plugins. Mirrors
+	 * definePlugin({ routes }) and drives route auth decisions; omitted routes
+	 * default to non-public.
 	 */
 	routes?: Array<ManifestRouteEntry | string>;
 	/**
-	 * Hook declarations this plugin implements, mirroring `definePlugin({ hooks })`.
-	 * Same rationale as `routes` -- needed for `sandboxed: []` since there's no
-	 * bundle manifest to read it from.
+	 * Hook declarations for sandboxed config-declared plugins. Mirrors
+	 * definePlugin({ hooks }).
 	 */
 	hooks?: Array<ManifestHookEntry | string>;
 }

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -673,6 +673,8 @@ export const sandboxedPlugins = [];
     allowedHosts: ${JSON.stringify(descriptor.allowedHosts ?? [])},
     storage: ${JSON.stringify(descriptor.storage ?? {})},
     mcp: ${JSON.stringify(descriptor.mcp)},
+    routes: ${JSON.stringify(descriptor.routes ?? [])},
+    hooks: ${JSON.stringify(descriptor.hooks ?? [])},
     adminPages: ${JSON.stringify(descriptor.adminPages ?? [])},
     adminWidgets: ${JSON.stringify(descriptor.adminWidgets ?? [])},
     settingsSchema: ${JSON.stringify(descriptor.settingsSchema)},

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -241,6 +241,10 @@ export interface SandboxedPluginEntry {
 	storage: PluginStorageConfig;
 	/** Serialized MCP declarations emitted at plugin build time. */
 	mcp?: PluginMcpManifestConfig;
+	/** Route declarations (name + public/permission/cacheControl), used for route auth decisions */
+	routes?: PluginManifest["routes"];
+	/** Hook declarations this plugin implements */
+	hooks?: PluginManifest["hooks"];
 	/** Admin pages */
 	adminPages?: Array<{ path: string; label?: string; icon?: string }>;
 	/** Dashboard widgets */
@@ -1977,8 +1981,8 @@ export class EmDashRuntime {
 					capabilities: entry.capabilities ?? [],
 					allowedHosts: entry.allowedHosts ?? [],
 					storage: entry.storage ?? {},
-					hooks: [],
-					routes: [],
+					hooks: entry.hooks ?? [],
+					routes: entry.routes ?? [],
 					admin: {},
 					mcp: entry.mcp,
 				};
@@ -1988,6 +1992,17 @@ export class EmDashRuntime {
 				console.log(
 					`EmDash: Loaded sandboxed plugin ${pluginKey} with capabilities: [${manifest.capabilities.join(", ")}]`,
 				);
+
+				if (manifest.routes.length > 0) {
+					const routeMetaMap = new Map<string, RouteMeta>();
+					for (const routeEntry of manifest.routes) {
+						const normalized = normalizeManifestRoute(routeEntry);
+						routeMetaMap.set(normalized.name, buildRouteMeta(normalized));
+					}
+					sandboxedRouteMetaCache.set(entry.id, routeMetaMap);
+				} else {
+					sandboxedRouteMetaCache.delete(entry.id);
+				}
 			} catch (error) {
 				console.error(`EmDash: Failed to load sandboxed plugin ${entry.id}:`, error);
 			}

--- a/packages/core/tests/integration/runtime/sandboxed-plugin-route-meta.test.ts
+++ b/packages/core/tests/integration/runtime/sandboxed-plugin-route-meta.test.ts
@@ -1,0 +1,67 @@
+/**
+ * A `sandboxed: []` (config-declared, non-marketplace) plugin never got its
+ * route auth metadata populated -- unlike marketplace/registry installs,
+ * which read `bundle.manifest.routes` off a downloaded bundle. Every one of
+ * its non-admin routes fell through to the sandbox's `{ public: false }`
+ * fallback regardless of what the plugin itself declared. See #2078.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import Database from "better-sqlite3";
+import { SqliteDialect } from "kysely";
+import { describe, expect, it, vi } from "vitest";
+
+import { EmDashRuntime, type RuntimeDependencies } from "../../../src/emdash-runtime.js";
+
+function createDeps(): RuntimeDependencies {
+	const entrypoint = `test-sandboxed-route-meta-${randomUUID()}`;
+	const runner = {
+		isAvailable: () => true,
+		isHealthy: () => true,
+		load: vi.fn().mockResolvedValue({ invokeHook: vi.fn() }),
+		setEmailSend: vi.fn(),
+		terminateAll: vi.fn(),
+	};
+	return {
+		config: { database: { entrypoint, config: {}, type: "sqlite" } },
+		plugins: [],
+		createDialect: () => new SqliteDialect({ database: new Database(":memory:") }),
+		createStorage: null,
+		sandboxEnabled: true,
+		sandboxedPluginEntries: [
+			{
+				id: "demo",
+				version: "1.0.0",
+				options: {},
+				code: "",
+				capabilities: [],
+				allowedHosts: [],
+				storage: {},
+				routes: [{ name: "ping", public: true }],
+			},
+		],
+		// eslint-disable-next-line typescript/no-explicit-any -- test fake matches the SandboxRunner shape create.test.ts already uses
+		createSandboxRunner: (() => runner) as any,
+	};
+}
+
+describe("EmDashRuntime — config-declared sandboxed plugin route metadata", () => {
+	it("honors public: true declared in the sandboxed entry's routes", async () => {
+		const runtime = await EmDashRuntime.create(createDeps());
+		try {
+			expect(runtime.getPluginRouteMeta("demo", "ping")).toMatchObject({ public: true });
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+
+	it("still falls back to non-public for a route the entry didn't declare", async () => {
+		const runtime = await EmDashRuntime.create(createDeps());
+		try {
+			expect(runtime.getPluginRouteMeta("demo", "other")).toMatchObject({ public: false });
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+});

--- a/packages/core/tests/integration/runtime/sandboxed-plugin-route-meta.test.ts
+++ b/packages/core/tests/integration/runtime/sandboxed-plugin-route-meta.test.ts
@@ -1,9 +1,5 @@
 /**
- * A `sandboxed: []` (config-declared, non-marketplace) plugin never got its
- * route auth metadata populated -- unlike marketplace/registry installs,
- * which read `bundle.manifest.routes` off a downloaded bundle. Every one of
- * its non-admin routes fell through to the sandbox's `{ public: false }`
- * fallback regardless of what the plugin itself declared. See #2078.
+ * Integration tests for route auth metadata on config-declared sandboxed plugins.
  */
 
 import { randomUUID } from "node:crypto";


### PR DESCRIPTION
## What does this PR do?

A plugin registered via `sandboxed: [somePlugin()]` in `astro.config.mjs` never gets its route auth metadata populated, so every non-admin route falls back to `{ public: false }` regardless of what the plugin's own `definePlugin({ routes })` declares — even a route explicitly marked `public: true` 401s.

Root cause: the manifest built for config-declared sandboxed plugins (`EmDashRuntime.loadSandboxedPlugins`) hardcoded `routes: []` and `hooks: []`, unlike marketplace/registry installs, which read this from a downloaded bundle's `manifest.json`. Config-declared plugins have no such bundle to read from at build time.

Fix: add `routes`/`hooks` fields to `PluginDescriptor` (the object a plugin's factory function returns), mirroring how `adminPages`/`capabilities`/`storage` are already manually declared there. Thread them through `generateSandboxedPluginsModule` → `SandboxedPluginEntry` → the manifest built in `loadSandboxedPlugins`, and populate `sandboxedRouteMetaCache` the same way the marketplace path already does.

This is additive — a plugin descriptor that doesn't declare `routes`/`hooks` behaves exactly as before.

Closes #2078

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no admin UI strings changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5