### PR TITLE
feat(admin): allow hiding a collection from the admin sidebar

### DIFF
--- a/.changeset/hidden-collections-sidebar.md
+++ b/.changeset/hidden-collections-sidebar.md
@@ -1,5 +1,5 @@
 ---
-"@emdash-cms/core": minor
+"emdash": minor
 "@emdash-cms/admin": minor
 ---
 

--- a/.changeset/hidden-collections-sidebar.md
+++ b/.changeset/hidden-collections-sidebar.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/core": minor
+"@emdash-cms/admin": minor
+---
+
+Adds a `hidden` flag to collections that omits their auto-generated entry from the admin sidebar. Hidden collections keep working everywhere else — REST API, MCP, plugin hooks, and their editor at `/_emdash/admin/content/<slug>` — so a plugin that owns a collection end to end can point editors at its own admin UI instead of a raw CRUD list. Set it in a seed file (`"hidden": true`) or via the schema API.

--- a/docs/src/content/docs/themes/seed-files.mdx
+++ b/docs/src/content/docs/themes/seed-files.mdx
@@ -121,7 +121,15 @@ Each collection definition creates a content type in the database:
 | `description`   | `string` | No       | Admin UI description                         |
 | `icon`          | `string` | No       | Lucide icon name                             |
 | `supports`      | `array`  | No       | Features: `"drafts"`, `"revisions"`          |
+| `hidden`        | `boolean`| No       | Omit the collection's admin sidebar entry    |
 | `fields`        | `array`  | Yes      | Field definitions                            |
+
+<Aside type="tip" title="Hiding a collection from the sidebar">
+	`hidden: true` only removes the auto-generated sidebar link. The collection keeps working
+	everywhere else — REST API, MCP tools, plugin hooks, and its editor at
+	`/_emdash/admin/content/<slug>`. Use it for collections a plugin owns end to end (autopopulated
+	entries, its own admin page), so editors aren't sent to a raw CRUD list they never need.
+</Aside>
 
 ### Field Properties
 

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -57,9 +57,24 @@ export function filterNavItemsByRole<T extends { minRole?: number }>(
 	return items.filter((item) => !item.minRole || userRole >= item.minRole);
 }
 
