### PR TITLE
docs: prefer native Workers Caching over legacy cloudflareCache()

### DIFF
--- a/.changeset/clarify-workers-cache-path.md
+++ b/.changeset/clarify-workers-cache-path.md
@@ -2,4 +2,4 @@
 "@emdash-cms/cloudflare": patch
 ---
 
-Documents that `cloudflareCache()` is the legacy Cache API + zone REST purge path. New sites should use native Workers Caching (`"cache": { "enabled": true }` in wrangler plus `cacheCloudflare()` from `@astrojs/cloudflare/cache`) and purge with `cache.purge()` — no zone ID or Cache Purge API token.
+Deprecates `cloudflareCache()` (legacy Cache API + zone REST purge). It now emits a one-time console warning and is marked `@deprecated` in types. New sites should use native Workers Caching (`"cache": { "enabled": true }` in wrangler plus `cacheCloudflare()` from `@astrojs/cloudflare/cache`) and purge with `cache.purge()` — no zone ID or Cache Purge API token.

--- a/.changeset/clarify-workers-cache-path.md
+++ b/.changeset/clarify-workers-cache-path.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Documents that `cloudflareCache()` is the legacy Cache API + zone REST purge path. New sites should use native Workers Caching (`"cache": { "enabled": true }` in wrangler plus `cacheCloudflare()` from `@astrojs/cloudflare/cache`) and purge with `cache.purge()` — no zone ID or Cache Purge API token.

--- a/demos/cloudflare/README.md
+++ b/demos/cloudflare/README.md
@@ -2,7 +2,7 @@
 
 This demo shows EmDash running on Cloudflare Workers with D1 database.
 
-Uses Astro 6 + `@astrojs/cloudflare` v13 which runs the real `workerd` runtime in development.
+Uses Astro 7 + `@astrojs/cloudflare` v14 which runs the real `workerd` runtime in development.
 
 ## Setup
 
@@ -15,6 +15,21 @@ pnpm dev
 EmDash runs migrations automatically on first request — no manual migration or DB-create step needed. Wrangler provisions the D1 database on first deploy.
 
 2. Open http://localhost:4321/\_emdash/admin
