### PR TITLE
fix(core): don't create pending media rows when storage can't pre-sign

### DIFF
--- a/.changeset/media-signed-upload-pending-rows.md
+++ b/.changeset/media-signed-upload-pending-rows.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the media table filling up with hidden, unusable `pending` records — one per upload attempt — when storage cannot create signed upload URLs, which is always the case for local storage and for R2 accessed through a Worker binding.

--- a/packages/core/src/astro/routes/api/media/upload-url.ts
+++ b/packages/core/src/astro/routes/api/media/upload-url.ts
@@ -103,17 +103,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const ext = path.extname(body.filename) || "";
 		const storageKey = `${id}${ext}`;
 
-		// Get signed upload URL from storage.
-		//
-		// This must happen BEFORE the pending record is created. Adapters that
-		// cannot pre-sign -- local storage, and R2 accessed through a Worker
-		// binding -- throw NOT_SUPPORTED here, which the catch below turns into a
-		// 501 so the client falls back to direct upload. Creating the record first
-		// meant every such request committed a `status='pending'` row with no
-		// object behind it: invisible in the library (findMany defaults to
-		// `status='ready'`, and the list query exposes no status filter) and only
-		// ever removed by cleanupPendingUploads(), which nothing schedules. On
-		// those setups the table grew by one dead row per upload attempt.
+		// Get the signed upload URL before creating the pending row, so adapters
+		// that cannot pre-sign don't leave an orphaned `pending` record.
 		const signedUrl = await emdash.storage.getSignedUploadUrl({
 			key: storageKey,
 			contentType: body.contentType,

--- a/packages/core/src/astro/routes/api/media/upload-url.ts
+++ b/packages/core/src/astro/routes/api/media/upload-url.ts
@@ -103,6 +103,24 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const ext = path.extname(body.filename) || "";
 		const storageKey = `${id}${ext}`;
 
+		// Get signed upload URL from storage.
+		//
+		// This must happen BEFORE the pending record is created. Adapters that
+		// cannot pre-sign -- local storage, and R2 accessed through a Worker
+		// binding -- throw NOT_SUPPORTED here, which the catch below turns into a
+		// 501 so the client falls back to direct upload. Creating the record first
+		// meant every such request committed a `status='pending'` row with no
+		// object behind it: invisible in the library (findMany defaults to
+		// `status='ready'`, and the list query exposes no status filter) and only
+		// ever removed by cleanupPendingUploads(), which nothing schedules. On
+		// those setups the table grew by one dead row per upload attempt.
+		const signedUrl = await emdash.storage.getSignedUploadUrl({
+			key: storageKey,
+			contentType: body.contentType,
+			size: body.size,
+			expiresIn: 3600, // 1 hour
+		});
+
 		// Create pending media record with content hash
 		const mediaItem = await repo.createPending({
 			filename: body.filename,
@@ -111,14 +129,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
 			storageKey,
 			contentHash: body.contentHash,
 			authorId: user?.id,
-		});
-
-		// Get signed upload URL from storage
-		const signedUrl = await emdash.storage.getSignedUploadUrl({
-			key: storageKey,
-			contentType: body.contentType,
-			size: body.size,
-			expiresIn: 3600, // 1 hour
 		});
 
 		const response: UploadUrlResponse = {

--- a/packages/core/tests/integration/api/media-upload-url-pending.test.ts
+++ b/packages/core/tests/integration/api/media-upload-url-pending.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The signed-upload endpoint must not leave a `pending` media row behind when
+ * storage cannot pre-sign.
+ *
+ * `POST /_emdash/api/media/upload-url` is the first call the admin's
+ * `uploadMedia()` makes; it falls back to direct multipart upload when the
+ * endpoint answers 501. Two shipped adapters can never pre-sign and always
+ * throw NOT_SUPPORTED — local storage (`LocalStorage.getSignedUploadUrl`) and
+ * R2 accessed through a Worker binding (`R2Storage.getSignedUploadUrl`) — so
+ * on those setups the 501 fallback is the *normal* path, taken on every single
+ * upload.
+ *
+ * The route used to create the pending record before asking storage for the
+ * URL, so each of those attempts committed a `status='pending'` row with no
+ * object behind it. The rows are invisible (`findMany` defaults to
+ * `status='ready'` and the list query exposes no status filter) and are only
+ * removed by `cleanupPendingUploads()`, which nothing schedules — so the table
+ * grew by one dead row per upload attempt, indefinitely.
+ */
+import { Role } from "@emdash-cms/auth";
+import type { APIContext } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST as requestUploadUrl } from "../../../src/astro/routes/api/media/upload-url.js";
+import type { DatabaseSchema } from "../../../src/database/types.js";
+import { EmDashStorageError } from "../../../src/storage/types.js";
+import type { Storage } from "../../../src/storage/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+/** Storage that behaves like local storage / an R2 binding: it cannot pre-sign. */
+function storageThatCannotPresign(): Storage {
+	return {
+		getSignedUploadUrl() {
+			throw new EmDashStorageError(
+				"Local storage does not support signed upload URLs. Upload files directly through the API.",
+				"NOT_SUPPORTED",
+			);
+		},
+	} as unknown as Storage;
+}
+
+function callRoute(db: Kysely<DatabaseSchema>, storage: Storage) {
+	const request = new Request("http://localhost:4321/_emdash/api/media/upload-url", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ filename: "photo.png", contentType: "image/png", size: 1024 }),
+	});
+
+	return requestUploadUrl({
+		request,
+		url: new URL(request.url),
+		params: {},
+		locals: {
+			emdash: { db, storage, config: {} },
+			user: { id: "admin-1", role: Role.ADMIN },
+		},
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- minimal stub for tests
+	} as unknown as APIContext);
+}
+
+async function countMedia(db: Kysely<DatabaseSchema>, status: string): Promise<number> {
+	const rows = await db.selectFrom("media").select("id").where("status", "=", status).execute();
+	return rows.length;
+}
+
+describe("POST /_emdash/api/media/upload-url with storage that cannot pre-sign", () => {
+	let db: Kysely<DatabaseSchema>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("answers 501 NOT_SUPPORTED so the client falls back to direct upload", async () => {
+		const response = await callRoute(db, storageThatCannotPresign());
+
+		expect(response.status).toBe(501);
+		const body = (await response.json()) as { error: { code: string } };
+		expect(body.error.code).toBe("NOT_SUPPORTED");
+	});
+
+	it("does not create a pending media row", async () => {
+		await callRoute(db, storageThatCannotPresign());
+
+		expect(await countMedia(db, "pending")).toBe(0);
+	});
+
+	it("does not accumulate rows across repeated attempts", async () => {
+		for (let i = 0; i < 5; i++) {
+			// oxlint-disable-next-line no-await-in-loop -- sequential on purpose: the point is that repeats don't accumulate
+			await callRoute(db, storageThatCannotPresign());
+		}
+
+		const all = await db.selectFrom("media").select("id").execute();
+		expect(all).toHaveLength(0);
+	});
+});

