### PR TITLE
fix: garbage-collect superseded media-usage generations

### DIFF
--- a/.changeset/media-usage-gc-sweep.md
+++ b/.changeset/media-usage-gc-sweep.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes media-usage tracking rows accumulating without bound. Superseded and abandoned usage generations are now garbage-collected by the periodic maintenance sweep, so the usage table no longer grows with every content save.

--- a/packages/core/src/cleanup.ts
+++ b/packages/core/src/cleanup.ts
@@ -143,7 +143,6 @@ export async function runSystemCleanup(
 		console.error("[cleanup] Failed to prune revisions:", error);
 	}
 
-	// 6. Media-usage occurrence rows superseded by newer generations
 	try {
 		const usage = await cleanupMediaUsageGenerations(db);
 		result.mediaUsageStaleGenerations = usage.staleGenerations;

--- a/packages/core/src/cleanup.ts
+++ b/packages/core/src/cleanup.ts
@@ -17,6 +17,7 @@ import { MediaRepository } from "./database/repositories/media.js";
 import { RevisionRepository } from "./database/repositories/revision.js";
 import type { Database } from "./database/types.js";
 import { removeUploadAttempt } from "./media/upload-attempts.js";
+import { cleanupMediaUsageGenerations } from "./media/usage/gc.js";
 import type { Storage } from "./storage/types.js";
 
 /**
@@ -30,6 +31,9 @@ export interface CleanupResult {
 	pendingUploadFiles: number;
 	uploadAttempts: number;
 	revisionsPruned: number;
+	mediaUsageStaleGenerations: number;
+	mediaUsageAbandonedGenerations: number;
+	mediaUsageOrphanOccurrences: number;
 }
 
 /** Max revisions to keep per entry during periodic pruning */
@@ -60,6 +64,9 @@ export async function runSystemCleanup(
 		pendingUploadFiles: -1,
 		uploadAttempts: -1,
 		revisionsPruned: -1,
+		mediaUsageStaleGenerations: -1,
+		mediaUsageAbandonedGenerations: -1,
+		mediaUsageOrphanOccurrences: -1,
 	};
 
 	// 1. Passkey challenges (expire after 60s, clean anything past 5 min)
@@ -134,6 +141,16 @@ export async function runSystemCleanup(
 		result.revisionsPruned = await pruneExcessiveRevisions(db);
 	} catch (error) {
 		console.error("[cleanup] Failed to prune revisions:", error);
+	}
+
+	// 6. Media-usage occurrence rows superseded by newer generations
+	try {
+		const usage = await cleanupMediaUsageGenerations(db);
+		result.mediaUsageStaleGenerations = usage.staleGenerations;
+		result.mediaUsageAbandonedGenerations = usage.abandonedGenerations;
+		result.mediaUsageOrphanOccurrences = usage.orphanOccurrences;
+	} catch (error) {
+		console.error("[cleanup] Failed to clean media-usage generations:", error);
 	}
 
 	return result;

--- a/packages/core/src/media/usage/gc.ts
+++ b/packages/core/src/media/usage/gc.ts
@@ -1,0 +1,50 @@
+/**
+ * Media-usage generation GC.
+ *
+ * Every save writes a fresh generation of `_emdash_media_usage` rows and
+ * leaves the superseded generation behind; reads join on
+ * `current_generation`, so non-current rows are dead weight. This sweep
+ * composes the repository GC methods behind a shared cutoff and batch limit,
+ * and is called from `runSystemCleanup` on every scheduler tick.
+ */
+
+import type { Kysely } from "kysely";
+
+import { MediaUsageRepository } from "../../database/repositories/media-usage.js";
+import type { Database } from "../../database/types.js";
+
+/**
+ * Only rows older than this are collected. Guarded writers insert occurrence
+ * rows before winning the source CAS, so the window must exceed any plausible
+ * in-flight write; mirrors the pending-upload abandonment window.
+ */
+const GC_MAX_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Per-tick cap on rows considered by each GC method, so a large backlog is
+ * amortized across ticks instead of one oversized batch (D1 bind limits).
+ */
+const GC_BATCH_LIMIT = 500;
+
+export interface MediaUsageCleanupResult {
+	staleGenerations: number;
+	abandonedGenerations: number;
+	orphanOccurrences: number;
+}
+
+/**
+ * Delete media-usage occurrence rows that can no longer be read: superseded
+ * generations, generations abandoned by losing CAS writers, and occurrences
+ * whose source row is gone.
+ */
+export async function cleanupMediaUsageGenerations(
+	db: Kysely<Database>,
+): Promise<MediaUsageCleanupResult> {
+	const cutoff = new Date(Date.now() - GC_MAX_AGE_MS).toISOString();
+	const repo = new MediaUsageRepository(db);
+	return {
+		staleGenerations: await repo.deleteStaleGenerationsOlderThan(cutoff, GC_BATCH_LIMIT),
+		abandonedGenerations: await repo.deleteAbandonedGenerationsOlderThan(cutoff, GC_BATCH_LIMIT),
+		orphanOccurrences: await repo.deleteOrphanOccurrencesOlderThan(cutoff, GC_BATCH_LIMIT),
+	};
+}

--- a/packages/core/tests/integration/database/media-usage-gc-sweep.test.ts
+++ b/packages/core/tests/integration/database/media-usage-gc-sweep.test.ts
@@ -4,12 +4,13 @@
  * Every content save writes a fresh generation of occurrence rows and leaves
  * the superseded generation behind; reads join on current_generation, so
  * stale rows are dead weight that grows one generation per save. The sweep
- * composes the repository GC methods behind a safety window and is exercised
- * here without the scheduler.
+ * composes the repository GC methods behind a safety window and runs from
+ * runSystemCleanup.
  */
 
 import { afterEach, beforeEach, expect, it } from "vitest";
 
+import { runSystemCleanup } from "../../../src/cleanup.js";
 import { MediaUsageRepository } from "../../../src/database/repositories/media-usage.js";
 import { cleanupMediaUsageGenerations } from "../../../src/media/usage/gc.js";
 import {
@@ -116,5 +117,23 @@ describeEachDialect("media-usage GC sweep", (dialect) => {
 		expect(result.staleGenerations).toBe(0);
 		const rows = await ctx.db.selectFrom("_emdash_media_usage").select("id").execute();
 		expect(rows).toHaveLength(2);
+	});
+
+	it("runs as part of the periodic system cleanup", async () => {
+		const first = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-old"),
+		]);
+		await repo.replaceSource(contentSource("entry1", "columns"), [occurrence("hero", "media-new")]);
+		await ctx.db
+			.updateTable("_emdash_media_usage")
+			.set({ created_at: "2026-01-01T00:00:00.000Z" })
+			.where("generation", "=", first.currentGeneration)
+			.execute();
+
+		const result = await runSystemCleanup(ctx.db);
+
+		expect(result.mediaUsageStaleGenerations).toBe(1);
+		const rows = await ctx.db.selectFrom("_emdash_media_usage").select("generation").execute();
+		expect(rows.map((r) => r.generation)).not.toContain(first.currentGeneration);
 	});
 });

