### PR TITLE
feat(admin): explicit collection order in the sidebar

### DIFF
--- a/.changeset/collection-sort-order.md
+++ b/.changeset/collection-sort-order.md
@@ -1,0 +1,6 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+---
+
+Adds an explicit sidebar order for collections. Drag the rows on the Content Types screen, or set `sortOrder` in a seed file, and the admin sidebar follows that order instead of sorting alphabetically by slug. Collections without a `sortOrder` keep the alphabetical order and are listed after the ordered ones, so existing sites look the same until someone reorders. `reorder` is now a reserved collection slug.

--- a/docs/src/content/docs/themes/seed-files.mdx
+++ b/docs/src/content/docs/themes/seed-files.mdx
@@ -122,6 +122,7 @@ Each collection definition creates a content type in the database:
 | `icon`          | `string` | No       | Lucide icon name                             |
 | `supports`      | `array`  | No       | Features: `"drafts"`, `"revisions"`          |
 | `hidden`        | `boolean`| No       | Omit the collection's admin sidebar entry    |
+| `sortOrder`     | `number` | No       | Position in the admin sidebar (ascending)    |
 | `fields`        | `array`  | Yes      | Field definitions                            |
 
 <Aside type="tip" title="Hiding a collection from the sidebar">
@@ -129,6 +130,13 @@ Each collection definition creates a content type in the database:
 	everywhere else — REST API, MCP tools, plugin hooks, and its editor at
 	`/_emdash/admin/content/<slug>`. Use it for collections a plugin owns end to end (autopopulated
 	entries, its own admin page), so editors aren't sent to a raw CRUD list they never need.