--- a/packages/core/tests/integration/api/media-upload-url-pending.test.ts
+++ b/packages/core/tests/integration/api/media-upload-url-pending.test.ts
@@ -1,22 +1,4 @@
-/**
- * The signed-upload endpoint must not leave a `pending` media row behind when
- * storage cannot pre-sign.
- *
- * `POST /_emdash/api/media/upload-url` is the first call the admin's
- * `uploadMedia()` makes; it falls back to direct multipart upload when the
- * endpoint answers 501. Two shipped adapters can never pre-sign and always
- * throw NOT_SUPPORTED — local storage (`LocalStorage.getSignedUploadUrl`) and
- * R2 accessed through a Worker binding (`R2Storage.getSignedUploadUrl`) — so
- * on those setups the 501 fallback is the *normal* path, taken on every single
- * upload.
- *
- * The route used to create the pending record before asking storage for the
- * URL, so each of those attempts committed a `status='pending'` row with no
- * object behind it. The rows are invisible (`findMany` defaults to
- * `status='ready'` and the list query exposes no status filter) and are only
- * removed by `cleanupPendingUploads()`, which nothing schedules — so the table
- * grew by one dead row per upload attempt, indefinitely.
- */
+/** The signed-upload endpoint must not leave a pending media row behind when storage cannot pre-sign. */
 import { Role } from "@emdash-cms/auth";
 import type { APIContext } from "astro";
 import type { Kysely } from "kysely";


