### PR TITLE
fix: preserve source locale when duplicating content

### DIFF
--- a/.changeset/duplicate-preserves-locale.md
+++ b/.changeset/duplicate-preserves-locale.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the Duplicate action creating the copy in the default locale instead of the source entry's locale. Duplicates of non-English entries now stay in their locale — so they appear in the locale-filtered admin list they were duplicated from — and no longer fail with a unique-constraint error when the generated slug already exists in the default locale.

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -322,6 +322,7 @@ export class ContentRepository {
 			data: newData,
 			status: "draft",
 			authorId: authorId || original.authorId || undefined,
+			locale: original.locale ?? undefined,
 		});
 	}
 

--- a/packages/core/tests/integration/i18n/i18n.test.ts
+++ b/packages/core/tests/integration/i18n/i18n.test.ts
@@ -189,6 +189,53 @@ describe("i18n (Integration)", () => {
 			).rejects.toThrow();
 		});
 
+		// ── duplicate ─────────────────────────────────────────────────
+
+		it("duplicate() preserves the source item's locale", async () => {
+			const original = await repo.create(
+				createPostFixture({ slug: "hola-mundo", locale: "es", data: { title: "Hola Mundo" } }),
+			);
+
+			const copy = await repo.duplicate("post", original.id);
+
+			expect(copy.locale).toBe("es");
+		});
+
+		it("duplicate() assigns a fresh translation group", async () => {
+			const enPost = await repo.create(createPostFixture({ slug: "hello", locale: "en" }));
+			const esPost = await repo.create(
+				createPostFixture({
+					slug: "hola",
+					locale: "es",
+					translationOf: enPost.id,
+					data: { title: "Hola" },
+				}),
+			);
+
+			const copy = await repo.duplicate("post", esPost.id);
+
+			expect(copy.translationGroup).toBe(copy.id);
+			expect(copy.translationGroup).not.toBe(esPost.translationGroup);
+		});
+
+		it("duplicate() does not collide with the generated slug in another locale", async () => {
+			await repo.create(
+				createPostFixture({
+					slug: "hola-mundo-copy",
+					locale: "en",
+					data: { title: "Unrelated EN Post" },
+				}),
+			);
+			const original = await repo.create(
+				createPostFixture({ slug: "hola-mundo", locale: "es", data: { title: "Hola Mundo" } }),
+			);
+
+			const copy = await repo.duplicate("post", original.id);
+
+			expect(copy.locale).toBe("es");
+			expect(copy.slug).toBe("hola-mundo-copy");
+		});
+
 		// ── findBySlug ────────────────────────────────────────────────
 
 		it("findBySlug() without locale returns any match", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes `ContentRepository.duplicate()` dropping the source entry's locale. It generated the copy's unique slug scoped to the *source* locale, then called `create()` without a `locale`, so the fallback landed every copy in `en` regardless of the source row's locale.

Two observable consequences on non-English content, both hit in production on an es-canonical site (emdash 0.31.1):

- The admin content list is scoped to the active locale, so clicking **Duplicate** appears to do nothing — the copy is born under `en` and is invisible in the list the editor is looking at. Stray `-copy` rows accumulate (18 on the audited production DB).
- Because the slug-uniqueness check ran against the source locale while the insert landed in `en`, duplicating could crash with a `UNIQUE(slug, locale)` constraint violation when the generated slug already existed in `en`.

The fix passes `locale: original.locale ?? undefined` through to `create()`, which also makes the slug-uniqueness scoping consistent with the inserted row. Duplicates keep getting a **fresh translation group** (a duplicate is a new entry, not a translation) — that was already `create()`'s default behavior, and a new test locks it in so it can't regress.

Found during a measured database audit of a production deployment (the Macabro festival site).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a: no admin UI strings changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a: bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

Failing first (on `main`, before the fix):

```
× duplicate() preserves the source item's locale
  → expected 'en' to be 'es'
× duplicate() does not collide with the generated slug in another locale
  → UNIQUE constraint failed: ec_post.slug, ec_post.locale
```

After the fix:

```
Test Files  3 passed (3)
     Tests  141 passed (141)   (i18n.test.ts, content.test.ts, content-handlers.test.ts)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