+/**
+ * Manifest collections that get an auto-generated sidebar entry, in manifest
+ * order. Pure function — exported so tests can pin the `hidden` contract
+ * without rendering the sidebar.
+ *
+ * A hidden collection is still shipped in the manifest and stays fully
+ * routable at `/content/:collection`; it only loses its nav link, so a plugin
+ * that owns the collection end to end can steer editors to its own admin UI.
+ */
+export function visibleCollectionEntries<T extends { hidden?: boolean }>(
+	collections: Record<string, T>,
+): Array<[string, T]> {
+	return Object.entries(collections).filter(([, config]) => !config.hidden);
+}
+
 export interface SidebarNavProps {
 	manifest: {
-		collections: Record<string, { label: string }>;
+		collections: Record<string, { label: string; hidden?: boolean }>;
 		plugins: Record<
 			string,
 			{
@@ -205,7 +220,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 	const contentItems: NavItem[] = [
 		{ to: "/", label: t`Dashboard`, icon: ADMIN_NAV_ICONS.dashboard },
 	];
-	for (const [name, config] of Object.entries(manifest.collections)) {
+	for (const [name, config] of visibleCollectionEntries(manifest.collections)) {
 		contentItems.push({
 			to: "/content/$collection",
 			label: config.label,

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -93,6 +93,7 @@ export interface AdminManifest {
 			supports: string[];
 			hasSeo: boolean;
 			urlPattern?: string;
+			hidden?: boolean;
 			fields: Record<
 				string,
 				{

--- a/packages/admin/src/lib/api/schema.ts
+++ b/packages/admin/src/lib/api/schema.ts
@@ -36,6 +36,8 @@ export interface SchemaCollection {
 	source?: string;
 	urlPattern?: string;
 	hasSeo: boolean;
+	/** Sidebar entry omitted in the admin; the collection stays reachable by URL */
+	hidden: boolean;
 	commentsEnabled: boolean;
 	commentsModeration: "all" | "first_time" | "none";
 	commentsClosedAfterDays: number;
@@ -83,6 +85,7 @@ export interface CreateCollectionInput {
 	supports?: string[];
 	urlPattern?: string;
 	hasSeo?: boolean;
+	hidden?: boolean;
 }
 
 export interface UpdateCollectionInput {
@@ -93,6 +96,7 @@ export interface UpdateCollectionInput {
 	supports?: string[];
 	urlPattern?: string;
 	hasSeo?: boolean;
+	hidden?: boolean;
 	commentsEnabled?: boolean;
 	commentsModeration?: "all" | "first_time" | "none";
 	commentsClosedAfterDays?: number;

--- a/packages/admin/tests/components/Sidebar.test.tsx
+++ b/packages/admin/tests/components/Sidebar.test.tsx
@@ -39,6 +39,7 @@ import {
 	resolveNavIcon,
 	resolvePluginPageLabel,
 	toPhosphorIconName,
+	visibleCollectionEntries,
 } from "../../src/components/Sidebar";
 import { render } from "../utils/render.tsx";
 
@@ -102,6 +103,30 @@ describe("filterNavItemsByRole", () => {
 		// must strip every gated entry at role=0.
 		const visible = filterNavItemsByRole(items, 0).map((i) => i.to);
 		expect(visible).toEqual(["/"]);
+	});
+});
+
+describe("visibleCollectionEntries (#1131)", () => {
+	const collections = {
+		posts: { label: "Posts" },
+		contact_submissions: { label: "Contact Submissions", hidden: true },
+		lead_notes: { label: "Lead Notes", hidden: true },
+		pages: { label: "Pages", hidden: false },
+	};
+
+	it("drops collections flagged hidden", () => {
+		expect(visibleCollectionEntries(collections).map(([slug]) => slug)).toEqual(["posts", "pages"]);
+	});
+
+	it("keeps manifest order for visible collections", () => {
+		expect(visibleCollectionEntries({ b: { label: "B" }, a: { label: "A" } })).toEqual([
+			["b", { label: "B" }],
+			["a", { label: "A" }],
+		]);
+	});
+
+	it("treats a missing hidden flag as visible", () => {
+		expect(visibleCollectionEntries({ posts: { label: "Posts" } })).toHaveLength(1);
 	});
 });
 

--- a/packages/admin/tests/components/Sidebar.test.tsx
+++ b/packages/admin/tests/components/Sidebar.test.tsx
@@ -106,7 +106,7 @@ describe("filterNavItemsByRole", () => {
 	});
 });
 
-describe("visibleCollectionEntries (#1131)", () => {
+describe("visibleCollectionEntries", () => {
 	const collections = {
 		posts: { label: "Posts" },
 		contact_submissions: { label: "Contact Submissions", hidden: true },

--- a/packages/core/src/api/schemas/schema.ts
+++ b/packages/core/src/api/schemas/schema.ts
@@ -181,6 +181,7 @@ export const collectionSchema = z
 		source: z.string().nullable(),
 		urlPattern: z.string().nullable(),
 		hasSeo: z.boolean(),
+		hidden: z.boolean(),
 		createdAt: z.string(),
 		updatedAt: z.string(),
 	})

--- a/packages/core/src/api/schemas/schema.ts
+++ b/packages/core/src/api/schemas/schema.ts
@@ -86,6 +86,7 @@ export const createCollectionBody = z
 		source: z.string().regex(collectionSourcePattern).optional(),
 		urlPattern: z.string().optional(),
 		hasSeo: z.boolean().optional(),
+		hidden: z.boolean().optional(),
 	})
 	.meta({ id: "CreateCollectionBody" });
 
@@ -98,6 +99,7 @@ export const updateCollectionBody = z
 		supports: z.array(collectionSupportValues).optional(),
 		urlPattern: z.string().nullish(),
 		hasSeo: z.boolean().optional(),
+		hidden: z.boolean().optional(),
 		commentsEnabled: z.boolean().optional(),
 		commentsModeration: z.enum(["all", "first_time", "none"]).optional(),
 		commentsClosedAfterDays: z.number().int().min(0).optional(),

--- a/packages/core/src/astro/routes/api/schema/index.ts
+++ b/packages/core/src/astro/routes/api/schema/index.ts
@@ -79,6 +79,7 @@ import type { PortableTextBlock } from "emdash";
 				description: c.description,
 				icon: c.icon,
 				supports: c.supports,
+				hidden: c.hidden,
 				fields: c.fields.map((f) => ({
 					slug: f.slug,
 					label: f.label,

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -31,6 +31,12 @@ export interface ManifestCollection {
 	supports: string[];
 	hasSeo: boolean;
 	urlPattern?: string;
+	/**
+	 * Omit the auto-generated sidebar entry in the admin. The collection is
+	 * still listed in the manifest so its routes, editor, and API keep working
+	 * — only the navigation link is dropped.
+	 */
+	hidden?: boolean;
 	fields: Record<
 		string,
 		{

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -316,6 +316,7 @@ async function exportCollections(db: Kysely<Database>): Promise<SeedCollection[]
 			icon: collection.icon || undefined,
 			supports: collection.supports.length > 0 ? collection.supports : undefined,
 			urlPattern: collection.urlPattern || undefined,
+			hidden: collection.hidden || undefined,
 			fields: fields.map(
 				(field): SeedField => ({
 					slug: field.slug,

--- a/packages/core/src/database/migrations/057_collection_hidden.ts
+++ b/packages/core/src/database/migrations/057_collection_hidden.ts
@@ -1,0 +1,24 @@
+import type { Kysely } from "kysely";
+
+import { columnExists } from "../dialect-helpers.js";
+
+/**
+ * Migration: hide a collection from the admin sidebar.
+ *
+ * Adds `hidden` to `_emdash_collections`. A hidden collection stays fully
+ * functional (REST API, MCP, plugin hooks, direct `/content/:collection`
+ * URLs) — only its auto-generated sidebar entry is omitted, so plugins that
+ * own a collection end to end can steer editors to their own admin UI.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+	if (!(await columnExists(db, "_emdash_collections", "hidden"))) {
+		await db.schema
+			.alterTable("_emdash_collections")
+			.addColumn("hidden", "integer", (col) => col.notNull().defaultTo(0))
+			.execute();
+	}
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema.alterTable("_emdash_collections").dropColumn("hidden").execute();
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -59,6 +59,7 @@ import * as m053 from "./053_plugin_mcp_tools.js";
 import * as m054 from "./054_media_upload_attempts.js";
 import * as m055 from "./055_content_translation_group_locale_index.js";
 import * as m056 from "./056_taxonomy_term_sort_order.js";
+import * as m057 from "./057_collection_hidden.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -116,6 +117,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"054_media_upload_attempts": m054,
 	"055_content_translation_group_locale_index": m055,
 	"056_taxonomy_term_sort_order": m056,
+	"057_collection_hidden": m057,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -308,6 +308,7 @@ export interface CollectionTable {
 	search_config: string | null; // JSON: SearchConfig
 	has_seo: number; // 0 or 1 — opt-in SEO fields for this collection
 	url_pattern: string | null; // URL pattern with {slug} placeholder (e.g. "/blog/{slug}")
+	hidden: Generated<number>; // 0 or 1 — omit the auto-generated admin sidebar entry
 	comments_enabled: Generated<number>; // 0 or 1
 	comments_moderation: Generated<string>; // 'all' | 'first_time' | 'none'
 	comments_closed_after_days: Generated<number>; // 0 = never close

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2419,6 +2419,9 @@ export class EmDashRuntime {
 					supports: collection.supports || [],
 					hasSeo: collection.hasSeo,
 					urlPattern: collection.urlPattern,
+					// Only emitted when set, so the manifest payload is unchanged
+					// for the overwhelmingly common visible collection.
+					...(collection.hidden ? { hidden: true } : {}),
 					fields,
 				};
 			}

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2419,8 +2419,6 @@ export class EmDashRuntime {
 					supports: collection.supports || [],
 					hasSeo: collection.hasSeo,
 					urlPattern: collection.urlPattern,
-					// Only emitted when set, so the manifest payload is unchanged
-					// for the overwhelmingly common visible collection.
 					...(collection.hidden ? { hidden: true } : {}),
 					fields,
 				};

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -256,6 +256,7 @@ export class SchemaRegistry {
 					supports: JSON.stringify(supports),
 					source: input.source ?? "manual",
 					has_seo: hasSeo ? 1 : 0,
+					hidden: input.hidden ? 1 : 0,
 					comments_enabled: input.commentsEnabled ? 1 : 0,
 					url_pattern: input.urlPattern ?? null,
 				})
@@ -354,6 +355,7 @@ export class SchemaRegistry {
 						supports: JSON.stringify(supports),
 						source: "seed",
 						has_seo: hasSeo ? 1 : 0,
+						hidden: input.hidden ? 1 : 0,
 						comments_enabled: input.commentsEnabled ? 1 : 0,
 						url_pattern: input.urlPattern ?? null,
 					})
@@ -416,6 +418,7 @@ export class SchemaRegistry {
 							? (input.urlPattern ?? null)
 							: (existing.urlPattern ?? null),
 					has_seo: hasSeo ? 1 : 0,
+					hidden: input.hidden !== undefined ? (input.hidden ? 1 : 0) : existing.hidden ? 1 : 0,
 					comments_enabled:
 						input.commentsEnabled !== undefined
 							? input.commentsEnabled
@@ -1242,6 +1245,7 @@ export class SchemaRegistry {
 			source: row.source && isCollectionSource(row.source) ? row.source : undefined,
 			hasSeo: row.has_seo === 1,
 			urlPattern: row.url_pattern ?? undefined,
+			hidden: row.hidden === 1,
 			commentsEnabled: row.comments_enabled === 1,
 			commentsModeration:
 				moderation === "all" || moderation === "first_time" || moderation === "none"

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -171,6 +171,13 @@ export interface Collection {
 	hasSeo: boolean;
 	/** URL pattern with {slug} placeholder (e.g. "/{slug}", "/blog/{slug}") */
 	urlPattern?: string;
+	/**
+	 * Omit this collection's auto-generated entry from the admin sidebar.
+	 * The collection stays fully functional everywhere else (API, MCP, hooks,
+	 * direct `/content/:collection` URLs) — this only hides the nav link, so a
+	 * plugin that owns the collection can point editors at its own admin UI.
+	 */
+	hidden: boolean;
 	/** Whether comments are enabled for this collection */
 	commentsEnabled: boolean;
 	/** Moderation strategy: "all" | "first_time" | "none" */
@@ -219,6 +226,8 @@ export interface CreateCollectionInput {
 	source?: CollectionSource;
 	urlPattern?: string;
 	hasSeo?: boolean;
+	/** Omit the auto-generated admin sidebar entry (defaults to false) */
+	hidden?: boolean;
 	commentsEnabled?: boolean;
 }
 
@@ -233,6 +242,8 @@ export interface UpdateCollectionInput {
 	supports?: CollectionSupport[];
 	urlPattern?: string;
 	hasSeo?: boolean;
+	/** Omit the auto-generated admin sidebar entry */
+	hidden?: boolean;
 	commentsEnabled?: boolean;
 	commentsModeration?: "all" | "first_time" | "none";
 	commentsClosedAfterDays?: number;

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -179,6 +179,7 @@ export async function applySeed(
 						icon: collection.icon,
 						supports: collection.supports || [],
 						urlPattern: collection.urlPattern,
+						hidden: collection.hidden,
 						commentsEnabled: collection.commentsEnabled,
 					});
 					result.collections.updated++;
@@ -247,6 +248,7 @@ export async function applySeed(
 					icon: collection.icon,
 					supports: collection.supports || [],
 					urlPattern: collection.urlPattern,
+					hidden: collection.hidden,
 					commentsEnabled: collection.commentsEnabled,
 				},
 				fields,

--- a/packages/core/src/seed/types.ts
+++ b/packages/core/src/seed/types.ts
@@ -74,6 +74,11 @@ export interface SeedCollection {
 	icon?: string;
 	supports?: ("drafts" | "revisions" | "preview" | "scheduling" | "search" | "seo")[];
 	urlPattern?: string;
+	/**
+	 * Omit this collection from the admin sidebar. It stays reachable through
+	 * the API, MCP, plugin hooks, and direct `/content/:collection` URLs.
+	 */
+	hidden?: boolean;
 	/** Enable comments on this collection */
 	commentsEnabled?: boolean;
 	fields: SeedField[];

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -143,6 +143,7 @@ describe("Database Migrations (Integration)", () => {
 			"054_media_upload_attempts",
 			"055_content_translation_group_locale_index",
 			"056_taxonomy_term_sort_order",
+			"057_collection_hidden",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -128,13 +128,13 @@ describe("SchemaRegistry", () => {
 			expect(updated.supports).toEqual(["drafts"]);
 		});
 
-		it("#1131: collections are visible in the sidebar by default", async () => {
+		it("collections are visible in the sidebar by default", async () => {
 			const collection = await registry.createCollection({ slug: "posts", label: "Posts" });
 
 			expect(collection.hidden).toBe(false);
 		});
 
-		it("#1131: creates a collection hidden from the sidebar", async () => {
+		it("creates a collection hidden from the sidebar", async () => {
 			const collection = await registry.createCollection({
 				slug: "contact_submissions",
 				label: "Contact Submissions",
@@ -150,14 +150,14 @@ describe("SchemaRegistry", () => {
 			expect(await registry.getCollection("contact_submissions")).not.toBeNull();
 		});
 
-		it("#1131: toggles hidden on an existing collection", async () => {
+		it("toggles hidden on an existing collection", async () => {
 			await registry.createCollection({ slug: "posts", label: "Posts" });
 
 			expect((await registry.updateCollection("posts", { hidden: true })).hidden).toBe(true);
 			expect((await registry.updateCollection("posts", { hidden: false })).hidden).toBe(false);
 		});
 
-		it("#1131: preserves hidden when an update omits it", async () => {
+		it("preserves hidden when an update omits it", async () => {
 			await registry.createCollection({ slug: "posts", label: "Posts", hidden: true });
 
 			const updated = await registry.updateCollection("posts", { label: "Blog Posts" });

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -128,6 +128,44 @@ describe("SchemaRegistry", () => {
 			expect(updated.supports).toEqual(["drafts"]);
 		});
 
+		it("#1131: collections are visible in the sidebar by default", async () => {
+			const collection = await registry.createCollection({ slug: "posts", label: "Posts" });
+
+			expect(collection.hidden).toBe(false);
+		});
+
+		it("#1131: creates a collection hidden from the sidebar", async () => {
+			const collection = await registry.createCollection({
+				slug: "contact_submissions",
+				label: "Contact Submissions",
+				hidden: true,
+			});
+
+			expect(collection.hidden).toBe(true);
+			// A hidden collection is only hidden from the sidebar — it must still
+			// be listed by the registry so its routes, editor, API, and MCP tools
+			// keep resolving.
+			const listed = await registry.listCollections();
+			expect(listed.map((c) => c.slug)).toContain("contact_submissions");
+			expect(await registry.getCollection("contact_submissions")).not.toBeNull();
+		});
+
+		it("#1131: toggles hidden on an existing collection", async () => {
+			await registry.createCollection({ slug: "posts", label: "Posts" });
+
+			expect((await registry.updateCollection("posts", { hidden: true })).hidden).toBe(true);
+			expect((await registry.updateCollection("posts", { hidden: false })).hidden).toBe(false);
+		});
+
+		it("#1131: preserves hidden when an update omits it", async () => {
+			await registry.createCollection({ slug: "posts", label: "Posts", hidden: true });
+
+			const updated = await registry.updateCollection("posts", { label: "Blog Posts" });
+
+			expect(updated.label).toBe("Blog Posts");
+			expect(updated.hidden).toBe(true);
+		});
+
 		it("should throw when updating non-existent collection", async () => {
 			await expect(registry.updateCollection("nonexistent", { label: "Test" })).rejects.toThrow(
 				SchemaError,

--- a/packages/core/tests/unit/seed/apply.test.ts
+++ b/packages/core/tests/unit/seed/apply.test.ts
@@ -163,7 +163,7 @@ describe("applySeed", () => {
 			expect(row.rows[0]?.title).toBe("Untitled");
 		});
 
-		it("#1131: applies the hidden flag from the seed", async () => {
+		it("applies the hidden flag from the seed", async () => {
 			const seed: SeedFile = {
 				version: "1",
 				collections: [
@@ -188,7 +188,7 @@ describe("applySeed", () => {
 			expect((await registry.getCollection("posts"))?.hidden).toBe(false);
 		});
 
-		it("#1131: updates the hidden flag when re-applying with onConflict update", async () => {
+		it("updates the hidden flag when re-applying with onConflict update", async () => {
 			const collection = {
 				slug: "contact_submissions",
 				label: "Contact Submissions",

--- a/packages/core/tests/unit/seed/apply.test.ts
+++ b/packages/core/tests/unit/seed/apply.test.ts
@@ -163,6 +163,51 @@ describe("applySeed", () => {
 			expect(row.rows[0]?.title).toBe("Untitled");
 		});
 
+		it("#1131: applies the hidden flag from the seed", async () => {
+			const seed: SeedFile = {
+				version: "1",
+				collections: [
+					{
+						slug: "contact_submissions",
+						label: "Contact Submissions",
+						hidden: true,
+						fields: [{ slug: "title", label: "Title", type: "string" }],
+					},
+					{
+						slug: "posts",
+						label: "Posts",
+						fields: [{ slug: "title", label: "Title", type: "string" }],
+					},
+				],
+			};
+
+			await applySeed(db, seed);
+
+			const registry = new SchemaRegistry(db);
+			expect((await registry.getCollection("contact_submissions"))?.hidden).toBe(true);
+			expect((await registry.getCollection("posts"))?.hidden).toBe(false);
+		});
+
+		it("#1131: updates the hidden flag when re-applying with onConflict update", async () => {
+			const collection = {
+				slug: "contact_submissions",
+				label: "Contact Submissions",
+				fields: [{ slug: "title", label: "Title", type: "string" as const }],
+			};
+			await applySeed(db, { version: "1", collections: [collection] });
+
+			await applySeed(
+				db,
+				{ version: "1", collections: [{ ...collection, hidden: true }] },
+				{
+					onConflict: "update",
+				},
+			);
+
+			const registry = new SchemaRegistry(db);
+			expect((await registry.getCollection("contact_submissions"))?.hidden).toBe(true);
+		});
+
 		it("should skip existing collections", async () => {
 			// Create collection first
 			const registry = new SchemaRegistry(db);


### PR DESCRIPTION
## What does this PR do?

Adds a `hidden` flag on a collection definition that omits its auto-generated entry from the admin sidebar.

Plugins that own a collection end to end — autopopulated entries plus their own admin page — had no way to suppress the CRUD entry the sidebar builds from the manifest, so editors saw raw collections they never use next to the ones they actually edit. The only workarounds were CSS injection or renaming the label to discourage clicks.

The flag is deliberately scoped to navigation only. A hidden collection is still shipped in the manifest and stays reachable through the REST API, MCP tools, plugin hooks, and its editor at `/content/:collection` — so plugins keep managing the data and admins can still navigate there directly. Schema, migrations, and query behavior are untouched.

Set it in a seed file:

```json
{ "slug": "contact_submissions", "label": "Contact Submissions", "hidden": true, "fields": [] }
```

…or through the schema API (`POST`/`PATCH /api/schema/collections`).

Implementation notes:

- Migration `054_collection_hidden` adds a `hidden` column to `_emdash_collections`, `NOT NULL DEFAULT 0`, guarded by `columnExists` like `053`. Existing collections stay visible.
- `updateCollection` preserves the stored value when the input omits `hidden`, matching the `commentsEnabled` precedent.
- The manifest only emits `hidden` when it is set, so the payload is unchanged for the common visible collection.
- `Sidebar.tsx` filters through a new exported pure helper `visibleCollectionEntries`, following the pattern the existing sidebar tests rely on (pure artefacts rather than DOM coupling against Kumo's portaled Sidebar primitive).

Closes #1131

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

> Discussion: https://github.com/emdash-cms/emdash/discussions/1764 — the Roadmap discussion mirroring #1131. The issue is on the [1.0 milestone](https://github.com/emdash-cms/emdash/milestone/1), labelled `roadmap/1.0` / `roadmap/editor-experience`, and listed in the [1.0 roadmap tracker](https://github.com/emdash-cms/emdash/issues/1873).
> 
> Scope note: this deliberately leaves out an admin toggle in the Content Type editor to keep the diff reviewable — happy to add it here or in a follow-up if you'd rather the flag be editable from the UI.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1764

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

No admin UI surface was added, so there is nothing new to screenshot — the change removes nav entries for collections flagged `hidden`.

Targeted tests (9 new):

- `packages/core/tests/unit/schema/registry.test.ts` — default is visible; a hidden collection is still returned by `listCollections`/`getCollection`; the flag toggles; an update that omits `hidden` preserves it.
- `packages/core/tests/unit/seed/apply.test.ts` — the seed flag is applied on create and on re-apply with `onConflict: "update"`.
- `packages/admin/tests/components/Sidebar.test.tsx` — `visibleCollectionEntries` drops hidden collections, preserves manifest order, and treats a missing flag as visible.

```
packages/core   vitest run tests/unit/schema/registry.test.ts tests/unit/seed/apply.test.ts   85 passed
packages/core   vitest run tests/database/migrations.test.ts tests/unit/openapi                14 passed
packages/admin  vitest run tests/components/Sidebar.test.tsx                                   18 passed

pnpm --filter @emdash-cms/core typecheck    clean
pnpm --filter @emdash-cms/admin typecheck   clean
oxlint --type-aware --deny-warnings         clean
oxfmt --check && prettier --check .         clean
```
