### PR TITLE
fix: allow inline code and links on the same text

### DIFF
--- a/.changeset/allow-linked-inline-code.md
+++ b/.changeset/allow-linked-inline-code.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Allows inline code and links on the same text in the content editor, including in headings.

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -49,6 +49,7 @@
     "@tanstack/react-router": "catalog:",
     "@tiptap/core": "catalog:",
     "@tiptap/extension-character-count": "catalog:",
+    "@tiptap/extension-code": "catalog:",
     "@tiptap/extension-code-block": "catalog:",
     "@tiptap/extension-collaboration": "catalog:",
     "@tiptap/extension-drag-handle": "catalog:",

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2545,7 +2545,7 @@ export function PortableTextEditor({
 				},
 				// Replaced with CodeBlockExtension below (adds language picker node view).
 				codeBlock: false,
-				// Replaced with CodeMark below so inline code can combine with link/etc.
+				// Replaced with CodeMarkExtension so inline code can combine with link/etc.
 				code: false,
 				// StarterKit v3 includes Link and Underline
 				link: {

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -116,6 +116,7 @@ import { cn } from "../lib/utils";
 import { CaretNext } from "./ArrowIcons.js";
 import { BlockKitMediaPickerField } from "./BlockKitMediaPickerField";
 import { CodeBlockExtension } from "./editor/CodeBlockNode";
+import { CodeMarkExtension } from "./editor/CodeMarkExtension";
 import { DragHandleWrapper } from "./editor/DragHandleWrapper";
 import { mediaItemToGalleryImage } from "./editor/GalleryDetailPanel";
 import { GalleryExtension, type GalleryImage } from "./editor/GalleryNode";
@@ -2544,6 +2545,8 @@ export function PortableTextEditor({
 				},
 				// Replaced with CodeBlockExtension below (adds language picker node view).
 				codeBlock: false,
+				// Replaced with CodeMark below so inline code can combine with link/etc.
+				code: false,
 				// StarterKit v3 includes Link and Underline
 				link: {
 					openOnClick: false,
@@ -2554,6 +2557,7 @@ export function PortableTextEditor({
 				},
 				underline: {},
 			}),
+			CodeMarkExtension,
 			CodeBlockExtension,
 			HtmlBlockExtension,
 			GalleryExtension,

--- a/packages/admin/src/components/editor/CodeMarkExtension.ts
+++ b/packages/admin/src/components/editor/CodeMarkExtension.ts
@@ -1,91 +1,11 @@
 /**
- * Inline code mark that can combine with other marks (e.g. link).
- *
  * TipTap's default Code mark sets `excludes: '_'`, which drops every other
- * mark on the same span. Portable Text allows decorator + annotation stacks,
- * so we ship our own mark with an empty excludes list.
+ * mark on the same span. Portable Text allows decorator + annotation stacks
+ * (e.g. linked inline code), so override only that field.
  */
 
-import { Mark, markInputRule, markPasteRule, mergeAttributes } from "@tiptap/core";
+import Code from "@tiptap/extension-code";
 
-export interface CodeMarkOptions {
-	HTMLAttributes: Record<string, unknown>;
-}
-
-declare module "@tiptap/core" {
-	interface Commands<ReturnType> {
-		code: {
-			setCode: () => ReturnType;
-			toggleCode: () => ReturnType;
-			unsetCode: () => ReturnType;
-		};
-	}
-}
-
-const inputRegex = /(^|[^`])`([^`]+)`(?!`)$/;
-const pasteRegex = /(^|[^`])`([^`]+)`(?!`)/g;
-
-export const CodeMarkExtension = Mark.create<CodeMarkOptions>({
-	name: "code",
-
-	addOptions() {
-		return {
-			HTMLAttributes: {},
-		};
-	},
-
+export const CodeMarkExtension = Code.extend({
 	excludes: "",
-
-	code: true,
-
-	exitable: true,
-
-	parseHTML() {
-		return [{ tag: "code" }];
-	},
-
-	renderHTML({ HTMLAttributes }) {
-		return ["code", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
-	},
-
-	addCommands() {
-		return {
-			setCode:
-				() =>
-				({ commands }) =>
-					commands.setMark(this.name),
-			toggleCode:
-				() =>
-				({ commands }) =>
-					commands.toggleMark(this.name),
-			unsetCode:
-				() =>
-				({ commands }) =>
-					commands.unsetMark(this.name),
-		};
-	},
-
-	addKeyboardShortcuts() {
-		return {
-			"Mod-e": () => this.editor.commands.toggleCode(),
-		};
-	},
-
-	addInputRules() {
-		return [
-			markInputRule({
-				find: inputRegex,
-				type: this.type,
-			}),
-		];
-	},
-
-	addPasteRules() {
-		return [
-			markPasteRule({
-				find: pasteRegex,
-				type: this.type,
-			}),
-		];
-	},
 });

--- a/packages/admin/src/components/editor/CodeMarkExtension.ts
+++ b/packages/admin/src/components/editor/CodeMarkExtension.ts
@@ -1,0 +1,91 @@
+/**
+ * Inline code mark that can combine with other marks (e.g. link).
+ *
+ * TipTap's default Code mark sets `excludes: '_'`, which drops every other
+ * mark on the same span. Portable Text allows decorator + annotation stacks,
+ * so we ship our own mark with an empty excludes list.
+ */
+
+import { Mark, markInputRule, markPasteRule, mergeAttributes } from "@tiptap/core";
+
+export interface CodeMarkOptions {
+	HTMLAttributes: Record<string, unknown>;
+}
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		code: {
+			setCode: () => ReturnType;
+			toggleCode: () => ReturnType;
+			unsetCode: () => ReturnType;
+		};
+	}
+}
+
+const inputRegex = /(^|[^`])`([^`]+)`(?!`)$/;
+const pasteRegex = /(^|[^`])`([^`]+)`(?!`)/g;
+
+export const CodeMarkExtension = Mark.create<CodeMarkOptions>({
+	name: "code",
+
+	addOptions() {
+		return {
+			HTMLAttributes: {},
+		};
+	},
+
+	excludes: "",
+
+	code: true,
+
+	exitable: true,
+
+	parseHTML() {
+		return [{ tag: "code" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["code", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+	},
+
+	addCommands() {
+		return {
+			setCode:
+				() =>
+				({ commands }) =>
+					commands.setMark(this.name),
+			toggleCode:
+				() =>
+				({ commands }) =>
+					commands.toggleMark(this.name),
+			unsetCode:
+				() =>
+				({ commands }) =>
+					commands.unsetMark(this.name),
+		};
+	},
+
+	addKeyboardShortcuts() {
+		return {
+			"Mod-e": () => this.editor.commands.toggleCode(),
+		};
+	},
+
+	addInputRules() {
+		return [
+			markInputRule({
+				find: inputRegex,
+				type: this.type,
+			}),
+		];
+	},
+
+	addPasteRules() {
+		return [
+			markPasteRule({
+				find: pasteRegex,
+				type: this.type,
+			}),
+		];
+	},
+});

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -348,6 +348,88 @@ describe("Portable Text ↔ ProseMirror conversion", () => {
 		expect(anchor!.getAttribute("href")).toBe("https://example.com");
 	});
 
+	it("renders linked inline code in body text", async () => {
+		const linkKey = "lnk-code";
+		await render(
+			<PortableTextEditor
+				value={[
+					textBlock("fetch", {
+						marks: ["code", linkKey],
+						markDefs: [{ _type: "link", _key: linkKey, href: "https://example.com/fetch" }],
+					}),
+				]}
+			/>,
+		);
+		const pm = await waitForEditor();
+		const code = pm.querySelector("code");
+		const anchor = pm.querySelector("a");
+		expect(code).toBeTruthy();
+		expect(anchor).toBeTruthy();
+		expect(code!.textContent).toBe("fetch");
+		expect(anchor!.getAttribute("href")).toBe("https://example.com/fetch");
+		expect(anchor!.querySelector("code") || code!.closest("a")).toBeTruthy();
+	});
+
+	it("renders linked inline code in headings", async () => {
+		const linkKey = "lnk-h-code";
+		await render(
+			<PortableTextEditor
+				value={[
+					textBlock("useState", {
+						style: "h2",
+						marks: ["code", linkKey],
+						markDefs: [
+							{ _type: "link", _key: linkKey, href: "https://react.dev/reference/react/useState" },
+						],
+					}),
+				]}
+			/>,
+		);
+		const pm = await waitForEditor();
+		const heading = pm.querySelector("h2");
+		expect(heading).toBeTruthy();
+		expect(heading!.querySelector("code")).toBeTruthy();
+		expect(heading!.querySelector("a")?.getAttribute("href")).toBe(
+			"https://react.dev/reference/react/useState",
+		);
+	});
+
+	it("keeps code and link marks together when both are toggled", async () => {
+		const onChange = vi.fn();
+		const { editor } = await renderAndGetEditor({
+			onChange,
+			value: [textBlock("API")],
+		});
+
+		editor
+			.chain()
+			.focus()
+			.selectAll()
+			.toggleCode()
+			.setLink({ href: "https://api.example.com" })
+			.run();
+
+		await vi.waitFor(() => {
+			expect(editor.isActive("code")).toBe(true);
+			expect(editor.isActive("link")).toBe(true);
+		});
+
+		await vi.waitFor(() => {
+			expect(onChange).toHaveBeenCalled();
+		});
+
+		const blocks = onChange.mock.calls.at(-1)![0] as Array<{
+			children?: Array<{ text?: string; marks?: string[] }>;
+			markDefs?: Array<{ _type: string; _key: string; href?: string }>;
+		}>;
+		const span = blocks[0]?.children?.[0];
+		expect(span?.text).toBe("API");
+		expect(span?.marks).toContain("code");
+		const linkDef = blocks[0]?.markDefs?.find((d) => d._type === "link");
+		expect(linkDef?.href).toBe("https://api.example.com");
+		expect(span?.marks).toContain(linkDef?._key);
+	});
+
 	it("renders a bullet list", async () => {
 		await render(
 			<PortableTextEditor

--- a/packages/admin/tests/editor/linked-code.test.ts
+++ b/packages/admin/tests/editor/linked-code.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Inline code + link can coexist on the same span.
+ *
+ * TipTap's default Code mark sets `excludes: '_'`, which drops every other
+ * mark. EmDash overrides that so linked code works in body text and headings.
+ */
+
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { CodeMarkExtension } from "../../src/components/editor/CodeMarkExtension";
+
+function createEditor() {
+	return new Editor({
+		extensions: [
+			StarterKit.configure({
+				code: false,
+				link: {
+					openOnClick: false,
+					enableClickSelection: true,
+				},
+			}),
+			CodeMarkExtension,
+		],
+		content: "<p>fetch</p>",
+	});
+}
+
+function marksOnFirstText(editor: Editor): string[] {
+	const names: string[] = [];
+	editor.state.doc.descendants((node) => {
+		if (node.isText && names.length === 0) {
+			for (const mark of node.marks) {
+				names.push(mark.type.name);
+			}
+		}
+	});
+	return names.toSorted();
+}
+
+function firstBlockType(editor: Editor): string | null {
+	const first = editor.state.doc.firstChild;
+	return first?.type.name ?? null;
+}
+
+describe("linked inline code marks", () => {
+	let editor: Editor;
+
+	beforeEach(() => {
+		editor = createEditor();
+	});
+
+	afterEach(() => {
+		editor.destroy();
+	});
+
+	it("allows code and link on the same text node (code then link)", () => {
+		editor.chain().focus().selectAll().toggleCode().setLink({ href: "https://example.com" }).run();
+
+		expect(editor.isActive("code")).toBe(true);
+		expect(editor.isActive("link")).toBe(true);
+		expect(marksOnFirstText(editor)).toEqual(["code", "link"]);
+	});
+
+	it("allows code and link on the same text node (link then code)", () => {
+		editor.chain().focus().selectAll().setLink({ href: "https://example.com" }).toggleCode().run();
+
+		expect(editor.isActive("code")).toBe(true);
+		expect(editor.isActive("link")).toBe(true);
+		expect(marksOnFirstText(editor)).toEqual(["code", "link"]);
+	});
+
+	it("allows code and link inside a heading", () => {
+		editor.commands.setContent("<h2>fetch</h2>");
+		editor.chain().focus().selectAll().toggleCode().setLink({ href: "https://example.com/api" }).run();
+
+		expect(firstBlockType(editor)).toBe("heading");
+		expect(editor.state.doc.firstChild?.attrs.level).toBe(2);
+		expect(marksOnFirstText(editor)).toEqual(["code", "link"]);
+	});
+});

--- a/packages/admin/tests/editor/linked-code.test.ts
+++ b/packages/admin/tests/editor/linked-code.test.ts
@@ -73,7 +73,13 @@ describe("linked inline code marks", () => {
 
 	it("allows code and link inside a heading", () => {
 		editor.commands.setContent("<h2>fetch</h2>");
-		editor.chain().focus().selectAll().toggleCode().setLink({ href: "https://example.com/api" }).run();
+		editor
+			.chain()
+			.focus()
+			.selectAll()
+			.toggleCode()
+			.setLink({ href: "https://example.com/api" })
+			.run();
 
 		expect(firstBlockType(editor)).toBe("heading");
 		expect(editor.state.doc.firstChild?.attrs.level).toBe(2);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -218,6 +218,7 @@
     "@oslojs/encoding": "catalog:",
     "@portabletext/toolkit": "^5.0.1",
     "@tiptap/core": "catalog:",
+    "@tiptap/extension-code": "catalog:",
     "@tiptap/extension-code-block": "catalog:",
     "@tiptap/extension-focus": "catalog:",
     "@tiptap/extension-image": "catalog:",

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -1943,7 +1943,7 @@ export function InlinePortableTextEditor({
 				dropcursor: { color: "#3b82f6", width: 2 },
 				// Replaced with InlineCodeBlockExtension below (adds language picker).
 				codeBlock: false,
-				// Replaced with CodeMark below so inline code can combine with link/etc.
+				// Replaced with CodeMarkExtension so inline code can combine with link/etc.
 				code: false,
 			}),
 			CodeMarkExtension,

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -26,6 +26,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 
 import { computeThumbnailSize } from "../media/thumbnail.js";
+import { CodeMarkExtension } from "./code-mark.js";
 import { InlineCodeBlockExtension } from "./inline-code-block.js";
 
 // ── Portable Text types ────────────────────────────────────────────
@@ -1942,7 +1943,10 @@ export function InlinePortableTextEditor({
 				dropcursor: { color: "#3b82f6", width: 2 },
 				// Replaced with InlineCodeBlockExtension below (adds language picker).
 				codeBlock: false,
+				// Replaced with CodeMark below so inline code can combine with link/etc.
+				code: false,
 			}),
+			CodeMarkExtension,
 			InlineCodeBlockExtension,
 			Image.extend({
 				addAttributes() {

--- a/packages/core/src/components/code-mark.ts
+++ b/packages/core/src/components/code-mark.ts
@@ -1,91 +1,11 @@
 /**
- * Inline code mark that can combine with other marks (e.g. link).
- *
  * TipTap's default Code mark sets `excludes: '_'`, which drops every other
- * mark on the same span. Portable Text allows decorator + annotation stacks,
- * so we ship our own mark with an empty excludes list.
+ * mark on the same span. Portable Text allows decorator + annotation stacks
+ * (e.g. linked inline code), so override only that field.
  */
 
-import { Mark, markInputRule, markPasteRule, mergeAttributes } from "@tiptap/core";
+import Code from "@tiptap/extension-code";
 
-export interface CodeMarkOptions {
-	HTMLAttributes: Record<string, unknown>;
-}
-
-declare module "@tiptap/core" {
-	interface Commands<ReturnType> {
-		code: {
-			setCode: () => ReturnType;
-			toggleCode: () => ReturnType;
-			unsetCode: () => ReturnType;
-		};
-	}
-}
-
-const inputRegex = /(^|[^`])`([^`]+)`(?!`)$/;
-const pasteRegex = /(^|[^`])`([^`]+)`(?!`)/g;
-
-export const CodeMarkExtension = Mark.create<CodeMarkOptions>({
-	name: "code",
-
-	addOptions() {
-		return {
-			HTMLAttributes: {},
-		};
-	},
-
+export const CodeMarkExtension = Code.extend({
 	excludes: "",
-
-	code: true,
-
-	exitable: true,
-
-	parseHTML() {
-		return [{ tag: "code" }];
-	},
-
-	renderHTML({ HTMLAttributes }) {
-		return ["code", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
-	},
-
-	addCommands() {
-		return {
-			setCode:
-				() =>
-				({ commands }) =>
-					commands.setMark(this.name),
-			toggleCode:
-				() =>
-				({ commands }) =>
-					commands.toggleMark(this.name),
-			unsetCode:
-				() =>
-				({ commands }) =>
-					commands.unsetMark(this.name),
-		};
-	},
-
-	addKeyboardShortcuts() {
-		return {
-			"Mod-e": () => this.editor.commands.toggleCode(),
-		};
-	},
-
-	addInputRules() {
-		return [
-			markInputRule({
-				find: inputRegex,
-				type: this.type,
-			}),
-		];
-	},
-
-	addPasteRules() {
-		return [
-			markPasteRule({
-				find: pasteRegex,
-				type: this.type,
-			}),
-		];
-	},
 });

--- a/packages/core/src/components/code-mark.ts
+++ b/packages/core/src/components/code-mark.ts
@@ -1,0 +1,91 @@
+/**
+ * Inline code mark that can combine with other marks (e.g. link).
+ *
+ * TipTap's default Code mark sets `excludes: '_'`, which drops every other
+ * mark on the same span. Portable Text allows decorator + annotation stacks,
+ * so we ship our own mark with an empty excludes list.
+ */
+
+import { Mark, markInputRule, markPasteRule, mergeAttributes } from "@tiptap/core";
+
+export interface CodeMarkOptions {
+	HTMLAttributes: Record<string, unknown>;
+}
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		code: {
+			setCode: () => ReturnType;
+			toggleCode: () => ReturnType;
+			unsetCode: () => ReturnType;
+		};
+	}
+}
+
+const inputRegex = /(^|[^`])`([^`]+)`(?!`)$/;
+const pasteRegex = /(^|[^`])`([^`]+)`(?!`)/g;
+
+export const CodeMarkExtension = Mark.create<CodeMarkOptions>({
+	name: "code",
+
+	addOptions() {
+		return {
+			HTMLAttributes: {},
+		};
+	},
+
+	excludes: "",
+
+	code: true,
+
+	exitable: true,
+
+	parseHTML() {
+		return [{ tag: "code" }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ["code", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+	},
+
+	addCommands() {
+		return {
+			setCode:
+				() =>
+				({ commands }) =>
+					commands.setMark(this.name),
+			toggleCode:
+				() =>
+				({ commands }) =>
+					commands.toggleMark(this.name),
+			unsetCode:
+				() =>
+				({ commands }) =>
+					commands.unsetMark(this.name),
+		};
+	},
+
+	addKeyboardShortcuts() {
+		return {
+			"Mod-e": () => this.editor.commands.toggleCode(),
+		};
+	},
+
+	addInputRules() {
+		return [
+			markInputRule({
+				find: inputRegex,
+				type: this.type,
+			}),
+		];
+	},
+
+	addPasteRules() {
+		return [
+			markPasteRule({
+				find: pasteRegex,
+				type: this.type,
+			}),
+		];
+	},
+});

--- a/packages/core/tests/unit/converters/linked-code-round-trip.test.ts
+++ b/packages/core/tests/unit/converters/linked-code-round-trip.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+
+import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
+import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
+import type {
+	PortableTextLinkMark,
+	PortableTextTextBlock,
+} from "../../../src/content/converters/types.js";
+
+describe("linked inline code round-trip (core converters)", () => {
+	it("preserves code + link marks on body text through PT → PM → PT", () => {
+		const pt: PortableTextTextBlock[] = [
+			{
+				_type: "block",
+				_key: "b1",
+				style: "normal",
+				markDefs: [
+					{
+						_type: "link",
+						_key: "l1",
+						href: "https://example.com/fetch",
+					},
+				],
+				children: [
+					{
+						_type: "span",
+						_key: "s1",
+						text: "fetch",
+						marks: ["code", "l1"],
+					},
+				],
+			},
+		];
+
+		const pm = portableTextToProsemirror(pt);
+		const textNode = pm.content[0]?.content?.[0];
+		expect(textNode?.type).toBe("text");
+		expect(textNode?.text).toBe("fetch");
+		const markTypes = (textNode?.marks ?? []).map((m) => m.type).toSorted();
+		expect(markTypes).toEqual(["code", "link"]);
+		expect(textNode?.marks?.find((m) => m.type === "link")?.attrs?.href).toBe(
+			"https://example.com/fetch",
+		);
+
+		const restored = prosemirrorToPortableText(pm);
+		expect(restored).toHaveLength(1);
+		const block = restored[0] as PortableTextTextBlock;
+		expect(block.style).toBe("normal");
+		const span = block.children[0];
+		expect(span?.text).toBe("fetch");
+		expect(span?.marks).toContain("code");
+		const linkDef = block.markDefs?.find((d) => d._type === "link") as
+			| PortableTextLinkMark
+			| undefined;
+		expect(linkDef?.href).toBe("https://example.com/fetch");
+		expect(span?.marks).toContain(linkDef?._key);
+	});
+
+	it("preserves code + link marks on headings through PT → PM → PT", () => {
+		const pt: PortableTextTextBlock[] = [
+			{
+				_type: "block",
+				_key: "b1",
+				style: "h2",
+				markDefs: [
+					{
+						_type: "link",
+						_key: "l1",
+						href: "https://react.dev/reference/react/useState",
+					},
+				],
+				children: [
+					{
+						_type: "span",
+						_key: "s1",
+						text: "useState",
+						marks: ["code", "l1"],
+					},
+				],
+			},
+		];
+
+		const pm = portableTextToProsemirror(pt);
+		expect(pm.content[0]?.type).toBe("heading");
+		expect(pm.content[0]?.attrs?.level).toBe(2);
+		const textNode = pm.content[0]?.content?.[0];
+		const markTypes = (textNode?.marks ?? []).map((m) => m.type).toSorted();
+		expect(markTypes).toEqual(["code", "link"]);
+
+		const restored = prosemirrorToPortableText(pm);
+		const block = restored[0] as PortableTextTextBlock;
+		expect(block.style).toBe("h2");
+		const span = block.children[0];
+		expect(span?.marks).toContain("code");
+		const linkDef = block.markDefs?.find((d) => d._type === "link") as
+			| PortableTextLinkMark
+			| undefined;
+		expect(linkDef?.href).toBe("https://react.dev/reference/react/useState");
+		expect(span?.marks).toContain(linkDef?._key);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ catalogs:
     '@tiptap/extension-character-count':
       specifier: ^3.20.0
       version: 3.20.0
+    '@tiptap/extension-code':
+      specifier: ^3.20.0
+      version: 3.20.0
     '@tiptap/extension-code-block':
       specifier: ^3.20.0
       version: 3.20.0
@@ -1167,6 +1170,9 @@ importers:
       '@tiptap/extension-character-count':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/extensions@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))
+      '@tiptap/extension-code':
+        specifier: 'catalog:'
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extension-code-block':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
@@ -1679,6 +1685,9 @@ importers:
       '@tiptap/core':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/pm@3.20.0)
+      '@tiptap/extension-code':
+        specifier: 'catalog:'
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extension-code-block':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,6 +119,7 @@ catalog:
   "@tanstack/react-router": 1.163.2
   "@tiptap/core": ^3.20.0
   "@tiptap/extension-character-count": ^3.20.0
+  "@tiptap/extension-code": ^3.20.0
   "@tiptap/extension-code-block": ^3.20.0
   "@tiptap/extension-collaboration": ^3.20.0
   "@tiptap/extension-drag-handle": ^3.20.0


### PR DESCRIPTION
## What does this PR do?

Lets authors apply **inline code and a link on the same span** in the content editor (body text and headings), in both the admin editor and visual editing.

TipTap’s default Code mark sets `excludes: '_'`, so any other mark (including link) is dropped. Portable Text already supports stacking a `code` decorator with a `link` annotation; converters and frontend rendering were fine. This overrides only that field via `Code.extend({ excludes: "" })` so we inherit upstream parse/render/input rules and commands.

No upstream TipTap PR — maintainers treat exclusivity as intentional ([#2149](https://github.com/ueberdosis/tiptap/issues/2149), [#4276](https://github.com/ueberdosis/tiptap/issues/4276)) and point downstreams at configuring `excludes`. Related open upstream note: [tiptap#5225](https://github.com/ueberdosis/tiptap/issues/5225) (clickability of code-inside-link in the editor); EmDash keeps `openOnClick: false` on links, and manual QA looked fine for our use.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: n/a (bug fix; maintainer PR)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: opencode + xAI grok-4.5

## Screenshots / test output

Targeted tests:

- `packages/admin` — `linked-code.test.ts`, PortableTextEditor linked-code cases
- `packages/core` — `linked-code-round-trip.test.ts` (PT ↔ PM for body + headings)