### PR TITLE
fix(core): stop Comments/CommentForm CSS from leaking into every emdash/ui page

### DIFF
--- a/.changeset/comments-css-barrel-isolation.md
+++ b/.changeset/comments-css-barrel-isolation.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `Comments`/`CommentForm` CSS being bundled into a shared, render-blocking chunk on every page that imports `PortableText` (or any other component) from `emdash/ui`, even when comments are never rendered on that page.

--- a/packages/core/src/components/comments.ts
+++ b/packages/core/src/components/comments.ts
@@ -1,0 +1,5 @@
+// Separate barrel so importing PortableText/block components from
+// `emdash/ui` doesn't pull Comments/CommentForm's CSS into the page's
+// shared chunk graph.
+export { default as Comments } from "./Comments.astro";
+export { default as CommentForm } from "./CommentForm.astro";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -22,10 +22,6 @@
 // Wrapper component with EmDash defaults
 export { default as PortableText } from "./PortableText.astro";
 
-// Comment components
-export { default as Comments } from "./Comments.astro";
-export { default as CommentForm } from "./CommentForm.astro";
-
 // Widget components
 export { default as WidgetArea } from "./WidgetArea.astro";
 

--- a/packages/core/src/ui.ts
+++ b/packages/core/src/ui.ts
@@ -52,9 +52,6 @@ export {
 	// Shares the name with the `type Block` re-export above; the
 	// type and the component live in different namespaces.
 	Block,
-	// Comment components
-	Comments,
-	CommentForm,
 	// Widget components
 	WidgetArea,
 	// Components object for manual use
@@ -78,3 +75,7 @@ export {
 	EmDashBodyStart,
 	EmDashBodyEnd,
 } from "./components/index.js";
+
+// Kept as a separate import so that pages using only PortableText/block
+// components don't pull Comments/CommentForm's CSS into their chunk graph.
+export { Comments, CommentForm } from "./components/comments.js";

--- a/packages/core/tests/unit/components/ui-comments-css-isolation.test.ts
+++ b/packages/core/tests/unit/components/ui-comments-css-isolation.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `Comments`/`CommentForm` used to live in the same barrel
+ * (`components/index.ts`) as `PortableText` and the block-type components.
+ * Astro's CSS module-graph scanner pulls in every `<style>` reachable from
+ * an imported module regardless of which named export a page actually
+ * uses, so any site importing `PortableText` from `emdash/ui` got
+ * Comments/CommentForm's CSS bundled into a shared, render-blocking chunk
+ * even when comments were never rendered. Fixed by moving Comments/
+ * CommentForm into their own module, re-exported from `emdash/ui`
+ * separately so the two stay on different static import paths.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+function readSrc(relativePath: string): string {
+	return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf-8");
+}
+
+describe("emdash/ui — Comments/CommentForm CSS isolation", () => {
+	it("keeps the PortableText/blocks barrel free of Comments/CommentForm", () => {
+		const barrel = readSrc("../../../src/components/index.ts");
+		expect(barrel).not.toMatch(/["']\.\/(Comments|CommentForm)\.astro["']/);
+	});
+
+	it("still exports Comments and CommentForm from emdash/ui, via a separate module", () => {
+		const ui = readSrc("../../../src/ui.ts");
+		const commentsExport = ui.match(
+			/export\s*\{\s*Comments,\s*CommentForm\s*\}\s*from\s*"([^"]+)"/,
+		);
+		expect(commentsExport).not.toBeNull();
+		expect(commentsExport?.[1]).not.toBe("./components/index.js");
+	});
+
+	it("the separate Comments module only re-exports Comments/CommentForm", () => {
+		const comments = readSrc("../../../src/components/comments.ts");
+		expect(comments).toMatch(/["']\.\/Comments\.astro["']/);
+		expect(comments).toMatch(/["']\.\/CommentForm\.astro["']/);
+		expect(comments).not.toMatch(/PortableText\.astro/);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`emdash/ui`'s barrel (`src/components/index.ts`) re-exported `Comments`/`CommentForm` alongside `PortableText` and the block-type components. Astro's CSS scanner bundles the `<style>` block of every component reachable in a barrel's static import graph into the page's CSS chunk, regardless of which named export a page actually imports — so any site doing `import { PortableText } from "emdash/ui"` got Comments/CommentForm's CSS (~13 KB uncompressed) bundled into a shared, render-blocking chunk on every page, even pages that never render comments.

Same class of bug already fixed for the admin stylesheet in #1281.

Fix: move `Comments`/`CommentForm` into their own module (`components/comments.ts`), re-exported from `emdash/ui` on a separate import statement so the two no longer share a static import graph. `emdash/ui`'s public export surface is unchanged — `import { PortableText, Comments, CommentForm } from "emdash/ui"` still works exactly as before; only pages that import solely `PortableText`/blocks stop pulling in comments' CSS.

No full production-build harness exists in this test suite to assert on emitted CSS chunk contents directly (same situation as #938's fix), so the regression test asserts the underlying structural condition instead: the PortableText/blocks barrel no longer references `Comments.astro`/`CommentForm.astro`, and `emdash/ui` still exports both via a distinct module.

Closes #2039

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no admin UI strings changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5