### PR TITLE
fix: materialize plugin-declared storage indexes

### DIFF
--- a/.changeset/plugin-storage-indexes.md
+++ b/.changeset/plugin-storage-indexes.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes plugin-declared storage indexes never being created. Indexes declared in a plugin manifest's `storage` section are now materialized on marketplace/registry install and update, dropped on uninstall, and synced for configured plugins on the scheduler tick — so plugin storage queries (like the audit-log dashboard widgets) use an index instead of scanning the whole table. The index shape also changed to a composite that SQLite actually uses on D1, where table statistics are never collected.

--- a/packages/core/src/api/handlers/marketplace.ts
+++ b/packages/core/src/api/handlers/marketplace.ts
@@ -24,6 +24,10 @@ import {
 } from "../../plugins/marketplace.js";
 import type { SandboxRunner } from "../../plugins/sandbox/types.js";
 import { PluginStateRepository } from "../../plugins/state.js";
+import {
+	removeAllPluginIndexes,
+	syncDeclaredStorageIndexes,
+} from "../../plugins/storage-indexes.js";
 import { normalizeCapabilities } from "../../plugins/types.js";
 import type { PluginManifest } from "../../plugins/types.js";
 import { EmDashStorageError } from "../../storage/types.js";
@@ -475,6 +479,9 @@ export async function handleMarketplaceInstall(
 			description: pluginDetail.description ?? undefined,
 		});
 
+		// Materialize declared storage indexes (logs failures, never throws)
+		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
+
 		// Fire-and-forget install stat
 		client.reportInstall(pluginId, version).catch(() => {
 			// Intentional: never fails the install
@@ -713,6 +720,9 @@ export async function handleMarketplaceUpdate(
 			mcpToolsConsent: null,
 		});
 
+		// Sync declared storage indexes — declarations can change between versions
+		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
+
 		// Clean up old bundle from R2 (best-effort)
 		deleteBundleFromR2(storage, pluginId, oldVersion).catch(() => {});
 
@@ -784,6 +794,14 @@ export async function handleMarketplaceUninstall(
 			} catch {
 				// Plugin storage table may not have data for this plugin
 			}
+		}
+
+		// Drop declared storage indexes — the plugin is gone either way, and
+		// orphaned indexes tax every _plugin_storage write
+		try {
+			await removeAllPluginIndexes(db, pluginId);
+		} catch {
+			// Nothing to drop, or tracking table predates the feature
 		}
 
 		// Delete state row

--- a/packages/core/src/api/handlers/marketplace.ts
+++ b/packages/core/src/api/handlers/marketplace.ts
@@ -479,7 +479,6 @@ export async function handleMarketplaceInstall(
 			description: pluginDetail.description ?? undefined,
 		});
 
-		// Materialize declared storage indexes (logs failures, never throws)
 		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
 
 		// Fire-and-forget install stat
@@ -720,7 +719,6 @@ export async function handleMarketplaceUpdate(
 			mcpToolsConsent: null,
 		});
 
-		// Sync declared storage indexes — declarations can change between versions
 		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
 
 		// Clean up old bundle from R2 (best-effort)
@@ -796,8 +794,6 @@ export async function handleMarketplaceUninstall(
 			}
 		}
 
