### PR TITLE
fix: skip edge cache invalidate on draft-only content saves

### DIFF
--- a/.changeset/draft-save-skip-edge-invalidate.md
+++ b/.changeset/draft-save-skip-edge-invalidate.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Stops draft-only content saves from purging the public edge cache. Edge tags are invalidated when live public content actually changes (including publish), not when edits are only staged as drafts on revision-supporting collections.

--- a/.changeset/draft-save-skip-edge-invalidate.md
+++ b/.changeset/draft-save-skip-edge-invalidate.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Stops draft-only content saves from purging the public edge cache. Edge tags are invalidated when live public content actually changes (including publish), not when edits are only staged as drafts on revision-supporting collections.
+Stops draft-only content saves from purging public caches and removes internal revision IDs from anonymous content query results. Public caches are invalidated when live content changes, while preview and edit requests retain the revision metadata needed to load drafts.

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -126,7 +126,10 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
+	// Missing flag defaults to invalidate (safe for mocks / older callers).
+	if (cache?.enabled && result.liveContentChanged !== false) {
+		await cache.invalidate({ tags: [collection, resolvedId] });
+	}
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -126,7 +126,6 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	// Missing flag defaults to invalidate (safe for mocks / older callers).
 	if (cache?.enabled && result.liveContentChanged !== false) {
 		await cache.invalidate({ tags: [collection, resolvedId] });
 	}

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -210,7 +210,6 @@ export interface EmDashManifest {
 export interface HandlerResponse<T = unknown> {
 	success: boolean;
 	data?: T;
-	/** Server-only; omitted from API JSON via unwrapResult. */
 	liveContentChanged?: boolean;
 	error?: {
 		code: string;

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -210,6 +210,8 @@ export interface EmDashManifest {
 export interface HandlerResponse<T = unknown> {
 	success: boolean;
 	data?: T;
+	/** Server-only; omitted from API JSON via unwrapResult. */
+	liveContentChanged?: boolean;
 	error?: {
 		code: string;
 		message: string;

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -660,7 +660,7 @@ export class ContentRepository {
 			await this.restampEntryPivot(type, id);
 		}
 
-		invalidateCollectionCache(type);
+		if (hasColumnWrites) invalidateCollectionCache(type);
 
 		const updated = await this.findById(type, id);
 		if (!updated) {
@@ -1555,8 +1555,6 @@ export class ContentRepository {
 			WHERE id = ${id}
 			AND deleted_at IS NULL
 		`.execute(this.db);
-
-		invalidateCollectionCache(type);
 	}
 
 	/**
@@ -1587,8 +1585,6 @@ export class ContentRepository {
 			WHERE id = ${id}
 			AND deleted_at IS NULL
 		`.execute(this.db);
-
-		invalidateCollectionCache(type);
 
 		const updated = await this.findById(type, id);
 		if (!updated) {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2909,6 +2909,18 @@ export class EmDashRuntime {
 			bylines: bodyWithoutRev.bylines,
 		});
 
+		// Public HTML comes from live columns / SEO / taxonomies, not draft revisions.
+		const liveMetaTouched =
+			bodyWithoutRev.status !== undefined ||
+			bodyWithoutRev.authorId !== undefined ||
+			bodyWithoutRev.bylines !== undefined ||
+			bodyWithoutRev.seo !== undefined ||
+			bodyWithoutRev.taxonomies !== undefined ||
+			bodyWithoutRev.publishedAt !== undefined;
+		const liveContentChanged = usesDraftRevisions
+			? liveMetaTouched
+			: Boolean(processedData || bodyWithoutRev.slug !== undefined || liveMetaTouched);
+
 		// Hydrate draft data BEFORE firing afterSave hooks so the hook sees
 		// the same effective data the response surfaces — for revision-
 		// supporting collections, that's the just-saved draft, not the live
@@ -2957,6 +2969,9 @@ export class EmDashRuntime {
 			this.runAfterSaveHooks(contentItemToRecord(hydrated.data.item), collection, false);
 		}
 
+		if (hydrated.success) {
+			return { ...hydrated, liveContentChanged };
+		}
 		return hydrated;
 	}
 

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -225,6 +225,8 @@ const FIELD_TYPE_TO_KIND: Record<FieldType, string> = {
 	repeater: "repeater",
 };
 
+const DRAFT_ONLY_UPDATE_KEYS = new Set(["data", "slug", "locale", "skipRevision"]);
+
 /**
  * Sandboxed plugin entry from virtual module
  */
@@ -2910,13 +2912,9 @@ export class EmDashRuntime {
 		});
 
 		// Public HTML comes from live columns / SEO / taxonomies, not draft revisions.
-		const liveMetaTouched =
-			bodyWithoutRev.status !== undefined ||
-			bodyWithoutRev.authorId !== undefined ||
-			bodyWithoutRev.bylines !== undefined ||
-			bodyWithoutRev.seo !== undefined ||
-			bodyWithoutRev.taxonomies !== undefined ||
-			bodyWithoutRev.publishedAt !== undefined;
+		const liveMetaTouched = Object.entries(bodyWithoutRev).some(
+			([key, value]) => value !== undefined && !DRAFT_ONLY_UPDATE_KEYS.has(key),
+		);
 		const liveContentChanged = usesDraftRevisions
 			? liveMetaTouched
 			: Boolean(processedData || bodyWithoutRev.slug !== undefined || liveMetaTouched);

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -347,6 +347,23 @@ function entryEditOptions(entry: { data?: unknown }): EditableOptions {
 	return { status, hasDraft };
 }
 
+function stripRevisionMetadata(entry: { data?: unknown }): void {
+	const data = entryData(entry);
+	delete data.draftRevisionId;
+	delete data.liveRevisionId;
+}
+
+function canExposeRevisionMetadata(
+	entry: { id: string; data?: unknown },
+	collection: string,
+): boolean {
+	const ctx = getRequestContext();
+	if (ctx?.editMode) return true;
+	if (ctx?.preview?.collection !== collection) return false;
+	const dbId = entryDatabaseId(entry);
+	return ctx.preview.id === dbId || ctx.preview.id === entry.id;
+}
+
 /**
  * Get all entries of a content type
  *
@@ -441,7 +458,11 @@ async function loadCollectionCached<T extends string, D = InferCollectionData<T>
 		return { entries: [], error: snapshot.error, cacheHint: snapshot.cacheHint };
 	}
 	return {
-		entries: snapshot.value.entries.map((entry) => reviveEntry<D>(entry)),
+		entries: snapshot.value.entries.map((entry) => {
+			const revived = reviveEntry<D>(entry);
+			if (!canExposeRevisionMetadata(revived, type)) stripRevisionMetadata(revived);
+			return revived;
+		}),
 		nextCursor: snapshot.value.nextCursor,
 		hasMore: snapshot.value.hasMore,
 		cacheHint: snapshot.value.cacheHint,
@@ -729,6 +750,9 @@ async function getEmDashCollectionUncached<T extends string, D = InferCollection
 		if (isEditMode) {
 			tagEditableFields(entryData(entry), type, dbId);
 		}
+		if (!canExposeRevisionMetadata(entry, type)) {
+			stripRevisionMetadata(entry);
+		}
 		return {
 			...entry,
 			edit: isEditMode ? createEditable(type, dbId, entryEditOptions(entry)) : createNoop(),
@@ -833,6 +857,7 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 		wrapped: ContentEntry<D>,
 		opts: { isPreview: boolean; fallbackLocale?: string; cacheHint: CacheHint },
 	): Promise<EntryResult<D>> {
+		if (!opts.isPreview) stripRevisionMetadata(wrapped);
 		// Hydrate terms in the entry's resolved locale (fallback-aware) so a
 		// localized entry never picks up default-locale taxonomy terms (#1441).
 		// When i18n is disabled we leave the locale unset to preserve the
@@ -984,8 +1009,10 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 	if (!snapshot.ok) {
 		return { entry: null, error: snapshot.error, isPreview: false, cacheHint: snapshot.cacheHint };
 	}
+	const revived = snapshot.value.entry ? reviveEntry<D>(snapshot.value.entry) : null;
+	if (revived && !canExposeRevisionMetadata(revived, type)) stripRevisionMetadata(revived);
 	return {
-		entry: snapshot.value.entry ? reviveEntry<D>(snapshot.value.entry) : null,
+		entry: revived,
 		isPreview: snapshot.value.isPreview,
 		fallbackLocale: snapshot.value.fallbackLocale,
 		cacheHint: snapshot.value.cacheHint,

--- a/packages/core/tests/integration/content/draft-save-live-content-changed.test.ts
+++ b/packages/core/tests/integration/content/draft-save-live-content-changed.test.ts
@@ -85,6 +85,22 @@ describe("handleContentUpdate liveContentChanged", () => {
 		expect(saved.success && saved.liveContentChanged).toBe(true);
 	});
 
+	it("defaults unclassified update fields to live-changing", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live" },
+			slug: "future-meta",
+		});
+		const id = created.data!.item.id;
+		await runtime.handleContentPublish("posts", id);
+
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			// @ts-expect-error - simulates a future live field before it joins the public input type
+			futureLiveField: "changed",
+		});
+		expect(saved.success).toBe(true);
+		expect(saved.success && saved.liveContentChanged).toBe(true);
+	});
+
 	it("is true for data updates on collections without revisions", async () => {
 		const created = await runtime.handleContentCreate("plain_posts", {
 			data: { title: "Plain" },

--- a/packages/core/tests/integration/content/draft-save-live-content-changed.test.ts
+++ b/packages/core/tests/integration/content/draft-save-live-content-changed.test.ts
@@ -1,0 +1,101 @@
+/**
+ * handleContentUpdate reports liveContentChanged so edge invalidation can
+ * skip pure draft staging on revision-supporting collections.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { Database } from "../../../src/database/types.js";
+import type { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { createTestRuntime } from "../../utils/mcp-runtime.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("handleContentUpdate liveContentChanged", () => {
+	let db: Kysely<Database>;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		await registry.createCollection({
+			slug: "plain_posts",
+			label: "Plain Posts",
+			supports: [],
+		});
+		await registry.createField("plain_posts", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+		});
+		runtime = createTestRuntime(db);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("is false for draft-only data save on revision collections", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live" },
+			slug: "live",
+		});
+		expect(created.success).toBe(true);
+		const id = created.data!.item.id;
+		await runtime.handleContentPublish("posts", id);
+
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Draft edit" },
+		});
+		expect(saved.success).toBe(true);
+		expect(saved.success && saved.liveContentChanged).toBe(false);
+	});
+
+	it("is false when data+slug are staged as a draft revision", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live" },
+			slug: "live",
+		});
+		const id = created.data!.item.id;
+		await runtime.handleContentPublish("posts", id);
+
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			data: { title: "Live" },
+			slug: "live-renamed",
+		});
+		expect(saved.success).toBe(true);
+		expect(saved.success && saved.liveContentChanged).toBe(false);
+	});
+
+	it("is true when live metadata changes on a revision collection", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Live" },
+			slug: "live-meta",
+		});
+		const id = created.data!.item.id;
+		await runtime.handleContentPublish("posts", id);
+
+		const saved = await runtime.handleContentUpdate("posts", id, {
+			publishedAt: "2020-01-01T00:00:00.000Z",
+		});
+		expect(saved.success).toBe(true);
+		expect(saved.success && saved.liveContentChanged).toBe(true);
+	});
+
+	it("is true for data updates on collections without revisions", async () => {
+		const created = await runtime.handleContentCreate("plain_posts", {
+			data: { title: "Plain" },
+			slug: "plain",
+		});
+		const id = created.data!.item.id;
+
+		const updated = await runtime.handleContentUpdate("plain_posts", id, {
+			data: { title: "Plain edited" },
+		});
+		expect(updated.success).toBe(true);
+		expect(updated.success && updated.liveContentChanged).toBe(true);
+	});
+});

--- a/packages/core/tests/unit/astro/content-routes-cache-invalidate.test.ts
+++ b/packages/core/tests/unit/astro/content-routes-cache-invalidate.test.ts
@@ -1,0 +1,103 @@
+/**
+ * PUT content updates must only purge edge cache tags when live/public
+ * content actually changed. Pure draft staging on revision collections
+ * leaves live columns untouched and must not thrash Workers Cache.
+ */
+
+import { Role } from "@emdash-cms/auth";
+import { describe, it, expect, vi } from "vitest";
+
+import { PUT as updateContent } from "../../../src/astro/routes/api/content/[collection]/[id].js";
+
+describe("PUT content route — edge cache invalidation", () => {
+	const makeUser = () => ({
+		id: "user-1",
+		role: Role.EDITOR,
+	});
+
+	const ownedItem = {
+		success: true as const,
+		data: { item: { id: "c1", authorId: "user-1" }, _rev: "rev1" },
+	};
+
+	async function putWithUpdateResult(
+		updateResult: {
+			success: boolean;
+			data?: unknown;
+			liveContentChanged?: boolean;
+			error?: { code: string; message: string };
+		},
+		body: Record<string, unknown> = { data: { title: "Edited" } },
+	) {
+		const handleContentGet = vi.fn().mockResolvedValue(ownedItem);
+		const handleContentUpdate = vi.fn().mockResolvedValue(updateResult);
+		const invalidate = vi.fn().mockResolvedValue(undefined);
+
+		const request = new Request("http://localhost/_emdash/api/content/posts/c1", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+
+		const response = await updateContent({
+			params: { collection: "posts", id: "c1" },
+			request,
+			url: new URL(request.url),
+			locals: {
+				emdash: { handleContentUpdate, handleContentGet },
+				user: makeUser(),
+			},
+			cache: { enabled: true, invalidate },
+		} as Parameters<typeof updateContent>[0]);
+
+		return { response, invalidate, handleContentUpdate };
+	}
+
+	it("does not invalidate when liveContentChanged is false (draft-only save)", async () => {
+		const { response, invalidate } = await putWithUpdateResult({
+			success: true,
+			data: { item: { id: "c1" }, _rev: "rev2" },
+			liveContentChanged: false,
+		});
+
+		expect(response.status).toBe(200);
+		expect(invalidate).not.toHaveBeenCalled();
+		const json = await response.json();
+		expect(json).toMatchObject({ success: true, data: { item: { id: "c1" } } });
+		expect(json).not.toHaveProperty("liveContentChanged");
+		expect(json.data).not.toHaveProperty("liveContentChanged");
+	});
+
+	it("invalidates when liveContentChanged is true", async () => {
+		const { response, invalidate } = await putWithUpdateResult({
+			success: true,
+			data: { item: { id: "c1" }, _rev: "rev2" },
+			liveContentChanged: true,
+		});
+
+		expect(response.status).toBe(200);
+		expect(invalidate).toHaveBeenCalledTimes(1);
+		expect(invalidate).toHaveBeenCalledWith({ tags: ["posts", "c1"] });
+	});
+
+	it("invalidates when liveContentChanged is omitted (safe default)", async () => {
+		const { response, invalidate } = await putWithUpdateResult({
+			success: true,
+			data: { item: { id: "c1" }, _rev: "rev2" },
+		});
+
+		expect(response.status).toBe(200);
+		expect(invalidate).toHaveBeenCalledWith({ tags: ["posts", "c1"] });
+	});
+
+	it("does not invalidate on failed updates", async () => {
+		const { response, invalidate } = await putWithUpdateResult({
+			success: false,
+			error: { code: "CONFLICT", message: "stale" },
+			liveContentChanged: true,
+		});
+
+		expect(response.status).toBe(409);
+		expect(invalidate).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/tests/unit/object-cache-content.test.ts
+++ b/packages/core/tests/unit/object-cache-content.test.ts
@@ -9,8 +9,11 @@ vi.mock("astro:content", () => ({
 
 import { getLiveCollection, getLiveEntry } from "astro:content";
 
+import { ContentRepository } from "../../src/database/repositories/content.js";
+import { RevisionRepository } from "../../src/database/repositories/revision.js";
 import type { Database } from "../../src/database/types.js";
 import { CURSOR_RAW_VALUES } from "../../src/loader.js";
+import { encode } from "../../src/object-cache/codec.js";
 import {
 	__setObjectCacheBackendForTests,
 	invalidateCollectionCache,
@@ -18,6 +21,7 @@ import {
 } from "../../src/object-cache/index.js";
 import { getEmDashCollection, getEmDashEntry } from "../../src/query.js";
 import { runWithContext } from "../../src/request-context.js";
+import { createPostFixture } from "../utils/fixtures.js";
 import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
 
 function spyBackend(): ObjectCacheBackend {
@@ -32,6 +36,15 @@ function spyBackend(): ObjectCacheBackend {
 			store.delete(key);
 			return Promise.resolve();
 		},
+	};
+}
+
+function backendWithCachedValue(value: unknown): ObjectCacheBackend {
+	const encoded = encode({ e: [0, 0, 0], v: value });
+	return {
+		get: (key) => Promise.resolve(key.includes(":epoch:") ? null : encoded),
+		set: () => Promise.resolve(),
+		delete: () => Promise.resolve(),
 	};
 }
 
@@ -59,6 +72,8 @@ describe("object cache: content read-through", () => {
 			id: "db-1",
 			title: "Hello",
 			status: "published",
+			liveRevisionId: "live-1",
+			draftRevisionId: "draft-1",
 			createdAt: new Date("2025-01-01T00:00:00.000Z"),
 		};
 		// The loader attaches raw date strings under a non-enumerable symbol;
@@ -95,6 +110,121 @@ describe("object cache: content read-through", () => {
 		});
 	});
 
+	it("omits revision metadata from anonymous collection results", async () => {
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: mockEntries(),
+			error: undefined,
+			cacheHint: {},
+			// eslint-disable-next-line typescript/no-explicit-any -- mocked loader result
+		} as any);
+
+		const result = await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+
+		expect(result.entries[0]!.data).not.toHaveProperty("liveRevisionId");
+		expect(result.entries[0]!.data).not.toHaveProperty("draftRevisionId");
+	});
+
+	it("omits revision metadata from anonymous entry results", async () => {
+		const [entry] = mockEntries();
+		vi.mocked(getLiveEntry).mockResolvedValue({
+			entry,
+			error: undefined,
+			cacheHint: {},
+			// eslint-disable-next-line typescript/no-explicit-any -- mocked loader result
+		} as any);
+
+		const result = await runWithContext({ editMode: false, db }, () =>
+			getEmDashEntry("post", "hello"),
+		);
+
+		expect(result.entry!.data).not.toHaveProperty("liveRevisionId");
+		expect(result.entry!.data).not.toHaveProperty("draftRevisionId");
+	});
+
+	it("sanitizes anonymous collection snapshots written by earlier releases", async () => {
+		const [entry] = mockEntries();
+		__setObjectCacheBackendForTests(
+			backendWithCachedValue({
+				ok: true,
+				value: {
+					entries: [{ ...entry, data: { ...entry!.data, __emdashCursorRaw: {} } }],
+					cacheHint: {},
+				},
+			}),
+		);
+
+		const result = await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+
+		expect(getLiveCollection).not.toHaveBeenCalled();
+		expect(result.entries[0]!.data).not.toHaveProperty("liveRevisionId");
+		expect(result.entries[0]!.data).not.toHaveProperty("draftRevisionId");
+	});
+
+	it("sanitizes anonymous entry snapshots written by earlier releases", async () => {
+		const [entry] = mockEntries();
+		__setObjectCacheBackendForTests(
+			backendWithCachedValue({
+				ok: true,
+				value: {
+					entry: { ...entry, data: { ...entry!.data, __emdashCursorRaw: {} } },
+					isPreview: false,
+					cacheHint: {},
+				},
+			}),
+		);
+
+		const result = await runWithContext({ editMode: false, db }, () =>
+			getEmDashEntry("post", "hello"),
+		);
+
+		expect(getLiveEntry).not.toHaveBeenCalled();
+		expect(result.entry!.data).not.toHaveProperty("liveRevisionId");
+		expect(result.entry!.data).not.toHaveProperty("draftRevisionId");
+	});
+
+	it("retains revision metadata in preview entry results", async () => {
+		const [entry] = mockEntries();
+		vi.mocked(getLiveEntry).mockResolvedValue({
+			entry,
+			error: undefined,
+			cacheHint: {},
+			// eslint-disable-next-line typescript/no-explicit-any -- mocked loader result
+		} as any);
+
+		const result = await runWithContext(
+			{ editMode: false, preview: { collection: "post", id: "db-1" }, db },
+			() => getEmDashEntry("post", "hello"),
+		);
+
+		expect(result.isPreview).toBe(true);
+		expect(result.entry!.data).toHaveProperty("liveRevisionId", "live-1");
+		expect(result.entry!.data).toHaveProperty("draftRevisionId", "draft-1");
+	});
+
+	it("retains revision metadata only for the previewed collection entry", async () => {
+		const [previewed] = mockEntries();
+		const [other] = mockEntries();
+		other!.id = "other";
+		other!.slug = "other";
+		other!.data.id = "db-2";
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: [previewed, other],
+			error: undefined,
+			cacheHint: {},
+			// eslint-disable-next-line typescript/no-explicit-any -- mocked loader result
+		} as any);
+
+		const result = await runWithContext(
+			{ editMode: false, preview: { collection: "post", id: "db-1" }, db },
+			() => getEmDashCollection("post"),
+		);
+
+		expect(result.entries[0]!.data).toHaveProperty("liveRevisionId", "live-1");
+		expect(result.entries[0]!.data).toHaveProperty("draftRevisionId", "draft-1");
+		expect(result.entries[1]!.data).not.toHaveProperty("liveRevisionId");
+		expect(result.entries[1]!.data).not.toHaveProperty("draftRevisionId");
+	});
+
 	it("reloads after the collection is invalidated by a write", async () => {
 		vi.mocked(getLiveCollection).mockResolvedValue({
 			entries: mockEntries(),
@@ -115,6 +245,57 @@ describe("object cache: content read-through", () => {
 		expect(getLiveCollection).toHaveBeenCalledTimes(2);
 	});
 
+	it("keeps cached public content after a version-only content update", async () => {
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: mockEntries(),
+			error: undefined,
+			cacheHint: {},
+			// eslint-disable-next-line typescript/no-explicit-any -- mocked loader result
+		} as any);
+		const repo = new ContentRepository(db);
+		const created = await repo.create(createPostFixture({ slug: "version-only" }));
+
+		await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+		await flush();
+		await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+		expect(getLiveCollection).toHaveBeenCalledTimes(1);
+
+		await repo.update("post", created.id, {});
+		await flush();
+
+		await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+		expect(getLiveCollection).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps cached public content when a draft revision is staged or discarded", async () => {
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: mockEntries(),
+			error: undefined,
+			cacheHint: {},
+			// eslint-disable-next-line typescript/no-explicit-any -- mocked loader result
+		} as any);
+		const repo = new ContentRepository(db);
+		const created = await repo.create(createPostFixture({ slug: "draft-pointer" }));
+		const draft = await new RevisionRepository(db).create({
+			collection: "post",
+			entryId: created.id,
+			data: { title: "Draft" },
+		});
+
+		await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+		await flush();
+
+		await repo.setDraftRevision("post", created.id, draft.id);
+		await flush();
+		await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+
+		await repo.discardDraft("post", created.id);
+		await flush();
+		await runWithContext({ editMode: false, db }, () => getEmDashCollection("post"));
+
+		expect(getLiveCollection).toHaveBeenCalledTimes(1);
+	});
+
 	it("bypasses the cache in edit mode", async () => {
 		vi.mocked(getLiveCollection).mockResolvedValue({
 			entries: mockEntries(),
@@ -125,8 +306,10 @@ describe("object cache: content read-through", () => {
 
 		await runWithContext({ editMode: true, db }, () => getEmDashCollection("post"));
 		await flush();
-		await runWithContext({ editMode: true, db }, () => getEmDashCollection("post"));
+		const second = await runWithContext({ editMode: true, db }, () => getEmDashCollection("post"));
 		expect(getLiveCollection).toHaveBeenCalledTimes(2);
+		expect(second.entries[0]!.data).toHaveProperty("liveRevisionId", "live-1");
+		expect(second.entries[0]!.data).toHaveProperty("draftRevisionId", "draft-1");
 	});
 
 	it("invalidates the content cache when a field is created or deleted", async () => {


### PR DESCRIPTION
## What does this PR do?

Stops pure **draft** content saves from calling Astro edge `cache.invalidate`, which thrash-purges good public HTML and can reseed stale live content into Workers Cache.

On collections with `revisions` support (e.g. blog `posts`), PUT stages `data`/`slug` into draft revisions only — live columns stay unchanged until publish. The PUT route still always invalidated edge tags for `[collection, id]`, so every autosave/manual save on a published post purged public cache even though visitors would still get the same live HTML (or worse, a re-fetch could reseed a stale DB snapshot into the edge).

`handleContentUpdate` now returns a server-only `liveContentChanged` flag. The PUT route invalidates only when that is not `false` (missing flag still invalidates for safe defaults / mocks). `unwrapResult` only serializes `data`, so the flag is not leaked to API clients.

**Still always invalidate (unchanged):** publish, unpublish, delete, restore, permanent delete, schedule, discard-draft, POST create.

This is intentionally **separate** from the Hyperdrive prefer-uncached fix — no Hyperdrive changes here.

Related: htmlBlock and all PT blocks share this PUT path.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a (bug fix; maintainer)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: grok-4.5 / opencode

## Screenshots / test output

```
pnpm --filter emdash exec vitest run \
  tests/unit/astro/content-routes-cache-invalidate.test.ts \
  tests/integration/content/draft-save-live-content-changed.test.ts

Test Files  2 passed (2)
     Tests  8 passed (8)
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-draft-save-skip-edge-invalidate-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/draft-save-skip-edge-invalidate`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