--- a/packages/core/tests/integration/database/media-usage-gc-sweep.test.ts
+++ b/packages/core/tests/integration/database/media-usage-gc-sweep.test.ts
@@ -4,8 +4,8 @@
  * Every content save writes a fresh generation of occurrence rows and leaves
  * the superseded generation behind; reads join on current_generation, so
  * stale rows are dead weight that grows one generation per save. The sweep
- * composes the repository GC methods behind a safety window and runs from
- * runSystemCleanup (untestable here directly — see tests/unit/cleanup.test.ts).
+ * composes the repository GC methods behind a safety window and is exercised
+ * here without the scheduler.
  */
 
 import { afterEach, beforeEach, expect, it } from "vitest";

--- a/packages/core/tests/integration/database/media-usage-gc-sweep.test.ts
+++ b/packages/core/tests/integration/database/media-usage-gc-sweep.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Maintenance sweep for media-usage generations.
+ *
+ * Every content save writes a fresh generation of occurrence rows and leaves
+ * the superseded generation behind; reads join on current_generation, so
+ * stale rows are dead weight that grows one generation per save. The sweep
+ * composes the repository GC methods behind a safety window and runs from
+ * runSystemCleanup (untestable here directly — see tests/unit/cleanup.test.ts).
+ */
+
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { MediaUsageRepository } from "../../../src/database/repositories/media-usage.js";
+import { cleanupMediaUsageGenerations } from "../../../src/media/usage/gc.js";
+import {
+	buildContentMediaUsageSourceKey,
+	type MediaUsageContentSourceVariant,
+} from "../../../src/media/usage/source-key.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("media-usage GC sweep", (dialect) => {
+	let ctx: DialectTestContext;
+	let repo: MediaUsageRepository;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		repo = new MediaUsageRepository(ctx.db);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	function contentSource(
+		contentId: string,
+		variant: MediaUsageContentSourceVariant,
+	): Parameters<MediaUsageRepository["replaceSource"]>[0] {
+		return {
+			sourceKey: buildContentMediaUsageSourceKey({
+				collectionSlug: "posts",
+				contentId,
+				sourceVariant: variant,
+			}),
+			sourceType: "content",
+			collectionSlug: "posts",
+			contentId,
+			sourceVariant: variant,
+			locale: "en",
+			translationGroup: `tg-${contentId}`,
+			contentSlug: "hello-world",
+			contentTitle: "Hello World",
+			contentStatus: "published",
+			contentScheduledAt: null,
+			contentDeletedAt: null,
+		};
+	}
+
+	function occurrence(
+		fieldSlug: string,
+		mediaId: string,
+	): Parameters<MediaUsageRepository["replaceSource"]>[1][number] {
+		return {
+			fieldSlug,
+			fieldPath: fieldSlug,
+			occurrenceIndex: 0,
+			referenceType: "image_field",
+			mediaId,
+			provider: "local",
+			providerAssetId: mediaId,
+			mediaKind: "image",
+			mimeType: null,
+		};
+	}
+
+	it("removes superseded generations after repeated saves, keeping current usage", async () => {
+		const first = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-old"),
+			occurrence("body", "media-old-2"),
+		]);
+		const second = await repo.replaceSource(contentSource("entry1", "columns"), [
+			occurrence("hero", "media-new"),
+		]);
+
+		// Age the superseded rows past the sweep's safety window.
+		await ctx.db
+			.updateTable("_emdash_media_usage")
+			.set({ created_at: "2026-01-01T00:00:00.000Z" })
+			.where("generation", "=", first.currentGeneration)
+			.execute();
+
+		const result = await cleanupMediaUsageGenerations(ctx.db);
+
+		expect(result.staleGenerations).toBe(2);
+		expect(result.abandonedGenerations).toBe(0);
+		expect(result.orphanOccurrences).toBe(0);
+
+		const remaining = await ctx.db
+			.selectFrom("_emdash_media_usage")
+			.select(["generation", "media_id"])
+			.execute();
+		expect(remaining).toEqual([{ generation: second.currentGeneration, media_id: "media-new" }]);
+		expect(await repo.findCurrentUsageByMediaId("media-new")).toHaveLength(1);
+	});
+
+	it("leaves superseded rows inside the safety window untouched", async () => {
+		await repo.replaceSource(contentSource("entry1", "columns"), [occurrence("hero", "media-old")]);
+		await repo.replaceSource(contentSource("entry1", "columns"), [occurrence("hero", "media-new")]);
+
+		const result = await cleanupMediaUsageGenerations(ctx.db);
+
+		expect(result.staleGenerations).toBe(0);
+		const rows = await ctx.db.selectFrom("_emdash_media_usage").select("id").execute();
+		expect(rows).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes `_emdash_media_usage` growing without bound: the table's generation model writes a fresh set of occurrence rows on every content save and leaves the superseded generation behind, and the three repository GC methods that exist to reclaim them (`deleteStaleGenerationsOlderThan`, `deleteAbandonedGenerationsOlderThan`, `deleteOrphanOccurrencesOlderThan`) had **zero call sites**. On the audited production deployment (emdash 0.31.1), 90.5% of rows (3,136 / 3,466) were stale generations, growing ~191 rows/day. Reads join on `current_generation`, so the stale rows are pure dead weight.

The fix wires the existing GC into the periodic maintenance path:

- New `cleanupMediaUsageGenerations(db)` in `media/usage/gc.ts` composes the three GC methods behind a shared one-hour cutoff and a bounded per-tick batch (500). The age gate matters: guarded writers insert occurrence rows *before* winning the source CAS, so the window must exceed any plausible in-flight write (it mirrors the pending-upload abandonment window). The batch cap amortizes a large backlog across ticks instead of one oversized D1 batch.
- `runSystemCleanup` runs it as a new independent, non-fatal step (same try/catch-per-subsystem pattern as the other five), which covers both scheduler drivers — the Cloudflare Cron Trigger path and the Node scheduler tick. `CleanupResult` is extended additively with three new count fields.

Deliberately *not* done: deleting the superseded generation inline in the save path. That would add a DELETE round-trip to every authenticated save on D1, would not reclaim abandoned (losing-CAS) generations or orphans anyway, and the repository's existing dialect-parity tests intentionally construct stale generations via `replaceSource` — the sweep-only fix is purely additive. The cron path is not the logged-out hot path, so the three idle SELECTs per tick are within the project's query rules.

Found during a measured database audit of a production deployment.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a: no admin UI strings changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a: bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

The new test fails on `main` (the sweep module does not exist — nothing calls the GC). After the fix, the sweep suite runs under `describeEachDialect` (SQLite + Postgres parity) and asserts: two saves + aged superseded rows → only the current generation survives and current usage still resolves; superseded rows younger than the safety window are untouched.

```
Tests  54 passed (54)   (media-usage-gc-sweep, media-usage-repository, cleanup suites)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
