### PR TITLE
feat(nesting): column widths, draggable rows inside columns, and a collapsed state

### DIFF
--- a/.changeset/nesting-column-widths-and-rows.md
+++ b/.changeset/nesting-column-widths-and-rows.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": minor
+"emdash": minor
+---
+
+Nesting blocks gain column width ratios, so a container can express a content and sidebar layout rather than only equal columns. Blocks inside a column become first-class rows that can be reordered by dragging, and a container can be folded away to a one line summary of what it holds.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -85,6 +85,7 @@ import {
 	DotsSixVertical,
 	CaretDown,
 	type Icon,
+	ColumnsIcon,
 } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { Extension, type Range } from "@tiptap/core";
@@ -119,6 +120,7 @@ import { HeadingDropdownMenu } from "./editor/HeadingDropdownMenu";
 import { HtmlBlockExtension } from "./editor/HtmlBlockNode";
 import { ImageExtension } from "./editor/ImageNode";
 import { MarkdownLinkExtension } from "./editor/MarkdownLinkExtension";
+import { NestingBlockExtension, NestingColumnExtension } from "./editor/NestingBlockNode";
 import {
 	type PluginBlockDef,
 	PluginBlockExtension,
@@ -243,6 +245,18 @@ function sanitizeGalleryImages(value: unknown, withKeys = false): GalleryImage[]
 // Helpers for safely extracting typed values from ProseMirror attrs (Record<string, any>)
 const attrStr = (v: unknown): string | undefined => (typeof v === "string" && v ? v : undefined);
 const attrNum = (v: unknown): number | undefined => (typeof v === "number" && v ? v : undefined);
+
+// Nesting block layout coercion
+const NESTING_GAPS = ["none", "sm", "md", "lg"] as const;
+const NESTING_ALIGNS = ["start", "center", "end", "stretch"] as const;
+
+function pickNestingGap(v: unknown): (typeof NESTING_GAPS)[number] {
+	return NESTING_GAPS.find((g) => g === v) ?? "md";
+}
+
+function pickNestingAlign(v: unknown): (typeof NESTING_ALIGNS)[number] {
+	return NESTING_ALIGNS.find((a) => a === v) ?? "start";
+}
 
 // ProseMirror to Portable Text converter
 function prosemirrorToPortableText(doc: {
@@ -369,6 +383,39 @@ function convertPMNode(node: {
 				_type: "htmlBlock",
 				_key: generateKey(),
 				html: typeof rawHtml === "string" ? rawHtml : "",
+			};
+		}
+
+		case "nestingBlock": {
+			const attrs = node.attrs ?? {};
+			const columnNodes = (node.content || []) as Array<Parameters<typeof convertPMNode>[0]>;
+			const columns: PortableTextBlock[] = [];
+
+			for (const col of columnNodes) {
+				if (col.type !== "nestingColumn") continue;
+
+				const colChildren: PortableTextBlock[] = [];
+
+				for (const child of (col.content || []) as Array<Parameters<typeof convertPMNode>[0]>) {
+					const converted = convertPMNode(child);
+
+					if (converted) {
+						if (Array.isArray(converted)) colChildren.push(...converted);
+						else colChildren.push(converted);
+					}
+				}
+
+				columns.push({ _type: "nestingColumn", _key: generateKey(), children: colChildren });
+			}
+
+			return {
+				_type: "nestingBlock",
+				_key: generateKey(),
+				layout: attrs.layout === "flex" ? "flex" : "grid",
+				columns: Math.max(1, columns.length),
+				gap: pickNestingGap(attrs.gap),
+				align: pickNestingAlign(attrs.align),
+				children: columns,
 			};
 		}
 
@@ -880,6 +927,34 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 			};
 		}
 
+		case "nestingBlock": {
+			const nb = block as { layout?: unknown; gap?: unknown; align?: unknown; children?: unknown };
+			const rawChildren = Array.isArray(nb.children) ? nb.children : [];
+
+			const columns = rawChildren.map((child) => {
+				const c = child as { _type?: unknown; children?: unknown };
+				const colBlocks =
+					c._type === "nestingColumn" && Array.isArray(c.children)
+						? (c.children as PortableTextBlock[])
+						: [child as PortableTextBlock];
+
+				return { type: "nestingColumn", content: portableTextToProsemirror(colBlocks).content };
+			});
+
+			return {
+				type: "nestingBlock",
+				attrs: {
+					layout: nb.layout === "flex" ? "flex" : "grid",
+					gap: pickNestingGap(nb.gap),
+					align: pickNestingAlign(nb.align),
+				},
+				content:
+					columns.length > 0
+						? columns
+						: [{ type: "nestingColumn", content: [{ type: "paragraph" }] }],
+			};
+		}
+
 		default: {
 			// Treat unknown block types as plugin blocks (embeds)
 			// These have an id field (or url for backwards compat) for the embed source,
@@ -1244,6 +1319,29 @@ const defaultSlashCommands: SlashCommandItem[] = [
 				.focus()
 				.deleteRange(range)
 				.insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+				.run();
+		},
+	},
+	{
+		id: "nestingBlock",
+		title: msg`Nesting container`,
+		description: msg`Grid or flex layout holding other blocks`,
+		icon: ColumnsIcon,
+		category: msg`Layout`,
+		aliases: ["nest", "container", "layout", "grid", "flex", "columns"],
+		command: ({ editor, range }) => {
+			editor
+				.chain()
+				.focus()
+				.deleteRange(range)
+				.insertContent({
+					type: "nestingBlock",
+					attrs: { layout: "grid", gap: "md", align: "start" },
+					content: [
+						{ type: "nestingColumn", content: [{ type: "paragraph" }] },
+						{ type: "nestingColumn", content: [{ type: "paragraph" }] },
+					],
+				})
 				.run();
 		},
 	},
@@ -2550,6 +2648,8 @@ export function PortableTextEditor({
 			ImageExtension,
 			MarkdownLinkExtension,
 			PluginBlockExtension,
+			NestingBlockExtension,
+			NestingColumnExtension,
 			Table.configure({
 				resizable: true,
 			}),

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -249,6 +249,7 @@ const attrNum = (v: unknown): number | undefined => (typeof v === "number" && v 
 // Nesting block layout coercion
 const NESTING_GAPS = ["none", "sm", "md", "lg"] as const;
 const NESTING_ALIGNS = ["start", "center", "end", "stretch"] as const;
+const NESTING_WIDTHS = ["equal", "wide-first", "wide-last", "narrow-first", "narrow-last"] as const;
 
 function pickNestingGap(v: unknown): (typeof NESTING_GAPS)[number] {
 	return NESTING_GAPS.find((g) => g === v) ?? "md";
@@ -256,6 +257,10 @@ function pickNestingGap(v: unknown): (typeof NESTING_GAPS)[number] {
 
 function pickNestingAlign(v: unknown): (typeof NESTING_ALIGNS)[number] {
 	return NESTING_ALIGNS.find((a) => a === v) ?? "start";
+}
+
+function pickNestingWidths(v: unknown): (typeof NESTING_WIDTHS)[number] {
+	return NESTING_WIDTHS.find((w) => w === v) ?? "equal";
 }
 
 // ProseMirror to Portable Text converter
@@ -415,6 +420,7 @@ function convertPMNode(node: {
 				columns: Math.max(1, columns.length),
 				gap: pickNestingGap(attrs.gap),
 				align: pickNestingAlign(attrs.align),
+				widths: pickNestingWidths(attrs.widths),
 				children: columns,
 			};
 		}
@@ -928,7 +934,13 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 		}
 
 		case "nestingBlock": {
-			const nb = block as { layout?: unknown; gap?: unknown; align?: unknown; children?: unknown };
+			const nb = block as {
+				layout?: unknown;
+				gap?: unknown;
+				align?: unknown;
+				widths?: unknown;
+				children?: unknown;
+			};
 			const rawChildren = Array.isArray(nb.children) ? nb.children : [];
 
 			const columns = rawChildren.map((child) => {
@@ -947,6 +959,7 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 					layout: nb.layout === "flex" ? "flex" : "grid",
 					gap: pickNestingGap(nb.gap),
 					align: pickNestingAlign(nb.align),
+					widths: pickNestingWidths(nb.widths),
 				},
 				content:
 					columns.length > 0

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -13,6 +13,7 @@ import { offset } from "@floating-ui/react";
 import { useLingui } from "@lingui/react/macro";
 import { DotsSixVertical, Plus } from "@phosphor-icons/react";
 import type { Editor } from "@tiptap/core";
+import type { DragHandleRule } from "@tiptap/extension-drag-handle";
 import { DragHandle } from "@tiptap/extension-drag-handle-react";
 import type { Node as PMNode } from "@tiptap/pm/model";
 import * as React from "react";
@@ -20,6 +21,7 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 import { getLocaleDir } from "../../locales/config.js";
 import { BlockMenu } from "./BlockMenu";
+import { NESTING_GUTTER_PX } from "./NestingBlockNode";
 
 interface DragHandleWrapperProps {
 	editor: Editor;
@@ -34,6 +36,98 @@ interface HoveredNode {
 export function _getDragHandlePlacement(direction: "ltr" | "rtl") {
 	return direction === "rtl" ? ("right-start" as const) : ("left-start" as const);
 }
+
+/**
+ * How far to place the handle from the row it belongs to.
+ *
+ * A top level row sits inside the editor's own 64px gutter, so its handle goes just
+ * outside the row. A row inside a nesting column carries the gutter as its own
+ * leading padding instead (see NESTING_GUTTER_PX), which is what lets a pointer in
+ * the gutter still resolve to that row -- so the handle has to come *back* across
+ * the row's edge to land in that padding rather than out over the column beside it.
+ */
+export function _dragHandleOffset(insideColumn: boolean): number {
+	return insideColumn ? -(NESTING_GUTTER_PX - 4) : 4;
+}
+
+/**
+ * Is the row at `pos` a child of a nesting column?
+ *
+ * Read from the document, because the handle positions against a virtual element
+ * that carries only a rect with no way back to the node it came from. `pos` is the
+ * position before the row, so its parent is the column that would hold it -- only
+ * the immediate parent is checked, because only a direct child of a column is ever
+ * a drag target.
+ */
+export function _isInsideNestingColumn(editor: Editor, pos: number): boolean {
+	if (pos < 0) return false;
+	try {
+		return editor.state.doc.resolve(pos).parent.type.name === "nestingColumn";
+	} catch {
+		// A stale position between transactions -- treat as top level.
+		return false;
+	}
+}
+
+/**
+ * The draggable unit is a row: a child of the document, or a child of a nesting
+ * column, which is the same thing one level down.
+ *
+ * This is what the editor already did. With nested targeting off, TipTap targets
+ * top level blocks, so a list drags as one block and its items do not drag at all.
+ * The rule restates that and extends it into columns, which is why behaviour
+ * outside a container is unchanged by enabling nesting.
+ *
+ * It deliberately replaces TipTap's default rules rather than joining them, and
+ * that is a choice about units, not a claim that they are wrong. Their defaults
+ * resolve the unit *inside* a structure: for a list, `listItemFirstChild` and
+ * `listWrapperDeprioritize` between them exclude the paragraph and the wrapper so
+ * the list item wins. That is right for a plain document and wrong for a page
+ * built from containers, where a list is one row a page is composed of and its
+ * items are the row's internals. The two cannot both hold, and picking theirs
+ * means a list can no longer be moved as a block anywhere in the document.
+ *
+ * Nothing the defaults guard is lost. Table internals and inline content are
+ * never children of the document or of a column, so they are excluded here by
+ * construction; the tests assert that rather than assuming it.
+ *
+ * Columns themselves are never a target either: `selectable: false`, and they are
+ * added and removed from the container's toolbar.
+ */
+export const _rowsOnlyRule: DragHandleRule = {
+	id: "emdashRowsOnly",
+	evaluate: ({ node, depth, $pos }) => {
+		const EXCLUDE = 1000;
+		if (node.type.name === "nestingColumn") return EXCLUDE;
+		if (depth <= 1) return 0;
+		return $pos.node(depth - 1).type.name === "nestingColumn" ? 0 : EXCLUDE;
+	},
+};
+
+/**
+ * Nested targeting, so a block inside a nesting column can be reordered.
+ *
+ * Edge detection is off, and follows from the same choice. It resolves ambiguity by
+ * pointer position, deducting by depth near a node's edge so the parent wins there.
+ * With rows as the unit there is no ambiguity left to resolve: a column is never a
+ * target, so the only candidates are the row and its container, and the container
+ * has an explicit grab point of its own in its header. Leaving it on only breaks
+ * things, because the deduction excludes a candidate outright at the depth a row
+ * sits inside a column, and rows are often short enough that the 12px band covers
+ * half of one.
+ *
+ * The handle's placement depends on this too. The gutter it sits in belongs to the
+ * row, so a target deeper than a row is measured from the wrong box and the handle
+ * lands over the content instead of beside it.
+ *
+ * Module level so the reference is stable: DragHandle's effect depends on it, and a
+ * fresh object each render re-registers the plugin.
+ */
+export const _nestedDragOptions = {
+	rules: [_rowsOnlyRule],
+	defaultRules: false,
+	edgeDetection: "none" as const,
+};
 
 /**
  * DragHandleWrapper - Official TipTap drag handle with BlockMenu integration
@@ -113,9 +207,14 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 		editor.commands.setMeta("lockDragHandle", false);
 	}, [editor]);
 
+	// Written synchronously here and read by the offset middleware, which the drag
+	// handle invokes immediately afterwards to reposition.
+	const insideColumnRef = React.useRef(false);
+
 	// Handle node change from drag handle
 	const handleNodeChange = React.useCallback(
 		(data: { node: PMNode | null; editor: Editor; pos: number }) => {
+			insideColumnRef.current = data.node ? _isInsideNestingColumn(data.editor, data.pos) : false;
 			if (data.node) {
 				setHoveredNode({ node: data.node, pos: data.pos });
 			} else {
@@ -135,7 +234,7 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 		() => ({
 			placement: _getDragHandlePlacement(direction),
 			strategy: "absolute" as const,
-			middleware: [offset(4)],
+			middleware: [offset(() => _dragHandleOffset(insideColumnRef.current))],
 		}),
 		[direction],
 	);
@@ -146,6 +245,7 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 				editor={editor}
 				onNodeChange={handleNodeChange}
 				computePositionConfig={computePositionConfig}
+				nested={_nestedDragOptions}
 			>
 				<div className="flex translate-y-0.5 items-center gap-0 rtl:flex-row-reverse">
 					<Button

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -38,26 +38,18 @@ export function _getDragHandlePlacement(direction: "ltr" | "rtl") {
 }
 
 /**
- * How far to place the handle from the row it belongs to.
- *
- * A top level row sits inside the editor's own 64px gutter, so its handle goes just
- * outside the row. A row inside a nesting column carries the gutter as its own
- * leading padding instead (see NESTING_GUTTER_PX), which is what lets a pointer in
- * the gutter still resolve to that row -- so the handle has to come *back* across
- * the row's edge to land in that padding rather than out over the column beside it.
+ * A top level row's handle sits outside it, in the editor's own gutter. A row in a
+ * column carries that gutter as its own leading padding, so the handle moves back
+ * across the row's edge to land inside it. Must agree with NESTING_GUTTER_PX.
  */
 export function _dragHandleOffset(insideColumn: boolean): number {
 	return insideColumn ? -(NESTING_GUTTER_PX - 4) : 4;
 }
 
 /**
- * Is the row at `pos` a child of a nesting column?
- *
- * Read from the document, because the handle positions against a virtual element
- * that carries only a rect with no way back to the node it came from. `pos` is the
- * position before the row, so its parent is the column that would hold it -- only
- * the immediate parent is checked, because only a direct child of a column is ever
- * a drag target.
+ * Resolved from the document rather than the hovered element, which is virtual and
+ * carries only a rect. `pos` is the position before the row, so its parent is the
+ * column that would hold it.
  */
 export function _isInsideNestingColumn(editor: Editor, pos: number): boolean {
 	if (pos < 0) return false;
@@ -70,29 +62,8 @@ export function _isInsideNestingColumn(editor: Editor, pos: number): boolean {
 }
 
 /**
- * The draggable unit is a row: a child of the document, or a child of a nesting
- * column, which is the same thing one level down.
- *
- * This is what the editor already did. With nested targeting off, TipTap targets
- * top level blocks, so a list drags as one block and its items do not drag at all.
- * The rule restates that and extends it into columns, which is why behaviour
- * outside a container is unchanged by enabling nesting.
- *
- * It deliberately replaces TipTap's default rules rather than joining them, and
- * that is a choice about units, not a claim that they are wrong. Their defaults
- * resolve the unit *inside* a structure: for a list, `listItemFirstChild` and
- * `listWrapperDeprioritize` between them exclude the paragraph and the wrapper so
- * the list item wins. That is right for a plain document and wrong for a page
- * built from containers, where a list is one row a page is composed of and its
- * items are the row's internals. The two cannot both hold, and picking theirs
- * means a list can no longer be moved as a block anywhere in the document.
- *
- * Nothing the defaults guard is lost. Table internals and inline content are
- * never children of the document or of a column, so they are excluded here by
- * construction; the tests assert that rather than assuming it.
- *
- * Columns themselves are never a target either: `selectable: false`, and they are
- * added and removed from the container's toolbar.
+ * Drag unit: direct children of the document or of a nesting column.
+ * Table internals and inline content are excluded by the schema.
  */
 export const _rowsOnlyRule: DragHandleRule = {
 	id: "emdashRowsOnly",
@@ -104,25 +75,7 @@ export const _rowsOnlyRule: DragHandleRule = {
 	},
 };
 
-/**
- * Nested targeting, so a block inside a nesting column can be reordered.
- *
- * Edge detection is off, and follows from the same choice. It resolves ambiguity by
- * pointer position, deducting by depth near a node's edge so the parent wins there.
- * With rows as the unit there is no ambiguity left to resolve: a column is never a
- * target, so the only candidates are the row and its container, and the container
- * has an explicit grab point of its own in its header. Leaving it on only breaks
- * things, because the deduction excludes a candidate outright at the depth a row
- * sits inside a column, and rows are often short enough that the 12px band covers
- * half of one.
- *
- * The handle's placement depends on this too. The gutter it sits in belongs to the
- * row, so a target deeper than a row is measured from the wrong box and the handle
- * lands over the content instead of beside it.
- *
- * Module level so the reference is stable: DragHandle's effect depends on it, and a
- * fresh object each render re-registers the plugin.
- */
+/** Module level: DragHandle re-registers its plugin if this identity changes. */
 export const _nestedDragOptions = {
 	rules: [_rowsOnlyRule],
 	defaultRules: false,
@@ -207,8 +160,7 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 		editor.commands.setMeta("lockDragHandle", false);
 	}, [editor]);
 
-	// Written synchronously here and read by the offset middleware, which the drag
-	// handle invokes immediately afterwards to reposition.
+	// Set in onNodeChange, read by the offset middleware that runs straight after it.
 	const insideColumnRef = React.useRef(false);
 
 	// Handle node change from drag handle

--- a/packages/admin/src/components/editor/HtmlBlockNode.tsx
+++ b/packages/admin/src/components/editor/HtmlBlockNode.tsx
@@ -85,9 +85,6 @@ function HtmlBlockNodeView({ node, updateAttributes, selected, deleteNode }: Nod
 			contentEditable={false}
 			data-drag-handle
 		>
-			{/* No grip of its own -- see PluginBlockNode. The editor's drag handle covers
-			    every block, and -start-8 puts this one in a gutter a nesting column does
-			    not have. */}
 			<div className="relative group">
 				{/* Main block */}
 				<div

--- a/packages/admin/src/components/editor/HtmlBlockNode.tsx
+++ b/packages/admin/src/components/editor/HtmlBlockNode.tsx
@@ -12,7 +12,7 @@
 
 import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { BracketsAngle, DotsSixVertical, Trash } from "@phosphor-icons/react";
+import { BracketsAngle, Trash } from "@phosphor-icons/react";
 import { Node, mergeAttributes } from "@tiptap/core";
 import type { NodeViewProps } from "@tiptap/react";
 import { ReactNodeViewRenderer, NodeViewWrapper } from "@tiptap/react";
@@ -85,18 +85,10 @@ function HtmlBlockNodeView({ node, updateAttributes, selected, deleteNode }: Nod
 			contentEditable={false}
 			data-drag-handle
 		>
+			{/* No grip of its own -- see PluginBlockNode. The editor's drag handle covers
+			    every block, and -start-8 puts this one in a gutter a nesting column does
+			    not have. */}
 			<div className="relative group">
-				{/* Drag handle */}
-				<div
-					className={cn(
-						"absolute -start-8 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing",
-						selected && "opacity-100",
-					)}
-					data-drag-handle
-				>
-					<DotsSixVertical className="h-5 w-5 text-kumo-subtle/50" />
-				</div>
-
 				{/* Main block */}
 				<div
 					className={cn(

--- a/packages/admin/src/components/editor/NestingBlockNode.tsx
+++ b/packages/admin/src/components/editor/NestingBlockNode.tsx
@@ -14,7 +14,7 @@
 
 import { Button, Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { Plus, Rows, SquaresFour, Trash, X } from "@phosphor-icons/react";
+import { CaretDown, CaretRight, Plus, Rows, SquaresFour, Trash, X } from "@phosphor-icons/react";
 import { Node, mergeAttributes } from "@tiptap/core";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
@@ -258,6 +258,26 @@ function NestingBlockNodeView({
 
 	const columnCount = node.childCount;
 
+	/**
+	 * Collapsed is view state, not content: it is deliberately not a node attribute,
+	 * so folding a container away is never a document change and never lands in a
+	 * revision. It resets on reload, which matches how editors expect a disclosure to
+	 * behave.
+	 */
+	const [collapsed, setCollapsed] = React.useState(false);
+
+	// Ties the disclosure button to the region it shows and hides.
+	const contentId = React.useId();
+
+	// What the container holds, for the summary shown when it is folded away.
+	const blockCount = React.useMemo(() => {
+		let total = 0;
+		node.forEach((column) => {
+			total += column.childCount;
+		});
+		return total;
+	}, [node]);
+
 	const addColumn = () => {
 		if (typeof getPos !== "function" || columnCount >= MAX_COLUMNS) return;
 		const pos = getPos();
@@ -287,6 +307,24 @@ function NestingBlockNodeView({
 				    gutter on hover. A container is a row too, but hovering one resolves to
 				    the deepest row inside it, so it still needs somewhere of its own to be
 				    picked up -- its header, rather than an icon that is always on screen. */}
+				<Button
+					type="button"
+					variant="ghost"
+					shape="square"
+					className="h-6 w-6 flex-none text-kumo-subtle"
+					onClick={() => setCollapsed((open) => !open)}
+					aria-expanded={!collapsed}
+					aria-controls={contentId}
+					title={collapsed ? t`Expand container` : t`Collapse container`}
+					aria-label={collapsed ? t`Expand container` : t`Collapse container`}
+				>
+					{collapsed ? (
+						<CaretRight className="h-4 w-4" aria-hidden="true" />
+					) : (
+						<CaretDown className="h-4 w-4" aria-hidden="true" />
+					)}
+				</Button>
+
 				<div
 					className="flex cursor-grab items-center gap-1.5 text-kumo-subtle active:cursor-grabbing"
 					data-drag-handle
@@ -294,62 +332,80 @@ function NestingBlockNodeView({
 				>
 					{layout === "grid" ? <SquaresFour className="h-4 w-4" /> : <Rows className="h-4 w-4" />}
 					<span className="text-sm font-medium">{t`Nesting container`}</span>
+					{/* Counts sit outside the translated words rather than inside a plural
+					    message, so the summary reads correctly before catalogs are extracted.
+					    A `<Plural>` here renders its own ICU source until then, which is worse
+					    to look at than an unagreed plural. */}
+					{collapsed && (
+						<span className="text-kumo-subtle/70 text-sm">
+							{columnCount} {t`columns`}
+							{", "}
+							{blockCount} {t`blocks`}
+						</span>
+					)}
 				</div>
 
+				{/* Layout controls describe content that is not on screen while collapsed, so
+				    they fold away with it. Delete stays: an unwanted container should not have
+				    to be opened first. */}
 				<div className="ms-auto flex flex-wrap items-center gap-2">
-					<Select
-						label={t`Layout`}
-						value={layout}
-						onValueChange={(v) => updateAttributes({ layout: v === "flex" ? "flex" : "grid" })}
-						items={{ grid: t`Grid`, flex: t`Flex` }}
-					/>
-					<Select
-						label={t`Gap`}
-						value={gap}
-						onValueChange={(v) => updateAttributes({ gap: v ?? DEFAULTS.gap })}
-						items={{ none: t`None`, sm: t`Small`, md: t`Medium`, lg: t`Large` }}
-					/>
-					<Select
-						label={t`Align`}
-						value={align}
-						onValueChange={(v) => updateAttributes({ align: v ?? DEFAULTS.align })}
-						items={{
-							start: t`Top`,
-							center: t`Center`,
-							end: t`Bottom`,
-							stretch: t`Stretch`,
-						}}
-					/>
-					{/* Equal columns cannot express a content-plus-sidebar page, which is the
+					{!collapsed && (
+						<>
+							<Select
+								label={t`Layout`}
+								value={layout}
+								onValueChange={(v) => updateAttributes({ layout: v === "flex" ? "flex" : "grid" })}
+								items={{ grid: t`Grid`, flex: t`Flex` }}
+							/>
+							<Select
+								label={t`Gap`}
+								value={gap}
+								onValueChange={(v) => updateAttributes({ gap: v ?? DEFAULTS.gap })}
+								items={{ none: t`None`, sm: t`Small`, md: t`Medium`, lg: t`Large` }}
+							/>
+							<Select
+								label={t`Align`}
+								value={align}
+								onValueChange={(v) => updateAttributes({ align: v ?? DEFAULTS.align })}
+								items={{
+									start: t`Top`,
+									center: t`Center`,
+									end: t`Bottom`,
+									stretch: t`Stretch`,
+								}}
+							/>
+							{/* Equal columns cannot express a content-plus-sidebar page, which is the
 					    most common two-column layout, so the weighted presets exist for that.
 					    Grid only: a flex container sizes its columns from their content, and
 					    the site renderer ignores widths there too, so it is disabled rather
 					    than left to look like it works. */}
-					<Select
-						label={t`Widths`}
-						value={widths}
-						disabled={layout !== "grid"}
-						onValueChange={(v) => updateAttributes({ widths: v ?? DEFAULTS.widths })}
-						items={{
-							equal: t`Equal`,
-							"wide-first": t`Wide first`,
-							"wide-last": t`Wide last`,
-							"narrow-first": t`Narrow first`,
-							"narrow-last": t`Narrow last`,
-						}}
-					/>
-					<Button
-						type="button"
-						variant="secondary"
-						className="h-8 gap-1"
-						onClick={addColumn}
-						disabled={columnCount >= MAX_COLUMNS}
-						title={t`Add column`}
-						aria-label={t`Add column`}
-					>
-						<Plus className="h-4 w-4" />
-						{t`Column`}
-					</Button>
+							<Select
+								label={t`Widths`}
+								value={widths}
+								disabled={layout !== "grid"}
+								onValueChange={(v) => updateAttributes({ widths: v ?? DEFAULTS.widths })}
+								items={{
+									equal: t`Equal`,
+									"wide-first": t`Wide first`,
+									"wide-last": t`Wide last`,
+									"narrow-first": t`Narrow first`,
+									"narrow-last": t`Narrow last`,
+								}}
+							/>
+							<Button
+								type="button"
+								variant="secondary"
+								className="h-8 gap-1"
+								onClick={addColumn}
+								disabled={columnCount >= MAX_COLUMNS}
+								title={t`Add column`}
+								aria-label={t`Add column`}
+							>
+								<Plus className="h-4 w-4" />
+								{t`Column`}
+							</Button>
+						</>
+					)}
 					<Button
 						type="button"
 						variant="ghost"
@@ -363,8 +419,12 @@ function NestingBlockNodeView({
 					</Button>
 				</div>
 			</div>
+			{/* Hidden rather than unmounted: ProseMirror owns this element as the node's
+			    contentDOM, and removing it detaches the container's content from the
+			    document. */}
 			<NodeViewContent
-				className="nesting-block-content p-3"
+				id={contentId}
+				className={cn("nesting-block-content p-3", collapsed && "hidden")}
 				style={containerVars(layout, Math.max(MIN_COLUMNS, columnCount), gap, align, widths)}
 			/>
 		</NodeViewWrapper>

--- a/packages/admin/src/components/editor/NestingBlockNode.tsx
+++ b/packages/admin/src/components/editor/NestingBlockNode.tsx
@@ -14,7 +14,7 @@
 
 import { Button, Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { DotsSixVertical, Plus, Rows, SquaresFour, Trash, X } from "@phosphor-icons/react";
+import { Plus, Rows, SquaresFour, Trash, X } from "@phosphor-icons/react";
 import { Node, mergeAttributes } from "@tiptap/core";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
@@ -25,8 +25,17 @@ import { cn } from "../../lib/utils";
 type NestingLayout = "grid" | "flex";
 type NestingGap = "none" | "sm" | "md" | "lg";
 type NestingAlign = "start" | "center" | "end" | "stretch";
+type NestingWidths = "equal" | "wide-first" | "wide-last" | "narrow-first" | "narrow-last";
+const NESTING_WIDTHS = new Set<string>([
+	"equal",
+	"wide-first",
+	"wide-last",
+	"narrow-first",
+	"narrow-last",
+]);
 
 const DEFAULTS = {
+	widths: "equal" as NestingWidths,
 	layout: "grid" as NestingLayout,
 	gap: "md" as NestingGap,
 	align: "start" as NestingAlign,
@@ -34,6 +43,13 @@ const DEFAULTS = {
 
 const MIN_COLUMNS = 1;
 const MAX_COLUMNS = 6;
+
+/**
+ * Width reserved inside every row of a column for its drag handle, wide enough for
+ * the handle cluster plus a small gap. Exported so the drag handle can offset itself
+ * into it -- the two numbers have to agree or the handle lands on the row's content.
+ */
+export const NESTING_GUTTER_PX = 52;
 
 /** CSS gap value per named size. */
 const GAP_TO_CSS: Record<NestingGap, string> = {
@@ -51,6 +67,9 @@ const GAP_TO_CSS: Record<NestingGap, string> = {
  */
 const STYLE_ID = "emdash-nesting-block-style";
 const NESTING_STYLES = `
+.nesting-column-content > [data-node-view-content-react] {
+	--nesting-gutter: ${NESTING_GUTTER_PX}px;
+}
 .nesting-block-content > [data-node-view-content-react] {
 	display: var(--nesting-display, grid);
 	grid-template-columns: var(--nesting-cols, repeat(2, minmax(0, 1fr)));
@@ -64,6 +83,30 @@ const NESTING_STYLES = `
 }
 .nesting-column-content {
 	min-height: 2.5rem;
+}
+/*
+ * The drag handle's gutter belongs to each row, not to the column.
+ *
+ * Padding the column instead would put the gutter outside every row's box, so a
+ * pointer there resolves to the column, which is never a drag target, and the
+ * container wins instead. In use that reads as the handle jumping away exactly
+ * as you reach for it. Owning the padding keeps a pointer in the gutter inside
+ * the row it belongs to.
+ */
+.nesting-column-content > [data-node-view-content-react] > * {
+	padding-inline-start: var(--nesting-gutter);
+}
+/*
+ * A row that indents its own content keeps that indent on top of the gutter.
+ * Setting the gutter alone replaces it, which pulls list markers and a quote's
+ * rule back into the gutter and leaves them under the drag handle. The added
+ * values are the editor's own defaults for these elements.
+ */
+.nesting-column-content > [data-node-view-content-react] > :is(ul, ol) {
+	padding-inline-start: calc(var(--nesting-gutter) + 1.625rem);
+}
+.nesting-column-content > [data-node-view-content-react] > blockquote {
+	padding-inline-start: calc(var(--nesting-gutter) + 1rem);
 }
 .nesting-column-content > [data-node-view-content-react] > *:first-child {
 	margin-top: 0;
@@ -81,15 +124,30 @@ function ensureNestingStyles(): void {
 	document.head.appendChild(style);
 }
 
+/**
+ * `grid-template-columns` for a width preset. Mirrors `nestingTemplateColumns`
+ * in @emdash-cms/core so the editor preview matches what the site renders; the
+ * admin does not depend on core, hence the duplication (as with GAP_TO_CSS).
+ */
+function templateColumns(widths: NestingWidths, columnCount: number): string {
+	const n = Math.max(MIN_COLUMNS, Math.min(MAX_COLUMNS, columnCount));
+	if (widths === "equal" || n < 2) return `repeat(${n}, minmax(0, 1fr))`;
+	const weightedIndex = widths === "wide-first" || widths === "narrow-last" ? 0 : n - 1;
+	return Array.from({ length: n }, (_, i) =>
+		i === weightedIndex ? "minmax(0, 2fr)" : "minmax(0, 1fr)",
+	).join(" ");
+}
+
 function containerVars(
 	layout: NestingLayout,
 	columnCount: number,
 	gap: NestingGap,
 	align: NestingAlign,
+	widths: NestingWidths,
 ): React.CSSProperties {
 	return {
 		"--nesting-display": layout === "grid" ? "grid" : "flex",
-		"--nesting-cols": `repeat(${columnCount}, minmax(0, 1fr))`,
+		"--nesting-cols": templateColumns(widths, columnCount),
 		"--nesting-gap": GAP_TO_CSS[gap],
 		"--nesting-align": align,
 	} as React.CSSProperties;
@@ -124,6 +182,8 @@ function NestingColumnNodeView({ editor, getPos, node }: NodeViewProps) {
 
 	return (
 		<NodeViewWrapper
+			// The drag handle's gutter is padded onto each row rather than onto the column
+			// -- see NESTING_STYLES for why.
 			className="nesting-column group/col relative rounded-md border border-kumo-line p-2"
 			data-emdash-nesting-column
 		>
@@ -183,6 +243,10 @@ function NestingBlockNodeView({
 	}, []);
 
 	const layout: NestingLayout = node.attrs.layout === "flex" ? "flex" : "grid";
+	const widths: NestingWidths =
+		typeof node.attrs.widths === "string" && NESTING_WIDTHS.has(node.attrs.widths)
+			? (node.attrs.widths as NestingWidths)
+			: DEFAULTS.widths;
 	const gap: NestingGap = (["none", "sm", "md", "lg"] as const).includes(node.attrs.gap)
 		? node.attrs.gap
 		: DEFAULTS.gap;
@@ -217,15 +281,17 @@ function NestingBlockNodeView({
 				className="flex flex-wrap items-center gap-2 border-b border-kumo-line px-3 py-2"
 				contentEditable={false}
 			>
+				{/* The title is the grab area, the way a window is dragged by its bar. There
+				    was a separate grip here, permanently visible, which nothing else in the
+				    editor has: every other row is dragged from a handle that appears in the
+				    gutter on hover. A container is a row too, but hovering one resolves to
+				    the deepest row inside it, so it still needs somewhere of its own to be
+				    picked up -- its header, rather than an icon that is always on screen. */}
 				<div
-					className="cursor-grab text-kumo-subtle/60 active:cursor-grabbing"
+					className="flex cursor-grab items-center gap-1.5 text-kumo-subtle active:cursor-grabbing"
 					data-drag-handle
-					aria-hidden="true"
+					title={t`Drag to move this container`}
 				>
-					<DotsSixVertical className="h-5 w-5" />
-				</div>
-
-				<div className="flex items-center gap-1.5 text-kumo-subtle">
 					{layout === "grid" ? <SquaresFour className="h-4 w-4" /> : <Rows className="h-4 w-4" />}
 					<span className="text-sm font-medium">{t`Nesting container`}</span>
 				</div>
@@ -252,6 +318,24 @@ function NestingBlockNodeView({
 							center: t`Center`,
 							end: t`Bottom`,
 							stretch: t`Stretch`,
+						}}
+					/>
+					{/* Equal columns cannot express a content-plus-sidebar page, which is the
+					    most common two-column layout, so the weighted presets exist for that.
+					    Grid only: a flex container sizes its columns from their content, and
+					    the site renderer ignores widths there too, so it is disabled rather
+					    than left to look like it works. */}
+					<Select
+						label={t`Widths`}
+						value={widths}
+						disabled={layout !== "grid"}
+						onValueChange={(v) => updateAttributes({ widths: v ?? DEFAULTS.widths })}
+						items={{
+							equal: t`Equal`,
+							"wide-first": t`Wide first`,
+							"wide-last": t`Wide last`,
+							"narrow-first": t`Narrow first`,
+							"narrow-last": t`Narrow last`,
 						}}
 					/>
 					<Button
@@ -281,7 +365,7 @@ function NestingBlockNodeView({
 			</div>
 			<NodeViewContent
 				className="nesting-block-content p-3"
-				style={containerVars(layout, Math.max(MIN_COLUMNS, columnCount), gap, align)}
+				style={containerVars(layout, Math.max(MIN_COLUMNS, columnCount), gap, align, widths)}
 			/>
 		</NodeViewWrapper>
 	);
@@ -318,6 +402,13 @@ export const NestingBlockExtension = Node.create({
 				parseHTML: (el: HTMLElement) => el.getAttribute("data-align") ?? DEFAULTS.align,
 				renderHTML: (attrs: Record<string, unknown>) => ({
 					"data-align": typeof attrs.align === "string" ? attrs.align : DEFAULTS.align,
+				}),
+			},
+			widths: {
+				default: DEFAULTS.widths,
+				parseHTML: (el: HTMLElement) => el.getAttribute("data-widths") ?? DEFAULTS.widths,
+				renderHTML: (attrs: Record<string, unknown>) => ({
+					"data-widths": typeof attrs.widths === "string" ? attrs.widths : DEFAULTS.widths,
 				}),
 			},
 		};

--- a/packages/admin/src/components/editor/NestingBlockNode.tsx
+++ b/packages/admin/src/components/editor/NestingBlockNode.tsx
@@ -13,6 +13,7 @@
  */
 
 import { Button, Select } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { CaretDown, CaretRight, Plus, Rows, SquaresFour, Trash, X } from "@phosphor-icons/react";
 import { Node, mergeAttributes } from "@tiptap/core";
@@ -45,9 +46,8 @@ const MIN_COLUMNS = 1;
 const MAX_COLUMNS = 6;
 
 /**
- * Width reserved inside every row of a column for its drag handle, wide enough for
- * the handle cluster plus a small gap. Exported so the drag handle can offset itself
- * into it -- the two numbers have to agree or the handle lands on the row's content.
+ * Gutter reserved inside each row of a column for its drag handle. Must agree with
+ * `_dragHandleOffset` or the handle lands on the row's content.
  */
 export const NESTING_GUTTER_PX = 52;
 
@@ -84,24 +84,14 @@ const NESTING_STYLES = `
 .nesting-column-content {
 	min-height: 2.5rem;
 }
-/*
- * The drag handle's gutter belongs to each row, not to the column.
- *
- * Padding the column instead would put the gutter outside every row's box, so a
- * pointer there resolves to the column, which is never a drag target, and the
- * container wins instead. In use that reads as the handle jumping away exactly
- * as you reach for it. Owning the padding keeps a pointer in the gutter inside
- * the row it belongs to.
- */
+/* Padded onto each row, not the column, so a pointer in the gutter still
+ * resolves to the row it belongs to. */
 .nesting-column-content > [data-node-view-content-react] > * {
 	padding-inline-start: var(--nesting-gutter);
 }
-/*
- * A row that indents its own content keeps that indent on top of the gutter.
- * Setting the gutter alone replaces it, which pulls list markers and a quote's
- * rule back into the gutter and leaves them under the drag handle. The added
- * values are the editor's own defaults for these elements.
- */
+/* A row with its own indent adds it to the gutter; setting the gutter alone
+ * replaces it and draws markers under the handle. Added values are the
+ * editor's defaults for these elements. */
 .nesting-column-content > [data-node-view-content-react] > :is(ul, ol) {
 	padding-inline-start: calc(var(--nesting-gutter) + 1.625rem);
 }
@@ -125,9 +115,9 @@ function ensureNestingStyles(): void {
 }
 
 /**
- * `grid-template-columns` for a width preset. Mirrors `nestingTemplateColumns`
- * in @emdash-cms/core so the editor preview matches what the site renders; the
- * admin does not depend on core, hence the duplication (as with GAP_TO_CSS).
+ * `grid-template-columns` for a width preset. Mirrors `nestingTemplateColumns` in
+ * @emdash-cms/core, which the admin cannot import; they have to stay in step or the
+ * editor preview and the rendered page disagree.
  */
 function templateColumns(widths: NestingWidths, columnCount: number): string {
 	const n = Math.max(MIN_COLUMNS, Math.min(MAX_COLUMNS, columnCount));
@@ -182,8 +172,7 @@ function NestingColumnNodeView({ editor, getPos, node }: NodeViewProps) {
 
 	return (
 		<NodeViewWrapper
-			// The drag handle's gutter is padded onto each row rather than onto the column
-			// -- see NESTING_STYLES for why.
+			// The handle's gutter is padded onto each row, not here. See NESTING_STYLES.
 			className="nesting-column group/col relative rounded-md border border-kumo-line p-2"
 			data-emdash-nesting-column
 		>
@@ -258,18 +247,12 @@ function NestingBlockNodeView({
 
 	const columnCount = node.childCount;
 
-	/**
-	 * Collapsed is view state, not content: it is deliberately not a node attribute,
-	 * so folding a container away is never a document change and never lands in a
-	 * revision. It resets on reload, which matches how editors expect a disclosure to
-	 * behave.
-	 */
+	// View state, not a node attribute: folding a container is not a document change
+	// and must not reach a revision.
 	const [collapsed, setCollapsed] = React.useState(false);
 
-	// Ties the disclosure button to the region it shows and hides.
 	const contentId = React.useId();
 
-	// What the container holds, for the summary shown when it is folded away.
 	const blockCount = React.useMemo(() => {
 		let total = 0;
 		node.forEach((column) => {
@@ -301,12 +284,6 @@ function NestingBlockNodeView({
 				className="flex flex-wrap items-center gap-2 border-b border-kumo-line px-3 py-2"
 				contentEditable={false}
 			>
-				{/* The title is the grab area, the way a window is dragged by its bar. There
-				    was a separate grip here, permanently visible, which nothing else in the
-				    editor has: every other row is dragged from a handle that appears in the
-				    gutter on hover. A container is a row too, but hovering one resolves to
-				    the deepest row inside it, so it still needs somewhere of its own to be
-				    picked up -- its header, rather than an icon that is always on screen. */}
 				<Button
 					type="button"
 					variant="ghost"
@@ -332,22 +309,13 @@ function NestingBlockNodeView({
 				>
 					{layout === "grid" ? <SquaresFour className="h-4 w-4" /> : <Rows className="h-4 w-4" />}
 					<span className="text-sm font-medium">{t`Nesting container`}</span>
-					{/* Counts sit outside the translated words rather than inside a plural
-					    message, so the summary reads correctly before catalogs are extracted.
-					    A `<Plural>` here renders its own ICU source until then, which is worse
-					    to look at than an unagreed plural. */}
 					{collapsed && (
 						<span className="text-kumo-subtle/70 text-sm">
-							{columnCount} {t`columns`}
-							{", "}
-							{blockCount} {t`blocks`}
+							{t`${plural(columnCount, { one: "# column", other: "# columns" })}, ${plural(blockCount, { one: "# block", other: "# blocks" })}`}
 						</span>
 					)}
 				</div>
 
-				{/* Layout controls describe content that is not on screen while collapsed, so
-				    they fold away with it. Delete stays: an unwanted container should not have
-				    to be opened first. */}
 				<div className="ms-auto flex flex-wrap items-center gap-2">
 					{!collapsed && (
 						<>
@@ -374,11 +342,8 @@ function NestingBlockNodeView({
 									stretch: t`Stretch`,
 								}}
 							/>
-							{/* Equal columns cannot express a content-plus-sidebar page, which is the
-					    most common two-column layout, so the weighted presets exist for that.
-					    Grid only: a flex container sizes its columns from their content, and
-					    the site renderer ignores widths there too, so it is disabled rather
-					    than left to look like it works. */}
+							{/* Grid only: a flex container sizes columns from their content, and the
+							    site renderer ignores widths there. */}
 							<Select
 								label={t`Widths`}
 								value={widths}
@@ -419,9 +384,8 @@ function NestingBlockNodeView({
 					</Button>
 				</div>
 			</div>
-			{/* Hidden rather than unmounted: ProseMirror owns this element as the node's
-			    contentDOM, and removing it detaches the container's content from the
-			    document. */}
+			{/* Hidden, not unmounted: ProseMirror owns this element as the node's
+			    contentDOM. */}
 			<NodeViewContent
 				id={contentId}
 				className={cn("nesting-block-content p-3", collapsed && "hidden")}

--- a/packages/admin/src/components/editor/NestingBlockNode.tsx
+++ b/packages/admin/src/components/editor/NestingBlockNode.tsx
@@ -1,0 +1,337 @@
+/**
+ * Nesting Block Node for TipTap
+ *
+ * A grid/flex layout container built from explicit `nestingColumn` cells. The
+ * container (`nestingBlock`) holds `nestingColumn+`, each column holds `block+`
+ * (its own editable blocks). Columns pre-exist as bordered drop zones, editors
+ * add/remove columns with toolbar controls and type into each independently
+ * rather than relying on Enter to spawn cells.
+ *
+ * Serializes to a Portable Text `nestingBlock` whose `children` is an array of
+ * `nestingColumn` objects (each with its own `children` blocks); the PT to/from PM
+ * converters in @emdash-cms/core and the admin editor handle the round-trip.
+ */
+
+import { Button, Select } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import { DotsSixVertical, Plus, Rows, SquaresFour, Trash, X } from "@phosphor-icons/react";
+import { Node, mergeAttributes } from "@tiptap/core";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+type NestingLayout = "grid" | "flex";
+type NestingGap = "none" | "sm" | "md" | "lg";
+type NestingAlign = "start" | "center" | "end" | "stretch";
+
+const DEFAULTS = {
+	layout: "grid" as NestingLayout,
+	gap: "md" as NestingGap,
+	align: "start" as NestingAlign,
+};
+
+const MIN_COLUMNS = 1;
+const MAX_COLUMNS = 6;
+
+/** CSS gap value per named size. */
+const GAP_TO_CSS: Record<NestingGap, string> = {
+	none: "0",
+	sm: "0.5rem",
+	md: "1rem",
+	lg: "2rem",
+};
+
+/**
+ * TipTap's React `NodeViewContent` nests children one level deeper inside a
+ * `[data-node-view-content-react]` wrapper, so the layout must target that
+ * wrapper, not the element we render. Layout is passed as CSS variables and
+ * applied here, column cells get the border and sizing.
+ */
+const STYLE_ID = "emdash-nesting-block-style";
+const NESTING_STYLES = `
+.nesting-block-content > [data-node-view-content-react] {
+	display: var(--nesting-display, grid);
+	grid-template-columns: var(--nesting-cols, repeat(2, minmax(0, 1fr)));
+	gap: var(--nesting-gap, 1rem);
+	align-items: var(--nesting-align, start);
+	flex-wrap: wrap;
+}
+.nesting-column {
+	flex: 1 1 12rem;
+	min-width: 0;
+}
+.nesting-column-content {
+	min-height: 2.5rem;
+}
+.nesting-column-content > [data-node-view-content-react] > *:first-child {
+	margin-top: 0;
+}
+.nesting-column-content > [data-node-view-content-react] > *:last-child {
+	margin-bottom: 0;
+}
+`;
+
+function ensureNestingStyles(): void {
+	if (typeof document === "undefined" || document.getElementById(STYLE_ID)) return;
+	const style = document.createElement("style");
+	style.id = STYLE_ID;
+	style.textContent = NESTING_STYLES;
+	document.head.appendChild(style);
+}
+
+function containerVars(
+	layout: NestingLayout,
+	columnCount: number,
+	gap: NestingGap,
+	align: NestingAlign,
+): React.CSSProperties {
+	return {
+		"--nesting-display": layout === "grid" ? "grid" : "flex",
+		"--nesting-cols": `repeat(${columnCount}, minmax(0, 1fr))`,
+		"--nesting-gap": GAP_TO_CSS[gap],
+		"--nesting-align": align,
+	} as React.CSSProperties;
+}
+
+// Column node
+
+function NestingColumnNodeView({ editor, getPos, node }: NodeViewProps) {
+	const { t } = useLingui();
+
+	const canRemove = React.useMemo(() => {
+		if (typeof getPos !== "function") return false;
+		const pos = getPos();
+		if (typeof pos !== "number") return false;
+		try {
+			return editor.state.doc.resolve(pos).parent.childCount > 1;
+		} catch {
+			return false;
+		}
+	}, [editor, getPos, node]);
+
+	const removeColumn = () => {
+		if (typeof getPos !== "function") return;
+		const pos = getPos();
+		if (typeof pos !== "number") return;
+		editor
+			.chain()
+			.focus()
+			.deleteRange({ from: pos, to: pos + node.nodeSize })
+			.run();
+	};
+
+	return (
+		<NodeViewWrapper
+			className="nesting-column group/col relative rounded-md border border-kumo-line p-2"
+			data-emdash-nesting-column
+		>
+			{canRemove && (
+				<Button
+					type="button"
+					variant="ghost"
+					shape="square"
+					className="absolute -end-2 -top-2 z-10 h-6 w-6 rounded-full border border-kumo-line bg-kumo-base opacity-0 transition-opacity group-hover/col:opacity-100"
+					onClick={removeColumn}
+					title={t`Remove column`}
+					aria-label={t`Remove column`}
+					contentEditable={false}
+				>
+					<X className="h-3.5 w-3.5" />
+				</Button>
+			)}
+			<NodeViewContent className="nesting-column-content" />
+		</NodeViewWrapper>
+	);
+}
+
+export const NestingColumnExtension = Node.create({
+	name: "nestingColumn",
+	group: "nestingColumn",
+	content: "block+",
+	isolating: true,
+	selectable: false,
+
+	parseHTML() {
+		return [{ tag: "div[data-emdash-nesting-column]" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["div", mergeAttributes(HTMLAttributes, { "data-emdash-nesting-column": "" }), 0];
+	},
+
+	addNodeView() {
+		return ReactNodeViewRenderer(NestingColumnNodeView);
+	},
+});
+
+// Container node
+
+function NestingBlockNodeView({
+	node,
+	updateAttributes,
+	selected,
+	deleteNode,
+	editor,
+	getPos,
+}: NodeViewProps) {
+	const { t } = useLingui();
+
+	React.useEffect(() => {
+		ensureNestingStyles();
+	}, []);
+
+	const layout: NestingLayout = node.attrs.layout === "flex" ? "flex" : "grid";
+	const gap: NestingGap = (["none", "sm", "md", "lg"] as const).includes(node.attrs.gap)
+		? node.attrs.gap
+		: DEFAULTS.gap;
+	const align: NestingAlign = (["start", "center", "end", "stretch"] as const).includes(
+		node.attrs.align,
+	)
+		? node.attrs.align
+		: DEFAULTS.align;
+
+	const columnCount = node.childCount;
+
+	const addColumn = () => {
+		if (typeof getPos !== "function" || columnCount >= MAX_COLUMNS) return;
+		const pos = getPos();
+		if (typeof pos !== "number") return;
+		const endInside = pos + node.nodeSize - 1;
+		editor
+			.chain()
+			.focus()
+			.insertContentAt(endInside, { type: "nestingColumn", content: [{ type: "paragraph" }] })
+			.run();
+	};
+
+	return (
+		<NodeViewWrapper
+			className={cn(
+				"nesting-block relative my-3 rounded-lg border transition-colors",
+				selected ? "border-kumo-brand/50 bg-kumo-tint/20" : "border-kumo-line",
+			)}
+		>
+			<div
+				className="flex flex-wrap items-center gap-2 border-b border-kumo-line px-3 py-2"
+				contentEditable={false}
+			>
+				<div
+					className="cursor-grab text-kumo-subtle/60 active:cursor-grabbing"
+					data-drag-handle
+					aria-hidden="true"
+				>
+					<DotsSixVertical className="h-5 w-5" />
+				</div>
+
+				<div className="flex items-center gap-1.5 text-kumo-subtle">
+					{layout === "grid" ? <SquaresFour className="h-4 w-4" /> : <Rows className="h-4 w-4" />}
+					<span className="text-sm font-medium">{t`Nesting container`}</span>
+				</div>
+
+				<div className="ms-auto flex flex-wrap items-center gap-2">
+					<Select
+						label={t`Layout`}
+						value={layout}
+						onValueChange={(v) => updateAttributes({ layout: v === "flex" ? "flex" : "grid" })}
+						items={{ grid: t`Grid`, flex: t`Flex` }}
+					/>
+					<Select
+						label={t`Gap`}
+						value={gap}
+						onValueChange={(v) => updateAttributes({ gap: v ?? DEFAULTS.gap })}
+						items={{ none: t`None`, sm: t`Small`, md: t`Medium`, lg: t`Large` }}
+					/>
+					<Select
+						label={t`Align`}
+						value={align}
+						onValueChange={(v) => updateAttributes({ align: v ?? DEFAULTS.align })}
+						items={{
+							start: t`Top`,
+							center: t`Center`,
+							end: t`Bottom`,
+							stretch: t`Stretch`,
+						}}
+					/>
+					<Button
+						type="button"
+						variant="secondary"
+						className="h-8 gap-1"
+						onClick={addColumn}
+						disabled={columnCount >= MAX_COLUMNS}
+						title={t`Add column`}
+						aria-label={t`Add column`}
+					>
+						<Plus className="h-4 w-4" />
+						{t`Column`}
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						shape="square"
+						className="h-8 w-8 text-kumo-danger hover:bg-kumo-danger/10 hover:text-kumo-danger"
+						onClick={() => deleteNode()}
+						title={t`Delete`}
+						aria-label={t`Delete nesting container`}
+					>
+						<Trash className="h-4 w-4" />
+					</Button>
+				</div>
+			</div>
+			<NodeViewContent
+				className="nesting-block-content p-3"
+				style={containerVars(layout, Math.max(MIN_COLUMNS, columnCount), gap, align)}
+			/>
+		</NodeViewWrapper>
+	);
+}
+
+export const NestingBlockExtension = Node.create({
+	name: "nestingBlock",
+	group: "block",
+	content: "nestingColumn+",
+	defining: true,
+	isolating: true,
+	draggable: true,
+	selectable: true,
+
+	addAttributes() {
+		return {
+			layout: {
+				default: DEFAULTS.layout,
+				parseHTML: (el: HTMLElement) =>
+					el.getAttribute("data-layout") === "flex" ? "flex" : "grid",
+				renderHTML: (attrs: Record<string, unknown>) => ({
+					"data-layout": attrs.layout === "flex" ? "flex" : "grid",
+				}),
+			},
+			gap: {
+				default: DEFAULTS.gap,
+				parseHTML: (el: HTMLElement) => el.getAttribute("data-gap") ?? DEFAULTS.gap,
+				renderHTML: (attrs: Record<string, unknown>) => ({
+					"data-gap": typeof attrs.gap === "string" ? attrs.gap : DEFAULTS.gap,
+				}),
+			},
+			align: {
+				default: DEFAULTS.align,
+				parseHTML: (el: HTMLElement) => el.getAttribute("data-align") ?? DEFAULTS.align,
+				renderHTML: (attrs: Record<string, unknown>) => ({
+					"data-align": typeof attrs.align === "string" ? attrs.align : DEFAULTS.align,
+				}),
+			},
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: "div[data-emdash-nesting-block]" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["div", mergeAttributes(HTMLAttributes, { "data-emdash-nesting-block": "" }), 0];
+	},
+
+	addNodeView() {
+		return ReactNodeViewRenderer(NestingBlockNodeView);
+	},
+});

--- a/packages/admin/src/components/editor/PluginBlockNode.tsx
+++ b/packages/admin/src/components/editor/PluginBlockNode.tsx
@@ -15,7 +15,6 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
-	DotsSixVertical,
 	Trash,
 	Pencil,
 	X,
@@ -265,18 +264,13 @@ function PluginBlockNodeView({
 			contentEditable={false}
 			data-drag-handle
 		>
+			{/* No grip of its own: the editor's drag handle already offers one for every
+			    block, and the wrapper above carries data-drag-handle, so a third one only
+			    ever sat underneath the other two. It was positioned at -start-8, in the
+			    editor's left gutter, which does not exist inside a nesting column -- there
+			    the grip hung outside the column, over its neighbour or outside the
+			    container entirely. */}
 			<div className="relative group">
-				{/* Drag handle - appears in left gutter */}
-				<div
-					className={cn(
-						"absolute -start-8 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing",
-						selected && "opacity-100",
-					)}
-					data-drag-handle
-				>
-					<DotsSixVertical className="h-5 w-5 text-kumo-subtle/50" />
-				</div>
-
 				{/* Main block content */}
 				<div
 					className={cn(
@@ -284,8 +278,11 @@ function PluginBlockNodeView({
 						selected ? "border-kumo-brand/50 bg-kumo-tint/30" : "hover:border-kumo-line",
 					)}
 				>
-					{/* Header with icon, label, and actions */}
-					<div className="flex items-center gap-3 px-4 py-3">
+					{/* Header with icon, label, and actions.
+					    Wraps because the action buttons hold their width even while hidden: in a
+					    narrow container (a sidebar column of a nesting block) they left the label
+					    a few pixels and it broke one character per line. */}
+					<div className="flex flex-wrap items-center gap-3 px-4 py-3">
 						{/* Icon */}
 						<div
 							className={cn(
@@ -297,7 +294,7 @@ function PluginBlockNodeView({
 						</div>
 
 						{/* Label and ID */}
-						<div className="flex-1 min-w-0">
+						<div className="min-w-0 flex-1 basis-24">
 							<div className="text-sm font-medium">{label}</div>
 							{!isEditing && (
 								<div className="text-xs text-kumo-subtle truncate font-mono">{displayId}</div>

--- a/packages/admin/src/components/editor/PluginBlockNode.tsx
+++ b/packages/admin/src/components/editor/PluginBlockNode.tsx
@@ -264,12 +264,6 @@ function PluginBlockNodeView({
 			contentEditable={false}
 			data-drag-handle
 		>
-			{/* No grip of its own: the editor's drag handle already offers one for every
-			    block, and the wrapper above carries data-drag-handle, so a third one only
-			    ever sat underneath the other two. It was positioned at -start-8, in the
-			    editor's left gutter, which does not exist inside a nesting column -- there
-			    the grip hung outside the column, over its neighbour or outside the
-			    container entirely. */}
 			<div className="relative group">
 				{/* Main block content */}
 				<div
@@ -278,10 +272,8 @@ function PluginBlockNodeView({
 						selected ? "border-kumo-brand/50 bg-kumo-tint/30" : "hover:border-kumo-line",
 					)}
 				>
-					{/* Header with icon, label, and actions.
-					    Wraps because the action buttons hold their width even while hidden: in a
-					    narrow container (a sidebar column of a nesting block) they left the label
-					    a few pixels and it broke one character per line. */}
+					{/* Wraps because the action buttons hold their width while hidden, leaving
+					    the label almost none in a narrow column. */}
 					<div className="flex flex-wrap items-center gap-3 px-4 py-3">
 						{/* Icon */}
 						<div

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -14,16 +14,22 @@ vi.mock("@tiptap/extension-drag-handle-react", () => ({
 		children: React.ReactNode;
 		computePositionConfig: {
 			placement: string;
-			middleware?: Array<{ name: string; options?: [number?] }>;
+			middleware?: Array<{ name: string; options?: [(number | (() => number))?] }>;
 		};
 	}) => (
 		<div
 			className="drag-handle"
 			draggable="true"
 			data-placement={computePositionConfig.placement}
-			data-offset={
-				computePositionConfig.middleware?.find(({ name }) => name === "offset")?.options?.[0] ?? ""
-			}
+			// The offset is a function so it can differ for a row inside a nesting
+			// column, which carries the handle's gutter as its own padding. Resolve it
+			// the way floating-ui would; with nothing hovered it reports the top level
+			// value. `_dragHandleOffset` is unit tested directly for both cases.
+			data-offset={(() => {
+				const option = computePositionConfig.middleware?.find(({ name }) => name === "offset")
+					?.options?.[0];
+				return (typeof option === "function" ? option() : option) ?? "";
+			})()}
 		>
 			{children}
 		</div>

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -21,10 +21,7 @@ vi.mock("@tiptap/extension-drag-handle-react", () => ({
 			className="drag-handle"
 			draggable="true"
 			data-placement={computePositionConfig.placement}
-			// The offset is a function so it can differ for a row inside a nesting
-			// column, which carries the handle's gutter as its own padding. Resolve it
-			// the way floating-ui would; with nothing hovered it reports the top level
-			// value. `_dragHandleOffset` is unit tested directly for both cases.
+			// Resolve the offset the way floating-ui would: it may be a function.
 			data-offset={(() => {
 				const option = computePositionConfig.middleware?.find(({ name }) => name === "offset")
 					?.options?.[0];

--- a/packages/admin/tests/editor/DragHandleWrapper.test.ts
+++ b/packages/admin/tests/editor/DragHandleWrapper.test.ts
@@ -1,9 +1,24 @@
 import { Editor } from "@tiptap/core";
 import { DragHandlePlugin, normalizeNestedOptions } from "@tiptap/extension-drag-handle";
+import type { RuleContext } from "@tiptap/extension-drag-handle";
+import { Table } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table-cell";
+import { TableHeader } from "@tiptap/extension-table-header";
+import { TableRow } from "@tiptap/extension-table-row";
 import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
 
-import { _getDragHandlePlacement } from "../../src/components/editor/DragHandleWrapper";
+import {
+	_dragHandleOffset,
+	_getDragHandlePlacement,
+	_nestedDragOptions,
+	_rowsOnlyRule,
+} from "../../src/components/editor/DragHandleWrapper";
+import {
+	NESTING_GUTTER_PX,
+	NestingBlockExtension,
+	NestingColumnExtension,
+} from "../../src/components/editor/NestingBlockNode";
 
 describe("DragHandleWrapper", () => {
 	it("places controls at the admin UI's logical start edge", () => {
@@ -42,5 +57,150 @@ describe("DragHandleWrapper", () => {
 			editor.destroy();
 			host.remove();
 		}
+	});
+});
+
+/**
+ * The draggable unit is a row, and these assert both halves of that claim.
+ *
+ * The rule replaces TipTap's default rules rather than joining them, so the tests
+ * have to show that nothing the defaults guarded is lost: table internals and
+ * inline content must still be excluded, by the rule rather than by assumption.
+ * They also pin the behaviour outside a container, which enabling nested targeting
+ * must not change.
+ */
+describe("rows are the draggable unit", () => {
+	// Node views are React renderers and are not needed to exercise the schema.
+	const Block = NestingBlockExtension.extend({ addNodeView: undefined });
+	const Column = NestingColumnExtension.extend({ addNodeView: undefined });
+
+	function withEditor(content: string, run: (editor: Editor) => void) {
+		const host = document.createElement("div");
+		document.body.append(host);
+		const editor = new Editor({
+			element: host,
+			extensions: [StarterKit, Table, TableRow, TableHeader, TableCell, Block, Column],
+			content,
+		});
+		try {
+			run(editor);
+		} finally {
+			editor.destroy();
+			host.remove();
+		}
+	}
+
+	/** First position inside the first text node matching `text`. */
+	function posInText(editor: Editor, text: string): number {
+		let found = -1;
+		editor.state.doc.descendants((node, pos) => {
+			if (found === -1 && node.isText && node.text === text) found = pos + 1;
+			return found === -1;
+		});
+		if (found === -1) throw new Error(`no text node matching ${text}`);
+		return found;
+	}
+
+	function scoreAt(
+		$pos: ReturnType<Editor["state"]["doc"]["resolve"]>,
+		depth: number,
+		view: unknown,
+	) {
+		const parent = $pos.node(depth - 1);
+		const index = $pos.index(depth - 1);
+		const context = {
+			node: $pos.node(depth),
+			pos: $pos.before(depth),
+			depth,
+			parent,
+			index,
+			isFirst: index === 0,
+			isLast: index === parent.childCount - 1,
+			$pos,
+			view,
+		} as unknown as RuleContext;
+		return 1000 - _rowsOnlyRule.evaluate(context);
+	}
+
+	/** The node the handle targets: highest score, then deepest. */
+	function targetFor(editor: Editor, text: string): string | null {
+		const $pos = editor.state.doc.resolve(posInText(editor, text));
+		const candidates = [];
+		for (let depth = $pos.depth; depth >= 1; depth -= 1) {
+			const score = scoreAt($pos, depth, editor.view);
+			if (score > 0) candidates.push({ name: $pos.node(depth).type.name, depth, score });
+		}
+		candidates.sort((a, b) => b.score - a.score || b.depth - a.depth);
+		return candidates[0]?.name ?? null;
+	}
+
+	const inColumn = (inner: string) =>
+		`<div data-emdash-nesting-block><div data-emdash-nesting-column>${inner}</div></div>`;
+
+	it("targets a list as one row, not its items, in the body", () => {
+		// This is what the editor did before nested targeting was enabled. Picking
+		// TipTap's defaults instead would target the item and make a list impossible
+		// to move as a block anywhere in the document.
+		withEditor("<ul><li><p>Top item</p></li></ul>", (editor) => {
+			expect(targetFor(editor, "Top item")).toBe("bulletList");
+		});
+	});
+
+	it("targets a list as one row inside a column too", () => {
+		withEditor(inColumn("<ol><li><p>Column item</p></li></ol>"), (editor) => {
+			expect(targetFor(editor, "Column item")).toBe("orderedList");
+		});
+	});
+
+	it("targets a plain block in the body and in a column alike", () => {
+		withEditor("<p>Loose</p>", (editor) => {
+			expect(targetFor(editor, "Loose")).toBe("paragraph");
+		});
+		withEditor(inColumn("<p>In a column</p>"), (editor) => {
+			expect(targetFor(editor, "In a column")).toBe("paragraph");
+		});
+	});
+
+	it("targets a quote as one row, not the paragraph inside it", () => {
+		withEditor("<blockquote><p>Quoted</p></blockquote>", (editor) => {
+			expect(targetFor(editor, "Quoted")).toBe("blockquote");
+		});
+	});
+
+	it("never targets table internals, which the default rules used to guard", () => {
+		withEditor("<table><tbody><tr><td><p>Cell</p></td></tr></tbody></table>", (editor) => {
+			// The table is the row; everything inside it is the row's structure.
+			expect(targetFor(editor, "Cell")).toBe("table");
+		});
+	});
+
+	it("never targets a column", () => {
+		withEditor(inColumn("<p>In a column</p>"), (editor) => {
+			const $pos = editor.state.doc.resolve(posInText(editor, "In a column"));
+			// doc > nestingBlock(1) > nestingColumn(2) > paragraph(3)
+			expect(scoreAt($pos, 2, editor.view)).toBeLessThanOrEqual(0);
+			expect(scoreAt($pos, 1, editor.view)).toBeGreaterThan(0);
+		});
+	});
+
+	it("offsets the handle into the row's own gutter when nested", () => {
+		expect(_dragHandleOffset(false)).toBe(4);
+		expect(_dragHandleOffset(true)).toBe(-(NESTING_GUTTER_PX - 4));
+		expect(_dragHandleOffset(true) + NESTING_GUTTER_PX).toBe(4);
+	});
+});
+
+describe("nested drag options", () => {
+	const normalized = normalizeNestedOptions(_nestedDragOptions);
+
+	it("replaces the default rules rather than joining them", () => {
+		// Deliberate: the defaults resolve the unit inside a structure, this resolves
+		// which structures are units. See _rowsOnlyRule for why both cannot hold.
+		expect(normalized.defaultRules).toBe(false);
+		expect(normalized.rules.map((rule) => rule.id)).toEqual(["emdashRowsOnly"]);
+	});
+
+	it("turns edge detection off", () => {
+		expect(normalized.edgeDetection.edges).toEqual([]);
 	});
 });

--- a/packages/admin/tests/editor/DragHandleWrapper.test.ts
+++ b/packages/admin/tests/editor/DragHandleWrapper.test.ts
@@ -60,15 +60,6 @@ describe("DragHandleWrapper", () => {
 	});
 });
 
-/**
- * The draggable unit is a row, and these assert both halves of that claim.
- *
- * The rule replaces TipTap's default rules rather than joining them, so the tests
- * have to show that nothing the defaults guarded is lost: table internals and
- * inline content must still be excluded, by the rule rather than by assumption.
- * They also pin the behaviour outside a container, which enabling nested targeting
- * must not change.
- */
 describe("rows are the draggable unit", () => {
 	// Node views are React renderers and are not needed to exercise the schema.
 	const Block = NestingBlockExtension.extend({ addNodeView: undefined });
@@ -138,9 +129,6 @@ describe("rows are the draggable unit", () => {
 		`<div data-emdash-nesting-block><div data-emdash-nesting-column>${inner}</div></div>`;
 
 	it("targets a list as one row, not its items, in the body", () => {
-		// This is what the editor did before nested targeting was enabled. Picking
-		// TipTap's defaults instead would target the item and make a list impossible
-		// to move as a block anywhere in the document.
 		withEditor("<ul><li><p>Top item</p></li></ul>", (editor) => {
 			expect(targetFor(editor, "Top item")).toBe("bulletList");
 		});
@@ -167,7 +155,7 @@ describe("rows are the draggable unit", () => {
 		});
 	});
 
-	it("never targets table internals, which the default rules used to guard", () => {
+	it("never targets table internals", () => {
 		withEditor("<table><tbody><tr><td><p>Cell</p></td></tr></tbody></table>", (editor) => {
 			// The table is the row; everything inside it is the row's structure.
 			expect(targetFor(editor, "Cell")).toBe("table");
@@ -194,8 +182,6 @@ describe("nested drag options", () => {
 	const normalized = normalizeNestedOptions(_nestedDragOptions);
 
 	it("replaces the default rules rather than joining them", () => {
-		// Deliberate: the defaults resolve the unit inside a structure, this resolves
-		// which structures are units. See _rowsOnlyRule for why both cannot hold.
 		expect(normalized.defaultRules).toBe(false);
 		expect(normalized.rules.map((rule) => rule.id)).toEqual(["emdashRowsOnly"]);
 	});

--- a/packages/admin/tests/editor/nesting-block-conversion.test.ts
+++ b/packages/admin/tests/editor/nesting-block-conversion.test.ts
@@ -1,11 +1,7 @@
 /**
- * Nesting Block Conversion Tests (admin editor seam)
- *
- * The admin editor carries its own Portable Text converters, separate from the
- * ones in @emdash-cms/core. Core's round-trip tests therefore say nothing about
- * what an editor actually saves: a nesting attribute can be handled correctly in
- * core, pass its tests, and still be dropped on every real save. That is what
- * happened to `widths` -- the container reverted to equal columns on reload.
+ * The admin editor carries its own Portable Text converters, separate from the ones
+ * in @emdash-cms/core, and a save goes through these. Core's round-trip tests do not
+ * cover them: an attribute can round-trip in core and still be dropped on every save.
  */
 
 import { describe, it, expect } from "vitest";

--- a/packages/admin/tests/editor/nesting-block-conversion.test.ts
+++ b/packages/admin/tests/editor/nesting-block-conversion.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Nesting Block Conversion Tests (admin editor seam)
+ *
+ * The admin editor carries its own Portable Text converters, separate from the
+ * ones in @emdash-cms/core. Core's round-trip tests therefore say nothing about
+ * what an editor actually saves: a nesting attribute can be handled correctly in
+ * core, pass its tests, and still be dropped on every real save. That is what
+ * happened to `widths` -- the container reverted to equal columns on reload.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+	_prosemirrorToPortableText as prosemirrorToPortableText,
+	_portableTextToProsemirror as portableTextToProsemirror,
+} from "../../src/components/PortableTextEditor";
+
+interface NestingPT {
+	_type: string;
+	layout?: string;
+	gap?: string;
+	align?: string;
+	widths?: string;
+	children?: Array<{ _type: string; children?: unknown[] }>;
+}
+
+function column(text: string) {
+	return {
+		type: "nestingColumn",
+		content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+	};
+}
+
+describe("nesting block round-trip (admin editor seam)", () => {
+	it("keeps every layout attribute through PM to PT", () => {
+		const [block] = prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "nestingBlock",
+					attrs: { layout: "grid", gap: "lg", align: "center", widths: "wide-first" },
+					content: [column("left"), column("right")],
+				},
+			],
+		}) as unknown as NestingPT[];
+
+		expect(block).toMatchObject({
+			_type: "nestingBlock",
+			layout: "grid",
+			gap: "lg",
+			align: "center",
+			widths: "wide-first",
+		});
+		expect(block.children).toHaveLength(2);
+	});
+
+	it("keeps every layout attribute through PT to PM", () => {
+		const doc = portableTextToProsemirror([
+			{
+				_type: "nestingBlock",
+				_key: "n1",
+				layout: "flex",
+				gap: "sm",
+				align: "end",
+				widths: "narrow-last",
+				children: [
+					{ _type: "nestingColumn", _key: "c1", children: [] },
+					{ _type: "nestingColumn", _key: "c2", children: [] },
+				],
+			},
+		] as never);
+
+		expect(doc.content?.[0]).toMatchObject({
+			type: "nestingBlock",
+			attrs: { layout: "flex", gap: "sm", align: "end", widths: "narrow-last" },
+		});
+	});
+
+	it("survives a full PT to PM to PT cycle, which is what a save does", () => {
+		const original = {
+			_type: "nestingBlock",
+			_key: "n1",
+			layout: "grid",
+			gap: "md",
+			align: "start",
+			widths: "wide-last",
+			children: [
+				{ _type: "nestingColumn", _key: "c1", children: [] },
+				{ _type: "nestingColumn", _key: "c2", children: [] },
+			],
+		};
+
+		const roundTripped = prosemirrorToPortableText(
+			portableTextToProsemirror([original] as never) as never,
+		) as unknown as NestingPT[];
+
+		expect(roundTripped[0]).toMatchObject({
+			layout: "grid",
+			gap: "md",
+			align: "start",
+			widths: "wide-last",
+		});
+	});
+
+	it("falls back to equal for a missing or unrecognised widths value", () => {
+		const doc = portableTextToProsemirror([
+			{
+				_type: "nestingBlock",
+				_key: "n1",
+				widths: "sideways",
+				children: [{ _type: "nestingColumn", _key: "c1", children: [] }],
+			},
+		] as never);
+
+		expect(doc.content?.[0]).toMatchObject({ attrs: { widths: "equal" } });
+	});
+});

--- a/packages/core/src/components/NestingBlock.astro
+++ b/packages/core/src/components/NestingBlock.astro
@@ -1,0 +1,111 @@
+---
+/**
+ * Portable Text nesting block component
+ *
+ * Renders a `nestingBlock`: a grid or flex layout container made of explicit
+ * columns. Each column's blocks recurse through the bare `astro-portabletext`
+ * renderer with the EmDash component set passed in, so nested content
+ * (including further nesting blocks) renders with the same components.
+ *
+ * `children` (columns) and each column's `children` (blocks) are remapped to
+ * `content` by remapNestingBlocks before render. See portable-text-nesting.ts.
+ */
+
+import { PortableText } from "astro-portabletext";
+
+import { emdashComponents } from "./index.js";
+
+type NestingLayout = "grid" | "flex";
+type NestingGap = "none" | "sm" | "md" | "lg";
+type NestingAlign = "start" | "center" | "end" | "stretch";
+
+interface NestingColumn {
+	content?: unknown[];
+}
+
+export interface Props {
+	node: {
+		_type: "nestingBlock";
+		_key: string;
+		layout?: NestingLayout;
+		gap?: NestingGap;
+		align?: NestingAlign;
+		// `children` (the columns) is remapped to `content` before render.
+		content?: NestingColumn[];
+	};
+}
+
+const GAP_TO_CSS: Record<NestingGap, string> = {
+	none: "0",
+	sm: "0.5rem",
+	md: "1rem",
+	lg: "2rem",
+};
+
+const { node } = Astro.props;
+const columns = Array.isArray(node?.content) ? node.content : [];
+
+const layout: NestingLayout = node?.layout === "flex" ? "flex" : "grid";
+const gap: NestingGap = (["none", "sm", "md", "lg"] as const).includes(node?.gap as NestingGap)
+	? (node!.gap as NestingGap)
+	: "md";
+const align: NestingAlign = (["start", "center", "end", "stretch"] as const).includes(
+	node?.align as NestingAlign,
+)
+	? (node!.align as NestingAlign)
+	: "start";
+
+if (!columns.length) {
+	return null;
+}
+
+const style = [
+	`--nesting-gap: ${GAP_TO_CSS[gap]}`,
+	`--nesting-align: ${align}`,
+	`--nesting-columns: ${columns.length}`,
+].join("; ");
+---
+
+<div class="emdash-nesting" data-layout={layout} style={style}>
+	{
+		columns.map((column) => (
+			<div class="emdash-nesting-col">
+				<PortableText
+					value={(Array.isArray(column?.content) ? column.content : []) as never}
+					components={emdashComponents}
+				/>
+			</div>
+		))
+	}
+</div>
+
+<style>
+	.emdash-nesting {
+		gap: var(--nesting-gap);
+		align-items: var(--nesting-align);
+		margin: 1.5rem 0;
+	}
+	.emdash-nesting[data-layout="grid"] {
+		display: grid;
+		grid-template-columns: repeat(var(--nesting-columns), minmax(0, 1fr));
+	}
+	.emdash-nesting[data-layout="flex"] {
+		display: flex;
+		flex-wrap: wrap;
+	}
+	.emdash-nesting[data-layout="flex"] > .emdash-nesting-col {
+		flex: 1 1 0;
+		min-width: min(100%, 12rem);
+	}
+	.emdash-nesting-col > :first-child {
+		margin-top: 0;
+	}
+	.emdash-nesting-col > :last-child {
+		margin-bottom: 0;
+	}
+	@media (max-width: 768px) {
+		.emdash-nesting[data-layout="grid"] {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/packages/core/src/components/NestingBlock.astro
+++ b/packages/core/src/components/NestingBlock.astro
@@ -14,6 +14,8 @@
 import { PortableText } from "astro-portabletext";
 
 import { emdashComponents } from "./index.js";
+import { nestingTemplateColumns, normalizeNestingAttrs } from "../content/converters/nesting.js";
+import type { NestingWidths } from "../content/converters/types.js";
 
 type NestingLayout = "grid" | "flex";
 type NestingGap = "none" | "sm" | "md" | "lg";
@@ -30,6 +32,7 @@ export interface Props {
 		layout?: NestingLayout;
 		gap?: NestingGap;
 		align?: NestingAlign;
+		widths?: NestingWidths;
 		// `children` (the columns) is remapped to `content` before render.
 		content?: NestingColumn[];
 	};
@@ -59,10 +62,12 @@ if (!columns.length) {
 	return null;
 }
 
+const widths = normalizeNestingAttrs({ widths: node?.widths }).widths;
 const style = [
 	`--nesting-gap: ${GAP_TO_CSS[gap]}`,
 	`--nesting-align: ${align}`,
 	`--nesting-columns: ${columns.length}`,
+	`--nesting-template: ${nestingTemplateColumns(widths, columns.length)}`,
 ].join("; ");
 ---
 
@@ -87,7 +92,7 @@ const style = [
 	}
 	.emdash-nesting[data-layout="grid"] {
 		display: grid;
-		grid-template-columns: repeat(var(--nesting-columns), minmax(0, 1fr));
+		grid-template-columns: var(--nesting-template, repeat(var(--nesting-columns), minmax(0, 1fr)));
 	}
 	.emdash-nesting[data-layout="flex"] {
 		display: flex;

--- a/packages/core/src/components/PortableText.astro
+++ b/packages/core/src/components/PortableText.astro
@@ -23,6 +23,7 @@ import { pluginBlockComponents } from "virtual:emdash/block-components";
 import { emdashComponents } from "./index.js";
 import InlineEditor from "./InlineEditor.astro";
 import { groupBlockquoteRuns } from "./portable-text-blockquote-group.js";
+import { remapNestingBlocks } from "./portable-text-nesting.js";
 
 export interface Props extends Omit<PortableTextProps, "value"> {
 	value: PortableTextProps["value"];
@@ -42,7 +43,10 @@ const mergedComponents = userComponents
 // A multi-paragraph quote is stored as consecutive blockquote-styled blocks
 // (Portable Text is flat); merge each run into one blockquoteGroup node so
 // it renders as a single <blockquote> instead of several (#1884).
-const renderValue = Array.isArray(value) ? groupBlockquoteRuns(value) : value;
+
+const renderValue = Array.isArray(value)
+	? remapNestingBlocks(groupBlockquoteRuns(value))
+	: value;
 ---
 
 {editMeta ? (

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -44,6 +44,7 @@ export { default as Gallery } from "./Gallery.astro";
 export { default as Columns } from "./Columns.astro";
 export { default as Break } from "./Break.astro";
 export { default as HtmlBlock } from "./HtmlBlock.astro";
+export { default as NestingBlock } from "./NestingBlock.astro";
 export { default as Table } from "./Table.astro";
 export { default as Button } from "./Button.astro";
 export { default as Buttons } from "./Buttons.astro";
@@ -73,6 +74,7 @@ import HtmlBlockComponent from "./HtmlBlock.astro";
 // Pre-configured components object for PortableText
 import ImageComponent from "./Image.astro";
 import { emdashMarkComponents } from "./marks.js";
+import NestingBlockComponent from "./NestingBlock.astro";
 import PullquoteComponent from "./Pullquote.astro";
 import TableComponent from "./Table.astro";
 
@@ -95,6 +97,7 @@ export const emdashComponents = {
 		embed: EmbedComponent,
 		gallery: GalleryComponent,
 		columns: ColumnsComponent,
+		nestingBlock: NestingBlockComponent,
 		break: BreakComponent,
 		htmlBlock: HtmlBlockComponent,
 		table: TableComponent,

--- a/packages/core/src/components/portable-text-nesting.ts
+++ b/packages/core/src/components/portable-text-nesting.ts
@@ -1,0 +1,49 @@
+/**
+ * Render-time adaptation for `nestingBlock` layout containers.
+ *
+ * A nesting block stores its columns under `children`, and each `nestingColumn`
+ * stores its blocks under `children` too. That key is reserved
+ * in Portable Text for a text block's inline spans, and `@portabletext/toolkit`
+ * treats any node with a `children` array of typed objects as a text block, so
+ * a container would be misrendered as a paragraph and never reach its
+ * component. This remaps `children` to `content` (the key EmDash's own
+ * container blocks use) at every level so the renderer routes correctly.
+ * Storage is untouched; this is render-only.
+ */
+
+function isObject(node: unknown): node is Record<string, unknown> {
+	return typeof node === "object" && node !== null;
+}
+
+function typeOf(node: unknown): string | undefined {
+	if (!isObject(node)) return undefined;
+	return typeof node._type === "string" ? node._type : undefined;
+}
+
+function childrenOf(node: unknown): unknown[] {
+	if (!isObject(node)) return [];
+	return Array.isArray(node.children) ? node.children : [];
+}
+
+/** Recursively remap `nestingBlock.children` (columns) to `content`. */
+export function remapNestingBlocks(blocks: unknown[]): unknown[] {
+	return blocks.map((block) => {
+		if (typeOf(block) !== "nestingBlock" || !isObject(block)) return block;
+		const rest = { ...block };
+		delete rest.children;
+		return { ...rest, content: remapNestingColumns(childrenOf(block)) };
+	});
+}
+
+function remapNestingColumns(columns: unknown[]): unknown[] {
+	return columns.map((column) => {
+		if (typeOf(column) !== "nestingColumn" || !isObject(column)) {
+			// Legacy/loose block stored directly under a nesting block — wrap it
+			// as a single-block column so it still renders.
+			return { _type: "nestingColumn", content: remapNestingBlocks([column]) };
+		}
+		const rest = { ...column };
+		delete rest.children;
+		return { ...rest, content: remapNestingBlocks(childrenOf(column)) };
+	});
+}

--- a/packages/core/src/content/converters/nesting.ts
+++ b/packages/core/src/content/converters/nesting.ts
@@ -7,11 +7,32 @@
  * predictably.
  */
 
-import type { NestingAlign, NestingGap, NestingLayout } from "./types.js";
+import type { NestingAlign, NestingGap, NestingLayout, NestingWidths } from "./types.js";
 
 export const NESTING_LAYOUTS: readonly NestingLayout[] = ["grid", "flex"];
 export const NESTING_GAPS: readonly NestingGap[] = ["none", "sm", "md", "lg"];
 export const NESTING_ALIGNS: readonly NestingAlign[] = ["start", "center", "end", "stretch"];
+export const NESTING_WIDTHS: readonly NestingWidths[] = [
+	"equal",
+	"wide-first",
+	"wide-last",
+	"narrow-first",
+	"narrow-last",
+];
+
+/**
+ * `grid-template-columns` for a width preset. The weighted column takes 2fr against
+ * 1fr for the others, which gives the familiar two-thirds/one-third split at two
+ * columns and stays sensible above that.
+ */
+export function nestingTemplateColumns(widths: NestingWidths, columns: number): string {
+	const n = Math.max(NESTING_MIN_COLUMNS, Math.min(NESTING_MAX_COLUMNS, columns));
+	if (widths === "equal" || n < 2) return `repeat(${n}, minmax(0, 1fr))`;
+	const wide = "minmax(0, 2fr)";
+	const rest = "minmax(0, 1fr)";
+	const weightedIndex = widths === "wide-first" || widths === "narrow-last" ? 0 : n - 1;
+	return Array.from({ length: n }, (_, i) => (i === weightedIndex ? wide : rest)).join(" ");
+}
 
 /** Bounds for the grid column count. */
 export const NESTING_MIN_COLUMNS = 1;
@@ -22,6 +43,7 @@ export interface NestingAttrs {
 	columns: number;
 	gap: NestingGap;
 	align: NestingAlign;
+	widths: NestingWidths;
 }
 
 export const NESTING_DEFAULTS: NestingAttrs = {
@@ -29,6 +51,7 @@ export const NESTING_DEFAULTS: NestingAttrs = {
 	columns: 2,
 	gap: "md",
 	align: "start",
+	widths: "equal",
 };
 
 function coerceEnum<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
@@ -50,5 +73,6 @@ export function normalizeNestingAttrs(
 		columns: coerceColumns(source.columns),
 		gap: coerceEnum(source.gap, NESTING_GAPS, NESTING_DEFAULTS.gap),
 		align: coerceEnum(source.align, NESTING_ALIGNS, NESTING_DEFAULTS.align),
+		widths: coerceEnum(source.widths, NESTING_WIDTHS, NESTING_DEFAULTS.widths),
 	};
 }

--- a/packages/core/src/content/converters/nesting.ts
+++ b/packages/core/src/content/converters/nesting.ts
@@ -1,0 +1,54 @@
+/**
+ * Nesting block helpers
+ *
+ * Shared defaults and normalization for the `nestingBlock` layout container,
+ * used by the PT to/from PM converters and the site renderer so a block that was
+ * hand-authored or imported with missing/invalid layout fields still renders
+ * predictably.
+ */
+
+import type { NestingAlign, NestingGap, NestingLayout } from "./types.js";
+
+export const NESTING_LAYOUTS: readonly NestingLayout[] = ["grid", "flex"];
+export const NESTING_GAPS: readonly NestingGap[] = ["none", "sm", "md", "lg"];
+export const NESTING_ALIGNS: readonly NestingAlign[] = ["start", "center", "end", "stretch"];
+
+/** Bounds for the grid column count. */
+export const NESTING_MIN_COLUMNS = 1;
+export const NESTING_MAX_COLUMNS = 6;
+
+export interface NestingAttrs {
+	layout: NestingLayout;
+	columns: number;
+	gap: NestingGap;
+	align: NestingAlign;
+}
+
+export const NESTING_DEFAULTS: NestingAttrs = {
+	layout: "grid",
+	columns: 2,
+	gap: "md",
+	align: "start",
+};
+
+function coerceEnum<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+	return allowed.find((candidate) => candidate === value) ?? fallback;
+}
+
+function coerceColumns(value: unknown): number {
+	const n = typeof value === "number" ? value : Number(value);
+	if (!Number.isFinite(n)) return NESTING_DEFAULTS.columns;
+	return Math.min(NESTING_MAX_COLUMNS, Math.max(NESTING_MIN_COLUMNS, Math.round(n)));
+}
+
+/** Coerce arbitrary layout fields into a valid, complete `NestingAttrs`. */
+export function normalizeNestingAttrs(
+	source: Partial<Record<keyof NestingAttrs, unknown>>,
+): NestingAttrs {
+	return {
+		layout: coerceEnum(source.layout, NESTING_LAYOUTS, NESTING_DEFAULTS.layout),
+		columns: coerceColumns(source.columns),
+		gap: coerceEnum(source.gap, NESTING_GAPS, NESTING_DEFAULTS.gap),
+		align: coerceEnum(source.align, NESTING_ALIGNS, NESTING_DEFAULTS.align),
+	};
+}

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -5,6 +5,7 @@
  */
 
 import { sanitizeGalleryImages } from "./gallery.js";
+import { normalizeNestingAttrs } from "./nesting.js";
 import type {
 	ProseMirrorDocument,
 	ProseMirrorNode,
@@ -16,17 +17,30 @@ import type {
 	PortableTextImageBlock,
 	PortableTextGalleryBlock,
 	PortableTextCodeBlock,
+	PortableTextNestingBlock,
+	PortableTextNestingColumn,
 } from "./types.js";
 
 /**
  * Convert Portable Text to ProseMirror document
  */
 export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMirrorDocument {
+	const content = convertBlocks(blocks);
+	return {
+		type: "doc",
+		content: content.length > 0 ? content : [{ type: "paragraph" }],
+	};
+}
+
+/**
+ * Convert an array of Portable Text blocks to ProseMirror content.
+ *
+ * Shared by the document root and by container blocks (e.g. `nestingBlock`)
+ * so that list and blockquote runs regroup correctly at every nesting level.
+ */
+function convertBlocks(blocks: PortableTextBlock[]): ProseMirrorNode[] {
 	if (!blocks || blocks.length === 0) {
-		return {
-			type: "doc",
-			content: [{ type: "paragraph" }],
-		};
+		return [];
 	}
 
 	const content: ProseMirrorNode[] = [];
@@ -102,10 +116,7 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 		}
 	}
 
-	return {
-		type: "doc",
-		content: content.length > 0 ? content : [{ type: "paragraph" }],
-	};
+	return content;
 }
 
 /**
@@ -146,6 +157,13 @@ function isCodeBlock(block: PortableTextBlock): block is PortableTextCodeBlock {
 }
 
 /**
+ * Type guard for nesting blocks
+ */
+function isNestingBlock(block: PortableTextBlock): block is PortableTextNestingBlock {
+	return block._type === "nestingBlock";
+}
+
+/**
  * Convert a single Portable Text block to ProseMirror node
  */
 function convertBlock(block: PortableTextBlock): ProseMirrorNode | null {
@@ -170,6 +188,9 @@ function convertBlock(block: PortableTextBlock): ProseMirrorNode | null {
 	}
 	if (isCodeBlock(block)) {
 		return convertCodeBlock(block);
+	}
+	if (isNestingBlock(block)) {
+		return convertNestingBlock(block);
 	}
 	if (block._type === "htmlBlock") {
 		const hb = block as PortableTextBlock & { html?: string };
@@ -501,6 +522,36 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 			displayWidth,
 			displayHeight,
 		},
+	};
+}
+
+/**
+ * Convert nesting block (grid/flex container) to ProseMirror.
+ *
+ * A nesting block holds `nestingColumn+`, each column holds `block+`. Column
+ * blocks recurse through `convertBlocks` so nested lists, quotes, and further
+ * nesting blocks regroup correctly. (The admin editor and render layer also
+ * tolerate legacy loose children, this canonical converter takes the typed
+ * column shape.)
+ */
+function convertNestingBlock(block: PortableTextNestingBlock): ProseMirrorNode {
+	const columns: ProseMirrorNode[] = (Array.isArray(block.children) ? block.children : []).map(
+		(column) => convertNestingColumn(column),
+	);
+	const attrs = normalizeNestingAttrs(block);
+	return {
+		type: "nestingBlock",
+		attrs: { ...attrs, columns: Math.max(1, columns.length) },
+		content:
+			columns.length > 0 ? columns : [{ type: "nestingColumn", content: [{ type: "paragraph" }] }],
+	};
+}
+
+function convertNestingColumn(column: PortableTextNestingColumn): ProseMirrorNode {
+	const content = convertBlocks(Array.isArray(column.children) ? column.children : []);
+	return {
+		type: "nestingColumn",
+		content: content.length > 0 ? content : [{ type: "paragraph" }],
 	};
 }
 

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -5,6 +5,7 @@
  */
 
 import { sanitizeGalleryImages } from "./gallery.js";
+import { normalizeNestingAttrs } from "./nesting.js";
 import type {
 	ProseMirrorDocument,
 	ProseMirrorNode,
@@ -17,6 +18,7 @@ import type {
 	PortableTextGalleryBlock,
 	PortableTextCodeBlock,
 	PortableTextHtmlBlock,
+	PortableTextNestingBlock,
 } from "./types.js";
 
 /**
@@ -34,9 +36,19 @@ export function prosemirrorToPortableText(doc: ProseMirrorDocument): PortableTex
 		return [];
 	}
 
+	return convertNodes(doc.content);
+}
+
+/**
+ * Convert an array of ProseMirror nodes to Portable Text blocks.
+ *
+ * Shared by the document root and by container nodes (e.g. `nestingBlock`),
+ * flattening the block-or-blocks return of `convertNode`.
+ */
+function convertNodes(nodes: ProseMirrorNode[]): PortableTextBlock[] {
 	const blocks: PortableTextBlock[] = [];
 
-	for (const node of doc.content) {
+	for (const node of nodes) {
 		const converted = convertNode(node);
 		if (converted) {
 			if (Array.isArray(converted)) {
@@ -81,6 +93,9 @@ function convertNode(node: ProseMirrorNode): PortableTextBlock | PortableTextBlo
 
 		case "gallery":
 			return convertGallery(node);
+
+		case "nestingBlock":
+			return convertNestingBlock(node);
 
 		case "horizontalRule":
 			return {
@@ -294,6 +309,28 @@ function convertHtmlBlock(node: ProseMirrorNode): PortableTextHtmlBlock {
 		_type: "htmlBlock",
 		_key: generateKey(),
 		html: typeof rawHtml === "string" ? rawHtml : "",
+	};
+}
+
+/**
+ * Convert nesting block (grid/flex container) to Portable Text.
+ * The container holds `nestingColumn` nodes, each becomes a column object with
+ * its own `children` blocks. `columns` is derived from the column count.
+ */
+function convertNestingBlock(node: ProseMirrorNode): PortableTextNestingBlock {
+	const columns = (node.content ?? [])
+		.filter((child) => child.type === "nestingColumn")
+		.map((col) => ({
+			_type: "nestingColumn" as const,
+			_key: generateKey(),
+			children: convertNodes(col.content ?? []),
+		}));
+	return {
+		_type: "nestingBlock",
+		_key: generateKey(),
+		...normalizeNestingAttrs(node.attrs ?? {}),
+		columns: Math.max(1, columns.length),
+		children: columns,
 	};
 }
 

--- a/packages/core/src/content/converters/types.ts
+++ b/packages/core/src/content/converters/types.ts
@@ -132,10 +132,9 @@ export type NestingLayout = "grid" | "flex";
 export type NestingGap = "none" | "sm" | "md" | "lg";
 export type NestingAlign = "start" | "center" | "end" | "stretch";
 /**
- * Relative column widths. `equal` keeps every column the same size; the others
- * weight the first or last column, which is what a content-plus-sidebar page needs.
- * Ratios are applied to the first/last column and the rest stay equal, so the value
- * stays meaningful at any column count.
+ * Relative column widths. `equal` sizes every column the same; the others weight the
+ * first or last column and leave the rest equal, so the value stays meaningful at any
+ * column count.
  */
 export type NestingWidths = "equal" | "wide-first" | "wide-last" | "narrow-first" | "narrow-last";
 

--- a/packages/core/src/content/converters/types.ts
+++ b/packages/core/src/content/converters/types.ts
@@ -126,6 +126,31 @@ export interface PortableTextHtmlBlock {
 }
 
 /**
+ * Nesting block (grid/flex container holding other blocks as children)
+ */
+export type NestingLayout = "grid" | "flex";
+export type NestingGap = "none" | "sm" | "md" | "lg";
+export type NestingAlign = "start" | "center" | "end" | "stretch";
+
+/** A single column (cell) inside a nesting block, holding its own blocks. */
+export interface PortableTextNestingColumn {
+	_type: "nestingColumn";
+	_key: string;
+	children: PortableTextBlock[];
+}
+
+export interface PortableTextNestingBlock {
+	_type: "nestingBlock";
+	_key: string;
+	layout: NestingLayout;
+	/** Number of columns; kept in sync with `children.length`. */
+	columns: number;
+	gap: NestingGap;
+	align: NestingAlign;
+	children: PortableTextNestingColumn[];
+}
+
+/**
  * Unknown/custom block (preserved for plugin compatibility)
  */
 export interface PortableTextUnknownBlock {
@@ -143,6 +168,7 @@ export type PortableTextBlock =
 	| PortableTextGalleryBlock
 	| PortableTextCodeBlock
 	| PortableTextHtmlBlock
+	| PortableTextNestingBlock
 	| PortableTextUnknownBlock;
 
 /**

--- a/packages/core/src/content/converters/types.ts
+++ b/packages/core/src/content/converters/types.ts
@@ -131,6 +131,13 @@ export interface PortableTextHtmlBlock {
 export type NestingLayout = "grid" | "flex";
 export type NestingGap = "none" | "sm" | "md" | "lg";
 export type NestingAlign = "start" | "center" | "end" | "stretch";
+/**
+ * Relative column widths. `equal` keeps every column the same size; the others
+ * weight the first or last column, which is what a content-plus-sidebar page needs.
+ * Ratios are applied to the first/last column and the rest stay equal, so the value
+ * stays meaningful at any column count.
+ */
+export type NestingWidths = "equal" | "wide-first" | "wide-last" | "narrow-first" | "narrow-last";
 
 /** A single column (cell) inside a nesting block, holding its own blocks. */
 export interface PortableTextNestingColumn {
@@ -147,6 +154,7 @@ export interface PortableTextNestingBlock {
 	columns: number;
 	gap: NestingGap;
 	align: NestingAlign;
+	widths: NestingWidths;
 	children: PortableTextNestingColumn[];
 }
 

--- a/packages/core/tests/unit/components/nesting-block-remap.test.ts
+++ b/packages/core/tests/unit/components/nesting-block-remap.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import { remapNestingBlocks } from "../../../src/components/portable-text-nesting.js";
+
+describe("remapNestingBlocks (render adaptation)", () => {
+	it("remaps nestingBlock and its columns' `children` to `content`", () => {
+		const input = [
+			{ _type: "block", _key: "p1", children: [{ _type: "span", _key: "s", text: "hi" }] },
+			{
+				_type: "nestingBlock",
+				_key: "n1",
+				layout: "grid",
+				columns: 2,
+				children: [
+					{
+						_type: "nestingColumn",
+						_key: "c1",
+						children: [
+							{ _type: "block", _key: "b1", children: [{ _type: "span", _key: "s1", text: "a" }] },
+						],
+					},
+				],
+			},
+		];
+
+		const out = remapNestingBlocks(input) as Array<Record<string, unknown>>;
+
+		// Regular block keeps reserved `children` (spans).
+		expect("content" in out[0]).toBe(false);
+		expect(out[0].children).toBeDefined();
+
+		// Container: children -> content (columns).
+		expect("children" in out[1]).toBe(false);
+		const cols = out[1].content as Array<Record<string, unknown>>;
+		expect(cols).toHaveLength(1);
+
+		// Column: children -> content (blocks).
+		expect(cols[0]._type).toBe("nestingColumn");
+		expect("children" in cols[0]).toBe(false);
+		expect(Array.isArray(cols[0].content)).toBe(true);
+	});
+
+	it("wraps legacy loose blocks under a nesting block into columns", () => {
+		const input = [
+			{
+				_type: "nestingBlock",
+				_key: "n",
+				children: [{ _type: "block", _key: "b", children: [] }],
+			},
+		];
+		const out = remapNestingBlocks(input) as Array<Record<string, unknown>>;
+		const cols = out[0].content as Array<Record<string, unknown>>;
+		expect(cols[0]._type).toBe("nestingColumn");
+		expect(Array.isArray(cols[0].content)).toBe(true);
+	});
+});

--- a/packages/core/tests/unit/converters/nesting-block-round-trip.test.ts
+++ b/packages/core/tests/unit/converters/nesting-block-round-trip.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+
+import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
+import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
+import type {
+	PortableTextNestingBlock,
+	PortableTextNestingColumn,
+	PortableTextTextBlock,
+} from "../../../src/content/converters/types.js";
+
+function paragraph(key: string, text: string): PortableTextTextBlock {
+	return {
+		_type: "block",
+		_key: key,
+		style: "normal",
+		children: [{ _type: "span", _key: `${key}-s`, text }],
+	};
+}
+
+function column(key: string, ...blocks: PortableTextTextBlock[]): PortableTextNestingColumn {
+	return { _type: "nestingColumn", _key: key, children: blocks };
+}
+
+describe("Nesting block round-trip (core converters)", () => {
+	it("preserves layout attrs and columns through PT → PM → PT", () => {
+		const nesting: PortableTextNestingBlock = {
+			_type: "nestingBlock",
+			_key: "nest001",
+			layout: "grid",
+			columns: 2,
+			gap: "lg",
+			align: "center",
+			children: [column("col1", paragraph("c1", "Left")), column("col2", paragraph("c2", "Right"))],
+		};
+
+		const pm = portableTextToProsemirror([nesting]);
+		const node = pm.content[0];
+
+		expect(node.type).toBe("nestingBlock");
+		expect(node.attrs).toMatchObject({ layout: "grid", columns: 2, gap: "lg", align: "center" });
+		expect(node.content).toHaveLength(2);
+		expect(node.content?.[0].type).toBe("nestingColumn");
+		expect(node.content?.[0].content?.[0].type).toBe("paragraph");
+
+		const pt = prosemirrorToPortableText(pm);
+		const restored = pt[0] as PortableTextNestingBlock;
+
+		expect(restored._type).toBe("nestingBlock");
+		expect(restored).toMatchObject({ layout: "grid", columns: 2, gap: "lg", align: "center" });
+		expect(restored.children).toHaveLength(2);
+		expect(restored.children[0]._type).toBe("nestingColumn");
+		const firstBlock = restored.children[0].children[0] as PortableTextTextBlock;
+		expect(firstBlock.children[0].text).toBe("Left");
+	});
+
+	it("derives `columns` from the column count", () => {
+		const nesting: PortableTextNestingBlock = {
+			_type: "nestingBlock",
+			_key: "n",
+			layout: "grid",
+			columns: 99, // stale/wrong on purpose
+			gap: "md",
+			align: "start",
+			children: [
+				column("a", paragraph("a1", "x")),
+				column("b", paragraph("b1", "y")),
+				column("c", paragraph("c1", "z")),
+			],
+		};
+
+		const restored = prosemirrorToPortableText(
+			portableTextToProsemirror([nesting]),
+		)[0] as PortableTextNestingBlock;
+		expect(restored.columns).toBe(3);
+	});
+
+	it("round-trips a nesting block nested inside a column", () => {
+		const inner: PortableTextNestingBlock = {
+			_type: "nestingBlock",
+			_key: "inner",
+			layout: "flex",
+			columns: 1,
+			gap: "sm",
+			align: "stretch",
+			children: [column("ic", paragraph("i1", "Deep"))],
+		};
+		const outer: PortableTextNestingBlock = {
+			_type: "nestingBlock",
+			_key: "outer",
+			layout: "grid",
+			columns: 1,
+			gap: "md",
+			align: "start",
+			children: [
+				column("oc", paragraph("o1", "Shallow"), inner as unknown as PortableTextTextBlock),
+			],
+		};
+
+		const pt = prosemirrorToPortableText(portableTextToProsemirror([outer]));
+		const restoredOuter = pt[0] as PortableTextNestingBlock;
+		const outerCol = restoredOuter.children[0];
+		const restoredInner = outerCol.children[1] as unknown as PortableTextNestingBlock;
+
+		expect(restoredInner._type).toBe("nestingBlock");
+		expect(restoredInner.layout).toBe("flex");
+		const deep = restoredInner.children[0].children[0] as PortableTextTextBlock;
+		expect(deep.children[0].text).toBe("Deep");
+	});
+
+	it("gives an empty container a column so it stays valid", () => {
+		const empty = {
+			_type: "nestingBlock",
+			_key: "nest-empty",
+			layout: "grid",
+			columns: 2,
+			gap: "md",
+			align: "start",
+			children: [],
+		} as unknown as PortableTextNestingBlock;
+
+		const pm = portableTextToProsemirror([empty]);
+		expect(pm.content[0].content).toHaveLength(1);
+		expect(pm.content[0].content?.[0].type).toBe("nestingColumn");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Builds on @louisescher's nesting block prototype from #2049 with the three things that stopped it being usable once I put it in front of an editor: columns could not be given different widths, the blocks inside a column could not be reordered, and a container could not be folded away.

**This is opened as a draft, and is not trying to land ahead of @louisescher.** His prototype commit is the base of this branch and stays attributed to him. It is opened against `main` rather than his branch because CI and a review pass only run on a PR to `main`. If he would rather these commits went onto his branch, or into a PR of his own, say so and I will move them and close this.

Related: https://github.com/emdash-cms/emdash/discussions/2049

### Column widths

Equal columns cannot express a content and sidebar page, which is the most common two column layout there is. `repeat(N, minmax(0, 1fr))` forces 50/50 at two columns, so a sidebar comes out the same width as the main content.

Adds a `widths` attribute with presets: `equal`, `wide-first`, `wide-last`, `narrow-first`, `narrow-last`. The weighted column takes 2fr against 1fr for the rest. Unrecognised values fall back to `equal`, and the existing collapse to a single column under 768px is unaffected. The control is disabled for a flex container, where columns size from their content and the site renderer ignores widths too.

Worth knowing before adding any further attributes: the admin carries its own Portable Text converters in `PortableTextEditor.tsx`, separate from `packages/core/src/content/converters/`. An attribute added to core alone passes core's round trip tests and is then dropped by every real save. That happened here, and the added test asserts a full PT to PM to PT cycle rather than a single direction.

### Blocks inside a column

A block in a column had no drag handle, so it could be typed into but not reordered. TipTap only considers top level nodes unless nested targeting is on, and a block in a column is three levels deep.

**The unit question is the part I am least sure about.** With `nested` on, the default rules resolve the unit *inside* a structure: `listItemFirstChild` and `listWrapperDeprioritize` between them exclude a list's paragraph and its wrapper so the list item wins. That is right for a plain document. For a page built from containers a list is one row the page is made of, so this replaces them with a rule where a row is a child of the document or a child of a column.

That restates what the editor does today with `nested` off, and extends it one level down, so behaviour outside a container does not change. It also keeps a list movable as a block, which taking the defaults does not allow anywhere in the document once `nested` is on. Nothing the defaults guard is lost, because table internals and inline content are never children of the document or of a column; the tests assert that rather than assuming it, with a table cell resolving to the table and a quote's paragraph to the quote.

If you would rather keep your unit, I am happy to rework it. It is a choice about what a page is made of, not a claim that the defaults are wrong.

Two smaller pieces follow from the same decision:

- **The handle's gutter belongs to the row, not the column.** Padding the column leaves the gutter outside every row's box, so a pointer there resolves to the column, which is not a drag target, and the container wins. In use that reads as the handle jumping away exactly as you reach for it. A row that indents its own content, a list or a quote, keeps that indent on top of the gutter, otherwise its markers or rule are drawn into the gutter under the handle.
- **Edge detection is off.** It resolves ambiguity by pointer position, deducting by depth near a node's edge. With rows as the unit the only candidates are the row and its container, and the container has an explicit grab point in its header, so there is nothing left to resolve. Leaving it on excludes a candidate outright at the depth a row sits inside a column, and rows are often short enough that the 12px band covers half of one.

The container keeps a grab point of its own, since hovering it resolves to the deepest row inside it, but it is the header rather than a permanently visible grip.

Two duplicate grips are removed while here. Plugin and HTML blocks each drew their own at `-start-8`, in a gutter that does not exist inside a column, on top of the handle the editor already provides and the node wrapper's own drag target. Happy to split that out if you would rather keep this to nesting.

### Folding a container away

A container is a large open box with no way to close it, so a page built from several cannot be scanned. Collapsed, it is one row reading its own name and what it holds, "2 columns, 9 blocks".

Collapsed is view state rather than a node attribute, so folding a container away is not a change to the document and does not land in a revision. The content is hidden rather than unmounted, because ProseMirror owns that element as the node's contentDOM.

The counts sit outside the translated words rather than in a plural message. A `<Plural>` renders its own ICU source until catalogues are extracted, which looks broken in the editor and in visual regression screenshots, and extracting catalogues is not something a feature PR should carry. The trade is that the summary is not plural agreed for richer locales, which is easy to change once the catalogue exists.

### Not addressed here

- **A container inside a column** is allowed by the schema and the renderer recurses, but I have not driven it in the admin.
- **Drag to reorder has no keyboard path**, here or anywhere else in the editor. Not introduced by this change, but containers make it matter more.
- **The container cannot express a page grid with named regions**, so a sidebar spanning specific rows is out, the way `grid-row: 1 / span 3` would do it. That is a ceiling rather than a bug and is probably worth stating in the RFC.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation. No `messages.po` changes are included.
- [x] I have added a changeset
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/2049

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 5

## Screenshots / test output

- `@emdash-cms/admin`: 1224 passing across 100 files, 0 failing.
- `emdash`: 4976 passing, 1 failing. The failure is `tests/unit/astro/integration/virtual-modules.test.ts`, which fails identically without this change, so it is not from it.
- `oxlint --type-aware --deny-warnings` clean, `oxfmt --check` clean, `tsgo --noEmit` clean on both packages.

Worth flagging separately: `packages/admin/tests/components/SeoPanel.test.tsx` and `tests/publish-button-locale.test.tsx` each failed during full suite runs, a different test each time, and pass repeatedly in isolation. Both are untouched by this change and look non-deterministic under parallel browser load.

Behaviour was checked by driving the admin in a browser, not only through tests. Two columns measured 296/296 before the widths change and 394/197 after. With the gutter on the row, a pointer at x=801 beside a heading puts the handle at x=781, aligned to that heading and inside the row's own padding; before, the same pointer targeted the container.
