### PR TITLE
fix(core): batch taxonomy term counts under D1's compound-SELECT limit

### DIFF
--- a/.changeset/fix-taxonomy-term-counts-compound-select.md
+++ b/.changeset/fix-taxonomy-term-counts-compound-select.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the taxonomy term list returning a 500 and rendering empty on Cloudflare D1 when a taxonomy declares six or more collections.

--- a/packages/cloudflare/src/db/coalescing-d1.ts
+++ b/packages/cloudflare/src/db/coalescing-d1.ts
@@ -21,7 +21,7 @@ import {
 } from "kysely";
 import type { D1DialectConfig } from "kysely-d1";
 
-import { EmDashD1Dialect } from "./d1-dialect.js";
+import { D1Adapter, EmDashD1Dialect } from "./d1-dialect.js";
 
 /**
  * Statements safe to coalesce: plain SELECTs. Deliberately conservative —
@@ -284,7 +284,7 @@ export class CoalescingD1Driver implements Driver {
  * `executeQuery` calls — that is the whole point — so report `true`.
  * Transactions are rejected by the driver regardless.
  */
-class CoalescingD1Adapter extends SqliteAdapter {
+class CoalescingD1Adapter extends D1Adapter {
 	override get supportsMultipleConnections(): boolean {
 		return true;
 	}

--- a/packages/cloudflare/src/db/d1-dialect.ts
+++ b/packages/cloudflare/src/db/d1-dialect.ts
@@ -6,11 +6,30 @@
  * d1.ts, and without pulling cloudflare:workers into test environments.
  */
 
+import type { CompoundSelectLimitedAdapter } from "emdash";
 import type { DatabaseIntrospector, Kysely } from "kysely";
 import { SqliteAdapter } from "kysely";
 import { D1Dialect } from "kysely-d1";
 
 import { D1Introspector } from "./d1-introspector.js";
+
+/**
+ * Terms D1 allows in one compound SELECT (`UNION ALL`, `INTERSECT`, `EXCEPT`).
+ * D1 sets SQLITE_LIMIT_COMPOUND_SELECT to 5 where SQLite's upstream default is
+ * 500; a sixth branch is rejected with "too many terms in compound SELECT".
+ * Measured against a live D1.
+ */
+export const D1_COMPOUND_SELECT_LIMIT = 5;
+
+/**
+ * Base adapter for every D1-backed dialect. Declares the compound-SELECT
+ * ceiling, which core reads off the adapter to split statements that would
+ * exceed it; a dialect that overrides `createAdapter()` without extending this
+ * silently sends D1 compound SELECTs it rejects.
+ */
+export class D1Adapter extends SqliteAdapter implements CompoundSelectLimitedAdapter {
+	readonly compoundSelectLimit = D1_COMPOUND_SELECT_LIMIT;
+}
 
 /**
  * Adapter for the raw-binding (non-session) D1 dialect only.
@@ -38,7 +57,7 @@ import { D1Introspector } from "./d1-introspector.js";
  * single-in-flight op chain — see CoalescingD1Connection — but the plain
  * session path has no such replacement, so it must keep the mutex.)
  */
-class RawBindingD1Adapter extends SqliteAdapter {
+class RawBindingD1Adapter extends D1Adapter {
 	override get supportsMultipleConnections(): boolean {
 		return true;
 	}
@@ -51,6 +70,10 @@ class RawBindingD1Adapter extends SqliteAdapter {
  * cross-join with pragma_table_info() that D1 doesn't allow.
  */
 export class EmDashD1Dialect extends D1Dialect {
+	override createAdapter(): SqliteAdapter {
+		return new D1Adapter();
+	}
+
 	override createIntrospector(db: Kysely<any>): DatabaseIntrospector {
 		return new D1Introspector(db);
 	}

--- a/packages/cloudflare/tests/db/d1-dialect.test.ts
+++ b/packages/cloudflare/tests/db/d1-dialect.test.ts
@@ -1,7 +1,12 @@
 import { CompiledQuery, Kysely } from "kysely";
 import { describe, expect, it } from "vitest";
 
-import { EmDashD1Dialect, RawBindingD1Dialect } from "../../src/db/d1-dialect.js";
+import { CoalescingD1Dialect } from "../../src/db/coalescing-d1.js";
+import {
+	D1_COMPOUND_SELECT_LIMIT,
+	EmDashD1Dialect,
+	RawBindingD1Dialect,
+} from "../../src/db/d1-dialect.js";
 
 /**
  * Regression tests for #2040: with the default D1 config the singleton
@@ -107,6 +112,22 @@ describe("EmDashD1Dialect (session path keeps the mutex)", () => {
 		]);
 
 		expect(maxInFlight()).toBe(1);
+	});
+});
+
+describe("D1 compound-SELECT ceiling (#2330)", () => {
+	it.each([
+		["raw binding", RawBindingD1Dialect],
+		["session", EmDashD1Dialect],
+		["coalescing", CoalescingD1Dialect],
+	])("declares the ceiling on the %s adapter so core splits statements", (_name, Dialect) => {
+		const { database } = createMockD1();
+		const adapter = new Dialect({ database }).createAdapter();
+
+		// Core reads the ceiling off the adapter and leaves undeclaring backends
+		// on a single statement, so an adapter that drops it sends D1 compound
+		// SELECTs it rejects outright.
+		expect(adapter).toHaveProperty("compoundSelectLimit", D1_COMPOUND_SELECT_LIMIT);
 	});
 });
 

--- a/packages/cloudflare/tests/db/d1-dialect.test.ts
+++ b/packages/cloudflare/tests/db/d1-dialect.test.ts
@@ -115,7 +115,7 @@ describe("EmDashD1Dialect (session path keeps the mutex)", () => {
 	});
 });
 
-describe("D1 compound-SELECT ceiling (#2330)", () => {
+describe("D1 compound-SELECT ceiling", () => {
 	it.each([
 		["raw binding", RawBindingD1Dialect],
 		["session", EmDashD1Dialect],

--- a/packages/core/src/api/handlers/taxonomies.ts
+++ b/packages/core/src/api/handlers/taxonomies.ts
@@ -423,7 +423,8 @@ export async function handleTermList(
 		const isHierarchical = lookup.def.hierarchical === 1;
 		const result = isHierarchical ? buildTree(termData) : termData;
 		return { success: true, data: { terms: result } };
-	} catch {
+	} catch (error) {
+		console.error("[taxonomies] term list failed:", error);
 		return {
 			success: false,
 			error: { code: "TERM_LIST_ERROR", message: "Failed to list terms" },

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -38,6 +38,32 @@ export function isPostgres(db: Kysely<any>): boolean {
 }
 
 /**
+ * Declared by an adapter whose backend caps the number of terms in a compound
+ * SELECT (`UNION ALL`, `INTERSECT`, `EXCEPT`). SQLite's own
+ * SQLITE_LIMIT_COMPOUND_SELECT default is 500 — high enough that no query
+ * EmDash builds approaches it — but Cloudflare D1 sets it to 5 and rejects
+ * anything larger with "too many terms in compound SELECT".
+ */
+export interface CompoundSelectLimitedAdapter {
+	readonly compoundSelectLimit: number;
+}
+
+/**
+ * The backend's compound-SELECT ceiling, or null when it has none worth
+ * splitting statements for. Only the adapter knows: the limit is a property of
+ * the SQLite build behind the dialect, not of the SQL flavour, so two "sqlite"
+ * dialects can answer differently.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export function compoundSelectLimit(db: Kysely<any>): number | null {
+	const adapter: object = db.getExecutor().adapter;
+	if ("compoundSelectLimit" in adapter && typeof adapter.compoundSelectLimit === "number") {
+		return adapter.compoundSelectLimit;
+	}
+	return null;
+}
+
+/**
  * Default timestamp expression for column defaults.
  * Wrapped in parens for use in CREATE TABLE ... DEFAULT (...).
  *

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -45,6 +45,7 @@ export function isPostgres(db: Kysely<any>): boolean {
  * anything larger with "too many terms in compound SELECT".
  */
 export interface CompoundSelectLimitedAdapter {
+	/** Maximum terms per compound SELECT. Must be a positive integer. */
 	readonly compoundSelectLimit: number;
 }
 
@@ -53,14 +54,25 @@ export interface CompoundSelectLimitedAdapter {
  * splitting statements for. Only the adapter knows: the limit is a property of
  * the SQLite build behind the dialect, not of the SQL flavour, so two "sqlite"
  * dialects can answer differently.
+ *
+ * A declared ceiling must be a positive integer — callers batch by it, and
+ * every other value silently misbehaves rather than failing: 0 and negatives
+ * never advance the batch cursor, fractions overlap batches and double-count,
+ * NaN yields an empty batch. A malformed declaration throws here, where the
+ * message can name the adapter.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function compoundSelectLimit(db: Kysely<any>): number | null {
 	const adapter: object = db.getExecutor().adapter;
-	if ("compoundSelectLimit" in adapter && typeof adapter.compoundSelectLimit === "number") {
-		return adapter.compoundSelectLimit;
+	if (!("compoundSelectLimit" in adapter)) return null;
+
+	const limit: unknown = adapter.compoundSelectLimit;
+	if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1) {
+		throw new Error(
+			`${adapter.constructor.name} declares compoundSelectLimit ${String(limit)}; it must be a positive integer.`,
+		);
 	}
-	return null;
+	return limit;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export type {
 	FindManyResult,
 } from "./database/repositories/index.js";
 export type { MediaItem, CreateMediaInput } from "./database/repositories/media.js";
+export type { CompoundSelectLimitedAdapter } from "./database/dialect-helpers.js";
 
 // Fields
 export { portableText, image, file, reference } from "./fields/index.js";

--- a/packages/core/src/taxonomies/term-counts.ts
+++ b/packages/core/src/taxonomies/term-counts.ts
@@ -12,16 +12,16 @@
  *
  * The public render path is latency-sensitive on D1, so per-collection counts
  * are combined with UNION ALL — one query per taxonomy, never one per
- * collection, up to the backend's compound-SELECT ceiling.
+ * collection, split only where the backend caps compound-SELECT terms.
  */
 
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
-import { buildStatusCondition } from "../database/dialect-helpers.js";
+import { buildStatusCondition, compoundSelectLimit } from "../database/dialect-helpers.js";
 import type { Database } from "../database/types.js";
 import { validateIdentifier } from "../database/validate.js";
-import { chunks, SQL_COMPOUND_SELECT_LIMIT } from "../utils/chunks.js";
+import { chunks } from "../utils/chunks.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 
 interface CountRow {
@@ -118,11 +118,11 @@ async function runBatch(
  * rather than a throw.
  *
  * One database round-trip for the whole taxonomy (UNION ALL across
- * collections), or one per SQL_COMPOUND_SELECT_LIMIT collections beyond the
- * point where a single statement can carry them all — D1 rejects a compound
- * SELECT with more terms than that, so a taxonomy declaring enough
- * collections would otherwise take down every path that shows counts.
- * Per-collection sums are commutative, so batching cannot change the total.
+ * collections). On a backend that caps compound-SELECT terms — D1 allows five
+ * — the branches are split into one statement per batch, since a taxonomy
+ * declaring more collections than that would otherwise take down every path
+ * that shows counts. Per-collection sums are commutative, so batching cannot
+ * change the total.
  *
  * Callers on the public render path should go through the request-cached
  * wrapper in `taxonomies/index.ts` so a page rendering both the widget and a
@@ -137,9 +137,9 @@ export async function fetchVisibleTermCounts(
 	for (const collection of unique) validateIdentifier(collection, "collection slug");
 	if (unique.length === 0) return new Map();
 
-	const batches = await Promise.all(
-		chunks(unique, SQL_COMPOUND_SELECT_LIMIT).map((batch) => runBatch(db, taxonomyName, batch)),
-	);
+	const limit = compoundSelectLimit(db);
+	const batched = limit === null ? [unique] : chunks(unique, limit);
+	const batches = await Promise.all(batched.map((batch) => runBatch(db, taxonomyName, batch)));
 
 	const counts = new Map<string, number>();
 	for (const batch of batches) addCounts(counts, batch);

--- a/packages/core/src/taxonomies/term-counts.ts
+++ b/packages/core/src/taxonomies/term-counts.ts
@@ -11,8 +11,8 @@
  * visibility at query time rather than trusting a literal status value.
  *
  * The public render path is latency-sensitive on D1, so per-collection counts
- * are combined into a single round-trip with UNION ALL — one query per
- * taxonomy, never one per collection.
+ * are combined with UNION ALL — one query per taxonomy, never one per
+ * collection, up to the backend's compound-SELECT ceiling.
  */
 
 import type { Kysely } from "kysely";
@@ -21,6 +21,7 @@ import { sql } from "kysely";
 import { buildStatusCondition } from "../database/dialect-helpers.js";
 import type { Database } from "../database/types.js";
 import { validateIdentifier } from "../database/validate.js";
+import { chunks, SQL_COMPOUND_SELECT_LIMIT } from "../utils/chunks.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 
 interface CountRow {
@@ -76,6 +77,36 @@ async function runCounts(
 	return counts;
 }
 
+function addCounts(into: Map<string, number>, from: Map<string, number>): void {
+	for (const [group, count] of from) into.set(group, (into.get(group) ?? 0) + count);
+}
+
+/**
+ * Counts for one batch of collections, degrading to a query per collection
+ * when a declared collection has no ec_* table so the rest still contribute.
+ */
+async function runBatch(
+	db: Kysely<Database>,
+	taxonomyName: string,
+	collections: string[],
+): Promise<Map<string, number>> {
+	try {
+		return await runCounts(db, taxonomyName, collections);
+	} catch (error) {
+		if (!isMissingTableError(error)) throw error;
+	}
+
+	const counts = new Map<string, number>();
+	for (const collection of collections) {
+		try {
+			addCounts(counts, await runCounts(db, taxonomyName, [collection]));
+		} catch (error) {
+			if (!isMissingTableError(error)) throw error;
+		}
+	}
+	return counts;
+}
+
 /**
  * Count publicly-visible term assignments for one taxonomy, keyed by the
  * term's translation_group (what `content_taxonomies.taxonomy_id` stores).
@@ -87,9 +118,15 @@ async function runCounts(
  * rather than a throw.
  *
  * One database round-trip for the whole taxonomy (UNION ALL across
- * collections). Callers on the public render path should go through the
- * request-cached wrapper in `taxonomies/index.ts` so a page rendering both the
- * widget and a term detail shares one computation.
+ * collections), or one per SQL_COMPOUND_SELECT_LIMIT collections beyond the
+ * point where a single statement can carry them all — D1 rejects a compound
+ * SELECT with more terms than that, so a taxonomy declaring enough
+ * collections would otherwise take down every path that shows counts.
+ * Per-collection sums are commutative, so batching cannot change the total.
+ *
+ * Callers on the public render path should go through the request-cached
+ * wrapper in `taxonomies/index.ts` so a page rendering both the widget and a
+ * term detail shares one computation.
  */
 export async function fetchVisibleTermCounts(
 	db: Kysely<Database>,
@@ -100,23 +137,11 @@ export async function fetchVisibleTermCounts(
 	for (const collection of unique) validateIdentifier(collection, "collection slug");
 	if (unique.length === 0) return new Map();
 
-	try {
-		return await runCounts(db, taxonomyName, unique);
-	} catch (error) {
-		if (!isMissingTableError(error)) throw error;
-	}
+	const batches = await Promise.all(
+		chunks(unique, SQL_COMPOUND_SELECT_LIMIT).map((batch) => runBatch(db, taxonomyName, batch)),
+	);
 
-	// A declared collection has no ec_* table — retry per collection so the
-	// existing tables still contribute (still scheduled-aware + deleted_at).
 	const counts = new Map<string, number>();
-	for (const collection of unique) {
-		try {
-			for (const [group, count] of await runCounts(db, taxonomyName, [collection])) {
-				counts.set(group, (counts.get(group) ?? 0) + count);
-			}
-		} catch (error) {
-			if (!isMissingTableError(error)) throw error;
-		}
-	}
+	for (const batch of batches) addCounts(counts, batch);
 	return counts;
 }

--- a/packages/core/src/utils/chunks.ts
+++ b/packages/core/src/utils/chunks.ts
@@ -15,11 +15,3 @@ export function chunks<T>(arr: T[], size: number): T[][] {
 
 /** Conservative default chunk size for SQL IN clauses (well within D1's limit). */
 export const SQL_BATCH_SIZE = 50;
-
-/**
- * Maximum number of terms one compound SELECT (`UNION ALL`, `INTERSECT`,
- * `EXCEPT`) may have. SQLite's own default is 500, but Cloudflare D1 sets
- * SQLITE_LIMIT_COMPOUND_SELECT to 5 and rejects anything larger with
- * "too many terms in compound SELECT". Split into separate statements past it.
- */
-export const SQL_COMPOUND_SELECT_LIMIT = 5;

--- a/packages/core/src/utils/chunks.ts
+++ b/packages/core/src/utils/chunks.ts
@@ -15,3 +15,11 @@ export function chunks<T>(arr: T[], size: number): T[][] {
 
 /** Conservative default chunk size for SQL IN clauses (well within D1's limit). */
 export const SQL_BATCH_SIZE = 50;
+
+/**
+ * Maximum number of terms one compound SELECT (`UNION ALL`, `INTERSECT`,
+ * `EXCEPT`) may have. SQLite's own default is 500, but Cloudflare D1 sets
+ * SQLITE_LIMIT_COMPOUND_SELECT to 5 and rejects anything larger with
+ * "too many terms in compound SELECT". Split into separate statements past it.
+ */
+export const SQL_COMPOUND_SELECT_LIMIT = 5;

--- a/packages/core/tests/unit/database/compound-select-limit.test.ts
+++ b/packages/core/tests/unit/database/compound-select-limit.test.ts
@@ -1,0 +1,53 @@
+import type { Kysely as KyselyType } from "kysely";
+import { Kysely, SqliteAdapter, SqliteDialect } from "kysely";
+import { describe, expect, it } from "vitest";
+
+import { compoundSelectLimit } from "../../../src/database/dialect-helpers.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- adapter probe takes any instance
+type AnyDb = KyselyType<any>;
+
+function stockDb(): AnyDb {
+	return new Kysely({ dialect: new SqliteDialect({ database: {} as never }) });
+}
+
+function dbDeclaring(limit: unknown): AnyDb {
+	class DeclaringAdapter extends SqliteAdapter {
+		readonly compoundSelectLimit = limit;
+	}
+	class DeclaringDialect extends SqliteDialect {
+		override createAdapter(): SqliteAdapter {
+			return new DeclaringAdapter();
+		}
+	}
+	return new Kysely({ dialect: new DeclaringDialect({ database: {} as never }) });
+}
+
+describe("compoundSelectLimit", () => {
+	it("returns null for an adapter that declares no ceiling", () => {
+		expect(compoundSelectLimit(stockDb())).toBeNull();
+	});
+
+	it("returns the declared ceiling", () => {
+		expect(compoundSelectLimit(dbDeclaring(5))).toBe(5);
+		expect(compoundSelectLimit(dbDeclaring(1))).toBe(1);
+	});
+
+	it.each([
+		["zero", 0],
+		["negative", -1],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+		["fractional", 2.5],
+		["a numeric string", "5"],
+		["null", null],
+	])("throws for a %s ceiling instead of returning it", (_label, limit) => {
+		expect(() => compoundSelectLimit(dbDeclaring(limit))).toThrow(
+			/compoundSelectLimit.*positive integer/s,
+		);
+	});
+
+	it("names the offending adapter so the dialect can be found", () => {
+		expect(() => compoundSelectLimit(dbDeclaring(0))).toThrow(/DeclaringAdapter/);
+	});
+});

--- a/packages/core/tests/unit/taxonomies/term-counts.test.ts
+++ b/packages/core/tests/unit/taxonomies/term-counts.test.ts
@@ -334,10 +334,17 @@ describeEachDialect("visible term counts (#581)", (dialect) => {
 
 describe("visible term counts past the compound-SELECT ceiling", () => {
 	let db: Kysely<DatabaseSchema>;
+	let statements: string[];
 
-	beforeEach(async () => {
-		db = await setupTestDatabaseWithCompoundSelectLimit();
-	});
+	/** Back the test by a database that declares `limit` (null: no ceiling). */
+	async function useDatabase(limit: number | null): Promise<void> {
+		({ db, statements } = await setupTestDatabaseWithCompoundSelectLimit(limit));
+	}
+
+	/** How many statements the count query took; its subquery alias is unique to it. */
+	function countStatements(): number {
+		return statements.filter((source) => source.includes("per_collection")).length;
+	}
 
 	afterEach(async () => {
 		await teardownTestDatabase(db);
@@ -390,11 +397,13 @@ describe("visible term counts past the compound-SELECT ceiling", () => {
 	}
 
 	it("aggregates every declared collection when there are more than one statement can carry", async () => {
+		await useDatabase(D1_COMPOUND_SELECT_LIMIT);
 		const slugs = collectionSlugs(D1_COMPOUND_SELECT_LIMIT + 1);
 		const term = await seedTaxonomy(slugs, slugs);
 
 		const counts = await fetchVisibleTermCounts(db, "topic", slugs);
 		expect(counts.get(term.translationGroup ?? term.id)).toBe(slugs.length);
+		expect(countStatements()).toBe(2);
 
 		const list = await handleTermList(db, "topic");
 		if (!list.success) throw new Error(list.error.code);
@@ -402,10 +411,21 @@ describe("visible term counts past the compound-SELECT ceiling", () => {
 	});
 
 	it("still skips a missing ec_* table when it falls beyond the first batch", async () => {
+		await useDatabase(D1_COMPOUND_SELECT_LIMIT);
 		const existing = collectionSlugs(D1_COMPOUND_SELECT_LIMIT);
 		const term = await seedTaxonomy([...existing, "ghost"], existing);
 
 		const counts = await fetchVisibleTermCounts(db, "topic", [...existing, "ghost"]);
 		expect(counts.get(term.translationGroup ?? term.id)).toBe(existing.length);
+	});
+
+	it("takes a single statement on a backend that declares no ceiling", async () => {
+		await useDatabase(null);
+		const slugs = collectionSlugs(D1_COMPOUND_SELECT_LIMIT + 1);
+		const term = await seedTaxonomy(slugs, slugs);
+
+		const counts = await fetchVisibleTermCounts(db, "topic", slugs);
+		expect(counts.get(term.translationGroup ?? term.id)).toBe(slugs.length);
+		expect(countStatements()).toBe(1);
 	});
 });

--- a/packages/core/tests/unit/taxonomies/term-counts.test.ts
+++ b/packages/core/tests/unit/taxonomies/term-counts.test.ts
@@ -6,19 +6,25 @@
  * declared collections.
  */
 
+import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import { ulid } from "ulidx";
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { handleTermGet, handleTermList } from "../../../src/api/handlers/taxonomies.js";
 import { ContentRepository } from "../../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../../src/database/repositories/taxonomy.js";
+import type { Database as DatabaseSchema } from "../../../src/database/types.js";
 import { runWithContext } from "../../../src/request-context.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { fetchVisibleTermCounts } from "../../../src/taxonomies/term-counts.js";
 import {
+	D1_COMPOUND_SELECT_LIMIT,
 	describeEachDialect,
 	setupForDialectWithCollections,
+	setupTestDatabaseWithCompoundSelectLimit,
 	teardownForDialect,
+	teardownTestDatabase,
 	type DialectTestContext,
 } from "../../utils/test-db.js";
 
@@ -323,5 +329,89 @@ describeEachDialect("visible term counts (#581)", (dialect) => {
 
 		const counts = await fetchVisibleTermCounts(ctx.db, "empty_tax", []);
 		expect(counts.size).toBe(0);
+	});
+});
+
+/**
+ * #2330: counts were built as one UNION ALL branch per declared collection.
+ * Past D1's compound-SELECT ceiling the statement is rejected outright, and
+ * because the counts decorate the admin term list, the whole list 500s — the
+ * taxonomy becomes unmanageable while its terms are perfectly intact.
+ */
+describe("visible term counts past the compound-SELECT ceiling (#2330)", () => {
+	let db: Kysely<DatabaseSchema>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCompoundSelectLimit();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	/**
+	 * Declare `collections` on a taxonomy, create a table and one published,
+	 * term-tagged entry for each of `existing`, and return the term.
+	 */
+	async function seedTaxonomy(collections: string[], existing: string[]) {
+		const registry = new SchemaRegistry(db);
+		const contentRepo = new ContentRepository(db);
+		const taxRepo = new TaxonomyRepository(db);
+
+		for (const slug of existing) {
+			await registry.createCollection({ slug, label: slug, labelSingular: slug });
+			await registry.createField(slug, { slug: "title", label: "Title", type: "string" });
+		}
+
+		const defId = ulid();
+		await db
+			.insertInto("_emdash_taxonomy_defs")
+			.values({
+				id: defId,
+				name: "topic",
+				label: "Topics",
+				label_singular: null,
+				hierarchical: 0,
+				collections: JSON.stringify(collections),
+				locale: "en",
+				translation_group: defId,
+			})
+			.execute();
+
+		const term = await taxRepo.create({ name: "topic", slug: "science", label: "Science" });
+		for (const slug of existing) {
+			const entry = await contentRepo.create({
+				type: slug,
+				slug: `${slug}-entry`,
+				status: "published",
+				data: { title: slug },
+			});
+			await taxRepo.attachToEntry(slug, entry.id, term.id);
+		}
+		return term;
+	}
+
+	function collectionSlugs(count: number): string[] {
+		return Array.from({ length: count }, (_, i) => `coll_${String(i)}`);
+	}
+
+	it("aggregates every declared collection when there are more than one statement can carry", async () => {
+		const slugs = collectionSlugs(D1_COMPOUND_SELECT_LIMIT + 1);
+		const term = await seedTaxonomy(slugs, slugs);
+
+		const counts = await fetchVisibleTermCounts(db, "topic", slugs);
+		expect(counts.get(term.translationGroup ?? term.id)).toBe(slugs.length);
+
+		const list = await handleTermList(db, "topic");
+		if (!list.success) throw new Error(list.error.code);
+		expect(list.data.terms[0]!.count).toBe(slugs.length);
+	});
+
+	it("still skips a missing ec_* table when it falls beyond the first batch", async () => {
+		const existing = collectionSlugs(D1_COMPOUND_SELECT_LIMIT);
+		const term = await seedTaxonomy([...existing, "ghost"], existing);
+
+		const counts = await fetchVisibleTermCounts(db, "topic", [...existing, "ghost"]);
+		expect(counts.get(term.translationGroup ?? term.id)).toBe(existing.length);
 	});
 });

--- a/packages/core/tests/unit/taxonomies/term-counts.test.ts
+++ b/packages/core/tests/unit/taxonomies/term-counts.test.ts
@@ -332,13 +332,7 @@ describeEachDialect("visible term counts (#581)", (dialect) => {
 	});
 });
 
-/**
- * #2330: counts were built as one UNION ALL branch per declared collection.
- * Past D1's compound-SELECT ceiling the statement is rejected outright, and
- * because the counts decorate the admin term list, the whole list 500s — the
- * taxonomy becomes unmanageable while its terms are perfectly intact.
- */
-describe("visible term counts past the compound-SELECT ceiling (#2330)", () => {
+describe("visible term counts past the compound-SELECT ceiling", () => {
 	let db: Kysely<DatabaseSchema>;
 
 	beforeEach(async () => {

--- a/packages/core/tests/utils/test-db.ts
+++ b/packages/core/tests/utils/test-db.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 
 import Database from "better-sqlite3";
-import { Kysely, SqliteDialect } from "kysely";
+import type { SqliteDialectConfig } from "kysely";
+import { Kysely, SqliteAdapter, SqliteDialect } from "kysely";
 import { Pool } from "pg";
 import { describe } from "vitest";
 
@@ -128,31 +129,64 @@ export async function teardownTestDatabase(db: Kysely<DatabaseSchema>): Promise<
  */
 export const D1_COMPOUND_SELECT_LIMIT = 5;
 
+class LimitedCompoundSelectAdapter extends SqliteAdapter {
+	constructor(readonly compoundSelectLimit: number) {
+		super();
+	}
+}
+
+class LimitedCompoundSelectDialect extends SqliteDialect {
+	readonly #limit: number;
+
+	constructor(config: SqliteDialectConfig, limit: number) {
+		super(config);
+		this.#limit = limit;
+	}
+
+	override createAdapter(): SqliteAdapter {
+		return new LimitedCompoundSelectAdapter(this.#limit);
+	}
+}
+
+export interface CompoundSelectTestDatabase {
+	db: Kysely<DatabaseSchema>;
+	/** Every statement prepared against the database, in order. */
+	statements: string[];
+}
+
 /**
- * Test database that enforces D1's compound-SELECT ceiling.
+ * Test database standing in for a backend with — or without — a
+ * compound-SELECT ceiling.
  *
  * better-sqlite3 uses SQLite's upstream default of 500 and offers no way to
- * lower it, so query shapes that D1 rejects run happily in tests. The ceiling
- * is imposed when a statement is prepared — where SQLite itself raises it —
- * with D1's error text, so code that inspects the message behaves the same.
+ * lower it, so query shapes that D1 rejects run happily in tests. Pass a
+ * number and the dialect declares the ceiling the way the D1 dialect does,
+ * while prepare() rejects statements past it — where SQLite itself raises the
+ * error — with D1's error text, so code that inspects the message behaves the
+ * same. Pass null for a backend that imposes no ceiling.
  */
 export async function setupTestDatabaseWithCompoundSelectLimit(
-	limit = D1_COMPOUND_SELECT_LIMIT,
-): Promise<Kysely<DatabaseSchema>> {
+	limit: number | null = D1_COMPOUND_SELECT_LIMIT,
+): Promise<CompoundSelectTestDatabase> {
 	resetSchemaCachesForTests();
 	const sqlite = new Database(":memory:");
+	const statements: string[] = [];
 	const prepare = sqlite.prepare.bind(sqlite);
 	sqlite.prepare = ((source: string) => {
+		statements.push(source);
 		const terms = source.split(/\b(?:UNION|INTERSECT|EXCEPT)\b/i).length;
-		if (terms > limit) {
+		if (limit !== null && terms > limit) {
 			throw new Error("too many terms in compound SELECT: SQLITE_ERROR");
 		}
 		return prepare(source);
 	}) as typeof sqlite.prepare;
 
-	const db = new Kysely<DatabaseSchema>({ dialect: new SqliteDialect({ database: sqlite }) });
+	const config = { database: sqlite };
+	const dialect =
+		limit === null ? new SqliteDialect(config) : new LimitedCompoundSelectDialect(config, limit);
+	const db = new Kysely<DatabaseSchema>({ dialect });
 	await runMigrations(db);
-	return db;
+	return { db, statements };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/utils/test-db.ts
+++ b/packages/core/tests/utils/test-db.ts
@@ -121,6 +121,40 @@ export async function teardownTestDatabase(db: Kysely<DatabaseSchema>): Promise<
 	await db.destroy();
 }
 
+/**
+ * Number of terms Cloudflare D1 allows in a compound SELECT
+ * (SQLITE_LIMIT_COMPOUND_SELECT). Measured against a real D1: five
+ * `UNION ALL` branches compile, six are rejected.
+ */
+export const D1_COMPOUND_SELECT_LIMIT = 5;
+
+/**
+ * Test database that enforces D1's compound-SELECT ceiling.
+ *
+ * better-sqlite3 uses SQLite's upstream default of 500 and offers no way to
+ * lower it, so query shapes that D1 rejects run happily in tests. The ceiling
+ * is imposed when a statement is prepared — where SQLite itself raises it —
+ * with D1's error text, so code that inspects the message behaves the same.
+ */
+export async function setupTestDatabaseWithCompoundSelectLimit(
+	limit = D1_COMPOUND_SELECT_LIMIT,
+): Promise<Kysely<DatabaseSchema>> {
+	resetSchemaCachesForTests();
+	const sqlite = new Database(":memory:");
+	const prepare = sqlite.prepare.bind(sqlite);
+	sqlite.prepare = ((source: string) => {
+		const terms = source.split(/\b(?:UNION|INTERSECT|EXCEPT)\b/i).length;
+		if (terms > limit) {
+			throw new Error("too many terms in compound SELECT: SQLITE_ERROR");
+		}
+		return prepare(source);
+	}) as typeof sqlite.prepare;
+
+	const db = new Kysely<DatabaseSchema>({ dialect: new SqliteDialect({ database: sqlite }) });
+	await runMigrations(db);
+	return db;
+}
+
 // ---------------------------------------------------------------------------
 // PostgreSQL helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`fetchVisibleTermCounts` built one `UNION ALL` branch per declared collection. Cloudflare D1 sets `SQLITE_LIMIT_COMPOUND_SELECT` to 5 — SQLite's own default is 500 — so a taxonomy declaring six or more collections produced SQL the backend rejected outright. Because the counts decorate the admin term list, the failure took the whole list down: `GET /_emdash/api/taxonomies/:name/terms` returned 500 and the admin rendered an empty list for a taxonomy whose terms were perfectly intact.

**The ceiling is 5, measured against a live D1** rather than inferred: with the same query shape and only the branch count varying, five `UNION ALL` branches compile and six fail with `too many terms in compound SELECT`. That also settles #895, where the dashboard hit this at 9 arms and was fixed by fan-out without anyone bisecting the real threshold.

The fix splits the collections into batches the backend can carry, runs the batches concurrently, and sums the resulting maps — per-collection sums are commutative, so partitioning cannot change a total. The missing-`ec_*`-table fallback moves per batch, so one absent table only degrades its own batch instead of the whole computation.

**The ceiling belongs to the adapter, not to core.** `compoundSelectLimit(db)` (`database/dialect-helpers.ts`) reads it off the Kysely adapter and returns `null` when the backend declares none — which is every backend except D1, so Node/SQLite, libSQL and Postgres keep counting every collection in a single statement no matter how many there are. `@emdash-cms/cloudflare`'s three D1 dialects (raw binding, session, coalescing) share a `D1Adapter` base that declares `compoundSelectLimit = 5`. The limit is a property of the SQLite build behind the dialect rather than of the SQL flavour, which is why `detectDialect()`'s `sqlite | postgres` answer can't carry it.

On D1 the batch size is the measured 5, not a more conservative 4: **a taxonomy at or below the ceiling still issues exactly one query**, so nothing on the logged-out render path regresses. 4 would push every 5-collection taxonomy from one query to two. The perf fixture's taxonomies declare one collection each, so the query-count snapshots are unchanged.

`handleTermList`'s bare `catch` now logs the original error. Diagnosing this required reconstructing the generated SQL by hand, because nothing anywhere recorded *why* the list failed.

Closes #2330

### Notes on the issue's other two suggestions

Deliberately **not** included, happy to be overruled:

- **Widening the fallback's `isMissingTableError` predicate.** With the ceiling gone, the only errors a wider predicate would newly swallow are genuine ones.
- **Degrading `handleTermList` to counts-free terms on a count failure.** It trades a loud 500 for silently wrong-looking admin data, and the failure that motivated it no longer exists. That reads like a maintainer's call about how much decoration is allowed to fail, not something to slip into a bug fix.

### Testing

TDD: the regression test failed with exactly the reported error at `runCounts` before the fix.

better-sqlite3 uses SQLite's upstream default of 500 and offers no way to lower it, so a query shape D1 rejects runs happily in tests. `setupTestDatabaseWithCompoundSelectLimit(limit)` stands in for either kind of backend: given a number its dialect declares the ceiling the way D1's does and `prepare()` rejects statements past it — where SQLite raises the error too — with D1's error text; given `null` it declares nothing, like better-sqlite3 itself. It also hands back every prepared statement, so a test can assert how many round trips the count took.

Three cases, all at `LIMIT + 1` collections:

- with a declared ceiling, counts aggregate across every collection and `handleTermList` returns them (the reported symptom), in 2 statements;
- with no declared ceiling, the same counts come back in **1** statement;
- a missing `ec_*` table beyond the first batch is still skipped. Mutation-checked by restricting the fallback to the first batch — the test fails as intended.

On the `@emdash-cms/cloudflare` side, each of the three D1 dialects is asserted to declare the ceiling on its adapter — an adapter that drops it silently sends D1 compound SELECTs it rejects.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — `packages/core` unit suite (3448 passed), plus the taxonomy, database, utils and loader suites and `packages/cloudflare`'s `tests/db` re-run after the adapter change
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no admin UI strings; the added log line is server-side and English-only by convention
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

Before the fix, with the D1 ceiling imposed on the test database:

```
FAIL  tests/unit/taxonomies/term-counts.test.ts > visible term counts past the
      compound-SELECT ceiling > aggregates every declared collection when
      there are more than one statement can carry
Error: too many terms in compound SELECT: SQLITE_ERROR
 ❯ runCounts src/taxonomies/term-counts.ts:69:17
 ❯ Module.fetchVisibleTermCounts src/taxonomies/term-counts.ts:104:10
```

After, with the ceiling now read off the adapter — `packages/core` taxonomies (unit + integration) and `packages/cloudflare` `tests/db`:

```
Test Files  10 passed (10)
     Tests  87 passed (87)

Test Files  11 passed (11)
     Tests  176 passed (176)
```

## Review response

**Comment discipline — `#2330` in the test file (40fae20).** Fixed, and the review is right on both counts. The JSDoc block above the new `describe` is deleted outright rather than reworded: it was narrative about how the bug presented, which is exactly what the commit message and this description are for. The `describe` name is now `visible term counts past the compound-SELECT ceiling` — it already said what the block covers without the number. Nothing else in the diff carries an issue reference; the `#581` in `term-counts.ts:2` is pre-existing and untouched.

Targeted suite re-run after the edit: `tests/unit/taxonomies/term-counts.test.ts` — 10 passed.

**D1's ceiling was applied to every database — six collections went from one query to two on Node/SQLite.** Correct, and the measurement matches: batching was unconditional, so every backend paid for a limit only D1 has. The ceiling now comes from the adapter (`compoundSelectLimit(db)`, described above), so a backend that declares nothing runs the counts as a single statement at any collection count — Node/SQLite, libSQL and Postgres included — and only D1 splits. The new test asserts the single statement directly rather than trusting the shape: it fails on the previous commit.

Durable Object SQLite (`DOSqlDialect`, `PreviewDODialect`) deliberately declares nothing. D1 may well share the build, but I have no measurement for a DO the way I do for D1, and guessing here would cost the extra query on a backend that may not need it. Happy to add it if you know the answer.

**Why the changeset is still a single `emdash` patch.** The batching and the adapter lookup both live in core; `@emdash-cms/cloudflare` contributes one declared constant. Since `.changeset/config.json` puts the two packages in the same `fixed` group, listing `emdash` alone already versions cloudflare in lockstep — adding it to the changeset would only copy the same note into a second changelog without changing what anyone installs.





**`compoundSelectLimit` isn't validated — `0`/negative loop forever, `NaN`/fractions build invalid batches (060499c9).** Agreed, and the reasoning holds for every one of those values; the probe now requires a positive integer and throws naming the adapter class otherwise. The ceiling is read off a third-party Kysely adapter by duck-typing, so core has no compile-time guarantee about what it gets, and each malformed value fails silently rather than loudly:

- `0` or negative: `chunks()` never advances `i`, so `fetchVisibleTermCounts` hangs — worse than the 500 this PR set out to fix.
- fractional (`2.5`): `slice()` truncates both bounds, so batch 2 starts at index 2 after batch 1 ended there — an element lands in two batches and its count is added twice. Silently wrong numbers, no error anywhere.
- `NaN`: one empty batch, so the UNION has no terms and the statement is invalid SQL.

Declared-but-not-a-number (`"5"`) throws too rather than falling through to `null`. Silently ignoring a ceiling an adapter meant to declare is exactly the failure this PR exists to remove — it would send D1 the compound SELECTs it rejects, which is the reported bug with an extra step.

Throwing is the right severity here: this is a static property of the dialect, so it is wrong on the first request or never, and it can only be fixed by the person who wrote the adapter. A silent `null` would hide that from them.

New unit test (`tests/unit/database/compound-select-limit.test.ts`) covers `null` for an adapter declaring nothing, pass-through for `5` and `1`, and a throw for `0`, `-1`, `NaN`, `Infinity`, `2.5`, `"5"` and `null` — 8 of its 10 cases fail on the previous commit. `packages/core` taxonomies + database and `packages/cloudflare` `tests/db` re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