+</Aside>
+
+<Aside type="tip" title="Ordering the sidebar">
+	Collections are listed alphabetically by slug in the admin sidebar unless they carry a
+	`sortOrder`. Ordered collections come first, ascending; everything without one keeps the
+	alphabetical order and follows. Editors can also drag rows on the Content Types screen, which
+	writes the same value.
 </Aside>
 
 ### Field Properties

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -36,8 +36,8 @@ import { ConfirmDialog } from "./ConfirmDialog";
 import { RouterLinkButton } from "./RouterLinkButton.js";
 
 /**
- * Apply a drag-and-drop move to the collection order. Pure and exported so
- * tests can pin the reordering contract without driving a pointer.
+ * Apply a drag-and-drop move to the collection order. Returns the input array
+ * unchanged when the move is a no-op.
  */
 export function moveCollection(slugs: string[], activeSlug: string, overSlug: string): string[] {
 	const from = slugs.indexOf(activeSlug);

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -1,7 +1,32 @@
 import { Badge, Button } from "@cloudflare/kumo";
+import {
+	DndContext,
+	KeyboardSensor,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+	SortableContext,
+	sortableKeyboardCoordinates,
+	useSortable,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import { Plus, Pencil, Trash, Database, FileText, Warning, Check } from "@phosphor-icons/react";
+import {
+	Plus,
+	Pencil,
+	Trash,
+	Database,
+	FileText,
+	Warning,
+	Check,
+	DotsSixVertical,
+} from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
@@ -10,12 +35,28 @@ import { cn } from "../lib/utils";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { RouterLinkButton } from "./RouterLinkButton.js";
 
+/**
+ * Apply a drag-and-drop move to the collection order. Pure and exported so
+ * tests can pin the reordering contract without driving a pointer.
+ */
+export function moveCollection(slugs: string[], activeSlug: string, overSlug: string): string[] {
+	const from = slugs.indexOf(activeSlug);
+	const to = slugs.indexOf(overSlug);
+	if (from === -1 || to === -1 || from === to) return slugs;
+
+	const next = [...slugs];
+	next.splice(to, 0, next.splice(from, 1)[0]!);
+	return next;
+}
+
 export interface ContentTypeListProps {
 	collections: SchemaCollection[];
 	orphanedTables?: OrphanedTable[];
 	isLoading?: boolean;
 	onDelete?: (slug: string) => void;
 	onRegisterOrphan?: (slug: string) => void;
+	/** Persist a new sidebar order. Omit to render the list without reordering. */
+	onReorder?: (slugs: string[]) => void;
 }
 
 /**
@@ -27,10 +68,45 @@ export function ContentTypeList({
 	isLoading,
 	onDelete,
 	onRegisterOrphan,
+	onReorder,
 }: ContentTypeListProps) {
 	const { t } = useLingui();
 	const [deleteTarget, setDeleteTarget] = React.useState<SchemaCollection | null>(null);
 	const hasOrphans = orphanedTables && orphanedTables.length > 0;
+
+	// Optimistic order: the drop lands immediately, the server order takes
+	// over once the mutation invalidates the query.
+	const [order, setOrder] = React.useState<string[] | null>(null);
+	const serverOrder = React.useMemo(() => collections.map((c) => c.slug), [collections]);
+	const orderedSlugs = order ?? serverOrder;
+	React.useEffect(() => {
+		setOrder(null);
+	}, [serverOrder]);
+
+	const orderedCollections = React.useMemo(() => {
+		const bySlug = new Map(collections.map((c) => [c.slug, c]));
+		return orderedSlugs.map((slug) => bySlug.get(slug)).filter((c) => c !== undefined);
+	}, [collections, orderedSlugs]);
+
+	const canReorder = !!onReorder && collections.length > 1;
+
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+	);
+
+	const columnCount = canReorder ? 6 : 5;
+
+	const handleDragEnd = (event: DragEndEvent) => {
+		const { active, over } = event;
+		if (!over || active.id === over.id) return;
+
+		const next = moveCollection(orderedSlugs, String(active.id), String(over.id));
+		if (next === orderedSlugs) return;
+
+		setOrder(next);
+		onReorder?.(next);
+	};
 
 	return (
 		<div className="space-y-4">
@@ -88,55 +164,65 @@ export function ContentTypeList({
 			)}
 
 			{/* Table */}
-			<div className="rounded-md border bg-kumo-base overflow-x-auto">
-				<table className="w-full">
-					<thead>
-						<tr className="border-b bg-kumo-tint/50">
-							<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
-								{t`Name`}
-							</th>
-							<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
-								{t`Slug`}
-							</th>
-							<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
-								{t`Source`}
-							</th>
-							<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
-								{t`Features`}
-							</th>
-							<th scope="col" className="px-4 py-3 text-end text-sm font-medium">
-								{t`Actions`}
-							</th>
-						</tr>
-					</thead>
-					<tbody className="divide-y divide-kumo-line">
-						{isLoading ? (
-							<tr>
-								<td colSpan={5} className="px-4 py-8 text-center text-kumo-subtle">
-									{t`Loading collections...`}
-								</td>
+			<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+				<div className="rounded-md border bg-kumo-base overflow-x-auto">
+					<table className="w-full">
+						<thead>
+							<tr className="border-b bg-kumo-tint/50">
+								{canReorder && (
+									<th scope="col" className="w-10 px-2 py-3">
+										<span className="sr-only">{t`Reorder`}</span>
+									</th>
+								)}
+								<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
+									{t`Name`}
+								</th>
+								<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
+									{t`Slug`}
+								</th>
+								<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
+									{t`Source`}
+								</th>
+								<th scope="col" className="px-4 py-3 text-start text-sm font-medium">
+									{t`Features`}
+								</th>
+								<th scope="col" className="px-4 py-3 text-end text-sm font-medium">
+									{t`Actions`}
+								</th>
 							</tr>
-						) : collections.length === 0 && !hasOrphans ? (
-							<tr>
-								<td colSpan={5} className="px-4 py-8 text-center text-kumo-subtle">
-									{t`No content types yet.`}{" "}
-									<Link to="/content-types/new" className="text-kumo-link underline">
-										{t`Create your first one`}
-									</Link>
-								</td>
-							</tr>
-						) : (
-							collections.map((collection) => (
-								<ContentTypeRow
-									key={collection.id}
-									collection={collection}
-									onRequestDelete={setDeleteTarget}
-								/>
-							))
-						)}
-					</tbody>
-				</table>
-			</div>
+						</thead>
+						<tbody className="divide-y divide-kumo-line">
+							{isLoading ? (
+								<tr>
+									<td colSpan={columnCount} className="px-4 py-8 text-center text-kumo-subtle">
+										{t`Loading collections...`}
+									</td>
+								</tr>
+							) : collections.length === 0 && !hasOrphans ? (
+								<tr>
+									<td colSpan={columnCount} className="px-4 py-8 text-center text-kumo-subtle">
+										{t`No content types yet.`}{" "}
+										<Link to="/content-types/new" className="text-kumo-link underline">
+											{t`Create your first one`}
+										</Link>
+									</td>
+								</tr>
+							) : (
+								<SortableContext items={orderedSlugs} strategy={verticalListSortingStrategy}>
+									{orderedCollections.map((collection) => (
+										<ContentTypeRow
+											key={collection.id}
+											collection={collection}
+											canReorder={canReorder}
+											onRequestDelete={setDeleteTarget}
+										/>
+									))}
+								</SortableContext>
+							)}
+						</tbody>
+					</table>
+				</div>
+			</DndContext>
 
 			<ConfirmDialog
 				open={!!deleteTarget}
@@ -164,15 +250,41 @@ export function ContentTypeList({
 
 interface ContentTypeRowProps {
 	collection: SchemaCollection;
+	canReorder?: boolean;
 	onRequestDelete?: (collection: SchemaCollection) => void;
 }
 
-function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
+function ContentTypeRow({ collection, canReorder, onRequestDelete }: ContentTypeRowProps) {
 	const { t } = useLingui();
 	const isFromCode = collection.source === "code";
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+		id: collection.slug,
+	});
+
+	const style = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+	};
 
 	return (
-		<tr className="hover:bg-kumo-tint/25">
+		<tr
+			ref={setNodeRef}
+			style={style}
+			className={cn("hover:bg-kumo-tint/25", isDragging && "relative z-10 bg-kumo-base shadow-sm")}
+		>
+			{canReorder && (
+				<td className="w-10 px-2 py-3">
+					<button
+						type="button"
+						{...attributes}
+						{...listeners}
+						aria-label={t`Reorder ${collection.label}`}
+						className="flex h-8 w-8 cursor-grab items-center justify-center rounded-md text-kumo-subtle hover:bg-kumo-tint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-focus active:cursor-grabbing"
+					>
+						<DotsSixVertical className="h-4 w-4" aria-hidden="true" />
+					</button>
+				</td>
+			)}
 			<td className="px-4 py-3">
 				<div className="flex items-center space-x-3">
 					<div

--- a/packages/admin/src/lib/api/index.ts
+++ b/packages/admin/src/lib/api/index.ts
@@ -94,6 +94,7 @@ export {
 	updateField,
 	deleteField,
 	reorderFields,
+	reorderCollections,
 	fetchOrphanedTables,
 	registerOrphanedTable,
 } from "./schema.js";

--- a/packages/admin/src/lib/api/schema.ts
+++ b/packages/admin/src/lib/api/schema.ts
@@ -38,6 +38,8 @@ export interface SchemaCollection {
 	hasSeo: boolean;
 	/** Sidebar entry omitted in the admin; the collection stays reachable by URL */
 	hidden: boolean;
+	/** Explicit sidebar position; absent means the alphabetical fallback */
+	sortOrder?: number;
 	commentsEnabled: boolean;
 	commentsModeration: "all" | "first_time" | "none";
 	commentsClosedAfterDays: number;
@@ -86,6 +88,7 @@ export interface CreateCollectionInput {
 	urlPattern?: string;
 	hasSeo?: boolean;
 	hidden?: boolean;
+	sortOrder?: number | null;
 }
 
 export interface UpdateCollectionInput {
@@ -97,6 +100,7 @@ export interface UpdateCollectionInput {
 	urlPattern?: string;
 	hasSeo?: boolean;
 	hidden?: boolean;
+	sortOrder?: number | null;
 	commentsEnabled?: boolean;
 	commentsModeration?: "all" | "first_time" | "none";
 	commentsClosedAfterDays?: number;
@@ -295,6 +299,23 @@ export async function reorderFields(collectionSlug: string, fieldSlugs: string[]
 		},
 	);
 	if (!response.ok) await throwResponseError(response, i18n._(msg`Failed to reorder fields`));
+}
+
+/**
+ * Reorder collections in the admin sidebar.
+ *
+ * `slugs` is the full desired order — collections left out lose their
+ * explicit position and fall back to alphabetical order after the ordered
+ * ones.
+ */
+export async function reorderCollections(slugs: string[]): Promise<void> {
+	const response = await apiFetch(`${API_BASE}/schema/collections/reorder`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ slugs }),
+	});
+	if (!response.ok)
+		await throwResponseError(response, i18n._(msg`Failed to reorder content types`));
 }
 
 // ============================================

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -88,6 +88,7 @@ import {
 	updateField,
 	deleteField,
 	reorderFields,
+	reorderCollections,
 	fetchOrphanedTables,
 	registerOrphanedTable,
 	fetchUsers,
@@ -1881,6 +1882,16 @@ function ContentTypesListPage() {
 		},
 	});
 
