### PR TITLE
fix(admin): delete tables from block actions menu

### DIFF
--- a/.changeset/fix-table-block-delete.md
+++ b/.changeset/fix-table-block-delete.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes deleting tables from the portable text editor's block actions menu.

--- a/.changeset/polish-block-actions-menu.md
+++ b/.changeset/polish-block-actions-menu.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Updates the portable text editor's block actions menu with animated transitions, clearer hover feedback, and accessible keyboard navigation.
+Updates the portable text editor's block actions menu with animated transitions, clearer hover feedback, accessible keyboard navigation, and stable positioning while moving between blocks.

--- a/.changeset/polish-block-actions-menu.md
+++ b/.changeset/polish-block-actions-menu.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Updates the portable text editor's block actions menu with animated transitions, clearer hover feedback, and accessible keyboard navigation.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2563,6 +2563,7 @@ export function PortableTextEditor({
 			Subscript,
 			Superscript,
 			Table.configure({
+				allowTableNodeSelection: true,
 				resizable: true,
 			}),
 			TableRow,

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -140,6 +140,8 @@ const blockTransforms: BlockTransform[] = [
 	},
 ];
 
+const POPOVER_TRANSITION_MS = 150;
+
 interface BlockMenuProps {
 	editor: Editor;
 	/** The DOM element of the selected block (for positioning) */
@@ -157,15 +159,20 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 	const { i18n, t } = useLingui();
 	const [showTransforms, setShowTransforms] = React.useState(false);
 	const anchorRef = React.useRef<HTMLElement | null>(anchorElement);
+	const menuActionsRef = React.useRef<{ unmount: () => void; close: () => void } | null>(null);
 	const direction = getLocaleDir(i18n.locale);
 
 	if (anchorElement) anchorRef.current = anchorElement;
 
-	// Reset submenu state when menu closes
 	React.useEffect(() => {
-		if (!isOpen) {
-			setShowTransforms(false);
-		}
+		if (isOpen) return;
+
+		setShowTransforms(false);
+		const delay = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+			? 0
+			: POPOVER_TRANSITION_MS;
+		const timer = window.setTimeout(() => menuActionsRef.current?.unmount(), delay);
+		return () => window.clearTimeout(timer);
 	}, [isOpen]);
 
 	const handleDuplicate = () => {
@@ -200,6 +207,7 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 
 	return (
 		<DropdownMenu
+			actionsRef={menuActionsRef}
 			open={isOpen}
 			modal={false}
 			onOpenChange={(open, eventDetails) => {
@@ -209,6 +217,7 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 					setShowTransforms(false);
 					return;
 				}
+				eventDetails.preventUnmountOnClose();
 				onClose();
 			}}
 		>
@@ -222,7 +231,7 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 					"bg-kumo-base text-sm shadow-kumo-tip-shadow ring-kumo-fill",
 					"origin-(--transform-origin) transition-[transform,scale,opacity] duration-150",
 					"data-starting-style:scale-90 data-starting-style:opacity-0",
-					"data-ending-style:scale-90 data-ending-style:opacity-0 data-instant:duration-0",
+					"data-ending-style:scale-90 data-ending-style:opacity-0",
 					"data-[state=open]:animate-none data-[state=closed]:animate-none motion-reduce:transition-none",
 				)}
 			>

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -212,6 +212,10 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 			modal={false}
 			onOpenChange={(open, eventDetails) => {
 				if (open) return;
+				if (eventDetails.reason === "trigger-hover") {
+					eventDetails.cancel();
+					return;
+				}
 				if (showTransforms && eventDetails.reason === "escape-key") {
 					eventDetails.cancel();
 					setShowTransforms(false);

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -150,12 +150,20 @@ interface BlockMenuProps {
 	isOpen: boolean;
 	/** Callback to close the menu */
 	onClose: () => void;
+	/** Callback after the menu's exit transition completes */
+	onCloseComplete?: () => void;
 }
 
 /**
  * Block Menu - floating menu for block-level actions
  */
-export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuProps) {
+export function BlockMenu({
+	editor,
+	anchorElement,
+	isOpen,
+	onClose,
+	onCloseComplete,
+}: BlockMenuProps) {
 	const { i18n, t } = useLingui();
 	const [showTransforms, setShowTransforms] = React.useState(false);
 	const anchorRef = React.useRef<HTMLElement | null>(anchorElement);
@@ -210,6 +218,9 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 			actionsRef={menuActionsRef}
 			open={isOpen}
 			modal={false}
+			onOpenChangeComplete={(open) => {
+				if (!open) onCloseComplete?.();
+			}}
 			onOpenChange={(open, eventDetails) => {
 				if (open) return;
 				if (eventDetails.reason === "trigger-hover") {

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -170,7 +170,9 @@ export function BlockMenu({
 	const menuActionsRef = React.useRef<{ unmount: () => void; close: () => void } | null>(null);
 	const direction = getLocaleDir(i18n.locale);
 
-	if (anchorElement) anchorRef.current = anchorElement;
+	React.useLayoutEffect(() => {
+		if (anchorElement) anchorRef.current = anchorElement;
+	}, [anchorElement]);
 
 	React.useEffect(() => {
 		if (isOpen) return;

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -7,11 +7,10 @@
  * - Duplicate
  * - Delete
  *
- * Uses Floating UI for positioning relative to the selected block.
+ * Uses Kumo's menu primitive, anchored to the selected block's drag handle.
  */
 
-import { Button } from "@cloudflare/kumo";
-import { useFloating, offset, flip, shift, autoUpdate } from "@floating-ui/react";
+import { Button, DropdownMenu } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
@@ -35,10 +34,9 @@ import {
 import { NodeSelection } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
-import { createPortal } from "react-dom";
 
-import { useStableCallback } from "../../lib/hooks";
 import { cn } from "../../lib/utils";
+import { getLocaleDir } from "../../locales/config.js";
 import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 
 /**
@@ -156,67 +154,12 @@ interface BlockMenuProps {
  * Block Menu - floating menu for block-level actions
  */
 export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuProps) {
-	const { t } = useLingui();
+	const { i18n, t } = useLingui();
 	const [showTransforms, setShowTransforms] = React.useState(false);
-	const menuRef = React.useRef<HTMLDivElement>(null);
-	const stableOnClose = useStableCallback(onClose);
+	const anchorRef = React.useRef<HTMLElement | null>(anchorElement);
+	const direction = getLocaleDir(i18n.locale);
 
-	const { refs, floatingStyles } = useFloating({
-		open: isOpen,
-		placement: "left-start",
-		middleware: [offset({ mainAxis: 8, crossAxis: 0 }), flip(), shift({ padding: 8 })],
-		whileElementsMounted: autoUpdate,
-	});
-
-	// Sync the anchor element
-	React.useEffect(() => {
-		if (anchorElement) {
-			refs.setReference(anchorElement);
-		}
-	}, [anchorElement, refs]);
-
-	// Close on escape
-	React.useEffect(() => {
-		if (!isOpen) return;
-
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				e.preventDefault();
-				if (showTransforms) {
-					setShowTransforms(false);
-				} else {
-					stableOnClose();
-				}
-			}
-		};
-
-		document.addEventListener("keydown", handleKeyDown);
-		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [isOpen, stableOnClose, showTransforms]);
-
-	// Close on click outside
-	React.useEffect(() => {
-		if (!isOpen) return;
-
-		const handleClickOutside = (e: MouseEvent) => {
-			const target = e.target;
-			// Don't close if clicking on the drag handle or menu itself
-			if (target instanceof Node && menuRef.current?.contains(target)) return;
-			if (target instanceof Element && target.closest("[data-block-handle]")) return;
-
-			stableOnClose();
-		};
-
-		// Delay to avoid immediate close from the click that opened it
-		const timer = setTimeout(() => {
-			document.addEventListener("mousedown", handleClickOutside);
-		}, 0);
-
-		return () => {
-			clearTimeout(timer);
-			document.removeEventListener("mousedown", handleClickOutside);
-		};
-	}, [isOpen, stableOnClose]);
+	if (anchorElement) anchorRef.current = anchorElement;
 
 	// Reset submenu state when menu closes
 	React.useEffect(() => {
@@ -227,7 +170,6 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 
 	const handleDuplicate = () => {
 		if (!(editor.state.selection instanceof NodeSelection)) {
-			onClose();
 			return;
 		}
 
@@ -242,95 +184,117 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 				return true;
 			})
 			.run();
-
-		onClose();
 	};
 
 	const handleDelete = () => {
 		if (!(editor.state.selection instanceof NodeSelection)) {
-			onClose();
 			return;
 		}
 
 		editor.chain().focus().deleteSelection().run();
-		onClose();
 	};
 
 	const handleTransform = (transform: BlockTransform) => {
 		transform.transform(editor);
-		onClose();
 	};
 
-	if (!isOpen) return null;
-
-	return createPortal(
-		<div
-			ref={(node) => {
-				menuRef.current = node;
-				refs.setFloating(node);
+	return (
+		<DropdownMenu
+			open={isOpen}
+			modal={false}
+			onOpenChange={(open, eventDetails) => {
+				if (open) return;
+				if (showTransforms && eventDetails.reason === "escape-key") {
+					eventDetails.cancel();
+					setShowTransforms(false);
+					return;
+				}
+				onClose();
 			}}
-			style={floatingStyles}
-			className="z-[100] rounded-lg border bg-kumo-overlay shadow-lg min-w-[180px] overflow-hidden"
 		>
-			{showTransforms ? (
-				// Transform submenu
-				<div className="py-1">
-					<button
-						type="button"
-						className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-kumo-tint text-start"
-						onClick={() => setShowTransforms(false)}
-					>
-						<CaretPrev className="h-4 w-4" />
-						<span>{t`Back`}</span>
-					</button>
-					<div className="h-px bg-kumo-line my-1" />
-					{blockTransforms.map((transform) => (
-						<button
-							key={transform.id}
-							type="button"
-							className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-kumo-tint text-start"
-							onClick={() => handleTransform(transform)}
+			<DropdownMenu.Content
+				anchor={anchorRef}
+				side={direction === "rtl" ? "right" : "left"}
+				align="start"
+				collisionPadding={8}
+				className={cn(
+					"z-[100] min-w-[180px] max-h-[min(300px,var(--available-height))] overflow-y-auto overscroll-contain scroll-py-1",
+					"bg-kumo-base text-sm shadow-kumo-tip-shadow ring-kumo-fill",
+					"origin-(--transform-origin) transition-[transform,scale,opacity] duration-150",
+					"data-starting-style:scale-90 data-starting-style:opacity-0",
+					"data-ending-style:scale-90 data-ending-style:opacity-0 data-instant:duration-0",
+					"data-[state=open]:animate-none data-[state=closed]:animate-none motion-reduce:transition-none",
+				)}
+			>
+				{showTransforms ? (
+					<>
+						<DropdownMenu.Item
+							closeOnClick={false}
+							data-emdash-block-menu-item
+							icon={
+								<CaretPrev className="me-2 h-4 w-4 flex-none text-kumo-subtle" aria-hidden="true" />
+							}
+							className="text-sm"
+							onClick={() => setShowTransforms(false)}
 						>
-							<transform.icon className="h-4 w-4 text-kumo-subtle" />
-							<span>{t(transform.label)}</span>
-						</button>
-					))}
-				</div>
-			) : (
-				// Main menu
-				<div className="py-1">
-					<button
-						type="button"
-						className="flex items-center justify-between w-full px-3 py-2 text-sm hover:bg-kumo-tint text-start"
-						onClick={() => setShowTransforms(true)}
-					>
-						<span className="flex items-center gap-2">
-							<Paragraph className="h-4 w-4 text-kumo-subtle" />
-							<span>{t`Turn into`}</span>
-						</span>
-						<CaretNext className="h-4 w-4 text-kumo-subtle" />
-					</button>
-					<button
-						type="button"
-						className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-kumo-tint text-start"
-						onClick={handleDuplicate}
-					>
-						<Copy className="h-4 w-4 text-kumo-subtle" />
-						<span>{t`Duplicate`}</span>
-					</button>
-					<div className="h-px bg-kumo-line my-1" />
-					<button
-						type="button"
-						className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-kumo-tint text-start text-kumo-danger"
-						onClick={handleDelete}
-					>
-						<Trash className="h-4 w-4" />
-						<span>{t`Delete`}</span>
-					</button>
-				</div>
-			)}
-		</div>,
-		document.body,
+							{t`Back`}
+						</DropdownMenu.Item>
+						<DropdownMenu.Separator />
+						{blockTransforms.map((transform) => (
+							<DropdownMenu.Item
+								key={transform.id}
+								data-emdash-block-menu-item
+								icon={
+									<transform.icon
+										className="me-2 h-4 w-4 flex-none text-kumo-subtle"
+										aria-hidden="true"
+									/>
+								}
+								className="text-sm"
+								onClick={() => handleTransform(transform)}
+							>
+								{t(transform.label)}
+							</DropdownMenu.Item>
+						))}
+					</>
+				) : (
+					<>
+						<DropdownMenu.Item
+							closeOnClick={false}
+							data-emdash-block-menu-item
+							icon={
+								<Paragraph className="me-2 h-4 w-4 flex-none text-kumo-subtle" aria-hidden="true" />
+							}
+							className="text-sm"
+							onClick={() => setShowTransforms(true)}
+						>
+							{t`Turn into`}
+							<CaretNext
+								className="ms-auto h-4 w-4 flex-none text-kumo-subtle"
+								aria-hidden="true"
+							/>
+						</DropdownMenu.Item>
+						<DropdownMenu.Item
+							data-emdash-block-menu-item
+							icon={<Copy className="me-2 h-4 w-4 flex-none text-kumo-subtle" aria-hidden="true" />}
+							className="text-sm"
+							onClick={handleDuplicate}
+						>
+							{t`Duplicate`}
+						</DropdownMenu.Item>
+						<DropdownMenu.Separator />
+						<DropdownMenu.Item
+							variant="danger"
+							icon={<Trash className="me-2 h-4 w-4 flex-none" aria-hidden="true" />}
+							className="text-sm"
+							onClick={handleDelete}
+						>
+							{t`Delete`}
+						</DropdownMenu.Item>
+					</>
+				)}
+			</DropdownMenu.Content>
+		</DropdownMenu>
 	);
 }
 

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -109,6 +109,9 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 	// Close the menu
 	const handleCloseMenu = React.useCallback(() => {
 		setMenuOpen(false);
+	}, []);
+
+	const handleMenuCloseComplete = React.useCallback(() => {
 		setMenuAnchor(null);
 		editor.commands.setMeta("lockDragHandle", false);
 	}, [editor]);
@@ -197,6 +200,7 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 				anchorElement={menuAnchor}
 				isOpen={menuOpen}
 				onClose={handleCloseMenu}
+				onCloseComplete={handleMenuCloseComplete}
 			/>
 		</>
 	);

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -186,6 +186,8 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 						onClick={handleClick}
 						data-block-handle
 						aria-label={t`Block actions - drag to reorder, click for menu`}
+						aria-haspopup="menu"
+						aria-expanded={menuOpen}
 					>
 						<DotsSixVertical className="h-4 w-4" aria-hidden="true" />
 					</Button>

--- a/packages/admin/src/components/editor/DragHandleWrapper.tsx
+++ b/packages/admin/src/components/editor/DragHandleWrapper.tsx
@@ -119,13 +119,10 @@ export function DragHandleWrapper({ editor, onInsertBlock }: DragHandleWrapperPr
 			if (data.node) {
 				setHoveredNode({ node: data.node, pos: data.pos });
 			} else {
-				// Only clear if menu is not open
-				if (!menuOpen) {
-					setHoveredNode(null);
-				}
+				setHoveredNode(null);
 			}
 		},
-		[menuOpen],
+		[],
 	);
 
 	// Stable reference — DragHandle's useEffect depends on this by reference.

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -146,8 +146,9 @@ body {
 	}
 }
 
-/* Keep heading choices visibly distinct from the dropdown surface. */
-[data-emdash-heading-item][data-highlighted] {
+/* Keep editor menu choices visibly distinct from their dropdown surfaces. */
+[data-emdash-heading-item][data-highlighted],
+[data-emdash-block-menu-item][data-highlighted] {
 	background-color: var(--color-kumo-interact) !important;
 }
 

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -12,6 +12,8 @@ type NodeChangeHandler = (data: { node: PMNode | null; editor: Editor; pos: numb
 let dragHandleLocked = false;
 let dragHandleNodeChange: NodeChangeHandler | null = null;
 let moveDragHandle: ((pos: number) => void) | null = null;
+let closeBlockMenu: (() => void) | null = null;
+let completeBlockMenuExit: (() => void) | null = null;
 
 async function hoverBlock(editor: Editor, node: PMNode, pos: number) {
 	await React.act(async () => {
@@ -65,13 +67,26 @@ vi.mock("@tiptap/extension-drag-handle-react", () => ({
 }));
 
 vi.mock("../../src/components/editor/BlockMenu", () => ({
-	BlockMenu: ({ anchorElement, isOpen }: { anchorElement: HTMLElement | null; isOpen: boolean }) =>
-		isOpen ? (
+	BlockMenu: ({
+		anchorElement,
+		isOpen,
+		onClose,
+		onCloseComplete,
+	}: {
+		anchorElement: HTMLElement | null;
+		isOpen: boolean;
+		onClose: () => void;
+		onCloseComplete?: () => void;
+	}) => {
+		closeBlockMenu = onClose;
+		completeBlockMenuExit = onCloseComplete ?? null;
+		return isOpen ? (
 			<div
 				role="menu"
 				data-anchor-position={anchorElement?.closest(".drag-handle")?.dataset.nodePosition}
 			/>
-		) : null,
+		) : null;
+	},
 }));
 
 describe("DragHandleWrapper interactions", () => {
@@ -79,6 +94,8 @@ describe("DragHandleWrapper interactions", () => {
 		dragHandleLocked = false;
 		dragHandleNodeChange = null;
 		moveDragHandle = null;
+		closeBlockMenu = null;
+		completeBlockMenuExit = null;
 	});
 
 	it("uses Kumo buttons for both drag-handle controls", async () => {
@@ -197,5 +214,51 @@ describe("DragHandleWrapper interactions", () => {
 			actionsButton.element().closest(".drag-handle")?.getAttribute("data-node-position"),
 		).toBe("1");
 		expect(selectedPositions).toEqual([1]);
+	});
+
+	it("keeps the drag handle pinned until the menu exit completes", async () => {
+		const setMeta = vi.fn((_key: string, locked: boolean) => {
+			dragHandleLocked = locked;
+			return true;
+		});
+		const editor = {
+			view: { dom: document.createElement("div") },
+			commands: { setMeta },
+			chain: () => ({
+				setNodeSelection() {
+					return this;
+				},
+				run: () => true,
+			}),
+		} as unknown as Editor;
+		const screen = await render(<DragHandleWrapper editor={editor} onInsertBlock={vi.fn()} />);
+		const actionsButton = screen.getByRole("button", {
+			name: "Block actions - drag to reorder, click for menu",
+		});
+		const firstNode = { nodeSize: 2 } as PMNode;
+		const secondNode = { nodeSize: 3 } as PMNode;
+
+		await hoverBlock(editor, firstNode, 1);
+		actionsButton.element().click();
+		await vi.waitFor(() => {
+			expect(screen.getByRole("menu").element().dataset.anchorPosition).toBe("1");
+		});
+
+		await React.act(async () => closeBlockMenu?.());
+		await expect.element(actionsButton).toHaveAttribute("aria-expanded", "false");
+		expect(setMeta).toHaveBeenLastCalledWith("lockDragHandle", true);
+
+		await hoverBlock(editor, secondNode, 5);
+		expect(
+			actionsButton.element().closest(".drag-handle")?.getAttribute("data-node-position"),
+		).toBe("1");
+
+		await React.act(async () => completeBlockMenuExit?.());
+		expect(setMeta).toHaveBeenLastCalledWith("lockDragHandle", false);
+
+		await hoverBlock(editor, secondNode, 5);
+		expect(
+			actionsButton.element().closest(".drag-handle")?.getAttribute("data-node-position"),
+		).toBe("5");
 	});
 });

--- a/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
+++ b/packages/admin/tests/editor/DragHandleWrapper.interactions.test.tsx
@@ -1,40 +1,86 @@
 import { i18n } from "@lingui/core";
 import type { Editor } from "@tiptap/core";
+import type { Node as PMNode } from "@tiptap/pm/model";
 import * as React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DragHandleWrapper } from "../../src/components/editor/DragHandleWrapper";
 import { render } from "../utils/render";
+
+type NodeChangeHandler = (data: { node: PMNode | null; editor: Editor; pos: number }) => void;
+
+let dragHandleLocked = false;
+let dragHandleNodeChange: NodeChangeHandler | null = null;
+let moveDragHandle: ((pos: number) => void) | null = null;
+
+async function hoverBlock(editor: Editor, node: PMNode, pos: number) {
+	await React.act(async () => {
+		if (dragHandleLocked) return;
+		moveDragHandle?.(pos);
+		dragHandleNodeChange?.({ node, editor, pos });
+	});
+}
 
 vi.mock("@tiptap/extension-drag-handle-react", () => ({
 	DragHandle: ({
 		children,
 		computePositionConfig,
+		onNodeChange,
 	}: {
 		children: React.ReactNode;
 		computePositionConfig: {
 			placement: string;
 			middleware?: Array<{ name: string; options?: [number?] }>;
 		};
-	}) => (
-		<div
-			className="drag-handle"
-			draggable="true"
-			data-placement={computePositionConfig.placement}
-			data-offset={
-				computePositionConfig.middleware?.find(({ name }) => name === "offset")?.options?.[0] ?? ""
-			}
-		>
-			{children}
-		</div>
-	),
+		onNodeChange: NodeChangeHandler;
+	}) => {
+		const [nodePosition, setNodePosition] = React.useState<number | null>(null);
+
+		React.useEffect(() => {
+			dragHandleLocked = false;
+			dragHandleNodeChange = onNodeChange;
+			moveDragHandle = setNodePosition;
+
+			return () => {
+				dragHandleNodeChange = null;
+				moveDragHandle = null;
+			};
+		}, [onNodeChange]);
+
+		return (
+			<div
+				className="drag-handle"
+				draggable={!dragHandleLocked}
+				data-node-position={nodePosition ?? ""}
+				data-placement={computePositionConfig.placement}
+				data-offset={
+					computePositionConfig.middleware?.find(({ name }) => name === "offset")?.options?.[0] ??
+					""
+				}
+			>
+				{children}
+			</div>
+		);
+	},
 }));
 
 vi.mock("../../src/components/editor/BlockMenu", () => ({
-	BlockMenu: () => null,
+	BlockMenu: ({ anchorElement, isOpen }: { anchorElement: HTMLElement | null; isOpen: boolean }) =>
+		isOpen ? (
+			<div
+				role="menu"
+				data-anchor-position={anchorElement?.closest(".drag-handle")?.dataset.nodePosition}
+			/>
+		) : null,
 }));
 
 describe("DragHandleWrapper interactions", () => {
+	beforeEach(() => {
+		dragHandleLocked = false;
+		dragHandleNodeChange = null;
+		moveDragHandle = null;
+	});
+
 	it("uses Kumo buttons for both drag-handle controls", async () => {
 		const editor = {
 			view: { dom: document.createElement("div") },
@@ -108,5 +154,48 @@ describe("DragHandleWrapper interactions", () => {
 		} finally {
 			i18n.activate(previousLocale);
 		}
+	});
+
+	it("keeps the controls and menu pinned to the block that opened the menu", async () => {
+		const selectedPositions: number[] = [];
+		const setMeta = vi.fn((_key: string, locked: boolean) => {
+			dragHandleLocked = locked;
+			return true;
+		});
+		const editor = {
+			view: { dom: document.createElement("div") },
+			commands: { setMeta },
+			chain: () => ({
+				setNodeSelection(pos: number) {
+					selectedPositions.push(pos);
+					return this;
+				},
+				run: () => true,
+			}),
+		} as unknown as Editor;
+		const screen = await render(<DragHandleWrapper editor={editor} onInsertBlock={vi.fn()} />);
+		const firstNode = { nodeSize: 2 } as PMNode;
+		const secondNode = { nodeSize: 3 } as PMNode;
+
+		await hoverBlock(editor, firstNode, 1);
+		const actionsButton = screen.getByRole("button", {
+			name: "Block actions - drag to reorder, click for menu",
+		});
+		await expect.element(actionsButton).toBeVisible();
+		actionsButton.element().click();
+
+		await vi.waitFor(() => {
+			expect(screen.getByRole("menu").element().dataset.anchorPosition).toBe("1");
+		});
+		expect(selectedPositions).toEqual([1]);
+		expect(setMeta).toHaveBeenLastCalledWith("lockDragHandle", true);
+
+		await hoverBlock(editor, secondNode, 5);
+
+		expect(screen.getByRole("menu").element().dataset.anchorPosition).toBe("1");
+		expect(
+			actionsButton.element().closest(".drag-handle")?.getAttribute("data-node-position"),
+		).toBe("1");
+		expect(selectedPositions).toEqual([1]);
 	});
 });

--- a/packages/admin/tests/editor/block-menu.test.tsx
+++ b/packages/admin/tests/editor/block-menu.test.tsx
@@ -180,15 +180,15 @@ function getBlockMenu(): HTMLElement | null {
 	return null;
 }
 
-/** Get all text buttons in the menu */
-function getMenuButtons(menu: HTMLElement): HTMLButtonElement[] {
-	return [...menu.querySelectorAll("button")];
+/** Get all actionable items in the menu */
+function getMenuItems(menu: HTMLElement): HTMLElement[] {
+	return [...menu.querySelectorAll<HTMLElement>('[role="menuitem"]')];
 }
 
-/** Find a button by its text content */
-function findButtonByText(menu: HTMLElement, text: string): HTMLButtonElement | null {
-	const buttons = getMenuButtons(menu);
-	return buttons.find((btn) => btn.textContent?.includes(text)) ?? null;
+/** Find a menu item by its text content */
+function findButtonByText(menu: HTMLElement, text: string): HTMLElement | null {
+	const items = getMenuItems(menu);
+	return items.find((item) => item.textContent?.includes(text)) ?? null;
 }
 
 // =============================================================================
@@ -220,6 +220,22 @@ describe("BlockMenu", () => {
 		expect(findButtonByText(menu, "Turn into")).toBeTruthy();
 		expect(findButtonByText(menu, "Duplicate")).toBeTruthy();
 		expect(findButtonByText(menu, "Delete")).toBeTruthy();
+	});
+
+	it("exposes block actions as an accessible menu", async () => {
+		const { editor } = await getEditor();
+		const onClose = vi.fn();
+
+		await render(<BlockMenuTestWrapper editor={editor} isOpen={true} onClose={onClose} />);
+
+		await vi.waitFor(() => {
+			expect(document.querySelector('[role="menu"]')).toBeTruthy();
+		});
+
+		const menu = document.querySelector('[role="menu"]')!;
+		const items = [...menu.querySelectorAll('[role="menuitem"]')];
+
+		expect(items.map((item) => item.textContent)).toEqual(["Turn into", "Duplicate", "Delete"]);
 	});
 
 	it("shows Turn into submenu when Turn into is clicked", async () => {

--- a/packages/admin/tests/editor/block-menu.test.tsx
+++ b/packages/admin/tests/editor/block-menu.test.tsx
@@ -417,6 +417,36 @@ describe("BlockMenu", () => {
 		});
 	});
 
+	it("deletes a selected table when Delete is clicked", async () => {
+		const { editor, pm } = await getEditor();
+		const onClose = vi.fn();
+
+		editor.chain().focus("start").insertTable({ rows: 2, cols: 2, withHeaderRow: true }).run();
+
+		let tablePos = -1;
+		editor.state.doc.descendants((node, pos) => {
+			if (node.type.name !== "table") return true;
+			tablePos = pos;
+			return false;
+		});
+		expect(tablePos).toBeGreaterThanOrEqual(0);
+
+		editor.commands.setNodeSelection(tablePos);
+
+		await render(<BlockMenuTestWrapper editor={editor} isOpen={true} onClose={onClose} />);
+
+		await vi.waitFor(() => {
+			expect(getBlockMenu()).toBeTruthy();
+		});
+
+		findButtonByText(getBlockMenu()!, "Delete")!.click();
+
+		expect(onClose).toHaveBeenCalled();
+		await vi.waitFor(() => {
+			expect(pm.querySelector("table")).toBeNull();
+		});
+	});
+
 	it("duplicates the current block when Duplicate is clicked", async () => {
 		const { editor, pm } = await getEditor();
 		const onClose = vi.fn();

--- a/packages/admin/tests/editor/block-menu.test.tsx
+++ b/packages/admin/tests/editor/block-menu.test.tsx
@@ -7,8 +7,8 @@
  * and click-outside dismissal.
  *
  * BlockMenu is a standalone component that takes an editor instance,
- * an anchor element, and open/close callbacks. It renders via
- * createPortal to document.body.
+ * an anchor element, and open/close callbacks. It renders through
+ * Kumo's dropdown primitive, anchored to the selected block.
  */
 
 import type { Editor } from "@tiptap/react";

--- a/packages/admin/tests/editor/block-menu.test.tsx
+++ b/packages/admin/tests/editor/block-menu.test.tsx
@@ -168,6 +168,31 @@ function BlockMenuTestWrapper({
 	);
 }
 
+function ClosingBlockMenuTestWrapper({
+	editor,
+	onCloseComplete,
+}: {
+	editor: Editor;
+	onCloseComplete: () => void;
+}) {
+	const [isOpen, setIsOpen] = React.useState(true);
+	const anchorRef = React.useRef<HTMLDivElement>(null);
+
+	return (
+		<>
+			<div ref={anchorRef}>Anchor</div>
+			<button type="button">Outside menu</button>
+			<BlockMenu
+				editor={editor}
+				anchorElement={anchorRef.current}
+				isOpen={isOpen}
+				onClose={() => setIsOpen(false)}
+				onCloseComplete={onCloseComplete}
+			/>
+		</>
+	);
+}
+
 /** Get the block menu portal element */
 function getBlockMenu(): HTMLElement | null {
 	const portals = document.querySelectorAll("body > div");
@@ -533,6 +558,24 @@ describe("BlockMenu", () => {
 		await userEvent.click(pm.querySelectorAll("p")[1]!);
 
 		expect(onClose).toHaveBeenCalled();
+	});
+
+	it("reports when the menu exit transition completes", async () => {
+		const { editor } = await getEditor();
+		const onCloseComplete = vi.fn();
+		const screen = await render(
+			<ClosingBlockMenuTestWrapper editor={editor} onCloseComplete={onCloseComplete} />,
+		);
+
+		await vi.waitFor(() => {
+			expect(getBlockMenu()).toBeTruthy();
+		});
+
+		await userEvent.click(screen.getByRole("button", { name: "Outside menu" }));
+
+		await vi.waitFor(() => {
+			expect(onCloseComplete).toHaveBeenCalledOnce();
+		});
 	});
 
 	it("closes transform submenu on Escape (returns to main, not full close)", async () => {

--- a/packages/admin/tests/editor/block-menu.test.tsx
+++ b/packages/admin/tests/editor/block-menu.test.tsx
@@ -503,6 +503,38 @@ describe("BlockMenu", () => {
 		expect(onClose).toHaveBeenCalled();
 	});
 
+	it("stays open when the pointer leaves a highlighted menu item", async () => {
+		const { editor, pm } = await getEditor();
+		const onClose = vi.fn();
+
+		await render(<BlockMenuTestWrapper editor={editor} isOpen={true} onClose={onClose} />);
+
+		await vi.waitFor(() => {
+			expect(getBlockMenu()).toBeTruthy();
+		});
+
+		await userEvent.hover(findButtonByText(getBlockMenu()!, "Duplicate")!);
+		await userEvent.hover(pm.querySelectorAll("p")[1]!);
+
+		expect(onClose).not.toHaveBeenCalled();
+		expect(getBlockMenu()).toBeTruthy();
+	});
+
+	it("closes when the user clicks outside the menu", async () => {
+		const { editor, pm } = await getEditor();
+		const onClose = vi.fn();
+
+		await render(<BlockMenuTestWrapper editor={editor} isOpen={true} onClose={onClose} />);
+
+		await vi.waitFor(() => {
+			expect(getBlockMenu()).toBeTruthy();
+		});
+
+		await userEvent.click(pm.querySelectorAll("p")[1]!);
+
+		expect(onClose).toHaveBeenCalled();
+	});
+
 	it("closes transform submenu on Escape (returns to main, not full close)", async () => {
 		const { editor } = await getEditor();
 		const onClose = vi.fn();


### PR DESCRIPTION
## What does this PR do?

Fixes the portable text editor's block actions menu so whole tables can be deleted. It also moves the menu to Kumo's dropdown primitive, keeps it pinned to the block that opened it, preserves its exit animation, and prevents pointer movement between blocks from dismissing or relocating it.

Closes #2266

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

- Admin tests: 1,249 passed across 104 files.
- Admin typecheck passed.
- Oxlint completed with zero diagnostics.
- Verified in English and Arabic RTL, including whole-table deletion and stable menu positioning during open and exit animations.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-2266-table-block-delete-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/2266-table-block-delete`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
