### PR TITLE
Allow WebVTT and SubRip caption uploads in global media allowlist

### DIFF
--- a/.changeset/allow-caption-uploads.md
+++ b/.changeset/allow-caption-uploads.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Adds WebVTT and SubRip caption files to the default media upload allowlist so Media Library and MCP uploads accept `.vtt` / `.srt`.

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -359,7 +359,7 @@ export function MediaLibrary({
 								ref={fileInputRef}
 								type="file"
 								multiple
-								accept="image/*,video/*,audio/*,.pdf,.doc,.docx,.xls,.xlsx"
+								accept="image/*,video/*,audio/*,.pdf,.doc,.docx,.xls,.xlsx,.vtt,.srt"
 								className="sr-only"
 								onChange={handleFileSelect}
 								aria-label={t`Upload files`}

--- a/packages/core/src/api/handlers/media-allowlist.ts
+++ b/packages/core/src/api/handlers/media-allowlist.ts
@@ -13,6 +13,9 @@ export const GLOBAL_UPLOAD_ALLOWLIST: readonly string[] = [
 	"video/",
 	"audio/",
 	"application/pdf",
+	// Caption/subtitle formats (matches AllowedTypesEditor Captions preset)
+	"text/vtt",
+	"application/x-subrip",
 ];
 
 /**

--- a/packages/core/tests/unit/media/mime.test.ts
+++ b/packages/core/tests/unit/media/mime.test.ts
@@ -1,10 +1,31 @@
 import { describe, it, expect } from "vitest";
 
+import { GLOBAL_UPLOAD_ALLOWLIST } from "../../../src/api/handlers/media-allowlist.js";
 import {
 	matchesMimeAllowlist,
 	normalizeMime,
 	expandExtensionShorthand,
 } from "../../../src/media/mime.js";
+
+describe("GLOBAL_UPLOAD_ALLOWLIST", () => {
+	it("allows WebVTT and SubRip caption uploads", () => {
+		expect(matchesMimeAllowlist("text/vtt", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+		expect(matchesMimeAllowlist("application/x-subrip", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+	});
+
+	it("still allows existing media and document types", () => {
+		expect(matchesMimeAllowlist("image/png", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+		expect(matchesMimeAllowlist("video/mp4", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+		expect(matchesMimeAllowlist("audio/mpeg", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+		expect(matchesMimeAllowlist("application/pdf", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+	});
+
+	it("still rejects unrelated types", () => {
+		expect(matchesMimeAllowlist("application/zip", GLOBAL_UPLOAD_ALLOWLIST)).toBe(false);
+		expect(matchesMimeAllowlist("text/plain", GLOBAL_UPLOAD_ALLOWLIST)).toBe(false);
+		expect(matchesMimeAllowlist("text/html", GLOBAL_UPLOAD_ALLOWLIST)).toBe(false);
+	});
+});
 
 describe("matchesMimeAllowlist", () => {
 	it("matches exact MIME types", () => {


### PR DESCRIPTION
## What does this PR do?

Adds `text/vtt` and `application/x-subrip` to `GLOBAL_UPLOAD_ALLOWLIST` so Media Library and MCP `media_upload` accept caption/subtitle files.

These MIME types were already in the Captions field-schema preset (`AllowedTypesEditor`) and `EXTENSION_TO_MIME`, but the global server gate rejected them. That blocked library/MCP uploads of `.vtt` / `.srt` even when a field allowed captions.

Also updates the Media Library file picker `accept` attribute so the OS dialog offers `.vtt` / `.srt`.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Composer

## Screenshots / test output

Unit coverage added in `packages/core/tests/unit/media/mime.test.ts` for caption MIME types against `GLOBAL_UPLOAD_ALLOWLIST`.

## Follow-up (not in this PR)

- Media Library type filter UI still has no dedicated **Captions** option (uploaded VTTs appear under **Documents**, which already filters `text/`). A Captions filter chip would be a separate admin UX change.
- Consumers on published npm (e.g. Freedom Times `emdash@^0.31.1`) need a patch release bump after this merges and is published.

Made with [Cursor](https://cursor.com)