### PR TITLE
fix: don't auto-redirect a slug another entry still holds

### DIFF
--- a/.changeset/slug-redirect-locale-aware.md
+++ b/.changeset/slug-redirect-locale-aware.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes renaming a translation taking its canonical page offline. When two locale variants share a slug, renaming either one created a 301 away from a URL the other still serves, making the live page unreachable. Slug-change redirects are now skipped when another entry still holds the old slug.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -376,6 +376,15 @@ async function createSlugChangeRedirect(
 	newSlug: string,
 	contentId: string,
 ): Promise<void> {
+	// A URL pattern has no locale token, so every locale variant of an entry
+	// generates the same URL, and slugs are unique per (slug, locale) — a
+	// translation may still hold the old slug. Redirecting away from a URL
+	// another row still answers on would take that page down: the redirect
+	// middleware runs `order: "pre"`, so routing never gets a chance.
+	// Any surviving row counts, published or not: a draft that publishes later
+	// would otherwise be shadowed by the redirect.
+	if (await slugStillTaken(db, collection, oldSlug, contentId)) return;
+
 	const collectionRow = await db
 		.selectFrom("_emdash_collections")
 		.select("url_pattern")
@@ -391,6 +400,24 @@ async function createSlugChangeRedirect(
 		collectionRow?.url_pattern ?? null,
 	);
 	invalidateRedirectCache();
+}
+
+/** Whether a row other than `contentId` still holds `slug` in this collection. */
+async function slugStillTaken(
+	db: Kysely<Database>,
+	collection: string,
+	slug: string,
+	contentId: string,
+): Promise<boolean> {
+	validateIdentifier(collection, "collection slug");
+	const result = await sql<{ id: string }>`
+		SELECT id FROM ${sql.ref(`ec_${collection}`)}
+		WHERE slug = ${slug}
+		AND id != ${contentId}
+		AND deleted_at IS NULL
+		LIMIT 1
+	`.execute(db);
+	return result.rows.length > 0;
 }
 
 /** Matches a date-only `YYYY-MM-DD` bound (no time component). */