### PR DESCRIPTION
## What does this PR do?

`POST /_emdash/api/media/upload-url` creates the pending media record **before** asking storage for a signed URL:

```ts
const mediaItem = await repo.createPending({ ... });   // :107
const signedUrl = await emdash.storage.getSignedUploadUrl({ ... });   // :117
```

Adapters that cannot pre-sign throw `NOT_SUPPORTED` on that second call. For R2 accessed through a Worker binding this is unconditional and permanent — a property of the adapter, not a misconfiguration (`packages/cloudflare/src/storage/r2.ts`) — and local storage behaves the same way. The route catches it and correctly answers `501`, the admin correctly falls back to direct upload, and the user-visible flow works. But the insert has already committed, and nothing rolls it back.

Those rows are invisible: `findMany()` defaults to `status='ready'` and the list query exposes no `status` parameter, so they never appear in the library or through the API. `cleanupPendingUploads()` exists but I could not find anything scheduling it. In practice the `media` table grows by one dead row per upload attempt, forever, on every such deployment. On our install 11 accumulated during one short debugging session before we noticed — and only because we were instrumenting something else.

This PR moves the `getSignedUploadUrl()` call above `createPending()`, so the record is written only once it is known a URL can be issued. The 501 response and the client fallback are unchanged.

This is the "possible side effect" noted at the end of #2256 — that issue reports the same endpoint from the user-facing angle (the failed request in DevTools). This PR fixes only the row-accumulation half; the question that issue raises, whether the admin should skip the probe altogether for adapters known not to support pre-signing, is a separate design call and is left open.

Refs #2256

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no admin UI change
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## Screenshots / test output

`packages/core/tests/integration/api/media-upload-url-pending.test.ts` covers the endpoint against a storage adapter that cannot pre-sign: it still answers 501, it writes no row, and repeated attempts do not accumulate. It detects a revert — with the fix backed out and everything else unchanged:

```
✓ answers 501 NOT_SUPPORTED so the client falls back to direct upload
× does not create a pending media row
× does not accumulate rows across repeated attempts

Test Files  1 failed (1)
     Tests  2 failed | 1 passed (3)
```

With the fix applied:

```
✓ tests/integration/api/media-upload-url-pending.test.ts (3 tests) 127ms
  Test Files  1 passed (1)
       Tests  3 passed (3)
```

Note the first assertion passes either way — that is deliberate, it pins the 501 contract this PR must not change.

Full suites on this branch's base (`668184f`):

```
packages/core   390 passed | 1 skipped (391 files), 5024 passed | 3 skipped
packages/admin  105 passed (105 files), 1241 passed
pnpm format     clean (no files changed outside this PR)
```

Two notes on the shared gates, both reproduced on a **clean checkout of `main` @ `668184f`** with no changes applied, i.e. pre-existing and unrelated to this PR:

- `pnpm typecheck` fails in `packages/core` — `src/plugins/context.ts(1212,24): error TS2345: Argument of type '"cache:purge"' is not assignable to parameter of type 'PluginCapability'`.
- `pnpm lint` reports 1 warning (and `--deny-warnings` turns it into a failure) — `typescript(no-unnecessary-type-assertion)` at `packages/cloudflare/src/sandbox/bridge.ts:1210`.

Happy to rebase once those are sorted if it makes CI easier to read.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 5** (Claude Code)
