### PR TITLE
fix(admin): keep content list view state in the URL

### DIFF
--- a/.changeset/content-list-view-state-in-url.md
+++ b/.changeset/content-list-view-state-in-url.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Keeps the content list's page, search, filters and sort in the URL, so opening an entry and pressing the browser's back button returns to the view you left instead of an unfiltered page 1. List views are now shareable and bookmarkable.

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -211,7 +211,15 @@ export function ContentList({
 	const [searchQuery, setSearchQuery] = React.useState(controlledSearchQuery);
 	const [internalPage, setInternalPage] = React.useState(0);
 	const page = controlledPage ?? internalPage;
-	const setPage = onPageChange ?? setInternalPage;
+	const requestedPage = React.useRef(controlledPage);
+	const setPage = React.useCallback(
+		(next: number) => {
+			requestedPage.current = next;
+			if (onPageChange) onPageChange(next);
+			else setInternalPage(next);
+		},
+		[onPageChange],
+	);
 	const [selectedIds, setSelectedIds] = React.useState<Set<string>>(() => new Set());
 
 	// Bulk selection is opt-in: the checkbox column + toolbar only render when
@@ -238,6 +246,16 @@ export function ContentList({
 		reportedQuery.current = controlledSearchQuery;
 		setSearchQuery(controlledSearchQuery);
 	}, [controlledSearchQuery]);
+
+	// A page the caller moved on its own (back/forward, a deep link) replaces
+	// the view wholesale, so an edit still waiting out the debounce belongs to
+	// a view that is gone. Re-seeding the input drops the pending timer with it.
+	React.useEffect(() => {
+		if (controlledPage === undefined || controlledPage === requestedPage.current) return;
+		requestedPage.current = controlledPage;
+		reportedQuery.current = controlledSearchQuery;
+		setSearchQuery(controlledSearchQuery);
+	}, [controlledPage, controlledSearchQuery]);
 
 	// Reset page when search changes. Guarded because `setPage` may write to
 	// the URL, and an unconditional reset would push a history entry per

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -92,6 +92,20 @@ export interface ContentListProps {
 	sort?: ContentListSort;
 	onSortChange?: (sort: ContentListSort) => void;
 	/**
+	 * Controlled pagination (0-based). Pass both to hold the current page
+	 * outside the component — the router keeps it in the URL so the browser's
+	 * back button returns to the page the user left. Without `onPageChange`
+	 * the component keeps its own page state and the pager still works.
+	 */
+	page?: number;
+	onPageChange?: (page: number) => void;
+	/**
+	 * Seeds the search box on mount, for callers that restore the query from
+	 * somewhere durable (the URL). The input stays internally controlled after
+	 * that, so typing isn't lagged by the debounce round-trip.
+	 */
+	initialSearchQuery?: string;
+	/**
 	 * Total rows matching the current filters (ignoring pagination). When
 	 * set, the pagination denominator reflects this stable count instead of
 	 * growing as more API pages are fetched.
@@ -175,6 +189,9 @@ export function ContentList({
 	urlPattern,
 	sort,
 	onSortChange,
+	page: controlledPage,
+	onPageChange,
+	initialSearchQuery = "",
 	total,
 	onSearchChange,
 	statusFilter = "all",
@@ -190,8 +207,10 @@ export function ContentList({
 }: ContentListProps) {
 	const { t } = useLingui();
 	const [activeTab, setActiveTab] = React.useState<ViewTab>("all");
-	const [searchQuery, setSearchQuery] = React.useState("");
-	const [page, setPage] = React.useState(0);
+	const [searchQuery, setSearchQuery] = React.useState(initialSearchQuery);
+	const [internalPage, setInternalPage] = React.useState(0);
+	const page = controlledPage ?? internalPage;
+	const setPage = onPageChange ?? setInternalPage;
 	const [selectedIds, setSelectedIds] = React.useState<Set<string>>(() => new Set());
 
 	// Bulk selection is opt-in: the checkbox column + toolbar only render when
@@ -208,10 +227,12 @@ export function ContentList({
 		if (onSearchChange) onSearchChange(debouncedSearch.trim());
 	}, [debouncedSearch, onSearchChange]);
 
-	// Reset page when search changes
+	// Reset page when search changes. Guarded because `setPage` may write to
+	// the URL, and an unconditional reset would push a history entry per
+	// keystroke.
 	const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setSearchQuery(e.target.value);
-		setPage(0);
+		if (page !== 0) setPage(0);
 	};
 
 	const filteredItems = React.useMemo(() => {

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -100,11 +100,12 @@ export interface ContentListProps {
 	page?: number;
 	onPageChange?: (page: number) => void;
 	/**
-	 * Seeds the search box on mount, for callers that restore the query from
-	 * somewhere durable (the URL). The input stays internally controlled after
-	 * that, so typing isn't lagged by the debounce round-trip.
+	 * The search term the caller holds (the URL, typically). The input keeps
+	 * its own state while typing so keystrokes aren't lagged by the debounce
+	 * round-trip, and re-syncs whenever this changes on its own — a deep link
+	 * or a back-navigation to a different query.
 	 */
-	initialSearchQuery?: string;
+	searchQuery?: string;
 	/**
 	 * Total rows matching the current filters (ignoring pagination). When
 	 * set, the pagination denominator reflects this stable count instead of
@@ -191,7 +192,7 @@ export function ContentList({
 	onSortChange,
 	page: controlledPage,
 	onPageChange,
-	initialSearchQuery = "",
+	searchQuery: controlledSearchQuery = "",
 	total,
 	onSearchChange,
 	statusFilter = "all",
@@ -207,7 +208,7 @@ export function ContentList({
 }: ContentListProps) {
 	const { t } = useLingui();
 	const [activeTab, setActiveTab] = React.useState<ViewTab>("all");
-	const [searchQuery, setSearchQuery] = React.useState(initialSearchQuery);
+	const [searchQuery, setSearchQuery] = React.useState(controlledSearchQuery);
 	const [internalPage, setInternalPage] = React.useState(0);
 	const page = controlledPage ?? internalPage;
 	const setPage = onPageChange ?? setInternalPage;
@@ -223,9 +224,20 @@ export function ContentList({
 	// loaded page" bug for non-title columns).
 	const serverSearch = !!onSearchChange;
 	const debouncedSearch = useDebouncedValue(searchQuery, 300);
+	const reportedQuery = React.useRef(controlledSearchQuery);
 	React.useEffect(() => {
-		if (onSearchChange) onSearchChange(debouncedSearch.trim());
+		reportedQuery.current = debouncedSearch.trim();
+		if (onSearchChange) onSearchChange(reportedQuery.current);
 	}, [debouncedSearch, onSearchChange]);
+
+	// Adopt a query the caller changed on its own. Comparing against what we
+	// last reported keeps the caller's echo of our own term from resetting the
+	// input mid-word.
+	React.useEffect(() => {
+		if (controlledSearchQuery === reportedQuery.current) return;
+		reportedQuery.current = controlledSearchQuery;
+		setSearchQuery(controlledSearchQuery);
+	}, [controlledSearchQuery]);
 
 	// Reset page when search changes. Guarded because `setPage` may write to
 	// the URL, and an unconditional reset would push a history entry per

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -347,7 +347,12 @@ function readOneOf<T extends string>(value: unknown, allowed: readonly T[]): T |
 
 function readCalendarDate(value: unknown): string | undefined {
 	const raw = readString(value);
-	return raw && CALENDAR_DATE_REGEX.test(raw) ? raw : undefined;
+	if (!raw || !CALENDAR_DATE_REGEX.test(raw)) return undefined;
+	// `Date` rolls impossible days forward — `2025-02-31` becomes March 3 —
+	// so only the round-trip rejects a date the calendar doesn't have.
+	const parsed = new Date(`${raw}T00:00:00.000Z`);
+	if (Number.isNaN(parsed.getTime())) return undefined;
+	return parsed.toISOString().startsWith(raw) ? raw : undefined;
 }
 
 export function parseContentListSearch(search: Record<string, unknown>): ContentListSearch {

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -351,8 +351,6 @@ function readCalendarDate(value: unknown): string | undefined {
 }
 
 export function parseContentListSearch(search: Record<string, unknown>): ContentListSearch {
-	// `dir` alone says nothing about which column to order by, so it only
-	// survives alongside a valid `sort`.
 	const sort = readOneOf(search.sort, SORT_FIELDS);
 
 	const rawPage = Number(search.page);
@@ -397,10 +395,6 @@ function ContentListPage() {
 	// Default to defaultLocale when i18n is enabled and no locale specified
 	const activeLocale = i18n ? (search.locale ?? i18n.defaultLocale) : undefined;
 
-	// Patch the URL in place. The updater form reads the live search params, so
-	// this callback stays referentially stable — ContentList's debounced-search
-	// effect depends on `onSearchChange`, and a new identity each render would
-	// re-fire it (and re-navigate) forever.
 	const updateSearch = React.useCallback(
 		(patch: Partial<ContentListSearch>, options?: { replace?: boolean }) => {
 			void navigate({
@@ -413,8 +407,6 @@ function ContentListPage() {
 		[navigate, collection],
 	);
 
-	// Sort is part of the query key, so changing direction invalidates the
-	// current cursor chain.
 	const sort: ContentListSort = React.useMemo(
 		() => ({
 			field: search.sort ?? DEFAULT_SORT.field,
@@ -435,8 +427,6 @@ function ContentListPage() {
 		[updateSearch],
 	);
 
-	// Server-side search term (debounced inside ContentList). Part of the query
-	// key so a new term restarts the cursor chain from a filtered first page.
 	const searchTerm = search.q ?? "";
 	const handleSearchChange = React.useCallback(
 		(q: string) => {
@@ -453,7 +443,6 @@ function ContentListPage() {
 		[navigate, collection],
 	);
 
-	// Changing a filter restarts the cursor chain from a filtered first page.
 	const statusFilter: ContentStatusFilter = search.status ?? "all";
 	const handleStatusFilterChange = React.useCallback(
 		(status: ContentStatusFilter) =>
@@ -715,8 +704,6 @@ function ContentListPage() {
 		return <ErrorScreen error={error.message} />;
 	}
 
-	// Filters and sort survive a locale switch; the page can't, since it indexes
-	// a different result set.
 	const handleLocaleChange = (locale: string) => {
 		updateSearch({ locale: locale || undefined, page: undefined });
 	};
@@ -745,7 +732,7 @@ function ContentListPage() {
 			page={page}
 			onPageChange={handlePageChange}
 			total={total}
-			initialSearchQuery={searchTerm}
+			searchQuery={searchTerm}
 			onSearchChange={handleSearchChange}
 			statusFilter={statusFilter}
 			onStatusFilterChange={handleStatusFilterChange}

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -310,7 +310,6 @@ function DashboardPage() {
 }
 
 // Content list route
-// List view state lives in URL search params so back/forward restore it.
 
 const DEFAULT_SORT: ContentListSort = { field: "updatedAt", direction: "desc" };
 const DEFAULT_DATE_FIELD: ContentDateField = "createdAt";
@@ -456,8 +455,7 @@ function ContentListPage() {
 		[navigate, collection],
 	);
 
-	// Filter state (#1288). All are part of the query key so changing any of
-	// them restarts the cursor chain from a filtered first page.
+	// Changing a filter restarts the cursor chain from a filtered first page.
 	const statusFilter: ContentStatusFilter = search.status ?? "all";
 	const handleStatusFilterChange = React.useCallback(
 		(status: ContentStatusFilter) =>

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -321,8 +321,6 @@ const DATE_FIELDS: ContentDateField[] = ["createdAt", "updatedAt", "publishedAt"
 /** `YYYY-MM-DD`, the shape the date inputs emit. */
 const CALENDAR_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
-// Routes link here supplying only the params they care about, so making any
-// key required breaks those links.
 export interface ContentListSearch {
 	locale?: string | undefined;
 	/** 1-based, and only ever set when past the first page. */

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -321,8 +321,8 @@ const DATE_FIELDS: ContentDateField[] = ["createdAt", "updatedAt", "publishedAt"
 /** `YYYY-MM-DD`, the shape the date inputs emit. */
 const CALENDAR_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
-// Every key is optional: defaults are omitted from the URL, and other routes
-// link here supplying only the params they care about (usually just `locale`).
+// Routes link here supplying only the params they care about, so making any
+// key required breaks those links.
 export interface ContentListSearch {
 	locale?: string | undefined;
 	/** 1-based, and only ever set when past the first page. */

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -25,9 +25,9 @@ import { CommentInbox } from "./components/comments/CommentInbox";
 import { ContentEditor } from "./components/ContentEditor";
 import {
 	ContentList,
-	EMPTY_DATE_FILTER,
 	type ContentDateFilter,
 	type ContentListSort,
+	type ContentListSortField,
 	type ContentStatusFilter,
 } from "./components/ContentList";
 import { ContentTypeEditor } from "./components/ContentTypeEditor";
@@ -110,6 +110,7 @@ import {
 	type CreateFieldInput,
 	type BylineCreditInput,
 	type ContentSeoInput,
+	type ContentDateField,
 	type ContentItem,
 	type Revision,
 } from "./lib/api";
@@ -309,19 +310,88 @@ function DashboardPage() {
 }
 
 // Content list route
+//
+// The whole list view — page, search, filters, sort — lives in the URL rather
+// than in component state, so opening an entry and hitting back returns the
+// editor to the view they left instead of an unfiltered page 1.
+//
+// Defaults are never serialized: a pristine list is `/content/posts` with no
+// query string, and clearing a control drops its param again.
+
+const DEFAULT_SORT: ContentListSort = { field: "updatedAt", direction: "desc" };
+const DEFAULT_DATE_FIELD: ContentDateField = "createdAt";
+
+const SORT_FIELDS: ContentListSortField[] = ["title", "status", "locale", "updatedAt"];
+const STATUS_FILTERS = ["published", "draft", "scheduled", "archived"] as const;
+const DATE_FIELDS: ContentDateField[] = ["createdAt", "updatedAt", "publishedAt"];
+
+/** `YYYY-MM-DD`, the shape the date inputs emit. */
+const CALENDAR_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+// Every key is optional: defaults are omitted from the URL, and other routes
+// link here supplying only the params they care about (usually just `locale`).
+export interface ContentListSearch {
+	locale?: string | undefined;
+	/** 1-based, and only ever set when past the first page. */
+	page?: number | undefined;
+	q?: string | undefined;
+	status?: (typeof STATUS_FILTERS)[number] | undefined;
+	author?: string | undefined;
+	sort?: ContentListSortField | undefined;
+	dir?: "asc" | "desc" | undefined;
+	dateField?: ContentDateField | undefined;
+	dateFrom?: string | undefined;
+	dateTo?: string | undefined;
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readOneOf<T extends string>(value: unknown, allowed: readonly T[]): T | undefined {
+	return typeof value === "string" && (allowed as readonly string[]).includes(value)
+		? (value as T)
+		: undefined;
+}
+
+function readCalendarDate(value: unknown): string | undefined {
+	const raw = readString(value);
+	return raw && CALENDAR_DATE_REGEX.test(raw) ? raw : undefined;
+}
+
+export function parseContentListSearch(search: Record<string, unknown>): ContentListSearch {
+	// `dir` alone says nothing about which column to order by, so it only
+	// survives alongside a valid `sort`.
+	const sort = readOneOf(search.sort, SORT_FIELDS);
+
+	const rawPage = Number(search.page);
+	const page = Number.isInteger(rawPage) && rawPage > 1 ? rawPage : undefined;
+
+	return {
+		locale: readString(search.locale),
+		page,
+		q: readString(search.q),
+		status: readOneOf(search.status, STATUS_FILTERS),
+		author: readString(search.author),
+		sort,
+		dir: sort ? (readOneOf(search.dir, ["asc", "desc"] as const) ?? "desc") : undefined,
+		dateField: readOneOf(search.dateField, DATE_FIELDS),
+		dateFrom: readCalendarDate(search.dateFrom),
+		dateTo: readCalendarDate(search.dateTo),
+	};
+}
+
 const contentListRoute = createRoute({
 	getParentRoute: () => adminLayoutRoute,
 	path: "/content/$collection",
 	component: ContentListPage,
-	validateSearch: (search: Record<string, unknown>) => ({
-		locale: typeof search.locale === "string" ? search.locale : undefined,
-	}),
+	validateSearch: parseContentListSearch,
 });
 
 function ContentListPage() {
 	const { t } = useLingui();
 	const { collection } = useParams({ from: "/_admin/content/$collection" });
-	const { locale: localeParam } = useSearch({ from: "/_admin/content/$collection" });
+	const search = useSearch({ from: "/_admin/content/$collection" });
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 	const toastManager = Toast.useToastManager();
@@ -334,24 +404,113 @@ function ContentListPage() {
 	const i18n = manifest?.i18n;
 
 	// Default to defaultLocale when i18n is enabled and no locale specified
-	const activeLocale = i18n ? (localeParam ?? i18n.defaultLocale) : undefined;
+	const activeLocale = i18n ? (search.locale ?? i18n.defaultLocale) : undefined;
 
-	// Controlled sort state — passed to the list, and included in the query
-	// key so changing direction invalidates the current cursor chain.
-	const [sort, setSort] = React.useState<ContentListSort>({
-		field: "updatedAt",
-		direction: "desc",
-	});
+	// Patch the URL in place. The updater form reads the live search params, so
+	// this callback stays referentially stable — ContentList's debounced-search
+	// effect depends on `onSearchChange`, and a new identity each render would
+	// re-fire it (and re-navigate) forever.
+	const updateSearch = React.useCallback(
+		(patch: Partial<ContentListSearch>, options?: { replace?: boolean }) => {
+			void navigate({
+				to: "/content/$collection",
+				params: { collection },
+				search: (prev) => ({ ...prev, ...patch }),
+				replace: options?.replace,
+			});
+		},
+		[navigate, collection],
+	);
+
+	// Every control resets `page`: page 4 of one filter set means nothing in
+	// another, and the cursor chain restarts from a fresh first page anyway.
+	// Discrete controls push a history entry (so back steps through them);
+	// debounced/keystroke-driven ones replace, to keep history usable.
+
+	// Sort is part of the query key, so changing direction invalidates the
+	// current cursor chain.
+	const sort: ContentListSort = React.useMemo(
+		() => ({
+			field: search.sort ?? DEFAULT_SORT.field,
+			direction: search.dir ?? DEFAULT_SORT.direction,
+		}),
+		[search.sort, search.dir],
+	);
+	const handleSortChange = React.useCallback(
+		(next: ContentListSort) => {
+			const isDefault =
+				next.field === DEFAULT_SORT.field && next.direction === DEFAULT_SORT.direction;
+			updateSearch({
+				sort: isDefault ? undefined : next.field,
+				dir: isDefault ? undefined : next.direction,
+				page: undefined,
+			});
+		},
+		[updateSearch],
+	);
 
 	// Server-side search term (debounced inside ContentList). Part of the query
 	// key so a new term restarts the cursor chain from a filtered first page.
-	const [searchTerm, setSearchTerm] = React.useState("");
+	const searchTerm = search.q ?? "";
+	const handleSearchChange = React.useCallback(
+		(q: string) => {
+			void navigate({
+				to: "/content/$collection",
+				params: { collection },
+				// ContentList reports the seeded query once on mount; treating that
+				// as a change would clear the very page we just restored.
+				search: (prev) =>
+					(prev.q ?? "") === q ? prev : { ...prev, q: q || undefined, page: undefined },
+				replace: true,
+			});
+		},
+		[navigate, collection],
+	);
 
 	// Filter state (#1288). All are part of the query key so changing any of
 	// them restarts the cursor chain from a filtered first page.
-	const [statusFilter, setStatusFilter] = React.useState<ContentStatusFilter>("all");
-	const [authorFilter, setAuthorFilter] = React.useState("");
-	const [dateFilter, setDateFilter] = React.useState<ContentDateFilter>(EMPTY_DATE_FILTER);
+	const statusFilter: ContentStatusFilter = search.status ?? "all";
+	const handleStatusFilterChange = React.useCallback(
+		(status: ContentStatusFilter) =>
+			updateSearch({ status: status === "all" ? undefined : status, page: undefined }),
+		[updateSearch],
+	);
+
+	const authorFilter = search.author ?? "";
+	const handleAuthorFilterChange = React.useCallback(
+		(author: string) => updateSearch({ author: author || undefined, page: undefined }),
+		[updateSearch],
+	);
+
+	const dateFilter: ContentDateFilter = React.useMemo(
+		() => ({
+			field: search.dateField ?? DEFAULT_DATE_FIELD,
+			from: search.dateFrom ?? "",
+			to: search.dateTo ?? "",
+		}),
+		[search.dateField, search.dateFrom, search.dateTo],
+	);
+	const handleDateFilterChange = React.useCallback(
+		(next: ContentDateFilter) =>
+			updateSearch(
+				{
+					dateField: next.field === DEFAULT_DATE_FIELD ? undefined : next.field,
+					dateFrom: next.from || undefined,
+					dateTo: next.to || undefined,
+					page: undefined,
+				},
+				// `<input type="date">` fires per edited segment, not per commit.
+				{ replace: true },
+			),
+		[updateSearch],
+	);
+
+	// ContentList counts pages from 0; the URL counts from 1 and omits page 1.
+	const page = (search.page ?? 1) - 1;
+	const handlePageChange = React.useCallback(
+		(next: number) => updateSearch({ page: next > 0 ? next + 1 : undefined }),
+		[updateSearch],
+	);
 
 	// The date inputs yield calendar dates; widen them to UTC day boundaries so
 	// the inclusive `dateTo` covers the whole day (timestamps are stored in UTC).
@@ -544,7 +703,7 @@ function ContentListPage() {
 	});
 
 	const items = React.useMemo(() => {
-		return data?.pages.flatMap((page) => page.items) || [];
+		return data?.pages.flatMap((apiPage) => apiPage.items) || [];
 	}, [data]);
 
 	// Server returns `total` on every page; the first page is authoritative
@@ -571,13 +730,11 @@ function ContentListPage() {
 		return <ErrorScreen error={error.message} />;
 	}
 
+	// Filters and sort carry across a locale switch — they describe how the
+	// editor wants to look at the collection, not at one language. The page
+	// can't: it indexes a different result set.
 	const handleLocaleChange = (locale: string) => {
-		// Update URL search params without full navigation
-		void navigate({
-			to: "/content/$collection",
-			params: { collection },
-			search: { locale: locale || undefined },
-		});
+		updateSearch({ locale: locale || undefined, page: undefined });
 	};
 
 	return (
@@ -600,16 +757,19 @@ function ContentListPage() {
 			onLocaleChange={handleLocaleChange}
 			urlPattern={collectionConfig.urlPattern}
 			sort={sort}
-			onSortChange={setSort}
+			onSortChange={handleSortChange}
+			page={page}
+			onPageChange={handlePageChange}
 			total={total}
-			onSearchChange={setSearchTerm}
+			initialSearchQuery={searchTerm}
+			onSearchChange={handleSearchChange}
 			statusFilter={statusFilter}
-			onStatusFilterChange={setStatusFilter}
+			onStatusFilterChange={handleStatusFilterChange}
 			authors={authors}
 			authorFilter={authorFilter}
-			onAuthorFilterChange={setAuthorFilter}
+			onAuthorFilterChange={handleAuthorFilterChange}
 			dateFilter={dateFilter}
-			onDateFilterChange={setDateFilter}
+			onDateFilterChange={handleDateFilterChange}
 			onBulkPublish={(ids) => bulkPublishMutation.mutateAsync(ids).then((r) => r.failedIds)}
 			onBulkUnpublish={(ids) => bulkUnpublishMutation.mutateAsync(ids).then((r) => r.failedIds)}
 			onBulkDelete={(ids) => bulkDeleteMutation.mutateAsync(ids).then((r) => r.failedIds)}

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -310,13 +310,7 @@ function DashboardPage() {
 }
 
 // Content list route
-//
-// The whole list view — page, search, filters, sort — lives in the URL rather
-// than in component state, so opening an entry and hitting back returns the
-// editor to the view they left instead of an unfiltered page 1.
-//
-// Defaults are never serialized: a pristine list is `/content/posts` with no
-// query string, and clearing a control drops its param again.
+// List view state lives in URL search params so back/forward restore it.
 
 const DEFAULT_SORT: ContentListSort = { field: "updatedAt", direction: "desc" };
 const DEFAULT_DATE_FIELD: ContentDateField = "createdAt";
@@ -421,11 +415,6 @@ function ContentListPage() {
 		},
 		[navigate, collection],
 	);
-
-	// Every control resets `page`: page 4 of one filter set means nothing in
-	// another, and the cursor chain restarts from a fresh first page anyway.
-	// Discrete controls push a history entry (so back steps through them);
-	// debounced/keystroke-driven ones replace, to keep history usable.
 
 	// Sort is part of the query key, so changing direction invalidates the
 	// current cursor chain.
@@ -730,9 +719,8 @@ function ContentListPage() {
 		return <ErrorScreen error={error.message} />;
 	}
 
-	// Filters and sort carry across a locale switch — they describe how the
-	// editor wants to look at the collection, not at one language. The page
-	// can't: it indexes a different result set.
+	// Filters and sort survive a locale switch; the page can't, since it indexes
+	// a different result set.
 	const handleLocaleChange = (locale: string) => {
 		updateSearch({ locale: locale || undefined, page: undefined });
 	};

--- a/packages/admin/tests/router-search.test.ts
+++ b/packages/admin/tests/router-search.test.ts
@@ -114,6 +114,19 @@ describe("parseContentListSearch", () => {
 		expect(parseContentListSearch({ dateTo: "2025-03-31T00:00:00Z" }).dateTo).toBeUndefined();
 	});
 
+	it("rejects dates that fit the format but never happened", () => {
+		// The API rejects these, and `2025-02-31` would otherwise reach it
+		// widened to a `2025-03-03` boundary.
+		expect(parseContentListSearch({ dateFrom: "2025-99-99" }).dateFrom).toBeUndefined();
+		expect(parseContentListSearch({ dateFrom: "2025-13-01" }).dateFrom).toBeUndefined();
+		expect(parseContentListSearch({ dateTo: "2025-02-31" }).dateTo).toBeUndefined();
+		expect(parseContentListSearch({ dateTo: "2025-02-29" }).dateTo).toBeUndefined();
+	});
+
+	it("keeps a leap day the calendar actually has", () => {
+		expect(parseContentListSearch({ dateFrom: "2024-02-29" }).dateFrom).toBe("2024-02-29");
+	});
+
 	it("treats empty strings as absent so a blank param never filters the list", () => {
 		// `?locale=` left as "" would beat the defaultLocale fallback and fetch
 		// every locale's rows while the switcher claims one is active.

--- a/packages/admin/tests/router-search.test.ts
+++ b/packages/admin/tests/router-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseBylinesLocaleSearch } from "../src/router";
+import { parseBylinesLocaleSearch, parseContentListSearch } from "../src/router";
 
 describe("parseBylinesLocaleSearch", () => {
 	it("returns the locale string when present and non-empty", () => {
@@ -21,5 +21,103 @@ describe("parseBylinesLocaleSearch", () => {
 	it("returns undefined when locale is not a string", () => {
 		expect(parseBylinesLocaleSearch({ locale: 42 })).toEqual({ locale: undefined });
 		expect(parseBylinesLocaleSearch({ locale: null })).toEqual({ locale: undefined });
+	});
+});
+
+describe("parseContentListSearch", () => {
+	it("reads a full view back off the URL", () => {
+		expect(
+			parseContentListSearch({
+				locale: "de",
+				page: "3",
+				q: "draft post",
+				status: "scheduled",
+				author: "user_01",
+				sort: "title",
+				dir: "asc",
+				dateField: "publishedAt",
+				dateFrom: "2025-01-01",
+				dateTo: "2025-03-31",
+			}),
+		).toEqual({
+			locale: "de",
+			page: 3,
+			q: "draft post",
+			status: "scheduled",
+			author: "user_01",
+			sort: "title",
+			dir: "asc",
+			dateField: "publishedAt",
+			dateFrom: "2025-01-01",
+			dateTo: "2025-03-31",
+		});
+	});
+
+	it("leaves every field unset for a bare list URL", () => {
+		expect(parseContentListSearch({})).toEqual({
+			locale: undefined,
+			page: undefined,
+			q: undefined,
+			status: undefined,
+			author: undefined,
+			sort: undefined,
+			dir: undefined,
+			dateField: undefined,
+			dateFrom: undefined,
+			dateTo: undefined,
+		});
+	});
+
+	it("normalizes page 1 and below away, since page 1 is the default view", () => {
+		expect(parseContentListSearch({ page: "1" }).page).toBeUndefined();
+		expect(parseContentListSearch({ page: "0" }).page).toBeUndefined();
+		expect(parseContentListSearch({ page: "-4" }).page).toBeUndefined();
+	});
+
+	it("rejects a non-integer page rather than passing NaN to the pager", () => {
+		expect(parseContentListSearch({ page: "abc" }).page).toBeUndefined();
+		expect(parseContentListSearch({ page: "2.5" }).page).toBeUndefined();
+		expect(parseContentListSearch({ page: null }).page).toBeUndefined();
+	});
+
+	it("drops values outside each control's vocabulary", () => {
+		const parsed = parseContentListSearch({
+			status: "all",
+			sort: "authorId",
+			dateField: "deletedAt",
+		});
+		// "all" is the status filter's cleared state, not a server-side filter.
+		expect(parsed.status).toBeUndefined();
+		expect(parsed.sort).toBeUndefined();
+		expect(parsed.dateField).toBeUndefined();
+	});
+
+	it("ignores a direction with no column to apply it to", () => {
+		expect(parseContentListSearch({ dir: "asc" })).toMatchObject({
+			sort: undefined,
+			dir: undefined,
+		});
+	});
+
+	it("defaults a column with no direction to descending", () => {
+		expect(parseContentListSearch({ sort: "status" })).toMatchObject({
+			sort: "status",
+			dir: "desc",
+		});
+	});
+
+	it("rejects date bounds the date inputs could not have produced", () => {
+		// These reach the API as a range filter, so a free-form string would be
+		// forwarded verbatim to the server.
+		expect(parseContentListSearch({ dateFrom: "yesterday" }).dateFrom).toBeUndefined();
+		expect(parseContentListSearch({ dateFrom: "2025-1-1" }).dateFrom).toBeUndefined();
+		expect(parseContentListSearch({ dateTo: "2025-03-31T00:00:00Z" }).dateTo).toBeUndefined();
+	});
+
+	it("treats empty strings as absent so a blank param never filters the list", () => {
+		// `?locale=` left as "" would beat the defaultLocale fallback and fetch
+		// every locale's rows while the switcher claims one is active.
+		const parsed = parseContentListSearch({ locale: "", q: "", author: "" });
+		expect(parsed).toMatchObject({ locale: undefined, q: undefined, author: undefined });
 	});
 });

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -745,3 +745,151 @@ describe("ContentEditPage – autosave cache patching", () => {
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: ContentListPage – list view state survives back-navigation
+// ---------------------------------------------------------------------------
+
+const PAGINATED_MANIFEST: AdminManifest = { ...MANIFEST, i18n: undefined };
+
+/** 45 entries — three pages at the list's 20-per-page client pagination. */
+const PAGINATED_ITEMS = Array.from({ length: 45 }, (_, i) => ({
+	id: `post_${i + 1}`,
+	type: "posts",
+	slug: `post-${i + 1}`,
+	status: "draft",
+	locale: "en",
+	translationGroup: null,
+	data: { title: `Post ${i + 1}` },
+	authorId: null,
+	primaryBylineId: null,
+	createdAt: "2025-01-01T00:00:00Z",
+	updatedAt: "2025-01-01T00:00:00Z",
+	publishedAt: null,
+	scheduledAt: null,
+	liveRevisionId: null,
+	draftRevisionId: null,
+}));
+
+describe("ContentListPage – view state survives back-navigation", () => {
+	let mockFetch: ReturnType<typeof createMockFetch>;
+
+	beforeEach(() => {
+		mockFetch = createMockFetch();
+
+		mockFetch
+			.on("GET", "/_emdash/api/manifest", { data: PAGINATED_MANIFEST })
+			.on("GET", "/_emdash/api/auth/me", { data: { id: "user_01", role: 60 } })
+			.on("GET", "/_emdash/api/bylines", { data: { items: [] } })
+			// Registered before the bare collection URL: the mock falls back to
+			// prefix matching for URLs carrying a query string, first match wins.
+			.on("GET", "/_emdash/api/content/posts/authors", { data: { items: [] } })
+			.on("GET", "/_emdash/api/content/posts/trash", { data: { items: [] } })
+			.on("GET", "/_emdash/api/content/posts/post_1", {
+				data: { item: PAGINATED_ITEMS[0] },
+			})
+			.on("GET", "/_emdash/api/content/posts/post_21", {
+				data: { item: PAGINATED_ITEMS[20] },
+			})
+			.on("GET", "/_emdash/api/content/posts", {
+				data: { items: PAGINATED_ITEMS, nextCursor: undefined, total: 45 },
+			});
+	});
+
+	afterEach(() => {
+		mockFetch.restore();
+	});
+
+	it("returns to the page the editor left from, not page 1", async () => {
+		const { router, TestApp } = buildRouter();
+
+		await router.navigate({ to: "/content/$collection", params: { collection: "posts" } });
+		const screen = await render(<TestApp />);
+
+		// Assertions target the row links and the page indicator: the mocked
+		// editor also renders an entry's title, so a bare text match would still
+		// pass while sitting on the edit screen.
+		await expect.element(screen.getByText("1 / 3", { exact: true })).toBeInTheDocument();
+
+		await screen.getByRole("button", { name: "Next page" }).click();
+		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
+
+		await screen.getByRole("link", { name: "Post 21", exact: true }).click();
+		await expect.element(screen.getByTestId("content-editor")).toBeInTheDocument();
+
+		router.history.back();
+
+		// The bug: `page` lived in ContentList's useState, so unmounting the list
+		// to open an entry threw it away and back landed on page 1.
+		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
+		await expect.element(screen.getByRole("link", { name: "Post 21", exact: true })).toBeVisible();
+	});
+
+	it("returns to the filters and sort the editor left from", async () => {
+		const { router, TestApp } = buildRouter();
+
+		await router.navigate({
+			to: "/content/$collection",
+			params: { collection: "posts" },
+			search: { status: "draft" },
+		});
+		const screen = await render(<TestApp />);
+
+		await expect.element(screen.getByText("Post 1", { exact: true })).toBeInTheDocument();
+
+		// Sorting by Title is doubly non-default (the list defaults to
+		// updatedAt), so a reset would show `none` on this column.
+		await screen.getByRole("button", { name: "Title" }).click();
+		await screen.getByRole("link", { name: "Post 1", exact: true }).click();
+		await expect.element(screen.getByTestId("content-editor")).toBeInTheDocument();
+
+		router.history.back();
+
+		await expect
+			.element(screen.getByRole("columnheader", { name: "Title" }))
+			.toHaveAttribute("aria-sort", "descending");
+		await waitFor(() => {
+			expect(router.state.location.search).toMatchObject({ status: "draft", sort: "title" });
+		});
+	});
+
+	it("keeps a pristine list free of query params, and drops them again when cleared", async () => {
+		const { router, TestApp } = buildRouter();
+
+		await router.navigate({ to: "/content/$collection", params: { collection: "posts" } });
+		const screen = await render(<TestApp />);
+
+		await expect.element(screen.getByText("1 / 3", { exact: true })).toBeInTheDocument();
+		expect(router.state.location.searchStr).toBe("");
+
+		await screen.getByRole("button", { name: "Next page" }).click();
+		await waitFor(() => {
+			expect(router.state.location.searchStr).toBe("?page=2");
+		});
+
+		await screen.getByRole("button", { name: "Previous page" }).click();
+		await waitFor(() => {
+			expect(router.state.location.searchStr).toBe("");
+		});
+	});
+
+	it("restores a page and a search term together", async () => {
+		const { router, TestApp } = buildRouter();
+
+		await router.navigate({
+			to: "/content/$collection",
+			params: { collection: "posts" },
+			search: { page: 2, q: "Post" },
+		});
+		const screen = await render(<TestApp />);
+
+		await expect.element(screen.getByRole("searchbox")).toHaveValue("Post");
+		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
+
+		// The list reports its seeded query once the debounce settles. Treating
+		// that as a user edit would reset the page we just restored.
+		await new Promise((resolve) => setTimeout(resolve, 800));
+		expect(router.state.location.search).toMatchObject({ page: 2, q: "Post" });
+		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
+	});
+});

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -888,6 +888,29 @@ describe("ContentListPage – view state survives back-navigation", () => {
 		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
 	});
 
+	it("lets back-navigation win over a search edit still inside the debounce", async () => {
+		const { router, TestApp } = buildRouter();
+
+		await router.navigate({ to: "/content/$collection", params: { collection: "posts" } });
+		const screen = await render(<TestApp />);
+
+		await screen.getByRole("button", { name: "Next page" }).click();
+		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
+
+		// Typing sends the list back to page 1; back undoes that while the term
+		// is still sitting in the debounce.
+		await screen.getByRole("searchbox").fill("Post 3");
+		await waitFor(() => {
+			expect(router.state.location.searchStr).toBe("");
+		});
+		router.history.back();
+
+		await new Promise((resolve) => setTimeout(resolve, 800));
+		expect(router.state.location.searchStr).toBe("?page=2");
+		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
+		await expect.element(screen.getByRole("searchbox")).toHaveValue("");
+	});
+
 	it("follows a search term that changes in the URL while the list stays mounted", async () => {
 		const { router, TestApp } = buildRouter();
 

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -806,9 +806,8 @@ describe("ContentListPage – view state survives back-navigation", () => {
 		await router.navigate({ to: "/content/$collection", params: { collection: "posts" } });
 		const screen = await render(<TestApp />);
 
-		// Assertions target the row links and the page indicator: the mocked
-		// editor also renders an entry's title, so a bare text match would still
-		// pass while sitting on the edit screen.
+		// The mocked editor renders the entry title too, so assert on the page
+		// indicator and row links rather than bare item text.
 		await expect.element(screen.getByText("1 / 3", { exact: true })).toBeInTheDocument();
 
 		await screen.getByRole("button", { name: "Next page" }).click();
@@ -819,8 +818,6 @@ describe("ContentListPage – view state survives back-navigation", () => {
 
 		router.history.back();
 
-		// The bug: `page` lived in ContentList's useState, so unmounting the list
-		// to open an entry threw it away and back landed on page 1.
 		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
 		await expect.element(screen.getByRole("link", { name: "Post 21", exact: true })).toBeVisible();
 	});
@@ -837,8 +834,6 @@ describe("ContentListPage – view state survives back-navigation", () => {
 
 		await expect.element(screen.getByText("Post 1", { exact: true })).toBeInTheDocument();
 
-		// Sorting by Title is doubly non-default (the list defaults to
-		// updatedAt), so a reset would show `none` on this column.
 		await screen.getByRole("button", { name: "Title" }).click();
 		await screen.getByRole("link", { name: "Post 1", exact: true }).click();
 		await expect.element(screen.getByTestId("content-editor")).toBeInTheDocument();
@@ -891,5 +886,29 @@ describe("ContentListPage – view state survives back-navigation", () => {
 		await new Promise((resolve) => setTimeout(resolve, 800));
 		expect(router.state.location.search).toMatchObject({ page: 2, q: "Post" });
 		await expect.element(screen.getByText("2 / 3", { exact: true })).toBeInTheDocument();
+	});
+
+	it("follows a search term that changes in the URL while the list stays mounted", async () => {
+		const { router, TestApp } = buildRouter();
+
+		await router.navigate({
+			to: "/content/$collection",
+			params: { collection: "posts" },
+			search: { q: "Post" },
+		});
+		const screen = await render(<TestApp />);
+
+		await expect.element(screen.getByRole("searchbox")).toHaveValue("Post");
+
+		await router.navigate({
+			to: "/content/$collection",
+			params: { collection: "posts" },
+			search: {},
+		});
+
+		await expect.element(screen.getByRole("searchbox")).toHaveValue("");
+
+		await new Promise((resolve) => setTimeout(resolve, 800));
+		expect(router.state.location.searchStr).toBe("");
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Reported by an editor and reproduced: on a collection's entry list, go to page 2 or 3, open an entry, then press the browser's back button — you land back on page 1.

`page` lived in `ContentList`'s `useState`, and sort/search/status/author/date lived in `ContentListPage`'s. Opening an entry unmounts the list, so back threw all of it away.

This moves the whole list view onto the route's search params, so back-navigation restores the view the editor left. List URLs become shareable and bookmarkable as a side effect.

- **Defaults are never serialized.** A pristine list is `/content/posts` with no query string; clearing a control drops its param again. Page is 1-based in the URL and omitted on page 1.
- **Every filter/sort change resets the page** — page 4 of one filter set indexes nothing in another, and the cursor chain restarts from a fresh first page anyway.
- **History stays usable.** Discrete clicks (page, sort, status, author) push an entry so back steps through them; the debounced search and the date inputs replace, since both fire on partial input rather than on commit.
- **Params are validated, not trusted.** `?sort=authorId`, `?page=2.5`, `?dateFrom=yesterday` are dropped rather than forwarded to the API.

`ContentList` gains optional `page`/`onPageChange` and `initialSearchQuery` props, following the existing opt-in pattern used by `sort`/`onSortChange` and the filter callbacks. The component is exported from `@emdash-cms/admin`, so all three are additive — callers that don't pass them keep the current internal-state behavior and a working pager.

### Not included: the All/Trash tab

`activeTab` is still `useState` in `ContentList`, so back always lands on **All**. It was out of scope for the reported bug and the trash tab has no pagination of its own.

The infrastructure does generalize to it — adding it later is the same three moves this PR already makes for `page`: a `tab` entry in `parseContentListSearch`, an `activeTab`/`onTabChange` controlled prop pair on `ContentList` mirroring `page`/`onPageChange`, and a page reset on tab switch. Happy to fold it in here if a reviewer would rather have it in one go.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes — `pnpm lint:json` reports 0 diagnostics
- [x] `pnpm test` passes (or targeted tests for my change) — full `packages/admin` suite, 1251 passed
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no new strings or markup; no `messages.po` changes included
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

Failing tests written first, then the fix.

Four browser-level regression tests in `tests/router.test.tsx` — page survives back-navigation, filters and sort survive back-navigation, pristine URLs stay free of query params, and page + search term restore together. Nine parser unit tests in `tests/router-search.test.ts`, alongside the existing `parseBylinesLocaleSearch` ones.

Two notes for reviewers:

- My first draft of the pagination test **passed against the broken code**. The mocked `ContentEditor` in that file renders the entry title, so `getByText("Post 21")` matched the editor rather than the list. The assertions now target the page indicator and the row links. Worth knowing when adding tests to that file.
- The subtlest guard in the change is in `handleSearchChange`: `ContentList` reports its seeded search query once when the debounce settles on mount, and treating that as a user edit wipes the page just restored from the URL. I removed the guard, confirmed `restores a page and a search term together` fails, and put it back.

```
 Test Files  104 passed (104)
      Tests  1251 passed (1251)
```

Not verified by hand against a seeded site — the suite runs in Chromium and covers the round trip, but I did not drive the real admin through `dev-bypass`. No new UI strings or layout, so there is no RTL/Arabic surface to re-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