--- a/packages/core/tests/integration/redirects/slug-change-redirect-locale.test.ts
+++ b/packages/core/tests/integration/redirects/slug-change-redirect-locale.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Slug-change auto-redirects must never point away from a URL that still
+ * serves content.
+ *
+ * A collection's `url_pattern` has no locale token, so every locale variant of
+ * an entry maps to the same generated URL. Slugs are unique per
+ * `(slug, locale)`, so a translation legitimately shares its canonical's slug
+ * — and renaming one of them would otherwise emit a 301 whose source is the
+ * other's live URL. The redirect middleware runs `order: "pre"`, so such a
+ * redirect takes the live page down with no way for routing to recover.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleContentUpdate } from "../../../src/api/handlers/content.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("slug-change auto-redirect — locale awareness", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		repo = new ContentRepository(db);
+
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({
+			slug: "venue",
+			label: "Venues",
+			labelSingular: "Venue",
+			urlPattern: "/sede/{slug}",
+		});
+		await registry.createField("venue", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+		});
+
+		// Spanish canonical site: es is the default locale, en is a translation.
+		setI18nConfig({ locales: ["es", "en"], defaultLocale: "es" });
+	});
+
+	afterEach(async () => {
+		setI18nConfig(null);
+		await teardownTestDatabase(db);
+	});
+
+	async function redirectSources(): Promise<string[]> {
+		const rows = await db.selectFrom("_emdash_redirects").select(["source"]).execute();
+		return rows.map((r) => r.source);
+	}
+
+	it("does not redirect the canonical URL when a translation sharing its slug is renamed", async () => {
+		const canonical = await repo.create({
+			type: "venue",
+			slug: "cineteca-nacional",
+			locale: "es",
+			status: "published",
+			data: { title: "Cineteca Nacional" },
+		});
+		const twin = await repo.create({
+			type: "venue",
+			slug: "cineteca-nacional",
+			locale: "en",
+			status: "published",
+			translationOf: canonical.id,
+			data: { title: "Cineteca Nacional" },
+		});
+
+		const result = await handleContentUpdate(db, "venue", twin.id, { slug: "cinematheque" });
+		expect(result.success).toBe(true);
+
+		// The canonical Spanish page still lives at /sede/cineteca-nacional/.
+		expect(await redirectSources()).not.toContain("/sede/cineteca-nacional");
+	});
+
+	it("does not redirect a URL still held by a translation when the canonical is renamed", async () => {
+		const canonical = await repo.create({
+			type: "venue",
+			slug: "cineteca-nacional",
+			locale: "es",
+			status: "published",
+			data: { title: "Cineteca Nacional" },
+		});
+		await repo.create({
+			type: "venue",
+			slug: "cineteca-nacional",
+			locale: "en",
+			status: "published",
+			translationOf: canonical.id,
+			data: { title: "Cineteca Nacional" },
+		});
+
+		const result = await handleContentUpdate(db, "venue", canonical.id, { slug: "cineteca" });
+		expect(result.success).toBe(true);
+
+		expect(await redirectSources()).not.toContain("/sede/cineteca-nacional");
+	});
+
+	it("still redirects when the renamed entry owned the URL outright", async () => {
+		const solo = await repo.create({
+			type: "venue",
+			slug: "teatro-viejo",
+			locale: "es",
+			status: "published",
+			data: { title: "Teatro Viejo" },
+		});
+
+		const result = await handleContentUpdate(db, "venue", solo.id, { slug: "teatro-nuevo" });
+		expect(result.success).toBe(true);
+
+		const rows = await db
+			.selectFrom("_emdash_redirects")
+			.select(["source", "destination"])
+			.execute();
+		expect(rows).toEqual([
+			expect.objectContaining({ source: "/sede/teatro-viejo", destination: "/sede/teatro-nuevo" }),
+		]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a slug rename taking a *different* entry's live page offline.

`createSlugChangeRedirect` builds the auto-redirect purely from the collection's `url_pattern` and the old/new slug — `RedirectRepository.createAutoRedirect` does a literal `urlPattern.replace("{slug}", oldSlug)`. A URL pattern has no locale token, so **every locale variant of an entry generates the same URL**, and slugs are unique per `(slug, locale)` — so a translation legitimately shares its canonical's slug (the standard emdash i18n shape).

Renaming either row therefore emits a 301 whose source is the *other* row's live URL:

- Canonical `es` venue at `cineteca-nacional`, `en` twin at the same slug.
- Rename the twin to `cinematheque` → writes `/sede/cineteca-nacional` → `/sede/cinematheque`.
- The Spanish page is still served at `/sede/cineteca-nacional`, but the redirect middleware is registered `order: "pre"`, so it intercepts before routing and the page can never recover.

The mirror case is just as bad: renaming the canonical while the translation still holds the old slug redirects away from a URL the translation answers on.

The fix skips the auto-redirect when another non-deleted entry in the collection still holds the old slug. This is the same invariant `createAutoRedirect` already enforces in the other direction (it deletes redirects *from* the new URL because "the new URL serves live content again — any redirect from it would shadow the page"). Any surviving row counts, published or not: a draft that publishes later would otherwise be shadowed by a redirect created while it was invisible. Renames that genuinely free the URL still redirect exactly as before.

I chose "is the old slug still taken?" over the narrower "skip when `locale !== defaultLocale`" because the latter fixes only one direction (it leaves the canonical-rename case broken) and would also suppress legitimate redirects for sites that serve translations through Astro's locale routing while keeping one unprefixed `url_pattern`. The occupancy check is correct under either routing model.

Impact worth noting: this is the reason the reporting deployment keeps `url_pattern` NULL on every collection — accepting junk `/<collection>/<slug>` redirects that match no route, rather than enable a feature that can take a live page down.

Found during a measured database audit of a production deployment (emdash 0.31.1).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a: no admin UI strings changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a: bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

Both destructive directions fail on `main` (the redirect source is the live canonical URL):

```
× does not redirect the canonical URL when a translation sharing its slug is renamed
  AssertionError: expected [ '/sede/cineteca-nacional' ] to not include '/sede/cineteca-nacional'
× does not redirect a URL still held by a translation when the canonical is renamed
```

A third test locks the positive path — a rename that genuinely frees the URL still produces the redirect — so the fix can't regress into "never redirect".

After the fix:

```
Tests  65 passed   (tests/integration/redirects/)
Tests  193 passed  (redirects + content handlers + i18n + content suites)
Full packages/core suite: 5075 passed — the single virtual-modules.test.ts failure is
pre-existing on a clean main checkout in this environment (macOS temp-dir realpath).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