-		// Drop declared storage indexes — the plugin is gone either way, and
-		// orphaned indexes tax every _plugin_storage write
 		try {
 			await removeAllPluginIndexes(db, pluginId);
 		} catch {

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -1185,7 +1185,6 @@ export async function handleRegistryInstall(
 			throw stateErr;
 		}
 
-		// Materialize declared storage indexes (logs failures, never throws)
 		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
 
 		return {
@@ -1295,8 +1294,6 @@ export async function handleRegistryUninstall(
 			await deleteBundleFromR2(storage, pluginId, version, "registry");
 		}
 
-		// Drop declared storage indexes — the plugin is gone either way, and
-		// orphaned indexes tax every _plugin_storage write
 		try {
 			await removeAllPluginIndexes(db, pluginId);
 		} catch {
@@ -1661,7 +1658,6 @@ export async function handleRegistryUpdate(
 			mcpToolsConsent: null,
 		});
 
-		// Sync declared storage indexes — declarations can change between versions
 		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
 
 		// Best-effort cleanup of the old bundle. Failures here don't roll

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -49,6 +49,10 @@ import { extractBundle } from "../../plugins/marketplace.js";
 import type { PluginBundle } from "../../plugins/marketplace.js";
 import type { SandboxRunner } from "../../plugins/sandbox/types.js";
 import { PluginStateRepository } from "../../plugins/state.js";
+import {
+	removeAllPluginIndexes,
+	syncDeclaredStorageIndexes,
+} from "../../plugins/storage-indexes.js";
 import { declaredAccessToCapabilities } from "../../plugins/types.js";
 import type { DeclaredAccess } from "../../plugins/types.js";
 import {
@@ -1181,6 +1185,9 @@ export async function handleRegistryInstall(
 			throw stateErr;
 		}
 
+		// Materialize declared storage indexes (logs failures, never throws)
+		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
+
 		return {
 			success: true,
 			data: {
@@ -1286,6 +1293,14 @@ export async function handleRegistryUninstall(
 
 		if (storage) {
 			await deleteBundleFromR2(storage, pluginId, version, "registry");
+		}
+
+		// Drop declared storage indexes — the plugin is gone either way, and
+		// orphaned indexes tax every _plugin_storage write
+		try {
+			await removeAllPluginIndexes(db, pluginId);
+		} catch {
+			// Nothing to drop, or tracking table predates the feature
 		}
 
 		await stateRepo.delete(pluginId);
@@ -1645,6 +1660,9 @@ export async function handleRegistryUpdate(
 			mcpToolsEnabled: false,
 			mcpToolsConsent: null,
 		});
+
+		// Sync declared storage indexes — declarations can change between versions
+		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
 
 		// Best-effort cleanup of the old bundle. Failures here don't roll
 		// back the upgrade (the new bundle is already stored and committed

--- a/packages/core/src/database/validate.ts
+++ b/packages/core/src/database/validate.ts
@@ -27,6 +27,13 @@ const GENERIC_IDENTIFIER_PATTERN = /^[a-zA-Z][a-zA-Z0-9_]*$/;
 const PLUGIN_IDENTIFIER_PATTERN = /^[a-z][a-z0-9_-]*$/;
 
 /**
+ * Pattern for plugin storage collection names.
+ * Manifests declare these as free-form keys, so both cases and hyphens are
+ * allowed; the charset still excludes quotes, whitespace, and punctuation.
+ */
+const STORAGE_COLLECTION_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+/**
  * Maximum length for SQL identifiers.
  * SQLite has no formal limit, but we cap at 128 for sanity.
  */
@@ -134,5 +141,37 @@ export function validatePluginIdentifier(value: string, label = "plugin identifi
 
 	if (!PLUGIN_IDENTIFIER_PATTERN.test(value)) {
 		throw new IdentifierError(`${label} must match /^[a-z][a-z0-9_-]*$/ (got "${value}")`, value);
+	}
+}
+
+/**
+ * Validate a plugin storage collection name.
+ *
+ * Collections are declared as free-form manifest keys and stored as opaque
+ * text, so this is deliberately more permissive than `validateIdentifier`:
+ * `form-submissions` and `formSubmissions` are legitimate. The charset still
+ * rejects quotes and punctuation, keeping generated index names inert.
+ *
+ * @param value - The string to validate
+ * @param label - Human-readable label for error messages
+ * @throws {IdentifierError} If the value is not valid
+ */
+export function validateStorageCollectionName(value: string, label = "collection name"): void {
+	if (!value || typeof value !== "string") {
+		throw new IdentifierError(`${label} must be a non-empty string`, String(value));
+	}
+
+	if (value.length > MAX_IDENTIFIER_LENGTH) {
+		throw new IdentifierError(
+			`${label} must be ${MAX_IDENTIFIER_LENGTH} characters or less, got ${value.length}`,
+			value,
+		);
+	}
+
+	if (!STORAGE_COLLECTION_PATTERN.test(value)) {
+		throw new IdentifierError(
+			`${label} must match /^[a-zA-Z][a-zA-Z0-9_-]*$/ (got "${value}")`,
+			value,
+		);
 	}
 }

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -701,10 +701,8 @@ export class EmDashRuntime {
 	/**
 	 * Materialize plugin-declared storage indexes, once per process.
 	 *
-	 * Runs on the scheduler tick — never the request path — because it is the
-	 * only moment configured (in-config) plugins pass through: unlike
-	 * marketplace/registry plugins they have no install handler. CREATE INDEX
-	 * IF NOT EXISTS is idempotent, so concurrent isolates converge.
+	 * Called from the scheduler path, not from request handlers — configured
+	 * plugins have no install handler, so the tick is their only sync moment.
 	 */
 	async syncPluginStorageIndexesOnce(): Promise<void> {
 		if (this.storageIndexesSynced) return;

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -493,6 +493,7 @@ const marketplaceManifestCache = new Map<
 			settingsSchema?: Record<string, SettingField>;
 		};
 		mcp?: PluginMcpManifestConfig;
+		storage?: PluginManifest["storage"];
 	}
 >();
 /** Route metadata for sandboxed plugins: pluginId -> routeName -> RouteMeta */
@@ -707,7 +708,13 @@ export class EmDashRuntime {
 	async syncPluginStorageIndexesOnce(): Promise<void> {
 		if (this.storageIndexesSynced) return;
 		this.storageIndexesSynced = true;
-		await syncDeclaredStorageIndexes(this.db, this.allPipelinePlugins);
+		// Sandboxed marketplace/registry plugins never join allPipelinePlugins;
+		// their manifests are cached at bundle load. Without them, plugins
+		// installed before this feature shipped would never get their indexes.
+		await syncDeclaredStorageIndexes(this.db, [
+			...this.allPipelinePlugins,
+			...marketplaceManifestCache.values(),
+		]);
 	}
 
 	/**
@@ -917,6 +924,7 @@ export class EmDashRuntime {
 					version: bundle.manifest.version,
 					admin: bundle.manifest.admin,
 					mcp: bundle.manifest.mcp,
+					storage: bundle.manifest.storage,
 				});
 
 				// Cache route metadata from manifest for auth decisions
@@ -1032,6 +1040,7 @@ export class EmDashRuntime {
 					version: bundle.manifest.version,
 					admin: bundle.manifest.admin,
 					mcp: bundle.manifest.mcp,
+					storage: bundle.manifest.storage,
 				});
 				if (bundle.manifest.routes.length > 0) {
 					const routeMetaMap = new Map<string, RouteMeta>();
@@ -2116,6 +2125,7 @@ export class EmDashRuntime {
 						version: bundle.manifest.version,
 						admin: bundle.manifest.admin,
 						mcp: bundle.manifest.mcp,
+						storage: bundle.manifest.storage,
 					});
 
 					// Cache route metadata from manifest for auth decisions
@@ -2188,6 +2198,7 @@ export class EmDashRuntime {
 						version: bundle.manifest.version,
 						admin: bundle.manifest.admin,
 						mcp: bundle.manifest.mcp,
+						storage: bundle.manifest.storage,
 					});
 					if (bundle.manifest.routes.length > 0) {
 						const routeMeta = new Map<string, RouteMeta>();

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -196,6 +196,7 @@ import { extractRequestMeta, sanitizeHeadersForSandbox } from "./plugins/request
 import { buildRouteMeta, PluginRouteRegistry, type RouteMeta } from "./plugins/routes.js";
 import type { CronScheduler } from "./plugins/scheduler/types.js";
 import { PluginStateRepository } from "./plugins/state.js";
+import { syncDeclaredStorageIndexes } from "./plugins/storage-indexes.js";
 import { normalizeRegistryConfig } from "./registry/config.js";
 import { requestCached } from "./request-cache.js";
 import { getRequestContext } from "./request-context.js";
@@ -553,6 +554,8 @@ export class EmDashRuntime {
 	/** All plugins eligible for the hook pipeline (includes built-in plugins).
 	 *  Stored so we can rebuild the pipeline when plugins are enabled/disabled. */
 	private allPipelinePlugins: ResolvedPlugin[];
+	/** Guards the once-per-process plugin storage-index sync. */
+	private storageIndexesSynced = false;
 	/** Factory options for the hook pipeline context factory */
 	private pipelineFactoryOptions: {
 		db: Kysely<Database>;
@@ -683,10 +686,30 @@ export class EmDashRuntime {
 			console.error("[cleanup] System cleanup failed:", error);
 		}
 
+		try {
+			await this.syncPluginStorageIndexesOnce();
+		} catch (error) {
+			console.error("[plugins] Storage index sync failed:", error);
+		}
+
 		// Never throws; no-op unless scheduled backups are enabled and due.
 		await maybeRunScheduledBackup(this.db, this.storage ?? undefined);
 
 		return { published };
+	}
+
+	/**
+	 * Materialize plugin-declared storage indexes, once per process.
+	 *
+	 * Runs on the scheduler tick — never the request path — because it is the
+	 * only moment configured (in-config) plugins pass through: unlike
+	 * marketplace/registry plugins they have no install handler. CREATE INDEX
+	 * IF NOT EXISTS is idempotent, so concurrent isolates converge.
+	 */
+	async syncPluginStorageIndexesOnce(): Promise<void> {
+		if (this.storageIndexesSynced) return;
+		this.storageIndexesSynced = true;
+		await syncDeclaredStorageIndexes(this.db, this.allPipelinePlugins);
 	}
 
 	/**
@@ -1611,6 +1634,11 @@ export class EmDashRuntime {
 							// Non-fatal -- individual cleanup failures are already logged
 							// by runSystemCleanup. This catches unexpected errors.
 							console.error("[cleanup] System cleanup failed:", error);
+						}
+						try {
+							await runtimeRef.current?.syncPluginStorageIndexesOnce();
+						} catch (error) {
+							console.error("[plugins] Storage index sync failed:", error);
 						}
 						// Never throws; no-op unless scheduled backups are enabled and due.
 						await maybeRunScheduledBackup(db, storage ?? undefined);

--- a/packages/core/src/plugins/storage-indexes.ts
+++ b/packages/core/src/plugins/storage-indexes.ts
@@ -11,11 +11,7 @@ import { sql } from "kysely";
 
 import { jsonExtractExpr, isPostgres } from "../database/dialect-helpers.js";
 import type { Database } from "../database/types.js";
-import {
-	validateIdentifier,
-	validateJsonFieldName,
-	validatePluginIdentifier,
-} from "../database/validate.js";
+import { validateJsonFieldName, validatePluginIdentifier } from "../database/validate.js";
 
 /**
  * Generate a deterministic index name.
@@ -36,8 +32,9 @@ export function generateIndexName(
 /**
  * Generate a Kysely sql expression for creating an expression index.
  *
- * Validates all identifiers before interpolation to prevent SQL injection.
- * Plugin ID and collection values are parameterized in the WHERE clause.
+ * The plugin ID and field names are validated before interpolation; the
+ * collection is an opaque text value (the manifest schema allows arbitrary
+ * keys) and only appears inside the index name, which `sql.ref` quotes.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function generateCreateIndexSql(
@@ -47,9 +44,7 @@ export function generateCreateIndexSql(
 	fields: string[],
 	options?: { unique?: boolean },
 ): RawBuilder<unknown> {
-	// Validate all identifiers
 	validatePluginIdentifier(pluginId, "plugin ID");
-	validateIdentifier(collection, "collection name");
 	for (const field of fields) {
 		validateJsonFieldName(field, "index field name");
 	}

--- a/packages/core/src/plugins/storage-indexes.ts
+++ b/packages/core/src/plugins/storage-indexes.ts
@@ -68,14 +68,15 @@ export function generateCreateIndexSql(
 		})
 		.join(", ");
 
-	// Partial index filtered to this plugin/collection
-	// SQLite prohibits bound parameters in partial index WHERE clauses,
-	// so we use sql.lit() for literal string values. Both pluginId and
-	// collection are validated above, so this is safe.
+	// Composite non-partial index: the leading (plugin_id, collection) columns
+	// scope it per plugin/collection — including unique-index semantics — and
+	// let it serve the repository's bound-parameter WHERE plus the JSON
+	// expression ORDER BY. A partial index (WHERE plugin_id = 'x' AND
+	// collection = 'y') is never chosen by SQLite under bound parameters
+	// unless ANALYZE has run, and D1 never runs ANALYZE.
 	const createKeyword = options?.unique ? "CREATE UNIQUE INDEX" : "CREATE INDEX";
 	return sql`${sql.raw(createKeyword)} IF NOT EXISTS ${sql.ref(indexName)}
-		ON _plugin_storage(${sql.raw(expressions)})
-		WHERE plugin_id = ${sql.lit(pluginId)} AND collection = ${sql.lit(collection)}
+		ON _plugin_storage(plugin_id, collection, ${sql.raw(expressions)})
 	`;
 }
 
@@ -252,6 +253,43 @@ export async function syncStorageIndexes(
 		removed: removeResult.removed,
 		errors: [...createResult.errors, ...removeResult.errors],
 	};
+}
+
+/**
+ * Materialize the storage indexes a set of plugins declare in their
+ * manifests. Failures are logged per collection and never thrown — a missing
+ * index affects query performance, not correctness, so it must not fail an
+ * install or a scheduler tick.
+ */
+export async function syncDeclaredStorageIndexes(
+	db: Kysely<Database>,
+	plugins: Array<{
+		id: string;
+		storage?: Record<
+			string,
+			{ indexes: Array<string | string[]>; uniqueIndexes?: Array<string | string[]> }
+		>;
+	}>,
+): Promise<void> {
+	for (const plugin of plugins) {
+		for (const [collection, config] of Object.entries(plugin.storage ?? {})) {
+			try {
+				const result = await syncStorageIndexes(db, plugin.id, collection, config.indexes, {
+					uniqueIndexes: config.uniqueIndexes,
+				});
+				for (const failure of result.errors) {
+					console.error(
+						`[plugins] Failed to sync storage index ${failure.index} for ${plugin.id}/${collection}: ${failure.error}`,
+					);
+				}
+			} catch (error) {
+				console.error(
+					`[plugins] Failed to sync storage indexes for ${plugin.id}/${collection}:`,
+					error,
+				);
+			}
+		}
+	}
 }
 
 /**

--- a/packages/core/src/plugins/storage-indexes.ts
+++ b/packages/core/src/plugins/storage-indexes.ts
@@ -11,7 +11,11 @@ import { sql } from "kysely";
 
 import { jsonExtractExpr, isPostgres } from "../database/dialect-helpers.js";
 import type { Database } from "../database/types.js";
-import { validateJsonFieldName, validatePluginIdentifier } from "../database/validate.js";
+import {
+	validateJsonFieldName,
+	validatePluginIdentifier,
+	validateStorageCollectionName,
+} from "../database/validate.js";
 
 /**
  * Generate a deterministic index name.
@@ -32,9 +36,10 @@ export function generateIndexName(
 /**
  * Generate a Kysely sql expression for creating an expression index.
  *
- * The plugin ID and field names are validated before interpolation; the
- * collection is an opaque text value (the manifest schema allows arbitrary
- * keys) and only appears inside the index name, which `sql.ref` quotes.
+ * Validates all inputs before interpolation. The collection uses the
+ * permissive manifest-key rules rather than SQL-identifier rules — it is
+ * stored as opaque text and only reaches SQL inside the generated index
+ * name — so kebab-case collections index like any other.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function generateCreateIndexSql(
@@ -45,6 +50,7 @@ export function generateCreateIndexSql(
 	options?: { unique?: boolean },
 ): RawBuilder<unknown> {
 	validatePluginIdentifier(pluginId, "plugin ID");
+	validateStorageCollectionName(collection, "collection name");
 	for (const field of fields) {
 		validateJsonFieldName(field, "index field name");
 	}

--- a/packages/core/tests/integration/plugins/storage-indexes.test.ts
+++ b/packages/core/tests/integration/plugins/storage-indexes.test.ts
@@ -8,6 +8,7 @@ import {
 	createStorageIndexes,
 	removeOrphanedIndexes,
 	syncStorageIndexes,
+	syncDeclaredStorageIndexes,
 	removeAllPluginIndexes,
 	getPluginIndexStatus,
 } from "../../../src/plugins/storage-indexes.js";
@@ -375,6 +376,57 @@ describe("Plugin Storage Indexes Integration", () => {
 			const result = await repo.query({ where: { slug: "contact" } });
 			expect(result.items).toHaveLength(1);
 			expect(result.items[0].data.slug).toBe("contact");
+		});
+	});
+
+	describe("syncDeclaredStorageIndexes", () => {
+		it("materializes indexes for every declared collection and is idempotent", async () => {
+			const plugins = [
+				{ id: "audit-log", storage: { entries: { indexes: ["timestamp"] } } },
+				{
+					id: "forms",
+					storage: { submissions: { indexes: ["formId"], uniqueIndexes: ["token"] } },
+				},
+			];
+
+			await syncDeclaredStorageIndexes(db, plugins);
+			await syncDeclaredStorageIndexes(db, plugins);
+
+			const tracked = await db.selectFrom("_plugin_indexes").select("index_name").execute();
+			expect(tracked.map((r) => r.index_name).toSorted()).toEqual([
+				"idx_plugin_audit-log_entries_timestamp",
+				"idx_plugin_forms_submissions_formId",
+				"uidx_plugin_forms_submissions_token",
+			]);
+		});
+	});
+
+	describe("query plan", () => {
+		it("serves the repository's ORDER BY from the declared index without a temp B-tree", async () => {
+			await createStorageIndexes(db, "audit-log", "entries", ["timestamp"]);
+
+			const repo = new PluginStorageRepository<{ timestamp: string }>(db, "audit-log", "entries", [
+				"timestamp",
+			]);
+			for (let i = 1; i <= 5; i++) {
+				await repo.put(`key-${i}`, { timestamp: `2026-07-0${i}T00:00:00.000Z` });
+			}
+
+			// Mirror the repository's compiled query() shape: bound parameters for
+			// plugin_id/collection (the production reality — D1 never runs ANALYZE,
+			// and SQLite won't pick a partial index under bound parameters without
+			// statistics).
+			const plan = await sql<{ detail: string }>`
+				EXPLAIN QUERY PLAN
+				SELECT id, data, created_at FROM _plugin_storage
+				WHERE plugin_id = ${"audit-log"} AND collection = ${"entries"}
+				ORDER BY json_extract(data, '$.timestamp') DESC
+				LIMIT 6
+			`.execute(db);
+
+			const details = plan.rows.map((r) => r.detail).join("\n");
+			expect(details).toContain("idx_plugin_audit-log_entries_timestamp");
+			expect(details).not.toContain("USE TEMP B-TREE FOR ORDER BY");
 		});
 	});
 });

--- a/packages/core/tests/integration/plugins/storage-indexes.test.ts
+++ b/packages/core/tests/integration/plugins/storage-indexes.test.ts
@@ -69,6 +69,23 @@ describe("Plugin Storage Indexes Integration", () => {
 			expect(indexes.map((i) => JSON.parse(i.fields))).toContainEqual(["userId"]);
 		});
 
+		it("accepts collection names that are not SQL identifiers", async () => {
+			// The manifest schema allows arbitrary collection keys and the
+			// repository stores collection as opaque text — kebab-case names
+			// like "form-submissions" must index too.
+			const result = await createStorageIndexes(db, "forms", "form-submissions", ["slug"]);
+
+			expect(result.errors).toHaveLength(0);
+			expect(result.created).toContain("idx_plugin_forms_form-submissions_slug");
+
+			const indexes = await db
+				.selectFrom("_plugin_indexes")
+				.select("index_name")
+				.where("plugin_id", "=", "forms")
+				.execute();
+			expect(indexes).toHaveLength(1);
+		});
+
 		it("should be idempotent", async () => {
 			await createStorageIndexes(db, "my-plugin", "events", ["eventType"]);
 			const result = await createStorageIndexes(db, "my-plugin", "events", ["eventType"]);

--- a/packages/core/tests/unit/api/marketplace-handlers.test.ts
+++ b/packages/core/tests/unit/api/marketplace-handlers.test.ts
@@ -349,6 +349,59 @@ describe("Marketplace handlers", () => {
 			expect(state?.status).toBe("active");
 		});
 
+		it("materializes declared storage indexes on install and drops them on uninstall", async () => {
+			const manifest: PluginManifest = {
+				...mockManifest("audit-log", "1.0.0"),
+				storage: { entries: { indexes: ["timestamp", "action"] } },
+			};
+			const bundleBytes = await createMockBundle(manifest);
+			const detail = mockPluginDetail("audit-log", "1.0.0");
+			detail.latestVersion!.checksum = "";
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(detail), { status: 200 }));
+			fetchSpy.mockResolvedValueOnce(new Response(bundleBytes, { status: 200 }));
+			fetchSpy.mockResolvedValueOnce(new Response("OK", { status: 200 }));
+
+			const result = await handleMarketplaceInstall(
+				db,
+				storage,
+				sandboxRunner,
+				MARKETPLACE_URL,
+				"audit-log",
+			);
+			expect(result.success).toBe(true);
+
+			const indexNames = () =>
+				sqliteDb
+					.prepare(
+						"SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_plugin_audit-log_%'",
+					)
+					.all()
+					.map((row) => (row as { name: string }).name);
+			expect(indexNames()).toEqual(
+				expect.arrayContaining([
+					"idx_plugin_audit-log_entries_timestamp",
+					"idx_plugin_audit-log_entries_action",
+				]),
+			);
+			const tracked = await db
+				.selectFrom("_plugin_indexes")
+				.select("index_name")
+				.where("plugin_id", "=", "audit-log")
+				.execute();
+			expect(tracked).toHaveLength(2);
+
+			const uninstall = await handleMarketplaceUninstall(db, storage, "audit-log");
+			expect(uninstall.success).toBe(true);
+			expect(indexNames()).toEqual([]);
+			expect(
+				await db
+					.selectFrom("_plugin_indexes")
+					.select("index_name")
+					.where("plugin_id", "=", "audit-log")
+					.execute(),
+			).toEqual([]);
+		});
+
 		it("requires explicit consent before installing plugin MCP tools", async () => {
 			const manifest: PluginManifest = {
 				...mockManifest("test-seo", "1.0.0"),


### PR DESCRIPTION
## What does this PR do?

Fixes plugin-declared storage indexes never being created — and never being *usable* even if they had been.

The materialization machinery already exists (`plugins/storage-indexes.ts`, the `_plugin_indexes` tracking table from migration 004), but it has **zero production callers**: manifest `storage.indexes` declarations are consumed only as a query-validation allowlist. So `PluginStorageRepository.query()` ordering by a JSON field — e.g. the audit-log plugin's `orderBy: { timestamp: "desc" }` on its dashboard widget — runs as a full-table scan plus temp B-tree sort. Measured on the audited production deployment (Macabro festival site, emdash 0.31.1, 11 MiB `_plugin_storage`): 16.5–20.5 ms of synchronous main-thread work on every admin dashboard load, and `_plugin_indexes` empty.

Two coordinated changes:

1. **Wire the sync into every plugin lifecycle moment.** A new `syncDeclaredStorageIndexes()` (logs per-collection failures, never throws — a missing index is a performance problem, not a correctness one) runs on marketplace install/update, registry install/update, and index drops run on both uninstalls. Configured (in-config) plugins have no install handler at all, so they sync once per process on the scheduler tick — the cron path, never the request path, per the hot-path query rule.

2. **Fix the index shape.** The existing (never-invoked) generator built *partial* indexes (`WHERE plugin_id = 'x' AND collection = 'y'` via literals). Verified empirically: SQLite does not choose a partial index under bound parameters unless ANALYZE has run — and D1 never runs ANALYZE — so even wired up, the old shape would have indexed nothing in production. The new shape is a composite non-partial index `(plugin_id, collection, json_extract(data, '$.field'))`, which SQLite selects in every scenario and which also eliminates the temp B-tree for ORDER BY. Unique-index semantics are preserved (uniqueness stays scoped per plugin+collection via the leading columns). No migration is needed: no deployed database has old-shape indexes, because nothing ever created them — that is this bug.

Postgres note: the composite index accelerates WHERE filters there, but not the `jsonb` ORDER BY (ordering uses `->` for numeric-correct sorting while the index expression uses `->>`; one index expression cannot match both). SQLite/D1 — where the measured problem lives — serves both. Repository `query()` semantics, results, and cursor behavior are unchanged; only the plan changes.

Found during a measured database audit of a production deployment.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a: no admin UI strings changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a: bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

Failing first (on `main`, before the fix) — the query-plan regression test reproduces the exact production plan:

```
× serves the repository's ORDER BY from the declared index without a temp B-tree
  + SEARCH _plugin_storage USING INDEX idx_plugin_storage_list (plugin_id=? AND collection=?)
  + USE TEMP B-TREE FOR ORDER BY

× materializes declared storage indexes on install and drops them on uninstall
× materializes indexes for every declared collection and is idempotent
```

After the fix — plugin/marketplace/registry suites all green, and the full `packages/core` suite matches the `main` baseline (the single `virtual-modules.test.ts` failure is pre-existing on a clean checkout in this environment — macOS temp-dir realpath mismatch):

```
Tests  803 passed (803)   (tests/integration/plugins/, tests/unit/plugins/, marketplace + registry handler suites)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