+	const reorderMutation = useMutation({
+		mutationFn: (slugs: string[]) => reorderCollections(slugs),
+		// The manifest drives the sidebar order, so it has to be refetched
+		// alongside the collection list for the move to show up in the nav.
+		onSettled: () => {
+			void queryClient.invalidateQueries({ queryKey: ["schema", "collections"] });
+			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
+		},
+	});
+
 	const error = collectionsError || orphansError;
 	if (error) {
 		return <ErrorScreen error={error.message} />;
@@ -1893,6 +1904,7 @@ function ContentTypesListPage() {
 			isLoading={collectionsLoading || orphansLoading}
 			onDelete={(slug) => deleteMutation.mutate(slug)}
 			onRegisterOrphan={(slug) => registerOrphanMutation.mutate(slug)}
+			onReorder={(slugs) => reorderMutation.mutate(slugs)}
 		/>
 	);
 }

--- a/packages/admin/tests/components/ContentTypeList.test.tsx
+++ b/packages/admin/tests/components/ContentTypeList.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { ContentTypeList } from "../../src/components/ContentTypeList";
+import { ContentTypeList, moveCollection } from "../../src/components/ContentTypeList";
 import type { SchemaCollection, OrphanedTable } from "../../src/lib/api";
 import { render } from "../utils/render.tsx";
 
@@ -220,6 +220,71 @@ describe("ContentTypeList", () => {
 		it("shows loading message when isLoading is true", async () => {
 			const screen = await render(<ContentTypeList collections={[]} isLoading />);
 			await expect.element(screen.getByText("Loading collections...")).toBeInTheDocument();
+		});
+	});
+
+	describe("#474: reordering", () => {
+		const twoCollections = [
+			makeCollection({ id: "1", slug: "posts", label: "Posts" }),
+			makeCollection({ id: "2", slug: "pages", label: "Pages" }),
+		];
+
+		it("renders a labelled drag handle per row when onReorder is provided", async () => {
+			const screen = await render(
+				<ContentTypeList collections={twoCollections} onReorder={vi.fn()} />,
+			);
+
+			// The accessible name carries the collection, so screen-reader users
+			// know which row the handle moves.
+			await expect
+				.element(screen.getByRole("button", { name: "Reorder Posts" }))
+				.toBeInTheDocument();
+			await expect
+				.element(screen.getByRole("button", { name: "Reorder Pages" }))
+				.toBeInTheDocument();
+		});
+
+		it("renders no drag handles without onReorder", async () => {
+			const screen = await render(<ContentTypeList collections={twoCollections} />);
+
+			expect(screen.getByRole("button", { name: "Reorder Posts" }).query()).toBeNull();
+		});
+
+		it("renders no drag handles for a single collection (nothing to reorder)", async () => {
+			const screen = await render(
+				<ContentTypeList collections={[twoCollections[0]!]} onReorder={vi.fn()} />,
+			);
+
+			expect(screen.getByRole("button", { name: "Reorder Posts" }).query()).toBeNull();
+		});
+
+		it("renders collections in the order given, not alphabetically", async () => {
+			// The server already returns them ordered; the list must not re-sort.
+			const screen = await render(
+				<ContentTypeList collections={twoCollections} onReorder={vi.fn()} />,
+			);
+
+			const rendered = screen.container.querySelectorAll("tbody code");
+			expect(Array.from(rendered, (el) => el.textContent)).toEqual(["posts", "pages"]);
+		});
+	});
+
+	describe("#474: moveCollection", () => {
+		it("moves an item down to the drop target index", () => {
+			expect(moveCollection(["a", "b", "c"], "a", "c")).toEqual(["b", "c", "a"]);
+		});
+
+		it("moves an item up to the drop target index", () => {
+			expect(moveCollection(["a", "b", "c"], "c", "a")).toEqual(["c", "a", "b"]);
+		});
+
+		it("returns the same reference when the move is a no-op", () => {
+			const slugs = ["a", "b", "c"];
+			// Same identity lets the caller skip both the state update and the
+			// network request on a drop that changes nothing.
+			expect(moveCollection(slugs, "b", "b")).toBe(slugs);
+			expect(moveCollection(slugs, "b", "missing")).toBe(slugs);
+			expect(moveCollection(slugs, "missing", "b")).toBe(slugs);
 		});
 	});
 });

--- a/packages/admin/tests/components/ContentTypeList.test.tsx
+++ b/packages/admin/tests/components/ContentTypeList.test.tsx
@@ -223,7 +223,7 @@ describe("ContentTypeList", () => {
 		});
 	});
 
