### PR TITLE
fix(admin): use local time for schedule minimum

### DIFF
--- a/.changeset/local-schedule-minimum.md
+++ b/.changeset/local-schedule-minimum.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Use local wall time for the content scheduling minimum so operators outside UTC
+can schedule near-future content.

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -55,6 +55,11 @@ function formatScheduledDate(dateStr: string | null) {
 	return date.toLocaleString();
 }
 
+function formatDatetimeLocalValue(date: Date) {
+	const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+	return localDate.toISOString().slice(0, 16);
+}
+
 /**
  * Discard-draft confirmation shared by the settings action bar and the
  * distraction-free overlay, so the copy and behavior can't drift.
@@ -488,7 +493,7 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 												type="datetime-local"
 												value={scheduleDate}
 												onChange={(e) => setScheduleDate(e.target.value)}
-												min={new Date().toISOString().slice(0, 16)}
+												min={formatDatetimeLocalValue(new Date())}
 											/>
 											<div className="flex gap-2">
 												<Button

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent } from "@testing-library/react";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ContentEditorProps } from "../../src/components/ContentEditor";
 import {
@@ -120,6 +120,11 @@ describe("ContentSettingsPanel", () => {
 		vi.clearAllMocks();
 	});
 
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
 	it("renders all eight sections when every capability is enabled", async () => {
 		const screen = await render(<ContentSettingsPanel {...makePanelProps()} />);
 
@@ -224,6 +229,26 @@ describe("ContentSettingsPanel", () => {
 		});
 		expect(trashActions).not.toHaveClass("invisible", "pointer-events-none");
 		expect(trashActions).not.toHaveAttribute("aria-hidden");
+	});
+
+	it("accepts and submits a near-future local schedule in a negative UTC offset", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-23T16:00:00.000Z"));
+		vi.spyOn(Date.prototype, "getTimezoneOffset").mockReturnValue(240);
+		const onSchedule = vi.fn();
+		const screen = await render(
+			<ContentSettingsPanel {...makePanelProps({ canSchedule: true, onSchedule })} />,
+		);
+
+		await screen.getByRole("button", { name: "Schedule for later" }).click();
+		const scheduleInput = screen.getByLabelText("Schedule for");
+
+		await expect.element(scheduleInput).toHaveAttribute("min", "2026-07-23T12:00");
+		await scheduleInput.fill("2026-07-23T12:30");
+		expect((scheduleInput.element() as HTMLInputElement).checkValidity()).toBe(true);
+
+		await screen.getByRole("button", { name: "Schedule" }).click();
+		expect(onSchedule).toHaveBeenCalledWith(new Date("2026-07-23T12:30").toISOString());
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes the scheduling control's `datetime-local` minimum so it is generated from the operator's local wall time instead of UTC wall time. Operators in negative UTC offsets can schedule content in the near future, while submission still converts the selected local value to the correct ISO instant. A Toronto UTC-4 regression covers browser validity and submitted conversion.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- Focused `ContentSettingsPanel` tests: 19/19 passed.
- File-scoped type-aware lint and formatting passed.
- Package typecheck is currently blocked by an unrelated pre-existing `RegistryPluginDetail` implicit-any error outside this diff.
- Includes a patch changeset for `@emdash-cms/admin`.