### PR TITLE
fix(core): normalize media in repeater image sub-fields

### DIFF
--- a/.changeset/repeater-media-normalize.md
+++ b/.changeset/repeater-media-normalize.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Normalize media values inside repeater image sub-fields. A bare media id posted via the REST API into a repeater sub-field is now normalized into a full `MediaValue` (the same treatment top-level image/file fields already get), instead of being stored verbatim and rendered as "Image not found" in the admin.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -197,6 +197,7 @@ import { buildRouteMeta, PluginRouteRegistry, type RouteMeta } from "./plugins/r
 import type { CronScheduler } from "./plugins/scheduler/types.js";
 import { PluginStateRepository } from "./plugins/state.js";
 import { normalizeRegistryConfig } from "./registry/config.js";
+import { isRecord } from "./plugin-utils.js";
 import { requestCached } from "./request-cache.js";
 import { getRequestContext } from "./request-context.js";
 import { publishDueContent, type PublishedRef } from "./scheduled-publish.js";
@@ -3696,12 +3697,11 @@ export class EmDashRuntime {
 				.map((sub) => sub.slug);
 			if (mediaSubFieldSlugs.length === 0) continue;
 
+			const items: unknown[] = value;
 			result[field.slug] = await Promise.all(
-				value.map(async (item) => {
-					if (item == null || typeof item !== "object" || Array.isArray(item)) {
-						return item;
-					}
-					const normalizedItem = { ...(item as Record<string, unknown>) };
+				items.map(async (item) => {
+					if (!isRecord(item)) return item;
+					const normalizedItem: Record<string, unknown> = { ...item };
 					for (const slug of mediaSubFieldSlugs) {
 						const subValue = normalizedItem[slug];
 						if (subValue == null) continue;

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -3662,7 +3662,13 @@ export class EmDashRuntime {
 		const imageFields = collectionInfo.fields.filter(
 			(f) => f.type === "image" || f.type === "file",
 		);
-		if (imageFields.length === 0) return data;
+		// Repeater fields can contain image sub-fields, whose values need the same normalization
+		// (a bare media id posted inside a repeater item would otherwise be stored verbatim and
+		// render as "Image not found" in the admin).
+		const repeaterFields = collectionInfo.fields.filter(
+			(f) => f.type === "repeater" && Array.isArray(f.validation?.subFields),
+		);
+		if (imageFields.length === 0 && repeaterFields.length === 0) return data;
 
 		const getProvider = (id: string) => this.getMediaProvider(id);
 		const result = { ...data };
@@ -3679,6 +3685,38 @@ export class EmDashRuntime {
 			} catch {
 				// Don't fail the save if normalization fails for a single field
 			}
+		}
+
+		for (const field of repeaterFields) {
+			const value = result[field.slug];
+			if (!Array.isArray(value)) continue;
+
+			const mediaSubFieldSlugs = (field.validation?.subFields ?? [])
+				.filter((sub) => sub.type === "image")
+				.map((sub) => sub.slug);
+			if (mediaSubFieldSlugs.length === 0) continue;
+
+			result[field.slug] = await Promise.all(
+				value.map(async (item) => {
+					if (item == null || typeof item !== "object" || Array.isArray(item)) {
+						return item;
+					}
+					const normalizedItem = { ...(item as Record<string, unknown>) };
+					for (const slug of mediaSubFieldSlugs) {
+						const subValue = normalizedItem[slug];
+						if (subValue == null) continue;
+						try {
+							const normalized = await normalizeMediaValue(subValue, getProvider);
+							if (normalized) {
+								normalizedItem[slug] = normalized;
+							}
+						} catch {
+							// Don't fail the save if normalization fails for a single sub-field
+						}
+					}
+					return normalizedItem;
+				}),
+			);
 		}
 
 		return result;

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -182,6 +182,7 @@ import {
 	type Storage,
 } from "./index.js";
 import { getDb } from "./loader.js";
+import { isRecord } from "./plugin-utils.js";
 import { CronExecutor, type InvokeCronHookFn } from "./plugins/cron.js";
 import { definePlugin } from "./plugins/define-plugin.js";
 import { DEV_CONSOLE_EMAIL_PLUGIN_ID, devConsoleEmailDeliver } from "./plugins/email-console.js";
@@ -197,7 +198,6 @@ import { buildRouteMeta, PluginRouteRegistry, type RouteMeta } from "./plugins/r
 import type { CronScheduler } from "./plugins/scheduler/types.js";
 import { PluginStateRepository } from "./plugins/state.js";
 import { normalizeRegistryConfig } from "./registry/config.js";
-import { isRecord } from "./plugin-utils.js";
 import { requestCached } from "./request-cache.js";
 import { getRequestContext } from "./request-context.js";
 import { publishDueContent, type PublishedRef } from "./scheduled-publish.js";

--- a/packages/core/tests/integration/content/repeater-media-normalize.test.ts
+++ b/packages/core/tests/integration/content/repeater-media-normalize.test.ts
@@ -1,0 +1,81 @@
+import { ulid } from "ulidx";
+import { afterEach, beforeEach, expect } from "vitest";
+
+import type { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { createTestRuntime } from "../../utils/mcp-runtime.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("repeater media-field normalization", (dialect) => {
+	let ctx: DialectTestContext;
+	let runtime: EmDashRuntime;
+	let mediaId: string;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		const registry = new SchemaRegistry(ctx.db);
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		// A top-level image field, used as the reference for how a bare media id should normalize.
+		await registry.createField("posts", { slug: "hero", label: "Hero", type: "image" });
+		await registry.createField("posts", {
+			slug: "gallery",
+			label: "Gallery",
+			type: "repeater",
+			validation: { subFields: [{ slug: "image", type: "image", label: "Image" }] },
+		});
+
+		mediaId = ulid();
+		await ctx.db
+			.insertInto("media")
+			.values({
+				id: mediaId,
+				filename: "hero.jpg",
+				mime_type: "image/jpeg",
+				size: 100,
+				width: 1080,
+				height: 1920,
+				alt: null,
+				caption: null,
+				storage_key: "hero.jpg",
+				content_hash: null,
+				blurhash: null,
+				dominant_color: null,
+				status: "ready",
+				author_id: null,
+			})
+			.execute();
+
+		runtime = createTestRuntime(ctx.db);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("normalizes a bare media id inside a repeater image sub-field like a top-level field", async () => {
+		const result = await runtime.handleContentCreate("posts", {
+			slug: "p1",
+			data: { title: "p1", hero: mediaId, gallery: [{ image: mediaId }] },
+		});
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		const data = result.data.item.data as Record<string, unknown>;
+		const hero = data.hero;
+		const gallery = data.gallery as Array<Record<string, unknown>>;
+		const subImage = gallery[0].image;
+
+		// Before the fix the bare id string was stored verbatim inside the repeater item, so the
+		// admin rendered "Image not found". It must now be normalized exactly like the top-level
+		// `hero` field (a MediaValue object, not the raw id string).
+		expect(typeof subImage).toBe("object");
+		expect(subImage).not.toBe(mediaId);
+		expect(subImage).toEqual(hero);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`normalizeMediaFields` only visited fields whose **top-level** type is `image`/`file`, so a bare media id posted into a **repeater image sub-field** was stored verbatim and the admin rendered "Image not found". This walks the image sub-fields of repeater fields and normalizes their values the same way (via `normalizeMediaValue`), so a repeater sub-field gets the same treatment as a top-level image field. Top-level fields and non-repeater collections are unaffected; failures for a single sub-field are swallowed (as for top-level fields) so a save is never blocked.

Closes #2231

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [ ] This PR includes AI-generated code — model/tool:

## Screenshots / test output

Added `tests/integration/content/repeater-media-normalize.test.ts`: it posts the same bare media id into a top-level `image` field and a repeater `image` sub-field and asserts the repeater value normalizes **identically** to the top-level field (so it's harness-independent). It fails on `main` (the sub-field stays a raw id string) and passes here. The `content` integration suite + `media-usage-content-fields` stay green (55 tests); `oxlint` is clean on the changed files.

I ran targeted tests and `oxlint`/`prettier` on the changed files rather than the full `pnpm typecheck`/`pnpm lint`/`pnpm test` (which build the whole monorepo); happy to run those if you'd like.
