### PR TITLE
i18n(cs): add Czech translations for the admin UI

### DIFF
--- a/.changeset/czech-locale-cs.md
+++ b/.changeset/czech-locale-cs.md
@@ -2,4 +2,5 @@
 "@emdash-cms/admin": patch
 ---
 
-Adds Czech (Čeština) as a translatable admin UI locale.
+Adds Czech (Čeština) to the admin UI. Select it from the language picker on the
+login page or in Settings.

--- a/.changeset/czech-locale-cs.md
+++ b/.changeset/czech-locale-cs.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds Czech (Čeština) as a translatable admin UI locale.

--- a/packages/admin/src/locales/cs/messages.po
+++ b/packages/admin/src/locales/cs/messages.po
@@ -551,7 +551,7 @@ msgstr "Úvodní panel přes celou šířku s nadpisem, textem a tlačítkem vý
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:142
 msgid "A short description of your site"
-msgstr "Stručný popis vašeho webu"
+msgstr "Stručný popis webu"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:201
 msgid "Accept & Install"
@@ -576,7 +576,7 @@ msgstr "Přístup odepřen"
 #: packages/admin/src/lib/api/marketplace.ts:282
 #: packages/admin/src/lib/api/marketplace.ts:290
 msgid "Access your media library"
-msgstr "Přístup k vaší knihovně médií"
+msgstr "Přístup ke knihovně médií"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
@@ -683,7 +683,7 @@ msgstr "Přidejte pole jako „Pracovní pozice“ nebo „Zájmena“ a obohať
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:613
 msgid "Add fields to define the structure of your content"
-msgstr "Přidejte pole, která definují strukturu vašeho obsahu"
+msgstr "Přidejte pole a definujte strukturu obsahu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:616
 msgid "Add First Field"
@@ -2469,7 +2469,7 @@ msgstr "Popište obrázek..."
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
 #: packages/admin/src/components/MediaDetailPanel.tsx:374
 msgid "Describe this image for accessibility"
-msgstr "Popište tento obrázek pro přístupnost"
+msgstr "Popište obrázek pro čtečky obrazovky"
 
 #: packages/admin/src/components/SectionEditor.tsx:277
 msgid "Describe what this section is for..."
@@ -3052,7 +3052,7 @@ msgstr "Zadejte URL..."
 
 #: packages/admin/src/components/LoginPage.tsx:327
 msgid "Enter your handle to sign in."
-msgstr "Pro přihlášení zadejte své uživatelské jméno."
+msgstr "Zadejte uživatelské jméno."
 
 #: packages/admin/src/components/WordPressImport.tsx:1459
 msgid "Enter your WordPress credentials to import content directly."
@@ -3842,7 +3842,7 @@ msgstr "Filtrovat podle typu"
 
 #: packages/admin/src/routes/bylines.tsx:408
 msgid "Filter byline type"
-msgstr "Filtrovat typ autorského podpisu"
+msgstr "Filtrovat podle typu autorského podpisu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
@@ -3910,7 +3910,7 @@ msgstr "GitHub"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
 msgid "Give this passkey a name to help you identify it later."
-msgstr "Pojmenujte tento přístupový klíč, abyste jej později snadno poznali."
+msgstr "Pojmenujte klíč, ať jej později snadno poznáte."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:36
 msgid "Go"
@@ -6158,11 +6158,11 @@ msgstr "Číst uživatelské účty"
 #: packages/admin/src/lib/api/marketplace.ts:279
 #: packages/admin/src/lib/api/marketplace.ts:288
 msgid "Read your content"
-msgstr "Číst váš obsah"
+msgstr "Číst obsah"
 
 #: packages/admin/src/lib/api/marketplace.ts:281
 msgid "Read your taxonomies and terms"
-msgstr "Číst vaše taxonomie a jejich položky"
+msgstr "Číst taxonomie a jejich položky"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:269
 msgid "Reading"
@@ -8724,7 +8724,7 @@ msgstr "Můžete web prohlížet a přispívat do něj."
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
-msgstr "Vlastní roli nelze změnit"
+msgstr "Vlastní roli nemůžete změnit"
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."

--- a/packages/admin/src/locales/cs/messages.po
+++ b/packages/admin/src/locales/cs/messages.po
@@ -15,11 +15,11 @@ msgstr ""
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Guest"
-msgstr " - Host"
+msgstr " – Host"
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Linked"
-msgstr " - Propojeno"
+msgstr " – Propojeno"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:72
 #: packages/admin/src/components/TranslationsPanel.tsx:81
@@ -37,12 +37,12 @@ msgstr " (vybráno)"
 
 #: packages/admin/src/routes/bylines.tsx:706
 msgid "-- Select --"
-msgstr "-- Vybrat --"
+msgstr "-- Vyberte --"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
 msgid ", or open the admin at"
-msgstr ", nebo otevřete administraci na"
+msgstr ", nebo otevřete administraci na adrese"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
@@ -69,7 +69,7 @@ msgstr "(příliš nová)"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:310
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
-msgstr "(s vaším vývojovým portem)."
+msgstr "(s portem vývojového serveru)."
 
 #. placeholder {0}: items.length
 #. placeholder {0}: orphan.rowCount
@@ -169,7 +169,7 @@ msgstr "{0, plural, one {# vybráno} few {# vybráno} many {# vybráno} other {#
 #. placeholder {0}: result.skipped
 #: packages/admin/src/components/WordPressImport.tsx:2223
 msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
-msgstr "{0, plural, one {# přeskočeno (již existuje)} few {# přeskočeno (již existují)} many {# přeskočeno (již existují)} other {# přeskočeno (již existují)}}"
+msgstr "{0, plural, one {# přeskočeno (již existuje)} few {# přeskočeno (již existují)} many {# přeskočeno (již existuje)} other {# přeskočeno (již existují)}}"
 
 #. placeholder {0}: result.taxonomyAssignments
 #: packages/admin/src/components/WordPressImport.tsx:2247
@@ -189,19 +189,19 @@ msgstr "{0, plural, one {pole} few {pole} many {pole} other {polí}}"
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:164
 msgid "{0, plural, one {Media file} other {Media files}}"
-msgstr "{0, plural, one {Soubor médií} few {Soubory médií} many {Souborů médií} other {Souborů médií}}"
+msgstr "{0, plural, one {Soubor médií} few {Soubory médií} many {Souboru médií} other {Souborů médií}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:168
 msgid "{0, plural, one {User} other {Users}}"
-msgstr "{0, plural, one {Uživatel} few {Uživatelé} many {Uživatelů} other {Uživatelů}}"
+msgstr "{0, plural, one {Uživatel} few {Uživatelé} many {Uživatele} other {Uživatelů}}"
 
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
 #. placeholder {2}: m.host
 #: packages/admin/src/components/RegistryPluginDetail.tsx:636
 msgid "{0} {1} required — you have {2}."
-msgstr "Vyžadováno {0} {1} — máte {2}."
+msgstr "Požadavek: {0} {1}; vaše verze: {2}."
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-2xl font-semibold leading-tight">{t`Menus`}</h1> <p className="mt-1 text-sm leading-5 text-pretty text-kumo-subtle"> {t`Manage navigation menus for your site`} </p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
@@ -237,7 +237,7 @@ msgstr "Ikona {0}"
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:213
 msgid "{0} installs"
-msgstr "{0} instalací"
+msgstr "Počet instalací: {0}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:96
@@ -248,12 +248,12 @@ msgstr "{0} je nyní aktivní"
 #. placeholder {1}: postType.suggestedCollection
 #: packages/admin/src/components/WordPressImport.tsx:1973
 msgid "{0} items → {1}"
-msgstr "{0} položek → {1}"
+msgstr "{0, plural, one {# položka → {1}} few {# položky → {1}} many {# položky → {1}} other {# položek → {1}}}"
 
 #. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
 #: packages/admin/src/components/WordPressImport.tsx:1896
 msgid "{0} items will be imported"
-msgstr "Bude importováno {0} položek"
+msgstr "{0, plural, one {Bude importována # položka} few {Budou importovány # položky} many {Bude importováno # položky} other {Bude importováno # položek}}"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:535
@@ -273,7 +273,7 @@ msgstr "{0} z {total} se nepodařilo aktualizovat"
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:179
 msgid "{0} plugins"
-msgstr "{0} pluginů"
+msgstr "{0, plural, one {# plugin} few {# pluginy} many {# pluginu} other {# pluginů}}"
 
 #. placeholder {0}: theme.name
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:206
@@ -285,18 +285,18 @@ msgstr "Náhled {0}"
 #. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="truncate text-2xl font-semibold"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
 #: packages/admin/src/components/ContentTypeEditor.tsx:583
 msgid "{0} system + {1} custom {2}"
-msgstr "{0} systémových + {1} vlastních {2}"
+msgstr "Systémová pole: {0} · vlastní: {1} {2}"
 
 #. placeholder {0}: taxonomy.label
 #: packages/admin/src/components/TaxonomySidebar.tsx:360
 msgid "{0} updated"
-msgstr "{0} aktualizováno"
+msgstr "Aktualizováno: {0}"
 
 #. placeholder {0}: plugin.name
 #. placeholder {1}: updateInfo?.latest
 #: packages/admin/src/components/PluginManager.tsx:270
 msgid "{0} updated to v{1}"
-msgstr "{0} aktualizován na v{1}"
+msgstr "{0} aktualizován na verzi {1}"
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
@@ -313,7 +313,7 @@ msgstr "{0}/160 znaků"
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:313
 msgid "{base} to: {0}"
-msgstr "{base} na: {0}"
+msgstr "{base} na adresy: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:355
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
@@ -397,7 +397,7 @@ msgstr "{total, plural, one {# položka} few {# položky} many {# položky} othe
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:150
 msgid "{total, plural, one {# total} other {# total}}"
-msgstr "{total, plural, one {# celkem} few {# celkem} many {# celkem} other {# celkem}}"
+msgstr "{total, plural, one {Celkem: #} few {Celkem: #} many {Celkem: #} other {Celkem: #}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:211
 #: packages/admin/src/components/MediaLibrary.tsx:247
@@ -407,11 +407,11 @@ msgstr "{total, plural, one {Soubor nahrán} few {# soubory nahrány} many {# so
 #: packages/admin/src/components/MediaLibrary.tsx:216
 #: packages/admin/src/components/MediaLibrary.tsx:252
 msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
-msgstr "{total, plural, one {Nahrávání selhalo} few {Všechna # nahrávání selhala} many {Všech # nahrávání selhalo} other {Všech # nahrávání selhalo}}"
+msgstr "{total, plural, one {Nahrávání selhalo} few {Všechna # nahrávání selhala} many {# nahrání selhalo} other {Všech # nahrávání selhalo}}"
 
 #: packages/admin/src/components/Dashboard.tsx:152
 msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
-msgstr "{totalDrafts, plural, one {Koncept} few {Koncepty} many {Konceptů} other {Konceptů}}"
+msgstr "{totalDrafts, plural, one {Koncept} few {Koncepty} many {Konceptu} other {Konceptů}}"
 
 #: packages/admin/src/components/Dashboard.tsx:158
 msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
@@ -419,11 +419,11 @@ msgstr "{totalScheduled, plural, one {Naplánováno} few {Naplánováno} many {N
 
 #: packages/admin/src/components/RevisionHistory.tsx:367
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
-msgstr "{unchangedCount, plural, one {Skrýt # nezměněné} few {Skrýt # nezměněné} many {Skrýt # nezměněných} other {Skrýt # nezměněných}}"
+msgstr "{unchangedCount, plural, one {Skrýt # nezměněné} few {Skrýt # nezměněné} many {Skrýt # nezměněného} other {Skrýt # nezměněných}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:368
 msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
-msgstr "{unchangedCount, plural, one {Zobrazit # nezměněné} few {Zobrazit # nezměněné} many {Zobrazit # nezměněných} other {Zobrazit # nezměněných}}"
+msgstr "{unchangedCount, plural, one {Zobrazit # nezměněné} few {Zobrazit # nezměněné} many {Zobrazit # nezměněného} other {Zobrazit # nezměněných}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:221
 #: packages/admin/src/components/MediaLibrary.tsx:257
@@ -440,7 +440,7 @@ msgstr "/old-page nebo /blog/[slug]"
 
 #: packages/admin/src/components/WordPressImport.tsx:2093
 msgid "• Files are downloaded from your WordPress site"
-msgstr "• Soubory se stáhnou z vašeho webu WordPress"
+msgstr "• Soubory se stáhnou z vašeho webu na WordPressu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2094
 msgid "• Uploaded to your EmDash media storage"
@@ -467,7 +467,7 @@ msgstr "1. Přihlaste se do administrace WordPressu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1275
 msgid "1. Log into your WordPress admin dashboard"
-msgstr "1. Přihlaste se do administračního přehledu WordPressu"
+msgstr "1. Přihlaste se do administrace WordPressu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "2. Go to"
@@ -479,11 +479,11 @@ msgstr "2. Přejděte na Uživatelé → Profil"
 
 #: packages/admin/src/components/WordPressImport.tsx:1524
 msgid "3. Scroll to \"Application Passwords\""
-msgstr "3. Přejděte dolů na „Application Passwords“"
+msgstr "3. Přejděte dolů k části „Hesla aplikací“"
 
 #: packages/admin/src/components/WordPressImport.tsx:1279
 msgid "3. Select \"All content\""
-msgstr "3. Vyberte „All content“"
+msgstr "3. Vyberte „Veškerý obsah“"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
 msgid "30 days"
@@ -491,27 +491,27 @@ msgstr "30 dní"
 
 #: packages/admin/src/components/Redirects.tsx:156
 msgid "301 Permanent"
-msgstr "301 Trvalé"
+msgstr "301 – trvalé přesměrování"
 
 #: packages/admin/src/components/Redirects.tsx:157
 msgid "302 Temporary"
-msgstr "302 Dočasné"
+msgstr "302 – dočasné přesměrování"
 
 #: packages/admin/src/components/Redirects.tsx:158
 msgid "307 Temporary (Strict)"
-msgstr "307 Dočasné (striktní)"
+msgstr "307 – dočasné přesměrování (se zachováním metody)"
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "308 Permanent (Strict)"
-msgstr "308 Trvalé (striktní)"
+msgstr "308 – trvalé přesměrování (se zachováním metody)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1280
 msgid "4. Click \"Download Export File\""
-msgstr "4. Klikněte na „Download Export File“"
+msgstr "4. Klikněte na „Stáhnout soubor s exportem“"
 
 #: packages/admin/src/components/WordPressImport.tsx:1525
 msgid "4. Enter \"EmDash\" and click \"Add New\""
-msgstr "4. Zadejte „EmDash“ a klikněte na „Add New“"
+msgstr "4. Zadejte „EmDash“ a klikněte na „Přidat nové heslo aplikace“"
 
 #: packages/admin/src/components/Redirects.tsx:397
 msgid "404 Errors"
@@ -519,7 +519,7 @@ msgstr "Chyby 404"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "410 Content Deleted (Gone)"
-msgstr "410 Obsah smazán (Gone)"
+msgstr "410 Obsah trvale odstraněn"
 
 #: packages/admin/src/components/Redirects.tsx:161
 msgid "451 Unavailable for legal reasons"
@@ -547,7 +547,7 @@ msgstr "Stručný popis tohoto typu obsahu"
 
 #: packages/admin/src/components/Sections.tsx:203
 msgid "A full-width hero banner with heading, text, and CTA button"
-msgstr "Hero banner přes celou šířku s nadpisem, textem a tlačítkem CTA"
+msgstr "Úvodní panel přes celou šířku s nadpisem, textem a tlačítkem výzvy k akci"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:142
 msgid "A short description of your site"
@@ -625,11 +625,11 @@ msgstr "Přidat"
 #: packages/admin/src/components/TaxonomyManager.tsx:378
 #: packages/admin/src/components/TaxonomyManager.tsx:834
 msgid "Add {0}"
-msgstr "Přidat {0}"
+msgstr "Přidat položku: {0}"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:279
 msgid "Add {label}"
-msgstr "Přidat {label}"
+msgstr "Přidat: {label}"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:177
 msgid "Add a new passkey"
@@ -679,7 +679,7 @@ msgstr "Přidat pole"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr "Přidejte pole jako „Pracovní pozice“ nebo „Oslovení“ a obohaťte tak každý autorský podpis."
+msgstr "Přidejte pole jako „Pracovní pozice“ nebo „Zájmena“ a obohaťte tak každý autorský podpis."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:613
 msgid "Add fields to define the structure of your content"
@@ -723,16 +723,16 @@ msgstr "Přidat MIME typ nebo příponu"
 
 #: packages/admin/src/components/ContentList.tsx:342
 msgid "Add New"
-msgstr "Přidat nový"
+msgstr "Přidat položku"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:503
 msgid "Add new {0}"
-msgstr "Přidat {0}"
+msgstr "Přidat novou položku: {0}"
 
 #: packages/admin/src/components/SeoPanel.tsx:227
 msgid "Add noindex meta tag"
-msgstr "Přidat meta tag noindex"
+msgstr "Přidat metaznačku noindex"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:200
 msgid "Add Passkey"
@@ -846,7 +846,7 @@ msgstr "Všechny autorské podpisy"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:110
 msgid "All capabilities"
-msgstr "Všechny schopnosti"
+msgstr "Všechna oprávnění"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:134
 msgid "All collections"
@@ -885,7 +885,7 @@ msgstr "Všechny typy"
 
 #: packages/admin/src/components/PluginManager.tsx:545
 msgid "Allow MCP tokens with plugin-tool scope to invoke these routes."
-msgstr "Umožnit MCP tokenům s rozsahem plugin-tool volat tyto cesty."
+msgstr "Umožnit tokenům MCP s rozsahem plugin-tool volat tyto koncové body."
 
 #: packages/admin/src/components/Settings.tsx:100
 msgid "Allow users from specific domains to sign up"
@@ -915,19 +915,19 @@ msgstr "Smazat také uložená data pluginu"
 #: packages/admin/src/components/editor/ImageNode.tsx:231
 #: packages/admin/src/components/MediaLibrary.tsx:589
 msgid "Alt text"
-msgstr "Alt text"
+msgstr "Alternativní text"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
 #: packages/admin/src/components/MediaDetailPanel.tsx:354
 #: packages/admin/src/components/MediaDetailPanel.tsx:371
 msgid "Alt Text"
-msgstr "Alt text"
+msgstr "Alternativní text"
 
 #: packages/admin/src/components/MediaLibrary.tsx:835
 #: packages/admin/src/components/MediaLibrary.tsx:892
 msgid "Alt text set"
-msgstr "Alt text nastaven"
+msgstr "Alternativní text je nastaven"
 
 #: packages/admin/src/components/WordPressImport.tsx:1395
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
@@ -989,7 +989,7 @@ msgstr "Analýza souboru exportu..."
 
 #: packages/admin/src/components/WordPressImport.tsx:810
 msgid "Analyzing WordPress site..."
-msgstr "Analýza webu WordPress..."
+msgstr "Analýza webu na WordPressu…"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:105
 msgid "Any media type allowed (subject to global limits)."
@@ -1006,7 +1006,7 @@ msgstr "Zobrazuje se u příspěvků a stránek"
 
 #: packages/admin/src/components/WordPressImport.tsx:1490
 msgid "Application Password"
-msgstr "Aplikační heslo"
+msgstr "Heslo aplikace"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3827
 msgid "Apply"
@@ -1282,7 +1282,7 @@ msgstr "Ověření Bing"
 
 #: packages/admin/src/routes/bylines.tsx:496
 msgid "Bio"
-msgstr "Bio"
+msgstr "Medailonek"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
 msgid "Block actions - drag to reorder, click for menu"
@@ -1297,7 +1297,7 @@ msgstr "Tučné"
 #: packages/admin/src/components/FieldEditor.tsx:174
 #: packages/admin/src/components/FieldEditor.tsx:583
 msgid "Boolean"
-msgstr "Boolean"
+msgstr "Logická hodnota"
 
 #: packages/admin/src/components/SeoPanel.tsx:184
 msgid "Brief summary shown below the title in search results"
@@ -1318,11 +1318,11 @@ msgstr "Procházet soubory"
 
 #: packages/admin/src/components/PluginManager.tsx:204
 msgid "Browse the"
-msgstr "Procházet"
+msgstr "Pluginy můžete nainstalovat z"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
 msgid "Browse themes and preview them with your own content."
-msgstr "Procházejte motivy a prohlédněte si je s vlastním obsahem."
+msgstr "Procházejte šablony a zobrazte jejich náhled s vlastním obsahem."
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:129
 #: packages/admin/src/components/PortableTextEditor.tsx:1172
@@ -1427,7 +1427,7 @@ msgstr "Zrušit přejmenování"
 
 #: packages/admin/src/components/Sections.tsx:407
 msgid "Cannot delete theme sections"
-msgstr "Sekce motivu nelze smazat"
+msgstr "Sekce šablony nelze smazat"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:456
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
@@ -1440,11 +1440,11 @@ msgstr "Kanonická URL"
 
 #: packages/admin/src/components/PluginManager.tsx:519
 msgid "Capabilities"
-msgstr "Schopnosti"
+msgstr "Oprávnění"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:69
 msgid "Capability consent"
-msgstr "Souhlas se schopnostmi"
+msgstr "Souhlas s oprávněními"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:382
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:352
@@ -1494,7 +1494,7 @@ msgstr "Změnit <0>{0}</0> z <1>{1}</1> na <2>{2}</2>? Ztratí přístup k pokro
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:239
 msgid "Change Favicon"
-msgstr "Změnit favicon"
+msgstr "Změnit ikonu webu"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:167
 msgid "Change Image"
@@ -1564,7 +1564,7 @@ msgstr "Vymazat filtry"
 #: packages/admin/src/components/MediaLibrary.tsx:497
 #: packages/admin/src/components/MediaLibrary.tsx:521
 msgid "Clear search"
-msgstr "Vymazat hledání"
+msgstr "Vymazat hledaný výraz"
 
 #: packages/admin/src/components/PluginSettings.tsx:354
 msgid "Clear stored value"
@@ -1754,7 +1754,7 @@ msgstr "Připojit a analyzovat"
 #. placeholder {0}: siteTitle || "WordPress"
 #: packages/admin/src/components/WordPressImport.tsx:1457
 msgid "Connect to {0}"
-msgstr "Připojit k {0}"
+msgstr "Připojit: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1373
 msgid "Connect with WordPress"
@@ -1763,7 +1763,7 @@ msgstr "Připojit k WordPressu"
 #. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:286
 msgid "Connected {0}"
-msgstr "Připojeno {0}"
+msgstr "Připojeno dne {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:183
 msgid "content"
@@ -1811,7 +1811,7 @@ msgstr "Obsah je nyní veřejný"
 
 #: packages/admin/src/components/WordPressImport.tsx:2371
 msgid "content items"
-msgstr "položek obsahu"
+msgstr "– počet položek obsahu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
 msgid "Content Read"
@@ -1959,7 +1959,7 @@ msgstr "Vytvořit odrážkový seznam"
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:383
 msgid "Create a new {0}"
-msgstr "Vytvořit nový {0}"
+msgstr "Vytvořit novou položku: {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1183
 msgid "Create a numbered list"
@@ -2002,7 +2002,7 @@ msgstr "Vytvořit nový token"
 
 #: packages/admin/src/components/WordPressImport.tsx:1501
 msgid "Create one in WordPress: Users → Profile → Application Passwords"
-msgstr "Vytvořte jej ve WordPressu: Users → Profile → Application Passwords"
+msgstr "Vytvořte jej ve WordPressu: Uživatelé → Profil → Hesla aplikací"
 
 #: packages/admin/src/components/SetupWizard.tsx:298
 msgid "Create Passkey"
@@ -2086,7 +2086,7 @@ msgstr "Vytvářet, upravovat a mazat navigační nabídky"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:77
 msgid "Create, update, and delete taxonomy terms"
-msgstr "Vytvářet, upravovat a mazat taxonomické termíny"
+msgstr "Vytvářet, upravovat a mazat položky taxonomie"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:52
 msgid "Create, update, delete content"
@@ -2113,11 +2113,11 @@ msgstr "Vytvořeno {0}"
 #. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
 #: packages/admin/src/router.tsx:1120
 msgid "Created {0} translation"
-msgstr "Vytvořen překlad {0}"
+msgstr "Překlad vytvořen ({0})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "Created At"
-msgstr "Vytvořeno"
+msgstr "Datum vytvoření"
 
 #: packages/admin/src/components/WordPressImport.tsx:887
 msgid "Creating collections and fields..."
@@ -2362,7 +2362,7 @@ msgstr "Smazat obrázek"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:451
 msgid "Delete Media?"
-msgstr "Smazat média?"
+msgstr "Smazat médium?"
 
 #: packages/admin/src/components/MenuList.tsx:256
 msgid "Delete Menu"
@@ -2673,7 +2673,7 @@ msgstr "Doména aktualizována"
 
 #: packages/admin/src/components/LoginPage.tsx:334
 msgid "Don't have an account? <0>Sign up</0>"
-msgstr "Nemáte účet? <0>Zaregistrovat se</0>"
+msgstr "Nemáte účet? <0>Zaregistrujte se</0>"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:142
 #: packages/admin/src/components/WordPressImport.tsx:2128
@@ -2691,7 +2691,7 @@ msgstr "Stáhnout {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:158
 msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
-msgstr "Stáhněte si kompletní zálohu webu: veškerý obsah (včetně konceptů a koše), kolekce, taxonomie, nabídky, widgety, metadata médií a nastavení webu. Uživatelské účty a tajné klíče nejsou nikdy zahrnuty."
+msgstr "Stáhněte si kompletní zálohu webu: veškerý obsah (včetně konceptů a koše), kolekce, taxonomie, nabídky, widgety, metadata médií a nastavení webu. Uživatelské účty ani tajné údaje nejsou součástí zálohy."
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:160
 msgid "Download backup"
@@ -2835,7 +2835,7 @@ msgstr "Upravit pole {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:643
 msgid "Edit {itemLabel}"
-msgstr "Upravit {itemLabel}"
+msgstr "Upravit položku ({itemLabel})"
 
 #: packages/admin/src/components/ContentList.tsx:1019
 msgid "Edit {title}"
@@ -2939,7 +2939,7 @@ msgstr "E-mailový middleware"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:99
 msgid "Email Pipeline"
-msgstr "E-mailová pipeline"
+msgstr "Řetězec zpracování e-mailů"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:172
 msgid "Email provider active"
@@ -3052,7 +3052,7 @@ msgstr "Zadejte URL..."
 
 #: packages/admin/src/components/LoginPage.tsx:327
 msgid "Enter your handle to sign in."
-msgstr "Pro přihlášení zadejte svůj handle."
+msgstr "Pro přihlášení zadejte své uživatelské jméno."
 
 #: packages/admin/src/components/WordPressImport.tsx:1459
 msgid "Enter your WordPress credentials to import content directly."
@@ -3073,19 +3073,19 @@ msgstr "Chyba"
 
 #: packages/admin/src/components/Widgets.tsx:236
 msgid "Error adding widget"
-msgstr "Chyba při přidávání widgetu"
+msgstr "Nepodařilo se přidat widget"
 
 #: packages/admin/src/components/Widgets.tsx:297
 msgid "Error reordering widgets"
-msgstr "Chyba při změně pořadí widgetů"
+msgstr "Nepodařilo se změnit pořadí widgetů"
 
 #: packages/admin/src/components/SectionEditor.tsx:53
 msgid "Error saving section"
-msgstr "Chyba při ukládání sekce"
+msgstr "Nepodařilo se uložit sekci"
 
 #: packages/admin/src/components/Widgets.tsx:784
 msgid "Error updating widget"
-msgstr "Chyba při aktualizaci widgetu"
+msgstr "Nepodařilo se aktualizovat widget"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:596
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
@@ -3134,7 +3134,7 @@ msgstr "Facebook"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:345
 msgid "Fail"
-msgstr "Selhalo"
+msgstr "Neprošlo"
 
 #: packages/admin/src/components/WordPressImport.tsx:2130
 msgid "Failed"
@@ -3195,7 +3195,7 @@ msgstr "Nepodařilo se vytvořit některé kolekce"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:510
 msgid "Failed to create term"
-msgstr "Nepodařilo se vytvořit termín"
+msgstr "Nepodařilo se vytvořit položku taxonomie"
 
 #: packages/admin/src/router.tsx:1125
 msgid "Failed to create translation"
@@ -3272,7 +3272,7 @@ msgstr "Nepodařilo se smazat sekci"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
-msgstr "Nepodařilo se smazat termín"
+msgstr "Nepodařilo se smazat položku taxonomie"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
@@ -3347,7 +3347,7 @@ msgstr "Nepodařilo se načíst nastavení e-mailu"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:106
 msgid "Failed to fetch entry terms"
-msgstr "Nepodařilo se načíst štítky položky"
+msgstr "Nepodařilo se načíst položky taxonomie přiřazené k obsahu"
 
 #: packages/admin/src/lib/api/client.ts:238
 msgid "Failed to fetch manifest"
@@ -3405,7 +3405,7 @@ msgstr "Nepodařilo se načíst stav nastavení"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:87
 msgid "Failed to fetch terms"
-msgstr "Nepodařilo se načíst štítky"
+msgstr "Nepodařilo se načíst položky taxonomie"
 
 #: packages/admin/src/lib/api/current-user.ts:22
 #: packages/admin/src/lib/api/users.ts:88
@@ -3509,7 +3509,7 @@ msgstr "Nepodařilo se načíst nastavení"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
-msgstr "Nepodařilo se načíst motiv"
+msgstr "Nepodařilo se načíst šablonu"
 
 #. placeholder {0}: usersQuery.error.message
 #: packages/admin/src/routes/users.tsx:205
@@ -3615,7 +3615,7 @@ msgstr "Nepodařilo se naplánovat"
 #: packages/admin/src/components/LoginPage.tsx:71
 #: packages/admin/src/components/LoginPage.tsx:76
 msgid "Failed to send magic link"
-msgstr "Nepodařilo se odeslat magický odkaz"
+msgstr "Nepodařilo se odeslat přihlašovací odkaz"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
@@ -3632,7 +3632,7 @@ msgstr "Nepodařilo se odeslat ověřovací e-mail"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:129
 msgid "Failed to set entry terms"
-msgstr "Nepodařilo se nastavit štítky položky"
+msgstr "Nepodařilo se nastavit položky taxonomie přiřazené k obsahu"
 
 #: packages/admin/src/lib/api/marketplace.ts:249
 #: packages/admin/src/lib/api/registry.ts:858
@@ -3728,7 +3728,7 @@ msgstr "FAQ"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:213
 #: packages/admin/src/components/settings/GeneralSettings.tsx:219
 msgid "Favicon"
-msgstr "Favicon"
+msgstr "Ikona webu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1180
 msgid "Feature"
@@ -3808,7 +3808,7 @@ msgstr "Název souboru nelze po nahrání změnit"
 
 #: packages/admin/src/components/WordPressImport.tsx:2366
 msgid "files imported"
-msgstr "souborů importováno"
+msgstr "– počet importovaných souborů"
 
 #: packages/admin/src/components/ContentList.tsx:769
 msgid "Filter by author"
@@ -3816,7 +3816,7 @@ msgstr "Filtrovat podle autora"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:115
 msgid "Filter by capability"
-msgstr "Filtrovat podle schopnosti"
+msgstr "Filtrovat podle oprávnění"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:178
 msgid "Filter by collection"
@@ -3846,7 +3846,7 @@ msgstr "Filtrovat typ autorského podpisu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
-msgstr "Pouze noví komentující"
+msgstr "Pouze komentáře od nových komentujících"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:69
 msgid "Fonts"
@@ -3858,7 +3858,7 @@ msgstr "Pro úplný import včetně konceptů a veškerého obsahu proveďte exp
 
 #: packages/admin/src/components/WordPressImport.tsx:1207
 msgid "For the best import experience, install the"
-msgstr "Pro nejlepší průběh importu nainstalujte"
+msgstr "Pro co nejhladší import nainstalujte plugin"
 
 #: packages/admin/src/components/ContentList.tsx:806
 msgid "From date"
@@ -3923,7 +3923,7 @@ msgstr "Přejít na přehled"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:194
 msgid "Google Verification"
-msgstr "Ověření Google"
+msgstr "Ověření pro Google"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:37
 msgid "GraphQL"
@@ -3935,7 +3935,7 @@ msgstr "Zobrazení mřížky"
 
 #: packages/admin/src/components/Redirects.tsx:167
 msgid "Group (optional)"
-msgstr "Skupina (volitelné)"
+msgstr "Skupina (volitelná)"
 
 #: packages/admin/src/components/Widgets.tsx:162
 msgid "Group by"
@@ -4001,7 +4001,7 @@ msgstr "Hlavní banner"
 
 #: packages/admin/src/components/SectionEditor.tsx:286
 msgid "hero, banner, cta"
-msgstr "hero, banner, cta"
+msgstr "úvodní sekce, banner, výzva k akci"
 
 #: packages/admin/src/components/SeoPanel.tsx:230
 #: packages/admin/src/components/SeoPanel.tsx:233
@@ -4014,12 +4014,12 @@ msgstr "Skrýt token"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:671
 msgid "Hierarchical (like categories, with parent/child relationships)"
-msgstr "Hierarchická (jako kategorie, se vztahy nadřazený/podřazený)"
+msgstr "Hierarchická (jako kategorie, s nadřazenými a podřazenými položkami)"
 
 #: packages/admin/src/components/Redirects.tsx:226
 #: packages/admin/src/components/Redirects.tsx:473
 msgid "Hits"
-msgstr "Zásahy"
+msgstr "Výskyty"
 
 #: packages/admin/src/components/MenuEditor.tsx:416
 msgid "Home"
@@ -4117,7 +4117,7 @@ msgstr "URL obrázku"
 
 #: packages/admin/src/components/WordPressImport.tsx:2370
 msgid "image URLs updated in"
-msgstr "URL obrázků aktualizováno v"
+msgstr "– počet aktualizovaných adres URL obrázků;"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:192
@@ -4146,7 +4146,7 @@ msgstr "Importovat další soubor"
 
 #: packages/admin/src/components/WordPressImport.tsx:1174
 msgid "Import Capabilities"
-msgstr "Schopnosti importu"
+msgstr "Možnosti importu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2304
 msgid "Import Complete"
@@ -4233,7 +4233,7 @@ msgstr "Indexováno"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3677
 msgid "Inline Code"
-msgstr "Vložený kód"
+msgstr "Řádkový kód"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:567
 #: packages/admin/src/components/MediaPickerModal.tsx:811
@@ -4297,7 +4297,7 @@ msgstr "Vložit odkaz"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1213
 msgid "Insert raw HTML"
-msgstr "Vložit přímé HTML"
+msgstr "Vložit nezpracované HTML"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:58
 msgid "Insert Section"
@@ -4314,7 +4314,7 @@ msgstr "Nainstalovat"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:155
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr "Nainstalujte a aktivujte plugin poskytovatele e-mailu, abyste povolili e-mailové funkce jako pozvánky, magické odkazy a obnovu hesla."
+msgstr "Nainstalujte a aktivujte plugin pro odesílání e-mailů. Tím zpřístupníte pozvánky, přihlašovací odkazy a obnovení hesla."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:197
 msgid "Install blocked"
@@ -4322,7 +4322,7 @@ msgstr "Instalace blokována"
 
 #: packages/admin/src/components/WordPressImport.tsx:1039
 msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
-msgstr "Nainstalujte plugin EmDash Exporter na svůj web WordPress a vygenerujte klíč v Nástroje → EmDash Migration."
+msgstr "Nainstalujte plugin EmDash Exporter na svůj web na WordPressu a v nabídce Nástroje → EmDash Migration vygenerujte klíč."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:806
 msgid "Installation"
@@ -4338,7 +4338,7 @@ msgstr "Nainstalováno"
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:583
 msgid "Installed from marketplace (v{0})"
-msgstr "Nainstalováno z tržiště (v{0})"
+msgstr "Nainstalováno z tržiště (verze {0})"
 
 #: packages/admin/src/components/PluginManager.tsx:602
 msgid "Installed:"
@@ -4453,7 +4453,7 @@ msgstr "Ponechte tuto kartu otevřenou. Import probíhá po malých krocích a l
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:882
 msgid "Keep typing to narrow down more bylines."
-msgstr "Pokračujte v psaní pro zúžení výběru autorských podpisů."
+msgstr "Pokračujte v psaní a výběr autorských podpisů dále zúžíte."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283
@@ -4510,7 +4510,7 @@ msgstr "Poslední přihlášení"
 
 #: packages/admin/src/components/Redirects.tsx:227
 msgid "Last seen"
-msgstr "Naposledy viděno"
+msgstr "Poslední výskyt"
 
 #: packages/admin/src/components/users/UserDetail.tsx:223
 msgid "Last updated"
@@ -4533,7 +4533,7 @@ msgstr "Zjistit více"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:339
 msgid "Leave blank to use a discoverable passkey."
-msgstr "Ponechte prázdné pro použití zjistitelného přístupového klíče."
+msgstr "Chcete-li použít zjistitelný přístupový klíč, ponechte pole prázdné."
 
 #: packages/admin/src/components/WordPressImport.tsx:2497
 msgid "Leave unassigned"
@@ -4685,7 +4685,7 @@ msgstr "Načítání průvodce..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:847
 msgid "Loading terms..."
-msgstr "Načítání termínů..."
+msgstr "Načítání položek taxonomie…"
 
 #: packages/admin/src/components/Widgets.tsx:372
 msgid "Loading widgets..."
@@ -4740,7 +4740,7 @@ msgstr "Logo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1832
 msgid "Logo & favicon"
-msgstr "Logo a favicon"
+msgstr "Logo a ikona webu"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:53
 msgid "Long text"
@@ -4753,7 +4753,7 @@ msgstr "Dlouhý text"
 
 #: packages/admin/src/components/Sections.tsx:193
 msgid "Lowercase letters, numbers, and hyphens only"
-msgstr "Pouze malá písmena, číslice a pomlčky"
+msgstr "Pouze malá písmena, číslice a spojovníky"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:663
 msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
@@ -4771,7 +4771,7 @@ msgstr "Provádět síťové požadavky"
 #: packages/admin/src/lib/api/marketplace.ts:286
 #: packages/admin/src/lib/api/marketplace.ts:294
 msgid "Make network requests to any host (unrestricted)"
-msgstr "Provádět síťové požadavky na libovolný host (bez omezení)"
+msgstr "Provádět síťové požadavky na libovolného hostitele (bez omezení)"
 
 #: packages/admin/src/components/Sidebar.tsx:375
 msgid "Manage"
@@ -4781,7 +4781,7 @@ msgstr "Spravovat"
 #. placeholder {1}: taxonomyDef.collections.join(", ")
 #: packages/admin/src/components/TaxonomyManager.tsx:818
 msgid "Manage {0} for {1}"
-msgstr "Spravovat {0} pro {1}"
+msgstr "Správa: {0}; pro: {1}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:844
 msgid "Manage bylines in {entryLocale}"
@@ -4831,11 +4831,11 @@ msgstr "Přiřadit uživatele WordPressu {0} k uživateli EmDash"
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:256
 msgid "Mark {0} as Gone (410)"
-msgstr "Označit {0} jako Gone (410)"
+msgstr "Označit adresu {0} jako trvale odstraněnou (410)"
 
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr "Označit jako Gone (410) — sdělí vyhledávačům, že bylo trvale smazáno"
+msgstr "Označit jako trvale odstraněné (410) — sdělí vyhledávačům, že daná adresa byla trvale odstraněna"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:502
 msgid "Mark as spam"
@@ -4887,7 +4887,7 @@ msgstr "Média"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:222
 msgid "Media Details"
-msgstr "Podrobnosti média"
+msgstr "Podrobnosti o médiu"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2400
@@ -5046,7 +5046,7 @@ msgstr "Měsíční/roční archivy"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:111
 msgid "More information about {label}"
-msgstr "Více informací o {label}"
+msgstr "Další informace – {label}"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
@@ -5064,7 +5064,7 @@ msgstr "Přesunout „{0}“ nahoru"
 
 #: packages/admin/src/components/ContentList.tsx:1048
 msgid "Move \"{title}\" to trash? You can restore it later."
-msgstr "Přesunout „{title}“ do koše? Později lze obnovit."
+msgstr "Přesunout „{title}“ do koše? Položku bude možné později obnovit."
 
 #: packages/admin/src/components/ContentList.tsx:1039
 msgid "Move {title} to trash"
@@ -5097,11 +5097,11 @@ msgstr "Přesunout nahoru"
 
 #: packages/admin/src/router.tsx:510
 msgid "Moved {total} items to draft"
-msgstr "Přesunuto {total} položek do konceptů"
+msgstr "{total, plural, one {Přesunuta # položka do konceptů} few {Přesunuty # položky do konceptů} many {Přesunuto # položky do konceptů} other {Přesunuto # položek do konceptů}}"
 
 #: packages/admin/src/router.tsx:531
 msgid "Moved {total} items to trash"
-msgstr "Přesunuto {total} položek do koše"
+msgstr "{total, plural, one {Přesunuta # položka do koše} few {Přesunuty # položky do koše} many {Přesunuto # položky do koše} other {Přesunuto # položek do koše}}"
 
 #: packages/admin/src/components/FieldEditor.tsx:192
 msgid "Multi Select"
@@ -5113,7 +5113,7 @@ msgstr "Víceřádkový prostý text"
 
 #: packages/admin/src/components/FieldEditor.tsx:193
 msgid "Multiple choices from options"
-msgstr "Více voleb z možností"
+msgstr "Výběr více možností"
 
 #: packages/admin/src/components/SetupWizard.tsx:120
 msgid "My Awesome Blog"
@@ -5154,7 +5154,7 @@ msgstr "nový"
 
 #: packages/admin/src/routes/bylines.tsx:426
 msgid "New"
-msgstr "Nové"
+msgstr "Nový"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:111
 msgid "NEW"
@@ -5163,11 +5163,11 @@ msgstr "NOVÉ"
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:479
 msgid "New {0}"
-msgstr "Nový {0}"
+msgstr "Nová položka: {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:643
 msgid "New {itemLabel}"
-msgstr "Nový {itemLabel}"
+msgstr "Nová položka: {itemLabel}"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
@@ -5188,7 +5188,7 @@ msgstr "Nové pole"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:122
 msgid "New public routes"
-msgstr "Nové veřejné cesty"
+msgstr "Nové veřejné koncové body"
 
 #: packages/admin/src/components/Redirects.tsx:106
 #: packages/admin/src/components/Redirects.tsx:365
@@ -5248,17 +5248,17 @@ msgstr "Ne (sdíleno napříč překlady)"
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:449
 msgid "No {0} available."
-msgstr "Žádné {0} k dispozici."
+msgstr "K dispozici nejsou žádné položky ({0})."
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:549
 msgid "No {0} yet."
-msgstr "Zatím žádné {0}."
+msgstr "Zatím nejsou žádné položky ({0})."
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:850
 msgid "No {0} yet. Create one to get started."
-msgstr "Zatím žádné {0}. Začněte vytvořením první položky."
+msgstr "Zatím nejsou žádné položky ({0}). Začněte vytvořením první položky."
 
 #: packages/admin/src/components/Redirects.tsx:218
 msgid "No 404 errors recorded yet."
@@ -5347,7 +5347,7 @@ msgstr "Nenalezeni žádní uživatelé EmDash"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
 msgid "No expiry"
-msgstr "Bez expirace"
+msgstr "Bez omezení platnosti"
 
 #: packages/admin/src/components/RevisionHistory.tsx:345
 msgid "No fields to compare"
@@ -5363,7 +5363,7 @@ msgstr "V této galerii zatím nejsou žádné obrázky."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:594
 msgid "No installable releases"
-msgstr "Žádné instalovatelné verze"
+msgstr "Žádná instalovatelná vydání"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:193
 msgid "No invite token provided"
@@ -5520,7 +5520,7 @@ msgstr "Žádné spamové komentáře."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
 msgid "No themes found"
-msgstr "Nenalezeny žádné motivy"
+msgstr "Nenalezeny žádné šablony"
 
 #: packages/admin/src/components/users/UserList.tsx:120
 msgid "No users found matching your filters."
@@ -5572,7 +5572,7 @@ msgstr "Číslovaný seznam"
 
 #: packages/admin/src/components/WordPressImport.tsx:494
 msgid "OAuth authorization requires HTTPS. Please use manual credentials."
-msgstr "Autorizace OAuth vyžaduje HTTPS. Použijte prosím ruční přihlašovací údaje."
+msgstr "Autorizace OAuth vyžaduje HTTPS. Zadejte přihlašovací údaje ručně."
 
 #: packages/admin/src/components/SeoImageField.tsx:46
 msgid "OG Image"
@@ -5581,11 +5581,11 @@ msgstr "OG obrázek"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
 msgid "on a custom hostname is not treated as secure, even on loopback."
-msgstr "na vlastním názvu hostitele není považován za zabezpečený, ani na loopbacku."
+msgstr "na vlastní doméně se nepovažuje za bezpečný ani při přístupu z místního počítače."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
-msgstr "Autorizujte pouze kódy, které znáte."
+msgstr "Schvalujte pouze kódy, které poznáváte."
 
 #: packages/admin/src/components/SignupPage.tsx:97
 msgid "Only email addresses from allowed domains can sign up."
@@ -5593,7 +5593,7 @@ msgstr "Zaregistrovat se mohou pouze e-mailové adresy z povolených domén."
 
 #: packages/admin/src/components/MenuList.tsx:162
 msgid "Only lowercase letters, numbers, and hyphens"
-msgstr "Pouze malá písmena, číslice a pomlčky"
+msgstr "Pouze malá písmena, číslice a spojovníky"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:106
 msgid "Only the listed MIME types will be accepted for this field."
@@ -5610,11 +5610,11 @@ msgstr "Jejda!"
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:333
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:334
 msgid "Open in new tab"
-msgstr "Otevřít na nové kartě"
+msgstr "Otevřít v nové kartě"
 
 #: packages/admin/src/components/WordPressImport.tsx:1534
 msgid "Open WordPress Profile"
-msgstr "Otevřít profil WordPress"
+msgstr "Otevřít profil ve WordPressu"
 
 #: packages/admin/src/components/FieldEditor.tsx:515
 msgid ""
@@ -5659,7 +5659,7 @@ msgstr "nebo vyberte z knihovny"
 
 #: packages/admin/src/components/WordPressImport.tsx:1590
 msgid "Or click to browse. Accepts .xml files exported from WordPress."
-msgstr "Nebo klikněte pro procházení. Přijímá soubory .xml exportované z WordPressu."
+msgstr "Nebo kliknutím vyberte soubor. Podporovány jsou soubory .xml exportované z WordPressu."
 
 #: packages/admin/src/components/WordPressImport.tsx:1071
 msgid "or connect by URL"
@@ -5748,7 +5748,7 @@ msgstr "Název přístupového klíče"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
 msgid "Passkey Name (optional)"
-msgstr "Název přístupového klíče (volitelné)"
+msgstr "Volitelný název přístupového klíče"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
 msgid "Passkey registered successfully!"
@@ -5829,11 +5829,11 @@ msgstr "čeká"
 #: packages/admin/src/components/comments/CommentInbox.tsx:198
 #: packages/admin/src/components/Dashboard.tsx:353
 msgid "Pending"
-msgstr "Čeká"
+msgstr "Čekající"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:453
 msgid "Pending changes"
-msgstr "Nevyřízené změny"
+msgstr "Neuložené změny"
 
 #: packages/admin/src/components/ContentList.tsx:1119
 msgid "Permanently delete \"{title}\"? This cannot be undone."
@@ -5862,7 +5862,7 @@ msgstr "Zástupný text"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:311
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
 msgid "Plain"
-msgstr "Samotné"
+msgstr "Protokol"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:27
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:120
@@ -5936,7 +5936,7 @@ msgstr "Plugin nebyl nalezen. Identifikátor vydavatele nebo slug může být ne
 
 #: packages/admin/src/components/WordPressImport.tsx:1209
 msgid "plugin on your WordPress site."
-msgstr "plugin na vašem webu WordPress."
+msgstr "na svůj web ve WordPressu."
 
 #: packages/admin/src/components/PluginManager.tsx:483
 msgid "Plugin pages"
@@ -5953,12 +5953,12 @@ msgstr "Registr pluginů"
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginPage.tsx:40
 msgid "Plugin responded with {0}: {text}"
-msgstr "Plugin odpověděl s {0}: {text}"
+msgstr "Plugin vrátil stav {0}: {text}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:452
 msgid "Plugin tools: {0}"
-msgstr "Nástroje pluginů: {0}"
+msgstr "Nástroje pluginu: {0}"
 
 #: packages/admin/src/components/PluginManager.tsx:323
 msgid "Plugin uninstalled"
@@ -6035,7 +6035,7 @@ msgstr "Náhled"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:82
 msgid "Preview content before publishing"
-msgstr "Náhled obsahu před publikováním"
+msgstr "Zobrazit náhled obsahu před publikováním"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:158
 msgid "Preview draft"
@@ -6074,7 +6074,7 @@ msgstr "Publikovat"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:189
 msgid "Publish {itemLabel}"
-msgstr "Publikovat {itemLabel}"
+msgstr "Publikovat položku ({itemLabel})"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:196
 msgid "Publish updates"
@@ -6101,7 +6101,7 @@ msgstr "Publikováno {0}"
 
 #: packages/admin/src/router.tsx:487
 msgid "Published {total} items"
-msgstr "Publikováno {total} položek"
+msgstr "{total, plural, one {Publikována # položka} few {Publikovány # položky} many {Publikováno # položky} other {Publikováno # položek}}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
@@ -6109,7 +6109,7 @@ msgstr "Publikováno dne"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:472
 msgid "Published by"
-msgstr "Publikoval"
+msgstr "Vydavatel:"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
@@ -6128,7 +6128,7 @@ msgstr "Rychlá úprava alternativního textu"
 #: packages/admin/src/components/PortableTextEditor.tsx:1192
 #: packages/admin/src/components/PortableTextEditor.tsx:3711
 msgid "Quote"
-msgstr "Citace"
+msgstr "Citát"
 
 #: packages/admin/src/components/WordPressImport.tsx:1162
 msgid "Raw meta"
@@ -6162,11 +6162,11 @@ msgstr "Číst váš obsah"
 
 #: packages/admin/src/lib/api/marketplace.ts:281
 msgid "Read your taxonomies and terms"
-msgstr "Číst vaše taxonomie a termíny"
+msgstr "Číst vaše taxonomie a jejich položky"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:269
 msgid "Reading"
-msgstr "Čtení"
+msgstr "Zobrazování"
 
 #: packages/admin/src/components/WordPressImport.tsx:1986
 msgid "Ready"
@@ -6200,7 +6200,7 @@ msgstr "Zjištěna smyčka přesměrování"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:163
 msgid "Redirecting to login..."
-msgstr "Přesměrování na přihlášení…"
+msgstr "Přesměrování na přihlašovací stránku…"
 
 #: packages/admin/src/components/Redirects.tsx:359
 #: packages/admin/src/components/Redirects.tsx:380
@@ -6214,11 +6214,11 @@ msgstr "Znovu"
 
 #: packages/admin/src/components/FieldEditor.tsx:216
 msgid "Reference"
-msgstr "Reference"
+msgstr "Odkaz na obsah"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:228
 msgid "Referenced favicon unavailable."
-msgstr "Odkazovaný favicon není dostupný."
+msgstr "Odkazovaná ikona webu není dostupná."
 
 #: packages/admin/src/components/Dashboard.tsx:76
 msgid "Refresh the page or try again."
@@ -6251,7 +6251,7 @@ msgstr "Registr"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:610
 msgid "Release is too new to install"
-msgstr "Vydání je příliš nové na instalaci"
+msgstr "Toto vydání zatím nelze nainstalovat, protože je příliš nové"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
@@ -6356,7 +6356,7 @@ msgstr "Přejmenovat přístupový klíč"
 
 #: packages/admin/src/components/FieldEditor.tsx:240
 msgid "Repeater"
-msgstr "Opakovač"
+msgstr "Opakovaná skupina"
 
 #: packages/admin/src/components/FieldEditor.tsx:241
 msgid "Repeating group of fields"
@@ -6375,7 +6375,7 @@ msgstr "Nahradit obrázek"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:117
 msgid "Reply to:"
-msgstr "Odpověď na:"
+msgstr "Odpověď na komentář:"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
 msgid "Repository"
@@ -6468,7 +6468,7 @@ msgstr "Znovupoužitelné bloky obsahu, které lze vložit do libovolného obsah
 
 #: packages/admin/src/router.tsx:1047
 msgid "Reverted to published version"
-msgstr "Vráceno na publikovanou verzi"
+msgstr "Obnovena publikovaná verze"
 
 #: packages/admin/src/components/WordPressImport.tsx:724
 msgid "Review"
@@ -6541,7 +6541,7 @@ msgstr "Označení role"
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:149
 #: packages/admin/src/components/PluginManager.tsx:568
 msgid "Route: {0} · Permission: {1}"
-msgstr "Cesta: {0} · Oprávnění: {1}"
+msgstr "Koncový bod: {0} · Oprávnění: {1}"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
@@ -6728,7 +6728,7 @@ msgstr "Snímek obrazovky {0} z {1}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:257
 msgid "Screenshot blurred due to image audit"
-msgstr "Snímek obrazovky je rozmazaný kvůli kontrole obrázků"
+msgstr "Snímek obrazovky je rozmazaný kvůli výsledku kontroly obrázku"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:444
 msgid "Screenshot viewer"
@@ -6752,12 +6752,12 @@ msgstr "Hledání"
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:353
 msgid "Search {0}"
-msgstr "Hledat {0}"
+msgstr "Hledat: {0}"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:352
 msgid "Search {0}..."
-msgstr "Hledat {0}..."
+msgstr "Hledat: {0}…"
 
 #: packages/admin/src/components/MediaLibrary.tsx:415
 #: packages/admin/src/components/MediaPickerModal.tsx:626
@@ -6831,11 +6831,11 @@ msgstr "Hledat zdroj nebo cíl..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
 msgid "Search themes"
-msgstr "Hledat motivy"
+msgstr "Hledat šablony"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
 msgid "Search themes..."
-msgstr "Hledat motivy..."
+msgstr "Hledat šablony…"
 
 #: packages/admin/src/components/users/UserList.tsx:73
 msgid "Search users"
@@ -6953,7 +6953,7 @@ msgstr "Vybrat"
 #: packages/admin/src/components/ContentEditor.tsx:1718
 #: packages/admin/src/components/ImageFieldRenderer.tsx:198
 msgid "Select {label}"
-msgstr "Vybrat {label}"
+msgstr "Vybrat: {label}"
 
 #: packages/admin/src/components/ContentList.tsx:973
 msgid "Select {title}"
@@ -6991,7 +6991,7 @@ msgstr "Vybrat výchozí obrázek pro sociální sítě"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:260
 #: packages/admin/src/components/settings/GeneralSettings.tsx:321
 msgid "Select Favicon"
-msgstr "Vybrat favicon"
+msgstr "Vybrat ikonu webu"
 
 #: packages/admin/src/components/ContentEditor.tsx:1706
 msgid "Select file"
@@ -7044,7 +7044,7 @@ msgstr "Vybrat..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1488
 msgid "Selected {selectedItemTitle}"
-msgstr "Vybráno {selectedItemTitle}"
+msgstr "Vybrána položka {selectedItemTitle}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:795
 msgid "Selected:"
@@ -7061,7 +7061,7 @@ msgstr "Odešlete testovací e-mail celým řetězcem a ověřte tak nastavení 
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr "Odeslat pozvánku e-mailem novému členovi týmu."
+msgstr "Pošlete novému členovi týmu pozvánku e-mailem."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:201
 msgid "Send Invite"
@@ -7069,7 +7069,7 @@ msgstr "Odeslat pozvánku"
 
 #: packages/admin/src/components/LoginPage.tsx:150
 msgid "Send magic link"
-msgstr "Odeslat magický odkaz"
+msgstr "Odeslat přihlašovací odkaz"
 
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Send Recovery Link"
@@ -7120,7 +7120,7 @@ msgstr "SEO titulek"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
 msgid "Set a custom display size for this image instance."
-msgstr "Nastavte vlastní velikost zobrazení pro tuto instanci obrázku."
+msgstr "Nastavte vlastní velikost pro toto vložení obrázku."
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:146
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:150
@@ -7262,7 +7262,7 @@ msgstr "Přihlásit se přístupovým klíčem"
 #. placeholder {0}: user.email
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:190
 msgid "Signed in as {0}"
-msgstr "Přihlášen jako {0}"
+msgstr "Přihlášený účet: {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:187
 msgid "Single choice from options"
@@ -7282,11 +7282,11 @@ msgstr "Identita webu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2270
 msgid "site identity applied (title, tagline, logo)"
-msgstr "identita webu použita (titulek, podtitulek, logo)"
+msgstr "identita webu použita (název, podtitulek, logo)"
 
 #: packages/admin/src/components/Settings.tsx:71
 msgid "Site identity, logo, favicon, and reading preferences"
-msgstr "Identita webu, logo, favicon a předvolby čtení"
+msgstr "Identita webu, logo, ikona webu a nastavení zobrazování obsahu"
 
 #: packages/admin/src/components/SetupWizard.tsx:351
 #: packages/admin/src/components/WordPressImport.tsx:1151
@@ -7400,7 +7400,7 @@ msgstr "Řadit pluginy"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
 msgid "Sort themes"
-msgstr "Řadit motivy"
+msgstr "Řadit šablony"
 
 #: packages/admin/src/components/ContentTypeList.tsx:102
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
@@ -7487,7 +7487,7 @@ msgstr "Struktura"
 
 #: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Structured"
-msgstr "Strukturovaný"
+msgstr "Strukturovaná data"
 
 #: packages/admin/src/components/FieldEditor.tsx:523
 msgid "Sub-Fields"
@@ -7587,17 +7587,17 @@ msgstr "Šablona:"
 #: packages/admin/src/components/TaxonomyManager.tsx:378
 #: packages/admin/src/components/TaxonomyManager.tsx:834
 msgid "Term"
-msgstr "Termín"
+msgstr "Položka"
 
 #. placeholder {0}: term.label
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:781
 msgid "Term \"{0}\" created in {1}."
-msgstr "Termín „{0}“ vytvořen v {1}."
+msgstr "Položka „{0}“ byla vytvořena v jazyce {1}."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:763
 msgid "Term deleted"
-msgstr "Termín smazán"
+msgstr "Položka taxonomie smazána"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:122
 msgid "test@example.com"
@@ -7630,7 +7630,7 @@ msgstr "Platnost odkazu vyprší za 15 minut."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:179
 msgid "The marketplace is empty. Check back later for new plugins."
-msgstr "Tržiště je prázdné. Nové pluginy zkontrolujte později."
+msgstr "Tržiště je prázdné. Zkuste se sem později vrátit, až přibudou nové pluginy."
 
 #: packages/admin/src/components/MenuList.tsx:76
 msgid "The menu has been deleted."
@@ -7662,28 +7662,28 @@ msgstr "Odkazované logo již není k dispozici. Vyberte nové, nebo odkaz odebe
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
 msgid "The theme marketplace is empty. Check back later."
-msgstr "Tržiště motivů je prázdné. Zkontrolujte to později."
+msgstr "Tržiště šablon je prázdné. Zkuste se sem vrátit později."
 
 #: packages/admin/src/components/Sections.tsx:45
 msgid "Theme"
-msgstr "Motiv"
+msgstr "Šablona"
 
 #. placeholder {0}: section.themeId
 #: packages/admin/src/components/SectionEditor.tsx:307
 msgid "Theme ID: {0}"
-msgstr "ID motivu: {0}"
+msgstr "ID šablony: {0}"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
 msgid "Theme not found"
-msgstr "Motiv nenalezen"
+msgstr "Šablona nenalezena"
 
 #: packages/admin/src/components/SectionEditor.tsx:185
 msgid "Theme Section"
-msgstr "Sekce motivu"
+msgstr "Sekce šablony"
 
 #: packages/admin/src/components/Sections.tsx:300
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
-msgstr "Sekce poskytnuté motivem nelze smazat. Upravte sekci a vytvořte vlastní kopii, kterou pak můžete smazat."
+msgstr "Sekce poskytované šablonou nelze smazat. Úpravou sekce vytvoříte vlastní kopii, kterou pak můžete smazat."
 
 #: packages/admin/src/components/ThemeToggle.tsx:33
 msgid "Theme: {label}"
@@ -7692,7 +7692,7 @@ msgstr "Motiv: {label}"
 #: packages/admin/src/components/Sidebar.tsx:281
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
 msgid "Themes"
-msgstr "Motivy"
+msgstr "Šablony"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:141
 msgid "These tools remain disabled after installation until you explicitly enable agent access."
@@ -7762,11 +7762,11 @@ msgstr "Tato verze vyžaduje novější prostředí, než na jakém web běží.
 
 #: packages/admin/src/routes/bylines.tsx:623
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr "Odstraní profil autorského podpisu. Odkazy autorského podpisu v obsahu budou odebrány a hlavní ukazatele vymazány."
+msgstr "Profil autorského podpisu bude odstraněn. Z obsahu budou odebrány odkazy na tento podpis a bude zrušeno jeho označení jako hlavního autora."
 
 #: packages/admin/src/components/SectionEditor.tsx:298
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
-msgstr "Tuto sekci poskytuje motiv. Úpravou vznikne vlastní kopie, která verzi z motivu přepíše."
+msgstr "Tuto sekci poskytuje šablona. Úpravou vznikne vlastní kopie, která nahradí verzi ze šablony."
 
 #: packages/admin/src/components/SectionEditor.tsx:303
 msgid "This section was imported from another system."
@@ -7774,7 +7774,7 @@ msgstr "Tato sekce byla naimportována z jiného systému."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:125
 msgid "This update exposes the following routes without authentication:"
-msgstr "Tato aktualizace zpřístupní následující cesty bez ověření:"
+msgstr "Tato aktualizace zpřístupní následující koncové body bez ověření:"
 
 #: packages/admin/src/components/Widgets.tsx:715
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
@@ -7853,7 +7853,7 @@ msgstr "Datum do"
 
 #: packages/admin/src/components/PluginManager.tsx:208
 msgid "to install plugins, or add them to your astro.config.mjs."
-msgstr "k instalaci pluginů, nebo je přidejte do astro.config.mjs."
+msgstr "nebo je přidat do souboru astro.config.mjs."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:473
 msgid "to select"
@@ -7883,7 +7883,7 @@ msgstr "TOML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "Tools → Export"
-msgstr "Tools → Export"
+msgstr "Nástroje → Export"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:77
 msgid "Track content history"
@@ -7952,7 +7952,7 @@ msgstr "Přepínač ano/ne"
 
 #: packages/admin/src/components/MediaLibrary.tsx:493
 msgid "Try a broader media type or clear your filters."
-msgstr "Zkuste širší typ média nebo zrušte filtry."
+msgstr "Zkuste zvolit obecnější typ médií nebo zrušte filtry."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:691
 msgid "Try a different search term"
@@ -8065,7 +8065,7 @@ msgstr "Odinstalování..."
 #: packages/admin/src/components/ContentTypeEditor.tsx:731
 #: packages/admin/src/components/FieldEditor.tsx:442
 msgid "Unique"
-msgstr "Unikátní"
+msgstr "Jedinečná hodnota"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:107
 msgid "Unique identifier (ULID)"
@@ -8073,7 +8073,7 @@ msgstr "Jedinečný identifikátor (ULID)"
 
 #: packages/admin/src/components/users/useRolesConfig.ts:7
 msgid "Unknown"
-msgstr "Neznámé"
+msgstr "Neznámá role"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:62
 msgid "Unknown role"
@@ -8093,7 +8093,7 @@ msgstr "Nepojmenovaný přístupový klíč"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:202
 msgid "Unpublish {itemLabel}"
-msgstr "Zrušit publikování {itemLabel}"
+msgstr "Zrušit publikování položky ({itemLabel})"
 
 #: packages/admin/src/router.tsx:1027
 msgid "Unpublished"
@@ -8157,7 +8157,7 @@ msgstr "Aktualizovat nastavení webu"
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:382
 msgid "Update the {0} details"
-msgstr "Aktualizovat údaje: {0}"
+msgstr "Upravit podrobnosti položky ({0})"
 
 #: packages/admin/src/components/Redirects.tsx:110
 msgid "Update this redirect rule."
@@ -8166,7 +8166,7 @@ msgstr "Aktualizovat toto pravidlo přesměrování."
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:452
 msgid "Update to v{0}"
-msgstr "Aktualizovat na v{0}"
+msgstr "Aktualizovat na verzi {0}"
 
 #: packages/admin/src/components/ContentList.tsx:737
 #: packages/admin/src/components/ContentSettingsPanel.tsx:541
@@ -8324,7 +8324,7 @@ msgstr "K bezpečnému přihlášení použijte zaregistrovaný přístupový kl
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:140
 msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
-msgstr "Použije se jako záložní Open Graph obrázek, když stránka žádný nemá. Doporučená velikost: 1200×630."
+msgstr "Použije se jako záložní obrázek Open Graph, pokud stránka vlastní obrázek nemá. Doporučená velikost: 1200×630."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:666
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
@@ -8336,7 +8336,7 @@ msgstr "Použije se jako hlavní vizuál tohoto příspěvku ve výpisech a v je
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:122
 msgid "Used by screen readers and when image fails to load"
-msgstr "Používají čtečky obrazovky a zobrazí se, když se obrázek nenačte"
+msgstr "Používají jej čtečky obrazovky a zobrazí se také tehdy, když se obrázek nenačte"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:408
 msgid "Used in URLs and API endpoints"
@@ -8384,7 +8384,7 @@ msgstr "Uživatelé s e-mailovými adresami z těchto domén se mohou registrova
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:387
 msgid "v{0} available"
-msgstr "K dispozici je v{0}"
+msgstr "K dispozici je verze {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:460
 #: packages/admin/src/components/FieldEditor.tsx:490
@@ -8398,15 +8398,15 @@ msgstr "Ověřený vydavatel"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:461
 msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
-msgstr "Ověřený vydavatel, potvrzeno labellerem {verifiedLabeller}"
+msgstr "Ověřený vydavatel; identitu potvrdil ověřovatel {verifiedLabeller}"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:452
 msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
-msgstr "Ověřený vydavatel. Labeller ({verifiedLabeller}) potvrdil identitu tohoto vydavatele."
+msgstr "Ověřený vydavatel. Ověřovatel identity ({verifiedLabeller}) potvrdil identitu tohoto vydavatele."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:453
 msgid "Verified publisher. A labeller has confirmed this publisher's identity."
-msgstr "Ověřený vydavatel. Labeller potvrdil identitu tohoto vydavatele."
+msgstr "Ověřený vydavatel. Ověřovatel identity potvrdil identitu tohoto vydavatele."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:228
 msgid "Verifying your invite..."
@@ -8442,7 +8442,7 @@ msgstr "Zobrazit stav poskytovatele e-mailu a odeslat testovací e-maily"
 
 #: packages/admin/src/components/PluginManager.tsx:464
 msgid "View in Marketplace"
-msgstr "Zobrazit v tržišti"
+msgstr "Zobrazit na tržišti"
 
 #: packages/admin/src/components/MediaLibrary.tsx:447
 msgid "View mode"
@@ -8479,12 +8479,12 @@ msgstr "Čekání na přístupový klíč…"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:335
 msgid "Warn"
-msgstr "Varování"
+msgstr "S výhradami"
 
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1266
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr "Nepodařilo se připojit k webu WordPress na adrese {0}. Web možná neběží na WordPressu, REST API je vypnuté nebo web není dostupný."
+msgstr "Nepodařilo se připojit k webu na WordPressu na adrese {0}. Web možná neběží na WordPressu, REST API je vypnuté nebo web není dostupný."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:577
 msgid "We couldn't verify this publisher's identity"
@@ -8586,7 +8586,7 @@ msgstr "Proč je to důležité?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
 msgid "Wide"
-msgstr "Široký"
+msgstr "Na šířku"
 
 #: packages/admin/src/components/Widgets.tsx:802
 #: packages/admin/src/components/Widgets.tsx:817
@@ -8656,7 +8656,7 @@ msgstr "Uživatelské jméno ve WordPressu"
 
 #: packages/admin/src/components/ContentList.tsx:404
 msgid "Working on {selectedCount} items…"
-msgstr "Zpracovává se {selectedCount} položek…"
+msgstr "{selectedCount, plural, one {Zpracovává se # položka…} few {Zpracovávají se # položky…} many {Zpracovává se # položky…} other {Zpracovává se # položek…}}"
 
 #: packages/admin/src/components/Widgets.tsx:904
 msgid "Write widget content..."
@@ -8726,7 +8726,7 @@ msgstr "Ke správě schématu autorských podpisů jsou potřeba oprávnění sp
 
 #: packages/admin/src/router.tsx:1486
 msgid "You need Editor permissions to moderate comments."
-msgstr "K moderování komentářů jsou potřeba oprávnění role Editor."
+msgstr "K moderování komentářů potřebujete oprávnění editora."
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:204
@@ -8744,7 +8744,7 @@ msgstr "Připojíte se jako <0>{0}</0>"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
-msgstr "Budete vyzváni k použití biometrického ověření, bezpečnostního klíče nebo PIN vašeho zařízení."
+msgstr "Budete vyzváni k použití biometrického ověření zařízení, bezpečnostního klíče nebo kódu PIN."
 
 #: packages/admin/src/components/WordPressImport.tsx:1369
 msgid "You'll be redirected to WordPress to authorize the connection."
@@ -8830,20 +8830,20 @@ msgstr "Váš web vyžaduje, aby byly verze staré alespoň {0}, než je lze nai
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:109
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr "Váš účet na Twitteru/X (např. @username)"
+msgstr "Vaše uživatelské jméno na Twitteru/X (např. @username)"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:437
 msgid "Your unsaved media changes will be lost."
-msgstr "Neuložené změny médií budou ztraceny."
+msgstr "Neuložené změny tohoto souboru budou ztraceny."
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:2062
 msgid "Your WordPress export contains {0} media files."
-msgstr "Váš export z WordPressu obsahuje {0} mediálních souborů."
+msgstr "Počet souborů médií v exportu z WordPressu: {0}."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:139
 msgid "Your YouTube channel ID or handle"
-msgstr "ID nebo název vašeho kanálu na YouTube"
+msgstr "ID nebo uživatelské jméno vašeho kanálu na YouTube"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:136
 msgid "YouTube"

--- a/packages/admin/src/locales/cs/messages.po
+++ b/packages/admin/src/locales/cs/messages.po
@@ -621,7 +621,7 @@ msgstr "Přidat"
 
 #. placeholder {0}: field.item_label
 #. placeholder {0}: taxonomyDef.labelSingular || t`Term`
-#: packages/admin/src/components/PortableTextEditor.tsx:1863
+#: packages/admin/src/components/PortableTextEditor.tsx:1873
 #: packages/admin/src/components/TaxonomyManager.tsx:378
 #: packages/admin/src/components/TaxonomyManager.tsx:834
 msgid "Add {0}"
@@ -643,11 +643,11 @@ msgstr "Přidat povolenou doménu"
 msgid "Add at least one sub-field to define the repeater structure."
 msgstr "Přidejte alespoň jedno podpole pro definici struktury opakovače."
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3370
+#: packages/admin/src/components/PortableTextEditor.tsx:3398
 msgid "Add column after"
 msgstr "Přidat sloupec za"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3364
+#: packages/admin/src/components/PortableTextEditor.tsx:3392
 msgid "Add column before"
 msgstr "Přidat sloupec před"
 
@@ -701,7 +701,7 @@ msgstr "Přidat obrázky"
 msgid "Add images to gallery"
 msgstr "Přidat obrázky do galerie"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1863
+#: packages/admin/src/components/PortableTextEditor.tsx:1873
 msgid "Add item"
 msgstr "Přidat položku"
 
@@ -709,7 +709,7 @@ msgstr "Přidat položku"
 msgid "Add Item"
 msgstr "Přidat položku"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3299
+#: packages/admin/src/components/PortableTextEditor.tsx:3327
 msgid "Add link"
 msgstr "Přidat odkaz"
 
@@ -742,11 +742,11 @@ msgstr "Přidat přístupový klíč"
 msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
 msgstr "Přidáním pluginů do astro.config.mjs rozšíříte funkce EmDash."
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3391
+#: packages/admin/src/components/PortableTextEditor.tsx:3419
 msgid "Add row after"
 msgstr "Vložit řádek pod"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3385
+#: packages/admin/src/components/PortableTextEditor.tsx:3413
 msgid "Add row before"
 msgstr "Vložit řádek nad"
 
@@ -814,15 +814,15 @@ msgstr "Přístup pro agenty u {0} byl aktualizován"
 msgid "Agent-callable MCP tools"
 msgstr "MCP nástroje volatelné agentem"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3738
+#: packages/admin/src/components/PortableTextEditor.tsx:3782
 msgid "Align Center"
 msgstr "Zarovnat na střed"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3731
+#: packages/admin/src/components/PortableTextEditor.tsx:3775
 msgid "Align Left"
 msgstr "Zarovnat vlevo"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3745
+#: packages/admin/src/components/PortableTextEditor.tsx:3789
 msgid "Align Right"
 msgstr "Zarovnat vpravo"
 
@@ -1008,7 +1008,7 @@ msgstr "Zobrazuje se u příspěvků a stránek"
 msgid "Application Password"
 msgstr "Heslo aplikace"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3827
+#: packages/admin/src/components/PortableTextEditor.tsx:3871
 msgid "Apply"
 msgstr "Použít"
 
@@ -1017,8 +1017,8 @@ msgstr "Použít"
 msgid "Apply language"
 msgstr "Použít jazyk"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3239
-#: packages/admin/src/components/PortableTextEditor.tsx:3240
+#: packages/admin/src/components/PortableTextEditor.tsx:3253
+#: packages/admin/src/components/PortableTextEditor.tsx:3254
 msgid "Apply link"
 msgstr "Použít odkaz"
 
@@ -1288,8 +1288,8 @@ msgstr "Medailonek"
 msgid "Block actions - drag to reorder, click for menu"
 msgstr "Akce bloku – přetažením změníte pořadí, kliknutím otevřete nabídku"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3263
-#: packages/admin/src/components/PortableTextEditor.tsx:3649
+#: packages/admin/src/components/PortableTextEditor.tsx:3277
+#: packages/admin/src/components/PortableTextEditor.tsx:3679
 msgid "Bold"
 msgstr "Tučné"
 
@@ -1325,8 +1325,8 @@ msgid "Browse themes and preview them with your own content."
 msgstr "Procházejte šablony a zobrazte jejich náhled s vlastním obsahem."
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:129
-#: packages/admin/src/components/PortableTextEditor.tsx:1172
-#: packages/admin/src/components/PortableTextEditor.tsx:3697
+#: packages/admin/src/components/PortableTextEditor.tsx:1182
+#: packages/admin/src/components/PortableTextEditor.tsx:3741
 msgid "Bullet List"
 msgstr "Odrážkový seznam"
 
@@ -1399,7 +1399,7 @@ msgstr "Může zobrazit obsah"
 #: packages/admin/src/components/MenuEditor.tsx:623
 #: packages/admin/src/components/MenuList.tsx:175
 #: packages/admin/src/components/PluginManager.tsx:725
-#: packages/admin/src/components/PortableTextEditor.tsx:3811
+#: packages/admin/src/components/PortableTextEditor.tsx:3855
 #: packages/admin/src/components/Redirects.tsx:183
 #: packages/admin/src/components/SectionPickerModal.tsx:131
 #: packages/admin/src/components/Sections.tsx:209
@@ -1611,9 +1611,9 @@ msgstr "Přihlaste se kliknutím na odkaz v e-mailu."
 #: packages/admin/src/components/MenuList.tsx:139
 #: packages/admin/src/components/MenuList.tsx:145
 #: packages/admin/src/components/MenuList.tsx:149
-#: packages/admin/src/components/PortableTextEditor.tsx:1647
-#: packages/admin/src/components/PortableTextEditor.tsx:1653
 #: packages/admin/src/components/PortableTextEditor.tsx:1657
+#: packages/admin/src/components/PortableTextEditor.tsx:1663
+#: packages/admin/src/components/PortableTextEditor.tsx:1667
 #: packages/admin/src/components/Redirects.tsx:115
 #: packages/admin/src/components/Redirects.tsx:121
 #: packages/admin/src/components/SectionPickerModal.tsx:61
@@ -1660,14 +1660,14 @@ msgid "Close settings"
 msgstr "Zavřít nastavení"
 
 #: packages/admin/src/components/ContentTypeList.tsx:244
-#: packages/admin/src/components/PortableTextEditor.tsx:3291
+#: packages/admin/src/components/PortableTextEditor.tsx:3319
 #: packages/admin/src/components/Redirects.tsx:472
 msgid "Code"
 msgstr "Kód"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:121
-#: packages/admin/src/components/PortableTextEditor.tsx:1202
-#: packages/admin/src/components/PortableTextEditor.tsx:3718
+#: packages/admin/src/components/PortableTextEditor.tsx:1212
+#: packages/admin/src/components/PortableTextEditor.tsx:3762
 msgid "Code Block"
 msgstr "Blok kódu"
 
@@ -1773,7 +1773,7 @@ msgstr "obsah"
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
 #: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/Dashboard.tsx:220
-#: packages/admin/src/components/PortableTextEditor.tsx:2461
+#: packages/admin/src/components/PortableTextEditor.tsx:2471
 #: packages/admin/src/components/SectionEditor.tsx:195
 #: packages/admin/src/components/Sidebar.tsx:365
 #: packages/admin/src/components/Widgets.tsx:899
@@ -1952,7 +1952,7 @@ msgstr "Vytvořit"
 msgid "Create \"{trimmedInput}\""
 msgstr "Vytvořit „{trimmedInput}“"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1173
+#: packages/admin/src/components/PortableTextEditor.tsx:1183
 msgid "Create a bullet list"
 msgstr "Vytvořit odrážkový seznam"
 
@@ -1961,7 +1961,7 @@ msgstr "Vytvořit odrážkový seznam"
 msgid "Create a new {0}"
 msgstr "Vytvořit novou položku: {0}"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1183
+#: packages/admin/src/components/PortableTextEditor.tsx:1193
 msgid "Create a numbered list"
 msgstr "Vytvořit číslovaný seznam"
 
@@ -2325,7 +2325,7 @@ msgstr "Smazat pole autorského podpisu?"
 msgid "Delete Byline?"
 msgstr "Smazat autorský podpis?"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3376
+#: packages/admin/src/components/PortableTextEditor.tsx:3404
 msgid "Delete column"
 msgstr "Smazat sloupec"
 
@@ -2394,7 +2394,7 @@ msgstr "Smazat přesměrování {0}"
 msgid "Delete Redirect?"
 msgstr "Smazat přesměrování?"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3395
+#: packages/admin/src/components/PortableTextEditor.tsx:3423
 msgid "Delete row"
 msgstr "Smazat řádek"
 
@@ -2402,7 +2402,7 @@ msgstr "Smazat řádek"
 msgid "Delete Section?"
 msgstr "Smazat sekci?"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3410
+#: packages/admin/src/components/PortableTextEditor.tsx:3438
 msgid "Delete table"
 msgstr "Smazat tabulku"
 
@@ -2642,7 +2642,7 @@ msgstr "Zobrazí se pod obrázkem jako viditelný popisek."
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr "Režim bez rušivých prvků (⌘⇧\\)"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1227
+#: packages/admin/src/components/PortableTextEditor.tsx:1237
 msgid "Divider"
 msgstr "Oddělovač"
 
@@ -2745,7 +2745,7 @@ msgstr "Přetáhněte sem soubor nebo klikněte pro výběr (.xml)"
 msgid "Drag here to add"
 msgstr "Přetažením sem přidáte"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:2039
+#: packages/admin/src/components/PortableTextEditor.tsx:2049
 msgid "Drag to reorder"
 msgstr "Přetažením změníte pořadí"
 
@@ -2819,7 +2819,7 @@ msgstr "Upravit"
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #: packages/admin/src/components/ContentTypeList.tsx:220
-#: packages/admin/src/components/PortableTextEditor.tsx:1644
+#: packages/admin/src/components/PortableTextEditor.tsx:1654
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:243
 #: packages/admin/src/components/TaxonomyManager.tsx:109
 #: packages/admin/src/components/TaxonomyManager.tsx:377
@@ -2862,7 +2862,7 @@ msgstr "Upravit pole"
 msgid "Edit image {0}"
 msgstr "Upravit obrázek {0}"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3299
+#: packages/admin/src/components/PortableTextEditor.tsx:3327
 msgid "Edit link"
 msgstr "Upravit odkaz"
 
@@ -2959,11 +2959,11 @@ msgid "Email verified!"
 msgstr "E-mail ověřen!"
 
 #. placeholder {0}: block.label
-#: packages/admin/src/components/PortableTextEditor.tsx:2475
+#: packages/admin/src/components/PortableTextEditor.tsx:2485
 msgid "Embed a {0}"
 msgstr "Vložit {0}"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:2478
+#: packages/admin/src/components/PortableTextEditor.tsx:2488
 msgid "Embeds"
 msgstr "Vložený obsah"
 
@@ -3099,7 +3099,7 @@ msgstr "Existuje"
 msgid "Exit distraction-free mode"
 msgstr "Vypnout režim bez rušení"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3863
+#: packages/admin/src/components/PortableTextEditor.tsx:3907
 msgid "Exit Spotlight Mode"
 msgstr "Ukončit režim soustředění"
 
@@ -3878,7 +3878,7 @@ msgid "Full admin access"
 msgstr "Plný přístup správce"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:171
-#: packages/admin/src/components/PortableTextEditor.tsx:2442
+#: packages/admin/src/components/PortableTextEditor.tsx:2452
 msgid "Gallery"
 msgstr "Galerie"
 
@@ -3951,37 +3951,37 @@ msgstr "Pouze hosté"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:65
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
-#: packages/admin/src/components/PortableTextEditor.tsx:1112
+#: packages/admin/src/components/PortableTextEditor.tsx:1122
 msgid "Heading 1"
 msgstr "Nadpis 1"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:73
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:33
-#: packages/admin/src/components/PortableTextEditor.tsx:1122
+#: packages/admin/src/components/PortableTextEditor.tsx:1132
 msgid "Heading 2"
 msgstr "Nadpis 2"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:81
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:34
-#: packages/admin/src/components/PortableTextEditor.tsx:1132
+#: packages/admin/src/components/PortableTextEditor.tsx:1142
 msgid "Heading 3"
 msgstr "Nadpis 3"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:89
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
-#: packages/admin/src/components/PortableTextEditor.tsx:1142
+#: packages/admin/src/components/PortableTextEditor.tsx:1152
 msgid "Heading 4"
 msgstr "Nadpis 4"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:97
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
-#: packages/admin/src/components/PortableTextEditor.tsx:1152
+#: packages/admin/src/components/PortableTextEditor.tsx:1162
 msgid "Heading 5"
 msgstr "Nadpis 5"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:105
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
-#: packages/admin/src/components/PortableTextEditor.tsx:1162
+#: packages/admin/src/components/PortableTextEditor.tsx:1172
 msgid "Heading 6"
 msgstr "Nadpis 6"
 
@@ -4039,7 +4039,7 @@ msgstr "Jak vytvořit heslo aplikace"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:38
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
-#: packages/admin/src/components/PortableTextEditor.tsx:1212
+#: packages/admin/src/components/PortableTextEditor.tsx:1222
 msgid "HTML"
 msgstr "HTML"
 
@@ -4047,8 +4047,8 @@ msgstr "HTML"
 msgid "HTML source"
 msgstr "Zdrojový kód HTML"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3226
-#: packages/admin/src/components/PortableTextEditor.tsx:3793
+#: packages/admin/src/components/PortableTextEditor.tsx:3240
+#: packages/admin/src/components/PortableTextEditor.tsx:3837
 msgid "https://..."
 msgstr "https://..."
 
@@ -4079,7 +4079,7 @@ msgstr "Pokud pro <0>{email}</0> existuje účet, odeslali jsme přihlašovací 
 
 #: packages/admin/src/components/FieldEditor.tsx:204
 #: packages/admin/src/components/FieldEditor.tsx:587
-#: packages/admin/src/components/PortableTextEditor.tsx:2427
+#: packages/admin/src/components/PortableTextEditor.tsx:2437
 msgid "Image"
 msgstr "Obrázek"
 
@@ -4231,7 +4231,7 @@ msgstr "Nekompatibilní"
 msgid "Indexed"
 msgstr "Indexováno"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3677
+#: packages/admin/src/components/PortableTextEditor.tsx:3721
 msgid "Inline Code"
 msgstr "Řádkový kód"
 
@@ -4241,44 +4241,44 @@ msgid "Insert"
 msgstr "Vložit"
 
 #. placeholder {0}: block?.label || ""
-#: packages/admin/src/components/PortableTextEditor.tsx:1644
+#: packages/admin/src/components/PortableTextEditor.tsx:1654
 msgid "Insert {0}"
 msgstr "Vložit {0}"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1193
+#: packages/admin/src/components/PortableTextEditor.tsx:1203
 msgid "Insert a blockquote"
 msgstr "Vložit citaci"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1203
+#: packages/admin/src/components/PortableTextEditor.tsx:1213
 msgid "Insert a code block"
 msgstr "Vložit blok kódu"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1228
+#: packages/admin/src/components/PortableTextEditor.tsx:1238
 msgid "Insert a horizontal rule"
 msgstr "Vložit vodorovnou čáru"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:2458
+#: packages/admin/src/components/PortableTextEditor.tsx:2468
 msgid "Insert a reusable section"
 msgstr "Vložit opakovaně použitelnou sekci"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1238
+#: packages/admin/src/components/PortableTextEditor.tsx:1248
 msgid "Insert a table"
 msgstr "Vložit tabulku"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:2428
+#: packages/admin/src/components/PortableTextEditor.tsx:2438
 msgid "Insert an image"
 msgstr "Vložit obrázek"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:2443
+#: packages/admin/src/components/PortableTextEditor.tsx:2453
 msgid "Insert an image gallery"
 msgstr "Vložit galerii obrázků"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1472
+#: packages/admin/src/components/PortableTextEditor.tsx:1482
 msgid "Insert block"
 msgstr "Vložit blok"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3629
-#: packages/admin/src/components/PortableTextEditor.tsx:3639
+#: packages/admin/src/components/PortableTextEditor.tsx:3659
+#: packages/admin/src/components/PortableTextEditor.tsx:3669
 msgid "Insert block after current block"
 msgstr "Vložit blok za aktuální blok"
 
@@ -4290,12 +4290,12 @@ msgstr "Vložit blok níže"
 msgid "Insert from URL"
 msgstr "Vložit z URL"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3763
-#: packages/admin/src/components/PortableTextEditor.tsx:3777
+#: packages/admin/src/components/PortableTextEditor.tsx:3807
+#: packages/admin/src/components/PortableTextEditor.tsx:3821
 msgid "Insert Link"
 msgstr "Vložit odkaz"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1213
+#: packages/admin/src/components/PortableTextEditor.tsx:1223
 msgid "Insert raw HTML"
 msgstr "Vložit nezpracované HTML"
 
@@ -4394,13 +4394,13 @@ msgstr "Volat MCP nástroje ze všech povolených pluginů"
 msgid "Invoke only this plugin's enabled MCP tools"
 msgstr "Volat pouze povolené MCP nástroje tohoto pluginu"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3270
-#: packages/admin/src/components/PortableTextEditor.tsx:3656
+#: packages/admin/src/components/PortableTextEditor.tsx:3284
+#: packages/admin/src/components/PortableTextEditor.tsx:3686
 msgid "Italic"
 msgstr "Kurzíva"
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/PortableTextEditor.tsx:2025
+#: packages/admin/src/components/PortableTextEditor.tsx:2035
 #: packages/admin/src/components/RepeaterField.tsx:239
 msgid "Item {0}"
 msgstr "Položka {0}"
@@ -4492,7 +4492,7 @@ msgstr "Popisek (jednotné číslo)"
 msgid "Language"
 msgstr "Jazyk"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1113
+#: packages/admin/src/components/PortableTextEditor.tsx:1123
 msgid "Large section heading"
 msgstr "Velký nadpis sekce"
 
@@ -4647,7 +4647,7 @@ msgstr "Načítání konfigurace..."
 msgid "Loading content..."
 msgstr "Načítání obsahu..."
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3018
+#: packages/admin/src/components/PortableTextEditor.tsx:3030
 msgid "Loading editor..."
 msgstr "Načítání editoru..."
 
@@ -4699,7 +4699,7 @@ msgstr "Načítání widgetů..."
 #: packages/admin/src/components/MarketplaceBrowse.tsx:200
 #: packages/admin/src/components/MediaLibrary.tsx:635
 #: packages/admin/src/components/MediaPickerModal.tsx:775
-#: packages/admin/src/components/PortableTextEditor.tsx:2152
+#: packages/admin/src/components/PortableTextEditor.tsx:2162
 #: packages/admin/src/components/RegistryBrowse.tsx:146
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:161
 #: packages/admin/src/components/settings/SecuritySettings.tsx:104
@@ -4876,8 +4876,8 @@ msgstr "Maximální počet štítků"
 msgid "MDX"
 msgstr "MDX"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:2431
-#: packages/admin/src/components/PortableTextEditor.tsx:2446
+#: packages/admin/src/components/PortableTextEditor.tsx:2441
+#: packages/admin/src/components/PortableTextEditor.tsx:2456
 #: packages/admin/src/components/Sidebar.tsx:216
 #: packages/admin/src/components/WordPressImport.tsx:752
 #: packages/admin/src/components/WordPressImport.tsx:1145
@@ -4919,7 +4919,7 @@ msgstr "Čtení médií"
 msgid "Media Write"
 msgstr "Zápis médií"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1123
+#: packages/admin/src/components/PortableTextEditor.tsx:1133
 msgid "Medium section heading"
 msgstr "Střední nadpis sekce"
 
@@ -5016,7 +5016,7 @@ msgstr "Min. délka"
 msgid "Min Value"
 msgstr "Min. hodnota"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1153
+#: packages/admin/src/components/PortableTextEditor.tsx:1163
 msgid "Minor section heading"
 msgstr "Menší nadpis sekce"
 
@@ -5369,7 +5369,7 @@ msgstr "Žádná instalovatelná vydání"
 msgid "No invite token provided"
 msgstr "Nebyl zadán žádný token pozvánky"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1948
+#: packages/admin/src/components/PortableTextEditor.tsx:1958
 #: packages/admin/src/components/RepeaterField.tsx:165
 msgid "No items yet"
 msgstr "Zatím žádné položky"
@@ -5478,7 +5478,7 @@ msgstr "Žádná nedávná aktivita"
 msgid "No redirects yet"
 msgstr "Zatím žádná přesměrování"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1497
+#: packages/admin/src/components/PortableTextEditor.tsx:1507
 #: packages/admin/src/components/RepeaterField.tsx:374
 msgid "No results"
 msgstr "Žádné výsledky"
@@ -5565,8 +5565,8 @@ msgid "Number of posts to show per page on list views"
 msgstr "Počet příspěvků zobrazených na stránku v seznamech"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:137
-#: packages/admin/src/components/PortableTextEditor.tsx:1182
-#: packages/admin/src/components/PortableTextEditor.tsx:3704
+#: packages/admin/src/components/PortableTextEditor.tsx:1192
+#: packages/admin/src/components/PortableTextEditor.tsx:3748
 msgid "Numbered List"
 msgstr "Číslovaný seznam"
 
@@ -6125,8 +6125,8 @@ msgid "Quick edit alt text"
 msgstr "Rychlá úprava alternativního textu"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:113
-#: packages/admin/src/components/PortableTextEditor.tsx:1192
-#: packages/admin/src/components/PortableTextEditor.tsx:3711
+#: packages/admin/src/components/PortableTextEditor.tsx:1202
+#: packages/admin/src/components/PortableTextEditor.tsx:3755
 msgid "Quote"
 msgstr "Citát"
 
@@ -6208,7 +6208,7 @@ msgstr "Přesměrování na přihlašovací stránku…"
 msgid "Redirects"
 msgstr "Přesměrování"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3850
+#: packages/admin/src/components/PortableTextEditor.tsx:3894
 msgid "Redo"
 msgstr "Znovu"
 
@@ -6257,7 +6257,7 @@ msgstr "Toto vydání zatím nelze nainstalovat, protože je příliš nové"
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
 #: packages/admin/src/components/ContentSettingsPanel.tsx:921
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:199
-#: packages/admin/src/components/PortableTextEditor.tsx:3823
+#: packages/admin/src/components/PortableTextEditor.tsx:3867
 #: packages/admin/src/components/settings/GeneralSettings.tsx:194
 #: packages/admin/src/components/settings/GeneralSettings.tsx:248
 #: packages/admin/src/components/settings/PasskeyItem.tsx:185
@@ -6310,13 +6310,13 @@ msgid "Remove Image?"
 msgstr "Odebrat obrázek?"
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/PortableTextEditor.tsx:2064
+#: packages/admin/src/components/PortableTextEditor.tsx:2074
 #: packages/admin/src/components/RepeaterField.tsx:275
 msgid "Remove item {0}"
 msgstr "Odebrat položku {0}"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3251
-#: packages/admin/src/components/PortableTextEditor.tsx:3252
+#: packages/admin/src/components/PortableTextEditor.tsx:3265
+#: packages/admin/src/components/PortableTextEditor.tsx:3266
 msgid "Remove link"
 msgstr "Odebrat odkaz"
 
@@ -6855,7 +6855,7 @@ msgstr "Prohledávatelné"
 msgid "Searching..."
 msgstr "Hledání..."
 
-#: packages/admin/src/components/PortableTextEditor.tsx:2457
+#: packages/admin/src/components/PortableTextEditor.tsx:2467
 msgid "Section"
 msgstr "Sekce"
 
@@ -7001,7 +7001,7 @@ msgstr "Vybrat soubor"
 msgid "Select File"
 msgstr "Vybrat soubor"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3094
+#: packages/admin/src/components/PortableTextEditor.tsx:3106
 msgid "Select Gallery Images"
 msgstr "Vybrat obrázky galerie"
 
@@ -7010,7 +7010,7 @@ msgid "Select image"
 msgstr "Vybrat obrázek"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:150
-#: packages/admin/src/components/PortableTextEditor.tsx:3080
+#: packages/admin/src/components/PortableTextEditor.tsx:3092
 #: packages/admin/src/components/settings/SeoSettings.tsx:188
 msgid "Select Image"
 msgstr "Vybrat obrázek"
@@ -7037,12 +7037,12 @@ msgid "Select which content types to import."
 msgstr "Vyberte typy obsahu, které se mají importovat."
 
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:108
-#: packages/admin/src/components/PortableTextEditor.tsx:2159
+#: packages/admin/src/components/PortableTextEditor.tsx:2169
 #: packages/admin/src/components/RepeaterField.tsx:372
 msgid "Select..."
 msgstr "Vybrat..."
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1488
+#: packages/admin/src/components/PortableTextEditor.tsx:1498
 msgid "Selected {selectedItemTitle}"
 msgstr "Vybrána položka {selectedItemTitle}"
 
@@ -7355,15 +7355,15 @@ msgstr "Slug zkopírován do schránky"
 msgid "Slugs cannot be changed after the field is created."
 msgstr "Slug nelze po vytvoření pole změnit."
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1133
+#: packages/admin/src/components/PortableTextEditor.tsx:1143
 msgid "Small section heading"
 msgstr "Malý nadpis sekce"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1143
+#: packages/admin/src/components/PortableTextEditor.tsx:1153
 msgid "Smaller section heading"
 msgstr "Menší nadpis sekce"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1163
+#: packages/admin/src/components/PortableTextEditor.tsx:1173
 msgid "Smallest section heading"
 msgstr "Nejmenší nadpis sekce"
 
@@ -7426,7 +7426,7 @@ msgstr "spam"
 msgid "Spam"
 msgstr "Spam"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3863
+#: packages/admin/src/components/PortableTextEditor.tsx:3907
 msgid "Spotlight Mode"
 msgstr "Režim soustředění"
 
@@ -7443,8 +7443,8 @@ msgid "Start Import"
 msgstr "Spustit import"
 
 #: packages/admin/src/components/ContentEditor.tsx:1208
-#: packages/admin/src/components/PortableTextEditor.tsx:2318
-#: packages/admin/src/components/PortableTextEditor.tsx:2319
+#: packages/admin/src/components/PortableTextEditor.tsx:2328
+#: packages/admin/src/components/PortableTextEditor.tsx:2329
 msgid "Start writing, or type '/' for commands"
 msgstr "Začněte psát, nebo napište „/“ pro příkazy"
 
@@ -7476,8 +7476,8 @@ msgstr "Uložené zálohy"
 msgid "Stored per locale — each translation of a byline gets its own value."
 msgstr "Ukládá se podle jazyka — každý překlad autorského podpisu má vlastní hodnotu."
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3284
-#: packages/admin/src/components/PortableTextEditor.tsx:3670
+#: packages/admin/src/components/PortableTextEditor.tsx:3298
+#: packages/admin/src/components/PortableTextEditor.tsx:3700
 msgid "Strikethrough"
 msgstr "Přeškrtnutí"
 
@@ -7497,6 +7497,16 @@ msgstr "Podpole"
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
 msgstr "Odběratel"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3305
+#: packages/admin/src/components/PortableTextEditor.tsx:3707
+msgid "Subscript"
+msgstr "Dolní index"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3312
+#: packages/admin/src/components/PortableTextEditor.tsx:3714
+msgid "Superscript"
+msgstr "Horní index"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:52
 msgid "Svelte"
@@ -7526,11 +7536,11 @@ msgstr "Systém ({resolvedLabel})"
 msgid "System Fields"
 msgstr "Systémová pole"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:1237
+#: packages/admin/src/components/PortableTextEditor.tsx:1247
 msgid "Table"
 msgstr "Tabulka"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3359
+#: packages/admin/src/components/PortableTextEditor.tsx:3387
 msgid "Table controls"
 msgstr "Ovládání tabulky"
 
@@ -7603,7 +7613,7 @@ msgstr "Položka taxonomie smazána"
 msgid "test@example.com"
 msgstr "test@example.com"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3621
+#: packages/admin/src/components/PortableTextEditor.tsx:3651
 msgid "Text formatting"
 msgstr "Formátování textu"
 
@@ -7859,7 +7869,7 @@ msgstr "nebo je přidat do souboru astro.config.mjs."
 msgid "to select"
 msgstr "vybrat"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3404
+#: packages/admin/src/components/PortableTextEditor.tsx:3432
 msgid "Toggle header row"
 msgstr "Přepnout řádek záhlaví"
 
@@ -8035,12 +8045,12 @@ msgstr "Tržiště není dostupné"
 msgid "Unassigned"
 msgstr "Nepřiřazeno"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3277
-#: packages/admin/src/components/PortableTextEditor.tsx:3663
+#: packages/admin/src/components/PortableTextEditor.tsx:3291
+#: packages/admin/src/components/PortableTextEditor.tsx:3693
 msgid "Underline"
 msgstr "Podtržení"
 
-#: packages/admin/src/components/PortableTextEditor.tsx:3843
+#: packages/admin/src/components/PortableTextEditor.tsx:3887
 msgid "Undo"
 msgstr "Zpět"
 
@@ -8287,9 +8297,9 @@ msgstr "Nahrávání..."
 #: packages/admin/src/components/FieldEditor.tsx:586
 #: packages/admin/src/components/MenuEditor.tsx:418
 #: packages/admin/src/components/MenuEditor.tsx:596
-#: packages/admin/src/components/PortableTextEditor.tsx:3231
-#: packages/admin/src/components/PortableTextEditor.tsx:3788
-#: packages/admin/src/components/PortableTextEditor.tsx:3798
+#: packages/admin/src/components/PortableTextEditor.tsx:3245
+#: packages/admin/src/components/PortableTextEditor.tsx:3832
+#: packages/admin/src/components/PortableTextEditor.tsx:3842
 msgid "URL"
 msgstr "URL"
 

--- a/packages/admin/src/locales/cs/messages.po
+++ b/packages/admin/src/locales/cs/messages.po
@@ -1,0 +1,8839 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-07-28 10:47+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: cs\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n>=2 && n<=4) ? 1 : (n!=Math.floor(n)) ? 2 : 3);\n"
+
+#: packages/admin/src/routes/bylines.tsx:446
+msgid " - Guest"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:446
+msgid " - Linked"
+msgstr ""
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:81
+msgid " (default)"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:521
+msgid " (opens in new window)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:867
+#: packages/admin/src/components/MediaPickerModal.tsx:950
+msgid " (selected)"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:706
+msgid "-- Select --"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ""
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:798
+msgid "(from {0})"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:533
+msgid "(pre-release)"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:156
+msgid "(synced)"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:536
+msgid "(too new)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:71
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr ""
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr ""
+
+#. placeholder {0}: result.comments.imported
+#: packages/admin/src/components/WordPressImport.tsx:2263
+msgid "{0, plural, one {# comment imported} other {# comments imported}}"
+msgstr ""
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1465
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:345
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2274
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
+#. placeholder {0}: selectedItems.length
+#: packages/admin/src/components/MediaPickerModal.tsx:787
+msgid "{0, plural, one {# item selected} other {# items selected}}"
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:636
+#: packages/admin/src/components/MenuList.tsx:220
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mcpTools.length
+#: packages/admin/src/components/PluginManager.tsx:420
+msgid "{0, plural, one {# MCP tool} other {# MCP tools}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2231
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
+#. placeholder {0}: result.menus.created
+#: packages/admin/src/components/WordPressImport.tsx:2255
+msgid "{0, plural, one {# menu imported} other {# menus imported}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1903
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:290
+#: packages/admin/src/components/PluginManager.tsx:434
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2486
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:447
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:229
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2223
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr ""
+
+#. placeholder {0}: result.taxonomyAssignments
+#: packages/admin/src/components/WordPressImport.tsx:2247
+msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
+msgstr ""
+
+#. placeholder {0}: result.taxonomiesCreated.length
+#: packages/admin/src/components/WordPressImport.tsx:2239
+msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
+msgstr ""
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:585
+msgid "{0, plural, one {field} other {fields}}"
+msgstr ""
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:164
+msgid "{0, plural, one {Media file} other {Media files}}"
+msgstr ""
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:168
+msgid "{0, plural, one {User} other {Users}}"
+msgstr ""
+
+#. placeholder {0}: envLabel(m.key)
+#. placeholder {1}: m.required
+#. placeholder {2}: m.host
+#: packages/admin/src/components/RegistryPluginDetail.tsx:636
+msgid "{0} {1} required — you have {2}."
+msgstr ""
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-2xl font-semibold leading-tight">{t`Menus`}</h1> <p className="mt-1 text-sm leading-5 text-pretty text-kumo-subtle"> {t`Manage navigation menus for your site`} </p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:218
+msgid "{0} • {1}"
+msgstr ""
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:425
+msgid "{0} banner"
+msgstr ""
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1303
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:115
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:324
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:437
+msgid "{0} icon"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:96
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1973
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:535
+msgid "{0} of {total} could not be deleted"
+msgstr ""
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:491
+msgid "{0} of {total} could not be published"
+msgstr ""
+
+#. placeholder {0}: failedIds.length
+#: packages/admin/src/router.tsx:514
+msgid "{0} of {total} could not be updated"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:179
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:206
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="truncate text-2xl font-semibold"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:583
+msgid "{0} system + {1} custom {2}"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:360
+msgid "{0} updated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:270
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:867
+#: packages/admin/src/components/MediaPickerModal.tsx:950
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:195
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:313
+msgid "{base} to: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:355
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "{current} of {total}"
+msgstr ""
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:933
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr ""
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr ""
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:922
+msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2473
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2461
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1879
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1888
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:83
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:84
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:128
+#: packages/admin/src/components/PluginSettings.tsx:142
+#: packages/admin/src/components/PluginSettings.tsx:170
+msgid "{pluginName} Settings"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:298
+msgid "{resultCount, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:405
+msgid "{selectedCount, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:446
+msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:928
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:150
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:211
+#: packages/admin/src/components/MediaLibrary.tsx:247
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:216
+#: packages/admin/src/components/MediaLibrary.tsx:252
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:152
+msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:158
+msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:367
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:368
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:221
+#: packages/admin/src/components/MediaLibrary.tsx:257
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:142
+msgid "/new-page or /articles/[slug]"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:133
+msgid "/old-page or /blog/[slug]"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2093
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2094
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2095
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1601
+msgid "← Back"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:36
+msgid "1 year"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1522
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1275
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1523
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1524
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1279
+msgid "3. Select \"All content\""
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "30 days"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:156
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:157
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:158
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1280
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1525
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:397
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "410 Content Deleted (Gone)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:161
+msgid "451 Unavailable for legal reasons"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1526
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1281
+msgid "5. Upload the file here"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "7 days"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "90 days"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:416
+msgid "A brief description of this content type"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:142
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:201
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:200
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:240
+msgid "Accept Invite"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:174
+msgid "Access denied"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1485
+msgid "Access Denied"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:282
+#: packages/admin/src/lib/api/marketplace.ts:290
+msgid "Access your media library"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:154
+msgid "Account already exists"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "ACF Fields"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
+#: packages/admin/src/components/ContentList.tsx:528
+#: packages/admin/src/components/ContentList.tsx:649
+#: packages/admin/src/components/ContentTypeList.tsx:108
+#: packages/admin/src/components/TaxonomyManager.tsx:843
+#: packages/admin/src/routes/byline-schema.tsx:249
+msgid "Actions"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentSettingsPanel.tsx:871
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/TaxonomySidebar.tsx:491
+msgid "Add"
+msgstr ""
+
+#. placeholder {0}: field.item_label
+#. placeholder {0}: taxonomyDef.labelSingular || t`Term`
+#: packages/admin/src/components/PortableTextEditor.tsx:1863
+#: packages/admin/src/components/TaxonomyManager.tsx:378
+#: packages/admin/src/components/TaxonomyManager.tsx:834
+msgid "Add {0}"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:279
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3370
+msgid "Add column after"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3364
+msgid "Add column before"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:378
+#: packages/admin/src/components/MenuEditor.tsx:493
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:390
+#: packages/admin/src/components/MenuEditor.tsx:397
+#: packages/admin/src/components/MenuEditor.tsx:496
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:316
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:591
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1984
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:293
+msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:613
+msgid "Add fields to define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:616
+msgid "Add First Field"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:174
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:200
+msgid "Add Images"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:247
+msgid "Add images to gallery"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1863
+msgid "Add item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:158
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3299
+msgid "Add link"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:486
+msgid "Add links to build your navigation menu"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:342
+msgid "Add New"
+msgstr ""
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:503
+msgid "Add new {0}"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:227
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:200
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:211
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3391
+msgid "Add row after"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3385
+msgid "Add row before"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:278
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:403
+msgid "Add Widget Area"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:102
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:441
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Additional data to import."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1483
+msgid "admin"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:101
+#: packages/admin/src/components/Sidebar.tsx:383
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:329
+msgid "Admin navigation"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:196
+msgid "After send:"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:543
+msgid "Agent access"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:335
+msgid "Agent access for {0} has been updated"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+msgid "Agent-callable MCP tools"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3738
+msgid "Align Center"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3731
+msgid "Align Left"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3745
+msgid "Align Right"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
+msgid "Alignment"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:369
+msgid "All"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:773
+#: packages/admin/src/components/ContentList.tsx:777
+msgid "All authors"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:412
+msgid "All bylines"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:110
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:134
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2518
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr ""
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:728
+#: packages/admin/src/components/Redirects.tsx:421
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:433
+#: packages/admin/src/components/Redirects.tsx:427
+msgid "All types"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:545
+msgid "Allow MCP tokens with plugin-tool scope to invoke these routes."
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:100
+msgid "Allow users from specific domains to sign up"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:719
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:376
+#: packages/admin/src/components/editor/ImageNode.tsx:231
+#: packages/admin/src/components/MediaLibrary.tsx:589
+msgid "Alt text"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
+#: packages/admin/src/components/MediaDetailPanel.tsx:354
+#: packages/admin/src/components/MediaDetailPanel.tsx:371
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:835
+#: packages/admin/src/components/MediaLibrary.tsx:892
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1395
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/DialogError.tsx:14
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/PluginManager.tsx:102
+#: packages/admin/src/components/PluginManager.tsx:121
+#: packages/admin/src/components/PluginSettings.tsx:75
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:71
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:95
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+#: packages/admin/src/components/settings/BackupSettings.tsx:85
+#: packages/admin/src/components/settings/BackupSettings.tsx:105
+#: packages/admin/src/components/settings/EmailSettings.tsx:51
+#: packages/admin/src/components/settings/GeneralSettings.tsx:51
+#: packages/admin/src/components/settings/SecuritySettings.tsx:54
+#: packages/admin/src/components/settings/SecuritySettings.tsx:71
+#: packages/admin/src/components/settings/SeoSettings.tsx:45
+#: packages/admin/src/components/settings/SocialSettings.tsx:43
+#: packages/admin/src/components/TaxonomySidebar.tsx:365
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:423
+#: packages/admin/src/router.tsx:438
+#: packages/admin/src/router.tsx:452
+#: packages/admin/src/router.tsx:466
+#: packages/admin/src/router.tsx:943
+#: packages/admin/src/router.tsx:996
+#: packages/admin/src/router.tsx:1014
+#: packages/admin/src/router.tsx:1032
+#: packages/admin/src/router.tsx:1053
+#: packages/admin/src/router.tsx:1074
+#: packages/admin/src/router.tsx:1095
+#: packages/admin/src/router.tsx:1126
+#: packages/admin/src/router.tsx:1146
+#: packages/admin/src/router.tsx:1430
+#: packages/admin/src/router.tsx:1446
+#: packages/admin/src/router.tsx:1471
+#: packages/admin/src/router.tsx:1960
+#: packages/admin/src/routes/byline-schema.tsx:103
+#: packages/admin/src/routes/byline-schema.tsx:123
+#: packages/admin/src/routes/byline-schema.tsx:139
+#: packages/admin/src/routes/byline-schema.tsx:153
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:272
+msgid "An unexpected error occurred."
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:251
+msgid "An unknown error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1575
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:810
+msgid "Analyzing WordPress site..."
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
+msgid "API Tokens"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:440
+msgid "Appears on posts and pages"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1490
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3827
+msgid "Apply"
+msgstr ""
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:181
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:182
+msgid "Apply language"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3239
+#: packages/admin/src/components/PortableTextEditor.tsx:3240
+msgid "Apply link"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:238
+#: packages/admin/src/components/comments/CommentInbox.tsx:490
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:203
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1166
+msgid "archived"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:732
+#: packages/admin/src/components/Dashboard.tsx:355
+msgid "Archived"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+#: packages/admin/src/components/Widgets.tsx:158
+msgid "Archives"
+msgstr ""
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:375
+msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:147
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:669
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:257
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2456
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:28
+msgid "Astro"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+#: packages/admin/src/components/MediaLibrary.tsx:436
+msgid "Audio"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:277
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:197
+msgid "Authentication error: {error}"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:254
+msgid "Authentication failed"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:120
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:261
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:288
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1081
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2471
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:685
+msgid "Authors"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:524
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:427
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:539
+msgid "Auto-approve authenticated users"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:424
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:167
+msgid "Automatic Backups"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:207
+msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
+msgstr ""
+
+#: packages/admin/src/router.tsx:995
+msgid "Autosave failed"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:710
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:205
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:466
+msgid "Available Widgets"
+msgstr ""
+
+#: packages/admin/src/components/BylineAvatarField.tsx:46
+#: packages/admin/src/components/BylineAvatarField.tsx:71
+msgid "Avatar"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:284
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/WordPressImport.tsx:1510
+#: packages/admin/src/components/WordPressImport.tsx:2527
+msgid "Back"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:636
+msgid "Back to {collectionLabel} list"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:172
+#: packages/admin/src/components/LoginPage.tsx:118
+#: packages/admin/src/components/LoginPage.tsx:154
+#: packages/admin/src/components/LoginPage.tsx:313
+#: packages/admin/src/components/SignupPage.tsx:282
+msgid "Back to login"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:126
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:404
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:118
+#: packages/admin/src/components/RegistryPluginDetail.tsx:820
+msgid "Back to plugins"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:74
+#: packages/admin/src/components/SectionEditor.tsx:175
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Back up now"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:199
+msgid "Backing up..."
+msgstr ""
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:97
+msgid "Backup created: {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:80
+msgid "Backup settings saved"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:122
+#: packages/admin/src/components/settings/BackupSettings.tsx:133
+#: packages/admin/src/components/settings/BackupSettings.tsx:148
+msgid "Backups"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:182
+msgid "Backups to keep"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:29
+msgid "Bash"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:191
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:496
+msgid "Bio"
+msgstr ""
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
+msgid "Block actions - drag to reorder, click for menu"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3263
+#: packages/admin/src/components/PortableTextEditor.tsx:3649
+msgid "Bold"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:55
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:184
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/RegistryBrowse.tsx:73
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:89
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1124
+#: packages/admin/src/components/WordPressImport.tsx:1594
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:204
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:129
+#: packages/admin/src/components/PortableTextEditor.tsx:1172
+#: packages/admin/src/components/PortableTextEditor.tsx:3697
+msgid "Bullet List"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:218
+#: packages/admin/src/routes/bylines.tsx:383
+msgid "Byline schema"
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:252
+msgid "Byline Schema"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:565
+#: packages/admin/src/components/ContentSettingsPanel.tsx:568
+#: packages/admin/src/components/Sidebar.tsx:242
+#: packages/admin/src/routes/bylines.tsx:375
+msgid "Bylines"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:30
+msgid "C"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:32
+msgid "C#"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:31
+msgid "C++"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:315
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:192
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentList.tsx:455
+#: packages/admin/src/components/ContentList.tsx:1054
+#: packages/admin/src/components/ContentList.tsx:1125
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/ContentSettingsPanel.tsx:90
+#: packages/admin/src/components/ContentSettingsPanel.tsx:512
+#: packages/admin/src/components/ContentSettingsPanel.tsx:682
+#: packages/admin/src/components/ContentSettingsPanel.tsx:985
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1038
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:193
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:194
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:586
+#: packages/admin/src/components/editor/ImageNode.tsx:252
+#: packages/admin/src/components/editor/ImageNode.tsx:253
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:649
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:805
+#: packages/admin/src/components/MenuEditor.tsx:438
+#: packages/admin/src/components/MenuEditor.tsx:623
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/PluginManager.tsx:725
+#: packages/admin/src/components/PortableTextEditor.tsx:3811
+#: packages/admin/src/components/Redirects.tsx:183
+#: packages/admin/src/components/SectionPickerModal.tsx:131
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:280
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:390
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:336
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:480
+#: packages/admin/src/components/settings/SecuritySettings.tsx:179
+#: packages/admin/src/components/TaxonomyManager.tsx:207
+#: packages/admin/src/components/TaxonomyManager.tsx:494
+#: packages/admin/src/components/TaxonomyManager.tsx:708
+#: packages/admin/src/components/users/InviteUserModal.tsx:198
+#: packages/admin/src/components/Widgets.tsx:451
+#: packages/admin/src/components/WordPressImport.tsx:1917
+msgid "Cancel"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:456
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:212
+#: packages/admin/src/components/SeoPanel.tsx:216
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:519
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:69
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:382
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:352
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:541
+#: packages/admin/src/components/MediaDetailPanel.tsx:381
+msgid "Caption"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:192
+#: packages/admin/src/components/Widgets.tsx:135
+msgid "Categories"
+msgstr ""
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1785
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "Categories & Tags"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
+msgid "Center"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1682
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/ImageFieldRenderer.tsx:133
+#: packages/admin/src/components/ImageFieldRenderer.tsx:162
+#: packages/admin/src/components/SeoImageField.tsx:53
+msgid "Change"
+msgstr ""
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:239
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:167
+msgid "Change Image"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:185
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:808
+msgid "Changelog"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1046
+msgid "Changes discarded"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:129
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:171
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1095
+msgid "Check Site"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:102
+#: packages/admin/src/components/SignupPage.tsx:131
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Check your email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:776
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr ""
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:362
+msgid "Checking how many stored values reference \"{0}\"…"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:137
+msgid "Choose your preferred admin language"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:481
+msgid "Clear"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:825
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:497
+#: packages/admin/src/components/MediaLibrary.tsx:521
+msgid "Clear search"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:354
+msgid "Clear stored value"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:352
+msgid "Clear stored value for {fieldKey}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:113
+msgid "Click the link in the email to sign in."
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:212
+#: packages/admin/src/components/BylineFieldEditor.tsx:218
+#: packages/admin/src/components/BylineFieldEditor.tsx:222
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:227
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:229
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:414
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:449
+#: packages/admin/src/components/MediaDetailPanel.tsx:229
+#: packages/admin/src/components/MediaDetailPanel.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:529
+#: packages/admin/src/components/MediaPickerModal.tsx:535
+#: packages/admin/src/components/MediaPickerModal.tsx:539
+#: packages/admin/src/components/MenuEditor.tsx:400
+#: packages/admin/src/components/MenuEditor.tsx:406
+#: packages/admin/src/components/MenuEditor.tsx:410
+#: packages/admin/src/components/MenuEditor.tsx:576
+#: packages/admin/src/components/MenuEditor.tsx:582
+#: packages/admin/src/components/MenuEditor.tsx:586
+#: packages/admin/src/components/MenuList.tsx:139
+#: packages/admin/src/components/MenuList.tsx:145
+#: packages/admin/src/components/MenuList.tsx:149
+#: packages/admin/src/components/PortableTextEditor.tsx:1647
+#: packages/admin/src/components/PortableTextEditor.tsx:1653
+#: packages/admin/src/components/PortableTextEditor.tsx:1657
+#: packages/admin/src/components/Redirects.tsx:115
+#: packages/admin/src/components/Redirects.tsx:121
+#: packages/admin/src/components/SectionPickerModal.tsx:61
+#: packages/admin/src/components/SectionPickerModal.tsx:67
+#: packages/admin/src/components/SectionPickerModal.tsx:71
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:338
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:348
+#: packages/admin/src/components/TaxonomyManager.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:387
+#: packages/admin/src/components/TaxonomyManager.tsx:393
+#: packages/admin/src/components/TaxonomyManager.tsx:397
+#: packages/admin/src/components/TaxonomyManager.tsx:627
+#: packages/admin/src/components/TaxonomyManager.tsx:633
+#: packages/admin/src/components/TaxonomyManager.tsx:637
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:413
+#: packages/admin/src/components/Widgets.tsx:419
+#: packages/admin/src/components/Widgets.tsx:423
+msgid "Close"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:518
+msgid "Close comments after (days)"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:178
+msgid "Close gallery settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1053
+msgid "Close settings"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/PortableTextEditor.tsx:3291
+#: packages/admin/src/components/Redirects.tsx:472
+msgid "Code"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:121
+#: packages/admin/src/components/PortableTextEditor.tsx:1202
+#: packages/admin/src/components/PortableTextEditor.tsx:3718
+msgid "Code Block"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:506
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:500
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:156
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:678
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2327
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:185
+msgid "Columns"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:291
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:147
+#: packages/admin/src/components/ContentTypeEditor.tsx:485
+#: packages/admin/src/components/Sidebar.tsx:221
+msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:542
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:931
+msgid "Component"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
+msgid "Confirm"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+#: packages/admin/src/components/WordPressImport.tsx:1054
+msgid "Connect"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1507
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1457
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:183
+msgid "content"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:378
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
+#: packages/admin/src/components/Dashboard.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:2461
+#: packages/admin/src/components/SectionEditor.tsx:195
+#: packages/admin/src/components/Sidebar.tsx:365
+#: packages/admin/src/components/Widgets.tsx:899
+msgid "Content"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:98
+msgid "Content Block"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2382
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1317
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1068
+msgid "Content has been scheduled for publishing"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1009
+msgid "Content is now live"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2371
+msgid "content items"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Content Read"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1027
+msgid "Content removed from public view"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1089
+msgid "Content reverted to draft"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:314
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1731
+msgid "Content to Import"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:184
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:248
+msgid "Content Types"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2310
+msgid "Content was skipped because it already exists"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Content Write"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:92
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2529
+msgid "Continue Import"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:234
+#: packages/admin/src/components/users/InviteUserModal.tsx:133
+msgid "Copied to clipboard"
+msgstr ""
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Copy this token now — it won't be shown again."
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
+msgid "Copy token"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+#: packages/admin/src/components/MediaDetailPanel.tsx:301
+msgid "Copy URL"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:136
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:75
+msgid "Could not load dashboard data"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:486
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1264
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:268
+msgid "Couldn't load byline fields."
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:547
+msgid "Couldn't load custom fields."
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:877
+msgid "Couldn't search bylines. Please try again."
+msgstr ""
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:369
+msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:842
+msgid "Count"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1009
+#: packages/admin/src/components/MenuList.tsx:178
+#: packages/admin/src/components/Redirects.tsx:192
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:501
+#: packages/admin/src/components/Widgets.tsx:454
+#: packages/admin/src/routes/bylines.tsx:579
+msgid "Create"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:305
+msgid "Create \"{trimmedInput}\""
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1173
+msgid "Create a bullet list"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:383
+msgid "Create a new {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1183
+msgid "Create a numbered list"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:84
+#: packages/admin/src/components/SignupPage.tsx:221
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Create an account"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:957
+#: packages/admin/src/routes/bylines.tsx:476
+msgid "Create byline"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Create field"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:129
+#: packages/admin/src/components/MenuList.tsx:192
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:136
+msgid "Create New Menu"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:409
+msgid "Create New Token"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1501
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:111
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:195
+msgid "Create personal access tokens for programmatic API access"
+msgstr ""
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:248
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:247
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:464
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1921
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:110
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:620
+#: packages/admin/src/components/TaxonomyManager.tsx:711
+msgid "Create Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:269
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:477
+msgid "Create Token"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:410
+msgid "Create Widget Area"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:190
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:556
+#: packages/admin/src/components/ContentTypeList.tsx:124
+msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:75
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Create your passkey"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:280
+#: packages/admin/src/lib/api/marketplace.ts:289
+msgid "Create, update, and delete content"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:82
+msgid "Create, update, and delete navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:77
+msgid "Create, update, and delete taxonomy terms"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:52
+msgid "Create, update, delete content"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:736
+#: packages/admin/src/components/ContentSettingsPanel.tsx:537
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:96
+msgid "Created \"{0}\"."
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr ""
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:1120
+msgid "Created {0} translation"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:887
+msgid "Creating collections and fields..."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1009
+#: packages/admin/src/components/MenuList.tsx:178
+#: packages/admin/src/components/Redirects.tsx:189
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:477
+#: packages/admin/src/components/TaxonomyManager.tsx:711
+#: packages/admin/src/components/TaxonomySidebar.tsx:305
+msgid "Creating..."
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:33
+msgid "CSS"
+msgstr ""
+
+#: packages/admin/src/components/TranslationsPanel.tsx:83
+msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:282
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:340
+msgid "Currently set — enter a new value to replace"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:623
+msgid "Custom Fields"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:210
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:185
+msgid "Custom Section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Custom Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:176
+msgid "Daily automatic backups"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:130
+#: packages/admin/src/components/ContentTypeList.tsx:246
+#: packages/admin/src/components/Dashboard.tsx:41
+#: packages/admin/src/components/Sidebar.tsx:206
+#: packages/admin/src/components/Sidebar.tsx:356
+msgid "Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+#: packages/admin/src/components/ContentList.tsx:525
+msgid "Date"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:790
+msgid "Date field to filter on"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:281
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:750
+msgid "Declared permissions"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:294
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:356
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:233
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:147
+msgid "Default social image"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:138
+msgid "Default Social Image"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:220
+msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:42
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:360
+msgid "Defined in code"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:268
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:672
+#: packages/admin/src/components/ContentTypeList.tsx:150
+#: packages/admin/src/components/editor/BlockMenu.tsx:328
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:130
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:453
+#: packages/admin/src/components/MenuEditor.tsx:549
+#: packages/admin/src/components/MenuList.tsx:258
+#: packages/admin/src/components/Redirects.tsx:585
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/settings/BackupSettings.tsx:284
+#: packages/admin/src/components/TaxonomyManager.tsx:906
+#: packages/admin/src/components/Widgets.tsx:716
+#: packages/admin/src/routes/byline-schema.tsx:378
+#: packages/admin/src/routes/bylines.tsx:588
+#: packages/admin/src/routes/bylines.tsx:624
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:452
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: archive.name
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:229
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:252
+#: packages/admin/src/components/settings/BackupSettings.tsx:245
+#: packages/admin/src/components/TaxonomyManager.tsx:117
+#: packages/admin/src/components/Widgets.tsx:817
+#: packages/admin/src/routes/byline-schema.tsx:458
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:749
+msgid "Delete {0} field"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:240
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:664
+msgid "Delete {0} widget area"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:902
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:282
+msgid "Delete backup?"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:358
+msgid "Delete byline field?"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:622
+msgid "Delete Byline?"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3376
+msgid "Delete column"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:666
+msgid "Delete Field?"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:237
+#: packages/admin/src/components/editor/GalleryNode.tsx:219
+#: packages/admin/src/components/editor/GalleryNode.tsx:220
+msgid "Delete gallery"
+msgstr ""
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
+msgid "Delete HTML block"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:220
+#: packages/admin/src/components/editor/ImageNode.tsx:221
+msgid "Delete image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:451
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:256
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:526
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:1136
+msgid "Delete Permanently"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1116
+msgid "Delete Permanently?"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:538
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:539
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:583
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3395
+msgid "Delete row"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3410
+msgid "Delete table"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:714
+msgid "Delete Widget Area?"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:646
+msgid "Deleted"
+msgstr ""
+
+#. placeholder {0}: deletingField.label
+#. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
+#: packages/admin/src/routes/byline-schema.tsx:371
+msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:409
+#: packages/admin/src/components/ContentTypeEditor.tsx:673
+#: packages/admin/src/components/ContentTypeList.tsx:151
+#: packages/admin/src/components/MediaDetailPanel.tsx:410
+#: packages/admin/src/components/MediaDetailPanel.tsx:454
+#: packages/admin/src/components/MenuList.tsx:259
+#: packages/admin/src/components/Redirects.tsx:586
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/settings/BackupSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:907
+#: packages/admin/src/components/Widgets.tsx:717
+#: packages/admin/src/routes/bylines.tsx:625
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:379
+msgid "Deleting…"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:379
+#: packages/admin/src/components/editor/ImageNode.tsx:238
+msgid "Describe the image..."
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
+#: packages/admin/src/components/MediaDetailPanel.tsx:374
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:277
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:413
+#: packages/admin/src/components/RegistryPluginDetail.tsx:805
+#: packages/admin/src/components/SectionEditor.tsx:274
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:438
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:456
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:471
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:141
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:153
+#: packages/admin/src/components/PluginManager.tsx:564
+msgid "Destructive"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:506
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:144
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:34
+msgid "Diff"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:280
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:494
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:554
+msgid "Disable plugin MCP tools"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:507
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:383
+#: packages/admin/src/components/Redirects.tsx:421
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:614
+msgid "Disabled:"
+msgstr ""
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:438
+msgid "Discard"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:77
+#: packages/admin/src/components/ContentSettingsPanel.tsx:97
+msgid "Discard changes"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:436
+msgid "Discard changes?"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:82
+msgid "Discard draft changes?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:439
+msgid "Discarding..."
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:241
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:243
+msgid "Dismiss"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:127
+msgid "Display a list of recent posts"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:105
+msgid "Display a navigation menu"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:136
+msgid "Display category list"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:960
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1022
+#: packages/admin/src/routes/bylines.tsx:481
+msgid "Display name"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:170
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:269
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:458
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:144
+msgid "Display tag cloud"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:697
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1227
+msgid "Divider"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:35
+msgid "Dockerfile"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+#: packages/admin/src/components/MediaLibrary.tsx:437
+msgid "Documents"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:286
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:66
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Domain updated"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:334
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:142
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Done"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:903
+msgid "Down"
+msgstr ""
+
+#. placeholder {0}: archive.name
+#: packages/admin/src/components/settings/BackupSettings.tsx:238
+msgid "Download {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:158
+msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:160
+msgid "Download backup"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:155
+msgid "Download Backup"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:123
+msgid "Download backups and schedule automatic backups to storage"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:492
+msgid "Download SBOM"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2126
+msgid "Downloading"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1162
+msgid "draft"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:730
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+#: packages/admin/src/components/ContentSettingsPanel.tsx:454
+#: packages/admin/src/components/Dashboard.tsx:351
+msgid "Draft"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:254
+msgid "Drafts"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1166
+msgid "Drafts & Private"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:700
+msgid "Drag here to add"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2039
+msgid "Drag to reorder"
+msgstr ""
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:716
+#: packages/admin/src/components/Widgets.tsx:802
+msgid "Drag to reorder {0}"
+msgstr ""
+
+#: packages/admin/src/components/SortableContentSettingsSections.tsx:215
+#: packages/admin/src/components/SortableContentSettingsSections.tsx:216
+msgid "Drag to reorder {label}"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:365
+msgid "Drag to reorder block"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:704
+msgid "Drag widgets here to add them"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:467
+msgid "Drag widgets into an area to add them"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:700
+msgid "Drop to add widget"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1588
+msgid "Drop your WordPress export file here"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:319
+msgid "Duplicate"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1027
+msgid "Duplicate {title}"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:168
+msgid "e.g. import, blog"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:423
+msgid "e.g., CI/CD Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:912
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:544
+#: packages/admin/src/components/MenuList.tsx:234
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TranslationsPanel.tsx:93
+msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: block?.label || ""
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:1644
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:243
+#: packages/admin/src/components/TaxonomyManager.tsx:109
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/routes/byline-schema.tsx:449
+#: packages/admin/src/routes/bylines.tsx:476
+msgid "Edit {0}"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:741
+msgid "Edit {0} field"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:643
+msgid "Edit {itemLabel}"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1019
+msgid "Edit {title}"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1019
+msgid "Edit byline"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "Edit byline field"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:331
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/editor/GalleryNode.tsx:178
+msgid "Edit image {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3299
+msgid "Edit link"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:573
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:369
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:530
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:531
+msgid "Edit redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1044
+msgid "em1.…"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:62
+#: packages/admin/src/components/Settings.tsx:116
+#: packages/admin/src/components/SignupPage.tsx:198
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:330
+msgid "Email (optional)"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:127
+#: packages/admin/src/components/SignupPage.tsx:67
+#: packages/admin/src/components/users/InviteUserModal.tsx:152
+msgid "Email address"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:50
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:99
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:172
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:77
+#: packages/admin/src/components/settings/EmailSettings.tsx:92
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "Email verified!"
+msgstr ""
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2475
+msgid "Embed a {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2478
+msgid "Embeds"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1307
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryNode.tsx:160
+msgid "Empty gallery — open settings to add images"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:493
+msgid "Enable comments"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:494
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:555
+msgid "Enable plugin MCP tools"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:507
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/Redirects.tsx:421
+msgid "Enabled"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:423
+#: packages/admin/src/components/MenuEditor.tsx:601
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1460
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1380
+msgid "Enter credentials manually"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:696
+msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr ""
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
+msgid "Enter HTML..."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1234
+msgid "Enter markdown content..."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:327
+msgid "Enter your handle to sign in."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1459
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1082
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:155
+#: packages/admin/src/components/MenuEditor.tsx:193
+#: packages/admin/src/components/MenuEditor.tsx:233
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:769
+#: packages/admin/src/router.tsx:2174
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:236
+msgid "Error adding widget"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:297
+msgid "Error reordering widgets"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:53
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:784
+msgid "Error updating widget"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:596
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2010
+msgid "Exists"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:755
+msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3863
+msgid "Exit Spotlight Mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:506
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:500
+msgid "Expand details"
+msgstr ""
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:298
+msgid "Expires {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:463
+msgid "Expiry"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1273
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1397
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:118
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:345
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2130
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:199
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:70
+msgid "Failed to add domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:188
+msgid "Failed to add passkey"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:413
+msgid "Failed to analyze WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:155
+msgid "Failed to confirm upload"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:104
+#: packages/admin/src/lib/api/backups.ts:51
+msgid "Failed to create backup"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1003
+msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/lib/api/byline-fields.ts:120
+msgid "Failed to create byline field"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:102
+msgid "Failed to create field"
+msgstr ""
+
+#: packages/admin/src/lib/api/sections.ts:88
+msgid "Failed to create section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1714
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:510
+msgid "Failed to create term"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1125
+msgid "Failed to create translation"
+msgstr ""
+
+#: packages/admin/src/router.tsx:422
+#: packages/admin/src/router.tsx:451
+#: packages/admin/src/router.tsx:534
+#: packages/admin/src/router.tsx:1145
+msgid "Failed to delete"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr ""
+
+#: packages/admin/src/lib/api/backups.ts:58
+msgid "Failed to delete backup"
+msgstr ""
+
+#: packages/admin/src/lib/api/bylines.ts:143
+msgid "Failed to delete byline"
+msgstr ""
+
+#: packages/admin/src/lib/api/byline-fields.ts:143
+msgid "Failed to delete byline field"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr ""
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1445
+msgid "Failed to delete comment"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:279
+msgid "Failed to delete content"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:278
+#: packages/admin/src/routes/byline-schema.tsx:138
+msgid "Failed to delete field"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:389
+msgid "Failed to delete from provider"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:259
+msgid "Failed to delete media"
+msgstr ""
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr ""
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr ""
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr ""
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr ""
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr ""
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr ""
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:120
+#: packages/admin/src/lib/api/plugins.ts:160
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/search.ts:32
+msgid "Failed to disable search"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1052
+msgid "Failed to discard changes"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr ""
+
+#: packages/admin/src/router.tsx:465
+msgid "Failed to duplicate"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:101
+#: packages/admin/src/lib/api/plugins.ts:146
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/search.ts:31
+msgid "Failed to enable search"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:340
+msgid "Failed to execute import"
+msgstr ""
+
+#: packages/admin/src/lib/api/client.ts:255
+msgid "Failed to fetch auth mode"
+msgstr ""
+
+#: packages/admin/src/lib/api/backups.ts:37
+msgid "Failed to fetch backup settings"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr ""
+
+#: packages/admin/src/lib/api/dashboard.ts:42
+msgid "Failed to fetch dashboard stats"
+msgstr ""
+
+#: packages/admin/src/lib/api/email-settings.ts:34
+msgid "Failed to fetch email settings"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:106
+msgid "Failed to fetch entry terms"
+msgstr ""
+
+#: packages/admin/src/lib/api/client.ts:238
+msgid "Failed to fetch manifest"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:76
+msgid "Failed to fetch media"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:89
+msgid "Failed to fetch media item"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:325
+msgid "Failed to fetch media providers"
+msgstr ""
+
+#: packages/admin/src/lib/api/plugins.ts:70
+#: packages/admin/src/lib/api/plugins.ts:74
+msgid "Failed to fetch plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/plugins.ts:114
+msgid "Failed to fetch plugin settings"
+msgstr ""
+
+#: packages/admin/src/lib/api/plugins.ts:56
+msgid "Failed to fetch plugins"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:355
+msgid "Failed to fetch provider media"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:556
+#: packages/admin/src/lib/api/content.ts:561
+msgid "Failed to fetch revision"
+msgstr ""
+
+#: packages/admin/src/lib/api/sections.ts:76
+msgid "Failed to fetch section"
+msgstr ""
+
+#: packages/admin/src/lib/api/sections.ts:68
+msgid "Failed to fetch sections"
+msgstr ""
+
+#: packages/admin/src/lib/api/settings.ts:50
+msgid "Failed to fetch settings"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:87
+msgid "Failed to fetch terms"
+msgstr ""
+
+#: packages/admin/src/lib/api/current-user.ts:22
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:852
+#: packages/admin/src/router.tsx:1376
+msgid "Failed to fetch user"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:263
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:131
+msgid "Failed to get upload URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:436
+msgid "Failed to import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:365
+#: packages/admin/src/lib/api/import.ts:422
+msgid "Failed to import media"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:208
+#: packages/admin/src/lib/api/registry.ts:702
+msgid "Failed to install plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/byline-fields.ts:98
+msgid "Failed to list byline fields"
+msgstr ""
+
+#: packages/admin/src/router.tsx:282
+msgid "Failed to load admin"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:135
+msgid "Failed to load backup settings"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:365
+msgid "Failed to load bylines: {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:81
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:465
+msgid "Failed to load image"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:135
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:121
+msgid "Failed to load plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:146
+msgid "Failed to load plugin settings"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:149
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RegistryBrowse.tsx:98
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:198
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr ""
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1470
+msgid "Failed to perform bulk action"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:322
+msgid "Failed to permanently delete content"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:321
+msgid "Failed to prepare import"
+msgstr ""
+
+#: packages/admin/src/router.tsx:490
+#: packages/admin/src/router.tsx:1013
+msgid "Failed to publish"
+msgstr ""
+
+#: packages/admin/src/lib/api/byline-fields.ts:106
+msgid "Failed to read byline field usage"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:112
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:70
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:53
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/lib/api/byline-fields.ts:156
+msgid "Failed to reorder byline fields"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:293
+#: packages/admin/src/routes/byline-schema.tsx:152
+msgid "Failed to reorder fields"
+msgstr ""
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr ""
+
+#: packages/admin/src/router.tsx:437
+msgid "Failed to restore"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:311
+msgid "Failed to restore content"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:578
+#: packages/admin/src/lib/api/content.ts:583
+msgid "Failed to restore revision"
+msgstr ""
+
+#: packages/admin/src/lib/api/api-tokens.ts:99
+msgid "Failed to revoke API token"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:378
+msgid "Failed to rewrite URLs"
+msgstr ""
+
+#: packages/admin/src/router.tsx:942
+#: packages/admin/src/router.tsx:1959
+msgid "Failed to save"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:84
+msgid "Failed to save backup settings"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:122
+msgid "Failed to save field"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:74
+#: packages/admin/src/components/settings/GeneralSettings.tsx:50
+#: packages/admin/src/components/settings/SeoSettings.tsx:44
+#: packages/admin/src/components/settings/SocialSettings.tsx:42
+msgid "Failed to save settings"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1073
+msgid "Failed to schedule"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:71
+#: packages/admin/src/components/LoginPage.tsx:76
+msgid "Failed to send magic link"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:50
+#: packages/admin/src/lib/api/email-settings.ts:45
+msgid "Failed to send test email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:351
+msgid "Failed to send verification email"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:129
+msgid "Failed to set entry terms"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:249
+#: packages/admin/src/lib/api/registry.ts:858
+msgid "Failed to uninstall plugin"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1031
+msgid "Failed to unpublish"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1094
+msgid "Failed to unschedule"
+msgstr ""
+
+#: packages/admin/src/router.tsx:513
+msgid "Failed to update"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:364
+msgid "Failed to update {0}"
+msgstr ""
+
+#: packages/admin/src/lib/api/backups.ts:46
+msgid "Failed to update backup settings"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1053
+msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/lib/api/byline-fields.ts:135
+msgid "Failed to update byline field"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:94
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:276
+msgid "Failed to update media"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:232
+#: packages/admin/src/lib/api/registry.ts:776
+msgid "Failed to update plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/plugins.ts:172
+msgid "Failed to update plugin MCP access"
+msgstr ""
+
+#: packages/admin/src/lib/api/plugins.ts:133
+msgid "Failed to update plugin settings"
+msgstr ""
+
+#: packages/admin/src/lib/api/sections.ts:100
+msgid "Failed to update section"
+msgstr ""
+
+#: packages/admin/src/lib/api/settings.ts:64
+msgid "Failed to update settings"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1429
+msgid "Failed to update status"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:173
+msgid "Failed to upload file"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:218
+msgid "Failed to upload media"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:377
+msgid "Failed to upload to provider"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:248
+msgid "Failed to verify authentication"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:807
+msgid "FAQ"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:213
+#: packages/admin/src/components/settings/GeneralSettings.tsx:219
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1180
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1148
+msgid "Featured Images"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:440
+#: packages/admin/src/components/ContentTypeList.tsx:105
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:95
+msgid "Field created"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:133
+msgid "Field deleted"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:268
+msgid "Field type cannot be changed after creation."
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:115
+msgid "Field updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:581
+msgid "Fields"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2158
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:325
+#: packages/admin/src/components/MediaDetailPanel.tsx:342
+#: packages/admin/src/components/MediaLibrary.tsx:586
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:120
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2366
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:769
+msgid "Filter by author"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:115
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:178
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:754
+#: packages/admin/src/components/Redirects.tsx:422
+msgid "Filter by status"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:439
+#: packages/admin/src/components/Redirects.tsx:428
+msgid "Filter by type"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:408
+msgid "Filter byline type"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1398
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1207
+msgid "For the best import experience, install the"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:806
+msgid "From date"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
+#: packages/admin/src/components/WordPressImport.tsx:1155
+msgid "Full"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:102
+msgid "Full admin access"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:171
+#: packages/admin/src/components/PortableTextEditor.tsx:2442
+msgid "Gallery"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryNode.tsx:207
+#: packages/admin/src/components/editor/GalleryNode.tsx:208
+msgid "Gallery settings"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "General"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:96
+#: packages/admin/src/components/settings/GeneralSettings.tsx:124
+msgid "General Settings"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:648
+msgid "Genres"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:112
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:36
+msgid "Go"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2418
+#: packages/admin/src/router.tsx:2194
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:194
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:37
+msgid "GraphQL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:460
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:167
+msgid "Group (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:162
+msgid "Group by"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:555
+msgid "Guest byline"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:413
+msgid "Guest only"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:65
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
+#: packages/admin/src/components/PortableTextEditor.tsx:1112
+msgid "Heading 1"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:73
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:33
+#: packages/admin/src/components/PortableTextEditor.tsx:1122
+msgid "Heading 2"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:81
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:34
+#: packages/admin/src/components/PortableTextEditor.tsx:1132
+msgid "Heading 3"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:89
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
+#: packages/admin/src/components/PortableTextEditor.tsx:1142
+msgid "Heading 4"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:97
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
+#: packages/admin/src/components/PortableTextEditor.tsx:1152
+msgid "Heading 5"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:105
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
+#: packages/admin/src/components/PortableTextEditor.tsx:1162
+msgid "Heading 6"
+msgstr ""
+
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:142
+#: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:158
+msgid "Headings"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:286
+msgid "hero, banner, cta"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:230
+#: packages/admin/src/components/SeoPanel.tsx:233
+msgid "Hide from search engines"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
+msgid "Hide token"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:671
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:226
+#: packages/admin/src/components/Redirects.tsx:473
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:416
+msgid "Home"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1520
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:38
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
+#: packages/admin/src/components/PortableTextEditor.tsx:1212
+msgid "HTML"
+msgstr ""
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
+msgid "HTML source"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3226
+#: packages/admin/src/components/PortableTextEditor.tsx:3793
+msgid "https://..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:424
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:555
+msgid "https://example.com/image.jpg"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1089
+msgid "https://yoursite.com"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:243
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:153
+msgid "Icon blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:104
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/FieldEditor.tsx:587
+#: packages/admin/src/components/PortableTextEditor.tsx:2427
+msgid "Image"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:294
+msgid "Image {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ImageFieldRenderer.tsx:124
+msgid "Image not found"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:208
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Image settings"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:43
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:556
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2370
+msgid "image URLs updated in"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:192
+#: packages/admin/src/components/MediaLibrary.tsx:434
+msgid "Images"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:226
+#: packages/admin/src/components/Sidebar.tsx:290
+#: packages/admin/src/components/WordPressImport.tsx:738
+msgid "Import"
+msgstr ""
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1366
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2416
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1174
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2305
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:691
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2060
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:693
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1814
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2344
+msgid "Imported by Collection"
+msgstr ""
+
+#. placeholder {0}: wpImportProgress.comments
+#: packages/admin/src/components/WordPressImport.tsx:903
+msgid "Importing comments... {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:920
+msgid "Importing content..."
+msgstr ""
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:901
+msgid "Importing content... {0}"
+msgstr ""
+
+#. placeholder {0}: wpImportProgress.processed
+#: packages/admin/src/components/WordPressImport.tsx:900
+msgid "Importing content... {0} of {totalSelectedPosts}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:904
+msgid "Importing menus and site settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1980
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:506
+msgid "Indexed"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3677
+msgid "Inline Code"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:567
+#: packages/admin/src/components/MediaPickerModal.tsx:811
+msgid "Insert"
+msgstr ""
+
+#. placeholder {0}: block?.label || ""
+#: packages/admin/src/components/PortableTextEditor.tsx:1644
+msgid "Insert {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1193
+msgid "Insert a blockquote"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1203
+msgid "Insert a code block"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1228
+msgid "Insert a horizontal rule"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2458
+msgid "Insert a reusable section"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1238
+msgid "Insert a table"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2428
+msgid "Insert an image"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2443
+msgid "Insert an image gallery"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1472
+msgid "Insert block"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3629
+#: packages/admin/src/components/PortableTextEditor.tsx:3639
+msgid "Insert block after current block"
+msgstr ""
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
+msgid "Insert block below"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:549
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3763
+#: packages/admin/src/components/PortableTextEditor.tsx:3777
+msgid "Insert Link"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1213
+msgid "Insert raw HTML"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:58
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+#: packages/admin/src/components/RegistryPluginDetail.tsx:554
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:155
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:197
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:806
+msgid "Installation"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:263
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:184
+#: packages/admin/src/components/RegistryBrowse.tsx:201
+#: packages/admin/src/components/RegistryPluginDetail.tsx:546
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:583
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:602
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:198
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:152
+msgid "Invalid invite link"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1529
+msgid "Invalid JSON"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:241
+msgid "Invite Error"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:150
+msgid "Invite expired"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:97
+msgid "Invoke MCP tools from all enabled plugins"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:454
+msgid "Invoke only this plugin's enabled MCP tools"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3270
+#: packages/admin/src/components/PortableTextEditor.tsx:3656
+msgid "Italic"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:2025
+#: packages/admin/src/components/RepeaterField.tsx:239
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:187
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:212
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:206
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:39
+msgid "Java"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:40
+msgid "JavaScript"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:235
+msgid "Job title"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:246
+msgid "job_title"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:41
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:42
+msgid "JSX"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:916
+msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:882
+msgid "Keep typing to narrow down more bylines."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:283
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:43
+msgid "Kotlin"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:232
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:416
+#: packages/admin/src/components/MenuEditor.tsx:593
+#: packages/admin/src/components/MenuList.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:645
+#: packages/admin/src/components/Widgets.tsx:436
+#: packages/admin/src/routes/byline-schema.tsx:234
+msgid "Label"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:392
+msgid "Label (Plural)"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:384
+msgid "Label (Singular)"
+msgstr ""
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:162
+#: packages/admin/src/components/LoginPage.tsx:347
+#: packages/admin/src/components/Settings.tsx:136
+#: packages/admin/src/components/Settings.tsx:141
+msgid "Language"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1113
+msgid "Large section heading"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:608
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:227
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:159
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:303
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:274
+msgid "Learn more"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:339
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2497
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
+msgid "Left"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:136
+#: packages/admin/src/components/MediaLibrary.tsx:273
+#: packages/admin/src/components/MediaLibrary.tsx:356
+#: packages/admin/src/components/MediaPickerModal.tsx:211
+#: packages/admin/src/components/MediaPickerModal.tsx:509
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:165
+msgid "Limit"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:414
+msgid "Linked only"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:506
+msgid "Linked user"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:130
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:469
+msgid "List view"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:677
+#: packages/admin/src/components/ContentEditor.tsx:720
+#: packages/admin/src/components/ContentSettingsPanel.tsx:256
+msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:200
+#: packages/admin/src/components/RegistryBrowse.tsx:146
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:468
+msgid "Load more"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:775
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr ""
+
+#: packages/admin/src/router.tsx:2149
+msgid "Loading"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:257
+msgid "Loading byline fields…"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:116
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:308
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/router.tsx:2151
+#: packages/admin/src/router.tsx:2163
+msgid "Loading configuration..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3018
+msgid "Loading editor..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:342
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:95
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:140
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:459
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:95
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:131
+#: packages/admin/src/components/settings/GeneralSettings.tsx:99
+#: packages/admin/src/components/settings/SeoSettings.tsx:93
+#: packages/admin/src/components/settings/SocialSettings.tsx:73
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:847
+msgid "Loading terms..."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:372
+msgid "Loading widgets..."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:538
+#: packages/admin/src/components/ContentList.tsx:630
+#: packages/admin/src/components/ContentList.tsx:659
+#: packages/admin/src/components/ContentList.tsx:687
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:200
+#: packages/admin/src/components/MediaLibrary.tsx:635
+#: packages/admin/src/components/MediaPickerModal.tsx:775
+#: packages/admin/src/components/PortableTextEditor.tsx:2152
+#: packages/admin/src/components/RegistryBrowse.tsx:146
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:161
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/TaxonomyManager.tsx:801
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:468
+msgid "Loading..."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:518
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Lock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:291
+msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
+msgstr ""
+
+#: packages/admin/src/components/Header.tsx:109
+msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1832
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:53
+msgid "Long text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:663
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:436
+msgid "Main Sidebar"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:285
+#: packages/admin/src/lib/api/marketplace.ts:293
+msgid "Make network requests"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:286
+#: packages/admin/src/lib/api/marketplace.ts:294
+msgid "Make network requests to any host (unrestricted)"
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:375
+msgid "Manage"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:818
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:844
+msgid "Manage bylines in {entryLocale}"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:390
+msgid "Manage content widgets in your widget areas"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:160
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:106
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:361
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:94
+msgid "Manage your passkeys and authentication"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:317
+msgid "Managed by {providerName}"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:318
+msgid "Managed by an external media provider"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:427
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2454
+msgid "Map Authors"
+msgstr ""
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2502
+msgid "Map WordPress user {0} to EmDash user"
+msgstr ""
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:256
+msgid "Mark {0} as Gone (410)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:255
+msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:502
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:44
+msgid "Markdown"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:206
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:176
+#: packages/admin/src/components/PluginManager.tsx:384
+#: packages/admin/src/components/Sidebar.tsx:272
+msgid "Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:627
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:147
+msgid "Maximum tags"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:45
+msgid "MDX"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2431
+#: packages/admin/src/components/PortableTextEditor.tsx:2446
+#: packages/admin/src/components/Sidebar.tsx:216
+#: packages/admin/src/components/WordPressImport.tsx:752
+#: packages/admin/src/components/WordPressImport.tsx:1145
+#: packages/admin/src/components/WordPressImport.tsx:1334
+msgid "Media"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:222
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2400
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2314
+msgid "Media import was skipped"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:153
+#: packages/admin/src/components/MediaLibrary.tsx:322
+msgid "Media Library"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Media Read"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Media Write"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1123
+msgid "Medium section heading"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:104
+#: packages/admin/src/components/Widgets.tsx:914
+msgid "Menu"
+msgstr ""
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:144
+msgid "Menu \"{0}\" ({1}) created."
+msgstr ""
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:175
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:188
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:213
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:350
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:228
+msgid "Menu order has been updated."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:160
+#: packages/admin/src/components/MenuList.tsx:104
+#: packages/admin/src/components/Sidebar.tsx:226
+#: packages/admin/src/components/WordPressImport.tsx:1149
+msgid "Menus"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1767
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Menus Manage"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:188
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:203
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:197
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1051
+msgid "Migration key"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1153
+msgid "Minor section heading"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:504
+msgid "Moderation"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:72
+msgid "Modify collection schemas"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:163
+msgid "Monthly"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:159
+msgid "Monthly/yearly archives"
+msgstr ""
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:111
+msgid "More information about {label}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:439
+msgid "Move \"{0}\" down"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:429
+msgid "Move \"{0}\" up"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1048
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1039
+msgid "Move {title} to trash"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:537
+msgid "Move down"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:439
+msgid "Move to trash"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:466
+#: packages/admin/src/components/ContentList.tsx:1061
+#: packages/admin/src/components/ContentSettingsPanel.tsx:669
+#: packages/admin/src/components/ContentSettingsPanel.tsx:689
+msgid "Move to Trash"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:444
+#: packages/admin/src/components/ContentList.tsx:1046
+#: packages/admin/src/components/ContentSettingsPanel.tsx:674
+msgid "Move to Trash?"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:528
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/router.tsx:510
+msgid "Moved {total} items to draft"
+msgstr ""
+
+#: packages/admin/src/router.tsx:531
+msgid "Moved {total} items to trash"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:157
+#: packages/admin/src/components/TaxonomyManager.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+#: packages/admin/src/components/TaxonomyManager.tsx:841
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:430
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:580
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:586
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:340
+msgid "Navigation"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1120
+msgid "new"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:426
+msgid "New"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:111
+msgid "NEW"
+msgstr ""
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:479
+msgid "New {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:643
+msgid "New {itemLabel}"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "New byline field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1982
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:46
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:224
+msgid "New field"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:122
+msgid "New public routes"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+#: packages/admin/src/components/Redirects.tsx:365
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:479
+msgid "new tab"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:831
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:433
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:612
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:408
+msgid "News"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:372
+#: packages/admin/src/components/ContentList.tsx:618
+msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:476
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "No"
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:420
+msgid "No (shared across translations)"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:449
+msgid "No {0} available."
+msgstr ""
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:549
+msgid "No {0} yet."
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:850
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:835
+#: packages/admin/src/components/MediaLibrary.tsx:892
+msgid "No alt text"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:281
+msgid "No API tokens yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No approved comments yet."
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:291
+msgid "No byline fields yet."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:836
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:452
+msgid "No bylines found"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:944
+msgid "No bylines selected."
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:226
+msgid "No collections configured"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:543
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:82
+msgid "No content"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:612
+msgid "No custom fields yet"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:262
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:152
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2516
+msgid "No EmDash users found"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "No expiry"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:345
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:213
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:205
+msgid "No images in this gallery yet."
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:594
+msgid "No installable releases"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:193
+msgid "No invite token provided"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1948
+#: packages/admin/src/components/RepeaterField.tsx:165
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:631
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:517
+msgid "No linked user"
+msgstr ""
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "No matches"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:879
+msgid "No matching bylines."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:489
+#: packages/admin/src/components/MediaLibrary.tsx:517
+msgid "No matching media"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:264
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:694
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:540
+msgid "No media available from this provider."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:539
+#: packages/admin/src/components/MediaPickerModal.tsx:688
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:485
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:329
+msgid "No parent (top level)"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:168
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:200
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:175
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/RegistryBrowse.tsx:120
+msgid "No plugins have been published to this registry yet."
+msgstr ""
+
+#: packages/admin/src/components/RegistryBrowse.tsx:119
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:304
+msgid "No public URL available"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:305
+msgid "No recent activity"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:463
+msgid "No redirects yet"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1497
+#: packages/admin/src/components/RepeaterField.tsx:374
+msgid "No results"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:546
+#: packages/admin/src/components/ContentList.tsx:565
+msgid "No results for \"{activeSearch}\""
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:465
+msgid "No results found"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:201
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:108
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:504
+msgid "No widget areas yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
+msgid "None"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:434
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:629
+msgid "Not compatible with this environment"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:341
+msgid "Not set"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:129
+msgid "Number of posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:278
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:137
+#: packages/admin/src/components/PortableTextEditor.tsx:1182
+#: packages/admin/src/components/PortableTextEditor.tsx:3704
+msgid "Numbered List"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:494
+msgid "OAuth authorization requires HTTPS. Please use manual credentials."
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:46
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:97
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:404
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:379
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:380
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:568
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:569
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1534
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:385
+msgid "Optional caption"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:384
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:459
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:553
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:302
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:579
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1590
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1071
+msgid "or connect by URL"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:97
+#: packages/admin/src/components/LoginPage.tsx:263
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:227
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:369
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:636
+#: packages/admin/src/components/editor/DocumentOutline.tsx:191
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:164
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:550
+#: packages/admin/src/components/ContentSettingsPanel.tsx:553
+msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:592
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/router.tsx:2189
+msgid "Page Not Found"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:402
+#: packages/admin/src/components/WordPressImport.tsx:1328
+msgid "Pages"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:57
+msgid "Paragraph"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:615
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:512
+#: packages/admin/src/components/Redirects.tsx:518
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1153
+msgid "Partial"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:324
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:89
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:49
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:150
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:154
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:77
+#: packages/admin/src/components/SignupPage.tsx:214
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:301
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:305
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "Paste your migration key"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:225
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr ""
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:435
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr ""
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:431
+msgid "Pattern must include a {0} placeholder"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:1185
+msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:198
+#: packages/admin/src/components/Dashboard.tsx:353
+msgid "Pending"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:453
+msgid "Pending changes"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1119
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1108
+msgid "Permanently delete {title}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:46
+msgid "PHP"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:154
+msgid "Placeholder text"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:311
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:27
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:120
+msgid "Plain text"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:166
+msgid "Please ask your administrator to send a new invite."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:55
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:442
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1182
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/plugins.ts:68
+msgid "Plugin \"{pluginId}\" not found"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:762
+msgid "Plugin details"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:114
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:95
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr ""
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:334
+msgid "Plugin MCP access updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Plugin MCP Tools"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:108
+msgid "Plugin MCP tools require explicit consent"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:123
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:411
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1209
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:483
+msgid "Plugin pages"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "Plugin Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Plugin Registry"
+msgstr ""
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:452
+msgid "Plugin tools: {0}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:323
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/lib/api/registry.ts:810
+msgid "Plugin update requires re-consent"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:269
+msgid "Plugin updated"
+msgstr ""
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
+msgid "Plugin widget error"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:218
+#: packages/admin/src/components/PluginManager.tsx:139
+#: packages/admin/src/components/PluginManager.tsx:148
+#: packages/admin/src/components/PluginManager.tsx:158
+#: packages/admin/src/components/Sidebar.tsx:256
+#: packages/admin/src/components/Sidebar.tsx:391
+msgid "Plugins"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:264
+msgid "Point-in-Time Restore"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:208
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:387
+msgid "Post"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:395
+#: packages/admin/src/components/WordPressImport.tsx:1322
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1144
+msgid "Posts & Pages"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:272
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:478
+msgid "Pre-release"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2179
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:158
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:585
+msgid "Preview"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:158
+msgid "Preview draft"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:353
+#: packages/admin/src/components/ContentList.tsx:606
+msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:458
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:169
+msgid "Primary Navigation"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:354
+msgid "Private"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:174
+msgid "Provider:"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:415
+#: packages/admin/src/components/ContentSettingsPanel.tsx:435
+#: packages/admin/src/components/ContentSettingsPanel.tsx:438
+msgid "Publish"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:189
+msgid "Publish {itemLabel}"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:196
+msgid "Publish updates"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1160
+msgid "published"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:729
+#: packages/admin/src/components/ContentList.tsx:738
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/ContentSettingsPanel.tsx:452
+#: packages/admin/src/components/Dashboard.tsx:248
+#: packages/admin/src/components/Dashboard.tsx:350
+#: packages/admin/src/router.tsx:1009
+msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
+msgstr ""
+
+#: packages/admin/src/router.tsx:487
+msgid "Published {total} items"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:472
+msgid "Published by"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:47
+msgid "Python"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:952
+msgid "Quick create byline"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:196
+#: packages/admin/src/components/editor/ImageNode.tsx:197
+msgid "Quick edit alt text"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:113
+#: packages/admin/src/components/PortableTextEditor.tsx:1192
+#: packages/admin/src/components/PortableTextEditor.tsx:3711
+msgid "Quote"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1162
+msgid "Raw meta"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:67
+msgid "Read collection schemas"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:47
+msgid "Read content entries"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:57
+msgid "Read media files"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:87
+msgid "Read site settings"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:284
+#: packages/admin/src/lib/api/marketplace.ts:292
+msgid "Read user accounts"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:279
+#: packages/admin/src/lib/api/marketplace.ts:288
+msgid "Read your content"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:281
+msgid "Read your taxonomies and terms"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:269
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1986
+msgid "Ready"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:299
+msgid "Recent Activity"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:126
+msgid "Recent Posts"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:118
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:445
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:359
+#: packages/admin/src/components/Redirects.tsx:380
+#: packages/admin/src/components/Sidebar.tsx:229
+msgid "Redirects"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3850
+msgid "Redo"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:228
+msgid "Referenced favicon unavailable."
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:76
+msgid "Refresh the page or try again."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:80
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:265
+msgid "Registry"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:610
+msgid "Release is too new to install"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentSettingsPanel.tsx:921
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:199
+#: packages/admin/src/components/PortableTextEditor.tsx:3823
+#: packages/admin/src/components/settings/GeneralSettings.tsx:194
+#: packages/admin/src/components/settings/GeneralSettings.tsx:248
+#: packages/admin/src/components/settings/PasskeyItem.tsx:185
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+#: packages/admin/src/components/settings/SeoSettings.tsx:176
+msgid "Remove"
+msgstr ""
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+#: packages/admin/src/components/TaxonomySidebar.tsx:259
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1690
+msgid "Remove {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:397
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+msgid "Remove Domain?"
+msgstr ""
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:141
+#: packages/admin/src/components/ImageFieldRenderer.tsx:170
+#: packages/admin/src/components/SeoImageField.tsx:61
+msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:392
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:582
+msgid "Remove Image"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:320
+msgid "Remove image {0}"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:2064
+#: packages/admin/src/components/RepeaterField.tsx:275
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3251
+#: packages/admin/src/components/PortableTextEditor.tsx:3252
+msgid "Remove link"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:186
+msgid "Remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:201
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:611
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:198
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:200
+#: packages/admin/src/components/settings/PasskeyItem.tsx:208
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:174
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:175
+msgid "Rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:363
+#: packages/admin/src/components/editor/GalleryDetailPanel.tsx:396
+msgid "Replace image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:435
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/lib/api/client.ts:226
+msgid "Request failed"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:280
+#: packages/admin/src/components/ContentTypeEditor.tsx:730
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:593
+#: packages/admin/src/routes/byline-schema.tsx:246
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1999
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:155
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:277
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:238
+msgid "Restore"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1096
+msgid "Restore {title}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:232
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:299
+#: packages/admin/src/components/RevisionHistory.tsx:300
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:235
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:239
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:143
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:2177
+#: packages/admin/src/routes/byline-schema.tsx:280
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1047
+msgid "Reverted to published version"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:724
+msgid "Review"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:644
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:168
+msgid "Revisions"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:344
+msgid "Revoke token"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:319
+msgid "Revoke?"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
+msgid "Revoking..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:99
+msgid "Rich text content"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
+msgid "Right"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:164
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:926
+msgid "Role label"
+msgstr ""
+
+#. placeholder {0}: tool.route
+#. placeholder {1}: tool.permission
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:149
+#: packages/admin/src/components/PluginManager.tsx:568
+msgid "Route: {0} · Permission: {1}"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:48
+msgid "Ruby"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:49
+msgid "Rust"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:430
+#: packages/admin/src/components/MenuEditor.tsx:432
+#: packages/admin/src/components/MenuEditor.tsx:609
+#: packages/admin/src/components/MenuEditor.tsx:611
+msgid "Same window"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1059
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:395
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:589
+#: packages/admin/src/components/editor/ImageNode.tsx:264
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/Redirects.tsx:191
+#: packages/admin/src/components/SaveButton.tsx:32
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/Widgets.tsx:983
+#: packages/admin/src/routes/bylines.tsx:579
+msgid "Save"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:265
+msgid "Save alt text"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Save changes"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:166
+#: packages/admin/src/components/PluginSettings.tsx:209
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Save Social Links"
+msgstr ""
+
+#: packages/admin/src/components/SaveButton.tsx:34
+msgid "Saved"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:116
+msgid "Saved \"{0}\"."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1059
+#: packages/admin/src/components/FieldEditor.tsx:660
+#: packages/admin/src/components/MediaDetailPanel.tsx:425
+#: packages/admin/src/components/MenuEditor.tsx:626
+#: packages/admin/src/components/PluginSettings.tsx:166
+#: packages/admin/src/components/PluginSettings.tsx:209
+#: packages/admin/src/components/Redirects.tsx:188
+#: packages/admin/src/components/SaveButton.tsx:33
+#: packages/admin/src/components/settings/BackupSettings.tsx:192
+#: packages/admin/src/components/settings/GeneralSettings.tsx:120
+#: packages/admin/src/components/settings/GeneralSettings.tsx:298
+#: packages/admin/src/components/settings/SeoSettings.tsx:111
+#: packages/admin/src/components/settings/SeoSettings.tsx:218
+#: packages/admin/src/components/settings/SocialSettings.tsx:91
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+#: packages/admin/src/components/TaxonomyManager.tsx:498
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:983
+#: packages/admin/src/routes/bylines.tsx:579
+msgid "Saving..."
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Saving…"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:482
+msgid "SBOM"
+msgstr ""
+
+#. placeholder {0}: sbom.format
+#: packages/admin/src/components/RegistryPluginDetail.tsx:480
+msgid "SBOM · {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:501
+msgid "Schedule"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:487
+msgid "Schedule for"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:524
+msgid "Schedule for later"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1164
+msgid "scheduled"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:731
+#: packages/admin/src/components/ContentSettingsPanel.tsx:455
+#: packages/admin/src/components/Dashboard.tsx:352
+#: packages/admin/src/router.tsx:1067
+msgid "Scheduled"
+msgstr ""
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentSettingsPanel.tsx:475
+msgid "Scheduled for: {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1699
+msgid "Schema preparation failed"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Schema Read"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Schema Write"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:429
+msgid "Scopes"
+msgstr ""
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:295
+msgid "Scopes: {0}"
+msgstr ""
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/RegistryPluginDetail.tsx:655
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:466
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:444
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/RegistryPluginDetail.tsx:649
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:50
+msgid "SCSS"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+#: packages/admin/src/components/Widgets.tsx:151
+msgid "Search"
+msgstr ""
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:353
+msgid "Search {0}"
+msgstr ""
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:352
+msgid "Search {0}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:626
+msgid "Search by filename..."
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:853
+#: packages/admin/src/routes/bylines.tsx:401
+msgid "Search bylines"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:852
+msgid "Search bylines to add..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:164
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:122
+msgid "Search Engine Optimization"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:83
+msgid "Search engine optimization and verification"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:152
+msgid "Search form"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:416
+#: packages/admin/src/components/MediaPickerModal.tsx:627
+msgid "Search media"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:438
+msgid "Search pages and content..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:103
+#: packages/admin/src/components/RegistryBrowse.tsx:87
+msgid "Search plugins"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:99
+#: packages/admin/src/components/RegistryBrowse.tsx:83
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:82
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:412
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:415
+#: packages/admin/src/components/MediaPickerModal.tsx:626
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:857
+msgid "Searching..."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2457
+msgid "Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:83
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:248
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:79
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:254
+msgid "Section title"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:176
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:234
+msgid "Sections"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:306
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:809
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Security"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:342
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:332
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:179
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:180
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:321
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:718
+msgid "Security contacts"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:270
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:242
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/settings/SecuritySettings.tsx:95
+msgid "Security Settings"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:56
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1702
+#: packages/admin/src/components/ContentEditor.tsx:1718
+#: packages/admin/src/components/ImageFieldRenderer.tsx:198
+msgid "Select {label}"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:973
+msgid "Select {title}"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:956
+msgid "Select a component..."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:919
+msgid "Select a menu..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:284
+msgid "Select all"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:497
+msgid "Select all on this page"
+msgstr ""
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:457
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:235
+msgid "Select Default Social Image"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:260
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Select Favicon"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1706
+msgid "Select file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:150
+msgid "Select File"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3094
+msgid "Select Gallery Images"
+msgstr ""
+
+#: packages/admin/src/components/ImageFieldRenderer.tsx:186
+msgid "Select image"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:150
+#: packages/admin/src/components/PortableTextEditor.tsx:3080
+#: packages/admin/src/components/settings/SeoSettings.tsx:188
+msgid "Select Image"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:206
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:76
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:85
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:2159
+#: packages/admin/src/components/RepeaterField.tsx:372
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1488
+msgid "Selected {selectedItemTitle}"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:795
+msgid "Selected:"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:99
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:152
+msgid "Self-Signup Domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:113
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+msgid "Send Invite"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:150
+msgid "Send magic link"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:110
+msgid "Send Test Email"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:150
+#: packages/admin/src/components/settings/EmailSettings.tsx:127
+#: packages/admin/src/components/SignupPage.tsx:89
+#: packages/admin/src/components/SignupPage.tsx:152
+#: packages/admin/src/components/users/InviteUserModal.tsx:201
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:621
+#: packages/admin/src/components/ContentSettingsPanel.tsx:624
+#: packages/admin/src/components/ContentTypeEditor.tsx:472
+#: packages/admin/src/components/Settings.tsx:82
+msgid "SEO"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SeoSettings.tsx:115
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:40
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:168
+#: packages/admin/src/components/SeoPanel.tsx:172
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:146
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:150
+msgid "Set language"
+msgstr ""
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:147
+msgid "Set language (current: {label})"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:529
+msgid "Set to 0 to never close comments automatically."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:425
+msgid "Set to draft"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:234
+#: packages/admin/src/components/ContentEditor.tsx:809
+#: packages/admin/src/components/ContentEditor.tsx:1039
+#: packages/admin/src/components/ContentTypeEditor.tsx:381
+#: packages/admin/src/components/Header.tsx:101
+#: packages/admin/src/components/PluginManager.tsx:472
+#: packages/admin/src/components/Settings.tsx:63
+#: packages/admin/src/components/Sidebar.tsx:294
+#: packages/admin/src/components/WordPressImport.tsx:1811
+msgid "Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Settings Manage"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Settings Read"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:68
+#: packages/admin/src/components/settings/GeneralSettings.tsx:43
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:294
+msgid "Shared across all translations of the same byline."
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:52
+msgid "Short text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:146
+msgid "Show count"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:131
+msgid "Show date"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:139
+msgid "Show hierarchy"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:138
+msgid "Show post count"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:130
+msgid "Show thumbnails"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
+msgid "Show token"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:365
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:554
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:441
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:270
+msgid "Sign in instead"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:234
+msgid "Sign in to your site"
+msgstr ""
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:233
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:231
+msgid "Sign in with email"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:292
+msgid "Sign in with email link"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:254
+msgid "Sign in with Passkey"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:130
+msgid "Site Identity"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2270
+msgid "site identity applied (title, tagline, logo)"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:71
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+#: packages/admin/src/components/WordPressImport.tsx:1151
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:133
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1823
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:145
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:267
+msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:588
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:274
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2104
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2129
+msgid "Skipped"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:239
+#: packages/admin/src/components/ContentSettingsPanel.tsx:442
+#: packages/admin/src/components/ContentSettingsPanel.tsx:968
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1030
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:402
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:259
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:414
+#: packages/admin/src/routes/byline-schema.tsx:237
+#: packages/admin/src/routes/bylines.tsx:486
+msgid "Slug"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:251
+msgid "Slugs cannot be changed after the field is created."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1133
+msgid "Small section heading"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1143
+msgid "Smaller section heading"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1163
+msgid "Smallest section heading"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:76
+#: packages/admin/src/components/settings/SocialSettings.tsx:70
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
+msgid "Social Links"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:38
+msgid "Social links saved"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:77
+msgid "Social media profile links"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:100
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1860
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:155
+#: packages/admin/src/components/SignupPage.tsx:263
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:125
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:560
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:580
+#: packages/admin/src/components/Redirects.tsx:469
+#: packages/admin/src/components/SectionEditor.tsx:294
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:132
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:208
+#: packages/admin/src/components/comments/CommentInbox.tsx:248
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3863
+msgid "Spotlight Mode"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:51
+msgid "SQL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1922
+msgid "Start Import"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1208
+#: packages/admin/src/components/PortableTextEditor.tsx:2318
+#: packages/admin/src/components/PortableTextEditor.tsx:2319
+msgid "Start writing, or type '/' for commands"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:511
+#: packages/admin/src/components/ContentSettingsPanel.tsx:449
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:474
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:362
+msgid "Status: {status}"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:173
+msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
+msgstr ""
+
+#: packages/admin/src/components/settings/BackupSettings.tsx:218
+msgid "Stored Backups"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:293
+msgid "Stored per locale — each translation of a byline gets its own value."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3284
+#: packages/admin/src/components/PortableTextEditor.tsx:3670
+msgid "Strikethrough"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1752
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1164
+msgid "Structured"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:52
+msgid "Svelte"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:53
+msgid "Swift"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:777
+msgid "System"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:599
+msgid "System Fields"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1237
+msgid "Table"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3359
+msgid "Table controls"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:139
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:201
+#: packages/admin/src/components/Widgets.tsx:143
+msgid "Tags"
+msgstr ""
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1797
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:427
+#: packages/admin/src/components/MenuEditor.tsx:606
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:192
+msgid "Target locale"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:610
+#: packages/admin/src/components/TaxonomySidebar.tsx:550
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Taxonomies Manage"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:918
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:807
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:179
+msgid "Taxonomy: {taxonomyName}"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/components/TaxonomyManager.tsx:378
+#: packages/admin/src/components/TaxonomyManager.tsx:834
+msgid "Term"
+msgstr ""
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:781
+msgid "Term \"{0}\" created in {1}."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:763
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:122
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3621
+msgid "Text formatting"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:60
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:179
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:114
+#: packages/admin/src/components/SignupPage.tsx:140
+msgid "The link will expire in 15 minutes."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:179
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:76
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:136
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/router.tsx:2191
+msgid "The page you're looking for doesn't exist."
+msgstr ""
+
+#: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
+msgid "The plugin field widget failed to render."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:149
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:174
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:307
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:185
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:33
+msgid "Theme: {label}"
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:281
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:141
+msgid "These tools remain disabled after installation until you explicitly enable agent access."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:370
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1059
+msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "This field does not accept {sniffedMime} files."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1721
+#: packages/admin/src/components/ImageFieldRenderer.tsx:201
+msgid "This field is required"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:301
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1308
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:921
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#. placeholder {0}: archiveToDelete?.name ?? ""
+#: packages/admin/src/components/settings/BackupSettings.tsx:283
+msgid "This permanently deletes {0} from storage."
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:177
+msgid "This plugin has no configurable settings."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:579
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:584
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:631
+msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:623
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:298
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:303
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:125
+msgid "This update exposes the following routes without authentication:"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:715
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:676
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:904
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:714
+msgid "This will remove the plugin and its bundle from your site."
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:84
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:287
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:290
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:505
+#: packages/admin/src/components/ContentList.tsx:643
+#: packages/admin/src/components/SectionEditor.tsx:251
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:891
+msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:361
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:550
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+msgid "Title Separator"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:811
+msgid "to"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:483
+msgid "to close"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:815
+msgid "To date"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:208
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:473
+msgid "to select"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3404
+msgid "Toggle header row"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:31
+#: packages/admin/src/components/ThemeToggle.tsx:42
+msgid "Toggle theme (current: {label})"
+msgstr ""
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:207
+msgid "Token created: {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:420
+msgid "Token Name"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:54
+msgid "TOML"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1277
+msgid "Tools → Export"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:287
+#: packages/admin/src/routes/byline-schema.tsx:243
+msgid "Translatable"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:103
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translate"
+msgstr ""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:176
+msgid "Translate \"{0}\""
+msgstr ""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:100
+msgid "Translate {0}"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TranslationsPanel.tsx:104
+msgid "Translating..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:143
+#: packages/admin/src/components/TaxonomyManager.tsx:780
+#: packages/admin/src/router.tsx:1119
+msgid "Translation created"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:588
+#: packages/admin/src/components/TranslationsPanel.tsx:60
+msgid "Translations"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:217
+#: packages/admin/src/components/comments/CommentInbox.tsx:258
+#: packages/admin/src/components/comments/CommentInbox.tsx:514
+#: packages/admin/src/components/ContentList.tsx:375
+msgid "Trash"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:666
+msgid "Trash is empty"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:550
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:493
+msgid "Try a broader media type or clear your filters."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:691
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:103
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:518
+msgid "Try another filename or clear your search."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:492
+msgid "Try another filename, or clear your search and filters."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1286
+#: packages/admin/src/components/WordPressImport.tsx:1408
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:55
+msgid "TSX"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:309
+msgid "Turn into"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:106
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:260
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:587
+#: packages/admin/src/routes/byline-schema.tsx:240
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:2018
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:56
+msgid "TypeScript"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1073
+#: packages/admin/src/components/ContentSettingsPanel.tsx:1090
+msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3277
+#: packages/admin/src/components/PortableTextEditor.tsx:3663
+msgid "Underline"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3843
+msgid "Undo"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:191
+#: packages/admin/src/components/PluginManager.tsx:630
+#: packages/admin/src/components/PluginManager.tsx:728
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:712
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:707
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:728
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:731
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr ""
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:202
+msgid "Unpublish {itemLabel}"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1027
+msgid "Unpublished"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "Unregistered Content Tables Found"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:477
+msgid "Unschedule"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1088
+msgid "Unscheduled"
+msgstr ""
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:319
+msgid "Untitled"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1624
+msgid "Untitled file"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:536
+#: packages/admin/src/components/Widgets.tsx:809
+msgid "Untitled Widget"
+msgstr ""
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr ""
+
+#: packages/admin/src/components/ContentSettingsPanel.tsx:900
+msgid "Up"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:500
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:660
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:334
+msgid "Update settings for {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:92
+msgid "Update site settings"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:382
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:110
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:452
+msgid "Update to v{0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:737
+#: packages/admin/src/components/ContentSettingsPanel.tsx:541
+#: packages/admin/src/components/RegistryPluginDetail.tsx:501
+msgid "Updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:946
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:197
+#: packages/admin/src/components/PluginManager.tsx:452
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:649
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:152
+msgid "Upload a file to get started"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1391
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:153
+msgid "Upload an image to get started"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:62
+msgid "Upload and delete media"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:283
+#: packages/admin/src/lib/api/marketplace.ts:291
+msgid "Upload and manage media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1284
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:669
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:661
+msgid "Upload file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:154
+msgid "Upload File"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:365
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:508
+#: packages/admin/src/components/MediaLibrary.tsx:532
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:154
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:505
+msgid "Upload images, videos, and documents to keep reusable assets in one place."
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:114
+msgid "Upload Media"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:529
+msgid "Upload media to keep reusable assets in one place."
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:356
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:289
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2127
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:331
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:332
+#: packages/admin/src/components/MediaPickerModal.tsx:649
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:54
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:418
+#: packages/admin/src/components/MenuEditor.tsx:596
+#: packages/admin/src/components/PortableTextEditor.tsx:3231
+#: packages/admin/src/components/PortableTextEditor.tsx:3788
+#: packages/admin/src/components/PortableTextEditor.tsx:3798
+msgid "URL"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:423
+msgid "URL Pattern"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:165
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:295
+msgid "URL:"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:111
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:364
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:328
+msgid "Use your registered passkey to sign in securely."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:666
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1311
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:122
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:408
+msgid "Used in URLs and API endpoints"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:269
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:43
+#: packages/admin/src/components/Header.tsx:83
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:177
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:210
+#: packages/admin/src/components/Sidebar.tsx:253
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:383
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:211
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:387
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/RegistryBrowse.tsx:189
+#: packages/admin/src/components/RegistryPluginDetail.tsx:462
+msgid "Verified publisher"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:461
+msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:452
+msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:453
+msgid "Verified publisher. A labeller has confirmed this publisher's identity."
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:228
+msgid "Verifying your invite..."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:388
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:211
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+#: packages/admin/src/components/RegistryPluginDetail.tsx:515
+msgid "Version"
+msgstr ""
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:477
+msgid "Version {0}"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+#: packages/admin/src/components/MediaLibrary.tsx:435
+msgid "Video"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:117
+msgid "View email provider status and send test emails"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:464
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:447
+msgid "View mode"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:1011
+msgid "View published {title}"
+msgstr ""
+
+#: packages/admin/src/components/Header.tsx:59
+msgid "View Site"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:676
+msgid "View source"
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:931
+msgid "View the {license} license on spdx.org"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:57
+msgid "Vue"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:335
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1266
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:577
+msgid "We couldn't verify this publisher's identity"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1084
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "We'll send you a link to sign in without a password."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:133
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+#: packages/admin/src/components/RegistryPluginDetail.tsx:701
+msgid "Website"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:491
+msgid "Website URL"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1874
+msgid "What will happen when you import"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:680
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:121
+msgid "Why can't this be changed?"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:209
+msgid "Why is this important for duplicate pages?"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:185
+msgid "Why is this important for search result summaries?"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Why is this important for search result titles?"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:228
+msgid "Why is this important for search visibility?"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:44
+msgid "Why is this important for social sharing?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:123
+msgid "Why is this important?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
+msgid "Wide"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:802
+#: packages/admin/src/components/Widgets.tsx:817
+msgid "widget"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:232
+msgid "Widget added"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:220
+msgid "Widget area created"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:645
+msgid "Widget area deleted"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:765
+msgid "Widget deleted"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:894
+msgid "Widget title"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:780
+msgid "Widget updated"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:168
+#: packages/admin/src/components/PluginManager.tsx:408
+#: packages/admin/src/components/Sidebar.tsx:233
+#: packages/admin/src/components/Widgets.tsx:388
+#: packages/admin/src/components/WordPressImport.tsx:1157
+msgid "Widgets"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:284
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:473
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/PluginSettings.tsx:338
+msgid "Will be cleared on save"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2014
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:384
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:158
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:210
+msgid "WordPress authorization was rejected"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1476
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:404
+msgid "Working on {selectedCount} items…"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:904
+msgid "Write widget content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1181
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:58
+msgid "XML"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1497
+msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
+msgstr ""
+
+#: packages/admin/src/components/editor/codeBlockLanguages.ts:59
+msgid "YAML"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:163
+msgid "Yearly"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:420
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1160
+msgid "Yoast/RankMath"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:549
+msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr ""
+
+#: packages/admin/src/routes/byline-schema.tsx:175
+msgid "You need admin permissions to manage byline schema."
+msgstr ""
+
+#: packages/admin/src/router.tsx:1486
+msgid "You need Editor permissions to moderate comments."
+msgstr ""
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:55
+msgid "You'll be joining as <0>{0}</0>"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1369
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:192
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:53
+msgid "You've been invited!"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:71
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:334
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:316
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:267
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:121
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:115
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:127
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:133
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:504
+#: packages/admin/src/components/MediaLibrary.tsx:528
+msgid "Your media library is empty"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:65
+#: packages/admin/src/components/SignupPage.tsx:202
+msgid "Your name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr ""
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:612
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:109
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:437
+msgid "Your unsaved media changes will be lost."
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:2062
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:139
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:136
+msgid "YouTube"
+msgstr ""

--- a/packages/admin/src/locales/cs/messages.po
+++ b/packages/admin/src/locales/cs/messages.po
@@ -7,591 +7,596 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: cs\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n>=2 && n<=4) ? 1 : (n!=Math.floor(n)) ? 2 : 3);\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Guest"
-msgstr ""
+msgstr " - Host"
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Linked"
-msgstr ""
+msgstr " - Propojeno"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:72
 #: packages/admin/src/components/TranslationsPanel.tsx:81
 msgid " (default)"
-msgstr ""
+msgstr " (výchozí)"
 
 #: packages/admin/src/components/MenuEditor.tsx:521
 msgid " (opens in new window)"
-msgstr ""
+msgstr " (otevře se v novém okně)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:867
 #: packages/admin/src/components/MediaPickerModal.tsx:950
 msgid " (selected)"
-msgstr ""
+msgstr " (vybráno)"
 
 #: packages/admin/src/routes/bylines.tsx:706
 msgid "-- Select --"
-msgstr ""
+msgstr "-- Vybrat --"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
 msgid ", or open the admin at"
-msgstr ""
+msgstr ", nebo otevřete administraci na"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
 msgid ": use"
-msgstr ""
+msgstr ": použijte"
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
 #: packages/admin/src/components/MediaPickerModal.tsx:798
 msgid "(from {0})"
-msgstr ""
+msgstr "(z {0})"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:533
 msgid "(pre-release)"
-msgstr ""
+msgstr "(předběžná verze)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:156
 msgid "(synced)"
-msgstr ""
+msgstr "(synchronizováno)"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:536
 msgid "(too new)"
-msgstr ""
+msgstr "(příliš nová)"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:310
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
-msgstr ""
+msgstr "(s vaším vývojovým portem)."
 
 #. placeholder {0}: items.length
 #. placeholder {0}: orphan.rowCount
 #: packages/admin/src/components/ContentTypeList.tsx:71
 #: packages/admin/src/components/RepeaterField.tsx:152
 msgid "{0, plural, one {(# item)} other {(# items)}}"
-msgstr ""
+msgstr "{0, plural, one {(# položka)} few {(# položky)} many {(# položky)} other {(# položek)}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
 msgid "{0, plural, one {# collection} other {# collections}}"
-msgstr ""
+msgstr "{0, plural, one {# kolekce} few {# kolekce} many {# kolekce} other {# kolekcí}}"
 
 #. placeholder {0}: result.comments.imported
 #: packages/admin/src/components/WordPressImport.tsx:2263
 msgid "{0, plural, one {# comment imported} other {# comments imported}}"
-msgstr ""
+msgstr "{0, plural, one {# komentář importován} few {# komentáře importovány} many {# komentáře importováno} other {# komentářů importováno}}"
 
 #. placeholder {0}: result.affected
 #: packages/admin/src/router.tsx:1465
 msgid "{0, plural, one {# comment updated} other {# comments updated}}"
-msgstr ""
+msgstr "{0, plural, one {# komentář aktualizován} few {# komentáře aktualizovány} many {# komentáře aktualizováno} other {# komentářů aktualizováno}}"
 
 #. placeholder {0}: comments.length
 #: packages/admin/src/components/comments/CommentInbox.tsx:345
 msgid "{0, plural, one {# comment} other {# comments}}"
-msgstr ""
+msgstr "{0, plural, one {# komentář} few {# komentáře} many {# komentáře} other {# komentářů}}"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2274
 msgid "{0, plural, one {# content error} other {# content errors}}"
-msgstr ""
+msgstr "{0, plural, one {# chyba obsahu} few {# chyby obsahu} many {# chyby obsahu} other {# chyb obsahu}}"
 
 #. placeholder {0}: result.imported
 #: packages/admin/src/components/WordPressImport.tsx:2215
 msgid "{0, plural, one {# content item imported} other {# content items imported}}"
-msgstr ""
+msgstr "{0, plural, one {# položka obsahu importována} few {# položky obsahu importovány} many {# položky obsahu importováno} other {# položek obsahu importováno}}"
 
 #. placeholder {0}: selectedItems.length
 #: packages/admin/src/components/MediaPickerModal.tsx:787
 msgid "{0, plural, one {# item selected} other {# items selected}}"
-msgstr ""
+msgstr "{0, plural, one {# položka vybrána} few {# položky vybrány} many {# položky vybráno} other {# položek vybráno}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
 #: packages/admin/src/components/MediaPickerModal.tsx:636
 #: packages/admin/src/components/MenuList.tsx:220
 msgid "{0, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{0, plural, one {# položka} few {# položky} many {# položky} other {# položek}}"
 
 #. placeholder {0}: mcpTools.length
 #: packages/admin/src/components/PluginManager.tsx:420
 msgid "{0, plural, one {# MCP tool} other {# MCP tools}}"
-msgstr ""
+msgstr "{0, plural, one {# nástroj MCP} few {# nástroje MCP} many {# nástroje MCP} other {# nástrojů MCP}}"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2279
 msgid "{0, plural, one {# media error} other {# media errors}}"
-msgstr ""
+msgstr "{0, plural, one {# chyba médií} few {# chyby médií} many {# chyby médií} other {# chyb médií}}"
 
 #. placeholder {0}: mediaResult.imported.length
 #: packages/admin/src/components/WordPressImport.tsx:2231
 msgid "{0, plural, one {# media file imported} other {# media files imported}}"
-msgstr ""
+msgstr "{0, plural, one {# soubor médií importován} few {# soubory médií importovány} many {# souboru médií importováno} other {# souborů médií importováno}}"
 
 #. placeholder {0}: result.menus.created
 #: packages/admin/src/components/WordPressImport.tsx:2255
 msgid "{0, plural, one {# menu imported} other {# menus imported}}"
-msgstr ""
+msgstr "{0, plural, one {# nabídka importována} few {# nabídky importovány} many {# nabídky importováno} other {# nabídek importováno}}"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1903
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
-msgstr ""
+msgstr "{0, plural, one {Bude importována # nabídka} few {Budou importovány # nabídky} many {Bude importováno # nabídky} other {Bude importováno # nabídek}}"
 
 #. placeholder {0}: plugin.capabilities.length
 #: packages/admin/src/components/MarketplaceBrowse.tsx:290
 #: packages/admin/src/components/PluginManager.tsx:434
 msgid "{0, plural, one {# permission} other {# permissions}}"
-msgstr ""
+msgstr "{0, plural, one {# oprávnění} few {# oprávnění} many {# oprávnění} other {# oprávnění}}"
 
 #. placeholder {0}: mapping.postCount
 #: packages/admin/src/components/WordPressImport.tsx:2486
 msgid "{0, plural, one {# post} other {# posts}}"
-msgstr ""
+msgstr "{0, plural, one {# příspěvek} few {# příspěvky} many {# příspěvku} other {# příspěvků}}"
 
 #. placeholder {0}: loopRedirectIds.size
 #: packages/admin/src/components/Redirects.tsx:447
 msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
-msgstr ""
+msgstr "{0, plural, one {# přesměrování je součástí smyčky.} few {# přesměrování jsou součástí smyčky.} many {# přesměrování je součástí smyčky.} other {# přesměrování je součástí smyčky.}}"
 
 #. placeholder {0}: selected.size
 #: packages/admin/src/components/comments/CommentInbox.tsx:229
 msgid "{0, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{0, plural, one {# vybráno} few {# vybráno} many {# vybráno} other {# vybráno}}"
 
 #. placeholder {0}: result.skipped
 #: packages/admin/src/components/WordPressImport.tsx:2223
 msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
-msgstr ""
+msgstr "{0, plural, one {# přeskočeno (již existuje)} few {# přeskočeno (již existují)} many {# přeskočeno (již existují)} other {# přeskočeno (již existují)}}"
 
 #. placeholder {0}: result.taxonomyAssignments
 #: packages/admin/src/components/WordPressImport.tsx:2247
 msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
-msgstr ""
+msgstr "{0, plural, one {# přiřazení taxonomie} few {# přiřazení taxonomie} many {# přiřazení taxonomie} other {# přiřazení taxonomie}}"
 
 #. placeholder {0}: result.taxonomiesCreated.length
 #: packages/admin/src/components/WordPressImport.tsx:2239
 msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
-msgstr ""
+msgstr "{0, plural, one {# taxonomie vytvořena} few {# taxonomie vytvořeny} many {# taxonomie vytvořeno} other {# taxonomií vytvořeno}}"
 
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:585
 msgid "{0, plural, one {field} other {fields}}"
-msgstr ""
+msgstr "{0, plural, one {pole} few {pole} many {pole} other {polí}}"
 
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:164
 msgid "{0, plural, one {Media file} other {Media files}}"
-msgstr ""
+msgstr "{0, plural, one {Soubor médií} few {Soubory médií} many {Souborů médií} other {Souborů médií}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:168
 msgid "{0, plural, one {User} other {Users}}"
-msgstr ""
+msgstr "{0, plural, one {Uživatel} few {Uživatelé} many {Uživatelů} other {Uživatelů}}"
 
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
 #. placeholder {2}: m.host
 #: packages/admin/src/components/RegistryPluginDetail.tsx:636
 msgid "{0} {1} required — you have {2}."
-msgstr ""
+msgstr "Vyžadováno {0} {1} — máte {2}."
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-2xl font-semibold leading-tight">{t`Menus`}</h1> <p className="mt-1 text-sm leading-5 text-pretty text-kumo-subtle"> {t`Manage navigation menus for your site`} </p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
 #: packages/admin/src/components/MenuList.tsx:218
 msgid "{0} • {1}"
-msgstr ""
+msgstr "{0} • {1}"
 
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:425
 msgid "{0} banner"
-msgstr ""
+msgstr "Banner {0}"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1303
 msgid "{0} detected"
-msgstr ""
+msgstr "Zjištěno: {0}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:115
 msgid "{0} has been deactivated"
-msgstr ""
+msgstr "{0} byl deaktivován"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:324
 msgid "{0} has been removed"
-msgstr ""
+msgstr "{0} byl odebrán"
 
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:437
 msgid "{0} icon"
-msgstr ""
+msgstr "Ikona {0}"
 
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:213
 msgid "{0} installs"
-msgstr ""
+msgstr "{0} instalací"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:96
 msgid "{0} is now active"
-msgstr ""
+msgstr "{0} je nyní aktivní"
 
 #. placeholder {0}: postType.count
 #. placeholder {1}: postType.suggestedCollection
 #: packages/admin/src/components/WordPressImport.tsx:1973
 msgid "{0} items → {1}"
-msgstr ""
+msgstr "{0} položek → {1}"
 
 #. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
 #: packages/admin/src/components/WordPressImport.tsx:1896
 msgid "{0} items will be imported"
-msgstr ""
+msgstr "Bude importováno {0} položek"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:535
 msgid "{0} of {total} could not be deleted"
-msgstr ""
+msgstr "{0} z {total} se nepodařilo smazat"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:491
 msgid "{0} of {total} could not be published"
-msgstr ""
+msgstr "{0} z {total} se nepodařilo publikovat"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:514
 msgid "{0} of {total} could not be updated"
-msgstr ""
+msgstr "{0} z {total} se nepodařilo aktualizovat"
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:179
 msgid "{0} plugins"
-msgstr ""
+msgstr "{0} pluginů"
 
 #. placeholder {0}: theme.name
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:206
 msgid "{0} preview"
-msgstr ""
+msgstr "Náhled {0}"
 
 #. placeholder {0}: SYSTEM_FIELDS.length
 #. placeholder {1}: fields.length
 #. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="truncate text-2xl font-semibold"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
 #: packages/admin/src/components/ContentTypeEditor.tsx:583
 msgid "{0} system + {1} custom {2}"
-msgstr ""
+msgstr "{0} systémových + {1} vlastních {2}"
 
 #. placeholder {0}: taxonomy.label
 #: packages/admin/src/components/TaxonomySidebar.tsx:360
 msgid "{0} updated"
-msgstr ""
+msgstr "{0} aktualizováno"
 
 #. placeholder {0}: plugin.name
 #. placeholder {1}: updateInfo?.latest
 #: packages/admin/src/components/PluginManager.tsx:270
 msgid "{0} updated to v{1}"
-msgstr ""
+msgstr "{0} aktualizován na v{1}"
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
 #: packages/admin/src/components/MediaPickerModal.tsx:867
 #: packages/admin/src/components/MediaPickerModal.tsx:950
 msgid "{0}{1}"
-msgstr ""
+msgstr "{0}{1}"
 
 #. placeholder {0}: draft.description.length
 #: packages/admin/src/components/SeoPanel.tsx:195
 msgid "{0}/160 characters"
-msgstr ""
+msgstr "{0}/160 znaků"
 
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:313
 msgid "{base} to: {0}"
-msgstr ""
+msgstr "{base} na: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:355
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
-msgstr ""
+msgstr "{changedCount, plural, one {# změna oproti další revizi} few {# změny oproti další revizi} many {# změny oproti další revizi} other {# změn oproti další revizi}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2072
 msgid "{count, plural, one {# file} other {# files}}"
-msgstr ""
+msgstr "{count, plural, one {# soubor} few {# soubory} many {# souboru} other {# souborů}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2351
 msgid "{count, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{count, plural, one {# položka} few {# položky} many {# položky} other {# položek}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2143
 msgid "{current} of {total}"
-msgstr ""
+msgstr "{current} z {total}"
 
 #. placeholder {0}: hasMore ? "+" : ""
 #. placeholder {1}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:933
 msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
-msgstr ""
+msgstr "{filteredCount, plural, one {#{0} položka} few {#{1} položky} many {#{1} položky} other {#{1} položek}}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
-msgstr ""
+msgstr "{label} — bez překladu"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
-msgstr ""
+msgstr "{label} — zobrazit překlad"
 
 #: packages/admin/src/components/ContentList.tsx:922
 msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{matchCount, plural, one {# položka odpovídá „{searchQuery}“} few {# položky odpovídají „{searchQuery}“} many {# položky odpovídá „{searchQuery}“} other {# položek odpovídá „{searchQuery}“}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2473
 msgid "{matchedCount} of {totalCount} assigned"
-msgstr ""
+msgstr "Přiřazeno {matchedCount} z {totalCount}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2461
 msgid "{matchedCount} of {totalCount} authors matched by email"
-msgstr ""
+msgstr "{matchedCount} z {totalCount} autorů spárováno podle e-mailu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1879
 msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
-msgstr ""
+msgstr "{needsNewCollections, plural, one {Bude vytvořena # nová kolekce} few {Budou vytvořeny # nové kolekce} many {Bude vytvořeno # nové kolekce} other {Bude vytvořeno # nových kolekcí}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1888
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr ""
+msgstr "{needsNewFields, plural, one {Pole budou přidána do # existující kolekce} few {Pole budou přidána do # existujících kolekcí} many {Pole budou přidána do # existujících kolekcí} other {Pole budou přidána do # existujících kolekcí}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:83
 msgid "{pluginName} is requesting additional permissions:"
-msgstr ""
+msgstr "{pluginName} požaduje další oprávnění:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:84
 msgid "{pluginName} requires the following permissions:"
-msgstr ""
+msgstr "{pluginName} vyžaduje následující oprávnění:"
 
 #: packages/admin/src/components/PluginSettings.tsx:128
 #: packages/admin/src/components/PluginSettings.tsx:142
 #: packages/admin/src/components/PluginSettings.tsx:170
 msgid "{pluginName} Settings"
-msgstr ""
+msgstr "Nastavení {pluginName}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:298
 msgid "{resultCount, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{resultCount, plural, one {# položka} few {# položky} many {# položky} other {# položek}}"
 
 #: packages/admin/src/components/ContentList.tsx:405
 msgid "{selectedCount, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {# vybráno} few {# vybráno} many {# vybráno} other {# vybráno}}"
 
 #: packages/admin/src/components/ContentList.tsx:446
 msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {Přesunout # položku do koše? Později ji lze obnovit.} few {Přesunout # položky do koše? Později je lze obnovit.} many {Přesunout # položky do koše? Později je lze obnovit.} other {Přesunout # položek do koše? Později je lze obnovit.}}"
 
 #: packages/admin/src/components/ContentList.tsx:928
 msgid "{total, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{total, plural, one {# položka} few {# položky} many {# položky} other {# položek}}"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:150
 msgid "{total, plural, one {# total} other {# total}}"
-msgstr ""
+msgstr "{total, plural, one {# celkem} few {# celkem} many {# celkem} other {# celkem}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:211
 #: packages/admin/src/components/MediaLibrary.tsx:247
 msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
-msgstr ""
+msgstr "{total, plural, one {Soubor nahrán} few {# soubory nahrány} many {# souboru nahráno} other {# souborů nahráno}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:216
 #: packages/admin/src/components/MediaLibrary.tsx:252
 msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
-msgstr ""
+msgstr "{total, plural, one {Nahrávání selhalo} few {Všechna # nahrávání selhala} many {Všech # nahrávání selhalo} other {Všech # nahrávání selhalo}}"
 
 #: packages/admin/src/components/Dashboard.tsx:152
 msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
-msgstr ""
+msgstr "{totalDrafts, plural, one {Koncept} few {Koncepty} many {Konceptů} other {Konceptů}}"
 
 #: packages/admin/src/components/Dashboard.tsx:158
 msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
-msgstr ""
+msgstr "{totalScheduled, plural, one {Naplánováno} few {Naplánováno} many {Naplánováno} other {Naplánováno}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:367
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {Skrýt # nezměněné} few {Skrýt # nezměněné} many {Skrýt # nezměněných} other {Skrýt # nezměněných}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:368
 msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {Zobrazit # nezměněné} few {Zobrazit # nezměněné} many {Zobrazit # nezměněných} other {Zobrazit # nezměněných}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:221
 #: packages/admin/src/components/MediaLibrary.tsx:257
 msgid "{uploaded} uploaded, {failed} failed"
-msgstr ""
+msgstr "{uploaded} nahráno, {failed} selhalo"
 
 #: packages/admin/src/components/Redirects.tsx:142
 msgid "/new-page or /articles/[slug]"
-msgstr ""
+msgstr "/new-page nebo /articles/[slug]"
 
 #: packages/admin/src/components/Redirects.tsx:133
 msgid "/old-page or /blog/[slug]"
-msgstr ""
+msgstr "/old-page nebo /blog/[slug]"
 
 #: packages/admin/src/components/WordPressImport.tsx:2093
 msgid "• Files are downloaded from your WordPress site"
-msgstr ""
+msgstr "• Soubory se stáhnou z vašeho webu WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:2094
 msgid "• Uploaded to your EmDash media storage"
-msgstr ""
+msgstr "• Nahrají se do vašeho úložiště médií EmDash"
 
 #: packages/admin/src/components/WordPressImport.tsx:2095
 msgid "• URLs in your content are updated automatically"
-msgstr ""
+msgstr "• URL ve vašem obsahu se aktualizují automaticky"
 
 #: packages/admin/src/components/SetupWizard.tsx:225
 #: packages/admin/src/components/SetupWizard.tsx:277
 #: packages/admin/src/components/SetupWizard.tsx:332
 #: packages/admin/src/components/WordPressImport.tsx:1601
 msgid "← Back"
-msgstr ""
+msgstr "← Zpět"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:36
 msgid "1 year"
-msgstr ""
+msgstr "1 rok"
 
 #: packages/admin/src/components/WordPressImport.tsx:1522
 msgid "1. Log into your WordPress admin"
-msgstr ""
+msgstr "1. Přihlaste se do administrace WordPressu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1275
 msgid "1. Log into your WordPress admin dashboard"
-msgstr ""
+msgstr "1. Přihlaste se do administračního přehledu WordPressu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "2. Go to"
-msgstr ""
+msgstr "2. Přejděte na"
 
 #: packages/admin/src/components/WordPressImport.tsx:1523
 msgid "2. Go to Users → Profile"
-msgstr ""
+msgstr "2. Přejděte na Uživatelé → Profil"
 
 #: packages/admin/src/components/WordPressImport.tsx:1524
 msgid "3. Scroll to \"Application Passwords\""
-msgstr ""
+msgstr "3. Přejděte dolů na „Application Passwords“"
 
 #: packages/admin/src/components/WordPressImport.tsx:1279
 msgid "3. Select \"All content\""
-msgstr ""
+msgstr "3. Vyberte „All content“"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
 msgid "30 days"
-msgstr ""
+msgstr "30 dní"
 
 #: packages/admin/src/components/Redirects.tsx:156
 msgid "301 Permanent"
-msgstr ""
+msgstr "301 Trvalé"
 
 #: packages/admin/src/components/Redirects.tsx:157
 msgid "302 Temporary"
-msgstr ""
+msgstr "302 Dočasné"
 
 #: packages/admin/src/components/Redirects.tsx:158
 msgid "307 Temporary (Strict)"
-msgstr ""
+msgstr "307 Dočasné (striktní)"
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "308 Permanent (Strict)"
-msgstr ""
+msgstr "308 Trvalé (striktní)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1280
 msgid "4. Click \"Download Export File\""
-msgstr ""
+msgstr "4. Klikněte na „Download Export File“"
 
 #: packages/admin/src/components/WordPressImport.tsx:1525
 msgid "4. Enter \"EmDash\" and click \"Add New\""
-msgstr ""
+msgstr "4. Zadejte „EmDash“ a klikněte na „Add New“"
 
 #: packages/admin/src/components/Redirects.tsx:397
 msgid "404 Errors"
-msgstr ""
+msgstr "Chyby 404"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "410 Content Deleted (Gone)"
-msgstr ""
+msgstr "410 Obsah smazán (Gone)"
 
 #: packages/admin/src/components/Redirects.tsx:161
 msgid "451 Unavailable for legal reasons"
-msgstr ""
+msgstr "451 Nedostupné z právních důvodů"
 
 #: packages/admin/src/components/WordPressImport.tsx:1526
 msgid "5. Copy the generated password"
-msgstr ""
+msgstr "5. Zkopírujte vygenerované heslo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1281
 msgid "5. Upload the file here"
-msgstr ""
+msgstr "5. Nahrajte soubor sem"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
 msgid "7 days"
-msgstr ""
+msgstr "7 dní"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
 msgid "90 days"
-msgstr ""
+msgstr "90 dní"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:416
 msgid "A brief description of this content type"
-msgstr ""
+msgstr "Stručný popis tohoto typu obsahu"
 
 #: packages/admin/src/components/Sections.tsx:203
 msgid "A full-width hero banner with heading, text, and CTA button"
-msgstr ""
+msgstr "Hero banner přes celou šířku s nadpisem, textem a tlačítkem CTA"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:142
 msgid "A short description of your site"
-msgstr ""
+msgstr "Stručný popis vašeho webu"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:201
 msgid "Accept & Install"
-msgstr ""
+msgstr "Přijmout a nainstalovat"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:200
 msgid "Accept & Update"
-msgstr ""
+msgstr "Přijmout a aktualizovat"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:240
 msgid "Accept Invite"
-msgstr ""
+msgstr "Přijmout pozvánku"
 
 #: packages/admin/src/routes/byline-schema.tsx:174
 msgid "Access denied"
-msgstr ""
+msgstr "Přístup odepřen"
 
 #: packages/admin/src/router.tsx:1485
 msgid "Access Denied"
-msgstr ""
+msgstr "Přístup odepřen"
 
 #: packages/admin/src/lib/api/marketplace.ts:282
 #: packages/admin/src/lib/api/marketplace.ts:290
 msgid "Access your media library"
-msgstr ""
+msgstr "Přístup k vaší knihovně médií"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
-msgstr ""
+msgstr "Účet"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:154
 msgid "Account already exists"
-msgstr ""
+msgstr "Účet již existuje"
 
 #: packages/admin/src/components/SignupPage.tsx:262
 msgid "Account exists"
-msgstr ""
+msgstr "Účet existuje"
 
 #: packages/admin/src/components/users/UserDetail.tsx:216
 msgid "Account Info"
-msgstr ""
+msgstr "Informace o účtu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1158
 msgid "ACF Fields"
-msgstr ""
+msgstr "Pole ACF"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/ContentList.tsx:528
@@ -600,19 +605,19 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:843
 #: packages/admin/src/routes/byline-schema.tsx:249
 msgid "Actions"
-msgstr ""
+msgstr "Akce"
 
 #: packages/admin/src/components/users/UserDetail.tsx:206
 #: packages/admin/src/components/users/UserList.tsx:217
 msgid "Active"
-msgstr ""
+msgstr "Aktivní"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:171
 #: packages/admin/src/components/ContentSettingsPanel.tsx:871
 #: packages/admin/src/components/MenuEditor.tsx:441
 #: packages/admin/src/components/TaxonomySidebar.tsx:491
 msgid "Add"
-msgstr ""
+msgstr "Přidat"
 
 #. placeholder {0}: field.item_label
 #. placeholder {0}: taxonomyDef.labelSingular || t`Term`
@@ -620,313 +625,313 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:378
 #: packages/admin/src/components/TaxonomyManager.tsx:834
 msgid "Add {0}"
-msgstr ""
+msgstr "Přidat {0}"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:279
 msgid "Add {label}"
-msgstr ""
+msgstr "Přidat {label}"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:177
 msgid "Add a new passkey"
-msgstr ""
+msgstr "Přidat nový přístupový klíč"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
 msgid "Add an allowed domain"
-msgstr ""
+msgstr "Přidat povolenou doménu"
 
 #: packages/admin/src/components/FieldEditor.tsx:544
 msgid "Add at least one sub-field to define the repeater structure."
-msgstr ""
+msgstr "Přidejte alespoň jedno podpole pro definici struktury opakovače."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3370
 msgid "Add column after"
-msgstr ""
+msgstr "Přidat sloupec za"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3364
 msgid "Add column before"
-msgstr ""
+msgstr "Přidat sloupec před"
 
 #: packages/admin/src/components/MenuEditor.tsx:378
 #: packages/admin/src/components/MenuEditor.tsx:493
 msgid "Add Content"
-msgstr ""
+msgstr "Přidat obsah"
 
 #: packages/admin/src/components/MenuEditor.tsx:390
 #: packages/admin/src/components/MenuEditor.tsx:397
 #: packages/admin/src/components/MenuEditor.tsx:496
 msgid "Add Custom Link"
-msgstr ""
+msgstr "Přidat vlastní odkaz"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:316
 msgid "Add Domain"
-msgstr ""
+msgstr "Přidat doménu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:591
 #: packages/admin/src/components/FieldEditor.tsx:342
 #: packages/admin/src/components/FieldEditor.tsx:660
 msgid "Add Field"
-msgstr ""
+msgstr "Přidat pole"
 
 #: packages/admin/src/components/WordPressImport.tsx:1984
 msgid "Add fields"
-msgstr ""
+msgstr "Přidat pole"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr ""
+msgstr "Přidejte pole jako „Pracovní pozice“ nebo „Oslovení“ a obohaťte tak každý autorský podpis."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:613
 msgid "Add fields to define the structure of your content"
-msgstr ""
+msgstr "Přidejte pole, která definují strukturu vašeho obsahu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:616
 msgid "Add First Field"
-msgstr ""
+msgstr "Přidat první pole"
 
 #: packages/admin/src/components/RepeaterField.tsx:174
 msgid "Add First Item"
-msgstr ""
+msgstr "Přidat první položku"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:200
 msgid "Add Images"
-msgstr ""
+msgstr "Přidat obrázky"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:247
 msgid "Add images to gallery"
-msgstr ""
+msgstr "Přidat obrázky do galerie"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1863
 msgid "Add item"
-msgstr ""
+msgstr "Přidat položku"
 
 #: packages/admin/src/components/RepeaterField.tsx:158
 msgid "Add Item"
-msgstr ""
+msgstr "Přidat položku"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3299
 msgid "Add link"
-msgstr ""
+msgstr "Přidat odkaz"
 
 #: packages/admin/src/components/MenuEditor.tsx:486
 msgid "Add links to build your navigation menu"
-msgstr ""
+msgstr "Přidejte odkazy a sestavte tak navigační nabídku"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:162
 msgid "Add MIME type or extension"
-msgstr ""
+msgstr "Přidat MIME typ nebo příponu"
 
 #: packages/admin/src/components/ContentList.tsx:342
 msgid "Add New"
-msgstr ""
+msgstr "Přidat nový"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:503
 msgid "Add new {0}"
-msgstr ""
+msgstr "Přidat {0}"
 
 #: packages/admin/src/components/SeoPanel.tsx:227
 msgid "Add noindex meta tag"
-msgstr ""
+msgstr "Přidat meta tag noindex"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:200
 msgid "Add Passkey"
-msgstr ""
+msgstr "Přidat přístupový klíč"
 
 #: packages/admin/src/components/PluginManager.tsx:211
 msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
-msgstr ""
+msgstr "Přidáním pluginů do astro.config.mjs rozšíříte funkce EmDash."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3391
 msgid "Add row after"
-msgstr ""
+msgstr "Vložit řádek pod"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3385
 msgid "Add row before"
-msgstr ""
+msgstr "Vložit řádek nad"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:474
 msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
-msgstr ""
+msgstr "Přidat SEO metadata (titulek, popis, obrázek) a zahrnout do mapy webu"
 
 #: packages/admin/src/components/FieldEditor.tsx:538
 msgid "Add Sub-Field"
-msgstr ""
+msgstr "Přidat podřízené pole"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:278
 msgid "Add tags..."
-msgstr ""
+msgstr "Přidat štítky..."
 
 #: packages/admin/src/components/Widgets.tsx:403
 msgid "Add Widget Area"
-msgstr ""
+msgstr "Přidat oblast widgetů"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:102
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr ""
+msgstr "Přidejte své profily na sociálních sítích. Jsou dostupné šabloně webu a lze je zobrazit v záhlaví, zápatí nebo v profilech autorů."
 
 #: packages/admin/src/components/MenuEditor.tsx:441
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:311
 msgid "Adding..."
-msgstr ""
+msgstr "Přidávání..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1753
 msgid "Additional data to import."
-msgstr ""
+msgstr "Další data k importu."
 
 #: packages/admin/src/components/WordPressImport.tsx:1483
 msgid "admin"
-msgstr ""
+msgstr "admin"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:101
 #: packages/admin/src/components/Sidebar.tsx:383
 #: packages/admin/src/components/users/roleDefinitions.ts:42
 msgid "Admin"
-msgstr ""
+msgstr "Správce"
 
 #: packages/admin/src/components/Sidebar.tsx:329
 msgid "Admin navigation"
-msgstr ""
+msgstr "Navigace administrace"
 
 #: packages/admin/src/components/WelcomeModal.tsx:25
 msgid "Administrator"
-msgstr ""
+msgstr "Administrátor"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:196
 msgid "After send:"
-msgstr ""
+msgstr "Po odeslání:"
 
 #: packages/admin/src/components/PluginManager.tsx:543
 msgid "Agent access"
-msgstr ""
+msgstr "Přístup pro agenty"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:335
 msgid "Agent access for {0} has been updated"
-msgstr ""
+msgstr "Přístup pro agenty u {0} byl aktualizován"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:139
 msgid "Agent-callable MCP tools"
-msgstr ""
+msgstr "MCP nástroje volatelné agentem"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3738
 msgid "Align Center"
-msgstr ""
+msgstr "Zarovnat na střed"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3731
 msgid "Align Left"
-msgstr ""
+msgstr "Zarovnat vlevo"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3745
 msgid "Align Right"
-msgstr ""
+msgstr "Zarovnat vpravo"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
 msgid "Alignment"
-msgstr ""
+msgstr "Zarovnání"
 
 #: packages/admin/src/components/ContentList.tsx:369
 msgid "All"
-msgstr ""
+msgstr "Vše"
 
 #: packages/admin/src/components/ContentList.tsx:773
 #: packages/admin/src/components/ContentList.tsx:777
 msgid "All authors"
-msgstr ""
+msgstr "Všichni autoři"
 
 #: packages/admin/src/routes/bylines.tsx:412
 msgid "All bylines"
-msgstr ""
+msgstr "Všechny autorské podpisy"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:110
 msgid "All capabilities"
-msgstr ""
+msgstr "Všechny schopnosti"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:134
 msgid "All collections"
-msgstr ""
+msgstr "Všechny kolekce"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:63
 msgid "All comments require approval"
-msgstr ""
+msgstr "Všechny komentáře vyžadují schválení"
 
 #: packages/admin/src/components/WordPressImport.tsx:2518
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
-msgstr ""
+msgstr "Veškerý importovaný obsah zůstane bez přiřazení. Autory lze přiřadit později v editoru obsahu."
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
-msgstr ""
+msgstr "Všechny jazyky"
 
 #: packages/admin/src/components/users/UserList.tsx:42
 #: packages/admin/src/components/users/UserList.tsx:46
 msgid "All roles"
-msgstr ""
+msgstr "Všechny role"
 
 #: packages/admin/src/components/Sections.tsx:240
 msgid "All Sources"
-msgstr ""
+msgstr "Všechny zdroje"
 
 #: packages/admin/src/components/ContentList.tsx:728
 #: packages/admin/src/components/Redirects.tsx:421
 msgid "All statuses"
-msgstr ""
+msgstr "Všechny stavy"
 
 #: packages/admin/src/components/MediaLibrary.tsx:433
 #: packages/admin/src/components/Redirects.tsx:427
 msgid "All types"
-msgstr ""
+msgstr "Všechny typy"
 
 #: packages/admin/src/components/PluginManager.tsx:545
 msgid "Allow MCP tokens with plugin-tool scope to invoke these routes."
-msgstr ""
+msgstr "Umožnit MCP tokenům s rozsahem plugin-tool volat tyto cesty."
 
 #: packages/admin/src/components/Settings.tsx:100
 msgid "Allow users from specific domains to sign up"
-msgstr ""
+msgstr "Povolit registraci uživatelům z určitých domén"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:495
 msgid "Allow visitors to leave comments on this collection's content"
-msgstr ""
+msgstr "Umožnit návštěvníkům komentovat obsah této kolekce"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
 msgid "Allowed Domains"
-msgstr ""
+msgstr "Povolené domény"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:102
 msgid "Allowed types"
-msgstr ""
+msgstr "Povolené typy"
 
 #: packages/admin/src/components/SignupPage.tsx:439
 msgid "Already have an account?"
-msgstr ""
+msgstr "Máte již účet?"
 
 #: packages/admin/src/components/PluginManager.tsx:719
 msgid "Also delete plugin storage data"
-msgstr ""
+msgstr "Smazat také uložená data pluginu"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:376
 #: packages/admin/src/components/editor/ImageNode.tsx:231
 #: packages/admin/src/components/MediaLibrary.tsx:589
 msgid "Alt text"
-msgstr ""
+msgstr "Alt text"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
 #: packages/admin/src/components/MediaDetailPanel.tsx:354
 #: packages/admin/src/components/MediaDetailPanel.tsx:371
 msgid "Alt Text"
-msgstr ""
+msgstr "Alt text"
 
 #: packages/admin/src/components/MediaLibrary.tsx:835
 #: packages/admin/src/components/MediaLibrary.tsx:892
 msgid "Alt text set"
-msgstr ""
+msgstr "Alt text nastaven"
 
 #: packages/admin/src/components/WordPressImport.tsx:1395
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
-msgstr ""
+msgstr "Případně můžete provést export z WordPressu (Nástroje → Export) a soubor nahrát."
 
 #: packages/admin/src/components/DialogError.tsx:14
 #: packages/admin/src/components/MarketplaceBrowse.tsx:135
@@ -968,145 +973,145 @@ msgstr ""
 #: packages/admin/src/routes/byline-schema.tsx:139
 #: packages/admin/src/routes/byline-schema.tsx:153
 msgid "An error occurred"
-msgstr ""
+msgstr "Došlo k chybě"
 
 #: packages/admin/src/routes/byline-schema.tsx:272
 msgid "An unexpected error occurred."
-msgstr ""
+msgstr "Došlo k neočekávané chybě."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:251
 msgid "An unknown error occurred"
-msgstr ""
+msgstr "Došlo k neznámé chybě"
 
 #: packages/admin/src/components/WordPressImport.tsx:1575
 msgid "Analyzing export file..."
-msgstr ""
+msgstr "Analýza souboru exportu..."
 
 #: packages/admin/src/components/WordPressImport.tsx:810
 msgid "Analyzing WordPress site..."
-msgstr ""
+msgstr "Analýza webu WordPress..."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:105
 msgid "Any media type allowed (subject to global limits)."
-msgstr ""
+msgstr "Povoleny jsou všechny typy médií (v rámci globálních limitů)."
 
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "API Tokens"
-msgstr ""
+msgstr "API tokeny"
 
 #: packages/admin/src/components/Widgets.tsx:440
 msgid "Appears on posts and pages"
-msgstr ""
+msgstr "Zobrazuje se u příspěvků a stránek"
 
 #: packages/admin/src/components/WordPressImport.tsx:1490
 msgid "Application Password"
-msgstr ""
+msgstr "Aplikační heslo"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3827
 msgid "Apply"
-msgstr ""
+msgstr "Použít"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:181
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:182
 msgid "Apply language"
-msgstr ""
+msgstr "Použít jazyk"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3239
 #: packages/admin/src/components/PortableTextEditor.tsx:3240
 msgid "Apply link"
-msgstr ""
+msgstr "Použít odkaz"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:148
 #: packages/admin/src/components/comments/CommentInbox.tsx:238
 #: packages/admin/src/components/comments/CommentInbox.tsx:490
 msgid "Approve"
-msgstr ""
+msgstr "Schválit"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:195
 msgid "approved"
-msgstr ""
+msgstr "schváleno"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:203
 msgid "Approved"
-msgstr ""
+msgstr "Schváleno"
 
 #: packages/admin/src/components/FieldEditor.tsx:223
 msgid "Arbitrary JSON data"
-msgstr ""
+msgstr "Libovolná data ve formátu JSON"
 
 #: packages/admin/src/components/ContentList.tsx:1166
 msgid "archived"
-msgstr ""
+msgstr "archivováno"
 
 #: packages/admin/src/components/ContentList.tsx:732
 #: packages/admin/src/components/Dashboard.tsx:355
 msgid "Archived"
-msgstr ""
+msgstr "Archivováno"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 #: packages/admin/src/components/Widgets.tsx:158
 msgid "Archives"
-msgstr ""
+msgstr "Archivy"
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:375
 msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
-msgstr ""
+msgstr "Opravdu chcete smazat „{0}“? Na toto pole neodkazují žádné uložené hodnoty."
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:147
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
-msgstr ""
+msgstr "Opravdu chcete smazat „{0}“? Smaže se tím i veškerý obsah v této kolekci."
 
 #. placeholder {0}: deleteFieldTarget.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:669
 msgid "Are you sure you want to delete the \"{0}\" field?"
-msgstr ""
+msgstr "Opravdu chcete smazat pole „{0}“?"
 
 #: packages/admin/src/components/MenuList.tsx:257
 msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
-msgstr ""
+msgstr "Opravdu chcete smazat tuto nabídku? Smažou se tím i všechny její položky. Tuto akci nelze vrátit zpět."
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
-msgstr ""
+msgstr "Jako administrátor můžete pozvat další uživatele v sekci Uživatelé."
 
 #: packages/admin/src/components/WordPressImport.tsx:2456
 msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
-msgstr ""
+msgstr "Přiřaďte autory z WordPressu uživatelům EmDash. Příspěvky budou připsány vybranému uživateli."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:28
 msgid "Astro"
-msgstr ""
+msgstr "Astro"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 #: packages/admin/src/components/MediaLibrary.tsx:436
 msgid "Audio"
-msgstr ""
+msgstr "Audio"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:277
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
 msgid "Authentication error: {0}"
-msgstr ""
+msgstr "Chyba ověření: {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:197
 msgid "Authentication error: {error}"
-msgstr ""
+msgstr "Chyba ověření: {error}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:254
 msgid "Authentication failed"
-msgstr ""
+msgstr "Ověření selhalo"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/SecuritySettings.tsx:120
 msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
-msgstr ""
+msgstr "Ověřování spravuje externí poskytovatel ({0}). Při použití externího ověřování není nastavení přístupových klíčů dostupné."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:261
 msgid "Authentication was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "Ověření bylo zrušeno nebo vypršel jeho časový limit. Zkuste to prosím znovu."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:77
 #: packages/admin/src/components/comments/CommentInbox.tsx:288
@@ -1114,95 +1119,95 @@ msgstr ""
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
-msgstr ""
+msgstr "Autor"
 
 #: packages/admin/src/components/WordPressImport.tsx:2471
 msgid "Author Mapping"
-msgstr ""
+msgstr "Mapování autorů"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:197
 msgid "Authorization denied"
-msgstr ""
+msgstr "Autorizace zamítnuta"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:105
 msgid "Authorization failed"
-msgstr ""
+msgstr "Autorizace selhala"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorize"
-msgstr ""
+msgstr "Autorizovat"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:176
 msgid "Authorize Device"
-msgstr ""
+msgstr "Autorizovat zařízení"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorizing..."
-msgstr ""
+msgstr "Autorizace..."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:685
 msgid "Authors"
-msgstr ""
+msgstr "Autoři"
 
 #: packages/admin/src/components/Redirects.tsx:524
 msgid "auto"
-msgstr ""
+msgstr "automatické"
 
 #: packages/admin/src/components/Redirects.tsx:427
 msgid "Auto (slug change)"
-msgstr ""
+msgstr "Automaticky (změna slugu)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:539
 msgid "Auto-approve authenticated users"
-msgstr ""
+msgstr "Automaticky schvalovat přihlášené uživatele"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:424
 msgid "Auto-generated from name (you can edit)"
-msgstr ""
+msgstr "Vygenerováno automaticky z názvu (lze upravit)"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:167
 msgid "Automatic Backups"
-msgstr ""
+msgstr "Automatické zálohy"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:207
 msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
-msgstr ""
+msgstr "Automatické zálohy vyžadují úložiště (R2, S3 nebo lokální). Povolíte je nastavením úložiště v konfiguraci EmDash."
 
 #: packages/admin/src/router.tsx:995
 msgid "Autosave failed"
-msgstr ""
+msgstr "Automatické uložení selhalo"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:710
 msgid "Available media"
-msgstr ""
+msgstr "Dostupná média"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:205
 msgid "Available Providers"
-msgstr ""
+msgstr "Dostupní poskytovatelé"
 
 #: packages/admin/src/components/Widgets.tsx:466
 msgid "Available Widgets"
-msgstr ""
+msgstr "Dostupné widgety"
 
 #: packages/admin/src/components/BylineAvatarField.tsx:46
 #: packages/admin/src/components/BylineAvatarField.tsx:71
 msgid "Avatar"
-msgstr ""
+msgstr "Avatar"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:284
 #: packages/admin/src/components/MenuEditor.tsx:362
 #: packages/admin/src/components/WordPressImport.tsx:1510
 #: packages/admin/src/components/WordPressImport.tsx:2527
 msgid "Back"
-msgstr ""
+msgstr "Zpět"
 
 #: packages/admin/src/components/ContentEditor.tsx:636
 msgid "Back to {collectionLabel} list"
-msgstr ""
+msgstr "Zpět na seznam: {collectionLabel}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:336
 msgid "Back to Content Types"
-msgstr ""
+msgstr "Zpět na typy obsahu"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:172
 #: packages/admin/src/components/LoginPage.tsx:118
@@ -1210,164 +1215,164 @@ msgstr ""
 #: packages/admin/src/components/LoginPage.tsx:313
 #: packages/admin/src/components/SignupPage.tsx:282
 msgid "Back to login"
-msgstr ""
+msgstr "Zpět na přihlášení"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:126
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:404
 msgid "Back to marketplace"
-msgstr ""
+msgstr "Zpět na tržiště"
 
 #: packages/admin/src/components/PluginSettings.tsx:118
 #: packages/admin/src/components/RegistryPluginDetail.tsx:820
 msgid "Back to plugins"
-msgstr ""
+msgstr "Zpět na pluginy"
 
 #: packages/admin/src/components/SectionEditor.tsx:74
 #: packages/admin/src/components/SectionEditor.tsx:175
 msgid "Back to sections"
-msgstr ""
+msgstr "Zpět na sekce"
 
 #: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
 msgid "Back to settings"
-msgstr ""
+msgstr "Zpět na nastavení"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
 msgid "Back to Themes"
-msgstr ""
+msgstr "Zpět na šablony"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:199
 msgid "Back up now"
-msgstr ""
+msgstr "Zálohovat nyní"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:199
 msgid "Backing up..."
-msgstr ""
+msgstr "Zálohování..."
 
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:97
 msgid "Backup created: {0}"
-msgstr ""
+msgstr "Záloha vytvořena: {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:80
 msgid "Backup settings saved"
-msgstr ""
+msgstr "Nastavení záloh uloženo"
 
 #: packages/admin/src/components/Settings.tsx:122
 #: packages/admin/src/components/settings/BackupSettings.tsx:133
 #: packages/admin/src/components/settings/BackupSettings.tsx:148
 msgid "Backups"
-msgstr ""
+msgstr "Zálohy"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:182
 msgid "Backups to keep"
-msgstr ""
+msgstr "Počet uchovaných záloh"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:29
 msgid "Bash"
-msgstr ""
+msgstr "Bash"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:191
 msgid "Before send:"
-msgstr ""
+msgstr "Před odesláním:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:200
 msgid "Bing Verification"
-msgstr ""
+msgstr "Ověření Bing"
 
 #: packages/admin/src/routes/bylines.tsx:496
 msgid "Bio"
-msgstr ""
+msgstr "Bio"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
 msgid "Block actions - drag to reorder, click for menu"
-msgstr ""
+msgstr "Akce bloku – přetažením změníte pořadí, kliknutím otevřete nabídku"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3263
 #: packages/admin/src/components/PortableTextEditor.tsx:3649
 msgid "Bold"
-msgstr ""
+msgstr "Tučné"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:55
 #: packages/admin/src/components/FieldEditor.tsx:174
 #: packages/admin/src/components/FieldEditor.tsx:583
 msgid "Boolean"
-msgstr ""
+msgstr "Boolean"
 
 #: packages/admin/src/components/SeoPanel.tsx:184
 msgid "Brief summary shown below the title in search results"
-msgstr ""
+msgstr "Stručný souhrn zobrazený pod titulkem ve výsledcích hledání"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:73
 msgid "Browse and install plugins published to the decentralized registry."
-msgstr ""
+msgstr "Procházejte a instalujte pluginy publikované v decentralizovaném registru."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:89
 msgid "Browse and install plugins to extend your site."
-msgstr ""
+msgstr "Procházejte a instalujte pluginy, které rozšíří váš web."
 
 #: packages/admin/src/components/WordPressImport.tsx:1124
 #: packages/admin/src/components/WordPressImport.tsx:1594
 msgid "Browse Files"
-msgstr ""
+msgstr "Procházet soubory"
 
 #: packages/admin/src/components/PluginManager.tsx:204
 msgid "Browse the"
-msgstr ""
+msgstr "Procházet"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
 msgid "Browse themes and preview them with your own content."
-msgstr ""
+msgstr "Procházejte motivy a prohlédněte si je s vlastním obsahem."
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:129
 #: packages/admin/src/components/PortableTextEditor.tsx:1172
 #: packages/admin/src/components/PortableTextEditor.tsx:3697
 msgid "Bullet List"
-msgstr ""
+msgstr "Odrážkový seznam"
 
 #: packages/admin/src/routes/byline-schema.tsx:218
 #: packages/admin/src/routes/bylines.tsx:383
 msgid "Byline schema"
-msgstr ""
+msgstr "Schéma autorského podpisu"
 
 #: packages/admin/src/components/Sidebar.tsx:252
 msgid "Byline Schema"
-msgstr ""
+msgstr "Schéma autorského podpisu"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:565
 #: packages/admin/src/components/ContentSettingsPanel.tsx:568
 #: packages/admin/src/components/Sidebar.tsx:242
 #: packages/admin/src/routes/bylines.tsx:375
 msgid "Bylines"
-msgstr ""
+msgstr "Autorské podpisy"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
-msgstr ""
+msgstr "C"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:32
 msgid "C#"
-msgstr ""
+msgstr "C#"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:31
 msgid "C++"
-msgstr ""
+msgstr "C++"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
-msgstr ""
+msgstr "Může vytvářet obsah"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:37
 msgid "Can manage all content"
-msgstr ""
+msgstr "Může spravovat veškerý obsah"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:31
 msgid "Can publish own content"
-msgstr ""
+msgstr "Může publikovat vlastní obsah"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:19
 msgid "Can view content"
-msgstr ""
+msgstr "Může zobrazit obsah"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:315
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:192
@@ -1410,65 +1415,65 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:451
 #: packages/admin/src/components/WordPressImport.tsx:1917
 msgid "Cancel"
-msgstr ""
+msgstr "Zrušit"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:405
 msgid "Cancel (Esc)"
-msgstr ""
+msgstr "Zrušit (Esc)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:146
 msgid "Cancel rename"
-msgstr ""
+msgstr "Zrušit přejmenování"
 
 #: packages/admin/src/components/Sections.tsx:407
 msgid "Cannot delete theme sections"
-msgstr ""
+msgstr "Sekce motivu nelze smazat"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:456
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr ""
+msgstr "Z URL nelze určit typ MIME. Použijte URL končící rozpoznanou příponou obrázku (např. .jpg, .png, .webp)."
 
 #: packages/admin/src/components/SeoPanel.tsx:212
 #: packages/admin/src/components/SeoPanel.tsx:216
 msgid "Canonical URL"
-msgstr ""
+msgstr "Kanonická URL"
 
 #: packages/admin/src/components/PluginManager.tsx:519
 msgid "Capabilities"
-msgstr ""
+msgstr "Schopnosti"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:69
 msgid "Capability consent"
-msgstr ""
+msgstr "Souhlas se schopnostmi"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:382
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:352
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:541
 #: packages/admin/src/components/MediaDetailPanel.tsx:381
 msgid "Caption"
-msgstr ""
+msgstr "Popisek"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:68
 msgid "Captions / Subtitles"
-msgstr ""
+msgstr "Titulky / skryté titulky"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:192
 #: packages/admin/src/components/Widgets.tsx:135
 msgid "Categories"
-msgstr ""
+msgstr "Kategorie"
 
 #. placeholder {0}: analysis.categories
 #: packages/admin/src/components/WordPressImport.tsx:1785
 msgid "Categories ({0})"
-msgstr ""
+msgstr "Kategorie ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1146
 msgid "Categories & Tags"
-msgstr ""
+msgstr "Kategorie a štítky"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
 msgid "Center"
-msgstr ""
+msgstr "Na střed"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
@@ -1478,104 +1483,104 @@ msgstr ""
 #: packages/admin/src/components/ImageFieldRenderer.tsx:162
 #: packages/admin/src/components/SeoImageField.tsx:53
 msgid "Change"
-msgstr ""
+msgstr "Změnit"
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
 #. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
 #: packages/admin/src/routes/users.tsx:296
 msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
-msgstr ""
+msgstr "Změnit <0>{0}</0> z <1>{1}</1> na <2>{2}</2>? Ztratí přístup k pokročilejším funkcím."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:239
 msgid "Change Favicon"
-msgstr ""
+msgstr "Změnit favicon"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:167
 msgid "Change Image"
-msgstr ""
+msgstr "Změnit obrázek"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:185
 msgid "Change Logo"
-msgstr ""
+msgstr "Změnit logo"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:808
 msgid "Changelog"
-msgstr ""
+msgstr "Seznam změn"
 
 #: packages/admin/src/router.tsx:1046
 msgid "Changes discarded"
-msgstr ""
+msgstr "Změny byly zahozeny"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:129
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr ""
+msgstr "Znak mezi názvem stránky a názvem webu (např. „Můj příspěvek | Můj web“)"
 
 #: packages/admin/src/components/PluginManager.tsx:171
 msgid "Check for updates"
-msgstr ""
+msgstr "Zkontrolovat aktualizace"
 
 #: packages/admin/src/components/WordPressImport.tsx:1095
 msgid "Check Site"
-msgstr ""
+msgstr "Zkontrolovat web"
 
 #: packages/admin/src/components/LoginPage.tsx:102
 #: packages/admin/src/components/SignupPage.tsx:131
 #: packages/admin/src/components/SignupPage.tsx:402
 msgid "Check your email"
-msgstr ""
+msgstr "Zkontrolujte e-mail"
 
 #: packages/admin/src/components/WordPressImport.tsx:776
 msgid "Checking {urlInput}..."
-msgstr ""
+msgstr "Kontroluje se {urlInput}..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:155
 msgid "Checking authentication..."
-msgstr ""
+msgstr "Ověřuje se přihlášení..."
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:362
 msgid "Checking how many stored values reference \"{0}\"…"
-msgstr ""
+msgstr "Zjišťuje se, kolik uložených hodnot odkazuje na „{0}“…"
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
-msgstr ""
+msgstr "Zvolte způsob přihlášení"
 
 #: packages/admin/src/components/Settings.tsx:137
 msgid "Choose your preferred admin language"
-msgstr ""
+msgstr "Zvolte preferovaný jazyk administrace"
 
 #: packages/admin/src/components/ContentList.tsx:481
 msgid "Clear"
-msgstr ""
+msgstr "Vymazat"
 
 #: packages/admin/src/components/ContentList.tsx:825
 #: packages/admin/src/components/MediaLibrary.tsx:497
 #: packages/admin/src/components/users/UserList.tsx:129
 msgid "Clear filters"
-msgstr ""
+msgstr "Vymazat filtry"
 
 #: packages/admin/src/components/MediaLibrary.tsx:497
 #: packages/admin/src/components/MediaLibrary.tsx:521
 msgid "Clear search"
-msgstr ""
+msgstr "Vymazat hledání"
 
 #: packages/admin/src/components/PluginSettings.tsx:354
 msgid "Clear stored value"
-msgstr ""
+msgstr "Vymazat uloženou hodnotu"
 
 #: packages/admin/src/components/PluginSettings.tsx:352
 msgid "Clear stored value for {fieldKey}"
-msgstr ""
+msgstr "Vymazat uloženou hodnotu pro {fieldKey}"
 
 #: packages/admin/src/components/SignupPage.tsx:139
 msgid "Click the link in the email to continue setting up your account."
-msgstr ""
+msgstr "Pokračujte v nastavení účtu kliknutím na odkaz v e-mailu."
 
 #: packages/admin/src/components/LoginPage.tsx:113
 msgid "Click the link in the email to sign in."
-msgstr ""
+msgstr "Přihlaste se kliknutím na odkaz v e-mailu."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:212
 #: packages/admin/src/components/BylineFieldEditor.tsx:218
@@ -1636,133 +1641,133 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:419
 #: packages/admin/src/components/Widgets.tsx:423
 msgid "Close"
-msgstr ""
+msgstr "Zavřít"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:518
 msgid "Close comments after (days)"
-msgstr ""
+msgstr "Uzavřít komentáře po (dnech)"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:178
 msgid "Close gallery settings"
-msgstr ""
+msgstr "Zavřít nastavení galerie"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
-msgstr ""
+msgstr "Zavřít panel"
 
 #: packages/admin/src/components/ContentEditor.tsx:1053
 msgid "Close settings"
-msgstr ""
+msgstr "Zavřít nastavení"
 
 #: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/PortableTextEditor.tsx:3291
 #: packages/admin/src/components/Redirects.tsx:472
 msgid "Code"
-msgstr ""
+msgstr "Kód"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:121
 #: packages/admin/src/components/PortableTextEditor.tsx:1202
 #: packages/admin/src/components/PortableTextEditor.tsx:3718
 msgid "Code Block"
-msgstr ""
+msgstr "Blok kódu"
 
 #: packages/admin/src/components/PluginManager.tsx:506
 msgid "Collapse"
-msgstr ""
+msgstr "Sbalit"
 
 #: packages/admin/src/components/PluginManager.tsx:500
 msgid "Collapse details"
-msgstr ""
+msgstr "Sbalit podrobnosti"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:156
 msgid "colleague@example.com"
-msgstr ""
+msgstr "kolega@example.com"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
-msgstr ""
+msgstr "Kolekce"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:106
 msgid "Collection:"
-msgstr ""
+msgstr "Kolekce:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:678
 msgid "Collections"
-msgstr ""
+msgstr "Kolekce"
 
 #: packages/admin/src/components/WordPressImport.tsx:2327
 msgid "Collections created:"
-msgstr ""
+msgstr "Vytvořené kolekce:"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:185
 msgid "Columns"
-msgstr ""
+msgstr "Sloupce"
 
 #: packages/admin/src/components/SectionEditor.tsx:288
 msgid "Comma-separated keywords for search."
-msgstr ""
+msgstr "Klíčová slova pro hledání oddělená čárkami."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:95
 #: packages/admin/src/components/comments/CommentInbox.tsx:291
 msgid "Comment"
-msgstr ""
+msgstr "Komentář"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:58
 msgid "Comment Detail"
-msgstr ""
+msgstr "Detail komentáře"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:147
 #: packages/admin/src/components/ContentTypeEditor.tsx:485
 #: packages/admin/src/components/Sidebar.tsx:221
 msgid "Comments"
-msgstr ""
+msgstr "Komentáře"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:542
 msgid "Comments from logged-in CMS users are approved automatically"
-msgstr ""
+msgstr "Komentáře od přihlášených uživatelů CMS se schvalují automaticky"
 
 #: packages/admin/src/components/SignupPage.tsx:403
 msgid "Complete signup"
-msgstr ""
+msgstr "Dokončit registraci"
 
 #: packages/admin/src/components/Widgets.tsx:931
 msgid "Component"
-msgstr ""
+msgstr "Komponenta"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Configure Field"
-msgstr ""
+msgstr "Nastavit pole"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
 msgid "Confirm"
-msgstr ""
+msgstr "Potvrdit"
 
 #: packages/admin/src/components/WordPressImport.tsx:701
 #: packages/admin/src/components/WordPressImport.tsx:1054
 msgid "Connect"
-msgstr ""
+msgstr "Připojit"
 
 #: packages/admin/src/components/WordPressImport.tsx:1507
 msgid "Connect & Analyze"
-msgstr ""
+msgstr "Připojit a analyzovat"
 
 #. placeholder {0}: siteTitle || "WordPress"
 #: packages/admin/src/components/WordPressImport.tsx:1457
 msgid "Connect to {0}"
-msgstr ""
+msgstr "Připojit k {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1373
 msgid "Connect with WordPress"
-msgstr ""
+msgstr "Připojit k WordPressu"
 
 #. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:286
 msgid "Connected {0}"
-msgstr ""
+msgstr "Připojeno {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:183
 msgid "content"
-msgstr ""
+msgstr "obsah"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:378
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
@@ -1773,165 +1778,165 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:365
 #: packages/admin/src/components/Widgets.tsx:899
 msgid "Content"
-msgstr ""
+msgstr "Obsah"
 
 #: packages/admin/src/components/Widgets.tsx:98
 msgid "Content Block"
-msgstr ""
+msgstr "Blok obsahu"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2382
 msgid "Content Errors ({0})"
-msgstr ""
+msgstr "Chyby obsahu ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1317
 msgid "Content found:"
-msgstr ""
+msgstr "Nalezený obsah:"
 
 #: packages/admin/src/router.tsx:1068
 msgid "Content has been scheduled for publishing"
-msgstr ""
+msgstr "Obsah byl naplánován k publikování"
 
 #: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Content has been updated to the selected revision."
-msgstr ""
+msgstr "Obsah byl aktualizován na vybranou revizi."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
-msgstr ""
+msgstr "ID obsahu:"
 
 #: packages/admin/src/router.tsx:1009
 msgid "Content is now live"
-msgstr ""
+msgstr "Obsah je nyní veřejný"
 
 #: packages/admin/src/components/WordPressImport.tsx:2371
 msgid "content items"
-msgstr ""
+msgstr "položek obsahu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
 msgid "Content Read"
-msgstr ""
+msgstr "Čtení obsahu"
 
 #: packages/admin/src/router.tsx:1027
 msgid "Content removed from public view"
-msgstr ""
+msgstr "Obsah byl odebrán z veřejného zobrazení"
 
 #: packages/admin/src/router.tsx:1089
 msgid "Content reverted to draft"
-msgstr ""
+msgstr "Obsah byl vrácen do konceptu"
 
 #: packages/admin/src/components/RevisionHistory.tsx:314
 msgid "Content snapshot:"
-msgstr ""
+msgstr "Snímek obsahu:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1731
 msgid "Content to Import"
-msgstr ""
+msgstr "Obsah k importu"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:184
 #: packages/admin/src/components/ContentTypeList.tsx:40
 #: packages/admin/src/components/Sidebar.tsx:248
 msgid "Content Types"
-msgstr ""
+msgstr "Typy obsahu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2310
 msgid "Content was skipped because it already exists"
-msgstr ""
+msgstr "Obsah byl přeskočen, protože už existuje"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Content Write"
-msgstr ""
+msgstr "Zápis obsahu"
 
 #: packages/admin/src/components/SignupPage.tsx:92
 msgid "Continue"
-msgstr ""
+msgstr "Pokračovat"
 
 #: packages/admin/src/components/SetupWizard.tsx:150
 #: packages/admin/src/components/SetupWizard.tsx:233
 msgid "Continue →"
-msgstr ""
+msgstr "Pokračovat →"
 
 #: packages/admin/src/components/WordPressImport.tsx:2529
 msgid "Continue Import"
-msgstr ""
+msgstr "Pokračovat v importu"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
 msgid "Contributor"
-msgstr ""
+msgstr "Přispěvatel"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:234
 #: packages/admin/src/components/users/InviteUserModal.tsx:133
 msgid "Copied to clipboard"
-msgstr ""
+msgstr "Zkopírováno do schránky"
 
 #. placeholder {0}: section.slug
 #: packages/admin/src/components/Sections.tsx:399
 msgid "Copy {0} to clipboard"
-msgstr ""
+msgstr "Kopírovat {0} do schránky"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:124
 msgid "Copy invite link"
-msgstr ""
+msgstr "Kopírovat odkaz pozvánky"
 
 #: packages/admin/src/components/Sections.tsx:398
 msgid "Copy slug"
-msgstr ""
+msgstr "Kopírovat slug"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Copy this token now — it won't be shown again."
-msgstr ""
+msgstr "Zkopírujte token nyní — znovu se nezobrazí."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
 msgid "Copy token"
-msgstr ""
+msgstr "Kopírovat token"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:322
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:323
 #: packages/admin/src/components/MediaDetailPanel.tsx:301
 msgid "Copy URL"
-msgstr ""
+msgstr "Kopírovat URL"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:136
 msgid "Could not copy automatically. Please select the URL above and copy manually."
-msgstr ""
+msgstr "Automatické zkopírování se nezdařilo. Vyberte URL výše a zkopírujte ji ručně."
 
 #: packages/admin/src/components/Dashboard.tsx:75
 msgid "Could not load dashboard data"
-msgstr ""
+msgstr "Nepodařilo se načíst data přehledu"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:486
 msgid "Could not load image from URL"
-msgstr ""
+msgstr "Nepodařilo se načíst obrázek z URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1264
 msgid "Couldn't detect WordPress"
-msgstr ""
+msgstr "Nepodařilo se rozpoznat WordPress"
 
 #: packages/admin/src/routes/byline-schema.tsx:268
 msgid "Couldn't load byline fields."
-msgstr ""
+msgstr "Nepodařilo se načíst pole autorského podpisu."
 
 #: packages/admin/src/routes/bylines.tsx:547
 msgid "Couldn't load custom fields."
-msgstr ""
+msgstr "Nepodařilo se načíst vlastní pole."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:88
 msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
-msgstr ""
+msgstr "Nepodařilo se přiřadit „{draft}“ k typu MIME. Zadejte MIME přímo."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:877
 msgid "Couldn't search bylines. Please try again."
-msgstr ""
+msgstr "Nepodařilo se vyhledat autorské podpisy. Zkuste to prosím znovu."
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
 msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
-msgstr ""
+msgstr "Nepodařilo se ověřit, kolik hodnot odkazuje na „{0}“. Smazáním se přesto odstraní všechny uložené hodnoty tohoto pole — počet výše ale nebylo možné ověřit."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:842
 msgid "Count"
-msgstr ""
+msgstr "Počet"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1009
 #: packages/admin/src/components/MenuList.tsx:178
@@ -1941,182 +1946,182 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:454
 #: packages/admin/src/routes/bylines.tsx:579
 msgid "Create"
-msgstr ""
+msgstr "Vytvořit"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:305
 msgid "Create \"{trimmedInput}\""
-msgstr ""
+msgstr "Vytvořit „{trimmedInput}“"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1173
 msgid "Create a bullet list"
-msgstr ""
+msgstr "Vytvořit odrážkový seznam"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:383
 msgid "Create a new {0}"
-msgstr ""
+msgstr "Vytvořit nový {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1183
 msgid "Create a numbered list"
-msgstr ""
+msgstr "Vytvořit číslovaný seznam"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:84
 #: packages/admin/src/components/SignupPage.tsx:221
 msgid "Create Account"
-msgstr ""
+msgstr "Vytvořit účet"
 
 #: packages/admin/src/components/SignupPage.tsx:401
 msgid "Create an account"
-msgstr ""
+msgstr "Vytvořit účet"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:957
 #: packages/admin/src/routes/bylines.tsx:476
 msgid "Create byline"
-msgstr ""
+msgstr "Vytvořit autorský podpis"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 msgid "Create Content Type"
-msgstr ""
+msgstr "Vytvořit typ obsahu"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Create field"
-msgstr ""
+msgstr "Vytvořit pole"
 
 #: packages/admin/src/components/MenuList.tsx:129
 #: packages/admin/src/components/MenuList.tsx:192
 msgid "Create Menu"
-msgstr ""
+msgstr "Vytvořit nabídku"
 
 #: packages/admin/src/components/MenuList.tsx:136
 msgid "Create New Menu"
-msgstr ""
+msgstr "Vytvořit novou nabídku"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:409
 msgid "Create New Token"
-msgstr ""
+msgstr "Vytvořit nový token"
 
 #: packages/admin/src/components/WordPressImport.tsx:1501
 msgid "Create one in WordPress: Users → Profile → Application Passwords"
-msgstr ""
+msgstr "Vytvořte jej ve WordPressu: Users → Profile → Application Passwords"
 
 #: packages/admin/src/components/SetupWizard.tsx:298
 msgid "Create Passkey"
-msgstr ""
+msgstr "Vytvořit přístupový klíč"
 
 #: packages/admin/src/components/Settings.tsx:111
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:195
 msgid "Create personal access tokens for programmatic API access"
-msgstr ""
+msgstr "Vytvořte osobní přístupové tokeny pro programový přístup k API"
 
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:248
 msgid "Create redirect for {0}"
-msgstr ""
+msgstr "Vytvořit přesměrování pro {0}"
 
 #: packages/admin/src/components/Redirects.tsx:247
 msgid "Create redirect for this path"
-msgstr ""
+msgstr "Vytvořit přesměrování pro tuto cestu"
 
 #: packages/admin/src/components/Redirects.tsx:464
 msgid "Create redirect rules to manage URL changes."
-msgstr ""
+msgstr "Vytvořte pravidla přesměrování pro správu změn URL."
 
 #: packages/admin/src/components/WordPressImport.tsx:1921
 msgid "Create Schema & Import"
-msgstr ""
+msgstr "Vytvořit schéma a importovat"
 
 #: packages/admin/src/components/Sections.tsx:150
 #: packages/admin/src/components/Sections.tsx:270
 msgid "Create Section"
-msgstr ""
+msgstr "Vytvořit sekci"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:110
 msgid "Create sections in the Sections library to use them here"
-msgstr ""
+msgstr "Sekce vytvořte v knihovně sekcí, poté je zde můžete použít"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:620
 #: packages/admin/src/components/TaxonomyManager.tsx:711
 msgid "Create Taxonomy"
-msgstr ""
+msgstr "Vytvořit taxonomii"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:269
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:477
 msgid "Create Token"
-msgstr ""
+msgstr "Vytvořit token"
 
 #: packages/admin/src/components/Widgets.tsx:410
 msgid "Create Widget Area"
-msgstr ""
+msgstr "Vytvořit oblast widgetů"
 
 #: packages/admin/src/components/SetupWizard.tsx:560
 msgid "Create your account"
-msgstr ""
+msgstr "Vytvořte si účet"
 
 #: packages/admin/src/components/MenuList.tsx:190
 msgid "Create your first navigation menu to get started"
-msgstr ""
+msgstr "Začněte vytvořením první navigační nabídky"
 
 #: packages/admin/src/components/ContentList.tsx:556
 #: packages/admin/src/components/ContentTypeList.tsx:124
 msgid "Create your first one"
-msgstr ""
+msgstr "Vytvořte první položku"
 
 #: packages/admin/src/components/Sections.tsx:267
 msgid "Create your first reusable content section to get started."
-msgstr ""
+msgstr "Začněte vytvořením první opakovaně použitelné sekce obsahu."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:75
 #: packages/admin/src/components/SignupPage.tsx:212
 msgid "Create your passkey"
-msgstr ""
+msgstr "Vytvořte si přístupový klíč"
 
 #: packages/admin/src/lib/api/marketplace.ts:280
 #: packages/admin/src/lib/api/marketplace.ts:289
 msgid "Create, update, and delete content"
-msgstr ""
+msgstr "Vytvářet, upravovat a mazat obsah"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:82
 msgid "Create, update, and delete navigation menus"
-msgstr ""
+msgstr "Vytvářet, upravovat a mazat navigační nabídky"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:77
 msgid "Create, update, and delete taxonomy terms"
-msgstr ""
+msgstr "Vytvářet, upravovat a mazat taxonomické termíny"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:52
 msgid "Create, update, delete content"
-msgstr ""
+msgstr "Vytvářet, upravovat, mazat obsah"
 
 #: packages/admin/src/components/ContentList.tsx:736
 #: packages/admin/src/components/ContentSettingsPanel.tsx:537
 #: packages/admin/src/components/users/UserDetail.tsx:219
 msgid "Created"
-msgstr ""
+msgstr "Vytvořeno"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:96
 msgid "Created \"{0}\"."
-msgstr ""
+msgstr "Vytvořeno „{0}“."
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 #: packages/admin/src/components/users/UserDetail.tsx:260
 msgid "Created {0}"
-msgstr ""
+msgstr "Vytvořeno {0}"
 
 #. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
 #: packages/admin/src/router.tsx:1120
 msgid "Created {0} translation"
-msgstr ""
+msgstr "Vytvořen překlad {0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "Created At"
-msgstr ""
+msgstr "Vytvořeno"
 
 #: packages/admin/src/components/WordPressImport.tsx:887
 msgid "Creating collections and fields..."
-msgstr ""
+msgstr "Vytváření kolekcí a polí..."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1009
 #: packages/admin/src/components/MenuList.tsx:178
@@ -2126,55 +2131,55 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:711
 #: packages/admin/src/components/TaxonomySidebar.tsx:305
 msgid "Creating..."
-msgstr ""
+msgstr "Vytváření..."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:33
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:83
 msgid "current"
-msgstr ""
+msgstr "aktuální"
 
 #: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Current"
-msgstr ""
+msgstr "Aktuální"
 
 #: packages/admin/src/components/PluginSettings.tsx:340
 msgid "Currently set — enter a new value to replace"
-msgstr ""
+msgstr "Aktuálně nastaveno — nahradíte zadáním nové hodnoty"
 
 #: packages/admin/src/components/Sections.tsx:46
 msgid "Custom"
-msgstr ""
+msgstr "Vlastní"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:623
 msgid "Custom Fields"
-msgstr ""
+msgstr "Vlastní pole"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:210
 msgid "Custom robots.txt content. Leave empty to use the default."
-msgstr ""
+msgstr "Vlastní obsah souboru robots.txt. Ponechte prázdné pro použití výchozího."
 
 #: packages/admin/src/components/SectionEditor.tsx:185
 msgid "Custom Section"
-msgstr ""
+msgstr "Vlastní sekce"
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "Custom Taxonomies"
-msgstr ""
+msgstr "Vlastní taxonomie"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:176
 msgid "Daily automatic backups"
-msgstr ""
+msgstr "Denní automatické zálohy"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
-msgstr ""
+msgstr "tmavý"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "Dark"
-msgstr ""
+msgstr "Tmavý"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:130
 #: packages/admin/src/components/ContentTypeList.tsx:246
@@ -2182,70 +2187,70 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:206
 #: packages/admin/src/components/Sidebar.tsx:356
 msgid "Dashboard"
-msgstr ""
+msgstr "Přehled"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:297
 #: packages/admin/src/components/ContentList.tsx:525
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
 #: packages/admin/src/components/FieldEditor.tsx:180
 #: packages/admin/src/components/FieldEditor.tsx:584
 msgid "Date & Time"
-msgstr ""
+msgstr "Datum a čas"
 
 #: packages/admin/src/components/FieldEditor.tsx:181
 msgid "Date and time picker"
-msgstr ""
+msgstr "Výběr data a času"
 
 #: packages/admin/src/components/ContentList.tsx:790
 msgid "Date field to filter on"
-msgstr ""
+msgstr "Pole s datem pro filtrování"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:281
 msgid "Date Format"
-msgstr ""
+msgstr "Formát data"
 
 #: packages/admin/src/components/FieldEditor.tsx:163
 msgid "Decimal number"
-msgstr ""
+msgstr "Desetinné číslo"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:750
 msgid "Declared permissions"
-msgstr ""
+msgstr "Deklarovaná oprávnění"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:294
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:356
 msgid "Default Role"
-msgstr ""
+msgstr "Výchozí role"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:233
 msgid "Default role:"
-msgstr ""
+msgstr "Výchozí role:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:147
 msgid "Default social image"
-msgstr ""
+msgstr "Výchozí obrázek pro sociální sítě"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:138
 msgid "Default Social Image"
-msgstr ""
+msgstr "Výchozí obrázek pro sociální sítě"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:623
 msgid "Define a new taxonomy for classifying content"
-msgstr ""
+msgstr "Definujte novou taxonomii pro klasifikaci obsahu"
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr ""
+msgstr "Definujte vlastní pole ukládaná u každého autorského podpisu — pracovní pozici, zájmena, profily na sociálních sítích a další."
 
 #: packages/admin/src/components/ContentTypeList.tsx:42
 msgid "Define the structure of your content"
-msgstr ""
+msgstr "Definujte strukturu svého obsahu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:360
 msgid "Defined in code"
-msgstr ""
+msgstr "Definováno v kódu"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:268
 #: packages/admin/src/components/comments/CommentInbox.tsx:408
@@ -2268,12 +2273,12 @@ msgstr ""
 #: packages/admin/src/routes/bylines.tsx:588
 #: packages/admin/src/routes/bylines.tsx:624
 msgid "Delete"
-msgstr ""
+msgstr "Smazat"
 
 #. placeholder {0}: item.filename
 #: packages/admin/src/components/MediaDetailPanel.tsx:452
 msgid "Delete \"{0}\"? This cannot be undone."
-msgstr ""
+msgstr "Smazat „{0}“? Tuto akci nelze vrátit zpět."
 
 #. placeholder {0}: archive.name
 #. placeholder {0}: collection.label
@@ -2286,134 +2291,134 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:817
 #: packages/admin/src/routes/byline-schema.tsx:458
 msgid "Delete {0}"
-msgstr ""
+msgstr "Smazat {0}"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:749
 msgid "Delete {0} field"
-msgstr ""
+msgstr "Smazat pole {0}"
 
 #. placeholder {0}: menu.name
 #: packages/admin/src/components/MenuList.tsx:240
 msgid "Delete {0} menu"
-msgstr ""
+msgstr "Smazat nabídku {0}"
 
 #. placeholder {0}: area.label
 #: packages/admin/src/components/Widgets.tsx:664
 msgid "Delete {0} widget area"
-msgstr ""
+msgstr "Smazat oblast widgetů {0}"
 
 #. placeholder {0}: taxonomyDef.labelSingular || "Term"
 #: packages/admin/src/components/TaxonomyManager.tsx:902
 msgid "Delete {0}?"
-msgstr ""
+msgstr "Smazat {0}?"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:282
 msgid "Delete backup?"
-msgstr ""
+msgstr "Smazat zálohu?"
 
 #: packages/admin/src/routes/byline-schema.tsx:358
 msgid "Delete byline field?"
-msgstr ""
+msgstr "Smazat pole autorského podpisu?"
 
 #: packages/admin/src/routes/bylines.tsx:622
 msgid "Delete Byline?"
-msgstr ""
+msgstr "Smazat autorský podpis?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3376
 msgid "Delete column"
-msgstr ""
+msgstr "Smazat sloupec"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:406
 msgid "Delete Comment?"
-msgstr ""
+msgstr "Smazat komentář?"
 
 #: packages/admin/src/components/ContentTypeList.tsx:144
 msgid "Delete Content Type?"
-msgstr ""
+msgstr "Smazat typ obsahu?"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:379
 msgid "Delete embed"
-msgstr ""
+msgstr "Smazat vložený obsah"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:666
 msgid "Delete Field?"
-msgstr ""
+msgstr "Smazat pole?"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:237
 #: packages/admin/src/components/editor/GalleryNode.tsx:219
 #: packages/admin/src/components/editor/GalleryNode.tsx:220
 msgid "Delete gallery"
-msgstr ""
+msgstr "Smazat galerii"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
 msgid "Delete HTML block"
-msgstr ""
+msgstr "Smazat HTML blok"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:220
 #: packages/admin/src/components/editor/ImageNode.tsx:221
 msgid "Delete image"
-msgstr ""
+msgstr "Smazat obrázek"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:451
 msgid "Delete Media?"
-msgstr ""
+msgstr "Smazat média?"
 
 #: packages/admin/src/components/MenuList.tsx:256
 msgid "Delete Menu"
-msgstr ""
+msgstr "Smazat nabídku"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:526
 msgid "Delete permanently"
-msgstr ""
+msgstr "Smazat trvale"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:1136
 msgid "Delete Permanently"
-msgstr ""
+msgstr "Smazat trvale"
 
 #: packages/admin/src/components/ContentList.tsx:1116
 msgid "Delete Permanently?"
-msgstr ""
+msgstr "Smazat trvale?"
 
 #: packages/admin/src/components/Redirects.tsx:538
 msgid "Delete redirect"
-msgstr ""
+msgstr "Smazat přesměrování"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:539
 msgid "Delete redirect {0}"
-msgstr ""
+msgstr "Smazat přesměrování {0}"
 
 #: packages/admin/src/components/Redirects.tsx:583
 msgid "Delete Redirect?"
-msgstr ""
+msgstr "Smazat přesměrování?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3395
 msgid "Delete row"
-msgstr ""
+msgstr "Smazat řádek"
 
 #: packages/admin/src/components/Sections.tsx:296
 msgid "Delete Section?"
-msgstr ""
+msgstr "Smazat sekci?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3410
 msgid "Delete table"
-msgstr ""
+msgstr "Smazat tabulku"
 
 #: packages/admin/src/components/Widgets.tsx:714
 msgid "Delete Widget Area?"
-msgstr ""
+msgstr "Smazat oblast widgetů?"
 
 #: packages/admin/src/components/ContentList.tsx:646
 msgid "Deleted"
-msgstr ""
+msgstr "Smazáno"
 
 #. placeholder {0}: deletingField.label
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr ""
+msgstr "Smazáním „{0}“ se odstraní také {1, plural, one {# uložená hodnota} few {# uložené hodnoty} many {# uložené hodnoty} other {# uložených hodnot}} napříč všemi autorskými podpisy. Tuto akci nelze vrátit zpět."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:409
 #: packages/admin/src/components/ContentTypeEditor.tsx:673
@@ -2428,47 +2433,47 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:717
 #: packages/admin/src/routes/bylines.tsx:625
 msgid "Deleting..."
-msgstr ""
+msgstr "Mazání..."
 
 #: packages/admin/src/routes/byline-schema.tsx:379
 msgid "Deleting…"
-msgstr ""
+msgstr "Mazání…"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
 msgid "Demo"
-msgstr ""
+msgstr "Ukázka"
 
 #: packages/admin/src/routes/users.tsx:303
 msgid "Demote User"
-msgstr ""
+msgstr "Snížit oprávnění uživatele"
 
 #: packages/admin/src/routes/users.tsx:294
 msgid "Demote User?"
-msgstr ""
+msgstr "Snížit oprávnění uživatele?"
 
 #: packages/admin/src/routes/users.tsx:304
 msgid "Demoting..."
-msgstr ""
+msgstr "Snižování oprávnění..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:270
 msgid "Deny"
-msgstr ""
+msgstr "Odmítnout"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:379
 #: packages/admin/src/components/editor/ImageNode.tsx:238
 msgid "Describe the image..."
-msgstr ""
+msgstr "Popište obrázek..."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
 #: packages/admin/src/components/MediaDetailPanel.tsx:374
 msgid "Describe this image for accessibility"
-msgstr ""
+msgstr "Popište tento obrázek pro přístupnost"
 
 #: packages/admin/src/components/SectionEditor.tsx:277
 msgid "Describe what this section is for..."
-msgstr ""
+msgstr "Popište, k čemu tato sekce slouží..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:413
 #: packages/admin/src/components/RegistryPluginDetail.tsx:805
@@ -2476,329 +2481,329 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:200
 #: packages/admin/src/components/Widgets.tsx:438
 msgid "Description"
-msgstr ""
+msgstr "Popis"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:456
 msgid "Description (optional)"
-msgstr ""
+msgstr "Popis (volitelné)"
 
 #: packages/admin/src/components/Redirects.tsx:471
 msgid "Destination"
-msgstr ""
+msgstr "Cíl"
 
 #: packages/admin/src/components/Redirects.tsx:141
 msgid "Destination path"
-msgstr ""
+msgstr "Cílová cesta"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:153
 #: packages/admin/src/components/PluginManager.tsx:564
 msgid "Destructive"
-msgstr ""
+msgstr "Destruktivní"
 
 #: packages/admin/src/components/PluginManager.tsx:506
 msgid "details"
-msgstr ""
+msgstr "podrobnosti"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:186
 msgid "Device authorized"
-msgstr ""
+msgstr "Zařízení autorizováno"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:229
 msgid "Device code"
-msgstr ""
+msgstr "Kód zařízení"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Device-bound"
-msgstr ""
+msgstr "Vázáno na zařízení"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Device-bound passkey"
-msgstr ""
+msgstr "Přístupový klíč vázaný na zařízení"
 
 #: packages/admin/src/components/SignupPage.tsx:144
 msgid "Didn't receive the email?"
-msgstr ""
+msgstr "Nedorazil e-mail?"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:34
 msgid "Diff"
-msgstr ""
+msgstr "Diff"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:280
 msgid "Dimensions:"
-msgstr ""
+msgstr "Rozměry:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Disable"
-msgstr ""
+msgstr "Zakázat"
 
 #: packages/admin/src/components/PluginManager.tsx:494
 msgid "Disable plugin"
-msgstr ""
+msgstr "Zakázat plugin"
 
 #: packages/admin/src/components/PluginManager.tsx:554
 msgid "Disable plugin MCP tools"
-msgstr ""
+msgstr "Zakázat MCP nástroje pluginu"
 
 #: packages/admin/src/components/Redirects.tsx:507
 msgid "Disable redirect"
-msgstr ""
+msgstr "Zakázat přesměrování"
 
 #: packages/admin/src/routes/users.tsx:279
 msgid "Disable User"
-msgstr ""
+msgstr "Zakázat uživatele"
 
 #: packages/admin/src/routes/users.tsx:272
 msgid "Disable User?"
-msgstr ""
+msgstr "Zakázat uživatele?"
 
 #: packages/admin/src/components/PluginManager.tsx:383
 #: packages/admin/src/components/Redirects.tsx:421
 #: packages/admin/src/components/users/UserDetail.tsx:201
 #: packages/admin/src/components/users/UserList.tsx:212
 msgid "Disabled"
-msgstr ""
+msgstr "Zakázáno"
 
 #: packages/admin/src/components/PluginManager.tsx:614
 msgid "Disabled:"
-msgstr ""
+msgstr "Zakázáno:"
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #: packages/admin/src/routes/users.tsx:274
 msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
-msgstr ""
+msgstr "Zakázání účtu <0>{0}</0> znemožní přihlášení, dokud nebude znovu povolen. Obsah zůstane zachován."
 
 #: packages/admin/src/routes/users.tsx:280
 msgid "Disabling..."
-msgstr ""
+msgstr "Zakazování..."
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:438
 msgid "Discard"
-msgstr ""
+msgstr "Zahodit"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:77
 #: packages/admin/src/components/ContentSettingsPanel.tsx:97
 msgid "Discard changes"
-msgstr ""
+msgstr "Zahodit změny"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:436
 msgid "Discard changes?"
-msgstr ""
+msgstr "Zahodit změny?"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:82
 msgid "Discard draft changes?"
-msgstr ""
+msgstr "Zahodit změny konceptu?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:439
 msgid "Discarding..."
-msgstr ""
+msgstr "Zahazování..."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:241
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:243
 msgid "Dismiss"
-msgstr ""
+msgstr "Zavřít"
 
 #: packages/admin/src/components/Widgets.tsx:127
 msgid "Display a list of recent posts"
-msgstr ""
+msgstr "Zobrazí seznam nejnovějších příspěvků"
 
 #: packages/admin/src/components/Widgets.tsx:105
 msgid "Display a navigation menu"
-msgstr ""
+msgstr "Zobrazí navigační nabídku"
 
 #: packages/admin/src/components/Widgets.tsx:136
 msgid "Display category list"
-msgstr ""
+msgstr "Zobrazí seznam kategorií"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:960
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1022
 #: packages/admin/src/routes/bylines.tsx:481
 msgid "Display name"
-msgstr ""
+msgstr "Zobrazované jméno"
 
 #: packages/admin/src/components/MenuList.tsx:170
 msgid "Display name for admin interface"
-msgstr ""
+msgstr "Zobrazovaný název v administraci"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:269
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:458
 msgid "Display Size"
-msgstr ""
+msgstr "Velikost zobrazení"
 
 #: packages/admin/src/components/Widgets.tsx:144
 msgid "Display tag cloud"
-msgstr ""
+msgstr "Zobrazí mrak štítků"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
 msgid "Displayed below the image as a visible caption."
-msgstr ""
+msgstr "Zobrazí se pod obrázkem jako viditelný popisek."
 
 #: packages/admin/src/components/ContentEditor.tsx:697
 msgid "Distraction-free mode (⌘⇧\\)"
-msgstr ""
+msgstr "Režim bez rušivých prvků (⌘⇧\\)"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1227
 msgid "Divider"
-msgstr ""
+msgstr "Oddělovač"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:35
 msgid "Dockerfile"
-msgstr ""
+msgstr "Dockerfile"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 #: packages/admin/src/components/MediaLibrary.tsx:437
 msgid "Documents"
-msgstr ""
+msgstr "Dokumenty"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:286
 msgid "Domain"
-msgstr ""
+msgstr "Doména"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:66
 msgid "Domain added successfully"
-msgstr ""
+msgstr "Doména byla přidána"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
 msgid "Domain removed"
-msgstr ""
+msgstr "Doména odebrána"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
 msgid "Domain updated"
-msgstr ""
+msgstr "Doména aktualizována"
 
 #: packages/admin/src/components/LoginPage.tsx:334
 msgid "Don't have an account? <0>Sign up</0>"
-msgstr ""
+msgstr "Nemáte účet? <0>Zaregistrovat se</0>"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:142
 #: packages/admin/src/components/WordPressImport.tsx:2128
 msgid "Done"
-msgstr ""
+msgstr "Hotovo"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:903
 msgid "Down"
-msgstr ""
+msgstr "Dolů"
 
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:238
 msgid "Download {0}"
-msgstr ""
+msgstr "Stáhnout {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:158
 msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
-msgstr ""
+msgstr "Stáhněte si kompletní zálohu webu: veškerý obsah (včetně konceptů a koše), kolekce, taxonomie, nabídky, widgety, metadata médií a nastavení webu. Uživatelské účty a tajné klíče nejsou nikdy zahrnuty."
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:160
 msgid "Download backup"
-msgstr ""
+msgstr "Stáhnout zálohu"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:155
 msgid "Download Backup"
-msgstr ""
+msgstr "Stáhnout zálohu"
 
 #: packages/admin/src/components/Settings.tsx:123
 msgid "Download backups and schedule automatic backups to storage"
-msgstr ""
+msgstr "Stáhnout zálohy a naplánovat automatické zálohování do úložiště"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:492
 msgid "Download SBOM"
-msgstr ""
+msgstr "Stáhnout SBOM"
 
 #: packages/admin/src/components/WordPressImport.tsx:2126
 msgid "Downloading"
-msgstr ""
+msgstr "Stahování"
 
 #: packages/admin/src/components/ContentList.tsx:1162
 msgid "draft"
-msgstr ""
+msgstr "koncept"
 
 #: packages/admin/src/components/ContentList.tsx:730
 #: packages/admin/src/components/ContentPickerModal.tsx:212
 #: packages/admin/src/components/ContentSettingsPanel.tsx:454
 #: packages/admin/src/components/Dashboard.tsx:351
 msgid "Draft"
-msgstr ""
+msgstr "Koncept"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:119
 msgid "draft, published, or archived"
-msgstr ""
+msgstr "koncept, publikováno nebo archivováno"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:71
 #: packages/admin/src/components/Dashboard.tsx:254
 msgid "Drafts"
-msgstr ""
+msgstr "Koncepty"
 
 #: packages/admin/src/components/WordPressImport.tsx:1166
 msgid "Drafts & Private"
-msgstr ""
+msgstr "Koncepty a soukromé"
 
 #: packages/admin/src/components/WordPressImport.tsx:1119
 msgid "Drag and drop or click to browse (.xml)"
-msgstr ""
+msgstr "Přetáhněte sem soubor nebo klikněte pro výběr (.xml)"
 
 #: packages/admin/src/components/Widgets.tsx:700
 msgid "Drag here to add"
-msgstr ""
+msgstr "Přetažením sem přidáte"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2039
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Přetažením změníte pořadí"
 
 #. placeholder {0}: field.label
 #. placeholder {0}: widget.title ?? t`widget`
 #: packages/admin/src/components/ContentTypeEditor.tsx:716
 #: packages/admin/src/components/Widgets.tsx:802
 msgid "Drag to reorder {0}"
-msgstr ""
+msgstr "Přetažením změníte pořadí {0}"
 
 #: packages/admin/src/components/SortableContentSettingsSections.tsx:215
 #: packages/admin/src/components/SortableContentSettingsSections.tsx:216
 msgid "Drag to reorder {label}"
-msgstr ""
+msgstr "Přetažením změníte pořadí {label}"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:365
 msgid "Drag to reorder block"
-msgstr ""
+msgstr "Přetažením změníte pořadí bloku"
 
 #: packages/admin/src/components/Widgets.tsx:704
 msgid "Drag widgets here to add them"
-msgstr ""
+msgstr "Widgety přidáte přetažením sem"
 
 #: packages/admin/src/components/Widgets.tsx:467
 msgid "Drag widgets into an area to add them"
-msgstr ""
+msgstr "Widgety přidáte přetažením do oblasti"
 
 #: packages/admin/src/components/Widgets.tsx:700
 msgid "Drop to add widget"
-msgstr ""
+msgstr "Puštěním přidáte widget"
 
 #: packages/admin/src/components/WordPressImport.tsx:1588
 msgid "Drop your WordPress export file here"
-msgstr ""
+msgstr "Sem přetáhněte exportovaný soubor z WordPressu"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:319
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplikovat"
 
 #: packages/admin/src/components/ContentList.tsx:1027
 msgid "Duplicate {title}"
-msgstr ""
+msgstr "Duplikovat {title}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr ""
+msgstr "např. application/zip nebo .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:168
 msgid "e.g. import, blog"
-msgstr ""
+msgstr "např. import, blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:423
 msgid "e.g., CI/CD Pipeline"
-msgstr ""
+msgstr "např. CI/CD Pipeline"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr ""
+msgstr "např. MacBook Pro, iPhone"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:912
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
@@ -2808,7 +2813,7 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:392
 #: packages/admin/src/components/TranslationsPanel.tsx:93
 msgid "Edit"
-msgstr ""
+msgstr "Upravit"
 
 #. placeholder {0}: block?.label || ""
 #. placeholder {0}: collection.label
@@ -2821,76 +2826,76 @@ msgstr ""
 #: packages/admin/src/routes/byline-schema.tsx:449
 #: packages/admin/src/routes/bylines.tsx:476
 msgid "Edit {0}"
-msgstr ""
+msgstr "Upravit {0}"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:741
 msgid "Edit {0} field"
-msgstr ""
+msgstr "Upravit pole {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:643
 msgid "Edit {itemLabel}"
-msgstr ""
+msgstr "Upravit {itemLabel}"
 
 #: packages/admin/src/components/ContentList.tsx:1019
 msgid "Edit {title}"
-msgstr ""
+msgstr "Upravit {title}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1019
 msgid "Edit byline"
-msgstr ""
+msgstr "Upravit autorský podpis"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "Edit byline field"
-msgstr ""
+msgstr "Upravit pole autorského podpisu"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:331
 msgid "Edit Domain"
-msgstr ""
+msgstr "Upravit doménu"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Edit Field"
-msgstr ""
+msgstr "Upravit pole"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryNode.tsx:178
 msgid "Edit image {0}"
-msgstr ""
+msgstr "Upravit obrázek {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3299
 msgid "Edit link"
-msgstr ""
+msgstr "Upravit odkaz"
 
 #: packages/admin/src/components/MenuEditor.tsx:573
 msgid "Edit Menu Item"
-msgstr ""
+msgstr "Upravit položku nabídky"
 
 #: packages/admin/src/components/MenuEditor.tsx:369
 msgid "Edit menu items"
-msgstr ""
+msgstr "Upravit položky nabídky"
 
 #: packages/admin/src/components/Redirects.tsx:530
 msgid "Edit redirect"
-msgstr ""
+msgstr "Upravit přesměrování"
 
 #: packages/admin/src/components/Redirects.tsx:106
 msgid "Edit Redirect"
-msgstr ""
+msgstr "Upravit přesměrování"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:531
 msgid "Edit redirect {0}"
-msgstr ""
+msgstr "Upravit přesměrování {0}"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:368
 msgid "Edit URL"
-msgstr ""
+msgstr "Upravit URL"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
-msgstr ""
+msgstr "Redaktor"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:305
 msgid ""
@@ -2898,161 +2903,164 @@ msgid ""
 "Reporter\n"
 "Photographer"
 msgstr ""
+"Redaktor\n"
+"Reportér\n"
+"Fotograf"
 
 #: packages/admin/src/components/WordPressImport.tsx:1044
 msgid "em1.…"
-msgstr ""
+msgstr "em1.…"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:62
 #: packages/admin/src/components/Settings.tsx:116
 #: packages/admin/src/components/SignupPage.tsx:198
 #: packages/admin/src/components/users/UserDetail.tsx:154
 msgid "Email"
-msgstr ""
+msgstr "E-mail"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:330
 msgid "Email (optional)"
-msgstr ""
+msgstr "E-mail (nepovinné)"
 
 #: packages/admin/src/components/LoginPage.tsx:127
 #: packages/admin/src/components/SignupPage.tsx:67
 #: packages/admin/src/components/users/InviteUserModal.tsx:152
 msgid "Email address"
-msgstr ""
+msgstr "E-mailová adresa"
 
 #: packages/admin/src/components/SetupWizard.tsx:179
 #: packages/admin/src/components/SignupPage.tsx:50
 msgid "Email is required"
-msgstr ""
+msgstr "E-mail je povinný"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:187
 msgid "Email Middleware"
-msgstr ""
+msgstr "E-mailový middleware"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:99
 msgid "Email Pipeline"
-msgstr ""
+msgstr "E-mailová pipeline"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:172
 msgid "Email provider active"
-msgstr ""
+msgstr "Poskytovatel e-mailu je aktivní"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:77
 #: packages/admin/src/components/settings/EmailSettings.tsx:92
 msgid "Email Settings"
-msgstr ""
+msgstr "Nastavení e-mailu"
 
 #: packages/admin/src/components/users/UserDetail.tsx:235
 msgid "Email verified"
-msgstr ""
+msgstr "E-mail ověřen"
 
 #: packages/admin/src/components/SignupPage.tsx:190
 msgid "Email verified!"
-msgstr ""
+msgstr "E-mail ověřen!"
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:2475
 msgid "Embed a {0}"
-msgstr ""
+msgstr "Vložit {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2478
 msgid "Embeds"
-msgstr ""
+msgstr "Vložený obsah"
 
 #: packages/admin/src/components/WordPressImport.tsx:1208
 msgid "EmDash Exporter"
-msgstr ""
+msgstr "EmDash Exporter"
 
 #: packages/admin/src/components/WordPressImport.tsx:1307
 msgid "EmDash Exporter plugin detected! You can import directly."
-msgstr ""
+msgstr "Zjištěn plugin EmDash Exporter! Můžete importovat přímo."
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:160
 msgid "Empty gallery — open settings to add images"
-msgstr ""
+msgstr "Prázdná galerie — obrázky přidáte v nastavení"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
-msgstr ""
+msgstr "Povolit"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:493
 msgid "Enable comments"
-msgstr ""
+msgstr "Povolit komentáře"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:87
 msgid "Enable full-text search on this collection"
-msgstr ""
+msgstr "Povolit fulltextové hledání v této kolekci"
 
 #: packages/admin/src/components/PluginManager.tsx:494
 msgid "Enable plugin"
-msgstr ""
+msgstr "Povolit plugin"
 
 #: packages/admin/src/components/PluginManager.tsx:555
 msgid "Enable plugin MCP tools"
-msgstr ""
+msgstr "Povolit MCP nástroje pluginu"
 
 #: packages/admin/src/components/Redirects.tsx:507
 msgid "Enable redirect"
-msgstr ""
+msgstr "Povolit přesměrování"
 
 #: packages/admin/src/components/Redirects.tsx:176
 #: packages/admin/src/components/Redirects.tsx:421
 msgid "Enabled"
-msgstr ""
+msgstr "Povoleno"
 
 #: packages/admin/src/components/MenuEditor.tsx:423
 #: packages/admin/src/components/MenuEditor.tsx:601
 msgid "Enter a URL (https://…) or a relative path (/…)"
-msgstr ""
+msgstr "Zadejte URL (https://…) nebo relativní cestu (/…)"
 
 #: packages/admin/src/components/ContentEditor.tsx:1460
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr ""
+msgstr "Zadejte platnou URL (např. https://example.com)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1380
 msgid "Enter credentials manually"
-msgstr ""
+msgstr "Zadat přihlašovací údaje ručně"
 
 #: packages/admin/src/components/ContentEditor.tsx:696
 msgid "Enter distraction-free mode"
-msgstr ""
+msgstr "Zapnout režim bez rušení"
 
 #: packages/admin/src/components/users/UserDetail.tsx:158
 msgid "Enter email"
-msgstr ""
+msgstr "Zadejte e-mail"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
 msgid "Enter HTML..."
-msgstr ""
+msgstr "Zadejte HTML..."
 
 #: packages/admin/src/components/ContentEditor.tsx:1234
 msgid "Enter markdown content..."
-msgstr ""
+msgstr "Zadejte obsah v Markdownu..."
 
 #: packages/admin/src/components/users/UserDetail.tsx:151
 msgid "Enter name"
-msgstr ""
+msgstr "Zadejte jméno"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:177
 msgid "Enter the code from your terminal"
-msgstr ""
+msgstr "Zadejte kód z terminálu"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:123
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:132
 msgid "Enter URL..."
-msgstr ""
+msgstr "Zadejte URL..."
 
 #: packages/admin/src/components/LoginPage.tsx:327
 msgid "Enter your handle to sign in."
-msgstr ""
+msgstr "Pro přihlášení zadejte svůj handle."
 
 #: packages/admin/src/components/WordPressImport.tsx:1459
 msgid "Enter your WordPress credentials to import content directly."
-msgstr ""
+msgstr "Zadejte přihlašovací údaje k WordPressu pro přímý import obsahu."
 
 #: packages/admin/src/components/WordPressImport.tsx:1082
 msgid "Enter your WordPress site URL"
-msgstr ""
+msgstr "Zadejte URL svého webu na WordPressu"
 
 #: packages/admin/src/components/MenuEditor.tsx:155
 #: packages/admin/src/components/MenuEditor.tsx:193
@@ -3061,343 +3069,343 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:769
 #: packages/admin/src/router.tsx:2174
 msgid "Error"
-msgstr ""
+msgstr "Chyba"
 
 #: packages/admin/src/components/Widgets.tsx:236
 msgid "Error adding widget"
-msgstr ""
+msgstr "Chyba při přidávání widgetu"
 
 #: packages/admin/src/components/Widgets.tsx:297
 msgid "Error reordering widgets"
-msgstr ""
+msgstr "Chyba při změně pořadí widgetů"
 
 #: packages/admin/src/components/SectionEditor.tsx:53
 msgid "Error saving section"
-msgstr ""
+msgstr "Chyba při ukládání sekce"
 
 #: packages/admin/src/components/Widgets.tsx:784
 msgid "Error updating widget"
-msgstr ""
+msgstr "Chyba při aktualizaci widgetu"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:596
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
-msgstr ""
+msgstr "Všechna publikovaná vydání tohoto pluginu byla stažena nebo je nebylo možné ověřit. Zkuste to později nebo kontaktujte vydavatele."
 
 #: packages/admin/src/components/WordPressImport.tsx:2010
 msgid "Exists"
-msgstr ""
+msgstr "Existuje"
 
 #: packages/admin/src/components/ContentEditor.tsx:755
 msgid "Exit distraction-free mode"
-msgstr ""
+msgstr "Vypnout režim bez rušení"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3863
 msgid "Exit Spotlight Mode"
-msgstr ""
+msgstr "Ukončit režim soustředění"
 
 #: packages/admin/src/components/PluginManager.tsx:506
 msgid "Expand"
-msgstr ""
+msgstr "Rozbalit"
 
 #: packages/admin/src/components/PluginManager.tsx:500
 msgid "Expand details"
-msgstr ""
+msgstr "Rozbalit podrobnosti"
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:298
 msgid "Expires {0}"
-msgstr ""
+msgstr "Vyprší {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:463
 msgid "Expiry"
-msgstr ""
+msgstr "Platnost"
 
 #: packages/admin/src/components/WordPressImport.tsx:1273
 msgid "Export from WordPress manually"
-msgstr ""
+msgstr "Exportovat z WordPressu ručně"
 
 #: packages/admin/src/components/WordPressImport.tsx:1397
 msgid "Export your content from WordPress to import everything including drafts."
-msgstr ""
+msgstr "Exportujte obsah z WordPressu, abyste importovali vše včetně konceptů."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:118
 msgid "Facebook"
-msgstr ""
+msgstr "Facebook"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:345
 msgid "Fail"
-msgstr ""
+msgstr "Selhalo"
 
 #: packages/admin/src/components/WordPressImport.tsx:2130
 msgid "Failed"
-msgstr ""
+msgstr "Selhalo"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:199
 msgid "Failed security audit"
-msgstr ""
+msgstr "Neprošlo bezpečnostním auditem"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:70
 msgid "Failed to add domain"
-msgstr ""
+msgstr "Nepodařilo se přidat doménu"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:188
 msgid "Failed to add passkey"
-msgstr ""
+msgstr "Nepodařilo se přidat přístupový klíč"
 
 #: packages/admin/src/components/WordPressImport.tsx:413
 msgid "Failed to analyze WordPress site"
-msgstr ""
+msgstr "Nepodařilo se analyzovat web na WordPressu"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:54
 msgid "Failed to communicate with plugin"
-msgstr ""
+msgstr "Nepodařilo se komunikovat s pluginem"
 
 #: packages/admin/src/lib/api/media.ts:155
 msgid "Failed to confirm upload"
-msgstr ""
+msgstr "Nepodařilo se potvrdit nahrání"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
-msgstr ""
+msgstr "Nepodařilo se vytvořit správce"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:104
 #: packages/admin/src/lib/api/backups.ts:51
 msgid "Failed to create backup"
-msgstr ""
+msgstr "Nepodařilo se vytvořit zálohu"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1003
 msgid "Failed to create byline"
-msgstr ""
+msgstr "Nepodařilo se vytvořit autorský podpis"
 
 #: packages/admin/src/lib/api/byline-fields.ts:120
 msgid "Failed to create byline field"
-msgstr ""
+msgstr "Nepodařilo se vytvořit pole autorského podpisu"
 
 #: packages/admin/src/routes/byline-schema.tsx:102
 msgid "Failed to create field"
-msgstr ""
+msgstr "Nepodařilo se vytvořit pole"
 
 #: packages/admin/src/lib/api/sections.ts:88
 msgid "Failed to create section"
-msgstr ""
+msgstr "Nepodařilo se vytvořit sekci"
 
 #: packages/admin/src/components/WordPressImport.tsx:1714
 msgid "Failed to create some collections"
-msgstr ""
+msgstr "Nepodařilo se vytvořit některé kolekce"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:510
 msgid "Failed to create term"
-msgstr ""
+msgstr "Nepodařilo se vytvořit termín"
 
 #: packages/admin/src/router.tsx:1125
 msgid "Failed to create translation"
-msgstr ""
+msgstr "Nepodařilo se vytvořit překlad"
 
 #: packages/admin/src/router.tsx:422
 #: packages/admin/src/router.tsx:451
 #: packages/admin/src/router.tsx:534
 #: packages/admin/src/router.tsx:1145
 msgid "Failed to delete"
-msgstr ""
+msgstr "Nepodařilo se smazat"
 
 #: packages/admin/src/lib/api/users.ts:345
 msgid "Failed to delete allowed domain"
-msgstr ""
+msgstr "Nepodařilo se smazat povolenou doménu"
 
 #: packages/admin/src/lib/api/backups.ts:58
 msgid "Failed to delete backup"
-msgstr ""
+msgstr "Nepodařilo se smazat zálohu"
 
 #: packages/admin/src/lib/api/bylines.ts:143
 msgid "Failed to delete byline"
-msgstr ""
+msgstr "Nepodařilo se smazat autorský podpis"
 
 #: packages/admin/src/lib/api/byline-fields.ts:143
 msgid "Failed to delete byline field"
-msgstr ""
+msgstr "Nepodařilo se smazat pole autorského podpisu"
 
 #: packages/admin/src/lib/api/schema.ts:222
 msgid "Failed to delete collection"
-msgstr ""
+msgstr "Nepodařilo se smazat kolekci"
 
 #: packages/admin/src/lib/api/comments.ts:111
 #: packages/admin/src/router.tsx:1445
 msgid "Failed to delete comment"
-msgstr ""
+msgstr "Nepodařilo se smazat komentář"
 
 #: packages/admin/src/lib/api/content.ts:279
 msgid "Failed to delete content"
-msgstr ""
+msgstr "Nepodařilo se smazat obsah"
 
 #: packages/admin/src/lib/api/schema.ts:278
 #: packages/admin/src/routes/byline-schema.tsx:138
 msgid "Failed to delete field"
-msgstr ""
+msgstr "Nepodařilo se smazat pole"
 
 #: packages/admin/src/lib/api/media.ts:389
 msgid "Failed to delete from provider"
-msgstr ""
+msgstr "Nepodařilo se smazat u poskytovatele"
 
 #: packages/admin/src/lib/api/media.ts:259
 msgid "Failed to delete media"
-msgstr ""
+msgstr "Nepodařilo se smazat média"
 
 #: packages/admin/src/lib/api/menus.ts:163
 msgid "Failed to delete menu"
-msgstr ""
+msgstr "Nepodařilo se smazat nabídku"
 
 #: packages/admin/src/lib/api/menus.ts:217
 msgid "Failed to delete menu item"
-msgstr ""
+msgstr "Nepodařilo se smazat položku nabídky"
 
 #: packages/admin/src/lib/api/users.ts:256
 msgid "Failed to delete passkey"
-msgstr ""
+msgstr "Nepodařilo se smazat přístupový klíč"
 
 #: packages/admin/src/lib/api/redirects.ts:111
 msgid "Failed to delete redirect"
-msgstr ""
+msgstr "Nepodařilo se smazat přesměrování"
 
 #: packages/admin/src/lib/api/sections.ts:110
 msgid "Failed to delete section"
-msgstr ""
+msgstr "Nepodařilo se smazat sekci"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
-msgstr ""
+msgstr "Nepodařilo se smazat termín"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
-msgstr ""
+msgstr "Nepodařilo se smazat widget"
 
 #: packages/admin/src/lib/api/widgets.ts:108
 msgid "Failed to delete widget area"
-msgstr ""
+msgstr "Nepodařilo se smazat oblast widgetů"
 
 #: packages/admin/src/components/PluginManager.tsx:120
 #: packages/admin/src/lib/api/plugins.ts:160
 msgid "Failed to disable plugin"
-msgstr ""
+msgstr "Nepodařilo se zakázat plugin"
 
 #: packages/admin/src/lib/api/search.ts:32
 msgid "Failed to disable search"
-msgstr ""
+msgstr "Nepodařilo se vypnout hledání"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
-msgstr ""
+msgstr "Nepodařilo se deaktivovat uživatele"
 
 #: packages/admin/src/router.tsx:1052
 msgid "Failed to discard changes"
-msgstr ""
+msgstr "Nepodařilo se zahodit změny"
 
 #: packages/admin/src/components/WelcomeModal.tsx:70
 msgid "Failed to dismiss welcome"
-msgstr ""
+msgstr "Nepodařilo se zavřít uvítání"
 
 #: packages/admin/src/router.tsx:465
 msgid "Failed to duplicate"
-msgstr ""
+msgstr "Nepodařilo se duplikovat"
 
 #: packages/admin/src/components/PluginManager.tsx:101
 #: packages/admin/src/lib/api/plugins.ts:146
 msgid "Failed to enable plugin"
-msgstr ""
+msgstr "Nepodařilo se povolit plugin"
 
 #: packages/admin/src/lib/api/search.ts:31
 msgid "Failed to enable search"
-msgstr ""
+msgstr "Nepodařilo se zapnout hledání"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
-msgstr ""
+msgstr "Nepodařilo se aktivovat uživatele"
 
 #: packages/admin/src/components/WordPressImport.tsx:340
 msgid "Failed to execute import"
-msgstr ""
+msgstr "Nepodařilo se spustit import"
 
 #: packages/admin/src/lib/api/client.ts:255
 msgid "Failed to fetch auth mode"
-msgstr ""
+msgstr "Nepodařilo se načíst režim přihlášení"
 
 #: packages/admin/src/lib/api/backups.ts:37
 msgid "Failed to fetch backup settings"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení záloh"
 
 #: packages/admin/src/lib/api/schema.ts:170
 #: packages/admin/src/lib/api/schema.ts:174
 msgid "Failed to fetch collection"
-msgstr ""
+msgstr "Nepodařilo se načíst kolekci"
 
 #: packages/admin/src/lib/api/dashboard.ts:42
 msgid "Failed to fetch dashboard stats"
-msgstr ""
+msgstr "Nepodařilo se načíst statistiky přehledu"
 
 #: packages/admin/src/lib/api/email-settings.ts:34
 msgid "Failed to fetch email settings"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení e-mailu"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:106
 msgid "Failed to fetch entry terms"
-msgstr ""
+msgstr "Nepodařilo se načíst štítky položky"
 
 #: packages/admin/src/lib/api/client.ts:238
 msgid "Failed to fetch manifest"
-msgstr ""
+msgstr "Nepodařilo se načíst manifest"
 
 #: packages/admin/src/lib/api/media.ts:76
 msgid "Failed to fetch media"
-msgstr ""
+msgstr "Nepodařilo se načíst média"
 
 #: packages/admin/src/lib/api/media.ts:89
 msgid "Failed to fetch media item"
-msgstr ""
+msgstr "Nepodařilo se načíst položku médií"
 
 #: packages/admin/src/lib/api/media.ts:325
 msgid "Failed to fetch media providers"
-msgstr ""
+msgstr "Nepodařilo se načíst poskytovatele médií"
 
 #: packages/admin/src/lib/api/plugins.ts:70
 #: packages/admin/src/lib/api/plugins.ts:74
 msgid "Failed to fetch plugin"
-msgstr ""
+msgstr "Nepodařilo se načíst plugin"
 
 #: packages/admin/src/lib/api/plugins.ts:114
 msgid "Failed to fetch plugin settings"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení pluginu"
 
 #: packages/admin/src/lib/api/plugins.ts:56
 msgid "Failed to fetch plugins"
-msgstr ""
+msgstr "Nepodařilo se načíst pluginy"
 
 #: packages/admin/src/lib/api/media.ts:355
 msgid "Failed to fetch provider media"
-msgstr ""
+msgstr "Nepodařilo se načíst média poskytovatele"
 
 #: packages/admin/src/lib/api/content.ts:556
 #: packages/admin/src/lib/api/content.ts:561
 msgid "Failed to fetch revision"
-msgstr ""
+msgstr "Nepodařilo se načíst revizi"
 
 #: packages/admin/src/lib/api/sections.ts:76
 msgid "Failed to fetch section"
-msgstr ""
+msgstr "Nepodařilo se načíst sekci"
 
 #: packages/admin/src/lib/api/sections.ts:68
 msgid "Failed to fetch sections"
-msgstr ""
+msgstr "Nepodařilo se načíst sekce"
 
 #: packages/admin/src/lib/api/settings.ts:50
 msgid "Failed to fetch settings"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
-msgstr ""
+msgstr "Nepodařilo se načíst stav nastavení"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:87
 msgid "Failed to fetch terms"
-msgstr ""
+msgstr "Nepodařilo se načíst štítky"
 
 #: packages/admin/src/lib/api/current-user.ts:22
 #: packages/admin/src/lib/api/users.ts:88
@@ -3405,1057 +3413,1057 @@ msgstr ""
 #: packages/admin/src/router.tsx:852
 #: packages/admin/src/router.tsx:1376
 msgid "Failed to fetch user"
-msgstr ""
+msgstr "Nepodařilo se načíst uživatele"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:263
 msgid "Failed to generate preview"
-msgstr ""
+msgstr "Nepodařilo se vytvořit náhled"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
 msgid "Failed to generate preview URL"
-msgstr ""
+msgstr "Nepodařilo se vytvořit URL náhledu"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:176
 msgid "Failed to get authentication options"
-msgstr ""
+msgstr "Nepodařilo se získat možnosti ověření"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
 msgid "Failed to get registration options"
-msgstr ""
+msgstr "Nepodařilo se získat možnosti registrace"
 
 #: packages/admin/src/lib/api/media.ts:131
 msgid "Failed to get upload URL"
-msgstr ""
+msgstr "Nepodařilo se získat URL pro nahrání"
 
 #: packages/admin/src/components/WordPressImport.tsx:436
 msgid "Failed to import from WordPress"
-msgstr ""
+msgstr "Nepodařilo se importovat z WordPressu"
 
 #: packages/admin/src/components/WordPressImport.tsx:365
 #: packages/admin/src/lib/api/import.ts:422
 msgid "Failed to import media"
-msgstr ""
+msgstr "Nepodařilo se importovat média"
 
 #: packages/admin/src/lib/api/marketplace.ts:208
 #: packages/admin/src/lib/api/registry.ts:702
 msgid "Failed to install plugin"
-msgstr ""
+msgstr "Nepodařilo se nainstalovat plugin"
 
 #: packages/admin/src/lib/api/byline-fields.ts:98
 msgid "Failed to list byline fields"
-msgstr ""
+msgstr "Nepodařilo se načíst pole autorského podpisu"
 
 #: packages/admin/src/router.tsx:282
 msgid "Failed to load admin"
-msgstr ""
+msgstr "Nepodařilo se načíst administraci"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
 msgid "Failed to load allowed domains"
-msgstr ""
+msgstr "Nepodařilo se načíst povolené domény"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:135
 msgid "Failed to load backup settings"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení záloh"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "Failed to load bylines: {0}"
-msgstr ""
+msgstr "Nepodařilo se načíst autorské podpisy: {0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:81
 msgid "Failed to load email settings"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení e-mailu"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:465
 msgid "Failed to load image"
-msgstr ""
+msgstr "Nepodařilo se načíst obrázek"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:135
 msgid "Failed to load passkeys"
-msgstr ""
+msgstr "Nepodařilo se načíst přístupové klíče"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:121
 msgid "Failed to load plugin"
-msgstr ""
+msgstr "Nepodařilo se načíst plugin"
 
 #: packages/admin/src/components/PluginSettings.tsx:146
 msgid "Failed to load plugin settings"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení pluginu"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:149
 msgid "Failed to load plugins: {0}"
-msgstr ""
+msgstr "Nepodařilo se načíst pluginy: {0}"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:98
 msgid "Failed to load plugins. The registry aggregator may be unreachable."
-msgstr ""
+msgstr "Nepodařilo se načíst pluginy. Agregátor registru je možná nedostupný."
 
 #: packages/admin/src/components/RevisionHistory.tsx:198
 msgid "Failed to load revisions"
-msgstr ""
+msgstr "Nepodařilo se načíst revize"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
-msgstr ""
+msgstr "Nepodařilo se načíst nastavení"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
-msgstr ""
+msgstr "Nepodařilo se načíst motiv"
 
 #. placeholder {0}: usersQuery.error.message
 #: packages/admin/src/routes/users.tsx:205
 msgid "Failed to load users: {0}"
-msgstr ""
+msgstr "Nepodařilo se načíst uživatele: {0}"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:46
 msgid "Failed to load widget"
-msgstr ""
+msgstr "Nepodařilo se načíst widget"
 
 #: packages/admin/src/router.tsx:1470
 msgid "Failed to perform bulk action"
-msgstr ""
+msgstr "Nepodařilo se provést hromadnou akci"
 
 #: packages/admin/src/lib/api/content.ts:322
 msgid "Failed to permanently delete content"
-msgstr ""
+msgstr "Nepodařilo se trvale smazat obsah"
 
 #: packages/admin/src/components/WordPressImport.tsx:321
 msgid "Failed to prepare import"
-msgstr ""
+msgstr "Nepodařilo se připravit import"
 
 #: packages/admin/src/router.tsx:490
 #: packages/admin/src/router.tsx:1013
 msgid "Failed to publish"
-msgstr ""
+msgstr "Nepodařilo se publikovat"
 
 #: packages/admin/src/lib/api/byline-fields.ts:106
 msgid "Failed to read byline field usage"
-msgstr ""
+msgstr "Nepodařilo se načíst využití pole autorského podpisu"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:112
 msgid "Failed to remove domain"
-msgstr ""
+msgstr "Nepodařilo se odebrat doménu"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:99
 #: packages/admin/src/components/settings/SecuritySettings.tsx:70
 msgid "Failed to remove passkey"
-msgstr ""
+msgstr "Nepodařilo se odebrat přístupový klíč"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:53
 msgid "Failed to rename passkey"
-msgstr ""
+msgstr "Nepodařilo se přejmenovat přístupový klíč"
 
 #: packages/admin/src/lib/api/byline-fields.ts:156
 msgid "Failed to reorder byline fields"
-msgstr ""
+msgstr "Nepodařilo se přeřadit pole autorského podpisu"
 
 #: packages/admin/src/lib/api/schema.ts:293
 #: packages/admin/src/routes/byline-schema.tsx:152
 msgid "Failed to reorder fields"
-msgstr ""
+msgstr "Nepodařilo se přeřadit pole"
 
 #: packages/admin/src/lib/api/widgets.ts:158
 msgid "Failed to reorder widgets"
-msgstr ""
+msgstr "Nepodařilo se přeřadit widgety"
 
 #: packages/admin/src/router.tsx:437
 msgid "Failed to restore"
-msgstr ""
+msgstr "Nepodařilo se obnovit"
 
 #: packages/admin/src/lib/api/content.ts:311
 msgid "Failed to restore content"
-msgstr ""
+msgstr "Nepodařilo se obnovit obsah"
 
 #: packages/admin/src/lib/api/content.ts:578
 #: packages/admin/src/lib/api/content.ts:583
 msgid "Failed to restore revision"
-msgstr ""
+msgstr "Nepodařilo se obnovit revizi"
 
 #: packages/admin/src/lib/api/api-tokens.ts:99
 msgid "Failed to revoke API token"
-msgstr ""
+msgstr "Nepodařilo se zrušit API token"
 
 #: packages/admin/src/components/WordPressImport.tsx:378
 msgid "Failed to rewrite URLs"
-msgstr ""
+msgstr "Nepodařilo se přepsat URL"
 
 #: packages/admin/src/router.tsx:942
 #: packages/admin/src/router.tsx:1959
 msgid "Failed to save"
-msgstr ""
+msgstr "Nepodařilo se uložit"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:84
 msgid "Failed to save backup settings"
-msgstr ""
+msgstr "Nepodařilo se uložit nastavení záloh"
 
 #: packages/admin/src/routes/byline-schema.tsx:122
 msgid "Failed to save field"
-msgstr ""
+msgstr "Nepodařilo se uložit pole"
 
 #: packages/admin/src/components/PluginSettings.tsx:74
 #: packages/admin/src/components/settings/GeneralSettings.tsx:50
 #: packages/admin/src/components/settings/SeoSettings.tsx:44
 #: packages/admin/src/components/settings/SocialSettings.tsx:42
 msgid "Failed to save settings"
-msgstr ""
+msgstr "Nepodařilo se uložit nastavení"
 
 #: packages/admin/src/router.tsx:1073
 msgid "Failed to schedule"
-msgstr ""
+msgstr "Nepodařilo se naplánovat"
 
 #: packages/admin/src/components/LoginPage.tsx:71
 #: packages/admin/src/components/LoginPage.tsx:76
 msgid "Failed to send magic link"
-msgstr ""
+msgstr "Nepodařilo se odeslat magický odkaz"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
-msgstr ""
+msgstr "Nepodařilo se odeslat odkaz pro obnovení"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:50
 #: packages/admin/src/lib/api/email-settings.ts:45
 msgid "Failed to send test email"
-msgstr ""
+msgstr "Nepodařilo se odeslat zkušební e-mail"
 
 #: packages/admin/src/components/SignupPage.tsx:351
 msgid "Failed to send verification email"
-msgstr ""
+msgstr "Nepodařilo se odeslat ověřovací e-mail"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:129
 msgid "Failed to set entry terms"
-msgstr ""
+msgstr "Nepodařilo se nastavit štítky položky"
 
 #: packages/admin/src/lib/api/marketplace.ts:249
 #: packages/admin/src/lib/api/registry.ts:858
 msgid "Failed to uninstall plugin"
-msgstr ""
+msgstr "Nepodařilo se odinstalovat plugin"
 
 #: packages/admin/src/router.tsx:1031
 msgid "Failed to unpublish"
-msgstr ""
+msgstr "Nepodařilo se zrušit publikování"
 
 #: packages/admin/src/router.tsx:1094
 msgid "Failed to unschedule"
-msgstr ""
+msgstr "Nepodařilo se zrušit naplánování"
 
 #: packages/admin/src/router.tsx:513
 msgid "Failed to update"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:364
 msgid "Failed to update {0}"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat {0}"
 
 #: packages/admin/src/lib/api/backups.ts:46
 msgid "Failed to update backup settings"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat nastavení záloh"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1053
 msgid "Failed to update byline"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat autorský podpis"
 
 #: packages/admin/src/lib/api/byline-fields.ts:135
 msgid "Failed to update byline field"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat pole autorského podpisu"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:94
 msgid "Failed to update domain"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat doménu"
 
 #: packages/admin/src/lib/api/media.ts:276
 msgid "Failed to update media"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat média"
 
 #: packages/admin/src/lib/api/marketplace.ts:232
 #: packages/admin/src/lib/api/registry.ts:776
 msgid "Failed to update plugin"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat plugin"
 
 #: packages/admin/src/lib/api/plugins.ts:172
 msgid "Failed to update plugin MCP access"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat přístup pluginu k MCP"
 
 #: packages/admin/src/lib/api/plugins.ts:133
 msgid "Failed to update plugin settings"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat nastavení pluginu"
 
 #: packages/admin/src/lib/api/sections.ts:100
 msgid "Failed to update section"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat sekci"
 
 #: packages/admin/src/lib/api/settings.ts:64
 msgid "Failed to update settings"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat nastavení"
 
 #: packages/admin/src/router.tsx:1429
 msgid "Failed to update status"
-msgstr ""
+msgstr "Nepodařilo se aktualizovat stav"
 
 #: packages/admin/src/lib/api/media.ts:173
 msgid "Failed to upload file"
-msgstr ""
+msgstr "Nepodařilo se nahrát soubor"
 
 #: packages/admin/src/lib/api/media.ts:218
 msgid "Failed to upload media"
-msgstr ""
+msgstr "Nepodařilo se nahrát média"
 
 #: packages/admin/src/lib/api/media.ts:377
 msgid "Failed to upload to provider"
-msgstr ""
+msgstr "Nepodařilo se nahrát k poskytovateli"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:248
 msgid "Failed to verify authentication"
-msgstr ""
+msgstr "Nepodařilo se ověřit přihlášení"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
 msgid "Failed to verify registration"
-msgstr ""
+msgstr "Nepodařilo se ověřit registraci"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:807
 msgid "FAQ"
-msgstr ""
+msgstr "FAQ"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:213
 #: packages/admin/src/components/settings/GeneralSettings.tsx:219
 msgid "Favicon"
-msgstr ""
+msgstr "Favicon"
 
 #: packages/admin/src/components/WordPressImport.tsx:1180
 msgid "Feature"
-msgstr ""
+msgstr "Funkce"
 
 #: packages/admin/src/components/WordPressImport.tsx:1148
 msgid "Featured Images"
-msgstr ""
+msgstr "Náhledové obrázky"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:440
 #: packages/admin/src/components/ContentTypeList.tsx:105
 msgid "Features"
-msgstr ""
+msgstr "Funkce"
 
 #: packages/admin/src/components/WordPressImport.tsx:811
 msgid "Fetching content from the EmDash Exporter API."
-msgstr ""
+msgstr "Načítání obsahu z EmDash Exporter API."
 
 #: packages/admin/src/routes/byline-schema.tsx:95
 msgid "Field created"
-msgstr ""
+msgstr "Pole vytvořeno"
 
 #: packages/admin/src/routes/byline-schema.tsx:133
 msgid "Field deleted"
-msgstr ""
+msgstr "Pole smazáno"
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
-msgstr ""
+msgstr "Popisek pole"
 
 #: packages/admin/src/components/FieldEditor.tsx:414
 msgid "Field Label"
-msgstr ""
+msgstr "Popisek pole"
 
 #: packages/admin/src/components/FieldEditor.tsx:426
 msgid "Field slugs cannot be changed after creation"
-msgstr ""
+msgstr "Slug pole nelze po vytvoření změnit"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:268
 msgid "Field type cannot be changed after creation."
-msgstr ""
+msgstr "Typ pole nelze po vytvoření změnit."
 
 #: packages/admin/src/routes/byline-schema.tsx:115
 msgid "Field updated"
-msgstr ""
+msgstr "Pole aktualizováno"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:581
 msgid "Fields"
-msgstr ""
+msgstr "Pole"
 
 #: packages/admin/src/components/WordPressImport.tsx:2333
 msgid "Fields created:"
-msgstr ""
+msgstr "Vytvořená pole:"
 
 #: packages/admin/src/components/FieldEditor.tsx:210
 msgid "File"
-msgstr ""
+msgstr "Soubor"
 
 #. placeholder {0}: progress.current
 #: packages/admin/src/components/WordPressImport.tsx:2158
 msgid "File {0}"
-msgstr ""
+msgstr "Soubor {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:211
 msgid "File from media library"
-msgstr ""
+msgstr "Soubor z knihovny médií"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:325
 #: packages/admin/src/components/MediaDetailPanel.tsx:342
 #: packages/admin/src/components/MediaLibrary.tsx:586
 msgid "Filename"
-msgstr ""
+msgstr "Název souboru"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:120
 msgid "Filename cannot be changed after upload"
-msgstr ""
+msgstr "Název souboru nelze po nahrání změnit"
 
 #: packages/admin/src/components/WordPressImport.tsx:2366
 msgid "files imported"
-msgstr ""
+msgstr "souborů importováno"
 
 #: packages/admin/src/components/ContentList.tsx:769
 msgid "Filter by author"
-msgstr ""
+msgstr "Filtrovat podle autora"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:115
 msgid "Filter by capability"
-msgstr ""
+msgstr "Filtrovat podle schopnosti"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:178
 msgid "Filter by collection"
-msgstr ""
+msgstr "Filtrovat podle kolekce"
 
 #: packages/admin/src/components/users/UserList.tsx:82
 msgid "Filter by role"
-msgstr ""
+msgstr "Filtrovat podle role"
 
 #: packages/admin/src/components/Sections.tsx:245
 msgid "Filter by source"
-msgstr ""
+msgstr "Filtrovat podle zdroje"
 
 #: packages/admin/src/components/ContentList.tsx:754
 #: packages/admin/src/components/Redirects.tsx:422
 msgid "Filter by status"
-msgstr ""
+msgstr "Filtrovat podle stavu"
 
 #: packages/admin/src/components/MediaLibrary.tsx:439
 #: packages/admin/src/components/Redirects.tsx:428
 msgid "Filter by type"
-msgstr ""
+msgstr "Filtrovat podle typu"
 
 #: packages/admin/src/routes/bylines.tsx:408
 msgid "Filter byline type"
-msgstr ""
+msgstr "Filtrovat typ autorského podpisu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
-msgstr ""
+msgstr "Pouze noví komentující"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:69
 msgid "Fonts"
-msgstr ""
+msgstr "Písma"
 
 #: packages/admin/src/components/WordPressImport.tsx:1398
 msgid "For a complete import including drafts and all content, export from WordPress."
-msgstr ""
+msgstr "Pro úplný import včetně konceptů a veškerého obsahu proveďte export z WordPressu."
 
 #: packages/admin/src/components/WordPressImport.tsx:1207
 msgid "For the best import experience, install the"
-msgstr ""
+msgstr "Pro nejlepší průběh importu nainstalujte"
 
 #: packages/admin/src/components/ContentList.tsx:806
 msgid "From date"
-msgstr ""
+msgstr "Od data"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
 #: packages/admin/src/components/WordPressImport.tsx:1155
 msgid "Full"
-msgstr ""
+msgstr "Plná velikost"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
-msgstr ""
+msgstr "Plný přístup"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:102
 msgid "Full admin access"
-msgstr ""
+msgstr "Plný přístup správce"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:171
 #: packages/admin/src/components/PortableTextEditor.tsx:2442
 msgid "Gallery"
-msgstr ""
+msgstr "Galerie"
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:207
 #: packages/admin/src/components/editor/GalleryNode.tsx:208
 msgid "Gallery settings"
-msgstr ""
+msgstr "Nastavení galerie"
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "General"
-msgstr ""
+msgstr "Obecné"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:96
 #: packages/admin/src/components/settings/GeneralSettings.tsx:124
 msgid "General Settings"
-msgstr ""
+msgstr "Obecné nastavení"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:648
 msgid "Genres"
-msgstr ""
+msgstr "Žánry"
 
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
-msgstr ""
+msgstr "Začít"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:112
 msgid "GitHub"
-msgstr ""
+msgstr "GitHub"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
 msgid "Give this passkey a name to help you identify it later."
-msgstr ""
+msgstr "Pojmenujte tento přístupový klíč, abyste jej později snadno poznali."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:36
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: packages/admin/src/components/WordPressImport.tsx:2418
 #: packages/admin/src/router.tsx:2194
 msgid "Go to Dashboard"
-msgstr ""
+msgstr "Přejít na přehled"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:194
 msgid "Google Verification"
-msgstr ""
+msgstr "Ověření Google"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:37
 msgid "GraphQL"
-msgstr ""
+msgstr "GraphQL"
 
 #: packages/admin/src/components/MediaLibrary.tsx:460
 msgid "Grid view"
-msgstr ""
+msgstr "Zobrazení mřížky"
 
 #: packages/admin/src/components/Redirects.tsx:167
 msgid "Group (optional)"
-msgstr ""
+msgstr "Skupina (volitelné)"
 
 #: packages/admin/src/components/Widgets.tsx:162
 msgid "Group by"
-msgstr ""
+msgstr "Seskupit podle"
 
 #: packages/admin/src/routes/bylines.tsx:555
 msgid "Guest byline"
-msgstr ""
+msgstr "Hostující autorský podpis"
 
 #: packages/admin/src/routes/bylines.tsx:413
 msgid "Guest only"
-msgstr ""
+msgstr "Pouze hosté"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:65
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
 #: packages/admin/src/components/PortableTextEditor.tsx:1112
 msgid "Heading 1"
-msgstr ""
+msgstr "Nadpis 1"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:73
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:33
 #: packages/admin/src/components/PortableTextEditor.tsx:1122
 msgid "Heading 2"
-msgstr ""
+msgstr "Nadpis 2"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:81
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:34
 #: packages/admin/src/components/PortableTextEditor.tsx:1132
 msgid "Heading 3"
-msgstr ""
+msgstr "Nadpis 3"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:89
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
 #: packages/admin/src/components/PortableTextEditor.tsx:1142
 msgid "Heading 4"
-msgstr ""
+msgstr "Nadpis 4"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:97
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
 #: packages/admin/src/components/PortableTextEditor.tsx:1152
 msgid "Heading 5"
-msgstr ""
+msgstr "Nadpis 5"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:105
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
 #: packages/admin/src/components/PortableTextEditor.tsx:1162
 msgid "Heading 6"
-msgstr ""
+msgstr "Nadpis 6"
 
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:142
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:158
 msgid "Headings"
-msgstr ""
+msgstr "Nadpisy"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
 msgid "Height"
-msgstr ""
+msgstr "Výška"
 
 #: packages/admin/src/components/Sections.tsx:180
 msgid "Hero Banner"
-msgstr ""
+msgstr "Hlavní banner"
 
 #: packages/admin/src/components/SectionEditor.tsx:286
 msgid "hero, banner, cta"
-msgstr ""
+msgstr "hero, banner, cta"
 
 #: packages/admin/src/components/SeoPanel.tsx:230
 #: packages/admin/src/components/SeoPanel.tsx:233
 msgid "Hide from search engines"
-msgstr ""
+msgstr "Skrýt před vyhledávači"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
 msgid "Hide token"
-msgstr ""
+msgstr "Skrýt token"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:671
 msgid "Hierarchical (like categories, with parent/child relationships)"
-msgstr ""
+msgstr "Hierarchická (jako kategorie, se vztahy nadřazený/podřazený)"
 
 #: packages/admin/src/components/Redirects.tsx:226
 #: packages/admin/src/components/Redirects.tsx:473
 msgid "Hits"
-msgstr ""
+msgstr "Zásahy"
 
 #: packages/admin/src/components/MenuEditor.tsx:416
 msgid "Home"
-msgstr ""
+msgstr "Domů"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
 msgid "Homepage"
-msgstr ""
+msgstr "Domovská stránka"
 
 #: packages/admin/src/components/PluginManager.tsx:414
 msgid "Hooks"
-msgstr ""
+msgstr "Hooky"
 
 #: packages/admin/src/components/WordPressImport.tsx:1520
 msgid "How to create an Application Password"
-msgstr ""
+msgstr "Jak vytvořit heslo aplikace"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:38
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
 #: packages/admin/src/components/PortableTextEditor.tsx:1212
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
 msgid "HTML source"
-msgstr ""
+msgstr "Zdrojový kód HTML"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3226
 #: packages/admin/src/components/PortableTextEditor.tsx:3793
 msgid "https://..."
-msgstr ""
+msgstr "https://..."
 
 #: packages/admin/src/components/MenuEditor.tsx:424
 msgid "https://example.com or /about"
-msgstr ""
+msgstr "https://example.com nebo /about"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:555
 msgid "https://example.com/image.jpg"
-msgstr ""
+msgstr "https://example.com/image.jpg"
 
 #: packages/admin/src/components/WordPressImport.tsx:1089
 msgid "https://yoursite.com"
-msgstr ""
+msgstr "https://vasweb.cz"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:243
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:153
 msgid "Icon blurred due to image audit"
-msgstr ""
+msgstr "Ikona je rozmazána kvůli kontrole obrázků"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: packages/admin/src/components/LoginPage.tsx:104
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
-msgstr ""
+msgstr "Pokud pro <0>{email}</0> existuje účet, odeslali jsme přihlašovací odkaz."
 
 #: packages/admin/src/components/FieldEditor.tsx:204
 #: packages/admin/src/components/FieldEditor.tsx:587
 #: packages/admin/src/components/PortableTextEditor.tsx:2427
 msgid "Image"
-msgstr ""
+msgstr "Obrázek"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:294
 msgid "Image {0}"
-msgstr ""
+msgstr "Obrázek {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:205
 msgid "Image from media library"
-msgstr ""
+msgstr "Obrázek z knihovny médií"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
 #: packages/admin/src/components/ImageFieldRenderer.tsx:124
 msgid "Image not found"
-msgstr ""
+msgstr "Obrázek nenalezen"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:208
 #: packages/admin/src/components/editor/ImageNode.tsx:209
 msgid "Image settings"
-msgstr ""
+msgstr "Nastavení obrázku"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
 msgid "Image Settings"
-msgstr ""
+msgstr "Nastavení obrázku"
 
 #: packages/admin/src/components/SeoImageField.tsx:43
 msgid "Image shown when this page is shared on social media"
-msgstr ""
+msgstr "Obrázek zobrazený při sdílení této stránky na sociálních sítích"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:556
 msgid "Image URL"
-msgstr ""
+msgstr "URL obrázku"
 
 #: packages/admin/src/components/WordPressImport.tsx:2370
 msgid "image URLs updated in"
-msgstr ""
+msgstr "URL obrázků aktualizováno v"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:192
 #: packages/admin/src/components/MediaLibrary.tsx:434
 msgid "Images"
-msgstr ""
+msgstr "Obrázky"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:226
 #: packages/admin/src/components/Sidebar.tsx:290
 #: packages/admin/src/components/WordPressImport.tsx:738
 msgid "Import"
-msgstr ""
+msgstr "Import"
 
 #. placeholder {0}: postType.name
 #: packages/admin/src/components/WordPressImport.tsx:1958
 msgid "Import {0}"
-msgstr ""
+msgstr "Importovat {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1366
 msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
-msgstr ""
+msgstr "Importujte veškerý obsah přímo včetně konceptů, vlastních typů příspěvků, polí ACF a dat SEO. Není potřeba stahovat soubor."
 
 #: packages/admin/src/components/WordPressImport.tsx:2416
 msgid "Import Another File"
-msgstr ""
+msgstr "Importovat další soubor"
 
 #: packages/admin/src/components/WordPressImport.tsx:1174
 msgid "Import Capabilities"
-msgstr ""
+msgstr "Schopnosti importu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2304
 msgid "Import Complete"
-msgstr ""
+msgstr "Import dokončen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2305
 msgid "Import Completed with Errors"
-msgstr ""
+msgstr "Import dokončen s chybami"
 
 #: packages/admin/src/components/WordPressImport.tsx:1699
 msgid "Import failed"
-msgstr ""
+msgstr "Import selhal"
 
 #: packages/admin/src/components/WordPressImport.tsx:691
 msgid "Import from WordPress"
-msgstr ""
+msgstr "Import z WordPressu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2107
 msgid "Import Media"
-msgstr ""
+msgstr "Importovat média"
 
 #: packages/admin/src/components/WordPressImport.tsx:2060
 msgid "Import Media Files"
-msgstr ""
+msgstr "Importovat soubory médií"
 
 #: packages/admin/src/components/WordPressImport.tsx:693
 msgid "Import posts, pages, and custom post types from WordPress."
-msgstr ""
+msgstr "Importujte příspěvky, stránky a vlastní typy příspěvků z WordPressu."
 
 #: packages/admin/src/components/WordPressImport.tsx:1814
 msgid "Import site configuration from WordPress."
-msgstr ""
+msgstr "Importujte konfiguraci webu z WordPressu."
 
 #: packages/admin/src/components/WordPressImport.tsx:1364
 msgid "Import via EmDash Exporter"
-msgstr ""
+msgstr "Import přes EmDash Exporter"
 
 #: packages/admin/src/components/Sections.tsx:47
 msgid "Imported"
-msgstr ""
+msgstr "Importováno"
 
 #: packages/admin/src/components/WordPressImport.tsx:2344
 msgid "Imported by Collection"
-msgstr ""
+msgstr "Importováno podle kolekce"
 
 #. placeholder {0}: wpImportProgress.comments
 #: packages/admin/src/components/WordPressImport.tsx:903
 msgid "Importing comments... {0}"
-msgstr ""
+msgstr "Import komentářů... {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:920
 msgid "Importing content..."
-msgstr ""
+msgstr "Import obsahu..."
 
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:901
 msgid "Importing content... {0}"
-msgstr ""
+msgstr "Import obsahu... {0}"
 
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:900
 msgid "Importing content... {0} of {totalSelectedPosts}"
-msgstr ""
+msgstr "Import obsahu... {0} z {totalSelectedPosts}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2139
 msgid "Importing Media"
-msgstr ""
+msgstr "Import médií"
 
 #: packages/admin/src/components/WordPressImport.tsx:904
 msgid "Importing menus and site settings..."
-msgstr ""
+msgstr "Import nabídek a nastavení webu..."
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
-msgstr ""
+msgstr "Zahrnout ukázkový obsah (doporučeno pro nové weby)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1980
 msgid "Incompatible"
-msgstr ""
+msgstr "Nekompatibilní"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:506
 msgid "Indexed"
-msgstr ""
+msgstr "Indexováno"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3677
 msgid "Inline Code"
-msgstr ""
+msgstr "Vložený kód"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:567
 #: packages/admin/src/components/MediaPickerModal.tsx:811
 msgid "Insert"
-msgstr ""
+msgstr "Vložit"
 
 #. placeholder {0}: block?.label || ""
 #: packages/admin/src/components/PortableTextEditor.tsx:1644
 msgid "Insert {0}"
-msgstr ""
+msgstr "Vložit {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1193
 msgid "Insert a blockquote"
-msgstr ""
+msgstr "Vložit citaci"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1203
 msgid "Insert a code block"
-msgstr ""
+msgstr "Vložit blok kódu"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1228
 msgid "Insert a horizontal rule"
-msgstr ""
+msgstr "Vložit vodorovnou čáru"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2458
 msgid "Insert a reusable section"
-msgstr ""
+msgstr "Vložit opakovaně použitelnou sekci"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1238
 msgid "Insert a table"
-msgstr ""
+msgstr "Vložit tabulku"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2428
 msgid "Insert an image"
-msgstr ""
+msgstr "Vložit obrázek"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2443
 msgid "Insert an image gallery"
-msgstr ""
+msgstr "Vložit galerii obrázků"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1472
 msgid "Insert block"
-msgstr ""
+msgstr "Vložit blok"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3629
 #: packages/admin/src/components/PortableTextEditor.tsx:3639
 msgid "Insert block after current block"
-msgstr ""
+msgstr "Vložit blok za aktuální blok"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
 msgid "Insert block below"
-msgstr ""
+msgstr "Vložit blok níže"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:549
 msgid "Insert from URL"
-msgstr ""
+msgstr "Vložit z URL"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3763
 #: packages/admin/src/components/PortableTextEditor.tsx:3777
 msgid "Insert Link"
-msgstr ""
+msgstr "Vložit odkaz"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1213
 msgid "Insert raw HTML"
-msgstr ""
+msgstr "Vložit přímé HTML"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:58
 msgid "Insert Section"
-msgstr ""
+msgstr "Vložit sekci"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:124
 msgid "Instagram"
-msgstr ""
+msgstr "Instagram"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:203
 #: packages/admin/src/components/RegistryPluginDetail.tsx:554
 msgid "Install"
-msgstr ""
+msgstr "Nainstalovat"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:155
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr ""
+msgstr "Nainstalujte a aktivujte plugin poskytovatele e-mailu, abyste povolili e-mailové funkce jako pozvánky, magické odkazy a obnovu hesla."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:197
 msgid "Install blocked"
-msgstr ""
+msgstr "Instalace blokována"
 
 #: packages/admin/src/components/WordPressImport.tsx:1039
 msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
-msgstr ""
+msgstr "Nainstalujte plugin EmDash Exporter na svůj web WordPress a vygenerujte klíč v Nástroje → EmDash Migration."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:806
 msgid "Installation"
-msgstr ""
+msgstr "Instalace"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:263
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:184
 #: packages/admin/src/components/RegistryBrowse.tsx:201
 #: packages/admin/src/components/RegistryPluginDetail.tsx:546
 msgid "Installed"
-msgstr ""
+msgstr "Nainstalováno"
 
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:583
 msgid "Installed from marketplace (v{0})"
-msgstr ""
+msgstr "Nainstalováno z tržiště (v{0})"
 
 #: packages/admin/src/components/PluginManager.tsx:602
 msgid "Installed:"
-msgstr ""
+msgstr "Nainstalováno:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:198
 msgid "Installing..."
-msgstr ""
+msgstr "Instalace..."
 
 #: packages/admin/src/components/FieldEditor.tsx:168
 #: packages/admin/src/components/FieldEditor.tsx:582
 msgid "Integer"
-msgstr ""
+msgstr "Celé číslo"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:152
 msgid "Invalid invite link"
-msgstr ""
+msgstr "Neplatný odkaz na pozvánku"
 
 #: packages/admin/src/components/ContentEditor.tsx:1529
 msgid "Invalid JSON"
-msgstr ""
+msgstr "Neplatný JSON"
 
 #: packages/admin/src/components/SignupPage.tsx:260
 msgid "Invalid link"
-msgstr ""
+msgstr "Neplatný odkaz"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:241
 msgid "Invite Error"
-msgstr ""
+msgstr "Chyba pozvánky"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:150
 msgid "Invite expired"
-msgstr ""
+msgstr "Pozvánka vypršela"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 msgid "Invite Link Created"
-msgstr ""
+msgstr "Odkaz na pozvánku vytvořen"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 #: packages/admin/src/components/users/UserList.tsx:56
 msgid "Invite User"
-msgstr ""
+msgstr "Pozvat uživatele"
 
 #: packages/admin/src/components/users/UserList.tsx:140
 msgid "Invite your first team member"
-msgstr ""
+msgstr "Pozvěte prvního člena týmu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:97
 msgid "Invoke MCP tools from all enabled plugins"
-msgstr ""
+msgstr "Volat MCP nástroje ze všech povolených pluginů"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:454
 msgid "Invoke only this plugin's enabled MCP tools"
-msgstr ""
+msgstr "Volat pouze povolené MCP nástroje tohoto pluginu"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3270
 #: packages/admin/src/components/PortableTextEditor.tsx:3656
 msgid "Italic"
-msgstr ""
+msgstr "Kurzíva"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:2025
 #: packages/admin/src/components/RepeaterField.tsx:239
 msgid "Item {0}"
-msgstr ""
+msgstr "Položka {0}"
 
 #: packages/admin/src/components/MenuEditor.tsx:175
 msgid "Item added"
-msgstr ""
+msgstr "Položka přidána"
 
 #: packages/admin/src/components/MenuEditor.tsx:187
 msgid "Item deleted"
-msgstr ""
+msgstr "Položka smazána"
 
 #: packages/admin/src/components/MenuEditor.tsx:212
 msgid "Item updated"
-msgstr ""
+msgstr "Položka aktualizována"
 
 #: packages/admin/src/components/SetupWizard.tsx:213
 #: packages/admin/src/components/SignupPage.tsx:206
 msgid "Jane Doe"
-msgstr ""
+msgstr "Jana Nováková"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:39
 msgid "Java"
-msgstr ""
+msgstr "Java"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:40
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:235
 msgid "Job title"
-msgstr ""
+msgstr "Pracovní pozice"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:246
 msgid "job_title"
-msgstr ""
+msgstr "job_title"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:41
 #: packages/admin/src/components/FieldEditor.tsx:222
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:42
 msgid "JSX"
-msgstr ""
+msgstr "JSX"
 
 #: packages/admin/src/components/WordPressImport.tsx:916
 msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
-msgstr ""
+msgstr "Ponechte tuto kartu otevřenou. Import probíhá po malých krocích a lze jej při přerušení bezpečně spustit znovu."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:882
 msgid "Keep typing to narrow down more bylines."
-msgstr ""
+msgstr "Pokračujte v psaní pro zúžení výběru autorských podpisů."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
 msgid "Keywords"
-msgstr ""
+msgstr "Klíčová slova"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:43
 msgid "Kotlin"
-msgstr ""
+msgstr "Kotlin"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:232
 #: packages/admin/src/components/FieldEditor.tsx:411
@@ -4467,73 +4475,73 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:436
 #: packages/admin/src/routes/byline-schema.tsx:234
 msgid "Label"
-msgstr ""
+msgstr "Popisek"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:392
 msgid "Label (Plural)"
-msgstr ""
+msgstr "Popisek (množné číslo)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:384
 msgid "Label (Singular)"
-msgstr ""
+msgstr "Popisek (jednotné číslo)"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:162
 #: packages/admin/src/components/LoginPage.tsx:347
 #: packages/admin/src/components/Settings.tsx:136
 #: packages/admin/src/components/Settings.tsx:141
 msgid "Language"
-msgstr ""
+msgstr "Jazyk"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1113
 msgid "Large section heading"
-msgstr ""
+msgstr "Velký nadpis sekce"
 
 #: packages/admin/src/components/PluginManager.tsx:608
 msgid "Last enabled:"
-msgstr ""
+msgstr "Naposledy povoleno:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:227
 msgid "Last login"
-msgstr ""
+msgstr "Poslední přihlášení"
 
 #: packages/admin/src/components/users/UserList.tsx:107
 msgid "Last Login"
-msgstr ""
+msgstr "Poslední přihlášení"
 
 #: packages/admin/src/components/Redirects.tsx:227
 msgid "Last seen"
-msgstr ""
+msgstr "Naposledy viděno"
 
 #: packages/admin/src/components/users/UserDetail.tsx:223
 msgid "Last updated"
-msgstr ""
+msgstr "Poslední aktualizace"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:159
 msgid "Last used"
-msgstr ""
+msgstr "Naposledy použito"
 
 #. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:303
 #: packages/admin/src/components/users/UserDetail.tsx:262
 msgid "Last used {0}"
-msgstr ""
+msgstr "Naposledy použito {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:274
 msgid "Learn more"
-msgstr ""
+msgstr "Zjistit více"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:339
 msgid "Leave blank to use a discoverable passkey."
-msgstr ""
+msgstr "Ponechte prázdné pro použití zjistitelného přístupového klíče."
 
 #: packages/admin/src/components/WordPressImport.tsx:2497
 msgid "Leave unassigned"
-msgstr ""
+msgstr "Ponechat nepřiřazené"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
 msgid "Left"
-msgstr ""
+msgstr "Vlevo"
 
 #: packages/admin/src/components/MediaLibrary.tsx:136
 #: packages/admin/src/components/MediaLibrary.tsx:273
@@ -4541,62 +4549,62 @@ msgstr ""
 #: packages/admin/src/components/MediaPickerModal.tsx:211
 #: packages/admin/src/components/MediaPickerModal.tsx:509
 msgid "Library"
-msgstr ""
+msgstr "Knihovna"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
 msgid "License"
-msgstr ""
+msgstr "Licence"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
-msgstr ""
+msgstr "světlý"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "Light"
-msgstr ""
+msgstr "Světlý"
 
 #: packages/admin/src/components/Widgets.tsx:165
 msgid "Limit"
-msgstr ""
+msgstr "Limit"
 
 #: packages/admin/src/components/SignupPage.tsx:258
 msgid "Link expired"
-msgstr ""
+msgstr "Odkaz vypršel"
 
 #: packages/admin/src/components/FieldEditor.tsx:217
 msgid "Link to another content item"
-msgstr ""
+msgstr "Odkaz na jinou položku obsahu"
 
 #. placeholder {0}: user.oauthAccounts.length
 #: packages/admin/src/components/users/UserDetail.tsx:276
 msgid "Linked Accounts ({0})"
-msgstr ""
+msgstr "Propojené účty ({0})"
 
 #: packages/admin/src/routes/bylines.tsx:414
 msgid "Linked only"
-msgstr ""
+msgstr "Pouze propojené"
 
 #: packages/admin/src/routes/bylines.tsx:506
 msgid "Linked user"
-msgstr ""
+msgstr "Propojený uživatel"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:130
 msgid "LinkedIn"
-msgstr ""
+msgstr "LinkedIn"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
 msgid "Links"
-msgstr ""
+msgstr "Odkazy"
 
 #: packages/admin/src/components/MediaLibrary.tsx:469
 msgid "List view"
-msgstr ""
+msgstr "Zobrazení seznamu"
 
 #: packages/admin/src/components/ContentEditor.tsx:677
 #: packages/admin/src/components/ContentEditor.tsx:720
 #: packages/admin/src/components/ContentSettingsPanel.tsx:256
 msgid "Live View"
-msgstr ""
+msgstr "Živý náhled"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:236
 #: packages/admin/src/components/MarketplaceBrowse.tsx:200
@@ -4604,7 +4612,7 @@ msgstr ""
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
 #: packages/admin/src/routes/bylines.tsx:468
 msgid "Load more"
-msgstr ""
+msgstr "Načíst další"
 
 #: packages/admin/src/components/ContentList.tsx:630
 #: packages/admin/src/components/ContentList.tsx:687
@@ -4612,76 +4620,76 @@ msgstr ""
 #: packages/admin/src/components/MediaPickerModal.tsx:775
 #: packages/admin/src/components/users/UserList.tsx:169
 msgid "Load More"
-msgstr ""
+msgstr "Načíst další"
 
 #: packages/admin/src/router.tsx:2149
 msgid "Loading"
-msgstr ""
+msgstr "Načítání"
 
 #: packages/admin/src/routes/byline-schema.tsx:257
 msgid "Loading byline fields…"
-msgstr ""
+msgstr "Načítání polí autorského podpisu…"
 
 #: packages/admin/src/components/ContentTypeList.tsx:116
 msgid "Loading collections..."
-msgstr ""
+msgstr "Načítání kolekcí..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:308
 msgid "Loading comments..."
-msgstr ""
+msgstr "Načítání komentářů..."
 
 #: packages/admin/src/router.tsx:2151
 #: packages/admin/src/router.tsx:2163
 msgid "Loading configuration..."
-msgstr ""
+msgstr "Načítání konfigurace..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:164
 msgid "Loading content..."
-msgstr ""
+msgstr "Načítání obsahu..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3018
 msgid "Loading editor..."
-msgstr ""
+msgstr "Načítání editoru..."
 
 #: packages/admin/src/components/MenuEditor.tsx:342
 msgid "Loading menu..."
-msgstr ""
+msgstr "Načítání nabídky..."
 
 #: packages/admin/src/components/MenuList.tsx:95
 msgid "Loading menus..."
-msgstr ""
+msgstr "Načítání nabídek..."
 
 #: packages/admin/src/components/PluginManager.tsx:140
 msgid "Loading plugins..."
-msgstr ""
+msgstr "Načítání pluginů..."
 
 #: packages/admin/src/components/Redirects.tsx:459
 msgid "Loading redirects..."
-msgstr ""
+msgstr "Načítání přesměrování..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:95
 #: packages/admin/src/components/Sections.tsx:252
 msgid "Loading sections..."
-msgstr ""
+msgstr "Načítání sekcí..."
 
 #: packages/admin/src/components/PluginSettings.tsx:131
 #: packages/admin/src/components/settings/GeneralSettings.tsx:99
 #: packages/admin/src/components/settings/SeoSettings.tsx:93
 #: packages/admin/src/components/settings/SocialSettings.tsx:73
 msgid "Loading settings..."
-msgstr ""
+msgstr "Načítání nastavení..."
 
 #: packages/admin/src/components/SetupWizard.tsx:528
 msgid "Loading setup..."
-msgstr ""
+msgstr "Načítání průvodce..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:847
 msgid "Loading terms..."
-msgstr ""
+msgstr "Načítání termínů..."
 
 #: packages/admin/src/components/Widgets.tsx:372
 msgid "Loading widgets..."
-msgstr ""
+msgstr "Načítání widgetů..."
 
 #: packages/admin/src/components/ContentList.tsx:538
 #: packages/admin/src/components/ContentList.tsx:630
@@ -4703,170 +4711,170 @@ msgstr ""
 #: packages/admin/src/components/WelcomeModal.tsx:143
 #: packages/admin/src/routes/bylines.tsx:468
 msgid "Loading..."
-msgstr ""
+msgstr "Načítání..."
 
 #: packages/admin/src/components/ContentList.tsx:518
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
 msgid "Locale"
-msgstr ""
+msgstr "Jazyk"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
 msgid "Lock aspect ratio"
-msgstr ""
+msgstr "Zamknout poměr stran"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:291
 msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
-msgstr ""
+msgstr "Uzamčeno, protože toto pole má uložené hodnoty. Pro změnu smažte hodnoty (nebo pole)."
 
 #: packages/admin/src/components/Header.tsx:109
 msgid "Log out"
-msgstr ""
+msgstr "Odhlásit se"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:159
 #: packages/admin/src/components/settings/GeneralSettings.tsx:165
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1832
 msgid "Logo & favicon"
-msgstr ""
+msgstr "Logo a favicon"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:53
 msgid "Long text"
-msgstr ""
+msgstr "Dlouhý text"
 
 #: packages/admin/src/components/FieldEditor.tsx:156
 #: packages/admin/src/components/FieldEditor.tsx:580
 msgid "Long Text"
-msgstr ""
+msgstr "Dlouhý text"
 
 #: packages/admin/src/components/Sections.tsx:193
 msgid "Lowercase letters, numbers, and hyphens only"
-msgstr ""
+msgstr "Pouze malá písmena, číslice a pomlčky"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:663
 msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
-msgstr ""
+msgstr "Pouze malá písmena, číslice a podtržítka, začínající písmenem"
 
 #: packages/admin/src/components/Widgets.tsx:436
 msgid "Main Sidebar"
-msgstr ""
+msgstr "Hlavní postranní panel"
 
 #: packages/admin/src/lib/api/marketplace.ts:285
 #: packages/admin/src/lib/api/marketplace.ts:293
 msgid "Make network requests"
-msgstr ""
+msgstr "Provádět síťové požadavky"
 
 #: packages/admin/src/lib/api/marketplace.ts:286
 #: packages/admin/src/lib/api/marketplace.ts:294
 msgid "Make network requests to any host (unrestricted)"
-msgstr ""
+msgstr "Provádět síťové požadavky na libovolný host (bez omezení)"
 
 #: packages/admin/src/components/Sidebar.tsx:375
 msgid "Manage"
-msgstr ""
+msgstr "Spravovat"
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #. placeholder {1}: taxonomyDef.collections.join(", ")
 #: packages/admin/src/components/TaxonomyManager.tsx:818
 msgid "Manage {0} for {1}"
-msgstr ""
+msgstr "Spravovat {0} pro {1}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:844
 msgid "Manage bylines in {entryLocale}"
-msgstr ""
+msgstr "Spravovat autorské podpisy v jazyce {entryLocale}"
 
 #: packages/admin/src/components/Widgets.tsx:390
 msgid "Manage content widgets in your widget areas"
-msgstr ""
+msgstr "Spravovat obsahové widgety ve vašich oblastech widgetů"
 
 #: packages/admin/src/components/PluginManager.tsx:160
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
-msgstr ""
+msgstr "Spravovat nainstalované pluginy. Povolením nebo zakázáním pluginů řídíte jejich funkce."
 
 #: packages/admin/src/components/MenuList.tsx:106
 msgid "Manage navigation menus for your site"
-msgstr ""
+msgstr "Spravovat navigační nabídky webu"
 
 #: packages/admin/src/components/Redirects.tsx:361
 msgid "Manage URL redirects and view 404 errors."
-msgstr ""
+msgstr "Spravovat přesměrování URL a zobrazit chyby 404."
 
 #: packages/admin/src/components/Settings.tsx:94
 msgid "Manage your passkeys and authentication"
-msgstr ""
+msgstr "Spravovat přístupové klíče a ověřování"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:317
 msgid "Managed by {providerName}"
-msgstr ""
+msgstr "Spravováno službou {providerName}"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:318
 msgid "Managed by an external media provider"
-msgstr ""
+msgstr "Spravováno externím poskytovatelem médií"
 
 #: packages/admin/src/components/Redirects.tsx:427
 msgid "Manual"
-msgstr ""
+msgstr "Ruční"
 
 #: packages/admin/src/components/WordPressImport.tsx:2454
 msgid "Map Authors"
-msgstr ""
+msgstr "Přiřadit autory"
 
 #. placeholder {0}: mapping.wpLogin
 #: packages/admin/src/components/WordPressImport.tsx:2502
 msgid "Map WordPress user {0} to EmDash user"
-msgstr ""
+msgstr "Přiřadit uživatele WordPressu {0} k uživateli EmDash"
 
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:256
 msgid "Mark {0} as Gone (410)"
-msgstr ""
+msgstr "Označit {0} jako Gone (410)"
 
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr ""
+msgstr "Označit jako Gone (410) — sdělí vyhledávačům, že bylo trvale smazáno"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:502
 msgid "Mark as spam"
-msgstr ""
+msgstr "Označit jako spam"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:44
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 #: packages/admin/src/components/PluginManager.tsx:206
 msgid "marketplace"
-msgstr ""
+msgstr "tržiště"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:87
 #: packages/admin/src/components/PluginManager.tsx:176
 #: packages/admin/src/components/PluginManager.tsx:384
 #: packages/admin/src/components/Sidebar.tsx:272
 msgid "Marketplace"
-msgstr ""
+msgstr "Tržiště"
 
 #: packages/admin/src/components/FieldEditor.tsx:627
 msgid "Max Items"
-msgstr ""
+msgstr "Max. položek"
 
 #: packages/admin/src/components/FieldEditor.tsx:470
 msgid "Max Length"
-msgstr ""
+msgstr "Max. délka"
 
 #: packages/admin/src/components/FieldEditor.tsx:500
 msgid "Max Value"
-msgstr ""
+msgstr "Max. hodnota"
 
 #: packages/admin/src/components/Widgets.tsx:147
 msgid "Maximum tags"
-msgstr ""
+msgstr "Maximální počet štítků"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:45
 msgid "MDX"
-msgstr ""
+msgstr "MDX"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2431
 #: packages/admin/src/components/PortableTextEditor.tsx:2446
@@ -4875,241 +4883,241 @@ msgstr ""
 #: packages/admin/src/components/WordPressImport.tsx:1145
 #: packages/admin/src/components/WordPressImport.tsx:1334
 msgid "Media"
-msgstr ""
+msgstr "Média"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:222
 msgid "Media Details"
-msgstr ""
+msgstr "Podrobnosti média"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2400
 msgid "Media Errors ({0})"
-msgstr ""
+msgstr "Chyby médií ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:2362
 msgid "Media Import"
-msgstr ""
+msgstr "Import médií"
 
 #: packages/admin/src/components/WordPressImport.tsx:2303
 msgid "Media Import Complete"
-msgstr ""
+msgstr "Import médií dokončen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2314
 msgid "Media import was skipped"
-msgstr ""
+msgstr "Import médií byl přeskočen"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:153
 #: packages/admin/src/components/MediaLibrary.tsx:322
 msgid "Media Library"
-msgstr ""
+msgstr "Knihovna médií"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
 msgid "Media Read"
-msgstr ""
+msgstr "Čtení médií"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
 msgid "Media Write"
-msgstr ""
+msgstr "Zápis médií"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1123
 msgid "Medium section heading"
-msgstr ""
+msgstr "Střední nadpis sekce"
 
 #: packages/admin/src/components/Widgets.tsx:104
 #: packages/admin/src/components/Widgets.tsx:914
 msgid "Menu"
-msgstr ""
+msgstr "Nabídka"
 
 #. placeholder {0}: translated.label
 #. placeholder {1}: translated.locale.toUpperCase()
 #: packages/admin/src/components/MenuEditor.tsx:144
 msgid "Menu \"{0}\" ({1}) created."
-msgstr ""
+msgstr "Nabídka „{0}“ ({1}) byla vytvořena."
 
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:56
 msgid "Menu \"{0}\" has been created."
-msgstr ""
+msgstr "Nabídka „{0}“ byla vytvořena."
 
 #: packages/admin/src/components/MenuList.tsx:55
 msgid "Menu created"
-msgstr ""
+msgstr "Nabídka vytvořena"
 
 #: packages/admin/src/components/MenuList.tsx:75
 msgid "Menu deleted"
-msgstr ""
+msgstr "Nabídka smazána"
 
 #: packages/admin/src/components/MenuEditor.tsx:175
 msgid "Menu item has been added."
-msgstr ""
+msgstr "Položka nabídky byla přidána."
 
 #: packages/admin/src/components/MenuEditor.tsx:188
 msgid "Menu item has been deleted."
-msgstr ""
+msgstr "Položka nabídky byla smazána."
 
 #: packages/admin/src/components/MenuEditor.tsx:213
 msgid "Menu item has been updated."
-msgstr ""
+msgstr "Položka nabídky byla upravena."
 
 #: packages/admin/src/components/MenuEditor.tsx:350
 msgid "Menu not found"
-msgstr ""
+msgstr "Nabídka nenalezena"
 
 #: packages/admin/src/components/MenuEditor.tsx:228
 msgid "Menu order has been updated."
-msgstr ""
+msgstr "Pořadí nabídky bylo upraveno."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:160
 #: packages/admin/src/components/MenuList.tsx:104
 #: packages/admin/src/components/Sidebar.tsx:226
 #: packages/admin/src/components/WordPressImport.tsx:1149
 msgid "Menus"
-msgstr ""
+msgstr "Nabídky"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1767
 msgid "Menus ({0})"
-msgstr ""
+msgstr "Nabídky ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
 msgid "Menus Manage"
-msgstr ""
+msgstr "Správa nabídek"
 
 #: packages/admin/src/components/SeoPanel.tsx:188
 #: packages/admin/src/components/SeoPanel.tsx:192
 msgid "Meta Description"
-msgstr ""
+msgstr "Meta popis"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:203
 msgid "Meta tag content for Bing Webmaster Tools verification"
-msgstr ""
+msgstr "Obsah meta tagu pro ověření v Bing Webmaster Tools"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:197
 msgid "Meta tag content for Google Search Console verification"
-msgstr ""
+msgstr "Obsah meta tagu pro ověření v Google Search Console"
 
 #: packages/admin/src/components/WordPressImport.tsx:1845
 msgid "Meta titles, descriptions, and social images"
-msgstr ""
+msgstr "Meta názvy, popisy a obrázky pro sociální sítě"
 
 #: packages/admin/src/components/WordPressImport.tsx:1051
 msgid "Migration key"
-msgstr ""
+msgstr "Migrační klíč"
 
 #: packages/admin/src/components/FieldEditor.tsx:620
 msgid "Min Items"
-msgstr ""
+msgstr "Min. položek"
 
 #: packages/admin/src/components/FieldEditor.tsx:463
 msgid "Min Length"
-msgstr ""
+msgstr "Min. délka"
 
 #: packages/admin/src/components/FieldEditor.tsx:493
 msgid "Min Value"
-msgstr ""
+msgstr "Min. hodnota"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1153
 msgid "Minor section heading"
-msgstr ""
+msgstr "Menší nadpis sekce"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:504
 msgid "Moderation"
-msgstr ""
+msgstr "Moderování"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
-msgstr ""
+msgstr "Signály moderování"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:211
 msgid "Modified"
-msgstr ""
+msgstr "Upraveno"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:72
 msgid "Modify collection schemas"
-msgstr ""
+msgstr "Upravovat schémata kolekcí"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Monthly"
-msgstr ""
+msgstr "Měsíčně"
 
 #: packages/admin/src/components/Widgets.tsx:159
 msgid "Monthly/yearly archives"
-msgstr ""
+msgstr "Měsíční/roční archivy"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:111
 msgid "More information about {label}"
-msgstr ""
+msgstr "Více informací o {label}"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
-msgstr ""
+msgstr "Nejoblíbenější"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:439
 msgid "Move \"{0}\" down"
-msgstr ""
+msgstr "Přesunout „{0}“ dolů"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:429
 msgid "Move \"{0}\" up"
-msgstr ""
+msgstr "Přesunout „{0}“ nahoru"
 
 #: packages/admin/src/components/ContentList.tsx:1048
 msgid "Move \"{title}\" to trash? You can restore it later."
-msgstr ""
+msgstr "Přesunout „{title}“ do koše? Později lze obnovit."
 
 #: packages/admin/src/components/ContentList.tsx:1039
 msgid "Move {title} to trash"
-msgstr ""
+msgstr "Přesunout {title} do koše"
 
 #: packages/admin/src/components/MenuEditor.tsx:537
 msgid "Move down"
-msgstr ""
+msgstr "Přesunout dolů"
 
 #: packages/admin/src/components/ContentList.tsx:439
 msgid "Move to trash"
-msgstr ""
+msgstr "Přesunout do koše"
 
 #: packages/admin/src/components/ContentList.tsx:466
 #: packages/admin/src/components/ContentList.tsx:1061
 #: packages/admin/src/components/ContentSettingsPanel.tsx:669
 #: packages/admin/src/components/ContentSettingsPanel.tsx:689
 msgid "Move to Trash"
-msgstr ""
+msgstr "Přesunout do koše"
 
 #: packages/admin/src/components/ContentList.tsx:444
 #: packages/admin/src/components/ContentList.tsx:1046
 #: packages/admin/src/components/ContentSettingsPanel.tsx:674
 msgid "Move to Trash?"
-msgstr ""
+msgstr "Přesunout do koše?"
 
 #: packages/admin/src/components/MenuEditor.tsx:528
 msgid "Move up"
-msgstr ""
+msgstr "Přesunout nahoru"
 
 #: packages/admin/src/router.tsx:510
 msgid "Moved {total} items to draft"
-msgstr ""
+msgstr "Přesunuto {total} položek do konceptů"
 
 #: packages/admin/src/router.tsx:531
 msgid "Moved {total} items to trash"
-msgstr ""
+msgstr "Přesunuto {total} položek do koše"
 
 #: packages/admin/src/components/FieldEditor.tsx:192
 msgid "Multi Select"
-msgstr ""
+msgstr "Vícenásobný výběr"
 
 #: packages/admin/src/components/FieldEditor.tsx:157
 msgid "Multi-line plain text"
-msgstr ""
+msgstr "Víceřádkový prostý text"
 
 #: packages/admin/src/components/FieldEditor.tsx:193
 msgid "Multiple choices from options"
-msgstr ""
+msgstr "Více voleb z možností"
 
 #: packages/admin/src/components/SetupWizard.tsx:120
 msgid "My Awesome Blog"
-msgstr ""
+msgstr "Můj skvělý blog"
 
 #: packages/admin/src/components/ContentTypeList.tsx:96
 #: packages/admin/src/components/MarketplaceBrowse.tsx:45
@@ -5121,479 +5129,479 @@ msgstr ""
 #: packages/admin/src/components/users/UserDetail.tsx:148
 #: packages/admin/src/components/Widgets.tsx:430
 msgid "Name"
-msgstr ""
+msgstr "Název"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:580
 msgid "Name and label are required"
-msgstr ""
+msgstr "Název a popisek jsou povinné"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:586
 msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
-msgstr ""
+msgstr "Název musí začínat písmenem a obsahovat pouze malá písmena, číslice a podtržítka"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:340
 msgid "Navigation"
-msgstr ""
+msgstr "Navigace"
 
 #: packages/admin/src/components/users/UserDetail.tsx:231
 #: packages/admin/src/components/users/UserList.tsx:185
 msgid "Never"
-msgstr ""
+msgstr "Nikdy"
 
 #: packages/admin/src/router.tsx:1120
 msgid "new"
-msgstr ""
+msgstr "nový"
 
 #: packages/admin/src/routes/bylines.tsx:426
 msgid "New"
-msgstr ""
+msgstr "Nové"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:111
 msgid "NEW"
-msgstr ""
+msgstr "NOVÉ"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:479
 msgid "New {0}"
-msgstr ""
+msgstr "Nový {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:643
 msgid "New {itemLabel}"
-msgstr ""
+msgstr "Nový {itemLabel}"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
-msgstr ""
+msgstr "Nové pole autorského podpisu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1982
 msgid "New collection"
-msgstr ""
+msgstr "Nová kolekce"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:355
 #: packages/admin/src/components/ContentTypeList.tsx:46
 msgid "New Content Type"
-msgstr ""
+msgstr "Nový typ obsahu"
 
 #: packages/admin/src/routes/byline-schema.tsx:224
 msgid "New field"
-msgstr ""
+msgstr "Nové pole"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:122
 msgid "New public routes"
-msgstr ""
+msgstr "Nové veřejné cesty"
 
 #: packages/admin/src/components/Redirects.tsx:106
 #: packages/admin/src/components/Redirects.tsx:365
 msgid "New Redirect"
-msgstr ""
+msgstr "Nové přesměrování"
 
 #: packages/admin/src/components/Sections.tsx:143
 msgid "New Section"
-msgstr ""
+msgstr "Nová sekce"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:479
 msgid "new tab"
-msgstr ""
+msgstr "nová karta"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:831
 msgid "New Taxonomy"
-msgstr ""
+msgstr "Nová taxonomie"
 
 #: packages/admin/src/components/MenuEditor.tsx:430
 #: packages/admin/src/components/MenuEditor.tsx:433
 #: packages/admin/src/components/MenuEditor.tsx:609
 #: packages/admin/src/components/MenuEditor.tsx:612
 msgid "New window"
-msgstr ""
+msgstr "Nové okno"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:44
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
 msgid "Newest"
-msgstr ""
+msgstr "Nejnovější"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:408
 msgid "News"
-msgstr ""
+msgstr "Zprávy"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
 msgid "Next"
-msgstr ""
+msgstr "Další"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:372
 #: packages/admin/src/components/ContentList.tsx:618
 msgid "Next page"
-msgstr ""
+msgstr "Další stránka"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:476
 msgid "Next screenshot"
-msgstr ""
+msgstr "Další snímek obrazovky"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:422
 msgid "No"
-msgstr ""
+msgstr "Ne"
 
 #: packages/admin/src/routes/byline-schema.tsx:420
 msgid "No (shared across translations)"
-msgstr ""
+msgstr "Ne (sdíleno napříč překlady)"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:449
 msgid "No {0} available."
-msgstr ""
+msgstr "Žádné {0} k dispozici."
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:549
 msgid "No {0} yet."
-msgstr ""
+msgstr "Zatím žádné {0}."
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:850
 msgid "No {0} yet. Create one to get started."
-msgstr ""
+msgstr "Zatím žádné {0}. Začněte vytvořením první položky."
 
 #: packages/admin/src/components/Redirects.tsx:218
 msgid "No 404 errors recorded yet."
-msgstr ""
+msgstr "Zatím nebyly zaznamenány žádné chyby 404."
 
 #: packages/admin/src/components/MediaLibrary.tsx:835
 #: packages/admin/src/components/MediaLibrary.tsx:892
 msgid "No alt text"
-msgstr ""
+msgstr "Bez alternativního textu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:281
 msgid "No API tokens yet. Create one to get started."
-msgstr ""
+msgstr "Zatím žádné API tokeny. Začněte vytvořením prvního."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:548
 msgid "No approved comments yet."
-msgstr ""
+msgstr "Zatím žádné schválené komentáře."
 
 #: packages/admin/src/routes/byline-schema.tsx:291
 msgid "No byline fields yet."
-msgstr ""
+msgstr "Zatím žádná pole autorského podpisu."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:836
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr ""
+msgstr "V jazyce {entryLocale} nejsou k dispozici žádné autorské podpisy. Než některý u této položky uvedete, vytvořte variantu na stránce Autorské podpisy."
 
 #: packages/admin/src/routes/bylines.tsx:452
 msgid "No bylines found"
-msgstr ""
+msgstr "Nenalezeny žádné autorské podpisy"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:944
 msgid "No bylines selected."
-msgstr ""
+msgstr "Není vybrán žádný autorský podpis."
 
 #: packages/admin/src/components/Dashboard.tsx:226
 msgid "No collections configured"
-msgstr ""
+msgstr "Nejsou nastaveny žádné kolekce"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:547
 msgid "No comments awaiting moderation."
-msgstr ""
+msgstr "Žádné komentáře nečekají na moderaci."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:543
 msgid "No comments match your search."
-msgstr ""
+msgstr "Hledání neodpovídají žádné komentáře."
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:82
 msgid "No content"
-msgstr ""
+msgstr "Žádný obsah"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:171
 msgid "No content found"
-msgstr ""
+msgstr "Nenalezen žádný obsah"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:177
 msgid "No content in this collection"
-msgstr ""
+msgstr "V této kolekci není žádný obsah"
 
 #: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "No content types yet."
-msgstr ""
+msgstr "Zatím žádné typy obsahu."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:612
 msgid "No custom fields yet"
-msgstr ""
+msgstr "Zatím žádná vlastní pole"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:275
 msgid "No detailed description available."
-msgstr ""
+msgstr "Podrobný popis není k dispozici."
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:262
 msgid "No domains configured. Users must be invited individually."
-msgstr ""
+msgstr "Nejsou nastaveny žádné domény. Uživatele je nutné zvát jednotlivě."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:152
 msgid "No email provider configured"
-msgstr ""
+msgstr "Není nastaven žádný poskytovatel e-mailu"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:83
 msgid "No email provider configured. Share this link manually."
-msgstr ""
+msgstr "Není nastaven žádný poskytovatel e-mailu. Sdílejte tento odkaz ručně."
 
 #: packages/admin/src/components/WordPressImport.tsx:2516
 msgid "No EmDash users found"
-msgstr ""
+msgstr "Nenalezeni žádní uživatelé EmDash"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
 msgid "No expiry"
-msgstr ""
+msgstr "Bez expirace"
 
 #: packages/admin/src/components/RevisionHistory.tsx:345
 msgid "No fields to compare"
-msgstr ""
+msgstr "Žádná pole k porovnání"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:213
 msgid "No headings in document"
-msgstr ""
+msgstr "V dokumentu nejsou žádné nadpisy"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:205
 msgid "No images in this gallery yet."
-msgstr ""
+msgstr "V této galerii zatím nejsou žádné obrázky."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:594
 msgid "No installable releases"
-msgstr ""
+msgstr "Žádné instalovatelné verze"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:193
 msgid "No invite token provided"
-msgstr ""
+msgstr "Nebyl zadán žádný token pozvánky"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1948
 #: packages/admin/src/components/RepeaterField.tsx:165
 msgid "No items yet"
-msgstr ""
+msgstr "Zatím žádné položky"
 
 #: packages/admin/src/components/FieldEditor.tsx:631
 msgid "No limit"
-msgstr ""
+msgstr "Bez omezení"
 
 #: packages/admin/src/routes/bylines.tsx:517
 msgid "No linked user"
-msgstr ""
+msgstr "Žádný propojený uživatel"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:171
 msgid "No matches"
-msgstr ""
+msgstr "Žádné shody"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:879
 msgid "No matching bylines."
-msgstr ""
+msgstr "Žádné odpovídající autorské podpisy."
 
 #: packages/admin/src/components/MediaLibrary.tsx:489
 #: packages/admin/src/components/MediaLibrary.tsx:517
 msgid "No matching media"
-msgstr ""
+msgstr "Žádná odpovídající média"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:264
 msgid "No matching passkey found for this account."
-msgstr ""
+msgstr "Pro tento účet nebyl nalezen odpovídající přístupový klíč."
 
 #: packages/admin/src/components/FieldEditor.tsx:474
 #: packages/admin/src/components/FieldEditor.tsx:504
 msgid "No maximum"
-msgstr ""
+msgstr "Bez maxima"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:694
 msgid "No media available from this provider"
-msgstr ""
+msgstr "Od tohoto poskytovatele nejsou k dispozici žádná média"
 
 #: packages/admin/src/components/MediaLibrary.tsx:540
 msgid "No media available from this provider."
-msgstr ""
+msgstr "Od tohoto poskytovatele nejsou k dispozici žádná média."
 
 #: packages/admin/src/components/MediaLibrary.tsx:539
 #: packages/admin/src/components/MediaPickerModal.tsx:688
 msgid "No media found"
-msgstr ""
+msgstr "Nenalezena žádná média"
 
 #: packages/admin/src/components/MenuEditor.tsx:485
 msgid "No menu items yet"
-msgstr ""
+msgstr "Zatím žádné položky nabídky"
 
 #: packages/admin/src/components/MenuList.tsx:189
 msgid "No menus yet"
-msgstr ""
+msgstr "Zatím žádné nabídky"
 
 #: packages/admin/src/components/FieldEditor.tsx:467
 #: packages/admin/src/components/FieldEditor.tsx:497
 msgid "No minimum"
-msgstr ""
+msgstr "Bez minima"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:65
 msgid "No moderation (auto-approve all)"
-msgstr ""
+msgstr "Bez moderace (vše schvalovat automaticky)"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "No parent (top level)"
-msgstr ""
+msgstr "Bez nadřazené položky (nejvyšší úroveň)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:248
 msgid "No passkeys registered"
-msgstr ""
+msgstr "Žádné registrované přístupové klíče"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:168
 msgid "No passkeys registered yet."
-msgstr ""
+msgstr "Zatím nejsou registrovány žádné přístupové klíče."
 
 #: packages/admin/src/components/PluginManager.tsx:200
 msgid "No plugins configured"
-msgstr ""
+msgstr "Nejsou nastaveny žádné pluginy"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:175
 msgid "No plugins found"
-msgstr ""
+msgstr "Nenalezeny žádné pluginy"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:120
 msgid "No plugins have been published to this registry yet."
-msgstr ""
+msgstr "Do tohoto registru zatím nebyly publikovány žádné pluginy."
 
 #: packages/admin/src/components/RegistryBrowse.tsx:119
 msgid "No plugins match \"{debouncedQuery}\"."
-msgstr ""
+msgstr "Dotazu „{debouncedQuery}“ neodpovídají žádné pluginy."
 
 #: packages/admin/src/components/Sections.tsx:343
 msgid "No preview"
-msgstr ""
+msgstr "Bez náhledu"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:304
 msgid "No public URL available"
-msgstr ""
+msgstr "Není k dispozici veřejná URL"
 
 #: packages/admin/src/components/Dashboard.tsx:305
 msgid "No recent activity"
-msgstr ""
+msgstr "Žádná nedávná aktivita"
 
 #: packages/admin/src/components/Redirects.tsx:463
 msgid "No redirects yet"
-msgstr ""
+msgstr "Zatím žádná přesměrování"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1497
 #: packages/admin/src/components/RepeaterField.tsx:374
 msgid "No results"
-msgstr ""
+msgstr "Žádné výsledky"
 
 #: packages/admin/src/components/ContentList.tsx:546
 #: packages/admin/src/components/ContentList.tsx:565
 msgid "No results for \"{activeSearch}\""
-msgstr ""
+msgstr "Žádné výsledky pro „{activeSearch}“"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:178
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
-msgstr ""
+msgstr "Žádné výsledky pro „{debouncedQuery}“. Zkuste jiný výraz."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:465
 msgid "No results found"
-msgstr ""
+msgstr "Nenalezeny žádné výsledky"
 
 #: packages/admin/src/components/RevisionHistory.tsx:201
 msgid "No revisions yet"
-msgstr ""
+msgstr "Zatím žádné revize"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:108
 msgid "No sections available"
-msgstr ""
+msgstr "Nejsou k dispozici žádné sekce"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:102
 #: packages/admin/src/components/Sections.tsx:259
 msgid "No sections found"
-msgstr ""
+msgstr "Nenalezeny žádné sekce"
 
 #: packages/admin/src/components/Sections.tsx:265
 msgid "No sections yet"
-msgstr ""
+msgstr "Zatím žádné sekce"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:549
 msgid "No spam comments."
-msgstr ""
+msgstr "Žádné spamové komentáře."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
 msgid "No themes found"
-msgstr ""
+msgstr "Nenalezeny žádné motivy"
 
 #: packages/admin/src/components/users/UserList.tsx:120
 msgid "No users found matching your filters."
-msgstr ""
+msgstr "Filtrům neodpovídají žádní uživatelé."
 
 #: packages/admin/src/components/users/UserList.tsx:134
 msgid "No users yet."
-msgstr ""
+msgstr "Zatím žádní uživatelé."
 
 #: packages/admin/src/components/Widgets.tsx:504
 msgid "No widget areas yet. Create one to get started."
-msgstr ""
+msgstr "Zatím žádné oblasti widgetů. Začněte vytvořením první."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
 msgid "None"
-msgstr ""
+msgstr "Žádný"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:434
 #: packages/admin/src/components/TaxonomyManager.tsx:443
 msgid "None (top level)"
-msgstr ""
+msgstr "Žádná (nejvyšší úroveň)"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:629
 msgid "Not compatible with this environment"
-msgstr ""
+msgstr "Není kompatibilní s tímto prostředím"
 
 #: packages/admin/src/components/PluginSettings.tsx:341
 msgid "Not set"
-msgstr ""
+msgstr "Nenastaveno"
 
 #: packages/admin/src/components/FieldEditor.tsx:162
 #: packages/admin/src/components/FieldEditor.tsx:581
 msgid "Number"
-msgstr ""
+msgstr "Číslo"
 
 #: packages/admin/src/components/Widgets.tsx:129
 msgid "Number of posts"
-msgstr ""
+msgstr "Počet příspěvků"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:278
 msgid "Number of posts to show per page on list views"
-msgstr ""
+msgstr "Počet příspěvků zobrazených na stránku v seznamech"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:137
 #: packages/admin/src/components/PortableTextEditor.tsx:1182
 #: packages/admin/src/components/PortableTextEditor.tsx:3704
 msgid "Numbered List"
-msgstr ""
+msgstr "Číslovaný seznam"
 
 #: packages/admin/src/components/WordPressImport.tsx:494
 msgid "OAuth authorization requires HTTPS. Please use manual credentials."
-msgstr ""
+msgstr "Autorizace OAuth vyžaduje HTTPS. Použijte prosím ruční přihlašovací údaje."
 
 #: packages/admin/src/components/SeoImageField.tsx:46
 msgid "OG Image"
-msgstr ""
+msgstr "OG obrázek"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
 msgid "on a custom hostname is not treated as secure, even on loopback."
-msgstr ""
+msgstr "na vlastním názvu hostitele není považován za zabezpečený, ani na loopbacku."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
-msgstr ""
+msgstr "Autorizujte pouze kódy, které znáte."
 
 #: packages/admin/src/components/SignupPage.tsx:97
 msgid "Only email addresses from allowed domains can sign up."
-msgstr ""
+msgstr "Zaregistrovat se mohou pouze e-mailové adresy z povolených domén."
 
 #: packages/admin/src/components/MenuList.tsx:162
 msgid "Only lowercase letters, numbers, and hyphens"
-msgstr ""
+msgstr "Pouze malá písmena, číslice a pomlčky"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:106
 msgid "Only the listed MIME types will be accepted for this field."
-msgstr ""
+msgstr "Pro toto pole budou přijaty pouze uvedené typy MIME."
 
 #: packages/admin/src/components/SignupPage.tsx:404
 msgid "Oops!"
-msgstr ""
+msgstr "Jejda!"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:379
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:380
@@ -5602,11 +5610,11 @@ msgstr ""
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:333
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:334
 msgid "Open in new tab"
-msgstr ""
+msgstr "Otevřít na nové kartě"
 
 #: packages/admin/src/components/WordPressImport.tsx:1534
 msgid "Open WordPress Profile"
-msgstr ""
+msgstr "Otevřít profil WordPress"
 
 #: packages/admin/src/components/FieldEditor.tsx:515
 msgid ""
@@ -5614,356 +5622,359 @@ msgid ""
 "Option 2\n"
 "Option 3"
 msgstr ""
+"Možnost 1\n"
+"Možnost 2\n"
+"Možnost 3"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:385
 msgid "Optional caption"
-msgstr ""
+msgstr "Volitelný popisek"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
 msgid "Optional caption displayed below the image"
-msgstr ""
+msgstr "Volitelný popisek zobrazený pod obrázkem"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:384
 msgid "Optional caption for display"
-msgstr ""
+msgstr "Volitelný popisek pro zobrazení"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:459
 msgid "Optional description"
-msgstr ""
+msgstr "Volitelný popis"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:553
 msgid "Optional tooltip on hover"
-msgstr ""
+msgstr "Volitelný popisek při najetí myší"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:302
 #: packages/admin/src/components/FieldEditor.tsx:512
 msgid "Options (one per line)"
-msgstr ""
+msgstr "Možnosti (jedna na řádek)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:579
 msgid "or choose from library"
-msgstr ""
+msgstr "nebo vyberte z knihovny"
 
 #: packages/admin/src/components/WordPressImport.tsx:1590
 msgid "Or click to browse. Accepts .xml files exported from WordPress."
-msgstr ""
+msgstr "Nebo klikněte pro procházení. Přijímá soubory .xml exportované z WordPressu."
 
 #: packages/admin/src/components/WordPressImport.tsx:1071
 msgid "or connect by URL"
-msgstr ""
+msgstr "nebo připojit přes URL"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:97
 #: packages/admin/src/components/LoginPage.tsx:263
 #: packages/admin/src/components/SetupWizard.tsx:310
 msgid "Or continue with"
-msgstr ""
+msgstr "Nebo pokračujte pomocí"
 
 #: packages/admin/src/components/WordPressImport.tsx:1391
 msgid "Or upload an export file"
-msgstr ""
+msgstr "Nebo nahrajte exportní soubor"
 
 #: packages/admin/src/components/WordPressImport.tsx:1107
 msgid "or upload directly"
-msgstr ""
+msgstr "nebo nahrát přímo"
 
 #: packages/admin/src/components/MenuEditor.tsx:227
 msgid "Order saved"
-msgstr ""
+msgstr "Pořadí uloženo"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:369
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
 msgid "Original:"
-msgstr ""
+msgstr "Originál:"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:636
 #: packages/admin/src/components/editor/DocumentOutline.tsx:191
 msgid "Outline"
-msgstr ""
+msgstr "Osnova"
 
 #: packages/admin/src/components/SeoPanel.tsx:164
 msgid "Overrides the page title in search engine results"
-msgstr ""
+msgstr "Přepíše název stránky ve výsledcích vyhledávání"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:550
 #: packages/admin/src/components/ContentSettingsPanel.tsx:553
 msgid "Ownership"
-msgstr ""
+msgstr "Vlastnictví"
 
 #: packages/admin/src/components/PluginManager.tsx:592
 msgid "Package"
-msgstr ""
+msgstr "Balíček"
 
 #: packages/admin/src/router.tsx:2189
 msgid "Page Not Found"
-msgstr ""
+msgstr "Stránka nenalezena"
 
 #: packages/admin/src/components/PluginManager.tsx:402
 #: packages/admin/src/components/WordPressImport.tsx:1328
 msgid "Pages"
-msgstr ""
+msgstr "Stránky"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:57
 msgid "Paragraph"
-msgstr ""
+msgstr "Odstavec"
 
 #: packages/admin/src/components/MenuEditor.tsx:615
 #: packages/admin/src/components/TaxonomyManager.tsx:430
 msgid "Parent"
-msgstr ""
+msgstr "Nadřazená položka"
 
 #: packages/admin/src/components/Redirects.tsx:512
 #: packages/admin/src/components/Redirects.tsx:518
 msgid "Part of a redirect loop"
-msgstr ""
+msgstr "Součást smyčky přesměrování"
 
 #: packages/admin/src/components/WordPressImport.tsx:1153
 msgid "Partial"
-msgstr ""
+msgstr "Částečné"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:324
 msgid "Pass"
-msgstr ""
+msgstr "Prošlo"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:89
 msgid "Passkey added successfully"
-msgstr ""
+msgstr "Přístupový klíč byl přidán"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:129
 msgid "Passkey name"
-msgstr ""
+msgstr "Název přístupového klíče"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
 msgid "Passkey Name (optional)"
-msgstr ""
+msgstr "Název přístupového klíče (volitelné)"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
 msgid "Passkey registered successfully!"
-msgstr ""
+msgstr "Přístupový klíč byl zaregistrován!"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:66
 msgid "Passkey removed"
-msgstr ""
+msgstr "Přístupový klíč odebrán"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:49
 msgid "Passkey renamed"
-msgstr ""
+msgstr "Přístupový klíč přejmenován"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:150
 #: packages/admin/src/components/users/UserList.tsx:110
 msgid "Passkeys"
-msgstr ""
+msgstr "Přístupové klíče"
 
 #. placeholder {0}: user.credentials.length
 #: packages/admin/src/components/users/UserDetail.tsx:245
 msgid "Passkeys ({0})"
-msgstr ""
+msgstr "Přístupové klíče ({0})"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:154
 msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
-msgstr ""
+msgstr "Přístupové klíče jsou bezpečný způsob přihlášení bez hesla. Můžete si zaregistrovat více přístupových klíčů pro různá zařízení."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:77
 #: packages/admin/src/components/SignupPage.tsx:214
 msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
-msgstr ""
+msgstr "Přístupové klíče jsou bezpečný způsob přihlášení bez hesla pomocí biometrie, PIN kódu nebo bezpečnostního klíče vašeho zařízení."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:301
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
 msgid "Passkeys Not Available Here"
-msgstr ""
+msgstr "Přístupové klíče zde nejsou k dispozici"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:305
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
 msgid "Passkeys require a"
-msgstr ""
+msgstr "Přístupové klíče vyžadují"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:158
 msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
-msgstr ""
+msgstr "Přístupové klíče vyžadují HTTPS nebo http://localhost (s vaším portem); tento název hostitele není zabezpečený kontext prohlížeče."
 
 #: packages/admin/src/components/WordPressImport.tsx:1037
 msgid "Paste your migration key"
-msgstr ""
+msgstr "Vložte svůj migrační klíč"
 
 #: packages/admin/src/components/Redirects.tsx:225
 msgid "Path"
-msgstr ""
+msgstr "Cesta"
 
 #: packages/admin/src/components/FieldEditor.tsx:479
 msgid "Pattern (Regex)"
-msgstr ""
+msgstr "Vzor (regulární výraz)"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:435
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr ""
+msgstr "Vzor pro generování URL, např. /blog/{0}"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:431
 msgid "Pattern must include a {0} placeholder"
-msgstr ""
+msgstr "Vzor musí obsahovat zástupný symbol {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:62
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:1185
 msgid "pending"
-msgstr ""
+msgstr "čeká"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:198
 #: packages/admin/src/components/Dashboard.tsx:353
 msgid "Pending"
-msgstr ""
+msgstr "Čeká"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:453
 msgid "Pending changes"
-msgstr ""
+msgstr "Nevyřízené změny"
 
 #: packages/admin/src/components/ContentList.tsx:1119
 msgid "Permanently delete \"{title}\"? This cannot be undone."
-msgstr ""
+msgstr "Trvale smazat „{title}“? Tuto akci nelze vrátit zpět."
 
 #: packages/admin/src/components/ContentList.tsx:1108
 msgid "Permanently delete {title}"
-msgstr ""
+msgstr "Trvale smazat {title}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:284
 msgid "Permissions"
-msgstr ""
+msgstr "Oprávnění"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:46
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
-msgstr ""
+msgstr "Vyberte libovolný způsob vytvoření účtu správce."
 
 #: packages/admin/src/components/Widgets.tsx:154
 msgid "Placeholder text"
-msgstr ""
+msgstr "Zástupný text"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:311
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
 msgid "Plain"
-msgstr ""
+msgstr "Samotné"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:27
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:120
 msgid "Plain text"
-msgstr ""
+msgstr "Prostý text"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:166
 msgid "Please ask your administrator to send a new invite."
-msgstr ""
+msgstr "Požádejte svého správce o zaslání nové pozvánky."
 
 #: packages/admin/src/components/SetupWizard.tsx:181
 msgid "Please enter a valid email"
-msgstr ""
+msgstr "Zadejte platný e-mail"
 
 #: packages/admin/src/components/SignupPage.tsx:55
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "Zadejte platnou e-mailovou adresu"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:442
 msgid "Please enter a valid URL"
-msgstr ""
+msgstr "Zadejte platnou URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1182
 msgid "Plugin"
-msgstr ""
+msgstr "Plugin"
 
 #: packages/admin/src/lib/api/plugins.ts:68
 msgid "Plugin \"{pluginId}\" not found"
-msgstr ""
+msgstr "Plugin „{pluginId}“ nebyl nalezen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:762
 msgid "Plugin details"
-msgstr ""
+msgstr "Podrobnosti pluginu"
 
 #: packages/admin/src/components/PluginManager.tsx:114
 msgid "Plugin disabled"
-msgstr ""
+msgstr "Plugin zakázán"
 
 #: packages/admin/src/components/PluginManager.tsx:95
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Plugin povolen"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:89
 msgid "Plugin Error"
-msgstr ""
+msgstr "Chyba pluginu"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:37
 msgid "Plugin error ({0})"
-msgstr ""
+msgstr "Chyba pluginu ({0})"
 
 #: packages/admin/src/components/PluginManager.tsx:334
 msgid "Plugin MCP access updated"
-msgstr ""
+msgstr "Přístup pluginu k MCP aktualizován"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
 msgid "Plugin MCP Tools"
-msgstr ""
+msgstr "MCP nástroje pluginů"
 
 #: packages/admin/src/lib/api/marketplace.ts:108
 msgid "Plugin MCP tools require explicit consent"
-msgstr ""
+msgstr "MCP nástroje pluginů vyžadují výslovný souhlas"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:123
 msgid "Plugin not found"
-msgstr ""
+msgstr "Plugin nebyl nalezen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:411
 msgid "Plugin not found. The publisher handle or slug may be incorrect."
-msgstr ""
+msgstr "Plugin nebyl nalezen. Identifikátor vydavatele nebo slug může být nesprávný."
 
 #: packages/admin/src/components/WordPressImport.tsx:1209
 msgid "plugin on your WordPress site."
-msgstr ""
+msgstr "plugin na vašem webu WordPress."
 
 #: packages/admin/src/components/PluginManager.tsx:483
 msgid "Plugin pages"
-msgstr ""
+msgstr "Stránky pluginů"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "Plugin Permissions"
-msgstr ""
+msgstr "Oprávnění pluginu"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:71
 msgid "Plugin Registry"
-msgstr ""
+msgstr "Registr pluginů"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginPage.tsx:40
 msgid "Plugin responded with {0}: {text}"
-msgstr ""
+msgstr "Plugin odpověděl s {0}: {text}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:452
 msgid "Plugin tools: {0}"
-msgstr ""
+msgstr "Nástroje pluginů: {0}"
 
 #: packages/admin/src/components/PluginManager.tsx:323
 msgid "Plugin uninstalled"
-msgstr ""
+msgstr "Plugin odinstalován"
 
 #: packages/admin/src/lib/api/registry.ts:810
 msgid "Plugin update requires re-consent"
-msgstr ""
+msgstr "Aktualizace pluginu vyžaduje nový souhlas"
 
 #: packages/admin/src/components/PluginManager.tsx:269
 msgid "Plugin updated"
-msgstr ""
+msgstr "Plugin aktualizován"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
 msgid "Plugin widget error"
-msgstr ""
+msgstr "Chyba widgetu pluginu"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:218
 #: packages/admin/src/components/PluginManager.tsx:139
@@ -5972,106 +5983,106 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:256
 #: packages/admin/src/components/Sidebar.tsx:391
 msgid "Plugins"
-msgstr ""
+msgstr "Pluginy"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:264
 msgid "Point-in-Time Restore"
-msgstr ""
+msgstr "Obnovení k určitému okamžiku"
 
 #: packages/admin/src/components/SeoPanel.tsx:208
 msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
-msgstr ""
+msgstr "Nasměruje vyhledávače na původní verzi této stránky, pokud je duplikátem jiné URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:387
 msgid "Post"
-msgstr ""
+msgstr "Příspěvek"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:395
 #: packages/admin/src/components/WordPressImport.tsx:1322
 msgid "Posts"
-msgstr ""
+msgstr "Příspěvky"
 
 #: packages/admin/src/components/WordPressImport.tsx:1144
 msgid "Posts & Pages"
-msgstr ""
+msgstr "Příspěvky a stránky"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:272
 msgid "Posts Per Page"
-msgstr ""
+msgstr "Příspěvků na stránku"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:478
 msgid "Pre-release"
-msgstr ""
+msgstr "Předběžná verze"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
-msgstr ""
+msgstr "Příprava registrace…"
 
 #: packages/admin/src/components/WordPressImport.tsx:2179
 msgid "Preparing to download files from WordPress..."
-msgstr ""
+msgstr "Příprava stahování souborů z WordPressu…"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:166
 #: packages/admin/src/components/SetupWizard.tsx:233
 msgid "Preparing..."
-msgstr ""
+msgstr "Příprava…"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:158
 #: packages/admin/src/components/ContentTypeEditor.tsx:81
 #: packages/admin/src/components/MediaLibrary.tsx:585
 msgid "Preview"
-msgstr ""
+msgstr "Náhled"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:82
 msgid "Preview content before publishing"
-msgstr ""
+msgstr "Náhled obsahu před publikováním"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:158
 msgid "Preview draft"
-msgstr ""
+msgstr "Náhled konceptu"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
 msgid "Previous"
-msgstr ""
+msgstr "Předchozí"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:353
 #: packages/admin/src/components/ContentList.tsx:606
 msgid "Previous page"
-msgstr ""
+msgstr "Předchozí stránka"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:458
 msgid "Previous screenshot"
-msgstr ""
+msgstr "Předchozí snímek obrazovky"
 
 #: packages/admin/src/components/MenuList.tsx:169
 msgid "Primary Navigation"
-msgstr ""
+msgstr "Hlavní navigace"
 
 #: packages/admin/src/components/Dashboard.tsx:354
 msgid "Private"
-msgstr ""
+msgstr "Soukromé"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:174
 msgid "Provider:"
-msgstr ""
+msgstr "Poskytovatel:"
 
 #: packages/admin/src/components/ContentList.tsx:415
 #: packages/admin/src/components/ContentSettingsPanel.tsx:435
 #: packages/admin/src/components/ContentSettingsPanel.tsx:438
 msgid "Publish"
-msgstr ""
+msgstr "Publikovat"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:189
 msgid "Publish {itemLabel}"
-msgstr ""
+msgstr "Publikovat {itemLabel}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:196
 msgid "Publish updates"
-msgstr ""
+msgstr "Publikovat změny"
 
 #: packages/admin/src/components/ContentList.tsx:1160
 msgid "published"
-msgstr ""
+msgstr "publikováno"
 
 #: packages/admin/src/components/ContentList.tsx:729
 #: packages/admin/src/components/ContentList.tsx:738
@@ -6081,166 +6092,166 @@ msgstr ""
 #: packages/admin/src/components/Dashboard.tsx:350
 #: packages/admin/src/router.tsx:1009
 msgid "Published"
-msgstr ""
+msgstr "Publikováno"
 
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:337
 msgid "Published {0}"
-msgstr ""
+msgstr "Publikováno {0}"
 
 #: packages/admin/src/router.tsx:487
 msgid "Published {total} items"
-msgstr ""
+msgstr "Publikováno {total} položek"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
-msgstr ""
+msgstr "Publikováno dne"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:472
 msgid "Published by"
-msgstr ""
+msgstr "Publikoval"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
-msgstr ""
+msgstr "Python"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:952
 msgid "Quick create byline"
-msgstr ""
+msgstr "Rychle vytvořit autorský podpis"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:196
 #: packages/admin/src/components/editor/ImageNode.tsx:197
 msgid "Quick edit alt text"
-msgstr ""
+msgstr "Rychlá úprava alternativního textu"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:113
 #: packages/admin/src/components/PortableTextEditor.tsx:1192
 #: packages/admin/src/components/PortableTextEditor.tsx:3711
 msgid "Quote"
-msgstr ""
+msgstr "Citace"
 
 #: packages/admin/src/components/WordPressImport.tsx:1162
 msgid "Raw meta"
-msgstr ""
+msgstr "Nezpracovaná metadata"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:67
 msgid "Read collection schemas"
-msgstr ""
+msgstr "Číst schémata kolekcí"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:47
 msgid "Read content entries"
-msgstr ""
+msgstr "Číst položky obsahu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:57
 msgid "Read media files"
-msgstr ""
+msgstr "Číst soubory médií"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:87
 msgid "Read site settings"
-msgstr ""
+msgstr "Číst nastavení webu"
 
 #: packages/admin/src/lib/api/marketplace.ts:284
 #: packages/admin/src/lib/api/marketplace.ts:292
 msgid "Read user accounts"
-msgstr ""
+msgstr "Číst uživatelské účty"
 
 #: packages/admin/src/lib/api/marketplace.ts:279
 #: packages/admin/src/lib/api/marketplace.ts:288
 msgid "Read your content"
-msgstr ""
+msgstr "Číst váš obsah"
 
 #: packages/admin/src/lib/api/marketplace.ts:281
 msgid "Read your taxonomies and terms"
-msgstr ""
+msgstr "Číst vaše taxonomie a termíny"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:269
 msgid "Reading"
-msgstr ""
+msgstr "Čtení"
 
 #: packages/admin/src/components/WordPressImport.tsx:1986
 msgid "Ready"
-msgstr ""
+msgstr "Připraveno"
 
 #: packages/admin/src/components/Dashboard.tsx:299
 msgid "Recent Activity"
-msgstr ""
+msgstr "Nedávná aktivita"
 
 #: packages/admin/src/components/Widgets.tsx:126
 msgid "Recent Posts"
-msgstr ""
+msgstr "Nedávné příspěvky"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:43
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
 msgid "Recently Updated"
-msgstr ""
+msgstr "Nedávno aktualizované"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:118
 msgid "Recipient email"
-msgstr ""
+msgstr "E-mail příjemce"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/users/UserDetail.tsx:336
 msgid "Recovery link sent to {0}"
-msgstr ""
+msgstr "Odkaz pro obnovení odeslán na {0}"
 
 #: packages/admin/src/components/Redirects.tsx:445
 msgid "Redirect loop detected"
-msgstr ""
+msgstr "Zjištěna smyčka přesměrování"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:163
 msgid "Redirecting to login..."
-msgstr ""
+msgstr "Přesměrování na přihlášení…"
 
 #: packages/admin/src/components/Redirects.tsx:359
 #: packages/admin/src/components/Redirects.tsx:380
 #: packages/admin/src/components/Sidebar.tsx:229
 msgid "Redirects"
-msgstr ""
+msgstr "Přesměrování"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3850
 msgid "Redo"
-msgstr ""
+msgstr "Znovu"
 
 #: packages/admin/src/components/FieldEditor.tsx:216
 msgid "Reference"
-msgstr ""
+msgstr "Reference"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:228
 msgid "Referenced favicon unavailable."
-msgstr ""
+msgstr "Odkazovaný favicon není dostupný."
 
 #: packages/admin/src/components/Dashboard.tsx:76
 msgid "Refresh the page or try again."
-msgstr ""
+msgstr "Obnovte stránku nebo to zkuste znovu."
 
 #: packages/admin/src/components/ContentTypeList.tsx:80
 msgid "Register"
-msgstr ""
+msgstr "Zaregistrovat"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
 #: packages/admin/src/components/settings/SecuritySettings.tsx:195
 msgid "Register Passkey"
-msgstr ""
+msgstr "Zaregistrovat přístupový klíč"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:83
 msgid "Registered user"
-msgstr ""
+msgstr "Registrovaný uživatel"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
 msgid "Registration failed"
-msgstr ""
+msgstr "Registrace selhala"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
 msgid "Registration was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "Registrace byla zrušena nebo vypršel časový limit. Zkuste to prosím znovu."
 
 #: packages/admin/src/components/Sidebar.tsx:265
 msgid "Registry"
-msgstr ""
+msgstr "Registr"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:610
 msgid "Release is too new to install"
-msgstr ""
+msgstr "Vydání je příliš nové na instalaci"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
@@ -6253,130 +6264,130 @@ msgstr ""
 #: packages/admin/src/components/settings/PasskeyItem.tsx:207
 #: packages/admin/src/components/settings/SeoSettings.tsx:176
 msgid "Remove"
-msgstr ""
+msgstr "Odebrat"
 
 #. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:186
 #: packages/admin/src/components/TaxonomySidebar.tsx:259
 msgid "Remove {0}"
-msgstr ""
+msgstr "Odebrat {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:145
 msgid "Remove {entry}"
-msgstr ""
+msgstr "Odebrat {entry}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1690
 msgid "Remove {label}"
-msgstr ""
+msgstr "Odebrat {label}"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:397
 msgid "Remove Domain"
-msgstr ""
+msgstr "Odebrat doménu"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
 msgid "Remove Domain?"
-msgstr ""
+msgstr "Odebrat doménu?"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:141
 #: packages/admin/src/components/ImageFieldRenderer.tsx:170
 #: packages/admin/src/components/SeoImageField.tsx:61
 msgid "Remove image"
-msgstr ""
+msgstr "Odebrat obrázek"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:392
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:582
 msgid "Remove Image"
-msgstr ""
+msgstr "Odebrat obrázek"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:320
 msgid "Remove image {0}"
-msgstr ""
+msgstr "Odebrat obrázek {0}"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
 msgid "Remove Image?"
-msgstr ""
+msgstr "Odebrat obrázek?"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:2064
 #: packages/admin/src/components/RepeaterField.tsx:275
 msgid "Remove item {0}"
-msgstr ""
+msgstr "Odebrat položku {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3251
 #: packages/admin/src/components/PortableTextEditor.tsx:3252
 msgid "Remove link"
-msgstr ""
+msgstr "Odebrat odkaz"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:186
 msgid "Remove passkey"
-msgstr ""
+msgstr "Odebrat přístupový klíč"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:201
 msgid "Remove passkey?"
-msgstr ""
+msgstr "Odebrat přístupový klíč?"
 
 #: packages/admin/src/components/FieldEditor.tsx:611
 msgid "Remove sub-field"
-msgstr ""
+msgstr "Odebrat podřazené pole"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:198
 msgid "Remove this image from the document?"
-msgstr ""
+msgstr "Odebrat tento obrázek z dokumentu?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:200
 #: packages/admin/src/components/settings/PasskeyItem.tsx:208
 msgid "Removing..."
-msgstr ""
+msgstr "Odebírání…"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:174
 msgid "Rename"
-msgstr ""
+msgstr "Přejmenovat"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:175
 msgid "Rename {0}"
-msgstr ""
+msgstr "Přejmenovat {0}"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:175
 msgid "Rename passkey"
-msgstr ""
+msgstr "Přejmenovat přístupový klíč"
 
 #: packages/admin/src/components/FieldEditor.tsx:240
 msgid "Repeater"
-msgstr ""
+msgstr "Opakovač"
 
 #: packages/admin/src/components/FieldEditor.tsx:241
 msgid "Repeating group of fields"
-msgstr ""
+msgstr "Opakující se skupina polí"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:363
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:396
 msgid "Replace image"
-msgstr ""
+msgstr "Nahradit obrázek"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:435
 msgid "Replace Image"
-msgstr ""
+msgstr "Nahradit obrázek"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:117
 msgid "Reply to:"
-msgstr ""
+msgstr "Odpověď na:"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
 msgid "Repository"
-msgstr ""
+msgstr "Repozitář"
 
 #: packages/admin/src/components/SignupPage.tsx:274
 msgid "Request a new link"
-msgstr ""
+msgstr "Požádat o nový odkaz"
 
 #: packages/admin/src/lib/api/client.ts:226
 msgid "Request failed"
-msgstr ""
+msgstr "Požadavek selhal"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:280
 #: packages/admin/src/components/ContentTypeEditor.tsx:730
@@ -6384,64 +6395,64 @@ msgstr ""
 #: packages/admin/src/components/FieldEditor.tsx:593
 #: packages/admin/src/routes/byline-schema.tsx:246
 msgid "Required"
-msgstr ""
+msgstr "Povinné"
 
 #: packages/admin/src/components/WordPressImport.tsx:1999
 msgid "Required fields:"
-msgstr ""
+msgstr "Povinná pole:"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
 msgid "Required for accessibility. Describes the image for screen readers."
-msgstr ""
+msgstr "Povinné pro přístupnost. Popisuje obrázek pro čtečky obrazovky."
 
 #. placeholder {0}: latest.minEmDashVersion
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:335
 msgid "Requires EmDash {0}"
-msgstr ""
+msgstr "Vyžaduje EmDash {0}"
 
 #: packages/admin/src/components/SignupPage.tsx:155
 msgid "Resend email"
-msgstr ""
+msgstr "Odeslat e-mail znovu"
 
 #: packages/admin/src/components/SignupPage.tsx:154
 msgid "Resend in {resendCooldown}s"
-msgstr ""
+msgstr "Znovu odeslat za {resendCooldown} s"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:277
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
 msgid "Reset to original"
-msgstr ""
+msgstr "Obnovit původní"
 
 #: packages/admin/src/components/RevisionHistory.tsx:238
 msgid "Restore"
-msgstr ""
+msgstr "Obnovit"
 
 #: packages/admin/src/components/ContentList.tsx:1096
 msgid "Restore {title}"
-msgstr ""
+msgstr "Obnovit {title}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:135
 msgid "Restore failed"
-msgstr ""
+msgstr "Obnovení selhalo"
 
 #: packages/admin/src/components/RevisionHistory.tsx:232
 msgid "Restore Revision?"
-msgstr ""
+msgstr "Obnovit revizi?"
 
 #: packages/admin/src/components/RevisionHistory.tsx:299
 #: packages/admin/src/components/RevisionHistory.tsx:300
 msgid "Restore this version"
-msgstr ""
+msgstr "Obnovit tuto verzi"
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
 #: packages/admin/src/components/RevisionHistory.tsx:235
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
-msgstr ""
+msgstr "Obnovit tuto verzi z {0}? Aktuální obsah bude nahrazen daty této revize."
 
 #: packages/admin/src/components/RevisionHistory.tsx:239
 msgid "Restoring..."
-msgstr ""
+msgstr "Obnovování..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:143
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:44
@@ -6449,103 +6460,103 @@ msgstr ""
 #: packages/admin/src/router.tsx:2177
 #: packages/admin/src/routes/byline-schema.tsx:280
 msgid "Retry"
-msgstr ""
+msgstr "Zkusit znovu"
 
 #: packages/admin/src/components/Sections.tsx:136
 msgid "Reusable content blocks you can insert into any content"
-msgstr ""
+msgstr "Znovupoužitelné bloky obsahu, které lze vložit do libovolného obsahu"
 
 #: packages/admin/src/router.tsx:1047
 msgid "Reverted to published version"
-msgstr ""
+msgstr "Vráceno na publikovanou verzi"
 
 #: packages/admin/src/components/WordPressImport.tsx:724
 msgid "Review"
-msgstr ""
+msgstr "Kontrola"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "Review New Permissions"
-msgstr ""
+msgstr "Zkontrolovat nová oprávnění"
 
 #: packages/admin/src/components/RevisionHistory.tsx:129
 msgid "Revision restored"
-msgstr ""
+msgstr "Revize obnovena"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:644
 #: packages/admin/src/components/ContentTypeEditor.tsx:76
 #: packages/admin/src/components/RevisionHistory.tsx:168
 msgid "Revisions"
-msgstr ""
+msgstr "Revize"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:344
 msgid "Revoke token"
-msgstr ""
+msgstr "Odvolat token"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:319
 msgid "Revoke?"
-msgstr ""
+msgstr "Odvolat?"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
 msgid "Revoking..."
-msgstr ""
+msgstr "Odvolávání..."
 
 #: packages/admin/src/components/FieldEditor.tsx:198
 msgid "Rich Text"
-msgstr ""
+msgstr "Formátovaný text"
 
 #: packages/admin/src/components/Widgets.tsx:99
 msgid "Rich text content"
-msgstr ""
+msgstr "Formátovaný textový obsah"
 
 #: packages/admin/src/components/FieldEditor.tsx:199
 msgid "Rich text editor"
-msgstr ""
+msgstr "Editor formátovaného textu"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
 msgid "Right"
-msgstr ""
+msgstr "Vpravo"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:322
 msgid "Risk score: {0}/100"
-msgstr ""
+msgstr "Skóre rizika: {0}/100"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:164
 #: packages/admin/src/components/users/UserDetail.tsx:169
 #: packages/admin/src/components/users/UserDetail.tsx:181
 #: packages/admin/src/components/users/UserList.tsx:101
 msgid "Role"
-msgstr ""
+msgstr "Role"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
-msgstr ""
+msgstr "Role {role}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:926
 msgid "Role label"
-msgstr ""
+msgstr "Označení role"
 
 #. placeholder {0}: tool.route
 #. placeholder {1}: tool.permission
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:149
 #: packages/admin/src/components/PluginManager.tsx:568
 msgid "Route: {0} · Permission: {1}"
-msgstr ""
+msgstr "Cesta: {0} · Oprávnění: {1}"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
-msgstr ""
+msgstr "Ruby"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:49
 msgid "Rust"
-msgstr ""
+msgstr "Rust"
 
 #: packages/admin/src/components/MenuEditor.tsx:430
 #: packages/admin/src/components/MenuEditor.tsx:432
 #: packages/admin/src/components/MenuEditor.tsx:609
 #: packages/admin/src/components/MenuEditor.tsx:611
 msgid "Same window"
-msgstr ""
+msgstr "Stejné okno"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1059
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:395
@@ -6560,57 +6571,57 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:983
 #: packages/admin/src/routes/bylines.tsx:579
 msgid "Save"
-msgstr ""
+msgstr "Uložit"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:416
 msgid "Save (Enter)"
-msgstr ""
+msgstr "Uložit (Enter)"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:265
 msgid "Save alt text"
-msgstr ""
+msgstr "Uložit alternativní text"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Save changes"
-msgstr ""
+msgstr "Uložit změny"
 
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Save Changes"
-msgstr ""
+msgstr "Uložit změny"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:72
 msgid "Save content as draft before publishing"
-msgstr ""
+msgstr "Uložit obsah jako koncept před publikováním"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:137
 msgid "Save name"
-msgstr ""
+msgstr "Uložit název"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:111
 #: packages/admin/src/components/settings/SeoSettings.tsx:218
 msgid "Save SEO Settings"
-msgstr ""
+msgstr "Uložit nastavení SEO"
 
 #: packages/admin/src/components/PluginSettings.tsx:166
 #: packages/admin/src/components/PluginSettings.tsx:209
 #: packages/admin/src/components/settings/GeneralSettings.tsx:120
 #: packages/admin/src/components/settings/GeneralSettings.tsx:298
 msgid "Save Settings"
-msgstr ""
+msgstr "Uložit nastavení"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:91
 #: packages/admin/src/components/settings/SocialSettings.tsx:147
 msgid "Save Social Links"
-msgstr ""
+msgstr "Uložit odkazy na sociální sítě"
 
 #: packages/admin/src/components/SaveButton.tsx:34
 msgid "Saved"
-msgstr ""
+msgstr "Uloženo"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:116
 msgid "Saved \"{0}\"."
-msgstr ""
+msgstr "Uloženo „{0}“."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1059
 #: packages/admin/src/components/FieldEditor.tsx:660
@@ -6632,73 +6643,73 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:983
 #: packages/admin/src/routes/bylines.tsx:579
 msgid "Saving..."
-msgstr ""
+msgstr "Ukládání..."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Saving…"
-msgstr ""
+msgstr "Ukládání…"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:482
 msgid "SBOM"
-msgstr ""
+msgstr "SBOM"
 
 #. placeholder {0}: sbom.format
 #: packages/admin/src/components/RegistryPluginDetail.tsx:480
 msgid "SBOM · {0}"
-msgstr ""
+msgstr "SBOM · {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:501
 msgid "Schedule"
-msgstr ""
+msgstr "Naplánovat"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:487
 msgid "Schedule for"
-msgstr ""
+msgstr "Naplánovat na"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:524
 msgid "Schedule for later"
-msgstr ""
+msgstr "Naplánovat na později"
 
 #: packages/admin/src/components/ContentList.tsx:1164
 msgid "scheduled"
-msgstr ""
+msgstr "naplánováno"
 
 #: packages/admin/src/components/ContentList.tsx:731
 #: packages/admin/src/components/ContentSettingsPanel.tsx:455
 #: packages/admin/src/components/Dashboard.tsx:352
 #: packages/admin/src/router.tsx:1067
 msgid "Scheduled"
-msgstr ""
+msgstr "Naplánováno"
 
 #. placeholder {0}: formatScheduledDate(item.scheduledAt)
 #: packages/admin/src/components/ContentSettingsPanel.tsx:475
 msgid "Scheduled for: {0}"
-msgstr ""
+msgstr "Naplánováno na: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2322
 msgid "Schema Changes"
-msgstr ""
+msgstr "Změny schématu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1699
 msgid "Schema preparation failed"
-msgstr ""
+msgstr "Příprava schématu selhala"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
 msgid "Schema Read"
-msgstr ""
+msgstr "Čtení schématu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
 msgid "Schema Write"
-msgstr ""
+msgstr "Zápis schématu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:429
 msgid "Scopes"
-msgstr ""
+msgstr "Rozsahy"
 
 #. placeholder {0}: token.scopes.join(", ")
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:295
 msgid "Scopes: {0}"
-msgstr ""
+msgstr "Rozsahy: {0}"
 
 #. placeholder {0}: i + 1
 #. placeholder {0}: index + 1
@@ -6707,370 +6718,370 @@ msgstr ""
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
 msgid "Screenshot {0}"
-msgstr ""
+msgstr "Snímek obrazovky {0}"
 
 #. placeholder {0}: index + 1
 #. placeholder {1}: screenshots.length
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:466
 msgid "Screenshot {0} of {1}"
-msgstr ""
+msgstr "Snímek obrazovky {0} z {1}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:257
 msgid "Screenshot blurred due to image audit"
-msgstr ""
+msgstr "Snímek obrazovky je rozmazaný kvůli kontrole obrázků"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:444
 msgid "Screenshot viewer"
-msgstr ""
+msgstr "Prohlížeč snímků obrazovky"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:244
 #: packages/admin/src/components/RegistryPluginDetail.tsx:649
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
 msgid "Screenshots"
-msgstr ""
+msgstr "Snímky obrazovky"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:50
 msgid "SCSS"
-msgstr ""
+msgstr "SCSS"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 #: packages/admin/src/components/Widgets.tsx:151
 msgid "Search"
-msgstr ""
+msgstr "Hledání"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:353
 msgid "Search {0}"
-msgstr ""
+msgstr "Hledat {0}"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:352
 msgid "Search {0}..."
-msgstr ""
+msgstr "Hledat {0}..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:415
 #: packages/admin/src/components/MediaPickerModal.tsx:626
 msgid "Search by filename..."
-msgstr ""
+msgstr "Hledat podle názvu souboru..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
-msgstr ""
+msgstr "Hledat podle jména nebo e-mailu..."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:853
 #: packages/admin/src/routes/bylines.tsx:401
 msgid "Search bylines"
-msgstr ""
+msgstr "Hledat autorské podpisy"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:852
 msgid "Search bylines to add..."
-msgstr ""
+msgstr "Hledat autorské podpisy k přidání..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:164
 msgid "Search comments"
-msgstr ""
+msgstr "Hledat komentáře"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:163
 msgid "Search comments..."
-msgstr ""
+msgstr "Hledat komentáře..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:141
 msgid "Search content..."
-msgstr ""
+msgstr "Hledat obsah..."
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:122
 msgid "Search Engine Optimization"
-msgstr ""
+msgstr "Optimalizace pro vyhledávače"
 
 #: packages/admin/src/components/Settings.tsx:83
 msgid "Search engine optimization and verification"
-msgstr ""
+msgstr "Optimalizace pro vyhledávače a ověření"
 
 #: packages/admin/src/components/Widgets.tsx:152
 msgid "Search form"
-msgstr ""
+msgstr "Vyhledávací formulář"
 
 #: packages/admin/src/components/MediaLibrary.tsx:416
 #: packages/admin/src/components/MediaPickerModal.tsx:627
 msgid "Search media"
-msgstr ""
+msgstr "Hledat média"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:438
 msgid "Search pages and content..."
-msgstr ""
+msgstr "Hledat stránky a obsah..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:103
 #: packages/admin/src/components/RegistryBrowse.tsx:87
 msgid "Search plugins"
-msgstr ""
+msgstr "Hledat pluginy"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:99
 #: packages/admin/src/components/RegistryBrowse.tsx:83
 msgid "Search plugins..."
-msgstr ""
+msgstr "Hledat pluginy..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:82
 #: packages/admin/src/components/Sections.tsx:226
 msgid "Search sections..."
-msgstr ""
+msgstr "Hledat sekce..."
 
 #: packages/admin/src/components/Redirects.tsx:412
 msgid "Search source or destination..."
-msgstr ""
+msgstr "Hledat zdroj nebo cíl..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
 msgid "Search themes"
-msgstr ""
+msgstr "Hledat motivy"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
 msgid "Search themes..."
-msgstr ""
+msgstr "Hledat motivy..."
 
 #: packages/admin/src/components/users/UserList.tsx:73
 msgid "Search users"
-msgstr ""
+msgstr "Hledat uživatele"
 
 #: packages/admin/src/components/MediaLibrary.tsx:415
 #: packages/admin/src/components/MediaPickerModal.tsx:626
 msgid "Search..."
-msgstr ""
+msgstr "Hledat..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:732
 #: packages/admin/src/components/FieldEditor.tsx:452
 msgid "Searchable"
-msgstr ""
+msgstr "Prohledávatelné"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:857
 msgid "Searching..."
-msgstr ""
+msgstr "Hledání..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2457
 msgid "Section"
-msgstr ""
+msgstr "Sekce"
 
 #: packages/admin/src/components/SectionEditor.tsx:83
 msgid "Section \"{slug}\" could not be found."
-msgstr ""
+msgstr "Sekci „{slug}“ se nepodařilo najít."
 
 #: packages/admin/src/components/Sections.tsx:93
 msgid "Section created"
-msgstr ""
+msgstr "Sekce vytvořena"
 
 #: packages/admin/src/components/Sections.tsx:107
 msgid "Section deleted"
-msgstr ""
+msgstr "Sekce smazána"
 
 #: packages/admin/src/components/SectionEditor.tsx:248
 msgid "Section Details"
-msgstr ""
+msgstr "Podrobnosti sekce"
 
 #: packages/admin/src/components/SectionEditor.tsx:79
 msgid "Section Not Found"
-msgstr ""
+msgstr "Sekce nenalezena"
 
 #: packages/admin/src/components/SectionEditor.tsx:254
 msgid "Section title"
-msgstr ""
+msgstr "Název sekce"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:176
 #: packages/admin/src/components/Sections.tsx:134
 #: packages/admin/src/components/Sidebar.tsx:234
 msgid "Sections"
-msgstr ""
+msgstr "Sekce"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:306
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
 msgid "secure context"
-msgstr ""
+msgstr "zabezpečený kontext"
 
 #: packages/admin/src/components/SetupWizard.tsx:561
 msgid "Secure your account"
-msgstr ""
+msgstr "Zabezpečení účtu"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:809
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Security"
-msgstr ""
+msgstr "Zabezpečení"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:318
 msgid "Security Audit"
-msgstr ""
+msgstr "Bezpečnostní audit"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:342
 msgid "Security audit failed"
-msgstr ""
+msgstr "Bezpečnostní audit selhal"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:332
 msgid "Security audit flagged concerns"
-msgstr ""
+msgstr "Bezpečnostní audit označil rizika"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:179
 msgid "Security audit flagged potential concerns with this plugin."
-msgstr ""
+msgstr "Bezpečnostní audit u tohoto pluginu označil možná rizika."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:180
 msgid "Security audit flagged this plugin as potentially unsafe."
-msgstr ""
+msgstr "Bezpečnostní audit označil tento plugin jako potenciálně nebezpečný."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:321
 msgid "Security audit passed"
-msgstr ""
+msgstr "Bezpečnostní audit proběhl úspěšně"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:718
 msgid "Security contacts"
-msgstr ""
+msgstr "Bezpečnostní kontakty"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:270
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
 msgid "Security error. Make sure you're on a secure connection."
-msgstr ""
+msgstr "Chyba zabezpečení. Ujistěte se, že používáte zabezpečené připojení."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:242
 #: packages/admin/src/components/Header.tsx:93
 #: packages/admin/src/components/settings/SecuritySettings.tsx:95
 msgid "Security Settings"
-msgstr ""
+msgstr "Nastavení zabezpečení"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:56
 #: packages/admin/src/components/FieldEditor.tsx:186
 #: packages/admin/src/components/FieldEditor.tsx:585
 msgid "Select"
-msgstr ""
+msgstr "Vybrat"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
 #: packages/admin/src/components/ContentEditor.tsx:1702
 #: packages/admin/src/components/ContentEditor.tsx:1718
 #: packages/admin/src/components/ImageFieldRenderer.tsx:198
 msgid "Select {label}"
-msgstr ""
+msgstr "Vybrat {label}"
 
 #: packages/admin/src/components/ContentList.tsx:973
 msgid "Select {title}"
-msgstr ""
+msgstr "Vybrat {title}"
 
 #: packages/admin/src/components/Widgets.tsx:956
 msgid "Select a component..."
-msgstr ""
+msgstr "Vybrat komponentu..."
 
 #: packages/admin/src/components/Widgets.tsx:919
 msgid "Select a menu..."
-msgstr ""
+msgstr "Vybrat nabídku..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:284
 msgid "Select all"
-msgstr ""
+msgstr "Vybrat vše"
 
 #: packages/admin/src/components/ContentList.tsx:497
 msgid "Select all on this page"
-msgstr ""
+msgstr "Vybrat vše na této stránce"
 
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:457
 msgid "Select comment by {0}"
-msgstr ""
+msgstr "Vybrat komentář od {0}"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:117
 msgid "Select Content"
-msgstr ""
+msgstr "Vybrat obsah"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:235
 msgid "Select Default Social Image"
-msgstr ""
+msgstr "Vybrat výchozí obrázek pro sociální sítě"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:260
 #: packages/admin/src/components/settings/GeneralSettings.tsx:321
 msgid "Select Favicon"
-msgstr ""
+msgstr "Vybrat favicon"
 
 #: packages/admin/src/components/ContentEditor.tsx:1706
 msgid "Select file"
-msgstr ""
+msgstr "Vybrat soubor"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:150
 msgid "Select File"
-msgstr ""
+msgstr "Vybrat soubor"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3094
 msgid "Select Gallery Images"
-msgstr ""
+msgstr "Vybrat obrázky galerie"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:186
 msgid "Select image"
-msgstr ""
+msgstr "Vybrat obrázek"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:150
 #: packages/admin/src/components/PortableTextEditor.tsx:3080
 #: packages/admin/src/components/settings/SeoSettings.tsx:188
 msgid "Select Image"
-msgstr ""
+msgstr "Vybrat obrázek"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:206
 #: packages/admin/src/components/settings/GeneralSettings.tsx:313
 msgid "Select Logo"
-msgstr ""
+msgstr "Vybrat logo"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
 msgid "Select media"
-msgstr ""
+msgstr "Vybrat média"
 
 #: packages/admin/src/components/SeoImageField.tsx:76
 msgid "Select OG image"
-msgstr ""
+msgstr "Vybrat OG obrázek"
 
 #: packages/admin/src/components/SeoImageField.tsx:85
 msgid "Select OG Image"
-msgstr ""
+msgstr "Vybrat OG obrázek"
 
 #: packages/admin/src/components/WordPressImport.tsx:1732
 msgid "Select which content types to import."
-msgstr ""
+msgstr "Vyberte typy obsahu, které se mají importovat."
 
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:108
 #: packages/admin/src/components/PortableTextEditor.tsx:2159
 #: packages/admin/src/components/RepeaterField.tsx:372
 msgid "Select..."
-msgstr ""
+msgstr "Vybrat..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1488
 msgid "Selected {selectedItemTitle}"
-msgstr ""
+msgstr "Vybráno {selectedItemTitle}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:795
 msgid "Selected:"
-msgstr ""
+msgstr "Vybráno:"
 
 #: packages/admin/src/components/Settings.tsx:99
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:152
 msgid "Self-Signup Domains"
-msgstr ""
+msgstr "Domény pro samoregistraci"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:113
 msgid "Send a test email through the full pipeline to verify your email configuration."
-msgstr ""
+msgstr "Odešlete testovací e-mail celým řetězcem a ověřte tak nastavení e-mailu."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr ""
+msgstr "Odeslat pozvánku e-mailem novému členovi týmu."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:201
 msgid "Send Invite"
-msgstr ""
+msgstr "Odeslat pozvánku"
 
 #: packages/admin/src/components/LoginPage.tsx:150
 msgid "Send magic link"
-msgstr ""
+msgstr "Odeslat magický odkaz"
 
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Send Recovery Link"
-msgstr ""
+msgstr "Odeslat odkaz pro obnovení"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:127
 msgid "Send Test"
-msgstr ""
+msgstr "Odeslat test"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:110
 msgid "Send Test Email"
-msgstr ""
+msgstr "Odeslat testovací e-mail"
 
 #: packages/admin/src/components/LoginPage.tsx:150
 #: packages/admin/src/components/settings/EmailSettings.tsx:127
@@ -7079,62 +7090,62 @@ msgstr ""
 #: packages/admin/src/components/users/InviteUserModal.tsx:201
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Sending..."
-msgstr ""
+msgstr "Odesílání..."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:621
 #: packages/admin/src/components/ContentSettingsPanel.tsx:624
 #: packages/admin/src/components/ContentTypeEditor.tsx:472
 #: packages/admin/src/components/Settings.tsx:82
 msgid "SEO"
-msgstr ""
+msgstr "SEO"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:90
 #: packages/admin/src/components/settings/SeoSettings.tsx:115
 msgid "SEO Settings"
-msgstr ""
+msgstr "Nastavení SEO"
 
 #: packages/admin/src/components/WordPressImport.tsx:1843
 msgid "SEO settings (Yoast)"
-msgstr ""
+msgstr "Nastavení SEO (Yoast)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:40
 msgid "SEO settings saved"
-msgstr ""
+msgstr "Nastavení SEO uloženo"
 
 #: packages/admin/src/components/SeoPanel.tsx:168
 #: packages/admin/src/components/SeoPanel.tsx:172
 msgid "SEO Title"
-msgstr ""
+msgstr "SEO titulek"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:316
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:505
 msgid "Set a custom display size for this image instance."
-msgstr ""
+msgstr "Nastavte vlastní velikost zobrazení pro tuto instanci obrázku."
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:146
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:150
 msgid "Set language"
-msgstr ""
+msgstr "Nastavit jazyk"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:147
 msgid "Set language (current: {label})"
-msgstr ""
+msgstr "Nastavit jazyk (aktuální: {label})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:529
 msgid "Set to 0 to never close comments automatically."
-msgstr ""
+msgstr "Nastavte 0, pokud se komentáře nemají nikdy automaticky zavírat."
 
 #: packages/admin/src/components/ContentList.tsx:425
 msgid "Set to draft"
-msgstr ""
+msgstr "Nastavit jako koncept"
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
-msgstr ""
+msgstr "Nastavení webu"
 
 #: packages/admin/src/components/SetupWizard.tsx:150
 msgid "Setting up..."
-msgstr ""
+msgstr "Nastavování..."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:234
 #: packages/admin/src/components/ContentEditor.tsx:809
@@ -7146,178 +7157,178 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:294
 #: packages/admin/src/components/WordPressImport.tsx:1811
 msgid "Settings"
-msgstr ""
+msgstr "Nastavení"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
 msgid "Settings Manage"
-msgstr ""
+msgstr "Nastavení – správa"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
 msgid "Settings Read"
-msgstr ""
+msgstr "Nastavení – čtení"
 
 #: packages/admin/src/components/PluginSettings.tsx:68
 #: packages/admin/src/components/settings/GeneralSettings.tsx:43
 msgid "Settings saved successfully"
-msgstr ""
+msgstr "Nastavení bylo uloženo"
 
 #: packages/admin/src/components/SetupWizard.tsx:468
 msgid "Setup failed"
-msgstr ""
+msgstr "Nastavení selhalo"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
-msgstr ""
+msgstr "Sdílejte tento odkaz s pozvaným uživatelem"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:294
 msgid "Shared across all translations of the same byline."
-msgstr ""
+msgstr "Sdíleno napříč všemi překlady téhož autorského podpisu."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:52
 msgid "Short text"
-msgstr ""
+msgstr "Krátký text"
 
 #: packages/admin/src/components/FieldEditor.tsx:150
 #: packages/admin/src/components/FieldEditor.tsx:579
 msgid "Short Text"
-msgstr ""
+msgstr "Krátký text"
 
 #: packages/admin/src/components/Widgets.tsx:146
 msgid "Show count"
-msgstr ""
+msgstr "Zobrazit počet"
 
 #: packages/admin/src/components/Widgets.tsx:131
 msgid "Show date"
-msgstr ""
+msgstr "Zobrazit datum"
 
 #: packages/admin/src/components/Widgets.tsx:139
 msgid "Show hierarchy"
-msgstr ""
+msgstr "Zobrazit hierarchii"
 
 #: packages/admin/src/components/Widgets.tsx:138
 msgid "Show post count"
-msgstr ""
+msgstr "Zobrazit počet příspěvků"
 
 #: packages/admin/src/components/Widgets.tsx:130
 msgid "Show thumbnails"
-msgstr ""
+msgstr "Zobrazit náhledy"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:220
 msgid "Show token"
-msgstr ""
+msgstr "Zobrazit token"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:365
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:554
 msgid "Shown when hovering over the image."
-msgstr ""
+msgstr "Zobrazí se při najetí myší na obrázek."
 
 #: packages/admin/src/components/SignupPage.tsx:441
 msgid "Sign in"
-msgstr ""
+msgstr "Přihlásit se"
 
 #: packages/admin/src/components/SetupWizard.tsx:355
 msgid "Sign In"
-msgstr ""
+msgstr "Přihlásit se"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:162
 #: packages/admin/src/components/SignupPage.tsx:270
 msgid "Sign in instead"
-msgstr ""
+msgstr "Raději se přihlásit"
 
 #: packages/admin/src/components/LoginPage.tsx:234
 msgid "Sign in to your site"
-msgstr ""
+msgstr "Přihlaste se ke svému webu"
 
 #. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
 #. placeholder {0}: provider.label
 #: packages/admin/src/components/LoginPage.tsx:233
 #: packages/admin/src/components/SetupWizard.tsx:264
 msgid "Sign in with {0}"
-msgstr ""
+msgstr "Přihlásit se pomocí {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:231
 msgid "Sign in with email"
-msgstr ""
+msgstr "Přihlásit se e-mailem"
 
 #: packages/admin/src/components/LoginPage.tsx:292
 msgid "Sign in with email link"
-msgstr ""
+msgstr "Přihlásit se odkazem v e-mailu"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:254
 msgid "Sign in with Passkey"
-msgstr ""
+msgstr "Přihlásit se přístupovým klíčem"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:190
 msgid "Signed in as {0}"
-msgstr ""
+msgstr "Přihlášen jako {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:187
 msgid "Single choice from options"
-msgstr ""
+msgstr "Jedna volba z možností"
 
 #: packages/admin/src/components/FieldEditor.tsx:151
 msgid "Single line text input"
-msgstr ""
+msgstr "Jednořádkové textové pole"
 
 #: packages/admin/src/components/SetupWizard.tsx:353
 msgid "Site"
-msgstr ""
+msgstr "Web"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:130
 msgid "Site Identity"
-msgstr ""
+msgstr "Identita webu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2270
 msgid "site identity applied (title, tagline, logo)"
-msgstr ""
+msgstr "identita webu použita (titulek, podtitulek, logo)"
 
 #: packages/admin/src/components/Settings.tsx:71
 msgid "Site identity, logo, favicon, and reading preferences"
-msgstr ""
+msgstr "Identita webu, logo, favicon a předvolby čtení"
 
 #: packages/admin/src/components/SetupWizard.tsx:351
 #: packages/admin/src/components/WordPressImport.tsx:1151
 msgid "Site Settings"
-msgstr ""
+msgstr "Nastavení webu"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:133
 #: packages/admin/src/components/SetupWizard.tsx:116
 msgid "Site Title"
-msgstr ""
+msgstr "Název webu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1823
 msgid "Site title & tagline"
-msgstr ""
+msgstr "Název a podtitulek webu"
 
 #: packages/admin/src/components/SetupWizard.tsx:100
 msgid "Site title is required"
-msgstr ""
+msgstr "Název webu je povinný"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:145
 msgid "Site URL"
-msgstr ""
+msgstr "URL webu"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:267
 msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
-msgstr ""
+msgstr "Weby na Cloudflare D1 mohou navíc obnovit databázi k libovolné minutě za posledních 30 dní pomocí D1 Time Travel — vždy zapnuto, bez nutnosti nastavení."
 
 #: packages/admin/src/components/MediaLibrary.tsx:588
 msgid "Size"
-msgstr ""
+msgstr "Velikost"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:274
 msgid "Size:"
-msgstr ""
+msgstr "Velikost:"
 
 #: packages/admin/src/components/WordPressImport.tsx:2104
 msgid "Skip Media Import"
-msgstr ""
+msgstr "Přeskočit import médií"
 
 #: packages/admin/src/components/WordPressImport.tsx:2129
 msgid "Skipped"
-msgstr ""
+msgstr "Přeskočeno"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:239
 #: packages/admin/src/components/ContentSettingsPanel.tsx:442
@@ -7334,62 +7345,62 @@ msgstr ""
 #: packages/admin/src/routes/byline-schema.tsx:237
 #: packages/admin/src/routes/bylines.tsx:486
 msgid "Slug"
-msgstr ""
+msgstr "Slug"
 
 #: packages/admin/src/components/Sections.tsx:124
 msgid "Slug copied to clipboard"
-msgstr ""
+msgstr "Slug zkopírován do schránky"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:251
 msgid "Slugs cannot be changed after the field is created."
-msgstr ""
+msgstr "Slug nelze po vytvoření pole změnit."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1133
 msgid "Small section heading"
-msgstr ""
+msgstr "Malý nadpis sekce"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1143
 msgid "Smaller section heading"
-msgstr ""
+msgstr "Menší nadpis sekce"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1163
 msgid "Smallest section heading"
-msgstr ""
+msgstr "Nejmenší nadpis sekce"
 
 #: packages/admin/src/components/Settings.tsx:76
 #: packages/admin/src/components/settings/SocialSettings.tsx:70
 #: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Social Links"
-msgstr ""
+msgstr "Odkazy na sociální sítě"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:38
 msgid "Social links saved"
-msgstr ""
+msgstr "Odkazy na sociální sítě uloženy"
 
 #: packages/admin/src/components/Settings.tsx:77
 msgid "Social media profile links"
-msgstr ""
+msgstr "Odkazy na profily na sociálních sítích"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:100
 msgid "Social Profiles"
-msgstr ""
+msgstr "Profily na sociálních sítích"
 
 #: packages/admin/src/components/WordPressImport.tsx:1860
 msgid "Some content types cannot be imported"
-msgstr ""
+msgstr "Některé typy obsahu nelze importovat"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:155
 #: packages/admin/src/components/SignupPage.tsx:263
 msgid "Something went wrong"
-msgstr ""
+msgstr "Něco se pokazilo"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:125
 msgid "Sort plugins"
-msgstr ""
+msgstr "Řadit pluginy"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
 msgid "Sort themes"
-msgstr ""
+msgstr "Řadit motivy"
 
 #: packages/admin/src/components/ContentTypeList.tsx:102
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:371
@@ -7399,43 +7410,43 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:469
 #: packages/admin/src/components/SectionEditor.tsx:294
 msgid "Source"
-msgstr ""
+msgstr "Zdroj"
 
 #: packages/admin/src/components/Redirects.tsx:132
 msgid "Source path"
-msgstr ""
+msgstr "Zdrojová cesta"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:197
 msgid "spam"
-msgstr ""
+msgstr "spam"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:159
 #: packages/admin/src/components/comments/CommentInbox.tsx:208
 #: packages/admin/src/components/comments/CommentInbox.tsx:248
 msgid "Spam"
-msgstr ""
+msgstr "Spam"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3863
 msgid "Spotlight Mode"
-msgstr ""
+msgstr "Režim soustředění"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:64
 msgid "Spreadsheets"
-msgstr ""
+msgstr "Tabulkové soubory"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:51
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1922
 msgid "Start Import"
-msgstr ""
+msgstr "Spustit import"
 
 #: packages/admin/src/components/ContentEditor.tsx:1208
 #: packages/admin/src/components/PortableTextEditor.tsx:2318
 #: packages/admin/src/components/PortableTextEditor.tsx:2319
 msgid "Start writing, or type '/' for commands"
-msgstr ""
+msgstr "Začněte psát, nebo napište „/“ pro příkazy"
 
 #: packages/admin/src/components/ContentList.tsx:511
 #: packages/admin/src/components/ContentSettingsPanel.tsx:449
@@ -7443,373 +7454,373 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:474
 #: packages/admin/src/components/users/UserList.tsx:104
 msgid "Status"
-msgstr ""
+msgstr "Stav"
 
 #: packages/admin/src/components/Redirects.tsx:152
 msgid "Status code"
-msgstr ""
+msgstr "Stavový kód"
 
 #: packages/admin/src/components/Dashboard.tsx:362
 msgid "Status: {status}"
-msgstr ""
+msgstr "Stav: {status}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:173
 msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
-msgstr ""
+msgstr "Ukládat denní zálohu do úložiště vašeho webu. Staré zálohy se odstraňují automaticky."
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:218
 msgid "Stored Backups"
-msgstr ""
+msgstr "Uložené zálohy"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:293
 msgid "Stored per locale — each translation of a byline gets its own value."
-msgstr ""
+msgstr "Ukládá se podle jazyka — každý překlad autorského podpisu má vlastní hodnotu."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3284
 #: packages/admin/src/components/PortableTextEditor.tsx:3670
 msgid "Strikethrough"
-msgstr ""
+msgstr "Přeškrtnutí"
 
 #: packages/admin/src/components/WordPressImport.tsx:1752
 msgid "Structure"
-msgstr ""
+msgstr "Struktura"
 
 #: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Structured"
-msgstr ""
+msgstr "Strukturovaný"
 
 #: packages/admin/src/components/FieldEditor.tsx:523
 msgid "Sub-Fields"
-msgstr ""
+msgstr "Podpole"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
-msgstr ""
+msgstr "Odběratel"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:52
 msgid "Svelte"
-msgstr ""
+msgstr "Svelte"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:53
 msgid "Swift"
-msgstr ""
+msgstr "Swift"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
-msgstr ""
+msgstr "Synchronizováno"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Synced passkey"
-msgstr ""
+msgstr "Synchronizovaný přístupový klíč"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:777
 msgid "System"
-msgstr ""
+msgstr "Systém"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
-msgstr ""
+msgstr "Systém ({resolvedLabel})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:599
 msgid "System Fields"
-msgstr ""
+msgstr "Systémová pole"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1237
 msgid "Table"
-msgstr ""
+msgstr "Tabulka"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3359
 msgid "Table controls"
-msgstr ""
+msgstr "Ovládání tabulky"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:139
 #: packages/admin/src/components/SetupWizard.tsx:127
 msgid "Tagline"
-msgstr ""
+msgstr "Podtitulek"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:201
 #: packages/admin/src/components/Widgets.tsx:143
 msgid "Tags"
-msgstr ""
+msgstr "Štítky"
 
 #. placeholder {0}: analysis.tags
 #: packages/admin/src/components/WordPressImport.tsx:1797
 msgid "Tags ({0})"
-msgstr ""
+msgstr "Štítky ({0})"
 
 #: packages/admin/src/components/MenuEditor.tsx:427
 #: packages/admin/src/components/MenuEditor.tsx:606
 msgid "Target"
-msgstr ""
+msgstr "Cíl"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:192
 msgid "Target locale"
-msgstr ""
+msgstr "Cílový jazyk"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:610
 #: packages/admin/src/components/TaxonomySidebar.tsx:550
 msgid "Taxonomies"
-msgstr ""
+msgstr "Taxonomie"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Taxonomies Manage"
-msgstr ""
+msgstr "Taxonomie – správa"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:918
 msgid "Taxonomy created"
-msgstr ""
+msgstr "Taxonomie vytvořena"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:807
 msgid "Taxonomy not found:"
-msgstr ""
+msgstr "Taxonomie nenalezena:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:179
 msgid "Taxonomy: {taxonomyName}"
-msgstr ""
+msgstr "Taxonomie: {taxonomyName}"
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
-msgstr ""
+msgstr "Šablona:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:377
 #: packages/admin/src/components/TaxonomyManager.tsx:378
 #: packages/admin/src/components/TaxonomyManager.tsx:834
 msgid "Term"
-msgstr ""
+msgstr "Termín"
 
 #. placeholder {0}: term.label
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:781
 msgid "Term \"{0}\" created in {1}."
-msgstr ""
+msgstr "Termín „{0}“ vytvořen v {1}."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:763
 msgid "Term deleted"
-msgstr ""
+msgstr "Termín smazán"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:122
 msgid "test@example.com"
-msgstr ""
+msgstr "test@example.com"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3621
 msgid "Text formatting"
-msgstr ""
+msgstr "Formátování textu"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:198
 msgid "The device will not be granted access."
-msgstr ""
+msgstr "Zařízení nezíská přístup."
 
 #: packages/admin/src/components/WordPressImport.tsx:1862
 msgid "The existing collection has fields with incompatible types."
-msgstr ""
+msgstr "Stávající kolekce má pole s nekompatibilními typy."
 
 #: packages/admin/src/components/ContentTypeList.tsx:60
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
-msgstr ""
+msgstr "Následující tabulky obsahují obsah, ale nejsou registrovány jako kolekce. Zaregistrujte je, abyste tento obsah mohli spravovat v administraci."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:179
 msgid "The invited user will have this role once they complete registration."
-msgstr ""
+msgstr "Pozvaný uživatel získá tuto roli po dokončení registrace."
 
 #: packages/admin/src/components/LoginPage.tsx:114
 #: packages/admin/src/components/SignupPage.tsx:140
 msgid "The link will expire in 15 minutes."
-msgstr ""
+msgstr "Platnost odkazu vyprší za 15 minut."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:179
 msgid "The marketplace is empty. Check back later for new plugins."
-msgstr ""
+msgstr "Tržiště je prázdné. Nové pluginy zkontrolujte později."
 
 #: packages/admin/src/components/MenuList.tsx:76
 msgid "The menu has been deleted."
-msgstr ""
+msgstr "Nabídka byla smazána."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:136
 msgid "The name of your site, used in the header and metadata"
-msgstr ""
+msgstr "Název vašeho webu, používaný v hlavičce a metadatech"
 
 #: packages/admin/src/router.tsx:2191
 msgid "The page you're looking for doesn't exist."
-msgstr ""
+msgstr "Hledaná stránka neexistuje."
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
 msgid "The plugin field widget failed to render."
-msgstr ""
+msgstr "Widget pole pluginu se nepodařilo vykreslit."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:149
 msgid "The public URL of your site (used for canonical links and sitemaps)"
-msgstr ""
+msgstr "Veřejná URL vašeho webu (používá se pro kanonické odkazy a sitemapy)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:156
 msgid "The referenced image is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "Odkazovaný obrázek již není k dispozici. Vyberte nový, nebo odkaz odeberte."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:174
 msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "Odkazované logo již není k dispozici. Vyberte nové, nebo odkaz odeberte."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
 msgid "The theme marketplace is empty. Check back later."
-msgstr ""
+msgstr "Tržiště motivů je prázdné. Zkontrolujte to později."
 
 #: packages/admin/src/components/Sections.tsx:45
 msgid "Theme"
-msgstr ""
+msgstr "Motiv"
 
 #. placeholder {0}: section.themeId
 #: packages/admin/src/components/SectionEditor.tsx:307
 msgid "Theme ID: {0}"
-msgstr ""
+msgstr "ID motivu: {0}"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
 msgid "Theme not found"
-msgstr ""
+msgstr "Motiv nenalezen"
 
 #: packages/admin/src/components/SectionEditor.tsx:185
 msgid "Theme Section"
-msgstr ""
+msgstr "Sekce motivu"
 
 #: packages/admin/src/components/Sections.tsx:300
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
-msgstr ""
+msgstr "Sekce poskytnuté motivem nelze smazat. Upravte sekci a vytvořte vlastní kopii, kterou pak můžete smazat."
 
 #: packages/admin/src/components/ThemeToggle.tsx:33
 msgid "Theme: {label}"
-msgstr ""
+msgstr "Motiv: {label}"
 
 #: packages/admin/src/components/Sidebar.tsx:281
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
 msgid "Themes"
-msgstr ""
+msgstr "Motivy"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:141
 msgid "These tools remain disabled after installation until you explicitly enable agent access."
-msgstr ""
+msgstr "Tyto nástroje zůstanou po instalaci vypnuté, dokud výslovně nepovolíte přístup agenta."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:370
 msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
-msgstr ""
+msgstr "Tato kolekce je definována v kódu. Některá nastavení zde nelze změnit. Schéma upravte v souboru live.config.ts."
 
 #: packages/admin/src/components/WordPressImport.tsx:1059
 msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
-msgstr ""
+msgstr "Toto nevypadá jako platný migrační klíč. Vygenerujte nový v pluginu a vložte celý řetězec začínající „em1.“."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:461
 msgid "This field does not accept {sniffedMime} files."
-msgstr ""
+msgstr "Toto pole nepřijímá soubory typu {sniffedMime}."
 
 #: packages/admin/src/components/ContentEditor.tsx:1721
 #: packages/admin/src/components/ImageFieldRenderer.tsx:201
 msgid "This field is required"
-msgstr ""
+msgstr "Toto pole je povinné"
 
 #: packages/admin/src/components/SectionEditor.tsx:301
 msgid "This is a custom section."
-msgstr ""
+msgstr "Toto je vlastní sekce."
 
 #: packages/admin/src/components/WordPressImport.tsx:1308
 msgid "This is a WordPress site."
-msgstr ""
+msgstr "Toto je web na WordPressu."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:112
 msgid "This link expires in 7 days and can only be used once."
-msgstr ""
+msgstr "Platnost tohoto odkazu vyprší za 7 dní a lze jej použít pouze jednou."
 
 #: packages/admin/src/components/WordPressImport.tsx:921
 msgid "This may take a while for large exports."
-msgstr ""
+msgstr "U velkých exportů to může chvíli trvat."
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
 msgid "This passkey is already registered on this device."
-msgstr ""
+msgstr "Tento přístupový klíč je již na tomto zařízení zaregistrován."
 
 #. placeholder {0}: archiveToDelete?.name ?? ""
 #: packages/admin/src/components/settings/BackupSettings.tsx:283
 msgid "This permanently deletes {0} from storage."
-msgstr ""
+msgstr "Trvale odstraní {0} z úložiště."
 
 #: packages/admin/src/components/PluginSettings.tsx:177
 msgid "This plugin has no configurable settings."
-msgstr ""
+msgstr "Tento plugin nemá žádná nastavení."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:287
 msgid "This plugin requires no special permissions."
-msgstr ""
+msgstr "Tento plugin nevyžaduje žádná zvláštní oprávnění."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:579
 msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
-msgstr ""
+msgstr "Tento vydavatel si nárokuje jméno, jehož vlastnictví nedokázal prokázat — možná se vydává za někoho jiného. Instalace je zakázána. Pokud vydavatele znáte a důvěřujete mu, požádejte ho, aby před dalším pokusem opravil nastavení své identity."
 
 #: packages/admin/src/components/Redirects.tsx:584
 msgid "This redirect rule will be permanently removed."
-msgstr ""
+msgstr "Toto pravidlo přesměrování bude trvale odstraněno."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:631
 msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
-msgstr ""
+msgstr "Tato verze vyžaduje novější prostředí, než na jakém web běží. Před instalací proveďte upgrade."
 
 #: packages/admin/src/routes/bylines.tsx:623
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr ""
+msgstr "Odstraní profil autorského podpisu. Odkazy autorského podpisu v obsahu budou odebrány a hlavní ukazatele vymazány."
 
 #: packages/admin/src/components/SectionEditor.tsx:298
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
-msgstr ""
+msgstr "Tuto sekci poskytuje motiv. Úpravou vznikne vlastní kopie, která verzi z motivu přepíše."
 
 #: packages/admin/src/components/SectionEditor.tsx:303
 msgid "This section was imported from another system."
-msgstr ""
+msgstr "Tato sekce byla naimportována z jiného systému."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:125
 msgid "This update exposes the following routes without authentication:"
-msgstr ""
+msgstr "Tato aktualizace zpřístupní následující cesty bez ověření:"
 
 #: packages/admin/src/components/Widgets.tsx:715
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
-msgstr ""
+msgstr "Smaže oblast widgetů i všechny její widgety. Tuto akci nelze vrátit zpět."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:276
 msgid "This will grant CLI access with your permissions."
-msgstr ""
+msgstr "Udělí přístup z CLI s vašimi oprávněními."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:676
 msgid "This will move the item to trash. You can restore it later from the trash."
-msgstr ""
+msgstr "Položka bude přesunuta do koše. Později ji lze z koše obnovit."
 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:904
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr ""
+msgstr "Trvale smaže „{0}“ a odebere jej z veškerého obsahu."
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:304
 msgid "This will permanently delete \"{0}\". This action cannot be undone."
-msgstr ""
+msgstr "Trvale smaže „{0}“. Tuto akci nelze vrátit zpět."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:407
 msgid "This will permanently delete this comment. This action cannot be undone."
-msgstr ""
+msgstr "Trvale smaže tento komentář. Tuto akci nelze vrátit zpět."
 
 #: packages/admin/src/components/PluginManager.tsx:714
 msgid "This will remove the plugin and its bundle from your site."
-msgstr ""
+msgstr "Odebere plugin i jeho balíček z webu."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:84
 msgid "This will revert to the published version. Your draft changes will be lost."
-msgstr ""
+msgstr "Vrátí se k publikované verzi. Změny v konceptu budou ztraceny."
 
 #: packages/admin/src/components/SetupWizard.tsx:131
 msgid "Thoughts, tutorials, and more"
-msgstr ""
+msgstr "Postřehy, návody a další"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:287
 msgid "Timezone"
-msgstr ""
+msgstr "Časové pásmo"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:290
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr ""
+msgstr "Časové pásmo pro zobrazení dat (např. America/New_York)"
 
 #: packages/admin/src/components/ContentList.tsx:505
 #: packages/admin/src/components/ContentList.tsx:643
@@ -7817,107 +7828,107 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:170
 #: packages/admin/src/components/Widgets.tsx:891
 msgid "Title"
-msgstr ""
+msgstr "Titulek"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:361
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:550
 msgid "Title (Tooltip)"
-msgstr ""
+msgstr "Titulek (nápověda)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:126
 msgid "Title Separator"
-msgstr ""
+msgstr "Oddělovač titulku"
 
 #: packages/admin/src/components/ContentList.tsx:811
 msgid "to"
-msgstr ""
+msgstr "do"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:483
 msgid "to close"
-msgstr ""
+msgstr "zavřít"
 
 #: packages/admin/src/components/ContentList.tsx:815
 msgid "To date"
-msgstr ""
+msgstr "Datum do"
 
 #: packages/admin/src/components/PluginManager.tsx:208
 msgid "to install plugins, or add them to your astro.config.mjs."
-msgstr ""
+msgstr "k instalaci pluginů, nebo je přidejte do astro.config.mjs."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:473
 msgid "to select"
-msgstr ""
+msgstr "vybrat"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3404
 msgid "Toggle header row"
-msgstr ""
+msgstr "Přepnout řádek záhlaví"
 
 #: packages/admin/src/components/ThemeToggle.tsx:31
 #: packages/admin/src/components/ThemeToggle.tsx:42
 msgid "Toggle theme (current: {label})"
-msgstr ""
+msgstr "Přepnout motiv (aktuální: {label})"
 
 #. placeholder {0}: newToken.info.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:207
 msgid "Token created: {0}"
-msgstr ""
+msgstr "Token vytvořen: {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:420
 msgid "Token Name"
-msgstr ""
+msgstr "Název tokenu"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:54
 msgid "TOML"
-msgstr ""
+msgstr "TOML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "Tools → Export"
-msgstr ""
+msgstr "Tools → Export"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:77
 msgid "Track content history"
-msgstr ""
+msgstr "Sledovat historii obsahu"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:287
 #: packages/admin/src/routes/byline-schema.tsx:243
 msgid "Translatable"
-msgstr ""
+msgstr "Přeložitelné"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:103
 #: packages/admin/src/components/TaxonomyManager.tsx:214
 #: packages/admin/src/components/TranslationsPanel.tsx:104
 msgid "Translate"
-msgstr ""
+msgstr "Přeložit"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:176
 msgid "Translate \"{0}\""
-msgstr ""
+msgstr "Přeložit „{0}“"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:100
 msgid "Translate {0}"
-msgstr ""
+msgstr "Přeložit {0}"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:214
 #: packages/admin/src/components/TranslationsPanel.tsx:104
 msgid "Translating..."
-msgstr ""
+msgstr "Překládání..."
 
 #: packages/admin/src/components/MenuEditor.tsx:143
 #: packages/admin/src/components/TaxonomyManager.tsx:780
 #: packages/admin/src/router.tsx:1119
 msgid "Translation created"
-msgstr ""
+msgstr "Překlad vytvořen"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:588
 #: packages/admin/src/components/TranslationsPanel.tsx:60
 msgid "Translations"
-msgstr ""
+msgstr "Překlady"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:198
 msgid "trash"
-msgstr ""
+msgstr "koš"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:170
 #: packages/admin/src/components/comments/CommentInbox.tsx:217
@@ -7925,351 +7936,351 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:514
 #: packages/admin/src/components/ContentList.tsx:375
 msgid "Trash"
-msgstr ""
+msgstr "Koš"
 
 #: packages/admin/src/components/ContentList.tsx:666
 msgid "Trash is empty"
-msgstr ""
+msgstr "Koš je prázdný"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:550
 msgid "Trash is empty."
-msgstr ""
+msgstr "Koš je prázdný."
 
 #: packages/admin/src/components/FieldEditor.tsx:175
 msgid "True/false toggle"
-msgstr ""
+msgstr "Přepínač ano/ne"
 
 #: packages/admin/src/components/MediaLibrary.tsx:493
 msgid "Try a broader media type or clear your filters."
-msgstr ""
+msgstr "Zkuste širší typ média nebo zrušte filtry."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:691
 msgid "Try a different search term"
-msgstr ""
+msgstr "Zkuste jiný hledaný výraz"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:172
 #: packages/admin/src/components/SectionPickerModal.tsx:103
 msgid "Try adjusting your search"
-msgstr ""
+msgstr "Zkuste upravit hledání"
 
 #: packages/admin/src/components/Sections.tsx:260
 msgid "Try adjusting your search or filters."
-msgstr ""
+msgstr "Zkuste upravit hledání nebo filtry."
 
 #: packages/admin/src/routes/users.tsx:210
 msgid "Try again"
-msgstr ""
+msgstr "Zkusit znovu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1582
 msgid "Try Again"
-msgstr ""
+msgstr "Zkusit znovu"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:207
 msgid "Try another code"
-msgstr ""
+msgstr "Zkusit jiný kód"
 
 #: packages/admin/src/components/MediaLibrary.tsx:518
 msgid "Try another filename or clear your search."
-msgstr ""
+msgstr "Zkuste jiný název souboru nebo zrušte hledání."
 
 #: packages/admin/src/components/MediaLibrary.tsx:492
 msgid "Try another filename, or clear your search and filters."
-msgstr ""
+msgstr "Zkuste jiný název souboru nebo zrušte hledání a filtry."
 
 #: packages/admin/src/components/WordPressImport.tsx:1286
 #: packages/admin/src/components/WordPressImport.tsx:1408
 msgid "Try Another URL"
-msgstr ""
+msgstr "Zkusit jinou URL"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:244
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
 msgid "Try with my data"
-msgstr ""
+msgstr "Vyzkoušet s mými daty"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:55
 msgid "TSX"
-msgstr ""
+msgstr "TSX"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:309
 msgid "Turn into"
-msgstr ""
+msgstr "Změnit na"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:106
 msgid "Twitter"
-msgstr ""
+msgstr "Twitter"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:260
 #: packages/admin/src/components/FieldEditor.tsx:571
 #: packages/admin/src/components/MediaLibrary.tsx:587
 #: packages/admin/src/routes/byline-schema.tsx:240
 msgid "Type"
-msgstr ""
+msgstr "Typ"
 
 #. placeholder {0}: status.existingType
 #: packages/admin/src/components/WordPressImport.tsx:2018
 msgid "Type mismatch ({0})"
-msgstr ""
+msgstr "Neshoda typu ({0})"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:56
 msgid "TypeScript"
-msgstr ""
+msgstr "TypeScript"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:133
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
 msgid "Unable to reach marketplace"
-msgstr ""
+msgstr "Tržiště není dostupné"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1073
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1090
 msgid "Unassigned"
-msgstr ""
+msgstr "Nepřiřazeno"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3277
 #: packages/admin/src/components/PortableTextEditor.tsx:3663
 msgid "Underline"
-msgstr ""
+msgstr "Podtržení"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3843
 msgid "Undo"
-msgstr ""
+msgstr "Zpět"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:191
 #: packages/admin/src/components/PluginManager.tsx:630
 #: packages/admin/src/components/PluginManager.tsx:728
 msgid "Uninstall"
-msgstr ""
+msgstr "Odinstalovat"
 
 #: packages/admin/src/components/PluginManager.tsx:712
 msgid "Uninstall {pluginName}?"
-msgstr ""
+msgstr "Odinstalovat {pluginName}?"
 
 #: packages/admin/src/components/PluginManager.tsx:707
 msgid "Uninstall confirmation"
-msgstr ""
+msgstr "Potvrzení odinstalace"
 
 #: packages/admin/src/components/PluginManager.tsx:728
 msgid "Uninstalling..."
-msgstr ""
+msgstr "Odinstalování..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:731
 #: packages/admin/src/components/FieldEditor.tsx:442
 msgid "Unique"
-msgstr ""
+msgstr "Unikátní"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:107
 msgid "Unique identifier (ULID)"
-msgstr ""
+msgstr "Jedinečný identifikátor (ULID)"
 
 #: packages/admin/src/components/users/useRolesConfig.ts:7
 msgid "Unknown"
-msgstr ""
+msgstr "Neznámé"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:62
 msgid "Unknown role"
-msgstr ""
+msgstr "Neznámá role"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:485
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:486
 msgid "Unlock aspect ratio"
-msgstr ""
+msgstr "Odemknout poměr stran"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:152
 #: packages/admin/src/components/users/UserDetail.tsx:254
 msgid "Unnamed passkey"
-msgstr ""
+msgstr "Nepojmenovaný přístupový klíč"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:202
 msgid "Unpublish {itemLabel}"
-msgstr ""
+msgstr "Zrušit publikování {itemLabel}"
 
 #: packages/admin/src/router.tsx:1027
 msgid "Unpublished"
-msgstr ""
+msgstr "Nepublikováno"
 
 #: packages/admin/src/components/ContentTypeList.tsx:57
 msgid "Unregistered Content Tables Found"
-msgstr ""
+msgstr "Nalezeny neregistrované tabulky obsahu"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:477
 msgid "Unschedule"
-msgstr ""
+msgstr "Zrušit naplánování"
 
 #: packages/admin/src/router.tsx:1088
 msgid "Unscheduled"
-msgstr ""
+msgstr "Nenaplánováno"
 
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128
 msgid "Unsupported widget element type: {0}"
-msgstr ""
+msgstr "Nepodporovaný typ prvku widgetu: {0}"
 
 #: packages/admin/src/components/Dashboard.tsx:319
 msgid "Untitled"
-msgstr ""
+msgstr "Bez názvu"
 
 #: packages/admin/src/components/ContentEditor.tsx:1624
 msgid "Untitled file"
-msgstr ""
+msgstr "Soubor bez názvu"
 
 #: packages/admin/src/components/Widgets.tsx:536
 #: packages/admin/src/components/Widgets.tsx:809
 msgid "Untitled Widget"
-msgstr ""
+msgstr "Widget bez názvu"
 
 #: packages/admin/src/components/PublisherHandle.tsx:145
 msgid "Unverified publisher"
-msgstr ""
+msgstr "Neověřený vydavatel"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:900
 msgid "Up"
-msgstr ""
+msgstr "Nahoru"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:500
 msgid "Update"
-msgstr ""
+msgstr "Aktualizovat"
 
 #: packages/admin/src/components/FieldEditor.tsx:660
 msgid "Update Field"
-msgstr ""
+msgstr "Aktualizovat pole"
 
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:334
 msgid "Update settings for {0}"
-msgstr ""
+msgstr "Aktualizovat nastavení pro {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:92
 msgid "Update site settings"
-msgstr ""
+msgstr "Aktualizovat nastavení webu"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:382
 msgid "Update the {0} details"
-msgstr ""
+msgstr "Aktualizovat údaje: {0}"
 
 #: packages/admin/src/components/Redirects.tsx:110
 msgid "Update this redirect rule."
-msgstr ""
+msgstr "Aktualizovat toto pravidlo přesměrování."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:452
 msgid "Update to v{0}"
-msgstr ""
+msgstr "Aktualizovat na v{0}"
 
 #: packages/admin/src/components/ContentList.tsx:737
 #: packages/admin/src/components/ContentSettingsPanel.tsx:541
 #: packages/admin/src/components/RegistryPluginDetail.tsx:501
 msgid "Updated"
-msgstr ""
+msgstr "Aktualizováno"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:129
 msgid "Updated At"
-msgstr ""
+msgstr "Datum aktualizace"
 
 #: packages/admin/src/components/WordPressImport.tsx:946
 msgid "Updating content URLs..."
-msgstr ""
+msgstr "Aktualizace URL obsahu..."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:197
 #: packages/admin/src/components/PluginManager.tsx:452
 msgid "Updating..."
-msgstr ""
+msgstr "Aktualizace..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:649
 msgid "Upload"
-msgstr ""
+msgstr "Nahrát"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:152
 msgid "Upload a file to get started"
-msgstr ""
+msgstr "Začněte nahráním souboru"
 
 #: packages/admin/src/components/WordPressImport.tsx:1391
 msgid "Upload an export file"
-msgstr ""
+msgstr "Nahrát soubor exportu"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:153
 msgid "Upload an image to get started"
-msgstr ""
+msgstr "Začněte nahráním obrázku"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:62
 msgid "Upload and delete media"
-msgstr ""
+msgstr "Nahrávat a mazat média"
 
 #: packages/admin/src/lib/api/marketplace.ts:283
 #: packages/admin/src/lib/api/marketplace.ts:291
 msgid "Upload and manage media"
-msgstr ""
+msgstr "Nahrávat a spravovat média"
 
 #: packages/admin/src/components/WordPressImport.tsx:1284
 #: packages/admin/src/components/WordPressImport.tsx:1405
 msgid "Upload Export File"
-msgstr ""
+msgstr "Nahrát soubor exportu"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:669
 msgid "Upload failed: {uploadError}"
-msgstr ""
+msgstr "Nahrání selhalo: {uploadError}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:661
 msgid "Upload file"
-msgstr ""
+msgstr "Nahrát soubor"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:154
 msgid "Upload File"
-msgstr ""
+msgstr "Nahrát soubor"
 
 #: packages/admin/src/components/MediaLibrary.tsx:365
 msgid "Upload files"
-msgstr ""
+msgstr "Nahrát soubory"
 
 #: packages/admin/src/components/MediaLibrary.tsx:508
 #: packages/admin/src/components/MediaLibrary.tsx:532
 msgid "Upload Files"
-msgstr ""
+msgstr "Nahrát soubory"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:154
 msgid "Upload Image"
-msgstr ""
+msgstr "Nahrát obrázek"
 
 #: packages/admin/src/components/MediaLibrary.tsx:505
 msgid "Upload images, videos, and documents to keep reusable assets in one place."
-msgstr ""
+msgstr "Nahrajte obrázky, videa a dokumenty a mějte znovupoužitelné soubory na jednom místě."
 
 #: packages/admin/src/components/Dashboard.tsx:114
 msgid "Upload Media"
-msgstr ""
+msgstr "Nahrát média"
 
 #: packages/admin/src/components/MediaLibrary.tsx:529
 msgid "Upload media to keep reusable assets in one place."
-msgstr ""
+msgstr "Nahrajte média a mějte znovupoužitelné soubory na jednom místě."
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:356
 msgid "Upload to {0}"
-msgstr ""
+msgstr "Nahrát do {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1118
 msgid "Upload WordPress export file"
-msgstr ""
+msgstr "Nahrát soubor exportu z WordPressu"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:289
 msgid "Uploaded:"
-msgstr ""
+msgstr "Nahráno:"
 
 #: packages/admin/src/components/WordPressImport.tsx:2127
 msgid "Uploading"
-msgstr ""
+msgstr "Nahrávání"
 
 #. placeholder {0}: uploadState.progress.current
 #. placeholder {1}: uploadState.progress.total
 #: packages/admin/src/components/MediaLibrary.tsx:331
 msgid "Uploading {0}/{1}..."
-msgstr ""
+msgstr "Nahrávání {0}/{1}..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:332
 #: packages/admin/src/components/MediaPickerModal.tsx:649
 msgid "Uploading..."
-msgstr ""
+msgstr "Nahrávání..."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:54
 #: packages/admin/src/components/FieldEditor.tsx:234
@@ -8280,331 +8291,331 @@ msgstr ""
 #: packages/admin/src/components/PortableTextEditor.tsx:3788
 #: packages/admin/src/components/PortableTextEditor.tsx:3798
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:423
 msgid "URL Pattern"
-msgstr ""
+msgstr "Vzor URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:113
 #: packages/admin/src/components/FieldEditor.tsx:229
 msgid "URL-friendly identifier"
-msgstr ""
+msgstr "Identifikátor vhodný pro URL"
 
 #: packages/admin/src/components/MenuList.tsx:165
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr ""
+msgstr "Identifikátor vhodný pro URL (např. „primary“, „footer“)"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:295
 msgid "URL:"
-msgstr ""
+msgstr "URL:"
 
 #: packages/admin/src/components/Redirects.tsx:111
 msgid "Use [param] or [...rest] in paths for pattern matching."
-msgstr ""
+msgstr "Pro porovnávání vzorů použijte v cestách [param] nebo [...rest]."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:364
 msgid "Use your device's biometric authentication, security key, or PIN to sign in."
-msgstr ""
+msgstr "K přihlášení použijte biometrické ověření zařízení, bezpečnostní klíč nebo PIN."
 
 #: packages/admin/src/components/LoginPage.tsx:328
 msgid "Use your registered passkey to sign in securely."
-msgstr ""
+msgstr "K bezpečnému přihlášení použijte zaregistrovaný přístupový klíč."
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:140
 msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
-msgstr ""
+msgstr "Použije se jako záložní Open Graph obrázek, když stránka žádný nemá. Doporučená velikost: 1200×630."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:666
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
-msgstr ""
+msgstr "Použije se jako identifikátor. Pouze malá písmena, číslice a podtržítka."
 
 #: packages/admin/src/components/ContentEditor.tsx:1311
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
-msgstr ""
+msgstr "Použije se jako hlavní vizuál tohoto příspěvku ve výpisech a v jeho záhlaví"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:122
 msgid "Used by screen readers and when image fails to load"
-msgstr ""
+msgstr "Používají čtečky obrazovky a zobrazí se, když se obrázek nenačte"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:408
 msgid "Used in URLs and API endpoints"
-msgstr ""
+msgstr "Používá se v URL a API endpointech"
 
 #: packages/admin/src/components/SectionEditor.tsx:269
 #: packages/admin/src/components/Sections.tsx:196
 msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
-msgstr ""
+msgstr "Slouží k identifikaci této sekce. Pouze malá písmena, číslice a pomlčky."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:43
 #: packages/admin/src/components/Header.tsx:83
 #: packages/admin/src/components/users/UserList.tsx:98
 msgid "User"
-msgstr ""
+msgstr "Uživatel"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:177
 msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
-msgstr ""
+msgstr "Přístup uživatelů spravuje externí poskytovatel ({0}). Při použití externího ověřování nejsou nastavení domén pro samoregistraci dostupná."
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
-msgstr ""
+msgstr "Podrobnosti uživatele"
 
 #: packages/admin/src/components/users/UserDetail.tsx:296
 msgid "User not found"
-msgstr ""
+msgstr "Uživatel nenalezen"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:210
 #: packages/admin/src/components/Sidebar.tsx:253
 #: packages/admin/src/components/users/UserList.tsx:54
 msgid "Users"
-msgstr ""
+msgstr "Uživatelé"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:383
 msgid "Users from"
-msgstr ""
+msgstr "Uživatelé z"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:211
 msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
-msgstr ""
+msgstr "Uživatelé s e-mailovými adresami z těchto domén se mohou registrovat bez pozvánky. Automaticky jim bude přiřazena zvolená role."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:387
 msgid "v{0} available"
-msgstr ""
+msgstr "K dispozici je v{0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:460
 #: packages/admin/src/components/FieldEditor.tsx:490
 msgid "Validation"
-msgstr ""
+msgstr "Validace"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:189
 #: packages/admin/src/components/RegistryPluginDetail.tsx:462
 msgid "Verified publisher"
-msgstr ""
+msgstr "Ověřený vydavatel"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:461
 msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
-msgstr ""
+msgstr "Ověřený vydavatel, potvrzeno labellerem {verifiedLabeller}"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:452
 msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
-msgstr ""
+msgstr "Ověřený vydavatel. Labeller ({verifiedLabeller}) potvrdil identitu tohoto vydavatele."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:453
 msgid "Verified publisher. A labeller has confirmed this publisher's identity."
-msgstr ""
+msgstr "Ověřený vydavatel. Labeller potvrdil identitu tohoto vydavatele."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:228
 msgid "Verifying your invite..."
-msgstr ""
+msgstr "Ověřování pozvánky…"
 
 #: packages/admin/src/components/SignupPage.tsx:388
 msgid "Verifying your link..."
-msgstr ""
+msgstr "Ověřování odkazu…"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:211
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
 msgid "Verifying..."
-msgstr ""
+msgstr "Ověřování…"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:331
 #: packages/admin/src/components/RegistryPluginDetail.tsx:515
 msgid "Version"
-msgstr ""
+msgstr "Verze"
 
 #. placeholder {0}: release.version
 #: packages/admin/src/components/RegistryPluginDetail.tsx:477
 msgid "Version {0}"
-msgstr ""
+msgstr "Verze {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:67
 #: packages/admin/src/components/MediaLibrary.tsx:435
 msgid "Video"
-msgstr ""
+msgstr "Video"
 
 #: packages/admin/src/components/Settings.tsx:117
 msgid "View email provider status and send test emails"
-msgstr ""
+msgstr "Zobrazit stav poskytovatele e-mailu a odeslat testovací e-maily"
 
 #: packages/admin/src/components/PluginManager.tsx:464
 msgid "View in Marketplace"
-msgstr ""
+msgstr "Zobrazit v tržišti"
 
 #: packages/admin/src/components/MediaLibrary.tsx:447
 msgid "View mode"
-msgstr ""
+msgstr "Režim zobrazení"
 
 #: packages/admin/src/components/ContentList.tsx:1011
 msgid "View published {title}"
-msgstr ""
+msgstr "Zobrazit publikovanou verzi: {title}"
 
 #: packages/admin/src/components/Header.tsx:59
 msgid "View Site"
-msgstr ""
+msgstr "Zobrazit web"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:676
 msgid "View source"
-msgstr ""
+msgstr "Zobrazit zdrojový kód"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:931
 msgid "View the {license} license on spdx.org"
-msgstr ""
+msgstr "Zobrazit licenci {license} na spdx.org"
 
 #: packages/admin/src/components/Redirects.tsx:451
 msgid "Visitors hitting these paths will see an error."
-msgstr ""
+msgstr "Návštěvníci, kteří otevřou tyto cesty, uvidí chybu."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:57
 msgid "Vue"
-msgstr ""
+msgstr "Vue"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
 msgid "Waiting for passkey..."
-msgstr ""
+msgstr "Čekání na přístupový klíč…"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:335
 msgid "Warn"
-msgstr ""
+msgstr "Varování"
 
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1266
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr ""
+msgstr "Nepodařilo se připojit k webu WordPress na adrese {0}. Web možná neběží na WordPressu, REST API je vypnuté nebo web není dostupný."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:577
 msgid "We couldn't verify this publisher's identity"
-msgstr ""
+msgstr "Identitu tohoto vydavatele se nepodařilo ověřit"
 
 #: packages/admin/src/components/WordPressImport.tsx:1084
 msgid "We'll check what import options are available for your site."
-msgstr ""
+msgstr "Zjistíme, jaké možnosti importu jsou pro váš web dostupné."
 
 #: packages/admin/src/components/LoginPage.tsx:325
 msgid "We'll send you a link to sign in without a password."
-msgstr ""
+msgstr "Zašleme vám odkaz pro přihlášení bez hesla."
 
 #: packages/admin/src/components/SignupPage.tsx:133
 msgid "We've sent a verification link to"
-msgstr ""
+msgstr "Ověřovací odkaz jsme odeslali na"
 
 #: packages/admin/src/components/FieldEditor.tsx:235
 msgid "Web address"
-msgstr ""
+msgstr "Webová adresa"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:159
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
 msgid "WebAuthn is not supported in this browser"
-msgstr ""
+msgstr "WebAuthn není v tomto prohlížeči podporován"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:236
 #: packages/admin/src/components/RegistryPluginDetail.tsx:701
 msgid "Website"
-msgstr ""
+msgstr "Web"
 
 #: packages/admin/src/routes/bylines.tsx:491
 msgid "Website URL"
-msgstr ""
+msgstr "URL webu"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
-msgstr ""
+msgstr "Vítejte v EmDash, {firstName}!"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
-msgstr ""
+msgstr "Vítejte v EmDash!"
 
 #: packages/admin/src/components/WordPressImport.tsx:2091
 msgid "What happens when you import:"
-msgstr ""
+msgstr "Co se stane při importu:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1874
 msgid "What will happen when you import"
-msgstr ""
+msgstr "Co se stane při importu"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:125
 msgid "When the entry was created"
-msgstr ""
+msgstr "Kdy byla položka vytvořena"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:131
 msgid "When the entry was last modified"
-msgstr ""
+msgstr "Kdy byla položka naposledy změněna"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:137
 msgid "When the entry was published"
-msgstr ""
+msgstr "Kdy byla položka publikována"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:680
 msgid "Which content types can use this taxonomy"
-msgstr ""
+msgstr "Které typy obsahu mohou tuto taxonomii používat"
 
 #: packages/admin/src/components/FieldEditor.tsx:169
 msgid "Whole number"
-msgstr ""
+msgstr "Celé číslo"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:121
 msgid "Why can't this be changed?"
-msgstr ""
+msgstr "Proč to nelze změnit?"
 
 #: packages/admin/src/components/SeoPanel.tsx:209
 msgid "Why is this important for duplicate pages?"
-msgstr ""
+msgstr "Proč je to důležité u duplicitních stránek?"
 
 #: packages/admin/src/components/SeoPanel.tsx:185
 msgid "Why is this important for search result summaries?"
-msgstr ""
+msgstr "Proč je to důležité pro souhrny ve výsledcích hledání?"
 
 #: packages/admin/src/components/SeoPanel.tsx:165
 msgid "Why is this important for search result titles?"
-msgstr ""
+msgstr "Proč je to důležité pro názvy ve výsledcích hledání?"
 
 #: packages/admin/src/components/SeoPanel.tsx:228
 msgid "Why is this important for search visibility?"
-msgstr ""
+msgstr "Proč je to důležité pro viditelnost ve vyhledávání?"
 
 #: packages/admin/src/components/SeoImageField.tsx:44
 msgid "Why is this important for social sharing?"
-msgstr ""
+msgstr "Proč je to důležité pro sdílení na sociálních sítích?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:123
 msgid "Why is this important?"
-msgstr ""
+msgstr "Proč je to důležité?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
 msgid "Wide"
-msgstr ""
+msgstr "Široký"
 
 #: packages/admin/src/components/Widgets.tsx:802
 #: packages/admin/src/components/Widgets.tsx:817
 msgid "widget"
-msgstr ""
+msgstr "widget"
 
 #: packages/admin/src/components/Widgets.tsx:232
 msgid "Widget added"
-msgstr ""
+msgstr "Widget přidán"
 
 #: packages/admin/src/components/Widgets.tsx:220
 msgid "Widget area created"
-msgstr ""
+msgstr "Oblast widgetů vytvořena"
 
 #: packages/admin/src/components/Widgets.tsx:645
 msgid "Widget area deleted"
-msgstr ""
+msgstr "Oblast widgetů smazána"
 
 #: packages/admin/src/components/Widgets.tsx:765
 msgid "Widget deleted"
-msgstr ""
+msgstr "Widget smazán"
 
 #: packages/admin/src/components/Widgets.tsx:894
 msgid "Widget title"
-msgstr ""
+msgstr "Název widgetu"
 
 #: packages/admin/src/components/Widgets.tsx:780
 msgid "Widget updated"
-msgstr ""
+msgstr "Widget aktualizován"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:168
 #: packages/admin/src/components/PluginManager.tsx:408
@@ -8612,228 +8623,228 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:388
 #: packages/admin/src/components/WordPressImport.tsx:1157
 msgid "Widgets"
-msgstr ""
+msgstr "Widgety"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:284
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:473
 msgid "Width"
-msgstr ""
+msgstr "Šířka"
 
 #: packages/admin/src/components/PluginSettings.tsx:338
 msgid "Will be cleared on save"
-msgstr ""
+msgstr "Při uložení bude vymazáno"
 
 #: packages/admin/src/components/WordPressImport.tsx:2014
 msgid "Will create"
-msgstr ""
+msgstr "Vytvoří se"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:384
 msgid "will no longer be able to sign up without an invite. Existing users are not affected."
-msgstr ""
+msgstr "se již nebudou moci registrovat bez pozvánky. Stávající uživatelé nejsou dotčeni."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:158
 msgid "Without an email provider, invite links must be shared manually."
-msgstr ""
+msgstr "Bez poskytovatele e-mailu je nutné odkazy na pozvánky sdílet ručně."
 
 #: packages/admin/src/components/WordPressImport.tsx:210
 msgid "WordPress authorization was rejected"
-msgstr ""
+msgstr "Autorizace ve WordPressu byla odmítnuta"
 
 #: packages/admin/src/components/WordPressImport.tsx:1476
 msgid "WordPress Username"
-msgstr ""
+msgstr "Uživatelské jméno ve WordPressu"
 
 #: packages/admin/src/components/ContentList.tsx:404
 msgid "Working on {selectedCount} items…"
-msgstr ""
+msgstr "Zpracovává se {selectedCount} položek…"
 
 #: packages/admin/src/components/Widgets.tsx:904
 msgid "Write widget content..."
-msgstr ""
+msgstr "Napište obsah widgetu…"
 
 #: packages/admin/src/components/WordPressImport.tsx:1181
 msgid "WXR File"
-msgstr ""
+msgstr "Soubor WXR"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:58
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1497
 msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
-msgstr ""
+msgstr "xxxx xxxx xxxx xxxx xxxx xxxx"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:59
 msgid "YAML"
-msgstr ""
+msgstr "YAML"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Yearly"
-msgstr ""
+msgstr "Ročně"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:420
 #: packages/admin/src/routes/byline-schema.tsx:422
 msgid "Yes"
-msgstr ""
+msgstr "Ano"
 
 #: packages/admin/src/components/WordPressImport.tsx:1160
 msgid "Yoast/RankMath"
-msgstr ""
+msgstr "Yoast/RankMath"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."
-msgstr ""
+msgstr "Tuto stránku můžete zavřít a vrátit se do terminálu."
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
-msgstr ""
+msgstr "Můžete vytvářet a upravovat vlastní obsah."
 
 #: packages/admin/src/components/WelcomeModal.tsx:42
 msgid "You can manage content, media, menus, and taxonomies."
-msgstr ""
+msgstr "Můžete spravovat obsah, média, nabídky a taxonomie."
 
 #: packages/admin/src/routes/bylines.tsx:549
 msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
-msgstr ""
+msgstr "Pevná pole výše lze i nadále upravovat. Uložení neovlivní žádné uložené hodnoty vlastních polí."
 
 #: packages/admin/src/components/WelcomeModal.tsx:44
 msgid "You can view and contribute to the site."
-msgstr ""
+msgstr "Můžete web prohlížet a přispívat do něj."
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
-msgstr ""
+msgstr "Vlastní roli nelze změnit"
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
-msgstr ""
+msgstr "Máte plný přístup ke správě tohoto webu včetně uživatelů, nastavení a veškerého obsahu."
 
 #: packages/admin/src/routes/byline-schema.tsx:175
 msgid "You need admin permissions to manage byline schema."
-msgstr ""
+msgstr "Ke správě schématu autorských podpisů jsou potřeba oprávnění správce."
 
 #: packages/admin/src/router.tsx:1486
 msgid "You need Editor permissions to moderate comments."
-msgstr ""
+msgstr "K moderování komentářů jsou potřeba oprávnění role Editor."
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:204
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Pro přihlášení už nebude možné použít „{0}“. Tuto akci nelze vrátit zpět."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Tento přístupový klíč už nebude možné použít k přihlášení. Tuto akci nelze vrátit zpět."
 
 #. placeholder {0}: inviteData.roleName
 #: packages/admin/src/components/InviteAcceptPage.tsx:55
 msgid "You'll be joining as <0>{0}</0>"
-msgstr ""
+msgstr "Připojíte se jako <0>{0}</0>"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
-msgstr ""
+msgstr "Budete vyzváni k použití biometrického ověření, bezpečnostního klíče nebo PIN vašeho zařízení."
 
 #: packages/admin/src/components/WordPressImport.tsx:1369
 msgid "You'll be redirected to WordPress to authorize the connection."
-msgstr ""
+msgstr "Budete přesměrováni na WordPress, kde připojení autorizujete."
 
 #: packages/admin/src/components/SignupPage.tsx:192
 msgid "You'll be signing up as"
-msgstr ""
+msgstr "Registrujete se jako"
 
 #: packages/admin/src/components/SetupWizard.tsx:564
 msgid "You're signed in via Cloudflare Access"
-msgstr ""
+msgstr "Jste přihlášeni přes Cloudflare Access"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:53
 msgid "You've been invited!"
-msgstr ""
+msgstr "Máte pozvánku!"
 
 #: packages/admin/src/components/SignupPage.tsx:71
 msgid "you@company.com"
-msgstr ""
+msgstr "vy@firma.cz"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:334
 #: packages/admin/src/components/SetupWizard.tsx:201
 msgid "you@example.com"
-msgstr ""
+msgstr "vy@example.com"
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
-msgstr ""
+msgstr "Váš účet byl úspěšně vytvořen."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:316
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
 msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
-msgstr ""
+msgstr "Váš prohlížeč nepodporuje přístupové klíče. Použijte prosím moderní prohlížeč, například Chrome, Safari, Firefox nebo Edge."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:267
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
 msgid "Your device doesn't support the required security features."
-msgstr ""
+msgstr "Vaše zařízení nepodporuje požadované bezpečnostní funkce."
 
 #: packages/admin/src/components/SetupWizard.tsx:197
 msgid "Your Email"
-msgstr ""
+msgstr "Váš e-mail"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:121
 msgid "Your Facebook page or profile username"
-msgstr ""
+msgstr "Uživatelské jméno vaší stránky nebo profilu na Facebooku"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:115
 msgid "Your GitHub username"
-msgstr ""
+msgstr "Vaše uživatelské jméno na GitHubu"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:127
 msgid "Your Instagram username"
-msgstr ""
+msgstr "Vaše uživatelské jméno na Instagramu"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:133
 msgid "Your LinkedIn profile username"
-msgstr ""
+msgstr "Uživatelské jméno vašeho profilu na LinkedInu"
 
 #: packages/admin/src/components/MediaLibrary.tsx:504
 #: packages/admin/src/components/MediaLibrary.tsx:528
 msgid "Your media library is empty"
-msgstr ""
+msgstr "Vaše knihovna médií je prázdná"
 
 #: packages/admin/src/components/SetupWizard.tsx:209
 msgid "Your Name"
-msgstr ""
+msgstr "Vaše jméno"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:65
 #: packages/admin/src/components/SignupPage.tsx:202
 msgid "Your name (optional)"
-msgstr ""
+msgstr "Vaše jméno (nepovinné)"
 
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
-msgstr ""
+msgstr "Vaše role"
 
 #. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
 #: packages/admin/src/components/RegistryPluginDetail.tsx:612
 msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
-msgstr ""
+msgstr "Váš web vyžaduje, aby byly verze staré alespoň {0}, než je lze nainstalovat. Tuto verzi bude možné nainstalovat později."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:109
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr ""
+msgstr "Váš účet na Twitteru/X (např. @username)"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:437
 msgid "Your unsaved media changes will be lost."
-msgstr ""
+msgstr "Neuložené změny médií budou ztraceny."
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:2062
 msgid "Your WordPress export contains {0} media files."
-msgstr ""
+msgstr "Váš export z WordPressu obsahuje {0} mediálních souborů."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:139
 msgid "Your YouTube channel ID or handle"
-msgstr ""
+msgstr "ID nebo název vašeho kanálu na YouTube"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:136
 msgid "YouTube"
-msgstr ""
+msgstr "YouTube"

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -37,7 +37,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "ca", label: "Català", enabled: true }, // Catalan
 	{ code: "zh-CN", label: "简体中文", enabled: true }, // Chinese (Simplified)
 	{ code: "zh-TW", label: "繁體中文", enabled: true }, // Chinese (Traditional)
-	{ code: "cs", label: "Čeština", enabled: false }, // Czech
+	{ code: "cs", label: "Čeština", enabled: true }, // Czech
 	{ code: "nl", label: "Nederlands", enabled: true }, // Dutch
 	{ code: "en-GB", label: "English (UK)", enabled: true }, // English (United Kingdom)
 	{ code: "fa", label: "فارسی", enabled: true, dir: "rtl" }, // Farsi (also known as Persian)

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -37,6 +37,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "ca", label: "Català", enabled: true }, // Catalan
 	{ code: "zh-CN", label: "简体中文", enabled: true }, // Chinese (Simplified)
 	{ code: "zh-TW", label: "繁體中文", enabled: true }, // Chinese (Traditional)
+	{ code: "cs", label: "Čeština", enabled: false }, // Czech
 	{ code: "nl", label: "Nederlands", enabled: true }, // Dutch
 	{ code: "en-GB", label: "English (UK)", enabled: true }, // English (United Kingdom)
 	{ code: "fa", label: "فارسی", enabled: true, dir: "rtl" }, // Farsi (also known as Persian)


### PR DESCRIPTION
## What does this PR do?

Adds Czech (`cs`, Čeština) to the EmDash admin UI and enables it in the language picker.

The catalog translates all 1,938 current admin messages, including Czech ICU plural forms (`one`, `few`, `many`, and `other`). The translations were reviewed for source context, terminology consistency, placeholder integrity, and natural Czech UI wording by a fluent Czech speaker.

AI was used for the first translation pass and subsequent review assistance. The PR author remains responsible for the final Czech wording.

No related issue.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (not applicable: translation-only change)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no new source strings)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable (translation PR)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6 Sol

## Screenshots / test output

- `pnpm build` — passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm --filter @emdash-cms/admin test -- --run tests/lib/locales.test.ts` — 104 files and 1,243 tests passed, including catalog loading for every enabled locale
- `pnpm run locale:extract` — Czech: 1,938 messages, 0 missing
- `pnpm run locale:compile` — passed
- Catalog-wide structural audit — all 1,938 translations preserve ICU variables, XML tags, and boundary whitespace
- Runtime plural smoke test — verified Czech forms for counts 1, 3, and 8

The root `pnpm test` run reaches an unrelated `registry-verification` packaging check that invokes the native pnpm executable through Node on macOS and fails with `SyntaxError: Invalid or unexpected token`; all package tests before that point and the complete targeted admin suite pass.
