### PR TITLE
feat(forms): add durable delivery receipts and retries

### DIFF
--- a/.changeset/durable-forms-delivery.md
+++ b/.changeset/durable-forms-delivery.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/plugin-forms": minor
+---
+
+Add durable delivery receipts, retryable outbox processing, sanitized receipt
+and health routes, and self-healing delivery cron scheduling.

--- a/.changeset/durable-forms-delivery.md
+++ b/.changeset/durable-forms-delivery.md
@@ -3,4 +3,6 @@
 ---
 
 Add durable delivery receipts, retryable outbox processing, sanitized receipt
-and health routes, and self-healing delivery cron scheduling.
+and health routes, self-healing delivery cron scheduling with a synchronous
+fallback, serialized processing, duplicate-safe email dispatch barriers, and
+delivery-aware retention.

--- a/packages/plugins/forms/src/client/index.ts
+++ b/packages/plugins/forms/src/client/index.ts
@@ -22,6 +22,8 @@ type SubmitResponse = {
 	success?: boolean;
 	message?: string;
 	redirect?: string;
+	submissionId?: string;
+	receiptId?: string;
 	errors?: Array<{ field: string; message: string }>;
 };
 

--- a/packages/plugins/forms/src/handlers/cron.ts
+++ b/packages/plugins/forms/src/handlers/cron.ts
@@ -9,7 +9,9 @@ import type { PluginContext, StorageCollection } from "emdash";
 
 import { formatDigestText } from "../format.js";
 export { handleDelivery } from "../outbox.js";
-import type { FormDefinition, Submission } from "../types.js";
+import type { DeliveryDestination, FormDefinition, Submission } from "../types.js";
+
+export const TERMINAL_DELIVERY_RETENTION_DAYS = 30;
 
 /** Typed access to plugin storage collections */
 function forms(ctx: PluginContext): StorageCollection<FormDefinition> {
@@ -49,11 +51,14 @@ export async function handleCleanup(ctx: PluginContext) {
 					limit: 100,
 					cursor,
 				});
+				const eligible = batch.items.filter((item) =>
+					canDeleteSubmission(item.data, cutoff, new Date()),
+				);
 
 				// Delete media files
 				if (ctx.media && "delete" in ctx.media) {
 					const mediaWithDelete = ctx.media as { delete(id: string): Promise<boolean> };
-					for (const item of batch.items) {
+					for (const item of eligible) {
 						if (item.data.files) {
 							for (const file of item.data.files) {
 								await mediaWithDelete.delete(file.mediaId).catch(() => {});
@@ -62,7 +67,7 @@ export async function handleCleanup(ctx: PluginContext) {
 					}
 				}
 
-				const ids = batch.items.map((item) => item.id);
+				const ids = eligible.map((item) => item.id);
 				if (ids.length > 0) {
 					await submissions(ctx).deleteMany(ids);
 					deletedCount += ids.length;
@@ -89,6 +94,45 @@ export async function handleCleanup(ctx: PluginContext) {
 
 		formsCursor = formsBatch.cursor;
 	} while (formsCursor);
+}
+
+function latestTimestamp(
+	destinations: DeliveryDestination[],
+	field: "deliveredAt" | "terminalAt",
+): Date | null {
+	const value = destinations
+		.map((destination) => destination[field])
+		.filter((timestamp): timestamp is string => timestamp !== null)
+		.toSorted()
+		.at(-1);
+	if (!value) return null;
+	const date = new Date(value);
+	return Number.isFinite(date.getTime()) ? date : null;
+}
+
+function canDeleteSubmission(submission: Submission, formCutoff: Date, now: Date): boolean {
+	if (!submission.delivery || !submission.deliveryStatus) {
+		return new Date(submission.createdAt) < formCutoff;
+	}
+
+	if (
+		submission.deliveryStatus === "pending" ||
+		submission.deliveryStatus === "processing" ||
+		submission.deliveryStatus === "retrying"
+	) {
+		return false;
+	}
+
+	if (submission.deliveryStatus === "delivered") {
+		const deliveredAt = latestTimestamp(submission.delivery.destinations, "deliveredAt");
+		return deliveredAt !== null && deliveredAt < formCutoff;
+	}
+
+	const terminalAt = latestTimestamp(submission.delivery.destinations, "terminalAt");
+	if (!terminalAt) return false;
+	const terminalCutoff = new Date(now);
+	terminalCutoff.setDate(terminalCutoff.getDate() - TERMINAL_DELIVERY_RETENTION_DAYS);
+	return terminalAt < formCutoff && terminalAt < terminalCutoff;
 }
 
 /**

--- a/packages/plugins/forms/src/handlers/cron.ts
+++ b/packages/plugins/forms/src/handlers/cron.ts
@@ -8,6 +8,7 @@
 import type { PluginContext, StorageCollection } from "emdash";
 
 import { formatDigestText } from "../format.js";
+export { handleDelivery } from "../outbox.js";
 import type { FormDefinition, Submission } from "../types.js";
 
 /** Typed access to plugin storage collections */

--- a/packages/plugins/forms/src/handlers/delivery.ts
+++ b/packages/plugins/forms/src/handlers/delivery.ts
@@ -101,9 +101,11 @@ export async function deliveryHealthHandler(ctx: RouteContext, now = new Date())
 	const freshness =
 		!heartbeat || !Number.isFinite(completedAtMs)
 			? "missing"
-			: now.getTime() - completedAtMs > DELIVERY_HEARTBEAT_STALE_MS
-				? "stale"
-				: "fresh";
+			: heartbeat.status === "failure"
+				? "failing"
+				: now.getTime() - completedAtMs > DELIVERY_HEARTBEAT_STALE_MS
+					? "stale"
+					: "fresh";
 
 	return {
 		heartbeatStatus: freshness,

--- a/packages/plugins/forms/src/handlers/delivery.ts
+++ b/packages/plugins/forms/src/handlers/delivery.ts
@@ -1,0 +1,117 @@
+import type { RouteContext, StorageCollection } from "emdash";
+import { PluginRouteError } from "emdash";
+
+import {
+	DELIVERY_HEARTBEAT_KEY,
+	DELIVERY_HEARTBEAT_STALE_MS,
+	summarizeDelivery,
+} from "../outbox.js";
+import type { ReceiptStatusInput } from "../schemas.js";
+import type { DeliveryDestination, DeliveryHeartbeat, Submission } from "../types.js";
+
+function submissions(ctx: RouteContext): StorageCollection<Submission> {
+	return ctx.storage.submissions as StorageCollection<Submission>;
+}
+
+function destinationStatus(destination: DeliveryDestination) {
+	return {
+		id: destination.id,
+		type: destination.type,
+		status: destination.status,
+		attempts: destination.attempts,
+		timestamps: {
+			createdAt: destination.createdAt,
+			updatedAt: destination.updatedAt,
+			nextAttemptAt: destination.nextAttemptAt,
+			claimedAt: destination.claimedAt,
+			attemptedAt: destination.attemptedAt,
+			deliveredAt: destination.deliveredAt,
+			terminalAt: destination.terminalAt,
+		},
+	};
+}
+
+export async function receiptStatusHandler(ctx: RouteContext<ReceiptStatusInput>) {
+	const result = await submissions(ctx).query({
+		where: { receiptId: ctx.input.receiptId },
+		limit: 1,
+	});
+	const submission = result.items[0]?.data;
+	if (!submission?.delivery || submission.receiptId !== ctx.input.receiptId) {
+		throw PluginRouteError.notFound("Receipt not found");
+	}
+
+	const destinations = submission.delivery.destinations.map(destinationStatus);
+	return {
+		receiptId: submission.receiptId,
+		status: submission.deliveryStatus ?? summarizeDelivery(submission.delivery).status,
+		attempts: destinations.reduce((total, destination) => total + destination.attempts, 0),
+		timestamps: {
+			createdAt: submission.createdAt,
+			updatedAt:
+				destinations
+					.map((destination) => destination.timestamps.updatedAt)
+					.toSorted()
+					.at(-1) ?? submission.createdAt,
+			nextAttemptAt: submission.deliveryNextAttemptAt ?? null,
+			deliveredAt:
+				destinations.length > 0 &&
+				destinations.every((destination) => destination.timestamps.deliveredAt !== null)
+					? destinations
+							.map((destination) => destination.timestamps.deliveredAt!)
+							.toSorted()
+							.at(-1)!
+					: null,
+			terminalAt:
+				destinations
+					.map((destination) => destination.timestamps.terminalAt)
+					.filter((value): value is string => value !== null)
+					.toSorted()
+					.at(-1) ?? null,
+		},
+		destinations,
+	};
+}
+
+function validHeartbeat(value: DeliveryHeartbeat | null): value is DeliveryHeartbeat {
+	return (
+		value?.version === 1 &&
+		(value.status === "success" || value.status === "failure") &&
+		typeof value.completedAt === "string" &&
+		(value.lastSuccessAt === null || typeof value.lastSuccessAt === "string")
+	);
+}
+
+export async function deliveryHealthHandler(ctx: RouteContext, now = new Date()) {
+	const [heartbeatValue, dueCount, terminalCount, oldestDue] = await Promise.all([
+		ctx.kv.get<DeliveryHeartbeat>(DELIVERY_HEARTBEAT_KEY),
+		submissions(ctx).count({
+			deliveryNextAttemptAt: { lte: now.toISOString() },
+		}),
+		submissions(ctx).count({ deliveryStatus: "terminal" }),
+		submissions(ctx).query({
+			where: { deliveryNextAttemptAt: { lte: now.toISOString() } },
+			orderBy: { deliveryNextAttemptAt: "asc" },
+			limit: 1,
+		}),
+	]);
+
+	const heartbeat = validHeartbeat(heartbeatValue) ? heartbeatValue : null;
+	const completedAtMs = heartbeat ? Date.parse(heartbeat.completedAt) : NaN;
+	const freshness =
+		!heartbeat || !Number.isFinite(completedAtMs)
+			? "missing"
+			: now.getTime() - completedAtMs > DELIVERY_HEARTBEAT_STALE_MS
+				? "stale"
+				: "fresh";
+
+	return {
+		heartbeatStatus: freshness,
+		dueCount,
+		terminalCount,
+		oldestDueAt: oldestDue.items[0]?.data.deliveryNextAttemptAt ?? null,
+		lastRunAt: heartbeat?.completedAt ?? null,
+		lastSuccessAt: heartbeat?.lastSuccessAt ?? null,
+		lastError: heartbeat?.status === "failure" ? "Delivery processor failed" : null,
+	};
+}

--- a/packages/plugins/forms/src/handlers/submit.ts
+++ b/packages/plugins/forms/src/handlers/submit.ts
@@ -9,7 +9,12 @@ import type { RouteContext, StorageCollection } from "emdash";
 import { PluginRouteError } from "emdash";
 import { ulid } from "ulidx";
 
-import { formatSubmissionText, formatWebhookPayload } from "../format.js";
+import {
+	createSubmissionDelivery,
+	DELIVERY_CRON_NAME,
+	DELIVERY_CRON_SCHEDULE,
+	summarizeDelivery,
+} from "../outbox.js";
 import type { SubmitInput } from "../schemas.js";
 import { verifyTurnstile } from "../turnstile.js";
 import type { FormDefinition, Submission, SubmissionFile } from "../types.js";
@@ -27,6 +32,8 @@ function submissions(ctx: RouteContext): StorageCollection<Submission> {
 
 export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 	const input = ctx.input;
+	const submissionId = ulid();
+	const receiptId = ulid();
 
 	// 1. Load form definition (by ID first, then by slug)
 	let formId = input.formId;
@@ -88,6 +95,8 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 			return {
 				success: true,
 				message: settings.confirmationMessage,
+				submissionId,
+				receiptId,
 			};
 		}
 	}
@@ -98,6 +107,27 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 
 	if (!result.valid) {
 		return { success: false, errors: result.errors };
+	}
+
+	// Existing active installations do not rerun plugin:activate on upgrade. Check
+	// the durable scheduler before any upload or submission write so a scheduling
+	// failure cannot leave an accepted submission without an outbox worker.
+	if (!ctx.cron) {
+		throw PluginRouteError.internal("Form delivery is temporarily unavailable");
+	}
+	try {
+		const tasks = await ctx.cron.list();
+		const deliveryTask = tasks.find((task) => task.name === DELIVERY_CRON_NAME);
+		if (!deliveryTask || deliveryTask.schedule !== DELIVERY_CRON_SCHEDULE) {
+			await ctx.cron.schedule(DELIVERY_CRON_NAME, {
+				schedule: DELIVERY_CRON_SCHEDULE,
+			});
+		}
+	} catch (error) {
+		ctx.log.error("Failed to ensure Forms delivery cron", {
+			error: String(error).slice(0, 500),
+		});
+		throw PluginRouteError.internal("Form delivery is temporarily unavailable");
 	}
 
 	// 4. Upload files
@@ -157,20 +187,33 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 	}
 
 	// 5. Store submission
-	const submissionId = ulid();
+	const createdAt = new Date().toISOString();
+	const delivery = createSubmissionDelivery({
+		form,
+		submissionId,
+		receiptId,
+		data: result.data,
+		files: files.length > 0 ? files : undefined,
+		createdAt,
+	});
+	const deliverySummary = summarizeDelivery(delivery);
 	const submission: Submission = {
 		formId,
 		data: result.data,
 		files: files.length > 0 ? files : undefined,
 		status: "new",
 		starred: false,
-		createdAt: new Date().toISOString(),
+		createdAt,
 		meta: {
 			ip: ctx.requestMeta.ip,
 			userAgent: ctx.requestMeta.userAgent,
 			referer: ctx.requestMeta.referer,
 			country: ctx.requestMeta.geo?.country ?? null,
 		},
+		delivery,
+		receiptId,
+		deliveryStatus: deliverySummary.status,
+		deliveryNextAttemptAt: deliverySummary.nextAttemptAt,
 	};
 
 	await submissions(ctx).put(submissionId, submission);
@@ -184,64 +227,13 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 		lastSubmissionAt: new Date().toISOString(),
 	});
 
-	// 7. Immediate email notifications (not digest)
-	if (settings.notifyEmails.length > 0 && !settings.digestEnabled && ctx.email) {
-		const text = formatSubmissionText(form, result.data, files);
-		for (const email of settings.notifyEmails) {
-			await ctx.email
-				.send({
-					to: email,
-					subject: `New submission: ${form.name}`,
-					text,
-				})
-				.catch((err: unknown) => {
-					ctx.log.error("Failed to send notification email", {
-						error: String(err),
-						to: email,
-					});
-				});
-		}
-	}
-
-	// 8. Autoresponder
-	if (settings.autoresponder && ctx.email) {
-		const emailField = allFields.find((f) => f.type === "email");
-		const submitterEmail = emailField ? result.data[emailField.name] : null;
-		if (typeof submitterEmail === "string" && submitterEmail) {
-			await ctx.email
-				.send({
-					to: submitterEmail,
-					subject: settings.autoresponder.subject,
-					text: settings.autoresponder.body,
-				})
-				.catch((err: unknown) => {
-					ctx.log.error("Failed to send autoresponder", { error: String(err) });
-				});
-		}
-	}
-
-	// 9. Webhook (fire and forget)
-	if (settings.webhookUrl && ctx.http) {
-		const payload = formatWebhookPayload(form, submissionId, result.data, files);
-		ctx.http
-			.fetch(settings.webhookUrl, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(payload),
-			})
-			.catch((err: unknown) => {
-				ctx.log.error("Webhook failed", {
-					error: String(err),
-					url: settings.webhookUrl,
-				});
-			});
-	}
-
-	// 10. Return success
+	// 7. Return after the complete delivery plan is durably stored with the submission.
 	return {
 		success: true,
 		message: settings.confirmationMessage,
 		redirect: settings.redirectUrl,
+		submissionId,
+		receiptId,
 	};
 }
 

