### PR TITLE
fix(admin): adopt Kumo's brand colours

### DIFF
--- a/.changeset/admin-kumo-brand-colour.md
+++ b/.changeset/admin-kumo-brand-colour.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Updates the admin's brand colour to Kumo's blue, so primary buttons, links, and accents read brighter and more saturated.

--- a/.changeset/admin-kumo-brand-colour.md
+++ b/.changeset/admin-kumo-brand-colour.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Updates the admin's brand colour to Kumo's blue, so primary buttons, links, and accents read brighter and more saturated.
+Updates the admin to Kumo's brand colours: primary buttons and fills become a brighter blue, and brand text and accents pick up Kumo's orange.

--- a/.changeset/admin-kumo-brand-colour.md
+++ b/.changeset/admin-kumo-brand-colour.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Updates the admin to Kumo's brand colours: primary buttons and fills become a brighter blue, and brand text and accents pick up Kumo's orange.
+Updates the admin to Kumo's brand colours: primary buttons and fills become a brighter blue, and links and accent icons pick up Kumo's link colour.

--- a/e2e/tests/i18n.spec.ts
+++ b/e2e/tests/i18n.spec.ts
@@ -108,7 +108,7 @@ test.describe("i18n", () => {
 			await admin.waitForLoading();
 
 			// The "current" marker should appear next to EN
-			const currentMarker = admin.page.locator("span.text-kumo-brand", {
+			const currentMarker = admin.page.locator("span.text-kumo-link", {
 				hasText: "current",
 			});
 			await expect(currentMarker).toBeVisible();

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -551,7 +551,7 @@ export function ContentList({
 														to="/content/$collection/new"
 														params={{ collection }}
 														search={{ locale: activeLocale }}
-														className="text-kumo-brand underline"
+														className="text-kumo-link underline"
 													>
 														{t`Create your first one`}
 													</Link>
@@ -883,7 +883,7 @@ function SortableTh({ field, sort, onSortChange, label }: SortableThProps) {
 				type="button"
 				onClick={handleClick}
 				className={cn(
-					"inline-flex items-center gap-1 rounded text-kumo-default hover:text-kumo-brand",
+					"inline-flex items-center gap-1 rounded text-kumo-default hover:text-kumo-link",
 					"focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-brand",
 				)}
 			>
@@ -979,7 +979,7 @@ function ContentListItem({
 					to="/content/$collection/$id"
 					params={{ collection, id: item.id }}
 					search={{ locale: item.locale }}
-					className="font-medium hover:text-kumo-brand"
+					className="font-medium hover:text-kumo-link"
 				>
 					{title}
 				</Link>
@@ -1096,7 +1096,7 @@ function TrashedListItem({ item, onRestore, onPermanentDelete }: TrashedListItem
 						aria-label={t`Restore ${title}`}
 						onClick={() => onRestore?.(item.id)}
 					>
-						<ArrowCounterClockwise className="h-4 w-4 text-kumo-brand" aria-hidden="true" />
+						<ArrowCounterClockwise className="h-4 w-4 text-kumo-link" aria-hidden="true" />
 					</Button>
 					<Dialog.Root disablePointerDismissal>
 						<Dialog.Trigger

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -120,7 +120,7 @@ export function ContentTypeList({
 							<tr>
 								<td colSpan={5} className="px-4 py-8 text-center text-kumo-subtle">
 									{t`No content types yet.`}{" "}
-									<Link to="/content-types/new" className="text-kumo-brand underline">
+									<Link to="/content-types/new" className="text-kumo-link underline">
 										{t`Create your first one`}
 									</Link>
 								</td>
@@ -187,7 +187,7 @@ function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
 						<Link
 							to="/content-types/$slug"
 							params={{ slug: collection.slug }}
-							className="font-medium hover:text-kumo-brand"
+							className="font-medium hover:text-kumo-link"
 						>
 							{collection.label}
 						</Link>

--- a/packages/admin/src/components/DeviceAuthorizePage.tsx
+++ b/packages/admin/src/components/DeviceAuthorizePage.tsx
@@ -171,7 +171,7 @@ export function DeviceAuthorizePage() {
 				{/* Header */}
 				<div className="text-center mb-8">
 					<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-kumo-brand/10 mb-4">
-						<TerminalIcon className="w-6 h-6 text-kumo-brand" />
+						<TerminalIcon className="w-6 h-6 text-kumo-link" />
 					</div>
 					<h1 className="text-xl font-semibold tracking-tight">{t`Authorize Device`}</h1>
 					<p className="text-kumo-subtle text-sm mt-1.5">{t`Enter the code from your terminal`}</p>

--- a/packages/admin/src/components/InviteAcceptPage.tsx
+++ b/packages/admin/src/components/InviteAcceptPage.tsx
@@ -37,7 +37,7 @@ function RegisterStep({ inviteData, token }: RegisterStepProps) {
 			<div className="text-center">
 				<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-kumo-brand/10 mx-auto mb-4">
 					<svg
-						className="w-8 h-8 text-kumo-brand"
+						className="w-8 h-8 text-kumo-link"
 						fill="none"
 						stroke="currentColor"
 						viewBox="0 0 24 24"

--- a/packages/admin/src/components/LocaleSwitcher.tsx
+++ b/packages/admin/src/components/LocaleSwitcher.tsx
@@ -108,7 +108,7 @@ export function LocaleBadges({
 						className={cn(
 							"rounded px-1 py-0.5 text-[10px] font-semibold uppercase leading-none transition-colors",
 							exists
-								? "bg-kumo-brand/10 text-kumo-brand hover:bg-kumo-brand/20"
+								? "bg-kumo-brand/10 text-kumo-link hover:bg-kumo-brand/20"
 								: "bg-kumo-tint text-kumo-subtle/50",
 							onLocaleClick && exists && "cursor-pointer",
 							(!onLocaleClick || !exists) && "cursor-default",

--- a/packages/admin/src/components/LoginPage.tsx
+++ b/packages/admin/src/components/LoginPage.tsx
@@ -84,7 +84,7 @@ function MagicLinkForm({ onBack }: MagicLinkFormProps) {
 			<div className="space-y-6 text-center">
 				<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-kumo-brand/10 mx-auto">
 					<svg
-						className="w-8 h-8 text-kumo-brand"
+						className="w-8 h-8 text-kumo-link"
 						fill="none"
 						stroke="currentColor"
 						viewBox="0 0 24 24"
@@ -333,7 +333,7 @@ export function LoginPage({ redirectUrl = "/_emdash/admin" }: LoginPageProps) {
 					<p className="text-center mt-4 text-sm text-kumo-subtle">
 						<Trans>
 							Don't have an account?{" "}
-							<Link to="/signup" className="text-kumo-brand hover:underline font-medium">
+							<Link to="/signup" className="text-kumo-link hover:underline font-medium">
 								Sign up
 							</Link>
 						</Trans>

--- a/packages/admin/src/components/MarketplaceBrowse.tsx
+++ b/packages/admin/src/components/MarketplaceBrowse.tsx
@@ -249,7 +249,7 @@ function PluginCard({ plugin, isInstalled }: PluginCardProps) {
 				{/* Name + meta */}
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
-						<h3 className="truncate font-semibold group-hover:text-kumo-brand">{plugin.name}</h3>
+						<h3 className="truncate font-semibold group-hover:text-kumo-link">{plugin.name}</h3>
 						{isInstalled && (
 							<span
 								role="link"
@@ -266,7 +266,7 @@ function PluginCard({ plugin, isInstalled }: PluginCardProps) {
 					</div>
 					<div className="flex items-center gap-2 text-xs text-kumo-subtle">
 						<span>{plugin.author.name}</span>
-						{plugin.author.verified && <ShieldCheck className="h-3 w-3 text-kumo-brand" />}
+						{plugin.author.verified && <ShieldCheck className="h-3 w-3 text-kumo-link" />}
 						{plugin.latestVersion?.version && <span>v{plugin.latestVersion.version}</span>}
 					</div>
 				</div>
@@ -306,7 +306,7 @@ function PluginCard({ plugin, isInstalled }: PluginCardProps) {
 function PluginAvatar({ name }: { name: string }) {
 	const initial = name.charAt(0).toUpperCase();
 	return (
-		<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-kumo-brand/10 text-kumo-brand font-bold text-lg">
+		<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-kumo-brand/10 text-kumo-link font-bold text-lg">
 			{initial}
 		</div>
 	);

--- a/packages/admin/src/components/MarketplacePluginDetail.tsx
+++ b/packages/admin/src/components/MarketplacePluginDetail.tsx
@@ -122,7 +122,7 @@ export function MarketplacePluginDetail({
 					<p className="mt-1 text-sm text-kumo-subtle">
 						{error instanceof Error ? error.message : t`Plugin not found`}
 					</p>
-					<Link to="/plugins/marketplace" className="mt-4 inline-block text-kumo-brand text-sm">
+					<Link to="/plugins/marketplace" className="mt-4 inline-block text-kumo-link text-sm">
 						{t`Back to marketplace`}
 					</Link>
 				</div>
@@ -153,7 +153,7 @@ export function MarketplacePluginDetail({
 							aria-label={isImageFlagged ? t`Icon blurred due to image audit` : undefined}
 						/>
 					) : (
-						<div className="flex h-16 w-16 items-center justify-center rounded-xl bg-kumo-brand/10 text-kumo-brand text-2xl font-bold">
+						<div className="flex h-16 w-16 items-center justify-center rounded-xl bg-kumo-brand/10 text-kumo-link text-2xl font-bold">
 							{plugin.name.charAt(0).toUpperCase()}
 						</div>
 					)}
@@ -162,7 +162,7 @@ export function MarketplacePluginDetail({
 						<h1 className="text-2xl font-semibold leading-tight">{plugin.name}</h1>
 						<div className="mt-1 flex items-center gap-2 text-sm text-kumo-subtle">
 							<span>{plugin.author.name}</span>
-							{plugin.author.verified && <ShieldCheck className="h-4 w-4 text-kumo-brand" />}
+							{plugin.author.verified && <ShieldCheck className="h-4 w-4 text-kumo-link" />}
 							{latest && (
 								<>
 									<span aria-hidden="true">&middot;</span>
@@ -219,7 +219,7 @@ export function MarketplacePluginDetail({
 						href={plugin.repositoryUrl}
 						target="_blank"
 						rel="noopener noreferrer"
-						className="flex items-center gap-1 text-kumo-brand hover:underline"
+						className="flex items-center gap-1 text-kumo-link hover:underline"
 					>
 						<GithubLogo className="h-4 w-4" />
 						{t`Source`}
@@ -230,7 +230,7 @@ export function MarketplacePluginDetail({
 						href={plugin.homepageUrl}
 						target="_blank"
 						rel="noopener noreferrer"
-						className="flex items-center gap-1 text-kumo-brand hover:underline"
+						className="flex items-center gap-1 text-kumo-link hover:underline"
 					>
 						<Globe className="h-4 w-4" />
 						{t`Website`}
@@ -290,7 +290,7 @@ export function MarketplacePluginDetail({
 							<ul className="space-y-1.5">
 								{plugin.capabilities.map((cap) => (
 									<li key={cap} className="flex items-start gap-2 text-xs text-kumo-subtle">
-										<ShieldCheck className="mt-0.5 h-3 w-3 shrink-0 text-kumo-brand" />
+										<ShieldCheck className="mt-0.5 h-3 w-3 shrink-0 text-kumo-link" />
 										<span>{describeCapability(cap)}</span>
 									</li>
 								))}

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -670,7 +670,7 @@ function MediaEmptyIllustration({ hero: Hero }: { hero: Icon }) {
 			}}
 			aria-hidden="true"
 		>
-			<Hero size={36} className="text-kumo-brand" aria-hidden="true" />
+			<Hero size={36} className="text-kumo-link" aria-hidden="true" />
 		</div>
 	);
 }

--- a/packages/admin/src/components/MenuEditor.tsx
+++ b/packages/admin/src/components/MenuEditor.tsx
@@ -514,7 +514,7 @@ export function MenuEditor() {
 										{item.type === "custom" ? (
 											item.customUrl
 										) : (
-											<span className="inline-flex items-center rounded-full bg-kumo-brand/10 px-2 py-0.5 text-xs font-medium text-kumo-brand">
+											<span className="inline-flex items-center rounded-full bg-kumo-brand/10 px-2 py-0.5 text-xs font-medium text-kumo-link">
 												{item.referenceCollection ?? item.type}
 											</span>
 										)}

--- a/packages/admin/src/components/PluginFieldErrorBoundary.tsx
+++ b/packages/admin/src/components/PluginFieldErrorBoundary.tsx
@@ -38,7 +38,7 @@ export class PluginFieldErrorBoundary extends React.Component<Props, State> {
 					</p>
 					<button
 						type="button"
-						className="mt-2 text-xs font-medium text-kumo-brand underline"
+						className="mt-2 text-xs font-medium text-kumo-link underline"
 						onClick={() => this.setState({ hasError: false, error: undefined })}
 					>
 						<Trans>Retry</Trans>

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -202,7 +202,7 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 						{hasMarketplace ? (
 							<>
 								{t`Browse the`}{" "}
-								<Link to="/plugins/marketplace" className="text-kumo-brand hover:underline">
+								<Link to="/plugins/marketplace" className="text-kumo-link hover:underline">
 									{t`marketplace`}
 								</Link>{" "}
 								{t`to install plugins, or add them to your astro.config.mjs.`}
@@ -370,7 +370,7 @@ function PluginCard({
 							)}
 						>
 							<ADMIN_NAV_ICONS.plugins
-								className={cn("h-5 w-5", plugin.enabled ? "text-kumo-brand" : "text-kumo-subtle")}
+								className={cn("h-5 w-5", plugin.enabled ? "text-kumo-link" : "text-kumo-subtle")}
 							/>
 						</div>
 					)}
@@ -383,7 +383,7 @@ function PluginCard({
 							{!plugin.enabled && <Badge variant="secondary">{t`Disabled`}</Badge>}
 							{isMarketplace && <Badge variant="secondary">{t`Marketplace`}</Badge>}
 							{hasUpdate && (
-								<Badge variant="outline" className="border-kumo-brand text-kumo-brand">
+								<Badge variant="outline" className="border-kumo-brand text-kumo-link">
 									{t`v${updateInfo.latest} available`}
 								</Badge>
 							)}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2549,7 +2549,7 @@ export function PortableTextEditor({
 					openOnClick: false,
 					enableClickSelection: true,
 					HTMLAttributes: {
-						class: "text-kumo-brand underline",
+						class: "text-kumo-link underline",
 					},
 				},
 				underline: {},

--- a/packages/admin/src/components/Redirects.tsx
+++ b/packages/admin/src/components/Redirects.tsx
@@ -373,7 +373,7 @@ export function Redirects() {
 					className={cn(
 						"px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
 						tab === "redirects"
-							? "border-kumo-brand text-kumo-brand"
+							? "border-kumo-brand text-kumo-link"
 							: "border-transparent text-kumo-subtle hover:text-kumo-default",
 					)}
 				>
@@ -390,7 +390,7 @@ export function Redirects() {
 					className={cn(
 						"px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
 						tab === "404s"
-							? "border-kumo-brand text-kumo-brand"
+							? "border-kumo-brand text-kumo-link"
 							: "border-transparent text-kumo-subtle hover:text-kumo-default",
 					)}
 				>

--- a/packages/admin/src/components/RegistryBrowse.tsx
+++ b/packages/admin/src/components/RegistryBrowse.tsx
@@ -185,7 +185,7 @@ function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 						<h2 className="truncate font-semibold">{name ?? pkg.slug}</h2>
 						{verified ? (
 							<ShieldCheck
-								className="h-4 w-4 shrink-0 text-kumo-brand"
+								className="h-4 w-4 shrink-0 text-kumo-link"
 								aria-label={t`Verified publisher`}
 							/>
 						) : null}

--- a/packages/admin/src/components/RegistryPluginDetail.tsx
+++ b/packages/admin/src/components/RegistryPluginDetail.tsx
@@ -462,7 +462,7 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 												: t`Verified publisher`
 										}
 									>
-										<ShieldCheck className="h-5 w-5 text-kumo-brand" aria-hidden />
+										<ShieldCheck className="h-5 w-5 text-kumo-link" aria-hidden />
 									</button>
 								}
 							/>
@@ -487,7 +487,7 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 									target="_blank"
 									rel="noopener noreferrer"
 									download
-									className="text-xs text-kumo-brand hover:underline"
+									className="text-xs text-kumo-link hover:underline"
 								>
 									{t`Download SBOM`}
 								</a>
@@ -696,13 +696,13 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 										href={a.url}
 										target="_blank"
 										rel="noreferrer"
-										className="text-kumo-brand hover:underline"
+										className="text-kumo-link hover:underline"
 									>
 										{t`Website`}
 									</a>
 								) : null}
 								{a.email ? (
-									<a href={`mailto:${a.email}`} className="text-kumo-brand hover:underline">
+									<a href={`mailto:${a.email}`} className="text-kumo-link hover:underline">
 										{a.email}
 									</a>
 								) : null}
@@ -724,7 +724,7 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 								className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm"
 							>
 								{c.email ? (
-									<a href={`mailto:${c.email}`} className="text-kumo-brand hover:underline">
+									<a href={`mailto:${c.email}`} className="text-kumo-link hover:underline">
 										{c.email}
 									</a>
 								) : null}
@@ -733,7 +733,7 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 										href={c.url}
 										target="_blank"
 										rel="noreferrer"
-										className="text-kumo-brand hover:underline"
+										className="text-kumo-link hover:underline"
 									>
 										{c.url}
 									</a>

--- a/packages/admin/src/components/RevisionHistory.tsx
+++ b/packages/admin/src/components/RevisionHistory.tsx
@@ -361,7 +361,7 @@ function RevisionDiffView({ older, newer }: RevisionDiffViewProps) {
 					<button
 						type="button"
 						onClick={() => setShowUnchanged(!showUnchanged)}
-						className="text-xs text-kumo-brand hover:underline"
+						className="text-xs text-kumo-link hover:underline"
 					>
 						{showUnchanged
 							? plural(unchangedCount, { one: "Hide # unchanged", other: "Hide # unchanged" })

--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -113,7 +113,7 @@ function CheckEmailStep({ email, onResend, isResending, resendCooldown }: CheckE
 		<div className="space-y-6 text-center">
 			<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-kumo-brand/10 mx-auto">
 				<svg
-					className="w-8 h-8 text-kumo-brand"
+					className="w-8 h-8 text-kumo-link"
 					fill="none"
 					stroke="currentColor"
 					viewBox="0 0 24 24"
@@ -437,7 +437,7 @@ export function SignupPage() {
 				{step === "email" && (
 					<p className="text-center mt-6 text-sm text-kumo-subtle">
 						{t`Already have an account?`}{" "}
-						<Link to="/login" className="text-kumo-brand hover:underline font-medium">
+						<Link to="/login" className="text-kumo-link hover:underline font-medium">
 							{t`Sign in`}
 						</Link>
 					</p>

--- a/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
@@ -217,12 +217,12 @@ function ThemeCard({ theme }: { theme: ThemeSummary }) {
 			{/* Info */}
 			<div className="p-4">
 				<Link to={"/themes/marketplace/$themeId"} params={{ themeId: theme.id }} className="block">
-					<h3 className="font-semibold group-hover:text-kumo-brand truncate">{theme.name}</h3>
+					<h3 className="font-semibold group-hover:text-kumo-link truncate">{theme.name}</h3>
 				</Link>
 
 				<div className="flex items-center gap-2 mt-1 text-xs text-kumo-subtle">
 					<span>{theme.author.name}</span>
-					{theme.author.verified && <ShieldCheck className="h-3 w-3 text-kumo-brand" />}
+					{theme.author.verified && <ShieldCheck className="h-3 w-3 text-kumo-link" />}
 				</div>
 
 				{theme.description && (

--- a/packages/admin/src/components/ThemeMarketplaceDetail.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceDetail.tsx
@@ -117,14 +117,14 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 						<img src={thumbnailUrl} alt="" className="h-16 w-16 rounded-lg object-cover" />
 					) : (
 						<div className="flex h-16 w-16 items-center justify-center rounded-lg bg-kumo-brand/10">
-							<Palette className="h-8 w-8 text-kumo-brand" />
+							<Palette className="h-8 w-8 text-kumo-link" />
 						</div>
 					)}
 					<div>
 						<h1 className="text-2xl font-semibold leading-tight">{theme.name}</h1>
 						<div className="mt-1 flex items-center gap-2 text-sm text-kumo-subtle">
 							<span>{theme.author.name}</span>
-							{theme.author.verified && <ShieldCheck className="h-4 w-4 text-kumo-brand" />}
+							{theme.author.verified && <ShieldCheck className="h-4 w-4 text-kumo-link" />}
 						</div>
 						{theme.description && (
 							<p className="mt-2 text-sm text-kumo-subtle max-w-xl">{theme.description}</p>
@@ -214,7 +214,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 								href={theme.repositoryUrl}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="inline-flex items-center gap-1.5 text-sm text-kumo-brand hover:underline"
+								className="inline-flex items-center gap-1.5 text-sm text-kumo-link hover:underline"
 							>
 								<GithubLogo className="h-4 w-4" />
 								{t`Repository`}
@@ -225,7 +225,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 								href={theme.homepageUrl}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="inline-flex items-center gap-1.5 text-sm text-kumo-brand hover:underline"
+								className="inline-flex items-center gap-1.5 text-sm text-kumo-link hover:underline"
 							>
 								<Globe className="h-4 w-4" />
 								{t`Homepage`}

--- a/packages/admin/src/components/TranslationsPanel.tsx
+++ b/packages/admin/src/components/TranslationsPanel.tsx
@@ -80,7 +80,7 @@ export function TranslationsPanel({
 								{locale === defaultLocale && (
 									<span className="text-[10px] text-kumo-subtle">{t` (default)`}</span>
 								)}
-								{isCurrent && <span className="text-[10px] text-kumo-brand">{t`current`}</span>}
+								{isCurrent && <span className="text-[10px] text-kumo-link">{t`current`}</span>}
 							</div>
 							{isCurrent ? null : translation && onOpen ? (
 								<Button

--- a/packages/admin/src/components/WelcomeModal.tsx
+++ b/packages/admin/src/components/WelcomeModal.tsx
@@ -131,7 +131,7 @@ export function WelcomeModal({ open, onClose, userName, userRole }: WelcomeModal
 				<div className="space-y-4 py-4">
 					<div className="rounded-lg bg-kumo-tint p-4">
 						<div className="text-sm font-medium">{t(MSG_YOUR_ROLE)}</div>
-						<div className="text-lg font-semibold text-kumo-brand">{roleLabel}</div>
+						<div className="text-lg font-semibold text-kumo-link">{roleLabel}</div>
 						<p className="text-sm text-kumo-subtle mt-1">{t(scopeDescriptor(isAdmin, userRole))}</p>
 					</div>
 

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -693,7 +693,7 @@ function WidgetAreaPanel({
 					<div
 						className={`text-center py-4 rounded border-2 border-dashed transition-colors ${
 							isOver
-								? "border-kumo-brand bg-kumo-brand/5 text-kumo-brand"
+								? "border-kumo-brand bg-kumo-brand/5 text-kumo-link"
 								: "border-kumo-subtle/30 text-kumo-subtle"
 						}`}
 					>

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -1031,7 +1031,7 @@ function ChooseStep({
 			<div className="rounded-lg border border-kumo-brand/40 bg-kumo-base p-6">
 				<div className="flex items-start gap-4">
 					<div className="p-3 rounded-full bg-kumo-brand/10">
-						<Sparkle className="h-6 w-6 text-kumo-brand" />
+						<Sparkle className="h-6 w-6 text-kumo-link" />
 					</div>
 					<div className="flex-1">
 						<h3 className="text-lg font-medium">{t`Paste your migration key`}</h3>
@@ -1076,7 +1076,7 @@ function ChooseStep({
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<div className="flex items-start gap-4">
 					<div className="p-3 rounded-full bg-kumo-brand/10">
-						<Globe className="h-6 w-6 text-kumo-brand" />
+						<Globe className="h-6 w-6 text-kumo-link" />
 					</div>
 					<div className="flex-1">
 						<h3 className="text-lg font-medium">{t`Enter your WordPress site URL`}</h3>
@@ -1202,7 +1202,7 @@ function FeatureComparison() {
 			</div>
 			<div className="border-t p-3 bg-kumo-info-tint">
 				<div className="flex items-start gap-2 text-sm">
-					<Sparkle className="h-4 w-4 text-kumo-brand flex-shrink-0 mt-0.5" />
+					<Sparkle className="h-4 w-4 text-kumo-link flex-shrink-0 mt-0.5" />
 					<p className="text-kumo-default">
 						{t`For the best import experience, install the`}{" "}
 						<span className="font-medium">{t`EmDash Exporter`}</span>{" "}
@@ -1515,7 +1515,7 @@ function PluginAuthStep({
 
 			<div className="rounded-lg border-s-4 border-s-kumo-brand border border-kumo-line bg-kumo-base p-4">
 				<div className="flex gap-3">
-					<ArrowSquareOut className="h-5 w-5 text-kumo-brand flex-shrink-0" />
+					<ArrowSquareOut className="h-5 w-5 text-kumo-link flex-shrink-0" />
 					<div className="text-sm">
 						<p className="font-medium">{t`How to create an Application Password`}</p>
 						<ol className="mt-2 space-y-1 text-kumo-subtle">
@@ -1529,7 +1529,7 @@ function PluginAuthStep({
 							href={`${siteUrl}/wp-admin/profile.php#application-passwords-section`}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="mt-2 inline-flex items-center gap-1 text-kumo-brand hover:underline"
+							className="mt-2 inline-flex items-center gap-1 text-kumo-link hover:underline"
 						>
 							{t`Open WordPress Profile`}
 							<ArrowSquareOut className="h-3 w-3" aria-hidden="true" />
@@ -1869,7 +1869,7 @@ function ReviewStep({
 			{selectedCount > 0 && (
 				<div className="rounded-lg border-s-4 border-s-kumo-brand border border-kumo-line bg-kumo-base p-4">
 					<div className="flex gap-3">
-						<Database className="h-5 w-5 text-kumo-brand flex-shrink-0" />
+						<Database className="h-5 w-5 text-kumo-link flex-shrink-0" />
 						<div className="space-y-2">
 							<p className="font-medium">{t`What will happen when you import`}</p>
 							<ul className="text-sm text-kumo-subtle space-y-1">
@@ -2010,7 +2010,7 @@ function PostTypeRow({
 											<Check className="inline h-3 w-3" /> {t`Exists`}
 										</span>
 									) : status?.status === "missing" ? (
-										<span className="text-kumo-brand">
+										<span className="text-kumo-link">
 											<Plus className="inline h-3 w-3" /> {t`Will create`}
 										</span>
 									) : status?.status === "type_mismatch" ? (
@@ -2054,7 +2054,7 @@ function MediaStep({
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<div className="flex items-start gap-4">
 					<div className="p-3 rounded-full bg-kumo-brand/10">
-						<Image className="h-6 w-6 text-kumo-brand" />
+						<Image className="h-6 w-6 text-kumo-link" />
 					</div>
 					<div className="flex-1">
 						<h3 className="text-lg font-medium">{t`Import Media Files`}</h3>
@@ -2086,7 +2086,7 @@ function MediaStep({
 
 				<div className="mt-4 p-4 rounded-lg border-s-4 border-s-kumo-brand border border-kumo-line bg-kumo-base">
 					<div className="flex gap-3">
-						<DownloadSimple className="h-5 w-5 text-kumo-brand flex-shrink-0" />
+						<DownloadSimple className="h-5 w-5 text-kumo-link flex-shrink-0" />
 						<div className="text-sm">
 							<p className="font-medium">{t`What happens when you import:`}</p>
 							<ul className="mt-1 space-y-1 text-kumo-subtle">
@@ -2448,7 +2448,7 @@ function AuthorMappingStep({
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<div className="flex items-start gap-4">
 					<div className="p-3 rounded-full bg-kumo-brand/10">
-						<User className="h-6 w-6 text-kumo-brand" />
+						<User className="h-6 w-6 text-kumo-link" />
 					</div>
 					<div>
 						<h3 className="text-lg font-medium">{t`Map Authors`}</h3>

--- a/packages/admin/src/components/users/UserList.tsx
+++ b/packages/admin/src/components/users/UserList.tsx
@@ -120,7 +120,7 @@ export function UserList({
 											{t`No users found matching your filters.`}{" "}
 											<button
 												type="button"
-												className="text-kumo-brand underline"
+												className="text-kumo-link underline"
 												onClick={() => {
 													onSearchChange("");
 													onRoleFilterChange(undefined);
@@ -134,7 +134,7 @@ export function UserList({
 											{t`No users yet.`}{" "}
 											<button
 												type="button"
-												className="text-kumo-brand underline"
+												className="text-kumo-link underline"
 												onClick={onInviteUser}
 											>
 												{t`Invite your first team member`}

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -2190,7 +2190,7 @@ function NotFoundPage({ message }: { message?: string }) {
 				<p className="mt-2 text-sm text-kumo-subtle">
 					{message ?? t`The page you're looking for doesn't exist.`}
 				</p>
-				<Link to="/" className="mt-4 inline-block text-kumo-brand">
+				<Link to="/" className="mt-4 inline-block text-kumo-link">
 					{t`Go to Dashboard`}
 				</Link>
 			</div>

--- a/packages/admin/src/routes/users.tsx
+++ b/packages/admin/src/routes/users.tsx
@@ -205,7 +205,7 @@ export function UsersPage() {
 				<p className="text-kumo-danger">{t`Failed to load users: ${usersQuery.error.message}`}</p>
 				<button
 					onClick={() => usersQuery.refetch()}
-					className="mt-4 text-sm text-kumo-brand underline"
+					className="mt-4 text-sm text-kumo-link underline"
 				>
 					{t`Try again`}
 				</button>

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -29,12 +29,6 @@
  * Overrides kumo CSS custom properties with classic CMS admin values.
  * Applied via data-theme="classic" on <html> so portals inherit too.
  */
-[data-theme="classic"] {
-	/* Kumo reserves brand text for the Cloudflare orange wordmark; the admin uses
-	 * `text-kumo-brand` for links and accents, so it tracks the link colour. */
-	--text-color-kumo-brand: var(--text-color-kumo-link);
-}
-
 [data-theme="classic"]:not([data-mode="dark"]) {
 	/* Surfaces */
 	--color-kumo-canvas: oklch(98.75% 0 0);

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -30,10 +30,9 @@
  * Applied via data-theme="classic" on <html> so portals inherit too.
  */
 [data-theme="classic"] {
-	/* Primary brand blue */
-	--color-kumo-brand: #2271b1;
-	--color-kumo-brand-hover: #135e96;
-	--text-color-kumo-brand: #2271b1;
+	/* Kumo reserves brand text for the Cloudflare orange wordmark; the admin uses
+	 * `text-kumo-brand` for links and accents, so it tracks the link colour. */
+	--text-color-kumo-brand: var(--text-color-kumo-link);
 }
 
 [data-theme="classic"]:not([data-mode="dark"]) {
@@ -52,14 +51,12 @@
 
 	/* Borders */
 	--color-kumo-line: oklch(14.5% 0 0 / 0.1);
-	--color-kumo-ring: #2271b1;
 
 	/* Text hierarchy */
 	--text-color-kumo-default: #1d2327;
 	--text-color-kumo-strong: #50575e;
 	--text-color-kumo-subtle: #646970;
 	--text-color-kumo-inactive: #a7aaad;
-	--text-color-kumo-link: #2271b1;
 
 	/* Semantic colors */
 	--color-kumo-info: #72aee6;


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Removes the admin's overrides of Kumo's brand tokens, so buttons and accents use Kumo's own colours.

**Buttons.** The `classic` theme pinned `--color-kumo-brand` to the WordPress admin blue (`#2271b1`), about half the chroma of Kumo's brand, so every primary button rendered muted. Dropping the override brightens them and lets them track future Kumo releases.

**Links and accent icons.** Kumo maps `--text-color-kumo-brand` to the Cloudflare orange wordmark (`#f6821f`). The admin used `text-kumo-brand` for links and accent icons, so inheriting Kumo's value turned 62 sites orange at 2.5:1, below the 4.5:1 AA needs for text and the 3:1 for meaningful icons. Instead of overriding the token back to a blue, those call sites now use `text-kumo-link`, which already means interactive text.

| | Contrast on light surface |
| --- | --- |
| `#f6821f` (Kumo brand text, inherited) | 2.50:1, fails AA |
| `#2271b1` (previous override) | 4.99:1 |
| `text-kumo-link` (this PR) | 8.53:1 |

Net result: five theme-token overrides removed, none added. Border and background brand utilities are untouched, since they read `--color-kumo-brand`, which is blue in both themes.

**Correction to commit `83ff867`:** its message says `--color-kumo-ring` was removed because nothing read it. That is wrong, seven files do write `ring-kumo-ring`. The removal is still harmless, because `.ring-kumo-ring` never compiles (Kumo declares no `--color-kumo-ring` in `@theme`), so those rings already fell back to `currentColor`. Pre-existing bug, untouched here.

**Follow-up, not fixed here:** `packages/admin/src/styles.css:95` sets `border-color` on `*` outside any `@layer`. Unlayered rules beat `@layer utilities`, so all 106 `border-kumo-*` utilities in the admin are silently overridden by `--color-kumo-line`. The fix is one line but would switch on 106 dormant borders at once, so it needs its own branch and a visual pass.

If an admin-wide colour change counts as a feature rather than a bug fix, this should go to a Discussion first.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (via OpenCode)

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->

Checked in light and dark mode on a local `demos/simple` server:

- Primary button background is now `rgb(84,145,246)`, was `oklch(0.674 0.0875 247.8)`.
- Link and accent text resolves to 8.53:1 in light mode and 7.67:1 in dark.
- DOM sweep for Cloudflare orange `rgb(246,130,31)`: 0 elements.

Not checked: RTL, and pages I did not visit. This touches 28 files of colour utilities, so the marketplace, editor and media library are worth a click-through before merge.

Unticked above: no tests added, since there is no behaviour to assert; verified by measuring computed colours in-browser instead. No approved Discussion, since this is filed as a bug fix.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-admin-kumo-brand-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/admin-kumo-brand`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