+
+## Edge HTML cache (Workers Caching)
+
+This demo uses **native Workers Caching**, not the legacy EmDash `cloudflareCache()` helper:
+
+| Piece | Where |
+| --- | --- |
+| Platform cache on | `wrangler.jsonc` → `"cache": { "enabled": true }` |
+| Astro cache provider | `cacheCloudflare()` from `@astrojs/cloudflare/cache` |
+| Public page TTLs | `routeRules` in `astro.config.mjs` |
+| Purge | `cache.purge()` from `cloudflare:workers` (no zone ID / API token) |
+
+Do **not** copy `cloudflareCache()` from `@emdash-cms/cloudflare` for new sites. That path stores responses in the Cache API and invalidates via the zone REST purge API (`CF_ZONE_ID` + `CF_CACHE_PURGE_TOKEN`). It is a legacy stopgap; see [Deploy to Cloudflare → Workers Cache](https://docs.emdashcms.com/deployment/cloudflare#workers-cache).
+
+Object/query caching (`objectCache: kvCache({ binding: "CACHE" })`) is a separate layer and is optional.
 
 ## Preview
 
@@ -35,11 +50,6 @@ This builds and deploys to Cloudflare Workers. EmDash handles migrations automat
 
 ## Notes
 
-- `astro dev` now uses `workerd` (the real Workers runtime) - development matches production
+- `astro dev` uses `workerd` (the real Workers runtime) — development matches production
 - `wrangler types` runs automatically before dev/build to generate TypeScript types for bindings
-- No `platformProxy` config needed - Astro 6 handles this automatically
-
-## TODO
-
-- [ ] R2 storage for media uploads
-- [ ] Auth integration (Cloudflare Access or custom)
+- No `platformProxy` config needed — Astro handles this automatically

--- a/demos/cloudflare/README.md
+++ b/demos/cloudflare/README.md
@@ -20,12 +20,12 @@ EmDash runs migrations automatically on first request — no manual migration or
 
 This demo uses **native Workers Caching**, not the legacy EmDash `cloudflareCache()` helper:
 
-| Piece | Where |
-| --- | --- |
-| Platform cache on | `wrangler.jsonc` → `"cache": { "enabled": true }` |
-| Astro cache provider | `cacheCloudflare()` from `@astrojs/cloudflare/cache` |
-| Public page TTLs | `routeRules` in `astro.config.mjs` |
-| Purge | `cache.purge()` from `cloudflare:workers` (no zone ID / API token) |
+| Piece                | Where                                                              |
+| -------------------- | ------------------------------------------------------------------ |
+| Platform cache on    | `wrangler.jsonc` → `"cache": { "enabled": true }`                  |
+| Astro cache provider | `cacheCloudflare()` from `@astrojs/cloudflare/cache`               |
+| Public page TTLs     | `routeRules` in `astro.config.mjs`                                 |
+| Purge                | `cache.purge()` from `cloudflare:workers` (no zone ID / API token) |
 
 Do **not** copy `cloudflareCache()` from `@emdash-cms/cloudflare` for new sites. That path stores responses in the Cache API and invalidates via the zone REST purge API (`CF_ZONE_ID` + `CF_CACHE_PURGE_TOKEN`). It is a legacy stopgap; see [Deploy to Cloudflare → Workers Cache](https://docs.emdashcms.com/deployment/cloudflare#workers-cache).
 

--- a/demos/cloudflare/astro.config.mjs
+++ b/demos/cloudflare/astro.config.mjs
@@ -1,12 +1,12 @@
 // @ts-check
 import cloudflare from "@astrojs/cloudflare";
+import { cacheCloudflare } from "@astrojs/cloudflare/cache";
 import react from "@astrojs/react";
 import {
 	d1,
 	r2,
 	access,
 	sandbox,
-	cloudflareCache,
 	cloudflareImages,
 	cloudflareStream,
 } from "@emdash-cms/cloudflare";
@@ -81,8 +81,14 @@ export default defineConfig({
 			marketplace: "https://marketplace.emdashcms.com",
 		}),
 	],
+	// Preferred edge HTML cache: native Workers Caching via the Astro Cloudflare
+	// adapter. Pair with `"cache": { "enabled": true }` in wrangler.jsonc (the
+	// adapter also injects that when this provider is detected). Invalidation is
+	// `cache.purge()` from cloudflare:workers — no CF_ZONE_ID / API token.
+	// Do NOT use cloudflareCache() from @emdash-cms/cloudflare here; that is the
+	// legacy Cache API + zone REST purge path.
 	cache: {
-		provider: cloudflareCache(),
+		provider: cacheCloudflare(),
 	},
 	routeRules: {
 		"/": {

--- a/demos/cloudflare/wrangler.jsonc
+++ b/demos/cloudflare/wrangler.jsonc
@@ -6,6 +6,12 @@
 	// disable_nodejs_process_v2 needed until unenv fix lands in Pages
 	// See: https://github.com/withastro/astro/issues/14511
 	"compatibility_flags": ["nodejs_compat", "disable_nodejs_process_v2"],
+	// Native Workers Caching (edge HTML in front of the Worker). No zone ID or
+	// Cache Purge API token. Pair with cacheCloudflare() in astro.config.mjs.
+	// Purge from the Worker with cache.purge() from cloudflare:workers.
+	"cache": {
+		"enabled": true,
+	},
 	// Static assets served from dist/
 	"routes": [
 		{

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -151,15 +151,67 @@ See [Object Cache](/deployment/object-cache/) for KV setup, options, and invalid
 
 ## Workers Cache
 
-Cloudflare's [Workers Cache](https://developers.cloudflare.com/workers/cache/) (`"cache": { "enabled": true }` in `wrangler.jsonc`) puts an edge cache **in front of** your Worker: matching requests are served without running your Worker at all. This works well with EmDash:
+Cloudflare's [Workers Cache](https://developers.cloudflare.com/workers/cache/) puts an edge cache **in front of** your Worker: matching requests are served without running your Worker at all. This is the **preferred** edge HTML cache for EmDash on Cloudflare. It needs **no zone ID and no Cache Purge API token**.
 
-- EmDash admin and API responses send `Cache-Control: private, no-store` and are never stored.
-- Your public pages control their own caching through the `Cache-Control` headers they return.
+### Enable it
+
+1. Turn on the platform cache in `wrangler.jsonc`:
+
+```jsonc title="wrangler.jsonc"
+{
+	"cache": {
+		"enabled": true,
+	},
+}
+```
+
+2. Use Astro's Cloudflare cache provider so route rules / `Astro.cache` set the right headers and invalidation uses native `cache.purge()`:
+
+```js title="astro.config.mjs"
+import { cacheCloudflare } from "@astrojs/cloudflare/cache";
+
+export default defineConfig({
+	adapter: cloudflare(),
+	cache: {
+		provider: cacheCloudflare(),
+	},
+	routeRules: {
+		"/": { maxAge: 300, swr: 86400 },
+		// …
+	},
+});
+```
+
+With `cacheCloudflare()`, the `@astrojs/cloudflare` adapter also injects `"cache": { "enabled": true }` into the generated Wrangler config when it is missing — listing it explicitly in your own `wrangler.jsonc` keeps the intent obvious.
+
+3. Purge from the Worker with the platform API (no Cloudflare REST credentials):
+
+```ts
+import { cache } from "cloudflare:workers";
+
+await cache.purge({ purgeEverything: true });
+// or: await cache.purge({ tags: ["posts"] });
+```
+
+EmDash admin and API responses already send `Cache-Control: private, no-store` and are never stored. Public pages control their own caching through `Cache-Control` / `routeRules` / `Astro.cache`.
 
 Two things to know before enabling it:
 
 1. **Responses without a `Cache-Control` header are still cached.** Workers Cache applies RFC 9111 heuristic freshness — a `200` without any header is cached for 2 hours. Give every custom route an explicit `Cache-Control` (use `private, no-store` for anything session-dependent).
 2. **Cached pages are shared with logged-in editors.** The cache runs before your Worker, so it cannot bypass based on request cookies. A logged-in editor may receive the cached anonymous variant of a public page — without the visual editing toolbar — until the entry expires. Editor-rendered responses themselves are never stored (they carry `private, no-store`), so nothing leaks in the other direction.
+
+### Not the same as `cloudflareCache()` from `@emdash-cms/cloudflare`
+
+| | **Preferred: Workers Caching** | **Legacy: `cloudflareCache()`** |
+| --- | --- | --- |
+| Config | `"cache": { "enabled": true }` + `cacheCloudflare()` from `@astrojs/cloudflare/cache` | `cache: { provider: cloudflareCache() }` from `@emdash-cms/cloudflare` |
+| Storage | Platform Workers Caching | Cache API (`caches.open` / `put` / `match`) |
+| Purge | `cache.purge()` from `cloudflare:workers` | Zone REST `POST /zones/{id}/purge_cache` |
+| Secrets | None for purge | `CF_ZONE_ID` + `CF_CACHE_PURGE_TOKEN` |
+
+Use the preferred path for new sites. Keep `cloudflareCache()` only if you already depend on its Cache API behavior.
+
+Also do not confuse either of those with **object cache** (`objectCache: kvCache({ binding: "CACHE" })`), which caches database query results in KV — a separate layer under the Worker.
 
 ## Custom Domain
 

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -151,7 +151,7 @@ See [Object Cache](/deployment/object-cache/) for KV setup, options, and invalid
 
 ## Workers Cache
 
-Cloudflare's [Workers Cache](https://developers.cloudflare.com/workers/cache/) puts an edge cache **in front of** your Worker: matching requests are served without running your Worker at all. This is the **preferred** edge HTML cache for EmDash on Cloudflare. It needs **no zone ID and no Cache Purge API token**.
+Cloudflare's [Workers Cache](https://developers.cloudflare.com/workers/cache/) puts an edge cache **in front of** your Worker: matching requests are served without running your Worker at all.
 
 ### Enable it
 

--- a/packages/cloudflare/src/cache/config.ts
+++ b/packages/cloudflare/src/cache/config.ts
@@ -1,17 +1,25 @@
 /**
- * Cloudflare Cache API route cache provider - CONFIG ENTRY
+ * Legacy Cloudflare Cache API route cache provider — CONFIG ENTRY
  *
- * This is the config-time helper. Import it in your astro.config.mjs:
+ * @deprecated Prefer native Workers Caching for new sites:
  *
  * ```ts
- * import { cloudflareCache } from "@emdash-cms/cloudflare";
+ * // wrangler.jsonc
+ * { "cache": { "enabled": true } }
  *
+ * // astro.config.mjs
+ * import { cacheCloudflare } from "@astrojs/cloudflare/cache";
  * export default defineConfig({
- *   cache: {
- *     provider: cloudflareCache(),
- *   },
+ *   cache: { provider: cacheCloudflare() },
  * });
  * ```
+ *
+ * Native path invalidates with `cache.purge()` from `cloudflare:workers`
+ * (no zone ID or Cache Purge API token). See EmDash docs:
+ * Deploy to Cloudflare → Workers Cache.
+ *
+ * This helper is the older stopgap: Cache API storage + zone REST purge
+ * (`CF_ZONE_ID` + `CF_CACHE_PURGE_TOKEN`). Kept for existing sites.
  *
  * This module does NOT import cloudflare:workers and is safe to use at
  * config time.
@@ -24,26 +32,22 @@ import type { CloudflareCacheConfig } from "./runtime.js";
 export type { CloudflareCacheConfig };
 
 /**
- * Cloudflare Cache API route cache provider.
+ * Legacy Cloudflare Cache API route cache provider.
  *
- * Uses the Workers Cache API (`cache.put()`/`cache.match()`) to cache
- * rendered route responses at the edge. Invalidation uses the Cloudflare
- * purge-by-tag REST API for global purge across all edge locations.
+ * @deprecated Prefer `cacheCloudflare()` from `@astrojs/cloudflare/cache`
+ * with `"cache": { "enabled": true }` in wrangler. That uses native Workers
+ * Caching and `cache.purge()` — no zone credentials.
  *
- * This is a stopgap until CacheW provides native distributed caching
- * for Workers. Worker responses can't go through the CDN cache today,
- * so we use the Cache API directly. The standard `Cache-Tag` header is
- * set on stored responses so the purge-by-tag API can find them.
- *
- * Tag-based invalidation requires a Zone ID and an API token with
- * "Cache Purge" permission. These can be passed directly in the config
- * or read from environment variables at runtime (default: `CF_ZONE_ID`
- * and `CF_CACHE_PURGE_TOKEN`).
+ * This implementation stores responses with the Workers Cache API
+ * (`cache.put()` / `cache.match()`) and invalidates globally via the
+ * Cloudflare purge-by-tag REST API, which requires a Zone ID and an API
+ * token with "Cache Purge" permission (`CF_ZONE_ID` /
+ * `CF_CACHE_PURGE_TOKEN` by default).
  *
  * @param config Optional configuration.
  * @returns A {@link CacheProviderConfig} to pass to `cache.provider`.
  *
- * @example Basic usage (reads zone ID and token from env vars)
+ * @example Legacy usage (zone REST purge credentials required)
  * ```ts
  * import { defineConfig } from "astro/config";
  * import cloudflare from "@astrojs/cloudflare";
@@ -55,15 +59,6 @@ export type { CloudflareCacheConfig };
  *     provider: cloudflareCache(),
  *   },
  * });
- * ```
- *
- * @example With explicit config
- * ```ts
- * cloudflareCache({
- *   cacheName: "my-site",
- *   zoneId: "abc123...",
- *   apiToken: "xyz789...",
- * })
  * ```
  */
 export function cloudflareCache(

--- a/packages/cloudflare/src/cache/config.ts
+++ b/packages/cloudflare/src/cache/config.ts
@@ -31,6 +31,8 @@ import type { CloudflareCacheConfig } from "./runtime.js";
 
 export type { CloudflareCacheConfig };
 
+let deprecationWarned = false;
+
 /**
  * Legacy Cloudflare Cache API route cache provider.
  *
@@ -64,6 +66,16 @@ export type { CloudflareCacheConfig };
 export function cloudflareCache(
 	config: CloudflareCacheConfig = {},
 ): CacheProviderConfig<CloudflareCacheConfig> {
+	if (!deprecationWarned) {
+		deprecationWarned = true;
+		console.warn(
+			"[@emdash-cms/cloudflare] cloudflareCache() is deprecated. " +
+				'Prefer native Workers Caching: wrangler "cache": { "enabled": true } ' +
+				"and cacheCloudflare() from @astrojs/cloudflare/cache " +
+				"(purge via cache.purge() — no CF_ZONE_ID / CF_CACHE_PURGE_TOKEN). " +
+				"See https://docs.emdashcms.com/deployment/cloudflare#workers-cache",
+		);
+	}
 	return {
 		// Resolved by Vite/Astro at build time — points to the runtime module
 		entrypoint: "@emdash-cms/cloudflare/cache",

--- a/packages/cloudflare/src/cache/runtime.ts
+++ b/packages/cloudflare/src/cache/runtime.ts
@@ -1,21 +1,21 @@
 /**
- * Cloudflare Cache API route cache provider - RUNTIME ENTRY
+ * Legacy Cloudflare Cache API route cache provider — RUNTIME ENTRY
  *
- * Implements Astro's CacheProvider interface as a runtime provider using the
- * Workers Cache API for storage and the Cloudflare purge-by-tag REST API for
- * global invalidation.
+ * @deprecated Prefer native Workers Caching: wrangler `"cache": { "enabled": true }`
+ * + `cacheCloudflare()` from `@astrojs/cloudflare/cache`, purge via
+ * `cache.purge()` from `cloudflare:workers` (no zone credentials).
  *
- * This is a temporary solution until CacheW exists. Workers responses can't
- * go through the CDN cache, so we use cache.put()/cache.match() directly.
- * The standard `Cache-Tag` header (set by Astro's default setHeaders) is
- * preserved on cached responses so the purge-by-tag API works globally.
+ * This legacy provider implements Astro's CacheProvider with the Cache API
+ * (`put`/`match`) for storage and the zone purge-by-tag REST API for global
+ * invalidation (`CF_ZONE_ID` + `CF_CACHE_PURGE_TOKEN`). Kept for existing sites.
  *
  * We do NOT implement setHeaders() — Astro's defaultSetHeaders correctly
  * emits CDN-Cache-Control and Cache-Tag. Our onRequest() reads those
  * headers from the response that next() returns.
  *
  * Do NOT import this at config time. Use cloudflareCache() from
- * "@emdash-cms/cloudflare" or "@emdash-cms/cloudflare/cache/config" instead.
+ * "@emdash-cms/cloudflare" or "@emdash-cms/cloudflare/cache/config" instead
+ * (only if you intentionally need this legacy path).
  */
 
 import type { CacheProviderFactory } from "astro";

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -549,5 +549,7 @@ export function kvCache(config: KVCacheConfig): ObjectCacheDescriptor {
 export { cloudflareImages, type CloudflareImagesConfig } from "./media/images.js";
 export { cloudflareStream, type CloudflareStreamConfig } from "./media/stream.js";
 
-// Re-export cache provider config helper (config-time)
+// Legacy Cache API + zone REST purge provider (config-time). Prefer
+// cacheCloudflare() from @astrojs/cloudflare/cache with wrangler
+// "cache": { "enabled": true } for native Workers Caching.
 export { cloudflareCache, type CloudflareCacheConfig } from "./cache/config.js";


### PR DESCRIPTION
## What does this PR do?

Clears up a confusion trap: `demos/cloudflare` and `cloudflareCache()` from `@emdash-cms/cloudflare` looked like the canonical edge-cache setup, but they use the **legacy** Cache API + zone REST purge path (`CF_ZONE_ID` / `CF_CACHE_PURGE_TOKEN`). EmDash deploy docs already describe **native Workers Caching** (`"cache": { "enabled": true }`) as the preferred approach.

This PR aligns the demo and docs with that preferred path and marks the EmDash helper as legacy so agents/humans stop copying the wrong pattern.

### Changes
- **`demos/cloudflare`**: switch to `cacheCloudflare()` from `@astrojs/cloudflare/cache`; add `"cache": { "enabled": true }` to wrangler; README documents preferred vs legacy
- **Deploy docs (Workers Cache)**: full preferred setup (`wrangler` + `cacheCloudflare` + `cache.purge()`), comparison table vs legacy `cloudflareCache()`, note that object cache (`kvCache`) is a separate layer
- **`cloudflareCache()` JSDoc / export comment**: `@deprecated` guidance pointing at native Workers Caching

No runtime behavior change for existing sites that already use `cloudflareCache()`.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a (docs)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: opencode + xAI grok-4.5

## Screenshots / test output

n/a — docs + demo config comments only.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://docs-clarify-workers-cache-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `docs/clarify-workers-cache`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