--- a/packages/plugins/forms/src/handlers/submit.ts
+++ b/packages/plugins/forms/src/handlers/submit.ts
@@ -13,6 +13,7 @@ import {
 	createSubmissionDelivery,
 	DELIVERY_CRON_NAME,
 	DELIVERY_CRON_SCHEDULE,
+	handleDelivery,
 	summarizeDelivery,
 } from "../outbox.js";
 import type { SubmitInput } from "../schemas.js";
@@ -109,25 +110,24 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 		return { success: false, errors: result.errors };
 	}
 
-	// Existing active installations do not rerun plugin:activate on upgrade. Check
-	// the durable scheduler before any upload or submission write so a scheduling
-	// failure cannot leave an accepted submission without an outbox worker.
-	if (!ctx.cron) {
-		throw PluginRouteError.internal("Form delivery is temporarily unavailable");
-	}
-	try {
-		const tasks = await ctx.cron.list();
-		const deliveryTask = tasks.find((task) => task.name === DELIVERY_CRON_NAME);
-		if (!deliveryTask || deliveryTask.schedule !== DELIVERY_CRON_SCHEDULE) {
-			await ctx.cron.schedule(DELIVERY_CRON_NAME, {
-				schedule: DELIVERY_CRON_SCHEDULE,
+	// Existing active installations do not rerun plugin:activate on upgrade.
+	// Self-heal the durable scheduler when available; runtimes without cron use
+	// the same persisted outbox synchronously after the submission write.
+	if (ctx.cron) {
+		try {
+			const tasks = await ctx.cron.list();
+			const deliveryTask = tasks.find((task) => task.name === DELIVERY_CRON_NAME);
+			if (!deliveryTask || deliveryTask.schedule !== DELIVERY_CRON_SCHEDULE) {
+				await ctx.cron.schedule(DELIVERY_CRON_NAME, {
+					schedule: DELIVERY_CRON_SCHEDULE,
+				});
+			}
+		} catch (error) {
+			ctx.log.error("Failed to ensure Forms delivery cron", {
+				error: String(error).slice(0, 500),
 			});
+			throw PluginRouteError.internal("Form delivery is temporarily unavailable");
 		}
-	} catch (error) {
-		ctx.log.error("Failed to ensure Forms delivery cron", {
-			error: String(error).slice(0, 500),
-		});
-		throw PluginRouteError.internal("Form delivery is temporarily unavailable");
 	}
 
 	// 4. Upload files
@@ -226,6 +226,18 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 		submissionCount,
 		lastSubmissionAt: new Date().toISOString(),
 	});
+
+	if (!ctx.cron) {
+		try {
+			await handleDelivery(ctx, { retryFailures: false, submissionId });
+		} catch (error) {
+			ctx.log.error("Immediate Forms delivery processing failed", {
+				submissionId,
+				receiptId,
+				error: String(error).replaceAll(/\s+/g, " ").slice(0, 500),
+			});
+		}
+	}
 
 	// 7. Return after the complete delivery plan is durably stored with the submission.
 	return {

--- a/packages/plugins/forms/src/index.ts
+++ b/packages/plugins/forms/src/index.ts
@@ -22,7 +22,8 @@ import type { PluginDescriptor, ResolvedPlugin } from "emdash";
 import { definePlugin } from "emdash";
 
 import { version } from "../package.json";
-import { handleCleanup, handleDigest } from "./handlers/cron.js";
+import { handleCleanup, handleDelivery, handleDigest } from "./handlers/cron.js";
+import { deliveryHealthHandler, receiptStatusHandler } from "./handlers/delivery.js";
 import {
 	formsCreateHandler,
 	formsDeleteHandler,
@@ -38,6 +39,7 @@ import {
 	submissionUpdateHandler,
 } from "./handlers/submissions.js";
 import { definitionHandler, submitHandler } from "./handlers/submit.js";
+import { DELIVERY_CRON_NAME, DELIVERY_CRON_SCHEDULE } from "./outbox.js";
 import {
 	definitionSchema,
 	exportSchema,
@@ -48,6 +50,7 @@ import {
 	submissionDeleteSchema,
 	submissionGetSchema,
 	submissionsListSchema,
+	receiptStatusSchema,
 	submitSchema,
 	submissionUpdateSchema,
 } from "./schemas.js";
@@ -82,7 +85,17 @@ export function formsPlugin(
 		// Descriptor uses flat indexes only; composite indexes are in definePlugin
 		storage: {
 			forms: { indexes: ["status", "createdAt"], uniqueIndexes: ["slug"] },
-			submissions: { indexes: ["formId", "status", "starred", "createdAt"] },
+			submissions: {
+				indexes: [
+					"formId",
+					"status",
+					"starred",
+					"createdAt",
+					"receiptId",
+					"deliveryStatus",
+					"deliveryNextAttemptAt",
+				],
+			},
 		},
 	};
 }
@@ -104,6 +117,9 @@ export function createPlugin(_options: FormsPluginOptions = {}): ResolvedPlugin 
 					// Schedule weekly cleanup for expired submissions
 					if (ctx.cron) {
 						await ctx.cron.schedule("cleanup", { schedule: "@weekly" });
+						await ctx.cron.schedule(DELIVERY_CRON_NAME, {
+							schedule: DELIVERY_CRON_SCHEDULE,
+						});
 					}
 				},
 			},
@@ -112,6 +128,8 @@ export function createPlugin(_options: FormsPluginOptions = {}): ResolvedPlugin 
 				handler: async (event, ctx) => {
 					if (event.name === "cleanup") {
 						await handleCleanup(ctx);
+					} else if (event.name === DELIVERY_CRON_NAME) {
+						await handleDelivery(ctx);
 					} else if (event.name.startsWith("digest:")) {
 						const formId = event.name.slice("digest:".length);
 						await handleDigest(formId, ctx);
@@ -136,6 +154,19 @@ export function createPlugin(_options: FormsPluginOptions = {}): ResolvedPlugin 
 				public: true,
 				input: definitionSchema,
 				handler: definitionHandler as never,
+			},
+
+			"delivery/receipt": {
+				public: true,
+				cacheControl: "no-store",
+				input: receiptStatusSchema,
+				handler: receiptStatusHandler as never,
+			},
+
+			"delivery/health": {
+				public: true,
+				cacheControl: "no-store",
+				handler: deliveryHealthHandler,
 			},
 
 			// --- Admin routes (require auth) ---

--- a/packages/plugins/forms/src/outbox.ts
+++ b/packages/plugins/forms/src/outbox.ts
@@ -27,6 +27,9 @@ export const DELIVERY_HEARTBEAT_STALE_MS = 3 * 60 * 1000;
 
 interface DeliveryProcessorOptions {
 	now?: Date;
+	clock?: () => Date;
+	retryFailures?: boolean;
+	submissionId?: string;
 }
 
 function submissions(ctx: PluginContext): StorageCollection<Submission> {
@@ -36,6 +39,7 @@ function submissions(ctx: PluginContext): StorageCollection<Submission> {
 function destinationBase(id: string, now: string) {
 	return {
 		id,
+		idempotencyKey: id,
 		status: "pending" as const,
 		attempts: 0,
 		createdAt: now,
@@ -43,6 +47,7 @@ function destinationBase(id: string, now: string) {
 		nextAttemptAt: now,
 		claimedAt: null,
 		claimToken: null,
+		sideEffectStartedAt: null,
 		attemptedAt: null,
 		deliveredAt: null,
 		terminalAt: null,
@@ -163,7 +168,7 @@ async function recordHeartbeat(
 	ctx: PluginContext,
 	status: DeliveryHeartbeat["status"],
 	completedAt: string,
-	error: unknown | null,
+	error: unknown,
 ): Promise<void> {
 	const previous = await ctx.kv.get<DeliveryHeartbeat>(DELIVERY_HEARTBEAT_KEY);
 	const heartbeat: DeliveryHeartbeat = {
@@ -192,11 +197,12 @@ async function claimDestination(
 	submissionId: string,
 	destinationId: string,
 	ctx: PluginContext,
-	now: Date,
+	clock: () => Date,
 ): Promise<{ submission: Submission; destination: DeliveryDestination } | null> {
 	const collection = submissions(ctx);
 	const current = await collection.get(submissionId);
 	const destination = current ? findDestination(current, destinationId) : undefined;
+	const now = clock();
 	if (
 		!current?.delivery ||
 		!destination ||
@@ -205,6 +211,36 @@ async function claimDestination(
 		!destination.nextAttemptAt ||
 		destination.nextAttemptAt > now.toISOString()
 	) {
+		return null;
+	}
+
+	if (
+		destination.type !== "webhook" &&
+		destination.status === "processing" &&
+		destination.sideEffectStartedAt
+	) {
+		const timestamp = now.toISOString();
+		const interrupted: DeliveryDestination = {
+			...destination,
+			status: "terminal",
+			updatedAt: timestamp,
+			nextAttemptAt: null,
+			claimToken: null,
+			terminalAt: timestamp,
+			lastError: "Email delivery outcome is unknown after an interrupted provider call",
+		};
+		await collection.put(
+			submissionId,
+			withDeliverySummary({
+				...current,
+				delivery: {
+					...current.delivery,
+					destinations: current.delivery.destinations.map((item) =>
+						item.id === destinationId ? interrupted : item,
+					),
+				},
+			}),
+		);
 		return null;
 	}
 
@@ -233,11 +269,9 @@ async function claimDestination(
 
 	await collection.put(submissionId, updated);
 
-	// Plugin storage has no compare-and-set operation. Read-back verification plus the
-	// lease is the strongest cross-isolate claim available; concurrent isolates can
-	// still both deliver if their writes and reads interleave before either observes
-	// the other's token. Provider-side idempotency is therefore required for strict
-	// exactly-once effects.
+	// Plugin storage has no compare-and-set operation. The platform's atomic claim
+	// of the single named delivery cron task is the cross-isolate exclusion seam.
+	// This token remains a defensive lease for interrupted runs and direct callers.
 	const verified = await collection.get(submissionId);
 	const verifiedDestination = verified ? findDestination(verified, destinationId) : undefined;
 	if (!verified || verifiedDestination?.claimToken !== claimToken) {
@@ -245,6 +279,49 @@ async function claimDestination(
 	}
 
 	return { submission: verified, destination: verifiedDestination };
+}
+
+async function markEmailSideEffectStarted(
+	submissionId: string,
+	destinationId: string,
+	claimToken: string,
+	ctx: PluginContext,
+	clock: () => Date,
+): Promise<DeliveryDestination | null> {
+	const collection = submissions(ctx);
+	const current = await collection.get(submissionId);
+	const destination = current ? findDestination(current, destinationId) : undefined;
+	if (
+		!current?.delivery ||
+		!destination ||
+		destination.type === "webhook" ||
+		destination.claimToken !== claimToken
+	) {
+		return null;
+	}
+
+	const timestamp = clock().toISOString();
+	const marked: DeliveryDestination = {
+		...destination,
+		updatedAt: timestamp,
+		sideEffectStartedAt: timestamp,
+	};
+	await collection.put(submissionId, {
+		...current,
+		delivery: {
+			...current.delivery,
+			destinations: current.delivery.destinations.map((item) =>
+				item.id === destinationId ? marked : item,
+			),
+		},
+	});
+
+	const verified = await collection.get(submissionId);
+	const verifiedDestination = verified ? findDestination(verified, destinationId) : undefined;
+	return verifiedDestination?.claimToken === claimToken &&
+		verifiedDestination.sideEffectStartedAt === timestamp
+		? verifiedDestination
+		: null;
 }
 
 async function deliverDestination(
@@ -258,7 +335,7 @@ async function deliverDestination(
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"Idempotency-Key": destination.id,
+				"Idempotency-Key": destination.idempotencyKey ?? destination.id,
 				"X-EmDash-Submission-Id": String(destination.body.submissionId),
 				"X-EmDash-Receipt-Id": submission.delivery?.receiptId ?? "",
 			},
@@ -282,17 +359,23 @@ async function finishDestination(
 	submissionId: string,
 	destinationId: string,
 	claimToken: string,
-	error: unknown | null,
+	error: unknown,
 	ctx: PluginContext,
-	now: Date,
+	clock: () => Date,
+	retryFailures: boolean,
 ): Promise<void> {
 	const collection = submissions(ctx);
 	const current = await collection.get(submissionId);
 	const destination = current ? findDestination(current, destinationId) : undefined;
 	if (!current?.delivery || !destination || destination.claimToken !== claimToken) return;
 
+	const now = clock();
 	const timestamp = now.toISOString();
-	const terminal = error !== null && destination.attempts >= MAX_ATTEMPTS;
+	const ambiguousEmailFailure =
+		error !== null && destination.type !== "webhook" && destination.sideEffectStartedAt != null;
+	const terminal =
+		error !== null &&
+		(!retryFailures || ambiguousEmailFailure || destination.attempts >= MAX_ATTEMPTS);
 	const finished: DeliveryDestination =
 		error === null
 			? {
@@ -313,7 +396,9 @@ async function finishDestination(
 						: new Date(now.getTime() + nextBackoff(destination.attempts)).toISOString(),
 					claimToken: null,
 					terminalAt: terminal ? timestamp : null,
-					lastError: boundedError(error),
+					lastError: ambiguousEmailFailure
+						? "Email provider failed after dispatch began; delivery outcome is unknown"
+						: boundedError(error),
 				};
 
 	await collection.put(
@@ -334,17 +419,31 @@ async function processSubmission(
 	submissionId: string,
 	submission: Submission,
 	ctx: PluginContext,
-	now: Date,
+	clock: () => Date,
+	retryFailures: boolean,
 ): Promise<void> {
 	if (submission.delivery?.version !== DELIVERY_VERSION) return;
 
 	for (const destination of submission.delivery.destinations) {
-		const claim = await claimDestination(submissionId, destination.id, ctx, now);
+		const claim = await claimDestination(submissionId, destination.id, ctx, clock);
 		if (!claim) continue;
 
-		let error: unknown | null = null;
+		let error: unknown = null;
 		try {
-			await deliverDestination(claim.destination, claim.submission, ctx);
+			let deliveryDestination = claim.destination;
+			if (deliveryDestination.type !== "webhook") {
+				if (!ctx.email) throw new Error("Email delivery is not configured");
+				const marked = await markEmailSideEffectStarted(
+					submissionId,
+					destination.id,
+					claim.destination.claimToken!,
+					ctx,
+					clock,
+				);
+				if (!marked) continue;
+				deliveryDestination = marked;
+			}
+			await deliverDestination(deliveryDestination, claim.submission, ctx);
 		} catch (cause) {
 			error = cause;
 			ctx.log.error("Forms outbox delivery failed", {
@@ -361,15 +460,34 @@ async function processSubmission(
 			claim.destination.claimToken!,
 			error,
 			ctx,
-			now,
+			clock,
+			retryFailures,
 		);
 	}
 }
 
+// The platform atomically claims the single named delivery cron task across
+// isolates. This queue covers same-isolate/direct calls; no-cron submits target
+// only their newly persisted submission instead of running the global scanner.
 let deliveryRun: Promise<void> = Promise.resolve();
 
 async function runDelivery(ctx: PluginContext, options: DeliveryProcessorOptions): Promise<void> {
-	const now = options.now ?? new Date();
+	const clock = options.clock ?? (() => options.now ?? new Date());
+	const now = clock();
+	if (options.submissionId) {
+		const submission = await submissions(ctx).get(options.submissionId);
+		if (submission) {
+			await processSubmission(
+				options.submissionId,
+				submission,
+				ctx,
+				clock,
+				options.retryFailures ?? true,
+			);
+		}
+		return;
+	}
+
 	const batch = await submissions(ctx).query({
 		where: { deliveryNextAttemptAt: { lte: now.toISOString() } },
 		orderBy: { deliveryNextAttemptAt: "asc" },
@@ -377,7 +495,7 @@ async function runDelivery(ctx: PluginContext, options: DeliveryProcessorOptions
 	});
 
 	for (const item of batch.items) {
-		await processSubmission(item.id, item.data, ctx, now);
+		await processSubmission(item.id, item.data, ctx, clock, options.retryFailures ?? true);
 	}
 }
 
@@ -385,15 +503,19 @@ export function handleDelivery(
 	ctx: PluginContext,
 	options: DeliveryProcessorOptions = {},
 ): Promise<void> {
-	const now = options.now ?? new Date();
 	const run = deliveryRun.then(async () => {
+		const clock = options.clock ?? (() => options.now ?? new Date());
 		try {
-			await runDelivery(ctx, { now });
-			const completedAt = options.now ?? new Date();
+			await runDelivery(ctx, {
+				clock,
+				retryFailures: options.retryFailures,
+				submissionId: options.submissionId,
+			});
+			const completedAt = clock();
 			await recordHeartbeat(ctx, "success", completedAt.toISOString(), null);
 			return undefined;
 		} catch (error) {
-			const completedAt = options.now ?? new Date();
+			const completedAt = clock();
 			try {
 				await recordHeartbeat(ctx, "failure", completedAt.toISOString(), error);
 			} catch (heartbeatError) {

--- a/packages/plugins/forms/src/outbox.ts
+++ b/packages/plugins/forms/src/outbox.ts
@@ -1,0 +1,409 @@
+import type { PluginContext, StorageCollection } from "emdash";
+import { ulid } from "ulidx";
+
+import { formatSubmissionText, formatWebhookPayload } from "./format.js";
+import type {
+	DeliveryAggregateStatus,
+	DeliveryDestination,
+	DeliveryHeartbeat,
+	FormDefinition,
+	Submission,
+	SubmissionFile,
+	SubmissionDelivery,
+} from "./types.js";
+import { getFormFields } from "./types.js";
+
+const DELIVERY_VERSION = 1;
+const MAX_ATTEMPTS = 5;
+const MAX_ERROR_LENGTH = 500;
+const CLAIM_LEASE_MS = 5 * 60 * 1000;
+const BASE_BACKOFF_MS = 60 * 1000;
+const MAX_BACKOFF_MS = 60 * 60 * 1000;
+const DELIVERY_BATCH_SIZE = 100;
+export const DELIVERY_CRON_NAME = "delivery";
+export const DELIVERY_CRON_SCHEDULE = "* * * * *";
+export const DELIVERY_HEARTBEAT_KEY = "state:deliveryHeartbeat";
+export const DELIVERY_HEARTBEAT_STALE_MS = 3 * 60 * 1000;
+
+interface DeliveryProcessorOptions {
+	now?: Date;
+}
+
+function submissions(ctx: PluginContext): StorageCollection<Submission> {
+	return ctx.storage.submissions as StorageCollection<Submission>;
+}
+
+function destinationBase(id: string, now: string) {
+	return {
+		id,
+		status: "pending" as const,
+		attempts: 0,
+		createdAt: now,
+		updatedAt: now,
+		nextAttemptAt: now,
+		claimedAt: null,
+		claimToken: null,
+		attemptedAt: null,
+		deliveredAt: null,
+		terminalAt: null,
+		lastError: null,
+	};
+}
+
+export function createSubmissionDelivery(params: {
+	form: FormDefinition;
+	submissionId: string;
+	receiptId: string;
+	data: Record<string, unknown>;
+	files?: SubmissionFile[];
+	createdAt: string;
+}): SubmissionDelivery {
+	const { form, submissionId, receiptId, data, files, createdAt } = params;
+	const destinations: DeliveryDestination[] = [];
+	const notificationText = formatSubmissionText(form, data, files);
+
+	if (!form.settings.digestEnabled) {
+		for (const [index, email] of form.settings.notifyEmails.entries()) {
+			destinations.push({
+				...destinationBase(`${receiptId}:notification-email:${index}`, createdAt),
+				type: "notification-email",
+				to: email,
+				subject: `New submission: ${form.name}`,
+				text: notificationText,
+			});
+		}
+	}
+
+	if (form.settings.autoresponder) {
+		const emailField = getFormFields(form).find((field) => field.type === "email");
+		const submitterEmail = emailField ? data[emailField.name] : null;
+		if (typeof submitterEmail === "string" && submitterEmail) {
+			destinations.push({
+				...destinationBase(`${receiptId}:autoresponder-email`, createdAt),
+				type: "autoresponder-email",
+				to: submitterEmail,
+				subject: form.settings.autoresponder.subject,
+				text: form.settings.autoresponder.body,
+			});
+		}
+	}
+
+	if (form.settings.webhookUrl) {
+		destinations.push({
+			...destinationBase(`${receiptId}:webhook`, createdAt),
+			type: "webhook",
+			url: form.settings.webhookUrl,
+			body: {
+				...formatWebhookPayload(form, submissionId, data, files),
+				receiptId,
+			},
+		});
+	}
+
+	return {
+		version: DELIVERY_VERSION,
+		receiptId,
+		destinations,
+	};
+}
+
+export function summarizeDelivery(delivery: SubmissionDelivery): {
+	status: DeliveryAggregateStatus;
+	nextAttemptAt: string | null;
+} {
+	if (delivery.destinations.length === 0) {
+		return { status: "delivered", nextAttemptAt: null };
+	}
+
+	const active = delivery.destinations.filter(
+		(destination) => destination.status !== "delivered" && destination.status !== "terminal",
+	);
+	if (active.length === 0) {
+		return {
+			status: delivery.destinations.some((destination) => destination.status === "terminal")
+				? "terminal"
+				: "delivered",
+			nextAttemptAt: null,
+		};
+	}
+
+	const nextAttemptAt =
+		active
+			.map((destination) => destination.nextAttemptAt)
+			.filter((value): value is string => value !== null)
+			.toSorted()[0] ?? null;
+
+	const status: DeliveryAggregateStatus = active.some(
+		(destination) => destination.status === "processing",
+	)
+		? "processing"
+		: active.some((destination) => destination.status === "retrying")
+			? "retrying"
+			: "pending";
+
+	return { status, nextAttemptAt };
+}
+
+function withDeliverySummary(submission: Submission): Submission {
+	if (!submission.delivery) return submission;
+	const summary = summarizeDelivery(submission.delivery);
+	return {
+		...submission,
+		deliveryStatus: summary.status,
+		deliveryNextAttemptAt: summary.nextAttemptAt,
+	};
+}
+
+function boundedError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.replaceAll(/\s+/g, " ").slice(0, MAX_ERROR_LENGTH);
+}
+
+async function recordHeartbeat(
+	ctx: PluginContext,
+	status: DeliveryHeartbeat["status"],
+	completedAt: string,
+	error: unknown | null,
+): Promise<void> {
+	const previous = await ctx.kv.get<DeliveryHeartbeat>(DELIVERY_HEARTBEAT_KEY);
+	const heartbeat: DeliveryHeartbeat = {
+		version: 1,
+		status,
+		completedAt,
+		lastSuccessAt:
+			status === "success" ? completedAt : previous?.version === 1 ? previous.lastSuccessAt : null,
+		error: error === null ? null : boundedError(error),
+	};
+	await ctx.kv.set(DELIVERY_HEARTBEAT_KEY, heartbeat);
+}
+
+function nextBackoff(attempts: number): number {
+	return Math.min(BASE_BACKOFF_MS * 2 ** Math.max(0, attempts - 1), MAX_BACKOFF_MS);
+}
+
+function findDestination(
+	submission: Submission,
+	destinationId: string,
+): DeliveryDestination | undefined {
+	return submission.delivery?.destinations.find((destination) => destination.id === destinationId);
+}
+
+async function claimDestination(
+	submissionId: string,
+	destinationId: string,
+	ctx: PluginContext,
+	now: Date,
+): Promise<{ submission: Submission; destination: DeliveryDestination } | null> {
+	const collection = submissions(ctx);
+	const current = await collection.get(submissionId);
+	const destination = current ? findDestination(current, destinationId) : undefined;
+	if (
+		!current?.delivery ||
+		!destination ||
+		destination.status === "delivered" ||
+		destination.status === "terminal" ||
+		!destination.nextAttemptAt ||
+		destination.nextAttemptAt > now.toISOString()
+	) {
+		return null;
+	}
+
+	const claimToken = ulid();
+	const claimedAt = now.toISOString();
+	const leaseExpiresAt = new Date(now.getTime() + CLAIM_LEASE_MS).toISOString();
+	const claimed: DeliveryDestination = {
+		...destination,
+		status: "processing",
+		attempts: destination.attempts + 1,
+		updatedAt: claimedAt,
+		nextAttemptAt: leaseExpiresAt,
+		claimedAt,
+		claimToken,
+		attemptedAt: claimedAt,
+	};
+	const updated = withDeliverySummary({
+		...current,
+		delivery: {
+			...current.delivery,
+			destinations: current.delivery.destinations.map((item) =>
+				item.id === destinationId ? claimed : item,
+			),
+		},
+	});
+
+	await collection.put(submissionId, updated);
+
+	// Plugin storage has no compare-and-set operation. Read-back verification plus the
+	// lease is the strongest cross-isolate claim available; concurrent isolates can
+	// still both deliver if their writes and reads interleave before either observes
+	// the other's token. Provider-side idempotency is therefore required for strict
+	// exactly-once effects.
+	const verified = await collection.get(submissionId);
+	const verifiedDestination = verified ? findDestination(verified, destinationId) : undefined;
+	if (!verified || verifiedDestination?.claimToken !== claimToken) {
+		return null;
+	}
+
+	return { submission: verified, destination: verifiedDestination };
+}
+
+async function deliverDestination(
+	destination: DeliveryDestination,
+	submission: Submission,
+	ctx: PluginContext,
+): Promise<void> {
+	if (destination.type === "webhook") {
+		if (!ctx.http) throw new Error("HTTP delivery is not configured");
+		const response = await ctx.http.fetch(destination.url, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Idempotency-Key": destination.id,
+				"X-EmDash-Submission-Id": String(destination.body.submissionId),
+				"X-EmDash-Receipt-Id": submission.delivery?.receiptId ?? "",
+			},
+			body: JSON.stringify(destination.body),
+		});
+		if (!response.ok) {
+			throw new Error(`Webhook returned HTTP ${response.status}`);
+		}
+		return;
+	}
+
+	if (!ctx.email) throw new Error("Email delivery is not configured");
+	await ctx.email.send({
+		to: destination.to,
+		subject: destination.subject,
+		text: destination.text,
+	});
+}
+
+async function finishDestination(
+	submissionId: string,
+	destinationId: string,
+	claimToken: string,
+	error: unknown | null,
+	ctx: PluginContext,
+	now: Date,
+): Promise<void> {
+	const collection = submissions(ctx);
+	const current = await collection.get(submissionId);
+	const destination = current ? findDestination(current, destinationId) : undefined;
+	if (!current?.delivery || !destination || destination.claimToken !== claimToken) return;
+
+	const timestamp = now.toISOString();
+	const terminal = error !== null && destination.attempts >= MAX_ATTEMPTS;
+	const finished: DeliveryDestination =
+		error === null
+			? {
+					...destination,
+					status: "delivered",
+					updatedAt: timestamp,
+					nextAttemptAt: null,
+					claimToken: null,
+					deliveredAt: timestamp,
+					lastError: null,
+				}
+			: {
+					...destination,
+					status: terminal ? "terminal" : "retrying",
+					updatedAt: timestamp,
+					nextAttemptAt: terminal
+						? null
+						: new Date(now.getTime() + nextBackoff(destination.attempts)).toISOString(),
+					claimToken: null,
+					terminalAt: terminal ? timestamp : null,
+					lastError: boundedError(error),
+				};
+
+	await collection.put(
+		submissionId,
+		withDeliverySummary({
+			...current,
+			delivery: {
+				...current.delivery,
+				destinations: current.delivery.destinations.map((item) =>
+					item.id === destinationId ? finished : item,
+				),
+			},
+		}),
+	);
+}
+
+async function processSubmission(
+	submissionId: string,
+	submission: Submission,
+	ctx: PluginContext,
+	now: Date,
+): Promise<void> {
+	if (submission.delivery?.version !== DELIVERY_VERSION) return;
+
+	for (const destination of submission.delivery.destinations) {
+		const claim = await claimDestination(submissionId, destination.id, ctx, now);
+		if (!claim) continue;
+
+		let error: unknown | null = null;
+		try {
+			await deliverDestination(claim.destination, claim.submission, ctx);
+		} catch (cause) {
+			error = cause;
+			ctx.log.error("Forms outbox delivery failed", {
+				submissionId,
+				receiptId: claim.submission.delivery?.receiptId,
+				destinationId: destination.id,
+				error: boundedError(cause),
+			});
+		}
+
+		await finishDestination(
+			submissionId,
+			destination.id,
+			claim.destination.claimToken!,
+			error,
+			ctx,
+			now,
+		);
+	}
+}
+
+let deliveryRun: Promise<void> = Promise.resolve();
+
+async function runDelivery(ctx: PluginContext, options: DeliveryProcessorOptions): Promise<void> {
+	const now = options.now ?? new Date();
+	const batch = await submissions(ctx).query({
+		where: { deliveryNextAttemptAt: { lte: now.toISOString() } },
+		orderBy: { deliveryNextAttemptAt: "asc" },
+		limit: DELIVERY_BATCH_SIZE,
+	});
+
+	for (const item of batch.items) {
+		await processSubmission(item.id, item.data, ctx, now);
+	}
+}
+
+export function handleDelivery(
+	ctx: PluginContext,
+	options: DeliveryProcessorOptions = {},
+): Promise<void> {
+	const now = options.now ?? new Date();
+	const run = deliveryRun.then(async () => {
+		try {
+			await runDelivery(ctx, { now });
+			const completedAt = options.now ?? new Date();
+			await recordHeartbeat(ctx, "success", completedAt.toISOString(), null);
+			return undefined;
+		} catch (error) {
+			const completedAt = options.now ?? new Date();
+			try {
+				await recordHeartbeat(ctx, "failure", completedAt.toISOString(), error);
+			} catch (heartbeatError) {
+				ctx.log.error("Forms outbox heartbeat failed", {
+					error: boundedError(heartbeatError),
+				});
+			}
+			throw error;
+		}
+	});
+	deliveryRun = run.catch(() => {});
+	return run;
+}

--- a/packages/plugins/forms/src/schemas.ts
+++ b/packages/plugins/forms/src/schemas.ts
@@ -170,6 +170,10 @@ export const submitSchema = z.object({
 		.optional(),
 });
 
+export const receiptStatusSchema = z.object({
+	receiptId: z.string().min(1).max(128),
+});
+
 export const submissionsListSchema = z.object({
 	formId: z.string().min(1),
 	status: z.enum(["new", "read", "archived"]).optional(),
@@ -208,6 +212,7 @@ export type FormUpdateInput = z.infer<typeof formUpdateSchema>;
 export type FormDeleteInput = z.infer<typeof formDeleteSchema>;
 export type FormDuplicateInput = z.infer<typeof formDuplicateSchema>;
 export type SubmitInput = z.infer<typeof submitSchema>;
+export type ReceiptStatusInput = z.infer<typeof receiptStatusSchema>;
 export type SubmissionsListInput = z.infer<typeof submissionsListSchema>;
 export type SubmissionGetInput = z.infer<typeof submissionGetSchema>;
 export type SubmissionUpdateInput = z.infer<typeof submissionUpdateSchema>;

--- a/packages/plugins/forms/src/storage.ts
+++ b/packages/plugins/forms/src/storage.ts
@@ -19,6 +19,9 @@ export type FormsStorage = PluginStorageConfig & {
 			"createdAt",
 			["formId", "createdAt"],
 			["formId", "status"],
+			"receiptId",
+			"deliveryStatus",
+			"deliveryNextAttemptAt",
 		];
 	};
 };
@@ -36,6 +39,9 @@ export const FORMS_STORAGE_CONFIG = {
 			"createdAt",
 			["formId", "createdAt"],
 			["formId", "status"],
+			"receiptId",
+			"deliveryStatus",
+			"deliveryNextAttemptAt",
 		] as const,
 	},
 } satisfies PluginStorageConfig;

--- a/packages/plugins/forms/src/types.ts
+++ b/packages/plugins/forms/src/types.ts
@@ -152,6 +152,8 @@ export type DeliveryDestinationStatus =
 
 interface DeliveryDestinationBase {
 	id: string;
+	/** Stable key for provider or persisted side-effect deduplication. */
+	idempotencyKey?: string;
 	status: DeliveryDestinationStatus;
 	attempts: number;
 	createdAt: string;
@@ -159,6 +161,11 @@ interface DeliveryDestinationBase {
 	nextAttemptAt: string | null;
 	claimedAt: string | null;
 	claimToken: string | null;
+	/**
+	 * Persisted immediately before an email provider call. If the process exits
+	 * after this point, the outcome is terminal/unknown rather than retried.
+	 */
+	sideEffectStartedAt?: string | null;
 	attemptedAt: string | null;
 	deliveredAt: string | null;
 	terminalAt: string | null;

--- a/packages/plugins/forms/src/types.ts
+++ b/packages/plugins/forms/src/types.ts
@@ -128,6 +128,70 @@ export interface Submission {
 	notes?: string;
 	createdAt: string;
 	meta: SubmissionMeta;
+	/** Versioned delivery plan captured before the submit request returns. */
+	delivery?: SubmissionDelivery;
+	/** Denormalized fields used to find due outbox work through plugin storage indexes. */
+	receiptId?: string;
+	deliveryStatus?: DeliveryAggregateStatus;
+	deliveryNextAttemptAt?: string | null;
+}
+
+export type DeliveryAggregateStatus =
+	| "pending"
+	| "processing"
+	| "retrying"
+	| "delivered"
+	| "terminal";
+
+export type DeliveryDestinationStatus =
+	| "pending"
+	| "processing"
+	| "retrying"
+	| "delivered"
+	| "terminal";
+
+interface DeliveryDestinationBase {
+	id: string;
+	status: DeliveryDestinationStatus;
+	attempts: number;
+	createdAt: string;
+	updatedAt: string;
+	nextAttemptAt: string | null;
+	claimedAt: string | null;
+	claimToken: string | null;
+	attemptedAt: string | null;
+	deliveredAt: string | null;
+	terminalAt: string | null;
+	lastError: string | null;
+}
+
+export interface EmailDeliveryDestination extends DeliveryDestinationBase {
+	type: "notification-email" | "autoresponder-email";
+	to: string;
+	subject: string;
+	text: string;
+}
+
+export interface WebhookDeliveryDestination extends DeliveryDestinationBase {
+	type: "webhook";
+	url: string;
+	body: Record<string, unknown>;
+}
+
+export type DeliveryDestination = EmailDeliveryDestination | WebhookDeliveryDestination;
+
+export interface SubmissionDelivery {
+	version: 1;
+	receiptId: string;
+	destinations: DeliveryDestination[];
+}
+
+export interface DeliveryHeartbeat {
+	version: 1;
+	status: "success" | "failure";
+	completedAt: string;
+	lastSuccessAt: string | null;
+	error: string | null;
 }
 
 export interface SubmissionFile {

--- a/packages/plugins/forms/tests/client-submit-response.test.ts
+++ b/packages/plugins/forms/tests/client-submit-response.test.ts
@@ -10,9 +10,17 @@ describe("parseSubmitResponse", () => {
 					success: true,
 					message: "Thanks",
 					redirect: "/thanks",
+					submissionId: "submission-1",
+					receiptId: "receipt-1",
 				},
 			}),
-		).toEqual({ success: true, message: "Thanks", redirect: "/thanks" });
+		).toEqual({
+			success: true,
+			message: "Thanks",
+			redirect: "/thanks",
+			submissionId: "submission-1",
+			receiptId: "receipt-1",
+		});
 	});
 
 	it("keeps legacy top-level submit responses working", () => {

--- a/packages/plugins/forms/tests/delivery.test.ts
+++ b/packages/plugins/forms/tests/delivery.test.ts
@@ -261,12 +261,59 @@ describe("forms submission outbox", () => {
 			updatedAt: submission.createdAt,
 			nextAttemptAt: submission.createdAt,
 			claimedAt: null,
+			sideEffectStartedAt: null,
 			attemptedAt: null,
 			deliveredAt: null,
 			terminalAt: null,
 		});
 		expect(harness.send).not.toHaveBeenCalled();
 		expect(harness.fetch).not.toHaveBeenCalled();
+	});
+
+	it("delivers synchronously from the persisted outbox when cron is unavailable", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined }));
+		harness.fetch.mockResolvedValueOnce(new Response(null, { status: 503 }));
+		delete (harness.route as unknown as { cron?: unknown }).cron;
+		delete (harness.plugin as unknown as { cron?: unknown }).cron;
+
+		const response = await submitHandler(harness.route);
+		const [submissionId, persisted] = await onlySubmission(harness.submissions);
+		const submission = await harness.submissions.get(submissionId);
+
+		expect(response).toMatchObject({
+			success: true,
+			receiptId: persisted.receiptId,
+		});
+		expect(submission?.deliveryStatus).toBe("terminal");
+		expect(submission?.delivery?.destinations).toMatchObject([
+			{ type: "notification-email", status: "delivered" },
+			{ type: "webhook", status: "terminal", attempts: 1 },
+		]);
+		expect(harness.send).toHaveBeenCalledTimes(1);
+		expect(harness.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("limits the no-cron fallback to the submission created by that request", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined }));
+		await submitHandler(harness.route);
+		const [firstSubmissionId] = await onlySubmission(harness.submissions);
+		harness.send.mockClear();
+		harness.fetch.mockClear();
+		delete (harness.route as unknown as { cron?: unknown }).cron;
+		delete (harness.plugin as unknown as { cron?: unknown }).cron;
+		harness.route.input.data.email = "second@example.com";
+
+		const response = await submitHandler(harness.route);
+		if (!("receiptId" in response)) throw new Error("Expected a successful submission");
+		const first = await harness.submissions.get(firstSubmissionId);
+		const second = [...harness.submissions.records.values()].find(
+			(submission) => submission.receiptId === response.receiptId,
+		);
+
+		expect(first?.deliveryStatus).toBe("pending");
+		expect(second?.deliveryStatus).toBe("delivered");
+		expect(harness.send).toHaveBeenCalledTimes(1);
+		expect(harness.fetch).toHaveBeenCalledTimes(1);
 	});
 
 	it("self-heals an upgraded active plugin before acceptance without rescheduling every submit", async () => {
@@ -396,6 +443,134 @@ describe("forms submission outbox", () => {
 		expect(harness.send).toHaveBeenCalledTimes(1);
 		expect(harness.fetch).toHaveBeenCalledTimes(1);
 	});
+
+	it("delivers outbox rows created before dispatch idempotency fields existed", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined }));
+		await submitHandler(harness.route);
+		const [submissionId, submission] = await onlySubmission(harness.submissions);
+		for (const destination of submission.delivery!.destinations) {
+			delete destination.idempotencyKey;
+			delete destination.sideEffectStartedAt;
+		}
+		await harness.submissions.put(submissionId, submission);
+
+		await handleDelivery(harness.plugin, {
+			now: new Date("2090-01-01T00:00:00.000Z"),
+		});
+		const delivered = await harness.submissions.get(submissionId);
+
+		expect(delivered?.deliveryStatus).toBe("delivered");
+		expect(harness.fetch.mock.calls[0]![1]!.headers).toMatchObject({
+			"Idempotency-Key": expect.stringContaining(":webhook"),
+		});
+	});
+
+	it("serializes concurrent processor calls so an email side effect runs once", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined, webhookUrl: undefined }));
+		let releaseSend!: () => void;
+		harness.send.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					releaseSend = resolve;
+				}),
+		);
+		await submitHandler(harness.route);
+
+		const first = handleDelivery(harness.plugin, {
+			now: new Date("2090-01-01T00:00:00.000Z"),
+		});
+		const second = handleDelivery(harness.plugin, {
+			now: new Date("2090-01-01T00:00:00.000Z"),
+		});
+		await vi.waitFor(() => expect(harness.send).toHaveBeenCalledTimes(1));
+		releaseSend();
+		await Promise.all([first, second]);
+
+		expect(harness.send).toHaveBeenCalledTimes(1);
+	});
+
+	it("terminalizes an expired email lease after dispatch began instead of duplicating it", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined, webhookUrl: undefined }));
+		await submitHandler(harness.route);
+		const [submissionId, submission] = await onlySubmission(harness.submissions);
+		const destination = submission.delivery!.destinations[0]!;
+		submission.delivery!.destinations[0] = {
+			...destination,
+			status: "processing",
+			attempts: 1,
+			claimedAt: "2090-01-01T00:00:00.000Z",
+			claimToken: "abandoned",
+			sideEffectStartedAt: "2090-01-01T00:00:01.000Z",
+			attemptedAt: "2090-01-01T00:00:00.000Z",
+			nextAttemptAt: "2090-01-01T00:05:00.000Z",
+		};
+		submission.deliveryStatus = "processing";
+		submission.deliveryNextAttemptAt = "2090-01-01T00:05:00.000Z";
+		await harness.submissions.put(submissionId, submission);
+
+		await handleDelivery(harness.plugin, {
+			now: new Date("2090-01-01T00:06:00.000Z"),
+		});
+		const finished = await harness.submissions.get(submissionId);
+
+		expect(finished?.delivery?.destinations[0]).toMatchObject({
+			status: "terminal",
+			attempts: 1,
+			terminalAt: "2090-01-01T00:06:00.000Z",
+			lastError: expect.stringContaining("outcome is unknown"),
+		});
+		expect(finished?.deliveryStatus).toBe("terminal");
+		expect(harness.send).not.toHaveBeenCalled();
+	});
+
+	it("does not retry an ambiguous email provider failure", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined, webhookUrl: undefined }));
+		harness.send.mockRejectedValueOnce(new Error("provider timeout"));
+		await submitHandler(harness.route);
+		const [submissionId] = await onlySubmission(harness.submissions);
+
+		await handleDelivery(harness.plugin, {
+			now: new Date("2090-01-01T00:00:00.000Z"),
+		});
+		await handleDelivery(harness.plugin, {
+			now: new Date("2091-01-01T00:00:00.000Z"),
+		});
+		const submission = await harness.submissions.get(submissionId);
+
+		expect(submission?.delivery?.destinations[0]).toMatchObject({
+			status: "terminal",
+			attempts: 1,
+			sideEffectStartedAt: "2090-01-01T00:00:00.000Z",
+			lastError: expect.stringContaining("outcome is unknown"),
+		});
+		expect(harness.send).toHaveBeenCalledTimes(1);
+	});
+
+	it("timestamps a long-running attempt and retry from the actual operation times", async () => {
+		const harness = createHarness({
+			...makeForm({ notifyEmails: [], autoresponder: undefined }),
+		});
+		harness.fetch.mockResolvedValueOnce(new Response(null, { status: 503 }));
+		await submitHandler(harness.route);
+		const [submissionId] = await onlySubmission(harness.submissions);
+		const times = [
+			"2090-01-01T00:00:00.000Z",
+			"2090-01-01T00:00:01.000Z",
+			"2090-01-01T00:04:00.000Z",
+			"2090-01-01T00:04:01.000Z",
+		].map((value) => new Date(value));
+		const clock = () => times.shift() ?? new Date("2090-01-01T00:04:01.000Z");
+
+		await handleDelivery(harness.plugin, { clock });
+		const submission = await harness.submissions.get(submissionId);
+
+		expect(submission?.delivery?.destinations[0]).toMatchObject({
+			status: "retrying",
+			attemptedAt: "2090-01-01T00:00:01.000Z",
+			updatedAt: "2090-01-01T00:04:00.000Z",
+			nextAttemptAt: "2090-01-01T00:05:00.000Z",
+		});
+	});
 });
 
 describe("public delivery status", () => {
@@ -498,7 +673,7 @@ describe("public delivery health", () => {
 		const health = await deliveryHealthHandler(harness.route, now);
 		const serialized = JSON.stringify(health);
 		expect(health).toMatchObject({
-			heartbeatStatus: "fresh",
+			heartbeatStatus: "failing",
 			lastRunAt: now.toISOString(),
 			lastError: "Delivery processor failed",
 		});
@@ -548,5 +723,56 @@ describe("submission retention", () => {
 		expect(harness.submissions.records.has("expired")).toBe(false);
 		expect(harness.submissions.records.has("fresh")).toBe(true);
 		expect((await harness.forms.get("form-1"))?.submissionCount).toBe(1);
+	});
+
+	it("retains active delivery work and recent terminal receipts while deleting delivered work", async () => {
+		const form = makeForm({ retentionDays: 7, autoresponder: undefined });
+		const harness = createHarness(form);
+		await submitHandler(harness.route);
+		const [submissionId, pending] = await onlySubmission(harness.submissions);
+		const oldTimestamp = "2000-01-01T00:00:00.000Z";
+		const pendingDestination = pending.delivery!.destinations[0]!;
+		pending.createdAt = oldTimestamp;
+		pending.delivery!.destinations[0] = {
+			...pendingDestination,
+			createdAt: oldTimestamp,
+			updatedAt: oldTimestamp,
+			nextAttemptAt: oldTimestamp,
+		};
+		pending.deliveryNextAttemptAt = oldTimestamp;
+		await harness.submissions.put(submissionId, pending);
+
+		const terminal = structuredClone(pending);
+		const recentTerminalAt = new Date().toISOString();
+		terminal.receiptId = "terminal-receipt";
+		terminal.delivery!.receiptId = "terminal-receipt";
+		terminal.delivery!.destinations = terminal.delivery!.destinations.map((destination) => ({
+			...destination,
+			status: "terminal",
+			nextAttemptAt: null,
+			terminalAt: recentTerminalAt,
+		}));
+		terminal.deliveryStatus = "terminal";
+		terminal.deliveryNextAttemptAt = null;
+		await harness.submissions.put("terminal", terminal);
+
+		const delivered = structuredClone(pending);
+		delivered.receiptId = "delivered-receipt";
+		delivered.delivery!.receiptId = "delivered-receipt";
+		delivered.delivery!.destinations = delivered.delivery!.destinations.map((destination) => ({
+			...destination,
+			status: "delivered",
+			nextAttemptAt: null,
+			deliveredAt: oldTimestamp,
+		}));
+		delivered.deliveryStatus = "delivered";
+		delivered.deliveryNextAttemptAt = null;
+		await harness.submissions.put("delivered", delivered);
+
+		await handleCleanup(harness.plugin);
+
+		expect(harness.submissions.records.has(submissionId)).toBe(true);
+		expect(harness.submissions.records.has("terminal")).toBe(true);
+		expect(harness.submissions.records.has("delivered")).toBe(false);
 	});
 });

--- a/packages/plugins/forms/tests/delivery.test.ts
+++ b/packages/plugins/forms/tests/delivery.test.ts
@@ -1,0 +1,552 @@
+import type {
+	PluginContext,
+	QueryOptions,
+	RouteContext,
+	StorageCollection,
+	WhereValue,
+} from "emdash";
+import { describe, expect, it, vi } from "vitest";
+
+import { handleCleanup } from "../src/handlers/cron.js";
+import { deliveryHealthHandler, receiptStatusHandler } from "../src/handlers/delivery.js";
+import { submitHandler } from "../src/handlers/submit.js";
+import { createPlugin } from "../src/index.js";
+import {
+	DELIVERY_CRON_NAME,
+	DELIVERY_CRON_SCHEDULE,
+	DELIVERY_HEARTBEAT_KEY,
+} from "../src/outbox.js";
+import { handleDelivery } from "../src/outbox.js";
+import type { SubmitInput } from "../src/schemas.js";
+import type { DeliveryHeartbeat, FormDefinition, Submission } from "../src/types.js";
+
+class TestCollection<T> implements StorageCollection<T> {
+	readonly records = new Map<string, T>();
+	failNextQuery: Error | null = null;
+
+	async get(id: string): Promise<T | null> {
+		return this.records.get(id) ?? null;
+	}
+
+	async put(id: string, data: T): Promise<void> {
+		this.records.set(id, structuredClone(data));
+	}
+
+	async delete(id: string): Promise<boolean> {
+		return this.records.delete(id);
+	}
+
+	async exists(id: string): Promise<boolean> {
+		return this.records.has(id);
+	}
+
+	async getMany(ids: string[]): Promise<Map<string, T>> {
+		return new Map(
+			ids.flatMap((id) => (this.records.has(id) ? [[id, this.records.get(id)!]] : [])),
+		);
+	}
+
+	async putMany(items: Array<{ id: string; data: T }>): Promise<void> {
+		for (const item of items) await this.put(item.id, item.data);
+	}
+
+	async deleteMany(ids: string[]): Promise<number> {
+		let deleted = 0;
+		for (const id of ids) {
+			if (this.records.delete(id)) deleted++;
+		}
+		return deleted;
+	}
+
+	async query(options: QueryOptions = {}) {
+		if (this.failNextQuery) {
+			const error = this.failNextQuery;
+			this.failNextQuery = null;
+			throw error;
+		}
+		let items = Array.from(this.records, ([id, data]) => ({ id, data }));
+		if (options.where) {
+			items = items.filter(({ data }) =>
+				Object.entries(options.where!).every(([field, expected]) =>
+					matches((data as Record<string, unknown>)[field], expected),
+				),
+			);
+		}
+		if (options.orderBy) {
+			for (const [field, direction] of Object.entries(options.orderBy).toReversed()) {
+				items = items.toSorted((left, right) => {
+					const a = (left.data as Record<string, unknown>)[field];
+					const b = (right.data as Record<string, unknown>)[field];
+					return String(a).localeCompare(String(b)) * (direction === "asc" ? 1 : -1);
+				});
+			}
+		}
+		const limit = options.limit ?? 50;
+		return { items: items.slice(0, limit), hasMore: items.length > limit };
+	}
+
+	async count(where?: Record<string, WhereValue>): Promise<number> {
+		return (await this.query({ where, limit: 1000 })).items.length;
+	}
+}
+
+class TestKv {
+	readonly records = new Map<string, unknown>();
+
+	async get<T>(key: string): Promise<T | null> {
+		return (this.records.get(key) as T | undefined) ?? null;
+	}
+
+	async set(key: string, value: unknown): Promise<void> {
+		this.records.set(key, structuredClone(value));
+	}
+
+	async delete(key: string): Promise<boolean> {
+		return this.records.delete(key);
+	}
+
+	async list(prefix = "") {
+		return [...this.records]
+			.filter(([key]) => key.startsWith(prefix))
+			.map(([key, value]) => ({ key, value }));
+	}
+}
+
+function matches(actual: unknown, expected: WhereValue): boolean {
+	if (typeof expected !== "object" || expected === null) return actual === expected;
+	if ("in" in expected) return expected.in.includes(actual as string | number);
+	if ("startsWith" in expected) {
+		return typeof actual === "string" && actual.startsWith(expected.startsWith);
+	}
+	if (typeof actual !== "string" && typeof actual !== "number") return false;
+	if (expected.gt !== undefined && !(actual > expected.gt)) return false;
+	if (expected.gte !== undefined && !(actual >= expected.gte)) return false;
+	if (expected.lt !== undefined && !(actual < expected.lt)) return false;
+	if (expected.lte !== undefined && !(actual <= expected.lte)) return false;
+	return true;
+}
+
+function makeForm(overrides: Partial<FormDefinition["settings"]> = {}): FormDefinition {
+	return {
+		name: "Contact",
+		slug: "contact",
+		pages: [
+			{
+				fields: [
+					{
+						id: "email",
+						type: "email",
+						label: "Email",
+						name: "email",
+						required: true,
+						width: "full",
+					},
+				],
+			},
+		],
+		settings: {
+			confirmationMessage: "Thanks",
+			notifyEmails: ["owner@example.com"],
+			digestEnabled: false,
+			digestHour: 9,
+			autoresponder: { subject: "We got it", body: "Thank you" },
+			webhookUrl: "https://hooks.example.com/forms",
+			retentionDays: 0,
+			spamProtection: "none",
+			submitLabel: "Send",
+			...overrides,
+		},
+		status: "active",
+		submissionCount: 0,
+		lastSubmissionAt: null,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+function createHarness(form = makeForm()) {
+	const forms = new TestCollection<FormDefinition>();
+	const submissions = new TestCollection<Submission>();
+	const kv = new TestKv();
+	forms.records.set("form-1", form);
+	const send = vi.fn(async () => {});
+	const fetch = vi.fn(async () => new Response(null, { status: 204 }));
+	const log = {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	};
+	const cronTasks = new Map<
+		string,
+		{ name: string; schedule: string; nextRunAt: string; lastRunAt: string | null }
+	>();
+	const schedule = vi.fn(async (name: string, options: { schedule: string }) => {
+		cronTasks.set(name, {
+			name,
+			schedule: options.schedule,
+			nextRunAt: "2090-01-01T00:01:00.000Z",
+			lastRunAt: null,
+		});
+	});
+	const cron = {
+		schedule,
+		cancel: vi.fn(async (name: string) => {
+			cronTasks.delete(name);
+		}),
+		list: vi.fn(async () => [...cronTasks.values()]),
+	};
+	const shared = {
+		storage: { forms, submissions },
+		kv,
+		email: { send },
+		http: { fetch },
+		cron,
+		log,
+		site: { url: "https://example.com" },
+	};
+	const route = {
+		...shared,
+		input: { formId: "form-1", data: { email: "person@example.com" } },
+		requestMeta: {
+			ip: "203.0.113.1",
+			userAgent: "test",
+			referer: "https://example.com/contact",
+		},
+	} as unknown as RouteContext<SubmitInput>;
+
+	return {
+		forms,
+		submissions,
+		kv,
+		send,
+		fetch,
+		cron,
+		cronTasks,
+		log,
+		route,
+		plugin: shared as unknown as PluginContext,
+	};
+}
+
+async function onlySubmission(collection: TestCollection<Submission>) {
+	expect(collection.records.size).toBe(1);
+	return [...collection.records.entries()][0]!;
+}
+
+describe("forms submission outbox", () => {
+	it("persists a correlated delivery plan and returns both identifiers without request-time delivery", async () => {
+		const harness = createHarness();
+
+		const response = await submitHandler(harness.route);
+		const [submissionId, submission] = await onlySubmission(harness.submissions);
+
+		expect(response).toMatchObject({
+			success: true,
+			submissionId,
+			receiptId: submission.delivery?.receiptId,
+		});
+		expect(submission.delivery).toMatchObject({
+			version: 1,
+			destinations: [
+				{ type: "notification-email", status: "pending" },
+				{ type: "autoresponder-email", status: "pending" },
+				{ type: "webhook", status: "pending" },
+			],
+		});
+		expect(submission.deliveryStatus).toBe("pending");
+		expect(submission.deliveryNextAttemptAt).toBe(submission.createdAt);
+		expect(submission.delivery?.destinations[0]).toMatchObject({
+			createdAt: submission.createdAt,
+			updatedAt: submission.createdAt,
+			nextAttemptAt: submission.createdAt,
+			claimedAt: null,
+			attemptedAt: null,
+			deliveredAt: null,
+			terminalAt: null,
+		});
+		expect(harness.send).not.toHaveBeenCalled();
+		expect(harness.fetch).not.toHaveBeenCalled();
+	});
+
+	it("self-heals an upgraded active plugin before acceptance without rescheduling every submit", async () => {
+		const harness = createHarness();
+
+		await submitHandler(harness.route);
+		harness.route.input.data.email = "second@example.com";
+		await submitHandler(harness.route);
+
+		expect(harness.cron.schedule).toHaveBeenCalledTimes(1);
+		expect(harness.cron.schedule).toHaveBeenCalledWith(DELIVERY_CRON_NAME, {
+			schedule: DELIVERY_CRON_SCHEDULE,
+		});
+		expect(harness.submissions.records.size).toBe(2);
+	});
+
+	it("does not persist a submission when the upgrade cron cannot be scheduled", async () => {
+		const harness = createHarness();
+		harness.cron.schedule.mockRejectedValueOnce(new Error("scheduler unavailable"));
+
+		await expect(submitHandler(harness.route)).rejects.toMatchObject({
+			code: "INTERNAL_ERROR",
+			message: "Form delivery is temporarily unavailable",
+		});
+		expect(harness.submissions.records.size).toBe(0);
+		expect(harness.send).not.toHaveBeenCalled();
+		expect(harness.fetch).not.toHaveBeenCalled();
+	});
+
+	it("silently accepts honeypot submissions without storing or delivering them", async () => {
+		const harness = createHarness(makeForm({ spamProtection: "honeypot" }));
+		harness.route.input.data._hp = "filled";
+
+		const response = await submitHandler(harness.route);
+
+		expect(response).toMatchObject({
+			success: true,
+			submissionId: expect.any(String),
+			receiptId: expect.any(String),
+		});
+		expect(harness.submissions.records.size).toBe(0);
+		expect(harness.send).not.toHaveBeenCalled();
+		expect(harness.fetch).not.toHaveBeenCalled();
+	});
+
+	it("keeps successful destinations complete while retrying a partial failure", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined }));
+		harness.fetch.mockResolvedValueOnce(new Response(null, { status: 503 }));
+		await submitHandler(harness.route);
+		const [submissionId] = await onlySubmission(harness.submissions);
+
+		await handleDelivery(harness.plugin, { now: new Date("2090-01-01T00:00:00.000Z") });
+		let submission = await harness.submissions.get(submissionId);
+		expect(submission?.delivery?.destinations).toMatchObject([
+			{ type: "notification-email", status: "delivered", attempts: 1 },
+			{ type: "webhook", status: "retrying", attempts: 1 },
+		]);
+		expect(harness.send).toHaveBeenCalledTimes(1);
+		expect(harness.fetch).toHaveBeenCalledTimes(1);
+
+		await handleDelivery(harness.plugin, { now: new Date("2090-01-01T00:02:00.000Z") });
+		submission = await harness.submissions.get(submissionId);
+		expect(submission?.deliveryStatus).toBe("delivered");
+		expect(submission?.delivery?.destinations).toMatchObject([
+			{ status: "delivered", attempts: 1 },
+			{ status: "delivered", attempts: 2 },
+		]);
+		expect(harness.send).toHaveBeenCalledTimes(1);
+		expect(harness.fetch).toHaveBeenCalledTimes(2);
+
+		const webhookInit = harness.fetch.mock.calls[1]![1]!;
+		expect(webhookInit.headers).toMatchObject({
+			"Idempotency-Key": expect.stringContaining(":webhook"),
+			"X-EmDash-Submission-Id": submissionId,
+			"X-EmDash-Receipt-Id": submission?.delivery?.receiptId,
+		});
+	});
+
+	it("uses exponential retries, bounds errors, and stops permanently after five attempts", async () => {
+		const harness = createHarness({
+			...makeForm({ notifyEmails: [], autoresponder: undefined }),
+		});
+		harness.fetch.mockRejectedValue(new Error("x".repeat(800)));
+		await submitHandler(harness.route);
+		const [submissionId] = await onlySubmission(harness.submissions);
+
+		const attempts = [
+			"2090-01-01T00:00:00.000Z",
+			"2090-01-01T00:01:00.000Z",
+			"2090-01-01T00:03:00.000Z",
+			"2090-01-01T00:07:00.000Z",
+			"2090-01-01T00:15:00.000Z",
+		];
+		const retryTimes = attempts.slice(1);
+		for (const [index, now] of attempts.entries()) {
+			await handleDelivery(harness.plugin, { now: new Date(now) });
+			const current = await harness.submissions.get(submissionId);
+			if (index < retryTimes.length) {
+				expect(current?.delivery?.destinations[0]?.nextAttemptAt).toBe(retryTimes[index]);
+			}
+		}
+
+		const submission = await harness.submissions.get(submissionId);
+		const destination = submission?.delivery?.destinations[0];
+		expect(destination).toMatchObject({
+			status: "terminal",
+			attempts: 5,
+			nextAttemptAt: null,
+			terminalAt: attempts.at(-1),
+		});
+		expect(destination?.lastError).toHaveLength(500);
+		expect(submission?.deliveryStatus).toBe("terminal");
+		expect(submission?.deliveryNextAttemptAt).toBeNull();
+		expect(harness.fetch).toHaveBeenCalledTimes(5);
+
+		await handleDelivery(harness.plugin, { now: new Date("2091-01-01T00:00:00.000Z") });
+		expect(harness.fetch).toHaveBeenCalledTimes(5);
+	});
+
+	it("does not redeliver a completed outbox on later cron runs", async () => {
+		const harness = createHarness(makeForm({ autoresponder: undefined }));
+		await submitHandler(harness.route);
+
+		await handleDelivery(harness.plugin, { now: new Date("2090-01-01T00:00:00.000Z") });
+		await handleDelivery(harness.plugin, { now: new Date("2090-01-02T00:00:00.000Z") });
+
+		expect(harness.send).toHaveBeenCalledTimes(1);
+		expect(harness.fetch).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("public delivery status", () => {
+	it("returns a correlated status projection without payloads or destination PII", async () => {
+		const harness = createHarness();
+		const submitted = await submitHandler(harness.route);
+		if (!("receiptId" in submitted)) throw new Error("Expected a successful submission");
+
+		const status = await receiptStatusHandler({
+			...harness.route,
+			input: { receiptId: submitted.receiptId },
+		} as unknown as RouteContext<{ receiptId: string }>);
+		const serialized = JSON.stringify(status);
+
+		expect(status).toMatchObject({
+			receiptId: submitted.receiptId,
+			status: "pending",
+			attempts: 0,
+			destinations: [
+				{ type: "notification-email", status: "pending", attempts: 0 },
+				{ type: "autoresponder-email", status: "pending", attempts: 0 },
+				{ type: "webhook", status: "pending", attempts: 0 },
+			],
+		});
+		expect(serialized).not.toContain("owner@example.com");
+		expect(serialized).not.toContain("person@example.com");
+		expect(serialized).not.toContain("hooks.example.com");
+		expect(serialized).not.toContain("Thank you");
+		expect(serialized).not.toContain('"body"');
+		expect(serialized).not.toContain('"url"');
+		expect(serialized).not.toContain('"to"');
+	});
+
+	it("returns not found for an unknown receipt", async () => {
+		const harness = createHarness();
+
+		await expect(
+			receiptStatusHandler({
+				...harness.route,
+				input: { receiptId: "missing" },
+			} as unknown as RouteContext<{ receiptId: string }>),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+	});
+});
+
+describe("public delivery health", () => {
+	it("reports missing, fresh, and stale heartbeats with sanitized aggregate outbox counts", async () => {
+		const harness = createHarness();
+		await submitHandler(harness.route);
+		const [, dueSubmission] = await onlySubmission(harness.submissions);
+		harness.submissions.records.set("terminal", {
+			...structuredClone(dueSubmission),
+			receiptId: "terminal-receipt",
+			deliveryStatus: "terminal",
+			deliveryNextAttemptAt: null,
+		});
+		const now = new Date("2090-01-01T00:00:00.000Z");
+
+		let health = await deliveryHealthHandler(harness.route, now);
+		expect(health).toEqual({
+			heartbeatStatus: "missing",
+			dueCount: 1,
+			terminalCount: 1,
+			oldestDueAt: dueSubmission.deliveryNextAttemptAt,
+			lastRunAt: null,
+			lastSuccessAt: null,
+			lastError: null,
+		});
+
+		await handleDelivery(harness.plugin, { now });
+		health = await deliveryHealthHandler(harness.route, new Date("2090-01-01T00:01:00.000Z"));
+		expect(health).toMatchObject({
+			heartbeatStatus: "fresh",
+			lastRunAt: now.toISOString(),
+			lastSuccessAt: now.toISOString(),
+			lastError: null,
+		});
+
+		health = await deliveryHealthHandler(harness.route, new Date("2090-01-01T00:04:00.001Z"));
+		expect(health.heartbeatStatus).toBe("stale");
+	});
+
+	it("records processor failure while exposing only a bounded safe public error", async () => {
+		const harness = createHarness();
+		harness.submissions.failNextQuery = new Error(
+			"https://secret.example/hook owner@example.com " + "x".repeat(800),
+		);
+		const now = new Date("2090-01-01T00:00:00.000Z");
+
+		await expect(handleDelivery(harness.plugin, { now })).rejects.toThrow();
+		const heartbeat = await harness.kv.get<DeliveryHeartbeat>(DELIVERY_HEARTBEAT_KEY);
+		expect(heartbeat).toMatchObject({
+			version: 1,
+			status: "failure",
+			completedAt: now.toISOString(),
+			lastSuccessAt: null,
+		});
+		expect(heartbeat?.error?.length).toBeLessThanOrEqual(500);
+
+		const health = await deliveryHealthHandler(harness.route, now);
+		const serialized = JSON.stringify(health);
+		expect(health).toMatchObject({
+			heartbeatStatus: "fresh",
+			lastRunAt: now.toISOString(),
+			lastError: "Delivery processor failed",
+		});
+		expect(serialized).not.toContain("secret.example");
+		expect(serialized).not.toContain("owner@example.com");
+	});
+
+	it("registers both public delivery routes as no-store", () => {
+		const plugin = createPlugin() as unknown as {
+			routes: Record<string, { public?: boolean; cacheControl?: string }>;
+		};
+
+		expect(plugin.routes["delivery/receipt"]).toMatchObject({
+			public: true,
+			cacheControl: "no-store",
+		});
+		expect(plugin.routes["delivery/health"]).toMatchObject({
+			public: true,
+			cacheControl: "no-store",
+		});
+	});
+});
+
+describe("submission retention", () => {
+	it("deletes expired submissions while retaining fresh ones", async () => {
+		const form = makeForm({ retentionDays: 7 });
+		const harness = createHarness(form);
+		harness.submissions.records.set("expired", {
+			formId: "form-1",
+			data: {},
+			status: "new",
+			starred: false,
+			createdAt: "2000-01-01T00:00:00.000Z",
+			meta: { ip: null, userAgent: null, referer: null, country: null },
+		});
+		harness.submissions.records.set("fresh", {
+			formId: "form-1",
+			data: {},
+			status: "new",
+			starred: false,
+			createdAt: new Date().toISOString(),
+			meta: { ip: null, userAgent: null, referer: null, country: null },
+		});
+
+		await handleCleanup(harness.plugin);
+
+		expect(harness.submissions.records.has("expired")).toBe(false);
+		expect(harness.submissions.records.has("fresh")).toBe(true);
+		expect((await harness.forms.get("form-1"))?.submissionCount).toBe(1);
+	});
+});

--- a/packages/plugins/forms/tests/emdash-runtime.ts
+++ b/packages/plugins/forms/tests/emdash-runtime.ts
@@ -1,0 +1,29 @@
+export class PluginRouteError extends Error {
+	constructor(
+		readonly code: string,
+		message: string,
+		readonly status: number,
+	) {
+		super(message);
+	}
+
+	static notFound(message: string) {
+		return new PluginRouteError("NOT_FOUND", message, 404);
+	}
+
+	static forbidden(message: string) {
+		return new PluginRouteError("FORBIDDEN", message, 403);
+	}
+
+	static internal(message: string) {
+		return new PluginRouteError("INTERNAL_ERROR", message, 500);
+	}
+
+	static badRequest(message: string) {
+		return new PluginRouteError("BAD_REQUEST", message, 400);
+	}
+}
+
+export function definePlugin<T>(plugin: T): T {
+	return plugin;
+}

--- a/packages/plugins/forms/vitest.config.ts
+++ b/packages/plugins/forms/vitest.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	resolve: {
+		alias: [
+			{
+				find: /^emdash$/,
+				replacement: new URL("./tests/emdash-runtime.ts", import.meta.url).pathname,
+			},
+		],
+	},
 	test: {
 		globals: true,
 		environment: "node",


### PR DESCRIPTION
## What does this PR do?

Adds a durable Forms delivery outbox so persisted submissions have stable submission and receipt IDs, bounded delivery leases, retry/backoff state, terminal outcomes, and sanitized receipt/health readback. Email and webhook delivery use the same stored plan, while webhook requests carry a stable idempotency key. The plugin self-heals its delivery task for already-active installations before accepting a new submission.

EmDash plugin storage does not expose compare-and-set. Claims therefore use a durable lease, unique token, and read-back verification. The implementation documents the residual cross-isolate duplicate window; strict exactly-once effects still require provider-side idempotency.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- Forms tests: 39/39 passed.
- Forms package typecheck passed.
- Type-aware lint and formatting passed.
- Includes a minor changeset for `@emdash-cms/plugin-forms`.