### PR TITLE
fix: attribute redirect-driven content misses to the requested path in the 404 log

### DIFF
--- a/.changeset/404-log-error-page.md
+++ b/.changeset/404-log-error-page.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the 404 log counting the site's own /404 error page as a missed path. Every content miss that redirects to /404 was logged twice — once for the real missing path and once for "/404" itself — inflating the 404 summary with a meaningless top entry. Hits on /404 are no longer logged.

--- a/.changeset/404-log-error-page.md
+++ b/.changeset/404-log-error-page.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes the 404 log counting the site's own /404 error page as a missed path. Every content miss that redirects to /404 was logged twice — once for the real missing path and once for "/404" itself — inflating the 404 summary with a meaningless top entry. Hits on /404 are no longer logged.
+Fixes 404 logging for content misses. Templates answer a missing entry with a redirect to /404, which previously left the real missed path unrecorded — the log only ever accumulated one aggregate "/404" row. Misses are now logged under the path the visitor actually requested, and hits on the /404 error page itself are no longer logged.

--- a/packages/core/src/astro/middleware/redirect.ts
+++ b/packages/core/src/astro/middleware/redirect.ts
@@ -112,10 +112,18 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		// No redirect matched -- proceed and check for 404
 		const response = await next();
 
-		// Log 404s for unmatched paths (fire-and-forget). Skip /404 itself — Astro
-		// serves the site error page there with status 404 on every render, so logging
-		// it would double-count the original miss after templates redirect here.
-		if (response.status === 404 && pathname !== "/404" && pathname !== "/404/") {
+		// Log misses (fire-and-forget) under the path the visitor requested.
+		// Two shapes count as a miss: an unmatched route rendering the error
+		// page with status 404, and a matched route answering a content miss
+		// with a redirect to /404 (the documented template pattern) — there the
+		// missed path exists only on this first pass, before the browser
+		// follows the redirect. The error page itself is never logged: /404
+		// answers 404 by design and carries no path information.
+		const location = response.headers.get("location");
+		const missedByRedirect =
+			isRedirectCode(response.status) && (location === "/404" || location === "/404/");
+		const missedDirectly = response.status === 404 && pathname !== "/404" && pathname !== "/404/";
+		if (missedDirectly || missedByRedirect) {
 			const referrer = context.request.headers.get("referer") ?? null;
 			const userAgent = context.request.headers.get("user-agent") ?? null;
 			repo

--- a/packages/core/src/astro/middleware/redirect.ts
+++ b/packages/core/src/astro/middleware/redirect.ts
@@ -112,11 +112,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		// No redirect matched -- proceed and check for 404
 		const response = await next();
 
-		// Log 404s for unmatched paths (fire-and-forget). The site's own error
-		// page is excluded: its route answers 404 on every render — including
-		// the follow-up request after a content miss redirects to /404 — so
-		// logging it counts every real miss twice under one meaningless
-		// "/404" row while the missed path is already logged on the first pass.
+		// Log 404s for unmatched paths (fire-and-forget). Skip /404 itself — Astro
+		// serves the site error page there with status 404 on every render, so logging
+		// it would double-count the original miss after templates redirect here.
 		if (response.status === 404 && pathname !== "/404" && pathname !== "/404/") {
 			const referrer = context.request.headers.get("referer") ?? null;
 			const userAgent = context.request.headers.get("user-agent") ?? null;

--- a/packages/core/src/astro/middleware/redirect.ts
+++ b/packages/core/src/astro/middleware/redirect.ts
@@ -112,8 +112,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		// No redirect matched -- proceed and check for 404
 		const response = await next();
 
-		// Log 404s for unmatched paths (fire-and-forget)
-		if (response.status === 404) {
+		// Log 404s for unmatched paths (fire-and-forget). The site's own error
+		// page is excluded: its route answers 404 on every render — including
+		// the follow-up request after a content miss redirects to /404 — so
+		// logging it counts every real miss twice under one meaningless
+		// "/404" row while the missed path is already logged on the first pass.
+		if (response.status === 404 && pathname !== "/404" && pathname !== "/404/") {
 			const referrer = context.request.headers.get("referer") ?? null;
 			const userAgent = context.request.headers.get("user-agent") ?? null;
 			repo

--- a/packages/core/tests/unit/astro/middleware-redirect.test.ts
+++ b/packages/core/tests/unit/astro/middleware-redirect.test.ts
@@ -178,7 +178,7 @@ describe("redirect middleware — issue #808", () => {
 	});
 });
 
-describe("redirect middleware — 404 logging excludes the site error page", () => {
+describe("redirect middleware — 404 logging attributes misses to the requested path", () => {
 	let db: Kysely<Database>;
 
 	beforeEach(async () => {
@@ -192,7 +192,7 @@ describe("redirect middleware — 404 logging excludes the site error page", () 
 		await teardownTestDatabase(db);
 	});
 
-	it("logs a real missing path exactly once", async () => {
+	it("logs an unmatched path exactly once", async () => {
 		const log404 = vi.spyOn(RedirectRepository.prototype, "log404");
 		const { context } = buildContext({ pathname: "/no-such-page" });
 		const next = vi.fn(async () => new Response("not found", { status: 404 }));
@@ -204,6 +204,42 @@ describe("redirect middleware — 404 logging excludes the site error page", () 
 		await log404.mock.results[0]!.value;
 		const rows = await db.selectFrom("_emdash_404_log").select("path").execute();
 		expect(rows.map((r) => r.path)).toEqual(["/no-such-page"]);
+		log404.mockRestore();
+	});
+
+	it("logs a content miss under its real path across the redirect-to-/404 flow", async () => {
+		// The documented template pattern answers a content miss with
+		// Astro.redirect("/404"): the first request is a 302, the browser then
+		// requests /404, which renders with status 404.
+		const log404 = vi.spyOn(RedirectRepository.prototype, "log404");
+
+		const miss = buildContext({ pathname: "/posts/deleted-post" });
+		const redirectNext = vi.fn(
+			async () => new Response(null, { status: 302, headers: { Location: "/404" } }),
+		);
+		await onRequest(miss.context, redirectNext);
+
+		const errorPage = buildContext({ pathname: "/404" });
+		const errorNext = vi.fn(async () => new Response("not found", { status: 404 }));
+		await onRequest(errorPage.context, errorNext);
+
+		expect(log404).toHaveBeenCalledTimes(1);
+		expect(log404).toHaveBeenCalledWith(expect.objectContaining({ path: "/posts/deleted-post" }));
+		await log404.mock.results[0]!.value;
+		const rows = await db.selectFrom("_emdash_404_log").select("path").execute();
+		expect(rows.map((r) => r.path)).toEqual(["/posts/deleted-post"]);
+		log404.mockRestore();
+	});
+
+	it("does not log ordinary redirects", async () => {
+		const log404 = vi.spyOn(RedirectRepository.prototype, "log404");
+		const { context } = buildContext({ pathname: "/moved" });
+		const next = vi.fn(
+			async () => new Response(null, { status: 302, headers: { Location: "/new-home" } }),
+		);
+		await onRequest(context, next);
+
+		expect(log404).not.toHaveBeenCalled();
 		log404.mockRestore();
 	});
 

--- a/packages/core/tests/unit/astro/middleware-redirect.test.ts
+++ b/packages/core/tests/unit/astro/middleware-redirect.test.ts
@@ -178,6 +178,50 @@ describe("redirect middleware — issue #808", () => {
 	});
 });
 
+describe("redirect middleware — 404 logging excludes the site error page", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		invalidateRedirectCache();
+		db = await setupTestDatabase();
+		getDbMock.mockReset();
+		getDbMock.mockResolvedValue(db);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("logs a real missing path exactly once", async () => {
+		const log404 = vi.spyOn(RedirectRepository.prototype, "log404");
+		const { context } = buildContext({ pathname: "/no-such-page" });
+		const next = vi.fn(async () => new Response("not found", { status: 404 }));
+		await onRequest(context, next);
+
+		expect(log404).toHaveBeenCalledTimes(1);
+		expect(log404).toHaveBeenCalledWith(expect.objectContaining({ path: "/no-such-page" }));
+		// Await the fire-and-forget write before reading the table.
+		await log404.mock.results[0]!.value;
+		const rows = await db.selectFrom("_emdash_404_log").select("path").execute();
+		expect(rows.map((r) => r.path)).toEqual(["/no-such-page"]);
+		log404.mockRestore();
+	});
+
+	it("does not log the site's own /404 error page render", async () => {
+		const log404 = vi.spyOn(RedirectRepository.prototype, "log404");
+		for (const pathname of ["/404", "/404/"]) {
+			const { context } = buildContext({ pathname });
+			const next = vi.fn(async () => new Response("not found", { status: 404 }));
+			await onRequest(context, next);
+		}
+
+		expect(log404).not.toHaveBeenCalled();
+		const rows = await db.selectFrom("_emdash_404_log").select("path").execute();
+		expect(rows).toEqual([]);
+		log404.mockRestore();
+	});
+});
+
 describe("redirect middleware — trailing-slash normalisation (issue #1271)", () => {
 	let db: Kysely<Database>;
 


### PR DESCRIPTION
## What does this PR do?

Fixes 404 logging for content misses — both the noise and a telemetry hole the noise was hiding.

The documented template pattern answers a content miss with `return Astro.redirect("/404")` (every demo and the site-building docs use it). That flow has two consequences for the 404 log:

1. The first pass answers **302**, which the logger (gated on `response.status === 404`) never saw — so the real missed path was **never recorded**.
2. The browser then requests the literal `/404`, which Astro serves with status 404, and *that* got logged — so every content miss collapsed into one aggregate `"/404"` row. On the audited production deployment (Macabro festival site, emdash 0.31.1), that row carried 41% of 55k logged hits, burying the per-path signal while recording no usable path itself.

The fix logs the miss **on the first pass, under the path the visitor actually requested**: when a matched route answers with a redirect whose target is the error page (`/404` or `/404/`), that request is a content miss and is logged as such. Direct renders of `/404` itself are never logged — the route answers 404 by design and carries no path information. Fully-unmatched paths (bot scans, broken links to non-routes) keep logging exactly as before, since Astro renders the error page for them on the first pass with the real pathname.

Net effect for upgraders: the meaningless aggregate `/404` row stops growing, and the log gains something it never had — the actual missed paths for content misses. Ordinary redirects (not targeting the error page) are not logged.

An earlier revision of this PR only excluded `/404` from logging, on the assumption the missed path was already recorded on the first pass. Adversarial review of the branch proved that assumption wrong for the redirect flow (the first pass is a 302), which would have silently zeroed 404 telemetry for content misses — hence the current shape, which closes the hole instead. The test suite now models the full production sequence: 302-to-`/404` followed by the `/404` render asserts exactly one row, keyed by the real path (fails on `main`, which records `"/404"` instead), alongside tests for unmatched paths, ordinary redirects, and direct error-page visits.

Known limitations, deliberately out of scope: no `base`-path handling (consistent with the rest of the middleware, which matches raw pathnames everywhere), and locale-prefixed error pages (`/fr/404`) are not excluded for direct visits — excluding them properly needs the configured locale list, and the redirect flow is unaffected (templates redirect to the absolute `/404`). The pre-existing aggregate `/404` row on already-deployed sites is retained (deleting it would be a data-deleting migration, worth a separate explicit decision).

Found during a measured database audit of a production deployment.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a: no admin UI strings changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a: bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

The redirect-flow regression test fails on `main` (the miss is recorded as `"/404"` instead of the real path):

```
× logs a content miss under its real path across the redirect-to-/404 flow
  → expected log404 to be called with path "/posts/deleted-post"
```

After the fix — middleware suite plus redirect integration suites:

```
Tests  75 passed (75)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
