### PR TITLE
fix(admin): normalize content lifecycle status badges

### DIFF
--- a/.changeset/normalize-publish-labels.md
+++ b/.changeset/normalize-publish-labels.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Updates publish actions and status labels to use a consistent “Publish” label with a corresponding icon.
+Updates content lifecycle badges and status labels with consistent wording, icons, and semantic colors.

--- a/.changeset/normalize-publish-labels.md
+++ b/.changeset/normalize-publish-labels.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Updates publish actions and status labels to use a consistent “Publish” label with a corresponding icon.

--- a/e2e/tests/content-crud.spec.ts
+++ b/e2e/tests/content-crud.spec.ts
@@ -157,7 +157,7 @@ test.describe("Content CRUD", () => {
 
 			// Publish the draft
 			const publishButton = admin.page.getByRole("button", {
-				name: "Publish Post",
+				name: "Publish",
 				exact: true,
 			});
 			await expect(publishButton).toBeVisible();

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -22,6 +22,8 @@ import {
 	CaretUp,
 	CaretDown,
 	CaretUpDown,
+	CheckCircle,
+	Upload,
 	X,
 } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
@@ -411,6 +413,7 @@ export function ContentList({
 										variant="secondary"
 										disabled={bulkBusy}
 										onClick={() => runBulk(onBulkPublish)}
+										icon={<Upload />}
 									>
 										{t`Publish`}
 									</Button>
@@ -726,10 +729,21 @@ function FilterBar({
 
 	const statusItems: Record<string, string> = {
 		all: t`All statuses`,
-		published: t`Published`,
+		published: t`Publish`,
 		draft: t`Draft`,
 		scheduled: t`Scheduled`,
 		archived: t`Archived`,
+	};
+	const renderStatusLabel = (value: string) => {
+		const label = statusItems[value] ?? value;
+		return value === "published" ? (
+			<span className="flex items-center gap-1.5">
+				<CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
+				{label}
+			</span>
+		) : (
+			label
+		);
 	};
 
 	const dateFieldItems: Record<string, string> = {
@@ -754,11 +768,12 @@ function FilterBar({
 				aria-label={t`Filter by status`}
 				value={statusFilter}
 				onValueChange={(v) => onStatusFilterChange((v as ContentStatusFilter) ?? "all")}
+				renderValue={(v) => renderStatusLabel(typeof v === "string" ? v : "")}
 				items={statusItems}
 			>
-				{Object.entries(statusItems).map(([value, label]) => (
+				{Object.entries(statusItems).map(([value]) => (
 					<Select.Option key={value} value={value}>
-						{label}
+						{renderStatusLabel(value)}
 					</Select.Option>
 				))}
 			</Select>
@@ -1157,7 +1172,7 @@ function StatusBadge({
 
 	const statusLabel =
 		status === "published"
-			? t`published`
+			? t`Publish`
 			: status === "draft"
 				? t`draft`
 				: status === "scheduled"
@@ -1180,6 +1195,9 @@ function StatusBadge({
 					status === "archived" && "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
 				)}
 			>
+				{status === "published" && (
+					<CheckCircle className="me-1.5 h-3.5 w-3.5" aria-hidden="true" />
+				)}
 				{statusLabel}
 			</span>
 			{hasPendingChanges && <Badge variant="secondary">{t`pending`}</Badge>}

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -22,7 +22,6 @@ import {
 	CaretUp,
 	CaretDown,
 	CaretUpDown,
-	CheckCircle,
 	Upload,
 	X,
 } from "@phosphor-icons/react";
@@ -34,6 +33,12 @@ import { useDebouncedValue } from "../lib/hooks.js";
 import { contentUrl } from "../lib/url.js";
 import { cn } from "../lib/utils";
 import { CaretNext, CaretPrev } from "./ArrowIcons.js";
+import {
+	CONTENT_STATUS_ICONS,
+	ContentStatusBadge,
+	ContentStatusLabel,
+	type ContentStatusState,
+} from "./ContentStatusBadge.js";
 import { LocaleSwitcher } from "./LocaleSwitcher";
 import { RouterLinkButton } from "./RouterLinkButton.js";
 
@@ -727,24 +732,15 @@ function FilterBar({
 	const showAuthorFilter = !!onAuthorFilterChange && !!authors && authors.length > 0;
 	const showDateFilter = !!onDateFilterChange;
 
-	const statusItems: Record<string, string> = {
+	const statusItems: Record<ContentStatusFilter, string> = {
 		all: t`All statuses`,
 		published: t`Publish`,
 		draft: t`Draft`,
 		scheduled: t`Scheduled`,
 		archived: t`Archived`,
 	};
-	const renderStatusLabel = (value: string) => {
-		const label = statusItems[value] ?? value;
-		return value === "published" ? (
-			<span className="flex items-center gap-1.5">
-				<CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
-				{label}
-			</span>
-		) : (
-			label
-		);
-	};
+	const renderStatusLabel = (value: ContentStatusFilter) =>
+		value === "all" ? statusItems.all : <ContentStatusLabel state={value} />;
 
 	const dateFieldItems: Record<string, string> = {
 		createdAt: t`Created`,
@@ -768,12 +764,18 @@ function FilterBar({
 				aria-label={t`Filter by status`}
 				value={statusFilter}
 				onValueChange={(v) => onStatusFilterChange((v as ContentStatusFilter) ?? "all")}
-				renderValue={(v) => renderStatusLabel(typeof v === "string" ? v : "")}
+				renderValue={(v) =>
+					renderStatusLabel(
+						typeof v === "string" && Object.hasOwn(statusItems, v)
+							? (v as ContentStatusFilter)
+							: "all",
+					)
+				}
 				items={statusItems}
 			>
 				{Object.entries(statusItems).map(([value]) => (
 					<Select.Option key={value} value={value}>
-						{renderStatusLabel(value)}
+						{renderStatusLabel(value as ContentStatusFilter)}
 					</Select.Option>
 				))}
 			</Select>
@@ -1168,39 +1170,16 @@ function StatusBadge({
 	status: string;
 	hasPendingChanges?: boolean;
 }) {
-	const { t } = useLingui();
-
-	const statusLabel =
-		status === "published"
-			? t`Publish`
-			: status === "draft"
-				? t`draft`
-				: status === "scheduled"
-					? t`scheduled`
-					: status === "archived"
-						? t`archived`
-						: status;
+	const state = isContentStatusState(status) ? status : undefined;
 
 	return (
 		<span className="inline-flex items-center gap-1.5">
-			<span
-				className={cn(
-					"inline-flex items-center rounded-full px-2 py-1 text-xs font-medium",
-					status === "published" &&
-						"bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-					status === "draft" &&
-						"bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
-					status === "scheduled" &&
-						"bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
-					status === "archived" && "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
-				)}
-			>
-				{status === "published" && (
-					<CheckCircle className="me-1.5 h-3.5 w-3.5" aria-hidden="true" />
-				)}
-				{statusLabel}
-			</span>
-			{hasPendingChanges && <Badge variant="secondary">{t`pending`}</Badge>}
+			{state ? <ContentStatusBadge state={state} /> : <Badge variant="neutral">{status}</Badge>}
+			{hasPendingChanges && <ContentStatusBadge state="pendingChanges" />}
 		</span>
 	);
+}
+
+function isContentStatusState(status: string): status is ContentStatusState {
+	return Object.hasOwn(CONTENT_STATUS_ICONS, status);
 }

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -764,9 +764,7 @@ function FilterBar({
 				value={statusFilter}
 				onValueChange={(v) => onStatusFilterChange((v as ContentStatusFilter) ?? "all")}
 				renderValue={(v) =>
-					renderStatusLabel(
-						typeof v === "string" && Object.hasOwn(statusItems, v) ? v : "all",
-					)
+					renderStatusLabel(typeof v === "string" && Object.hasOwn(statusItems, v) ? v : "all")
 				}
 				items={statusItems}
 			>

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -34,10 +34,9 @@ import { contentUrl } from "../lib/url.js";
 import { cn } from "../lib/utils";
 import { CaretNext, CaretPrev } from "./ArrowIcons.js";
 import {
-	CONTENT_STATUS_ICONS,
 	ContentStatusBadge,
 	ContentStatusLabel,
-	type ContentStatusState,
+	isContentStatusState,
 } from "./ContentStatusBadge.js";
 import { LocaleSwitcher } from "./LocaleSwitcher";
 import { RouterLinkButton } from "./RouterLinkButton.js";
@@ -1178,8 +1177,4 @@ function StatusBadge({
 			{hasPendingChanges && <ContentStatusBadge state="pendingChanges" />}
 		</span>
 	);
-}
-
-function isContentStatusState(status: string): status is ContentStatusState {
-	return Object.hasOwn(CONTENT_STATUS_ICONS, status);
 }

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -765,9 +765,7 @@ function FilterBar({
 				onValueChange={(v) => onStatusFilterChange((v as ContentStatusFilter) ?? "all")}
 				renderValue={(v) =>
 					renderStatusLabel(
-						typeof v === "string" && Object.hasOwn(statusItems, v)
-							? (v as ContentStatusFilter)
-							: "all",
+						typeof v === "string" && Object.hasOwn(statusItems, v) ? v : "all",
 					)
 				}
 				items={statusItems}

--- a/packages/admin/src/components/ContentPickerModal.tsx
+++ b/packages/admin/src/components/ContentPickerModal.tsx
@@ -7,7 +7,7 @@
 
 import { Button, Dialog, Input, Loader, Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { CheckCircle, MagnifyingGlass, FolderOpen, X } from "@phosphor-icons/react";
+import { MagnifyingGlass, FolderOpen, X } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -15,6 +15,7 @@ import { fetchCollections, fetchContentList, getDraftStatus } from "../lib/api";
 import type { ContentItem } from "../lib/api";
 import { useDebouncedValue } from "../lib/hooks";
 import { cn } from "../lib/utils";
+import { ContentStatusLabel, type ContentStatusState } from "./ContentStatusBadge.js";
 
 interface ContentPickerModalProps {
 	open: boolean;
@@ -182,6 +183,12 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 						<div className="space-y-1">
 							{filteredItems.map((item) => {
 								const status = getDraftStatus(item);
+								const statusState: ContentStatusState =
+									status === "published"
+										? "published"
+										: status === "published_with_changes"
+											? "pendingChanges"
+											: "draft";
 								return (
 									<button
 										key={item.id}
@@ -195,23 +202,7 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 									>
 										<div className="font-medium">{getItemTitle(item)}</div>
 										<div className="text-sm text-kumo-subtle flex items-center gap-2">
-											{status === "published" ? (
-												<CheckCircle className="h-3.5 w-3.5 text-kumo-success" aria-hidden="true" />
-											) : (
-												<span
-													className={cn(
-														"inline-block h-2 w-2 rounded-full",
-														status === "published_with_changes"
-															? "bg-kumo-warning"
-															: "bg-kumo-fill",
-													)}
-												/>
-											)}
-											{status === "published"
-												? t`Publish`
-												: status === "published_with_changes"
-													? t`Modified`
-													: t`Draft`}
+											<ContentStatusLabel state={statusState} />
 											{item.slug && (
 												<>
 													<span className="text-kumo-subtle/50">/</span>

--- a/packages/admin/src/components/ContentPickerModal.tsx
+++ b/packages/admin/src/components/ContentPickerModal.tsx
@@ -7,7 +7,7 @@
 
 import { Button, Dialog, Input, Loader, Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { MagnifyingGlass, FolderOpen, X } from "@phosphor-icons/react";
+import { CheckCircle, MagnifyingGlass, FolderOpen, X } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -195,18 +195,20 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 									>
 										<div className="font-medium">{getItemTitle(item)}</div>
 										<div className="text-sm text-kumo-subtle flex items-center gap-2">
-											<span
-												className={cn(
-													"inline-block h-2 w-2 rounded-full",
-													status === "published"
-														? "bg-kumo-success"
-														: status === "published_with_changes"
+											{status === "published" ? (
+												<CheckCircle className="h-3.5 w-3.5 text-kumo-success" aria-hidden="true" />
+											) : (
+												<span
+													className={cn(
+														"inline-block h-2 w-2 rounded-full",
+														status === "published_with_changes"
 															? "bg-kumo-warning"
 															: "bg-kumo-fill",
-												)}
-											/>
+													)}
+												/>
+											)}
 											{status === "published"
-												? t`Published`
+												? t`Publish`
 												: status === "published_with_changes"
 													? t`Modified`
 													: t`Draft`}

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -35,7 +35,7 @@ import { fetchBylines } from "../lib/api";
 import { useDebouncedValue } from "../lib/hooks.js";
 import { cn, slugify } from "../lib/utils";
 import type { CurrentUserInfo } from "./ContentEditor.js";
-import { ContentStatusBadge } from "./ContentStatusBadge.js";
+import { ContentStatusBadge, isContentStatusState } from "./ContentStatusBadge.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { GalleryDetailPanel } from "./editor/GalleryDetailPanel";
 import type { GalleryAttributes } from "./editor/GalleryNode";
@@ -462,6 +462,8 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 											{!isLive && !hasSchedule && <ContentStatusBadge state="draft" />}
 											{hasSchedule && <ContentStatusBadge state="scheduled" />}
 										</>
+									) : isContentStatusState(status) ? (
+										<ContentStatusBadge state={status} />
 									) : (
 										<Badge variant="secondary">
 											{status.charAt(0).toUpperCase() + status.slice(1)}

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -12,7 +12,6 @@ import {
 import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowSquareOut,
-	CheckCircle,
 	Eye,
 	EyeSlash,
 	Trash,
@@ -36,6 +35,7 @@ import { fetchBylines } from "../lib/api";
 import { useDebouncedValue } from "../lib/hooks.js";
 import { cn, slugify } from "../lib/utils";
 import type { CurrentUserInfo } from "./ContentEditor.js";
+import { ContentStatusBadge } from "./ContentStatusBadge.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { GalleryDetailPanel } from "./editor/GalleryDetailPanel";
 import type { GalleryAttributes } from "./editor/GalleryNode";
@@ -457,15 +457,10 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 									<Label>{t`Status`}</Label>
 									{supportsDrafts ? (
 										<>
-											{isLive && (
-												<Badge variant="success" className="gap-1">
-													<CheckCircle className="h-3 w-3" aria-hidden="true" />
-													{t`Publish`}
-												</Badge>
-											)}
-											{hasPendingChanges && <Badge variant="secondary">{t`Pending changes`}</Badge>}
-											{!isLive && !hasSchedule && <Badge variant="secondary">{t`Draft`}</Badge>}
-											{hasSchedule && <Badge variant="outline">{t`Scheduled`}</Badge>}
+											{isLive && <ContentStatusBadge state="published" />}
+											{hasPendingChanges && <ContentStatusBadge state="pendingChanges" />}
+											{!isLive && !hasSchedule && <ContentStatusBadge state="draft" />}
+											{hasSchedule && <ContentStatusBadge state="scheduled" />}
 										</>
 									) : (
 										<Badge variant="secondary">

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -10,14 +10,7 @@ import {
 	Text,
 } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import {
-	ArrowSquareOut,
-	Eye,
-	EyeSlash,
-	Trash,
-	Upload,
-	X,
-} from "@phosphor-icons/react";
+import { ArrowSquareOut, Eye, EyeSlash, Trash, Upload, X } from "@phosphor-icons/react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -10,7 +10,15 @@ import {
 	Text,
 } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { ArrowSquareOut, Eye, EyeSlash, Trash, Upload, X } from "@phosphor-icons/react";
+import {
+	ArrowSquareOut,
+	CheckCircle,
+	Eye,
+	EyeSlash,
+	Trash,
+	Upload,
+	X,
+} from "@phosphor-icons/react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
@@ -186,14 +194,14 @@ export function PublishActions({
 	if (!isLive) {
 		return (
 			<Button type="button" variant="primary" size={size} onClick={onPublish} icon={<Upload />}>
-				{t`Publish ${itemLabel}`}
+				{t`Publish`}
 			</Button>
 		);
 	}
 	if (hasPendingChanges) {
 		return (
 			<Button type="button" variant="primary" size={size} onClick={onPublish} icon={<Upload />}>
-				{t`Publish updates`}
+				{t`Publish`}
 			</Button>
 		);
 	}
@@ -449,7 +457,12 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 									<Label>{t`Status`}</Label>
 									{supportsDrafts ? (
 										<>
-											{isLive && <Badge variant="success">{t`Published`}</Badge>}
+											{isLive && (
+												<Badge variant="success" className="gap-1">
+													<CheckCircle className="h-3 w-3" aria-hidden="true" />
+													{t`Publish`}
+												</Badge>
+											)}
 											{hasPendingChanges && <Badge variant="secondary">{t`Pending changes`}</Badge>}
 											{!isLive && !hasSchedule && <Badge variant="secondary">{t`Draft`}</Badge>}
 											{hasSchedule && <Badge variant="outline">{t`Scheduled`}</Badge>}

--- a/packages/admin/src/components/ContentStatusBadge.tsx
+++ b/packages/admin/src/components/ContentStatusBadge.tsx
@@ -1,0 +1,121 @@
+import { Badge, type BadgeVariant } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import {
+	Archive,
+	ArrowsClockwise,
+	CalendarDots,
+	CheckCircle,
+	CircleDashed,
+	LockKey,
+	type Icon,
+} from "@phosphor-icons/react";
+
+import { cn } from "../lib/utils";
+
+export type ContentStatusState =
+	| "published"
+	| "draft"
+	| "scheduled"
+	| "archived"
+	| "pendingChanges"
+	| "private";
+
+export const CONTENT_STATUS_ICONS: Record<ContentStatusState, Icon> = {
+	published: CheckCircle,
+	draft: CircleDashed,
+	scheduled: CalendarDots,
+	archived: Archive,
+	pendingChanges: ArrowsClockwise,
+	private: LockKey,
+};
+
+export const CONTENT_STATUS_ICON_COLORS: Record<ContentStatusState, string> = {
+	published: "text-kumo-success",
+	draft: "text-kumo-warning",
+	scheduled: "text-kumo-info",
+	archived: "text-kumo-subtle",
+	pendingChanges: "text-kumo-warning",
+	private: "text-kumo-subtle",
+};
+
+const CONTENT_STATUS_VARIANTS: Record<ContentStatusState, BadgeVariant> = {
+	published: "success",
+	draft: "warning",
+	scheduled: "info",
+	archived: "neutral",
+	pendingChanges: "warning",
+	private: "secondary",
+};
+
+function useContentStatusLabel(state: ContentStatusState): string {
+	const { t } = useLingui();
+
+	switch (state) {
+		case "published":
+			return t`Publish`;
+		case "draft":
+			return t`Draft`;
+		case "scheduled":
+			return t`Scheduled`;
+		case "archived":
+			return t`Archived`;
+		case "pendingChanges":
+			return t`Pending changes`;
+		case "private":
+			return t`Private`;
+	}
+}
+
+export interface ContentStatusProps {
+	state: ContentStatusState;
+	className?: string;
+}
+
+export function ContentStatusLabel({ state, className }: ContentStatusProps) {
+	const label = useContentStatusLabel(state);
+	const Icon = CONTENT_STATUS_ICONS[state];
+
+	return (
+		<span className={cn("inline-flex items-center gap-1.5", className)}>
+			<Icon
+				className={cn("h-3.5 w-3.5", CONTENT_STATUS_ICON_COLORS[state])}
+				aria-hidden="true"
+			/>
+			{label}
+		</span>
+	);
+}
+
+export function ContentStatusBadge({ state, className }: ContentStatusProps) {
+	const label = useContentStatusLabel(state);
+	const Icon = CONTENT_STATUS_ICONS[state];
+
+	return (
+		<Badge variant={CONTENT_STATUS_VARIANTS[state]} className={cn("gap-1.5", className)}>
+			<Icon className="h-3 w-3" aria-hidden="true" />
+			{label}
+		</Badge>
+	);
+}
+
+export interface ContentStatusIconProps extends ContentStatusProps {
+	decorative?: boolean;
+}
+
+export function ContentStatusIcon({ state, className, decorative = false }: ContentStatusIconProps) {
+	const label = useContentStatusLabel(state);
+	const Icon = CONTENT_STATUS_ICONS[state];
+
+	return decorative ? (
+		<Icon
+			className={cn("h-3.5 w-3.5", CONTENT_STATUS_ICON_COLORS[state], className)}
+			aria-hidden="true"
+		/>
+	) : (
+		<Icon
+			className={cn("h-3.5 w-3.5", CONTENT_STATUS_ICON_COLORS[state], className)}
+			role="img"
+			aria-label={label}
+		/>
+	);
+}

--- a/packages/admin/src/components/ContentStatusBadge.tsx
+++ b/packages/admin/src/components/ContentStatusBadge.tsx
@@ -38,6 +38,10 @@ export const CONTENT_STATUS_ICON_COLORS: Record<ContentStatusState, string> = {
 	private: "text-kumo-subtle",
 };
 
+export function isContentStatusState(status: string): status is ContentStatusState {
+	return Object.hasOwn(CONTENT_STATUS_ICONS, status);
+}
+
 const CONTENT_STATUS_VARIANTS: Record<ContentStatusState, BadgeVariant> = {
 	published: "success",
 	draft: "warning",

--- a/packages/admin/src/components/ContentStatusBadge.tsx
+++ b/packages/admin/src/components/ContentStatusBadge.tsx
@@ -81,10 +81,7 @@ export function ContentStatusLabel({ state, className }: ContentStatusProps) {
 
 	return (
 		<span className={cn("inline-flex items-center gap-1.5", className)}>
-			<Icon
-				className={cn("h-3.5 w-3.5", CONTENT_STATUS_ICON_COLORS[state])}
-				aria-hidden="true"
-			/>
+			<Icon className={cn("h-3.5 w-3.5", CONTENT_STATUS_ICON_COLORS[state])} aria-hidden="true" />
 			{label}
 		</span>
 	);
@@ -106,7 +103,11 @@ export interface ContentStatusIconProps extends ContentStatusProps {
 	decorative?: boolean;
 }
 
-export function ContentStatusIcon({ state, className, decorative = false }: ContentStatusIconProps) {
+export function ContentStatusIcon({
+	state,
+	className,
+	decorative = false,
+}: ContentStatusIconProps) {
 	const label = useContentStatusLabel(state);
 	const Icon = CONTENT_STATUS_ICONS[state];
 

--- a/packages/admin/src/components/Dashboard.tsx
+++ b/packages/admin/src/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { Badge, Banner, LayerCard, SkeletonLine } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import { Plus, Upload, CircleDashed, CheckCircle, PencilSimple } from "@phosphor-icons/react";
+import { Plus, Upload } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
@@ -11,8 +11,23 @@ import { fetchDashboardStats } from "../lib/api/dashboard";
 import { usePluginWidget } from "../lib/plugin-context";
 import { cn, formatRelativeTime } from "../lib/utils";
 import { ArrowNext } from "./ArrowIcons";
+import {
+	ContentStatusIcon,
+	CONTENT_STATUS_ICONS,
+	type ContentStatusState,
+} from "./ContentStatusBadge.js";
 import { RouterLinkButton } from "./RouterLinkButton";
 import { SandboxedPluginWidget } from "./SandboxedPluginWidget";
+
+const DASHBOARD_STATUS_STATES: Record<string, ContentStatusState> = {
+	published: "published",
+	draft: "draft",
+	scheduled: "scheduled",
+	pending: "pendingChanges",
+	pending_changes: "pendingChanges",
+	private: "private",
+	archived: "archived",
+};
 
 export interface DashboardProps {
 	manifest: AdminManifest;
@@ -242,15 +257,15 @@ function CollectionList({
 									</span>
 									<span className="flex shrink-0 items-center gap-2">
 										<CountBadge
-											icon={CheckCircle}
+											icon={CONTENT_STATUS_ICONS.published}
 											count={col.published}
 											variant="success"
 											label={t`Publish`}
 										/>
 										<CountBadge
-											icon={PencilSimple}
+											icon={CONTENT_STATUS_ICONS.draft}
 											count={col.draft}
-											variant="secondary"
+											variant="warning"
 											label={t`Drafts`}
 										/>
 										<ArrowNext
@@ -276,7 +291,7 @@ function CountBadge({
 }: {
 	icon: React.ElementType;
 	count: number;
-	variant: "success" | "secondary";
+	variant: "success" | "warning";
 	label: string;
 }) {
 	if (count === 0) return null;
@@ -339,27 +354,17 @@ function RecentActivity({ items, loading }: { items: RecentItem[]; loading: bool
 
 function StatusDot({ status }: { status: string }) {
 	const { t } = useLingui();
+	const state = Object.hasOwn(DASHBOARD_STATUS_STATES, status)
+		? DASHBOARD_STATUS_STATES[status]
+		: undefined;
 
-	// Semantic Kumo tokens (not raw text-green/amber/blue) render the same colors.
-	const colors: Record<string, string> = {
-		published: "text-kumo-success",
-		draft: "text-kumo-warning",
-		scheduled: "text-kumo-info",
-	};
-	const labels: Record<string, string> = {
-		published: t`Publish`,
-		draft: t`Draft`,
-		scheduled: t`Scheduled`,
-		pending: t`Pending`,
-		private: t`Private`,
-		archived: t`Archived`,
-	};
-
-	const Icon = status === "published" ? CheckCircle : CircleDashed;
-	return (
-		<Icon
-			className={`h-3.5 w-3.5 shrink-0 ${colors[status] ?? "text-kumo-subtle"}`}
-			aria-label={labels[status] ?? t`Status: ${status}`}
+	return state ? (
+		<ContentStatusIcon state={state} className="shrink-0" />
+	) : (
+		<span
+			className="h-3.5 w-3.5 shrink-0 rounded-full bg-kumo-fill"
+			role="img"
+			aria-label={t`Status: ${status}`}
 		/>
 	);
 }

--- a/packages/admin/src/components/Dashboard.tsx
+++ b/packages/admin/src/components/Dashboard.tsx
@@ -245,7 +245,7 @@ function CollectionList({
 											icon={CheckCircle}
 											count={col.published}
 											variant="success"
-											label={t`Published`}
+											label={t`Publish`}
 										/>
 										<CountBadge
 											icon={PencilSimple}
@@ -347,7 +347,7 @@ function StatusDot({ status }: { status: string }) {
 		scheduled: "text-kumo-info",
 	};
 	const labels: Record<string, string> = {
-		published: t`Published`,
+		published: t`Publish`,
 		draft: t`Draft`,
 		scheduled: t`Scheduled`,
 		pending: t`Pending`,

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -1101,7 +1101,7 @@ describe("ContentEditor", () => {
 			const item = makeItem({ status: "draft" });
 			const onPublish = vi.fn();
 			const screen = await renderEditor({ isNew: false, item, onPublish });
-			const publishBtn = screen.getByRole("button", { name: "Publish Post", exact: true });
+			const publishBtn = screen.getByRole("button", { name: "Publish", exact: true });
 			await expect.element(publishBtn).toBeInTheDocument();
 		});
 
@@ -1109,7 +1109,7 @@ describe("ContentEditor", () => {
 			const item = makeItem({ status: "draft" });
 			const onPublish = vi.fn();
 			const screen = await renderEditor({ isNew: false, item, onPublish });
-			const publishBtn = screen.getByRole("button", { name: "Publish Post", exact: true });
+			const publishBtn = screen.getByRole("button", { name: "Publish", exact: true });
 			await publishBtn.click();
 			expect(onPublish).toHaveBeenCalled();
 		});
@@ -1129,9 +1129,7 @@ describe("ContentEditor", () => {
 
 				await expect.element(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
 				await expect.element(screen.getByRole("button", { name: "Save" }).first()).toBeDisabled();
-				const publishButtons = screen
-					.getByRole("button", { name: "Publish Post", exact: true })
-					.all();
+				const publishButtons = screen.getByRole("button", { name: "Publish", exact: true }).all();
 				expect(publishButtons).toHaveLength(1);
 				await expect.element(publishButtons[0]!).toBeVisible();
 			} finally {
@@ -1337,7 +1335,7 @@ describe("ContentEditor", () => {
 					.element(screen.getByRole("button", { name: "Settings" }))
 					.not.toBeInTheDocument();
 				await expect
-					.element(screen.getByRole("button", { name: "Publish Post", exact: true }))
+					.element(screen.getByRole("button", { name: "Publish", exact: true }))
 					.toBeVisible();
 			} finally {
 				media.restore();
@@ -1565,7 +1563,7 @@ describe("ContentEditor", () => {
 			const onPublish = vi.fn();
 			const screen = await renderEditor({ isNew: false, item, onPublish });
 
-			const publishBtn = screen.getByRole("button", { name: "Publish Post", exact: true });
+			const publishBtn = screen.getByRole("button", { name: "Publish", exact: true });
 			await expect.element(publishBtn).toBeInTheDocument();
 		});
 
@@ -1574,7 +1572,7 @@ describe("ContentEditor", () => {
 			const onPublish = vi.fn();
 			const screen = await renderEditor({ isNew: false, item, onPublish });
 
-			const publishBtn = screen.getByRole("button", { name: "Publish Post", exact: true });
+			const publishBtn = screen.getByRole("button", { name: "Publish", exact: true });
 			await publishBtn.click();
 			expect(onPublish).toHaveBeenCalled();
 		});

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -159,31 +159,32 @@ describe("ContentList", () => {
 	});
 
 	describe("status badges", () => {
-		it("shows draft status", async () => {
-			const items = [makeItem({ id: "1", status: "draft" })];
+		it.each([
+			["draft", "Draft"],
+			["published", "Publish"],
+			["scheduled", "Scheduled"],
+			["archived", "Archived"],
+		] as const)("shows the normalized %s status with its icon", async (status, label) => {
+			const items = [makeItem({ id: "1", status })];
 			const screen = await render(<ContentList {...defaultProps} items={items} />);
-			await expect.element(screen.getByText("draft")).toBeInTheDocument();
+			const badge = screen.getByText(label).element();
+
+			expect(badge.querySelector("svg")).not.toBeNull();
 		});
 
-		it("shows the normalized Publish status", async () => {
-			const items = [makeItem({ id: "1", status: "published" })];
-			const screen = await render(<ContentList {...defaultProps} items={items} />);
-			await expect.element(screen.getByText("Publish")).toBeInTheDocument();
-		});
-
-		it("keeps the Publish icon before its label in Arabic RTL mode", async () => {
+		it("keeps status icons before their labels in Arabic RTL mode", async () => {
 			const previousLanguage = document.documentElement.lang;
 			const previousDirection = document.documentElement.dir;
 			document.documentElement.lang = "ar";
 			document.documentElement.dir = "rtl";
 
 			try {
-				const items = [makeItem({ id: "1", status: "published" })];
+				const items = [makeItem({ id: "1", status: "draft" })];
 				const screen = await render(<ContentList {...defaultProps} items={items} />);
-				const badge = screen.getByText("Publish").element();
+				const badge = screen.getByText("Draft").element();
 				const icon = badge.querySelector("svg");
 				const textNode = [...badge.childNodes].find(
-					(node) => node.nodeType === Node.TEXT_NODE && node.textContent?.includes("Publish"),
+					(node) => node.nodeType === Node.TEXT_NODE && node.textContent?.includes("Draft"),
 				);
 
 				expect(icon).not.toBeNull();
@@ -199,7 +200,7 @@ describe("ContentList", () => {
 			}
 		});
 
-		it("shows pending badge when draftRevisionId differs from liveRevisionId", async () => {
+		it("shows the Pending changes companion badge when revisions differ", async () => {
 			const items = [
 				makeItem({
 					id: "1",
@@ -209,7 +210,8 @@ describe("ContentList", () => {
 				}),
 			];
 			const screen = await render(<ContentList {...defaultProps} items={items} />);
-			await expect.element(screen.getByText("pending")).toBeInTheDocument();
+			const badge = screen.getByText("Pending changes").element();
+			expect(badge.querySelector("svg")).not.toBeNull();
 		});
 
 		it("does not show pending badge when revisions match", async () => {
@@ -222,7 +224,32 @@ describe("ContentList", () => {
 				}),
 			];
 			const screen = await render(<ContentList {...defaultProps} items={items} />);
-			expect(screen.getByText("pending").query()).toBeNull();
+			expect(screen.getByText("Pending changes").query()).toBeNull();
+		});
+
+		it("renders unknown status names without treating object properties as lifecycle states", async () => {
+			const items = [makeItem({ id: "1", status: "toString" })];
+			const screen = await render(<ContentList {...defaultProps} items={items} />);
+
+			await expect.element(screen.getByText("toString", { exact: true })).toBeInTheDocument();
+		});
+	});
+
+	describe("status filter", () => {
+		it("shows icons with the selected status and each lifecycle option", async () => {
+			const screen = await render(
+				<ContentList {...defaultProps} statusFilter="draft" onStatusFilterChange={vi.fn()} />,
+			);
+			const filter = screen.getByRole("combobox", { name: "Filter by status" });
+
+			expect(filter.element().querySelector("svg")).not.toBeNull();
+			await filter.click();
+
+			for (const label of ["Publish", "Draft", "Scheduled", "Archived"]) {
+				const option = screen.getByRole("option", { name: label });
+				await expect.element(option).toBeInTheDocument();
+				expect(option.element().querySelector("svg")).not.toBeNull();
+			}
 		});
 	});
 

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -165,10 +165,38 @@ describe("ContentList", () => {
 			await expect.element(screen.getByText("draft")).toBeInTheDocument();
 		});
 
-		it("shows published status", async () => {
+		it("shows the normalized Publish status", async () => {
 			const items = [makeItem({ id: "1", status: "published" })];
 			const screen = await render(<ContentList {...defaultProps} items={items} />);
-			await expect.element(screen.getByText("published")).toBeInTheDocument();
+			await expect.element(screen.getByText("Publish")).toBeInTheDocument();
+		});
+
+		it("keeps the Publish icon before its label in Arabic RTL mode", async () => {
+			const previousLanguage = document.documentElement.lang;
+			const previousDirection = document.documentElement.dir;
+			document.documentElement.lang = "ar";
+			document.documentElement.dir = "rtl";
+
+			try {
+				const items = [makeItem({ id: "1", status: "published" })];
+				const screen = await render(<ContentList {...defaultProps} items={items} />);
+				const badge = screen.getByText("Publish").element();
+				const icon = badge.querySelector("svg");
+				const textNode = [...badge.childNodes].find(
+					(node) => node.nodeType === Node.TEXT_NODE && node.textContent?.includes("Publish"),
+				);
+
+				expect(icon).not.toBeNull();
+				expect(textNode).toBeDefined();
+				const textRange = document.createRange();
+				textRange.selectNode(textNode!);
+				expect(icon!.getBoundingClientRect().left).toBeGreaterThan(
+					textRange.getBoundingClientRect().left,
+				);
+			} finally {
+				document.documentElement.lang = previousLanguage;
+				document.documentElement.dir = previousDirection;
+			}
 		});
 
 		it("shows pending badge when draftRevisionId differs from liveRevisionId", async () => {

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -251,30 +251,30 @@ describe("SettingsActionBar", () => {
 		vi.clearAllMocks();
 	});
 
-	it("shows Publish Post for an unpublished draft", async () => {
+	it("shows Publish for an unpublished draft", async () => {
 		const screen = await render(<SettingsActionBar {...makeBarProps()} />);
-		const publish = screen.getByRole("button", { name: "Publish Post" });
+		const publish = screen.getByRole("button", { name: "Publish", exact: true });
 
 		await expect.element(publish).toBeInTheDocument();
 		expect(publish.element().className).toContain("button-emphasis-bg");
 		expect(screen.container.textContent).not.toContain("Unpublish Post");
 	});
 
-	it("preserves configured collection label casing", async () => {
+	it("uses the normalized Publish label for every collection", async () => {
 		const screen = await render(
 			<SettingsActionBar {...makeBarProps({ collectionLabel: "API Docs" })} />,
 		);
 
 		await expect
-			.element(screen.getByRole("button", { name: "Publish API Docs", exact: true }))
+			.element(screen.getByRole("button", { name: "Publish", exact: true }))
 			.toBeInTheDocument();
 	});
 
-	it("shows Publish updates for a live item with edits", async () => {
+	it("shows Publish for a live item with edits", async () => {
 		const props = makeBarProps({ isLive: true, hasPendingChanges: true });
 		const screen = await render(<SettingsActionBar {...props} />);
 
-		const publishChanges = screen.getByRole("button", { name: "Publish updates" });
+		const publishChanges = screen.getByRole("button", { name: "Publish", exact: true });
 		await expect.element(publishChanges).toBeInTheDocument();
 		expect(publishChanges.element().className).toContain("button-emphasis-bg");
 
@@ -328,7 +328,7 @@ describe("SettingsActionBar", () => {
 			screen.getByRole("button", { name: "Saved" }).element(),
 			screen.getByRole("link", { name: "Live View" }).element(),
 			screen.getByRole("button", { name: "Preview draft" }).element(),
-			screen.getByRole("button", { name: "Publish updates" }).element(),
+			screen.getByRole("button", { name: "Publish", exact: true }).element(),
 		];
 		const slots = actions.map((action) => action.parentElement);
 

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -134,6 +134,25 @@ describe("ContentSettingsPanel", () => {
 		await expect.element(screen.getByRole("button", { name: "Move to Trash" })).toBeInTheDocument();
 	});
 
+	it("shows the normalized pending changes label", async () => {
+		const screen = await render(
+			<ContentSettingsPanel
+				{...makePanelProps({ isLive: true, hasPendingChanges: true })}
+			/>,
+		);
+
+		await expect.element(screen.getByText("Pending changes")).toBeInTheDocument();
+	});
+
+	it("shows Scheduled without a Draft companion", async () => {
+		const screen = await render(
+			<ContentSettingsPanel {...makePanelProps({ hasSchedule: true })} />,
+		);
+
+		await expect.element(screen.getByText("Scheduled", { exact: true })).toBeInTheDocument();
+		expect(screen.container.textContent).not.toContain("Draft");
+	});
+
 	it("hides Ownership and Bylines for users below the editor role", async () => {
 		const screen = await render(
 			<ContentSettingsPanel {...makePanelProps({ currentUser: AUTHOR_ROLE })} />,

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -137,9 +137,7 @@ describe("ContentSettingsPanel", () => {
 
 	it("shows the normalized pending changes label", async () => {
 		const screen = await render(
-			<ContentSettingsPanel
-				{...makePanelProps({ isLive: true, hasPendingChanges: true })}
-			/>,
+			<ContentSettingsPanel {...makePanelProps({ isLive: true, hasPendingChanges: true })} />,
 		);
 
 		await expect.element(screen.getByText("Pending changes")).toBeInTheDocument();
@@ -156,9 +154,7 @@ describe("ContentSettingsPanel", () => {
 
 	it("normalizes recognized statuses for collections without draft support", async () => {
 		const screen = await render(
-			<ContentSettingsPanel
-				{...makePanelProps({ status: "published", supportsDrafts: false })}
-			/>,
+			<ContentSettingsPanel {...makePanelProps({ status: "published", supportsDrafts: false })} />,
 		);
 		const statusRow = screen.getByText("Status", { exact: true }).element().parentElement!;
 
@@ -169,9 +165,7 @@ describe("ContentSettingsPanel", () => {
 
 	it("preserves custom statuses for collections without draft support", async () => {
 		const screen = await render(
-			<ContentSettingsPanel
-				{...makePanelProps({ status: "reviewing", supportsDrafts: false })}
-			/>,
+			<ContentSettingsPanel {...makePanelProps({ status: "reviewing", supportsDrafts: false })} />,
 		);
 		const statusRow = screen.getByText("Status", { exact: true }).element().parentElement!;
 

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -153,6 +153,31 @@ describe("ContentSettingsPanel", () => {
 		expect(screen.container.textContent).not.toContain("Draft");
 	});
 
+	it("normalizes recognized statuses for collections without draft support", async () => {
+		const screen = await render(
+			<ContentSettingsPanel
+				{...makePanelProps({ status: "published", supportsDrafts: false })}
+			/>,
+		);
+		const statusRow = screen.getByText("Status", { exact: true }).element().parentElement!;
+
+		expect(statusRow.textContent).toContain("Publish");
+		expect(statusRow.textContent).not.toContain("Published");
+		expect(statusRow.querySelector("svg")).not.toBeNull();
+	});
+
+	it("preserves custom statuses for collections without draft support", async () => {
+		const screen = await render(
+			<ContentSettingsPanel
+				{...makePanelProps({ status: "reviewing", supportsDrafts: false })}
+			/>,
+		);
+		const statusRow = screen.getByText("Status", { exact: true }).element().parentElement!;
+
+		expect(statusRow.textContent).toContain("Reviewing");
+		expect(statusRow.querySelector("svg")).toBeNull();
+	});
+
 	it("hides Ownership and Bylines for users below the editor role", async () => {
 		const screen = await render(
 			<ContentSettingsPanel {...makePanelProps({ currentUser: AUTHOR_ROLE })} />,

--- a/packages/admin/tests/components/ContentStatusBadge.test.tsx
+++ b/packages/admin/tests/components/ContentStatusBadge.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	ContentStatusBadge,
+	ContentStatusIcon,
+	ContentStatusLabel,
+	type ContentStatusState,
+} from "../../src/components/ContentStatusBadge";
+import { render } from "../utils/render";
+
+const statuses: Array<{ state: ContentStatusState; label: string }> = [
+	{ state: "published", label: "Publish" },
+	{ state: "draft", label: "Draft" },
+	{ state: "scheduled", label: "Scheduled" },
+	{ state: "archived", label: "Archived" },
+	{ state: "pendingChanges", label: "Pending changes" },
+	{ state: "private", label: "Private" },
+];
+
+describe("ContentStatusBadge", () => {
+	for (const { state, label } of statuses) {
+		it(`renders the ${state} state with its user-facing label`, async () => {
+			const screen = await render(<ContentStatusBadge state={state} />);
+
+			await expect.element(screen.getByText(label, { exact: true })).toBeVisible();
+			expect(screen.container.querySelector("svg[aria-hidden='true']")).not.toBeNull();
+		});
+	}
+
+	it("uses Kumo's warning treatment for Draft", async () => {
+		const screen = await render(<ContentStatusBadge state="draft" />);
+		const badge = screen.getByText("Draft", { exact: true }).element();
+
+		expect(badge.className).toContain("bg-kumo-warning");
+		expect(badge.className).toContain("text-kumo-warning");
+	});
+});
+
+describe("ContentStatusLabel", () => {
+	it("renders the icon and label as one readable value", async () => {
+		const screen = await render(<ContentStatusLabel state="pendingChanges" />);
+
+		await expect.element(screen.getByText("Pending changes", { exact: true })).toBeVisible();
+		const icon = screen.container.querySelector("svg[aria-hidden='true']");
+		expect(icon).not.toBeNull();
+		expect(icon?.getAttribute("class")).toContain("text-kumo-warning");
+	});
+});
+
+describe("ContentStatusIcon", () => {
+	for (const { state, label } of statuses) {
+		it(`gives the ${state} icon an accessible localized name`, async () => {
+			const screen = await render(<ContentStatusIcon state={state} />);
+
+			await expect.element(screen.getByRole("img", { name: label })).toBeVisible();
+		});
+	}
+
+	it("can be hidden when adjacent text already names the state", async () => {
+		const screen = await render(<ContentStatusIcon state="draft" decorative />);
+
+		expect(screen.container.querySelector("svg[aria-hidden='true']")).not.toBeNull();
+		expect(screen.container.querySelector("[role='img']")).toBeNull();
+	});
+});

--- a/packages/admin/tests/components/ContentStatusBadge.test.tsx
+++ b/packages/admin/tests/components/ContentStatusBadge.test.tsx
@@ -26,14 +26,6 @@ describe("ContentStatusBadge", () => {
 			expect(screen.container.querySelector("svg[aria-hidden='true']")).not.toBeNull();
 		});
 	}
-
-	it("uses Kumo's warning treatment for Draft", async () => {
-		const screen = await render(<ContentStatusBadge state="draft" />);
-		const badge = screen.getByText("Draft", { exact: true }).element();
-
-		expect(badge.className).toContain("bg-kumo-warning");
-		expect(badge.className).toContain("text-kumo-warning");
-	});
 });
 
 describe("ContentStatusLabel", () => {
@@ -43,7 +35,6 @@ describe("ContentStatusLabel", () => {
 		await expect.element(screen.getByText("Pending changes", { exact: true })).toBeVisible();
 		const icon = screen.container.querySelector("svg[aria-hidden='true']");
 		expect(icon).not.toBeNull();
-		expect(icon?.getAttribute("class")).toContain("text-kumo-warning");
 	});
 });
 

--- a/packages/admin/tests/components/Dashboard.test.tsx
+++ b/packages/admin/tests/components/Dashboard.test.tsx
@@ -135,7 +135,6 @@ describe("Dashboard", () => {
 
 		const statusIcon = screen.getByRole("img", { name: "Pending changes" });
 		await expect.element(statusIcon).toBeInTheDocument();
-		expect(statusIcon.element().getAttribute("class")).toContain("text-kumo-warning");
 		expect(screen.container.textContent).not.toContain("Modified");
 	});
 

--- a/packages/admin/tests/components/Dashboard.test.tsx
+++ b/packages/admin/tests/components/Dashboard.test.tsx
@@ -114,4 +114,49 @@ describe("Dashboard", () => {
 			await expect.element(screen.getByRole("heading", { level: 2, name })).toBeInTheDocument();
 		}
 	});
+
+	it("gives recent activity status icons normalized accessible labels", async () => {
+		const stats = makeStats([]);
+		stats.recentItems = [
+			{
+				id: "page-1",
+				collection: "pages",
+				collectionLabel: "Pages",
+				title: "Updated page",
+				slug: "updated-page",
+				status: "pending",
+				updatedAt: new Date().toISOString(),
+				authorId: null,
+			},
+		];
+		mockFetchDashboardStats.mockResolvedValue(stats);
+
+		const screen = await render(<Dashboard manifest={manifest} />);
+
+		const statusIcon = screen.getByRole("img", { name: "Pending changes" });
+		await expect.element(statusIcon).toBeInTheDocument();
+		expect(statusIcon.element().getAttribute("class")).toContain("text-kumo-warning");
+		expect(screen.container.textContent).not.toContain("Modified");
+	});
+
+	it("renders unknown status names without treating object properties as lifecycle states", async () => {
+		const stats = makeStats([]);
+		stats.recentItems = [
+			{
+				id: "page-1",
+				collection: "pages",
+				collectionLabel: "Pages",
+				title: "Unexpected status",
+				slug: "unexpected-status",
+				status: "toString",
+				updatedAt: new Date().toISOString(),
+				authorId: null,
+			},
+		];
+		mockFetchDashboardStats.mockResolvedValue(stats);
+
+		const screen = await render(<Dashboard manifest={manifest} />);
+
+		await expect.element(screen.getByRole("img", { name: "Status: toString" })).toBeInTheDocument();
+	});
 });

--- a/packages/admin/tests/publish-button-locale.test.tsx
+++ b/packages/admin/tests/publish-button-locale.test.tsx
@@ -2,9 +2,9 @@
  * Reproduction for emdash-cms/emdash#1557 — "Bug with publish button when editing posts".
  *
  * Two reported symptoms, one root cause:
- *   1. After saving an edit to a published post, no "Publish updates" button appears
+ *   1. After saving an edit to a published post, no "Publish" button appears
  *      until the page is refreshed.
- *   2. After refreshing and publishing, the button stays active ("Publish updates")
+ *   2. After refreshing and publishing, the button stays active ("Publish")
  *      instead of flipping to "Unpublish Post".
  *
  * Root cause (hypothesis under test):
@@ -23,7 +23,7 @@
  * save flow (symptom #1).
  *
  * Expected: after publishing, the button becomes "Unpublish Post".
- * Actual (bug): the stale cache is never refetched, so it stays "Publish updates".
+ * Actual (bug): the stale cache is never refetched, so it stays "Publish".
  *
  * NOTE: this file deliberately does NOT mock ContentEditor (unlike router.test.tsx),
  * so the real publish-button logic renders.
@@ -135,7 +135,7 @@ describe("ContentEditPage – publish button stays in sync after publishing (#15
 			.on("GET", "/_emdash/api/auth/me", { data: { id: "user_01", role: 30 } })
 			.on("GET", "/_emdash/api/bylines", { data: { items: [] } })
 			.on("GET", "/_emdash/api/users", { data: { items: [] } })
-			// Initial state: published WITH pending draft changes -> "Publish updates" shows.
+			// Initial state: published WITH pending draft changes -> "Publish" shows.
 			.on("GET", "/_emdash/api/content/posts/post_1", { data: { item: publishedWithChanges() } })
 			.on("GET", "/_emdash/api/revisions/rev_draft", {
 				data: {
@@ -159,7 +159,7 @@ describe("ContentEditPage – publish button stays in sync after publishing (#15
 		mockFetch.restore();
 	});
 
-	it("flips 'Publish updates' to 'Unpublish Post' after a successful publish", async () => {
+	it("flips 'Publish' to 'Unpublish Post' after a successful publish", async () => {
 		const { router, TestApp } = buildRouter();
 
 		await router.navigate({
@@ -170,7 +170,7 @@ describe("ContentEditPage – publish button stays in sync after publishing (#15
 		const screen = await render(<TestApp />);
 
 		// The editor loads in the published-with-changes state.
-		const publishBtn = screen.getByRole("button", { name: "Publish updates" });
+		const publishBtn = screen.getByRole("button", { name: "Publish", exact: true });
 		await expect.element(publishBtn).toBeInTheDocument();
 
 		// After this point the server reports no pending changes (live === draft),
@@ -189,7 +189,7 @@ describe("ContentEditPage – publish button stays in sync after publishing (#15
 
 		// The button must now reflect the published state. With the locale-key
 		// mismatch the invalidation matches nothing, the stale item is never
-		// refetched, and this assertion fails because "Publish updates" is still
+		// refetched, and this assertion fails because "Publish" is still
 		// shown instead of "Unpublish Post".
 		await expect
 			.element(screen.getByRole("button", { name: "Unpublish Post" }))
@@ -241,7 +241,7 @@ describe("ContentEditPage – publish button appears after saving an edit (#1557
 			.on("GET", "/_emdash/api/bylines", { data: { items: [] } })
 			.on("GET", "/_emdash/api/users", { data: { items: [] } })
 			// Initial state: published, no pending changes -> "Unpublish Post" shows, no
-			// "Publish updates" button.
+			// "Publish" button.
 			.on("GET", "/_emdash/api/content/posts/post_1", { data: { item: publishedClean() } })
 			.on("GET", "/_emdash/api/revisions/rev_1", {
 				data: {
@@ -277,7 +277,7 @@ describe("ContentEditPage – publish button appears after saving an edit (#1557
 		mockFetch.restore();
 	});
 
-	it("shows 'Publish updates' after editing the title and saving", async () => {
+	it("shows 'Publish' after editing the title and saving", async () => {
 		const { router, TestApp } = buildRouter();
 
 		await router.navigate({
@@ -287,7 +287,7 @@ describe("ContentEditPage – publish button appears after saving an edit (#1557
 
 		const screen = await render(<TestApp />);
 
-		// Loads in the clean published state: "Unpublish Post" present, no "Publish updates".
+		// Loads in the clean published state: "Unpublish Post" present, no "Publish".
 		await expect
 			.element(screen.getByRole("button", { name: "Unpublish Post" }))
 			.toBeInTheDocument();
@@ -304,10 +304,10 @@ describe("ContentEditPage – publish button appears after saving an edit (#1557
 
 		// After saving, the editor must offer to publish the new draft. With the
 		// locale-key mismatch the invalidation matches nothing, the item is never
-		// refetched, and this assertion fails because no "Publish updates" button
+		// refetched, and this assertion fails because no "Publish" button
 		// is rendered until a hard refresh.
 		await expect
-			.element(screen.getByRole("button", { name: "Publish updates" }))
+			.element(screen.getByRole("button", { name: "Publish", exact: true }))
 			.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Normalizes content lifecycle presentation across the admin UI so status badges, compact labels, filters, actions, and Dashboard indicators use consistent wording, icons, and semantic Kumo colors.

- Uses `Publish` instead of mixed `Published` labels for the normalized published state.
- Adds a shared localized status component for Publish, Draft, Scheduled, Archived, Pending changes, and Private.
- Preserves the dashed-circle Draft icon with Kumo's native warning treatment.
- Normalizes recognized statuses for collections without draft support while retaining custom-status fallbacks.
- Covers list rows and filters, the content picker, editor settings, and Dashboard status indicators.

Related issue: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5.6 Sol), with GPT-5.6 Terra xhigh adversarial review

## Screenshots / test output

Verified:

- `pnpm typecheck`
- `pnpm lint`
- 90 focused Chromium tests across ContentStatusBadge, ContentList, ContentSettingsPanel, and Dashboard
- English and Arabic RTL behavior on the local admin UI

No locale catalog files are included; the normal extraction workflow can update them after merge.
