### PR TITLE
fix(core): make snapshot generation dialect-aware so backups work on Postgres

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes backups and preview snapshots failing on PostgreSQL. Downloading a backup, running "Back up now", and the daily automatic backup all errored with `relation "sqlite_master" does not exist`, and the daily run failed silently — the Backups screen reported the feature as enabled and storage as available while producing no archives. Snapshot generation now uses dialect-aware table, column, and published-status queries, so it works on PostgreSQL as it already did on SQLite and D1.

--- a/packages/core/src/api/handlers/snapshot.ts
+++ b/packages/core/src/api/handlers/snapshot.ts
@@ -12,6 +12,11 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
+import {
+	buildStatusCondition,
+	listTableColumns,
+	listTablesLike,
+} from "../../database/dialect-helpers.js";
 import type { Database } from "../../database/types.js";
 
 // ─�� Preview signature verification ──────────────────────────────
@@ -211,12 +216,6 @@ function isExcluded(tableName: string): boolean {
 	return EXCLUDED_PREFIXES.some((prefix) => tableName.startsWith(prefix));
 }
 
-/** Column info from PRAGMA table_info */
-interface ColumnInfo {
-	name: string;
-	type: string;
-}
-
 export interface GenerateSnapshotOptions {
 	/** Include draft and scheduled content (default: false) */
 	includeDrafts?: boolean;
@@ -247,15 +246,9 @@ export async function generateSnapshot(
 	const includeTrashed = options?.includeTrashed ?? false;
 	const optionPrefixes = options?.optionPrefixes ?? SAFE_OPTIONS_PREFIXES;
 
-	// Discover all ec_* content tables
-	const tableResult = await sql<{ name: string }>`
-		SELECT name FROM sqlite_master
-		WHERE type = 'table'
-		AND name LIKE 'ec_%'
-		ORDER BY name
-	`.execute(db);
-
-	const contentTables = tableResult.rows.map((r) => r.name);
+	// Discover all ec_* content tables. Dialect-aware: sqlite_master does not
+	// exist on Postgres, where this threw 42P01 and failed every snapshot.
+	const contentTables = (await listTablesLike(db, "ec_%")).sort();
 
 	// Build list of all tables to export
 	const allTables = [...contentTables, ...SYSTEM_TABLES];
@@ -267,22 +260,21 @@ export async function generateSnapshot(
 		if (isExcluded(tableName)) continue;
 
 		// Validate identifier before interpolating into sql.raw().
-		// SYSTEM_TABLES are hardcoded and safe, but ec_* names come from
-		// sqlite_master and must be validated.
+		// SYSTEM_TABLES are hardcoded and safe, but ec_* names come from the
+		// database catalog and must be validated.
 		if (!SAFE_TABLE_NAME.test(tableName)) continue;
 
 		try {
-			// Get column info via PRAGMA
-			const pragmaResult = await sql<ColumnInfo>`
-				PRAGMA table_info(${sql.raw(`"${tableName}"`)})
-			`.execute(db);
+			// Column info, dialect-aware (PRAGMA table_info on SQLite,
+			// information_schema.columns on Postgres).
+			const columnInfo = await listTableColumns(db, tableName);
 
-			if (pragmaResult.rows.length === 0) continue;
+			if (columnInfo.length === 0) continue;
 
-			const columns = pragmaResult.rows.map((r) => r.name);
+			const columns = columnInfo.map((c) => c.name);
 			const types: Record<string, string> = {};
-			for (const row of pragmaResult.rows) {
-				types[row.name] = row.type || "TEXT";
+			for (const column of columnInfo) {
+				types[column.name] = column.type;
 			}
 
 			schema[tableName] = { columns, types };
@@ -307,12 +299,14 @@ export async function generateSnapshot(
 					`.execute(db)
 					).rows;
 				} else {
-					// Only export published content
+					// Only export published content. buildStatusCondition keeps the
+					// scheduled-and-due arm dialect-correct — the inline strftime()
+					// this replaced is SQLite-only and threw on Postgres.
 					rows = (
 						await sql<Record<string, unknown>>`
 						SELECT * FROM ${sql.raw(`"${tableName}"`)}
 						WHERE deleted_at IS NULL
-						AND (status = 'published' OR (status = 'scheduled' AND scheduled_at <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now')))
+						AND ${buildStatusCondition(db, "published")}
 					`.execute(db)
 					).rows;
 				}

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -175,6 +175,79 @@ export async function columnExists(
 	return result.rows.length > 0;
 }
 
+/** A table's columns, in declaration order, as reported by the dialect. */
+export interface TableColumnInfo {
+	name: string;
+	/** SQLite storage class — `TEXT`, `INTEGER`, `REAL`, `BLOB`, or `JSON`. */
+	type: string;
+}
+
+/**
+ * Map a Postgres `information_schema.columns.data_type` onto the SQLite storage
+ * class that best represents it.
+ *
+ * Snapshots are consumed by SQLite targets (the Durable Object preview
+ * database recreates every table with these types), so the type strings a
+ * snapshot carries are SQLite's, not the source dialect's. The consumer
+ * allowlists `TEXT`/`INTEGER`/`REAL`/`BLOB`/`JSON` and falls back to `TEXT`,
+ * so an unmapped type is safe — just lossy. Booleans map to `INTEGER` to match
+ * how EmDash stores them on SQLite.
+ */
+function postgresTypeToSqliteStorageClass(dataType: string): string {
+	switch (dataType) {
+		case "smallint":
+		case "integer":
+		case "bigint":
+		case "boolean":
+			return "INTEGER";
+		case "real":
+		case "double precision":
+		case "numeric":
+			return "REAL";
+		case "bytea":
+			return "BLOB";
+		case "json":
+		case "jsonb":
+			return "JSON";
+		default:
+			return "TEXT";
+	}
+}
+
+/**
+ * List a table's columns in declaration order.
+ *
+ * sqlite:   PRAGMA table_info("table")
+ * postgres: information_schema.columns, ordered by ordinal_position
+ *
+ * Returns an empty array for a table that does not exist, on both dialects.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export async function listTableColumns(
+	db: Kysely<any>,
+	tableName: string,
+): Promise<TableColumnInfo[]> {
+	if (isPostgres(db)) {
+		// Scoped to the connection's active schema for the same reason as
+		// listTablesLike — per-tenant and per-test schemas must not read the
+		// wrong table's columns.
+		const result = await sql<{ column_name: string; data_type: string }>`
+			SELECT column_name, data_type FROM information_schema.columns
+			WHERE table_schema = current_schema() AND table_name = ${tableName}
+			ORDER BY ordinal_position
+		`.execute(db);
+		return result.rows.map((r) => ({
+			name: r.column_name,
+			type: postgresTypeToSqliteStorageClass(r.data_type),
+		}));
+	}
+
+	const result = await sql<{ name: string; type: string }>`
+		SELECT name, type FROM pragma_table_info(${tableName})
+	`.execute(db);
+	return result.rows.map((r) => ({ name: r.name, type: r.type || "TEXT" }));
+}
+
 /**
  * List tables matching a LIKE pattern.
  */

--- a/packages/core/tests/integration/database/list-table-columns.test.ts
+++ b/packages/core/tests/integration/database/list-table-columns.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { listTableColumns } from "../../../src/database/dialect-helpers.js";
+import {
+	type DialectTestContext,
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+} from "../../utils/test-db.js";
+
+// `listTableColumns` replaces a bare `PRAGMA table_info(...)`, which does not
+// exist on Postgres. The types it reports are SQLite storage classes on both
+// dialects, because snapshot consumers recreate tables in SQLite from them.
+describeEachDialect("listTableColumns", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("lists a content table's columns in declaration order", async () => {
+		const columns = await listTableColumns(ctx.db, "ec_page");
+		const names = columns.map((c) => c.name);
+
+		expect(names[0]).toBe("id");
+		expect(names).toEqual(expect.arrayContaining(["slug", "status", "version", "title"]));
+	});
+
+	it("reports SQLite storage classes on both dialects", async () => {
+		const columns = await listTableColumns(ctx.db, "ec_page");
+
+		// Postgres data_type strings (`character varying`, `timestamp with time
+		// zone`, ...) must be mapped, not passed through: snapshot consumers
+		// allowlist exactly these and silently fall back to TEXT otherwise.
+		for (const column of columns) {
+			expect(["TEXT", "INTEGER", "REAL", "BLOB", "JSON"]).toContain(column.type);
+		}
+	});
+
+	it("maps an integer column to INTEGER on both dialects", async () => {
+		const columns = await listTableColumns(ctx.db, "ec_page");
+		const version = columns.find((c) => c.name === "version");
+
+		expect(version?.type).toBe("INTEGER");
+	});
+
+	it("returns an empty list for a table that does not exist", async () => {
+		expect(await listTableColumns(ctx.db, "ec_nonexistent")).toEqual([]);
+	});
+});

--- a/packages/core/tests/integration/snapshot/snapshot-dialect.test.ts
+++ b/packages/core/tests/integration/snapshot/snapshot-dialect.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { generateSnapshot } from "../../../src/api/handlers/snapshot.js";
+import {
+	type DialectTestContext,
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+} from "../../utils/test-db.js";
+
+// Regression: generateSnapshot discovered tables with `sqlite_master`, read
+// columns with `PRAGMA table_info`, and filtered published rows with
+// `strftime(...)` — all SQLite-only. On Postgres every one of them raised
+// 42P01 / 42883, so backups (download, "Back up now", and the daily scheduled
+// run) and the preview snapshot endpoint all failed. The Postgres variants of
+// these tests fail against the pre-fix implementation.
+describeEachDialect("generateSnapshot dialect parity", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("discovers content tables and their schema", async () => {
+		const snapshot = await generateSnapshot(ctx.db);
+
+		expect(snapshot.generatedAt).toBeTruthy();
+		expect(snapshot.schema).toHaveProperty("ec_post");
+		expect(snapshot.schema).toHaveProperty("ec_page");
+		expect(snapshot.schema.ec_post.columns).toContain("id");
+		expect(snapshot.schema.ec_post.columns).toContain("title");
+	});
+
+	it("reports column types the snapshot consumer understands", async () => {
+		const snapshot = await generateSnapshot(ctx.db);
+		const types = snapshot.schema.ec_post.types ?? {};
+
+		expect(Object.keys(types).length).toBeGreaterThan(0);
+		for (const type of Object.values(types)) {
+			expect(["TEXT", "INTEGER", "REAL", "BLOB", "JSON"]).toContain(type);
+		}
+	});
+
+	it("applies the published filter without SQLite-only date functions", async () => {
+		// The default (no drafts, no trash) path is the one the preview
+		// endpoint uses, and the only one that evaluates the status filter.
+		const snapshot = await generateSnapshot(ctx.db);
+
+		expect(snapshot.tables.ec_post).toEqual([]);
+	});
+
+	it("exports a full-fidelity backup snapshot", async () => {
+		// includeTrashed is what the backup handlers pass.
+		const snapshot = await generateSnapshot(ctx.db, {
+			includeDrafts: true,
+			includeTrashed: true,
+		});
+
+		expect(snapshot.schema).toHaveProperty("ec_post");
+		expect(snapshot.tables._emdash_collections).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`generateSnapshot()` reaches for three SQLite-only constructs with no dialect branch, so every snapshot-backed feature fails on PostgreSQL:

| Line | Construct | Postgres result |
| --- | --- | --- |
| `snapshot.ts:250` | `SELECT name FROM sqlite_master ... LIKE 'ec_%'` | `42P01` |
| `snapshot.ts:275` | `PRAGMA table_info("<table>")` | `42601` |
| `snapshot.ts:303` | `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` | `42883` |

Only the first appears in a traceback, because it fails first — the other two are on the same path behind it. Together they take out **Settings → Backups** (Download backup, Back up now, and the daily scheduled run) and **`/_emdash/api/snapshot`** (the preview-mode export). The `strftime` one is in the default no-drafts/no-trash branch, which is exactly the path preview uses, so this is not only a backups bug.

The scheduled path is the one worth fixing carefully: saving the settings succeeds and `GET /_emdash/api/settings/backups` keeps returning `{"enabled":true,"retention":30,...,"storageAvailable":true}`, so the admin presents daily backups as armed while every tick throws and the archive list stays empty. An operator on Postgres gets no signal that they have no backups.

**What changed.** Table discovery and the status filter now go through the helpers that already exist for exactly this — `listTablesLike` and `buildStatusCondition`. Column discovery had no equivalent, so this adds **`listTableColumns`** next to them in `dialect-helpers.ts`.

`listTableColumns` returns **SQLite storage classes on both dialects**, not the raw `information_schema.data_type`. That is the one design decision here worth reviewing: snapshots are consumed by SQLite targets — `EmDashPreviewDB.applySnapshot` recreates every table from these strings — and that consumer allowlists `TEXT`/`INTEGER`/`REAL`/`BLOB`/`JSON`, silently falling back to `TEXT`. Passing Postgres type names straight through would "work" while being lossy: `integer` happens to survive, but `bigint`, `boolean`, `jsonb` and `double precision` would all land as `TEXT`. The Postgres branch maps them explicitly instead. If you'd rather that mapping lived in the consumer, say so and I'll move it.

One behavioural detail preserved: `listTablesLike` has no `ORDER BY`, so the call site sorts in JS to keep the previous deterministic table order.

Closes #2233

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — **not run locally, see note below**
- [ ] `pnpm lint` passes — **not run locally, see note below**
- [ ] `pnpm test` passes (or targeted tests for my change) — **not run locally, see note below**
- [ ] `pnpm format` has been run — **not run locally, see note below**
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion — n/a, bug fix

**On the four unchecked boxes:** I could not run `pnpm install` / `build` / `typecheck` / `lint` / `test` locally. The machine that has the PostgreSQL deployment is disk-constrained (~2.6 GB free, and the monorepo install pulls Playwright browsers), so I verified the runtime behaviour there instead — see below — and wrote the tests to the conventions in `AGENTS.md` and the neighbouring `list-tables-like.test.ts` without executing them. I'd rather say that plainly than tick boxes I didn't earn. Please treat CI as the authority on the test files specifically; I'm happy to fix anything it flags.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 5** (Claude Code)

## Screenshots / test output

**End-to-end verification on a real deployment.** I applied these three changes to the built `0.31.1` server on a live Node + PostgreSQL 16 instance (Astro 6.4.8, `@astrojs/node`, ~30 `_emdash_*`/`ec_*` tables at migration `053`, R2 storage) and ran it on an isolated port against the production database:

```
BEFORE  GET /_emdash/api/settings/backups/export  -> 500 BACKUP_EXPORT_ERROR
AFTER   GET /_emdash/api/settings/backups/export  -> 200, 9,178,151 bytes
```

The resulting archive is well-formed:

```
format: emdash-backup v1 | emdash 0.31.1
tables exported: 18 | schema entries: 19
ec_* row counts: {'ec_events': 10, 'ec_pages': 210, 'ec_posts': 286, 'ec_publications': 108}
system tables:   {'revisions': 874, 'content_taxonomies': 614, '_emdash_menu_items': 114, ...}
ec_pages: 32 columns | type histogram: {'TEXT': 29, 'JSON': 2, 'INTEGER': 1} | version -> INTEGER
option keys: 6 | unsafe keys leaked: none
```

That last line is the `SAFE_OPTIONS_PREFIXES` allowlist still holding — no `plugin:`, `*secret*`, or `passkey_pending:` keys in the export.

**Tests added.** Two files using `describeEachDialect`, so they run against SQLite and against a real Postgres connection; their Postgres variants fail against the pre-fix implementation:

- `tests/integration/database/list-table-columns.test.ts` — declaration ordering, the storage-class invariant, integer mapping, and the missing-table case
- `tests/integration/snapshot/snapshot-dialect.test.ts` — `generateSnapshot` across both dialects, covering the default (preview) path that evaluates the status filter and the `includeTrashed` path the backup handlers use