-	describe("#474: reordering", () => {
+	describe("reordering", () => {
 		const twoCollections = [
 			makeCollection({ id: "1", slug: "posts", label: "Posts" }),
 			makeCollection({ id: "2", slug: "pages", label: "Pages" }),
@@ -269,7 +269,7 @@ describe("ContentTypeList", () => {
 		});
 	});
 
-	describe("#474: moveCollection", () => {
+	describe("moveCollection", () => {
 		it("moves an item down to the drop target index", () => {
 			expect(moveCollection(["a", "b", "c"], "a", "c")).toEqual(["b", "c", "a"]);
 		});

--- a/packages/core/src/api/handlers/schema.ts
+++ b/packages/core/src/api/handlers/schema.ts
@@ -424,6 +424,43 @@ export async function handleSchemaFieldDelete(
 }
 
 /**
+ * Reorder collections in the admin sidebar
+ */
+export async function handleSchemaCollectionReorder(
+	db: Kysely<Database>,
+	slugs: string[],
+): Promise<ApiResult<{ success: boolean }>> {
+	try {
+		const registry = new SchemaRegistry(db);
+		await registry.reorderCollections(slugs);
+
+		return {
+			success: true,
+			data: { success: true },
+		};
+	} catch (error) {
+		if (error instanceof SchemaError) {
+			return {
+				success: false,
+				error: {
+					code: error.code,
+					message: error.message,
+					details: error.details,
+				},
+			};
+		}
+		console.error("[emdash] Failed to reorder collections:", error);
+		return {
+			success: false,
+			error: {
+				code: "SCHEMA_COLLECTION_REORDER_ERROR",
+				message: "Failed to reorder collections",
+			},
+		};
+	}
+}
+
+/**
  * Reorder fields
  */
 export async function handleSchemaFieldReorder(

--- a/packages/core/src/api/openapi/document.ts
+++ b/packages/core/src/api/openapi/document.ts
@@ -88,6 +88,7 @@ import {
 	createCollectionBody,
 	createFieldBody,
 	fieldListResponseSchema,
+	collectionReorderBody,
 	fieldReorderBody,
 	fieldResponseSchema,
 	orphanedTableListResponseSchema,
@@ -1061,6 +1062,28 @@ const schemaPaths = {
 				},
 				...authErrors,
 				...standardErrors(404, 500),
+			},
+		},
+	},
+	"/_emdash/api/schema/collections/reorder": {
+		post: {
+			operationId: "reorderCollections",
+			summary: "Reorder collections in the admin sidebar",
+			description:
+				"Sets the sidebar order. Collections omitted from the list lose their explicit position and fall back to alphabetical order after the ordered ones.",
+			tags: ["Schema"],
+			requestBody: { content: { [JSON_CONTENT]: { schema: collectionReorderBody } } },
+			responses: {
+				"200": {
+					description: "Reordered",
+					content: {
+						[JSON_CONTENT]: {
+							schema: successEnvelope(z.object({ success: z.literal(true) })),
+						},
+					},
+				},
+				...authErrors,
+				...standardErrors(400, 404, 500),
 			},
 		},
 	},

--- a/packages/core/src/api/schemas/schema.ts
+++ b/packages/core/src/api/schemas/schema.ts
@@ -87,6 +87,7 @@ export const createCollectionBody = z
 		urlPattern: z.string().optional(),
 		hasSeo: z.boolean().optional(),
 		hidden: z.boolean().optional(),
+		sortOrder: z.number().int().nullish(),
 	})
 	.meta({ id: "CreateCollectionBody" });
 
@@ -100,6 +101,7 @@ export const updateCollectionBody = z
 		urlPattern: z.string().nullish(),
 		hasSeo: z.boolean().optional(),
 		hidden: z.boolean().optional(),
+		sortOrder: z.number().int().nullish(),
 		commentsEnabled: z.boolean().optional(),
 		commentsModeration: z.enum(["all", "first_time", "none"]).optional(),
 		commentsClosedAfterDays: z.number().int().min(0).optional(),
@@ -146,6 +148,13 @@ export const fieldReorderBody = z
 	})
 	.meta({ id: "FieldReorderBody" });
 
+export const collectionReorderBody = z
+	.object({
+		/** Full desired sidebar order. Collections left out fall back to alphabetical. */
+		slugs: z.array(z.string().min(1)),
+	})
+	.meta({ id: "CollectionReorderBody" });
+
 export const orphanRegisterBody = z
 	.object({
 		label: z.string().optional(),
@@ -182,6 +191,7 @@ export const collectionSchema = z
 		urlPattern: z.string().nullable(),
 		hasSeo: z.boolean(),
 		hidden: z.boolean(),
+		sortOrder: z.number().int().nullable(),
 		createdAt: z.string(),
 		updatedAt: z.string(),
 	})

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -313,6 +313,16 @@ export function injectCoreRoutes(
 		entrypoint: resolveRoute("api/schema/collections/index.ts"),
 	});
 
+	// Order matters: the static `reorder` route must precede the dynamic
+	// `[slug]` route so Astro's resolver dispatches POST
+	// /schema/collections/reorder to the reorder handler instead of treating
+	// "reorder" as a collection slug. The slug is also reserved at the data
+	// layer (RESERVED_COLLECTION_SLUGS) — defence in depth.
+	injectRoute({
+		pattern: "/_emdash/api/schema/collections/reorder",
+		entrypoint: resolveRoute("api/schema/collections/reorder.ts"),
+	});
+
 	injectRoute({
 		pattern: "/_emdash/api/schema/collections/[slug]",
 		entrypoint: resolveRoute("api/schema/collections/[slug]/index.ts"),

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -316,8 +316,7 @@ export function injectCoreRoutes(
 	// Order matters: the static `reorder` route must precede the dynamic
 	// `[slug]` route so Astro's resolver dispatches POST
 	// /schema/collections/reorder to the reorder handler instead of treating
-	// "reorder" as a collection slug. The slug is also reserved at the data
-	// layer (RESERVED_COLLECTION_SLUGS) — defence in depth.
+	// "reorder" as a collection slug.
 	injectRoute({
 		pattern: "/_emdash/api/schema/collections/reorder",
 		entrypoint: resolveRoute("api/schema/collections/reorder.ts"),

--- a/packages/core/src/astro/routes/api/schema/collections/reorder.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/reorder.ts
@@ -1,0 +1,31 @@
+/**
+ * Collection reorder endpoint
+ *
+ * POST /_emdash/api/schema/collections/reorder - Set the admin sidebar order
+ */
+
+import type { APIRoute } from "astro";
+
+import { requirePerm } from "#api/authorize.js";
+import { requireDb, unwrapResult } from "#api/error.js";
+import { handleSchemaCollectionReorder } from "#api/index.js";
+import { parseBody, isParseError } from "#api/parse.js";
+import { collectionReorderBody } from "#api/schemas.js";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, locals }) => {
+	const { emdash, user } = locals;
+
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
+
+	const denied = requirePerm(user, "schema:manage");
+	if (denied) return denied;
+
+	const body = await parseBody(request, collectionReorderBody);
+	if (isParseError(body)) return body;
+
+	const result = await handleSchemaCollectionReorder(emdash.db, body.slugs);
+	return unwrapResult(result);
+};

--- a/packages/core/src/astro/routes/api/schema/index.ts
+++ b/packages/core/src/astro/routes/api/schema/index.ts
@@ -80,6 +80,7 @@ import type { PortableTextBlock } from "emdash";
 				icon: c.icon,
 				supports: c.supports,
 				hidden: c.hidden,
+				sortOrder: c.sortOrder,
 				fields: c.fields.map((f) => ({
 					slug: f.slug,
 					label: f.label,

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -317,6 +317,7 @@ async function exportCollections(db: Kysely<Database>): Promise<SeedCollection[]
 			supports: collection.supports.length > 0 ? collection.supports : undefined,
 			urlPattern: collection.urlPattern || undefined,
 			hidden: collection.hidden || undefined,
+			sortOrder: collection.sortOrder,
 			fields: fields.map(
 				(field): SeedField => ({
 					slug: field.slug,

--- a/packages/core/src/database/migrations/058_collection_sort_order.ts
+++ b/packages/core/src/database/migrations/058_collection_sort_order.ts
@@ -5,12 +5,9 @@ import { columnExists } from "../dialect-helpers.js";
 /**
  * Migration: explicit collection order in the admin sidebar.
  *
- * Adds `sort_order` to `_emdash_collections`. The column is nullable on
- * purpose: NULL means "no explicit position", and those collections keep
- * falling back to the alphabetical-by-slug order the sidebar has always
- * used. Reads sort explicitly-ordered collections first (see
- * `COLLECTION_ORDER_SQL` in the schema registry), so existing sites are
- * untouched until someone reorders.
+ * Adds `sort_order` to `_emdash_collections`. A NULL `sort_order` means no
+ * explicit position: those collections sort after the ordered ones, keeping
+ * the alphabetical-by-slug order.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
 	if (!(await columnExists(db, "_emdash_collections", "sort_order"))) {

--- a/packages/core/src/database/migrations/058_collection_sort_order.ts
+++ b/packages/core/src/database/migrations/058_collection_sort_order.ts
@@ -1,0 +1,23 @@
+import type { Kysely } from "kysely";
+
+import { columnExists } from "../dialect-helpers.js";
+
+/**
+ * Migration: explicit collection order in the admin sidebar.
+ *
+ * Adds `sort_order` to `_emdash_collections`. The column is nullable on
+ * purpose: NULL means "no explicit position", and those collections keep
+ * falling back to the alphabetical-by-slug order the sidebar has always
+ * used. Reads sort explicitly-ordered collections first (see
+ * `COLLECTION_ORDER_SQL` in the schema registry), so existing sites are
+ * untouched until someone reorders.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+	if (!(await columnExists(db, "_emdash_collections", "sort_order"))) {
+		await db.schema.alterTable("_emdash_collections").addColumn("sort_order", "integer").execute();
+	}
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema.alterTable("_emdash_collections").dropColumn("sort_order").execute();
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -60,6 +60,7 @@ import * as m054 from "./054_media_upload_attempts.js";
 import * as m055 from "./055_content_translation_group_locale_index.js";
 import * as m056 from "./056_taxonomy_term_sort_order.js";
 import * as m057 from "./057_collection_hidden.js";
+import * as m058 from "./058_collection_sort_order.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -118,6 +119,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"055_content_translation_group_locale_index": m055,
 	"056_taxonomy_term_sort_order": m056,
 	"057_collection_hidden": m057,
+	"058_collection_sort_order": m058,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -309,6 +309,7 @@ export interface CollectionTable {
 	has_seo: number; // 0 or 1 — opt-in SEO fields for this collection
 	url_pattern: string | null; // URL pattern with {slug} placeholder (e.g. "/blog/{slug}")
 	hidden: Generated<number>; // 0 or 1 — omit the auto-generated admin sidebar entry
+	sort_order: number | null; // explicit admin sidebar position; NULL = alphabetical fallback
 	comments_enabled: Generated<number>; // 0 or 1
 	comments_moderation: Generated<string>; // 'all' | 'first_time' | 'none'
 	comments_closed_after_days: Generated<number>; // 0 = never close

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -74,19 +74,15 @@ const VALID_COLLECTION_SUPPORTS: ReadonlySet<string> = new Set<CollectionSupport
 const SEED_FIELD_INSERT_BATCH_SIZE = 6;
 
 /**
- * Sentinel used to sort collections without an explicit `sort_order` after
- * the ordered ones. SQLite sorts NULL first on ASC while Postgres sorts it
- * last, so the fallback is materialised with COALESCE instead of relying on
- * either dialect's NULL ordering. Matches SQLite's max signed 32-bit
- * INTEGER-literal comfort zone and is far above any hand-assigned position.
+ * Rank given to collections without an explicit `sort_order`. SQLite sorts
+ * NULL first on ASC while Postgres sorts it last, so the fallback is
+ * materialised with COALESCE rather than left to the dialect.
  */
 const UNORDERED_COLLECTION_RANK = 2147483647;
 
 /**
  * Collection ordering shared by every list read: explicit `sort_order`
- * first (ascending), then alphabetically by slug — which is both the
- * tie-break within one position and the complete order for a site that
- * has never reordered anything.
+ * first (ascending), then alphabetically by slug.
  */
 const collectionOrder = sql<number>`coalesce(sort_order, ${sql.lit(UNORDERED_COLLECTION_RANK)})`;
 
@@ -912,12 +908,8 @@ export class SchemaRegistry {
 	 *
 	 * `slugs` is the full desired order: every listed collection gets its
 	 * index as `sort_order`, and any collection left out has its explicit
-	 * position cleared, dropping it back to the alphabetical tail. That keeps
-	 * the stored state a faithful picture of what the admin renders rather
-	 * than a sparse set of positions the UI would have to reconcile.
-	 *
-	 * Unknown slugs are rejected up front so a stale client can't silently
-	 * reorder half the sidebar.
+	 * position cleared, dropping it back to the alphabetical tail. Unknown or
+	 * duplicate slugs throw before anything is written.
 	 */
 	async reorderCollections(slugs: string[]): Promise<void> {
 		const known = new Set((await this.listCollections()).map((collection) => collection.slug));

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -73,6 +73,23 @@ const VALID_COLLECTION_SUPPORTS: ReadonlySet<string> = new Set<CollectionSupport
 // multi-row INSERT below D1's 100-parameter statement limit.
 const SEED_FIELD_INSERT_BATCH_SIZE = 6;
 
+/**
+ * Sentinel used to sort collections without an explicit `sort_order` after
+ * the ordered ones. SQLite sorts NULL first on ASC while Postgres sorts it
+ * last, so the fallback is materialised with COALESCE instead of relying on
+ * either dialect's NULL ordering. Matches SQLite's max signed 32-bit
+ * INTEGER-literal comfort zone and is far above any hand-assigned position.
+ */
+const UNORDERED_COLLECTION_RANK = 2147483647;
+
+/**
+ * Collection ordering shared by every list read: explicit `sort_order`
+ * first (ascending), then alphabetically by slug — which is both the
+ * tie-break within one position and the complete order for a site that
+ * has never reordered anything.
+ */
+const collectionOrder = sql<number>`coalesce(sort_order, ${sql.lit(UNORDERED_COLLECTION_RANK)})`;
+
 function isCollectionSupport(value: unknown): value is CollectionSupport {
 	return typeof value === "string" && VALID_COLLECTION_SUPPORTS.has(value);
 }
@@ -126,6 +143,7 @@ export class SchemaRegistry {
 		const rows = await this.db
 			.selectFrom("_emdash_collections")
 			.selectAll()
+			.orderBy(collectionOrder, "asc")
 			.orderBy("slug", "asc")
 			.execute();
 
@@ -177,6 +195,7 @@ export class SchemaRegistry {
 		const collectionRows = await this.db
 			.selectFrom("_emdash_collections")
 			.selectAll()
+			.orderBy(collectionOrder, "asc")
 			.orderBy("slug", "asc")
 			.execute();
 
@@ -257,6 +276,7 @@ export class SchemaRegistry {
 					source: input.source ?? "manual",
 					has_seo: hasSeo ? 1 : 0,
 					hidden: input.hidden ? 1 : 0,
+					sort_order: input.sortOrder ?? null,
 					comments_enabled: input.commentsEnabled ? 1 : 0,
 					url_pattern: input.urlPattern ?? null,
 				})
@@ -356,6 +376,7 @@ export class SchemaRegistry {
 						source: "seed",
 						has_seo: hasSeo ? 1 : 0,
 						hidden: input.hidden ? 1 : 0,
+						sort_order: input.sortOrder ?? null,
 						comments_enabled: input.commentsEnabled ? 1 : 0,
 						url_pattern: input.urlPattern ?? null,
 					})
@@ -419,6 +440,8 @@ export class SchemaRegistry {
 							: (existing.urlPattern ?? null),
 					has_seo: hasSeo ? 1 : 0,
 					hidden: input.hidden !== undefined ? (input.hidden ? 1 : 0) : existing.hidden ? 1 : 0,
+					sort_order:
+						input.sortOrder !== undefined ? input.sortOrder : (existing.sortOrder ?? null),
 					comments_enabled:
 						input.commentsEnabled !== undefined
 							? input.commentsEnabled
@@ -885,6 +908,64 @@ export class SchemaRegistry {
 	}
 
 	/**
+	 * Reorder collections in the admin sidebar.
+	 *
+	 * `slugs` is the full desired order: every listed collection gets its
+	 * index as `sort_order`, and any collection left out has its explicit
+	 * position cleared, dropping it back to the alphabetical tail. That keeps
+	 * the stored state a faithful picture of what the admin renders rather
+	 * than a sparse set of positions the UI would have to reconcile.
+	 *
+	 * Unknown slugs are rejected up front so a stale client can't silently
+	 * reorder half the sidebar.
+	 */
+	async reorderCollections(slugs: string[]): Promise<void> {
+		const known = new Set((await this.listCollections()).map((collection) => collection.slug));
+
+		const unknown = slugs.filter((slug) => !known.has(slug));
+		if (unknown.length > 0) {
+			throw new SchemaError(
+				`Unknown collection${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}`,
+				"COLLECTION_NOT_FOUND",
+				{ slugs: unknown },
+			);
+		}
+
+		const duplicates = slugs.filter((slug, index) => slugs.indexOf(slug) !== index);
+		if (duplicates.length > 0) {
+			throw new SchemaError(
+				`Duplicate collection${duplicates.length > 1 ? "s" : ""}: ${[...new Set(duplicates)].join(", ")}`,
+				"DUPLICATE_SLUG",
+				{ slugs: [...new Set(duplicates)] },
+			);
+		}
+
+		const now = new Date().toISOString();
+		const ordered = new Set(slugs);
+
+		await withTransaction(this.db, async (trx) => {
+			for (const [index, slug] of slugs.entries()) {
+				await trx
+					.updateTable("_emdash_collections")
+					.set({ sort_order: index, updated_at: now })
+					.where("slug", "=", slug)
+					.execute();
+			}
+
+			const cleared = [...known].filter((slug) => !ordered.has(slug));
+			// Chunked to stay under D1's bound-parameter limit; typical sites
+			// clear far fewer than one chunk.
+			for (const slugChunk of chunks(cleared, SQL_BATCH_SIZE)) {
+				await trx
+					.updateTable("_emdash_collections")
+					.set({ sort_order: null, updated_at: now })
+					.where("slug", "in", slugChunk)
+					.execute();
+			}
+		});
+	}
+
+	/**
 	 * Reorder fields
 	 */
 	async reorderFields(collectionSlug: string, fieldSlugs: string[]): Promise<void> {
@@ -1246,6 +1327,7 @@ export class SchemaRegistry {
 			hasSeo: row.has_seo === 1,
 			urlPattern: row.url_pattern ?? undefined,
 			hidden: row.hidden === 1,
+			sortOrder: row.sort_order ?? undefined,
 			commentsEnabled: row.comments_enabled === 1,
 			commentsModeration:
 				moderation === "all" || moderation === "first_time" || moderation === "none"

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -352,10 +352,8 @@ export const RESERVED_COLLECTION_SLUGS = [
 	"taxonomies",
 	"options",
 	"audit_logs",
-	// Shadowed by the static POST /schema/collections/reorder route — a
-	// collection with this slug could never be addressed at
-	// /schema/collections/reorder. Reserved at the data layer as defence in
-	// depth, mirroring RESERVED_BYLINE_FIELD_SLUGS.
+	// Shadowed by the static POST /schema/collections/reorder route: a
+	// collection with this slug could never be addressed at its own URL.
 	"reorder",
 ];
 

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -178,6 +178,12 @@ export interface Collection {
 	 * plugin that owns the collection can point editors at its own admin UI.
 	 */
 	hidden: boolean;
+	/**
+	 * Explicit position in the admin sidebar. Collections with a `sortOrder`
+	 * come first, in ascending order; the rest keep the alphabetical-by-slug
+	 * order and follow. `undefined` means "no explicit position".
+	 */
+	sortOrder?: number;
 	/** Whether comments are enabled for this collection */
 	commentsEnabled: boolean;
 	/** Moderation strategy: "all" | "first_time" | "none" */
@@ -228,6 +234,8 @@ export interface CreateCollectionInput {
 	hasSeo?: boolean;
 	/** Omit the auto-generated admin sidebar entry (defaults to false) */
 	hidden?: boolean;
+	/** Explicit admin sidebar position (omit for the alphabetical fallback) */
+	sortOrder?: number | null;
 	commentsEnabled?: boolean;
 }
 
@@ -244,6 +252,8 @@ export interface UpdateCollectionInput {
 	hasSeo?: boolean;
 	/** Omit the auto-generated admin sidebar entry */
 	hidden?: boolean;
+	/** Explicit admin sidebar position; `null` clears it back to alphabetical */
+	sortOrder?: number | null;
 	commentsEnabled?: boolean;
 	commentsModeration?: "all" | "first_time" | "none";
 	commentsClosedAfterDays?: number;
@@ -342,6 +352,11 @@ export const RESERVED_COLLECTION_SLUGS = [
 	"taxonomies",
 	"options",
 	"audit_logs",
+	// Shadowed by the static POST /schema/collections/reorder route — a
+	// collection with this slug could never be addressed at
+	// /schema/collections/reorder. Reserved at the data layer as defence in
+	// depth, mirroring RESERVED_BYLINE_FIELD_SLUGS.
+	"reorder",
 ];
 
 /**

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -180,6 +180,7 @@ export async function applySeed(
 						supports: collection.supports || [],
 						urlPattern: collection.urlPattern,
 						hidden: collection.hidden,
+						sortOrder: collection.sortOrder,
 						commentsEnabled: collection.commentsEnabled,
 					});
 					result.collections.updated++;
@@ -249,6 +250,7 @@ export async function applySeed(
 					supports: collection.supports || [],
 					urlPattern: collection.urlPattern,
 					hidden: collection.hidden,
+					sortOrder: collection.sortOrder,
 					commentsEnabled: collection.commentsEnabled,
 				},
 				fields,

--- a/packages/core/src/seed/types.ts
+++ b/packages/core/src/seed/types.ts
@@ -79,6 +79,11 @@ export interface SeedCollection {
 	 * the API, MCP, plugin hooks, and direct `/content/:collection` URLs.
 	 */
 	hidden?: boolean;
+	/**
+	 * Explicit position in the admin sidebar (ascending). Collections without
+	 * a `sortOrder` keep the alphabetical order and follow the ordered ones.
+	 */
+	sortOrder?: number;
 	/** Enable comments on this collection */
 	commentsEnabled?: boolean;
 	fields: SeedField[];

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -144,6 +144,7 @@ describe("Database Migrations (Integration)", () => {
 			"055_content_translation_group_locale_index",
 			"056_taxonomy_term_sort_order",
 			"057_collection_hidden",
+			"058_collection_sort_order",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -95,6 +95,98 @@ describe("SchemaRegistry", () => {
 			expect(collections.map((c) => c.slug)).toEqual(["pages", "posts"]); // sorted
 		});
 
+		describe("#474: sidebar sort order", () => {
+			it("has no explicit order by default", async () => {
+				const collection = await registry.createCollection({ slug: "posts", label: "Posts" });
+
+				expect(collection.sortOrder).toBeUndefined();
+			});
+
+			it("lists explicitly ordered collections first, then the rest alphabetically", async () => {
+				// `projects` sorts last alphabetically but is pinned first;
+				// `education`/`certifications` have no position and keep the
+				// alphabetical fallback behind it.
+				await registry.createCollection({ slug: "education", label: "Education" });
+				await registry.createCollection({ slug: "projects", label: "Projects", sortOrder: 0 });
+				await registry.createCollection({ slug: "certifications", label: "Certifications" });
+				await registry.createCollection({ slug: "positions", label: "Positions", sortOrder: 1 });
+
+				const collections = await registry.listCollections();
+
+				expect(collections.map((c) => c.slug)).toEqual([
+					"projects",
+					"positions",
+					"certifications",
+					"education",
+				]);
+			});
+
+			it("applies the same order to listCollectionsWithFields (the manifest path)", async () => {
+				await registry.createCollection({ slug: "education", label: "Education" });
+				await registry.createCollection({ slug: "projects", label: "Projects", sortOrder: 0 });
+
+				const collections = await registry.listCollectionsWithFields();
+
+				expect(collections.map((c) => c.slug)).toEqual(["projects", "education"]);
+			});
+
+			it("reorderCollections assigns positions in the given order", async () => {
+				await registry.createCollection({ slug: "posts", label: "Posts" });
+				await registry.createCollection({ slug: "pages", label: "Pages" });
+				await registry.createCollection({ slug: "authors", label: "Authors" });
+
+				await registry.reorderCollections(["posts", "authors", "pages"]);
+
+				const collections = await registry.listCollections();
+				expect(collections.map((c) => c.slug)).toEqual(["posts", "authors", "pages"]);
+				expect(collections.map((c) => c.sortOrder)).toEqual([0, 1, 2]);
+			});
+
+			it("reorderCollections clears the position of collections left out", async () => {
+				await registry.createCollection({ slug: "posts", label: "Posts", sortOrder: 0 });
+				await registry.createCollection({ slug: "pages", label: "Pages", sortOrder: 1 });
+
+				await registry.reorderCollections(["pages"]);
+
+				// `posts` loses its pin and falls back to the alphabetical tail,
+				// so it must sort *after* the still-ordered `pages`.
+				const collections = await registry.listCollections();
+				expect(collections.map((c) => c.slug)).toEqual(["pages", "posts"]);
+				expect(await registry.getCollection("posts").then((c) => c?.sortOrder)).toBeUndefined();
+			});
+
+			it("reorderCollections rejects unknown slugs without touching the order", async () => {
+				await registry.createCollection({ slug: "posts", label: "Posts" });
+				await registry.createCollection({ slug: "pages", label: "Pages" });
+
+				await expect(registry.reorderCollections(["posts", "ghosts"])).rejects.toThrow(SchemaError);
+
+				const collections = await registry.listCollections();
+				expect(collections.map((c) => c.sortOrder)).toEqual([undefined, undefined]);
+			});
+
+			it("reorderCollections rejects duplicate slugs", async () => {
+				await registry.createCollection({ slug: "posts", label: "Posts" });
+
+				await expect(registry.reorderCollections(["posts", "posts"])).rejects.toThrow(SchemaError);
+			});
+
+			it("update preserves the position when sortOrder is omitted, and clears it on null", async () => {
+				await registry.createCollection({ slug: "posts", label: "Posts", sortOrder: 3 });
+
+				expect((await registry.updateCollection("posts", { label: "Blog" })).sortOrder).toBe(3);
+				expect((await registry.updateCollection("posts", { sortOrder: null })).sortOrder).toBe(
+					undefined,
+				);
+			});
+
+			it("rejects `reorder` as a collection slug (shadowed by the reorder route)", async () => {
+				await expect(
+					registry.createCollection({ slug: "reorder", label: "Reorder" }),
+				).rejects.toThrow(SchemaError);
+			});
+		});
+
 		it("should get a collection by slug", async () => {
 			await registry.createCollection({
 				slug: "products",

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -95,7 +95,7 @@ describe("SchemaRegistry", () => {
 			expect(collections.map((c) => c.slug)).toEqual(["pages", "posts"]); // sorted
 		});
 
-		describe("#474: sidebar sort order", () => {
+		describe("sidebar sort order", () => {
 			it("has no explicit order by default", async () => {
 				const collection = await registry.createCollection({ slug: "posts", label: "Posts" });
 

--- a/packages/core/tests/unit/seed/apply.test.ts
+++ b/packages/core/tests/unit/seed/apply.test.ts
@@ -208,6 +208,35 @@ describe("applySeed", () => {
 			expect((await registry.getCollection("contact_submissions"))?.hidden).toBe(true);
 		});
 
+		it("applies sortOrder from the seed and orders the list by it", async () => {
+			const seed: SeedFile = {
+				version: "1",
+				collections: [
+					{
+						slug: "education",
+						label: "Education",
+						fields: [{ slug: "title", label: "Title", type: "string" }],
+					},
+					{
+						slug: "projects",
+						label: "Projects",
+						sortOrder: 0,
+						fields: [{ slug: "title", label: "Title", type: "string" }],
+					},
+				],
+			};
+
+			await applySeed(db, seed);
+
+			const registry = new SchemaRegistry(db);
+			expect((await registry.getCollection("projects"))?.sortOrder).toBe(0);
+			expect((await registry.getCollection("education"))?.sortOrder).toBeUndefined();
+			expect((await registry.listCollections()).map((c) => c.slug)).toEqual([
+				"projects",
+				"education",
+			]);
+		});
+
 		it("should skip existing collections", async () => {
 			// Create collection first
 			const registry = new SchemaRegistry(db);


### PR DESCRIPTION
## What does this PR do?

Lets a site choose the order its collections appear in the admin sidebar, instead of always sorting alphabetically by slug.

Today `listCollections` sorts by slug, and that order flows through the manifest into the sidebar. The issue's example is a portfolio site that always renders "Certifications → Education → Endorsements → Pages → Positions → Posts → Projects", with no way out short of renaming slugs (breaking URLs and queries) or forking the admin.

Two ways to set it:

- **Drag the rows** on the Content Types screen.
- **`sortOrder` in a seed file**, for sites that provision their schema from code:

```jsonc
{ "slug": "projects", "label": "Projects", "sortOrder": 1, "fields": [] }
```

Three decisions worth flagging for review:

- **The column is nullable, not `DEFAULT 0`.** NULL means "no explicit position": those collections keep the alphabetical order and are listed *after* the ordered ones. With a `0` default, pinning two collections would have left every other one sorting *ahead* of them, which is the opposite of what pinning means. It also makes the migration a no-op visually — a site that never reorders renders exactly as before.
- **Reads materialise the fallback with `COALESCE` rather than relying on NULL ordering.** SQLite sorts NULL first on ASC, Postgres sorts it last, so a bare `ORDER BY sort_order` would have given D1 and Postgres sites *different* sidebars. `packages/core/tests/integration/database/dialect-compat.test.ts` covers the dialect pair generally; the ordering itself is asserted in the registry tests.
- **`reorder` is now a reserved collection slug.** The static `POST /schema/collections/reorder` route is injected before the dynamic `[slug]` route, so a collection called `reorder` could never be addressed at its own URL. Reserving it at the data layer mirrors what `byline-fields/reorder` already does. Sites with an existing collection by that name are unaffected — the reservation only rejects new creates.

`reorderCollections` takes the **full** desired order and clears the position of anything left out, so the stored state stays a faithful picture of what the admin renders rather than a sparse set the UI has to reconcile. Unknown and duplicate slugs are rejected rather than silently applied.

On accessibility: the drag handles are real buttons with an accessible name per row (`Reorder Posts`, not a bare icon), and the `KeyboardSensor` is wired with `sortableKeyboardCoordinates`, so the whole reorder is doable from the keyboard — same pattern as the widgets and repeater lists.

Closes #474

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

> Discussion: https://github.com/emdash-cms/emdash/discussions/1751 — the Roadmap discussion mirroring #474. The issue is on the [1.0 milestone](https://github.com/emdash-cms/emdash/milestone/1), labelled `roadmap/1.0` / `roadmap/editor-experience`. #795 was closed as a duplicate of it.
>
> Scope note: this is flat ordering only. #1023 (sidebar menu tree with collection grouping) is a larger reshaping of the same nav — `sort_order` is orthogonal to it and would carry over as the order *within* a group, but say the word if you'd rather this wait for that design to land.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1751

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

15 new tests:

- `packages/core/tests/unit/schema/registry.test.ts` — default is unordered; ordered collections come first and the rest stay alphabetical; the same order applies on the `listCollectionsWithFields` (manifest) path; `reorderCollections` assigns positions, clears omitted ones, and rejects unknown/duplicate slugs without touching the order; update preserves the position when `sortOrder` is omitted and clears it on `null`; `reorder` is rejected as a slug.
- `packages/core/tests/unit/seed/apply.test.ts` — `sortOrder` is applied from a seed and drives the resulting order.
- `packages/admin/tests/components/ContentTypeList.test.tsx` — a labelled drag handle per row when reordering is enabled, none without it or for a single collection, rows render in the given order, plus the pure `moveCollection` reducer (down, up, and the no-op cases that must skip the network call).

```
packages/core   vitest run tests/unit                    3432 passed, 1 failed
packages/core   vitest run tests/integration/openapi       14 passed
packages/admin  vitest run                               1249 passed
pnpm --filter @emdash-cms/core typecheck                 clean
pnpm --filter @emdash-cms/admin typecheck                clean
oxlint --type-aware --deny-warnings                      clean
oxfmt --check && prettier --check .                      clean
```

Two notes on that output, both checked against a clean `main` by stashing this branch:

- The core failure (`createVirtualModulesPlugin scheduler wiring watches resolved sandbox plugin entries`) **reproduces on unmodified `main`** on this machine — pre-existing, unrelated to this change.
- An earlier full admin run showed one failure in `SeoPanel.test.tsx` ("expected 1 times, got 2"). It passes in isolation and passed on a repeat full run (1249/1249); `SeoPanel` is untouched here. Flagging it as a flake I saw rather than leaving it out.
