### PR TITLE
fix(admin): report failed media uploads as failures

### DIFF
--- a/.changeset/media-upload-failure-reporting.md
+++ b/.changeset/media-upload-failure-reporting.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the Media Library reporting a failed upload as a success. A rejected upload now shows an error naming the reason, instead of a green "File uploaded" message with nothing added to the list.

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1341,11 +1341,6 @@ function MediaPage() {
 			isLoading={isLoading || isFetchingNextPage}
 			hasMore={!!hasNextPage}
 			onLoadMore={() => void fetchNextPage()}
-			// mutateAsync, not mutate: MediaLibrary awaits this call and counts
-			// rejections to decide between the success and error banner. mutate()
-			// never rejects, so a failed upload was scored as a success -- the
-			// green "File uploaded" banner appeared and nothing was added to the
-			// list, with the API's reason discarded.
 			onUpload={async (file) => {
 				await uploadMutation.mutateAsync(file);
 			}}

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1341,7 +1341,14 @@ function MediaPage() {
 			isLoading={isLoading || isFetchingNextPage}
 			hasMore={!!hasNextPage}
 			onLoadMore={() => void fetchNextPage()}
-			onUpload={(file) => uploadMutation.mutate(file)}
+			// mutateAsync, not mutate: MediaLibrary awaits this call and counts
+			// rejections to decide between the success and error banner. mutate()
+			// never rejects, so a failed upload was scored as a success -- the
+			// green "File uploaded" banner appeared and nothing was added to the
+			// list, with the API's reason discarded.
+			onUpload={async (file) => {
+				await uploadMutation.mutateAsync(file);
+			}}
 			onLocalSearchChange={setSearch}
 			onLocalMimeFilterChange={setMimeFilter}
 		/>

--- a/packages/admin/tests/media-upload-failure.test.tsx
+++ b/packages/admin/tests/media-upload-failure.test.tsx
@@ -1,25 +1,4 @@
 import { Toasty } from "@cloudflare/kumo";
-/**
- * MediaPage must surface a failed upload as a failure.
- *
- * `MediaLibrary.handleFileSelect` awaits the `onUpload` prop and decides between
- * the success and error banner by counting rejections:
- *
- *     try { await onUpload?.(file); uploaded++ }
- *     catch { failed++ }
- *     ...
- *     if (failed === 0) setUploadState({ status: "success", ... })
- *
- * MediaPage used to pass `uploadMutation.mutate`, which is fire-and-forget — it
- * returns `undefined` and never rejects. So `failed` stayed 0 no matter what the
- * API said, and a rejected upload rendered the green "File uploaded" banner
- * while nothing was added to the list, with the API's reason discarded. Passing
- * `mutateAsync` propagates the real error to that catch.
- *
- * The assertion is on the prop contract rather than the rendered banner: the
- * banner is MediaLibrary's behaviour (and is already correct), whereas the bug
- * was purely in how MediaPage wired the handler.
- */
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -117,8 +96,6 @@ describe("MediaPage upload failure reporting", () => {
 		const onUpload = await renderMediaPage();
 		expect(onUpload).toBeDefined();
 
-		// mutate() would resolve to undefined here and the failure would be
-		// silently scored as a success.
 		await expect(
 			Promise.resolve(onUpload?.(new File(["x"], "notes.txt", { type: "text/plain" }))),
 		).rejects.toThrow("File type not allowed");
@@ -137,9 +114,6 @@ describe("MediaPage upload failure reporting", () => {
 		const onUpload = await renderMediaPage();
 		expect(onUpload).toBeDefined();
 
-		// Companion check on the happy path -- the regression guard is the test
-		// above. The handler resolves to void, so the assertion is only that it
-		// settles without rejecting and that the upload was actually attempted.
 		await expect(
 			Promise.resolve(onUpload?.(new File(["x"], "photo.png", { type: "image/png" }))),
 		).resolves.toBeUndefined();

--- a/packages/admin/tests/media-upload-failure.test.tsx
+++ b/packages/admin/tests/media-upload-failure.test.tsx
@@ -1,0 +1,148 @@
+import { Toasty } from "@cloudflare/kumo";
+/**
+ * MediaPage must surface a failed upload as a failure.
+ *
+ * `MediaLibrary.handleFileSelect` awaits the `onUpload` prop and decides between
+ * the success and error banner by counting rejections:
+ *
+ *     try { await onUpload?.(file); uploaded++ }
+ *     catch { failed++ }
+ *     ...
+ *     if (failed === 0) setUploadState({ status: "success", ... })
+ *
+ * MediaPage used to pass `uploadMutation.mutate`, which is fire-and-forget — it
+ * returns `undefined` and never rejects. So `failed` stayed 0 no matter what the
+ * API said, and a rejected upload rendered the green "File uploaded" banner
+ * while nothing was added to the list, with the API's reason discarded. Passing
+ * `mutateAsync` propagates the real error to that catch.
+ *
+ * The assertion is on the prop contract rather than the rendered banner: the
+ * banner is MediaLibrary's behaviour (and is already correct), whereas the bug
+ * was purely in how MediaPage wired the handler.
+ */
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { AdminManifest } from "../src/lib/api";
+import { createAdminRouter } from "../src/router";
+import { render } from "./utils/render.tsx";
+import { createMockFetch, createTestQueryClient } from "./utils/test-helpers";
+
+const uploadMedia = vi.fn();
+
+vi.mock("../src/lib/api", async () => {
+	const actual = await vi.importActual("../src/lib/api");
+	return {
+		...actual,
+		fetchMediaList: vi.fn().mockResolvedValue({ items: [], nextCursor: undefined }),
+		uploadMedia: (file: File) => uploadMedia(file) as Promise<unknown>,
+	};
+});
+
+/** Capture the props MediaPage hands to MediaLibrary. */
+let capturedOnUpload: ((file: File) => Promise<void> | void) | undefined;
+
+vi.mock("../src/components/MediaLibrary", () => ({
+	MediaLibrary: (props: { onUpload?: (file: File) => Promise<void> | void }) => {
+		capturedOnUpload = props.onUpload;
+		return <div data-testid="media-library" />;
+	},
+}));
+
+vi.mock("../src/components/Shell", () => ({
+	Shell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+function buildRouter() {
+	const queryClient = createTestQueryClient();
+	const router = createAdminRouter(queryClient);
+	if (!i18n.locale) {
+		i18n.loadAndActivate({ locale: "en", messages: {} });
+	}
+	function TestApp() {
+		return (
+			<I18nProvider i18n={i18n}>
+				<Toasty>
+					<QueryClientProvider client={queryClient}>
+						<RouterProvider router={router} />
+					</QueryClientProvider>
+				</Toasty>
+			</I18nProvider>
+		);
+	}
+	return { router, TestApp };
+}
+
+async function renderMediaPage() {
+	capturedOnUpload = undefined;
+	const { router, TestApp } = buildRouter();
+	await router.navigate({ to: "/media" });
+	const screen = await render(<TestApp />);
+	await expect.element(screen.getByTestId("media-library")).toBeInTheDocument();
+	return capturedOnUpload;
+}
+
+const MANIFEST: AdminManifest = {
+	version: "1.0.0",
+	hash: "abc123",
+	authMode: "passkey",
+	collections: {},
+	plugins: {},
+	taxonomies: [],
+	i18n: { defaultLocale: "en", locales: ["en"] },
+};
+
+describe("MediaPage upload failure reporting", () => {
+	let mockFetch: ReturnType<typeof createMockFetch>;
+
+	beforeEach(() => {
+		uploadMedia.mockReset();
+		mockFetch = createMockFetch();
+		mockFetch
+			.on("GET", "/_emdash/api/manifest", { data: MANIFEST })
+			.on("GET", "/_emdash/api/auth/me", { data: { id: "user_01", role: 60 } });
+	});
+
+	afterEach(() => {
+		mockFetch.restore();
+	});
+
+	it("rejects when the upload fails, so MediaLibrary can show the error", async () => {
+		uploadMedia.mockRejectedValue(new Error("File type not allowed"));
+
+		const onUpload = await renderMediaPage();
+		expect(onUpload).toBeDefined();
+
+		// mutate() would resolve to undefined here and the failure would be
+		// silently scored as a success.
+		await expect(
+			Promise.resolve(onUpload?.(new File(["x"], "notes.txt", { type: "text/plain" }))),
+		).rejects.toThrow("File type not allowed");
+	});
+
+	it("resolves when the upload succeeds", async () => {
+		uploadMedia.mockResolvedValue({
+			id: "m1",
+			filename: "photo.png",
+			mimeType: "image/png",
+			url: "/_emdash/api/media/file/m1.png",
+			size: 10,
+			createdAt: "2026-01-01",
+		});
+
+		const onUpload = await renderMediaPage();
+		expect(onUpload).toBeDefined();
+
+		// Companion check on the happy path -- the regression guard is the test
+		// above. The handler resolves to void, so the assertion is only that it
+		// settles without rejecting and that the upload was actually attempted.
+		await expect(
+			Promise.resolve(onUpload?.(new File(["x"], "photo.png", { type: "image/png" }))),
+		).resolves.toBeUndefined();
+		expect(uploadMedia).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`MediaPage` passed `uploadMutation.mutate` as `MediaLibrary`'s `onUpload`. `MediaLibrary` awaits that call and counts rejections to decide between the success and the error banner — but `mutate()` is fire-and-forget: it returns `undefined` and never rejects. Every upload was therefore scored a success, so a **rejected** upload rendered the green "File uploaded" banner while nothing appeared in the list, and the reason the API gave (`File type not allowed`, `File exceeds maximum size of …`) was discarded.

The fix is to await `mutateAsync` so the rejection reaches the caller that is already written to handle it. No change to `MediaLibrary` itself.

This is worth more than the one-line diff suggests: with the banner lying *and* auto-clearing after 3s, a misconfigured install is indistinguishable from a working one. It sent our QA down a multi-day hunt for a broken upload pipeline that was never broken.

Closes #2282

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — no new strings; the existing error path is already wrapped
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 5** (Claude Code)

## Screenshots / test output

`packages/admin/tests/media-upload-failure.test.tsx` asserts that `onUpload` rejects when the upload fails. It detects a revert — with the fix backed out and everything else unchanged:

```
FAIL  chromium  tests/media-upload-failure.test.tsx > MediaPage upload failure reporting
  > rejects when the upload fails, so MediaLibrary can show the error
AssertionError: promise resolved "undefined" instead of rejecting
```

With the fix applied:

```
✓ chromium  tests/media-upload-failure.test.tsx (2 tests) 166ms
  Test Files  1 passed (1)
       Tests  2 passed (2)
```

Full suites on this branch's base (`668184f`):

```
packages/core   390 passed | 1 skipped (391 files), 5024 passed | 3 skipped
packages/admin  105 passed (105 files), 1241 passed
pnpm typecheck  packages/admin: Done
pnpm format     clean (no files changed outside this PR)
```

Two notes on the shared gates, both reproduced on a **clean checkout of `main` @ `668184f`** with no changes applied, i.e. pre-existing and unrelated to this PR:

- `pnpm typecheck` fails in `packages/core` — `src/plugins/context.ts(1212,24): error TS2345: Argument of type '"cache:purge"' is not assignable to parameter of type 'PluginCapability'`.
- `pnpm lint` reports 1 warning (and `--deny-warnings` turns it into a failure) — `typescript(no-unnecessary-type-assertion)` at `packages/cloudflare/src/sandbox/bridge.ts:1210`.

Happy to rebase once those are sorted if it makes CI easier to read.
