### PR TITLE
fix: preserve numbering across separated ordered-list segments

### DIFF
--- a/.changeset/fix-numbered-list-continuity.md
+++ b/.changeset/fix-numbered-list-continuity.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes numbered lists restarting at 1 after intervening content blocks in the editor and rendered pages.

--- a/docs/technical-specs/issue-2344-numbered-list-continuity.md
+++ b/docs/technical-specs/issue-2344-numbered-list-continuity.md
@@ -15,7 +15,7 @@ Add a persistent logical-list identity and base start to numbered Portable Text 
 - Recalculate later segment starts after items are inserted, deleted, or moved.
 - Preserve explicitly started lists, such as a list beginning at 2.
 - Keep independent and nested ordered lists independent.
-- Round-trip the behavior through the admin editor, inline visual editor, Portable Text, frontend rendering, and Markdown conversion where the format permits it.
+- Round-trip the behavior through the admin editor, inline visual editor, Portable Text, and frontend rendering.
 - Remain backward-compatible with existing Portable Text and third-party renderers.
 
 ## Non-goals
@@ -23,6 +23,7 @@ Add a persistent logical-list identity and base start to numbered Portable Text 
 - Do not make arbitrary blocks children of a single `<li>`. That requires a future structured rich-list block rather than flat Portable Text.
 - Do not rewrite existing content automatically or infer author intent across legacy separated lists.
 - Do not store Markdown-only hidden comments or add a database migration.
+- Do not synthesize numbered-list continuity metadata during Markdown import or export. Markdown cannot preserve independent logical identities reliably, especially across nested-list boundaries.
 - Do not change bullet-list behavior.
 - Do not change the Gutenberg importer or its output-only Portable Text types. It remains a legacy metadata-free producer; imported runs acquire identity when subsequently edited in EmDash.
 
@@ -46,7 +47,7 @@ For numbered blocks:
 - `listStart` is the logical list's base start, repeated on every numbered block carrying that `listId`. It is not the later segment's derived start.
 - The visible start of each segment is derived from its base plus the number of preceding direct items with the same `listId`.
 
-Apply the same validation contract in each conversion/rendering path. Core code uses one helper for its converters, inline editor, renderer, and Markdown client; the admin keeps a small local equivalent because `emdash` already depends on `@emdash-cms/admin` and the reverse dependency would be circular. Exercise both helpers with the same table of test vectors.
+Apply the same validation contract in each conversion/rendering path. Core code uses one helper for its converters, inline editor, and renderer; the admin keeps a small local equivalent because `emdash` already depends on `@emdash-cms/admin` and the reverse dependency would be circular. Exercise both helpers with the same table of test vectors.
 
 - A valid `listId` is a trimmed, non-empty string of at most 128 characters. Treat any other value as absent and never emit it into HTML.
 - A valid `listStart` is an integer from 1 through 2,147,483,647, matching the positive range consistently representable by `HTMLOListElement.start`. The derived `base + precedingDirectItemCount` must remain in that range; otherwise treat that malformed group's effective start as 1 rather than relying on browser-specific clamping.
@@ -58,7 +59,7 @@ Legacy numbered runs without a valid `listId` remain independent and start at 1.
 
 ### Numbering algorithm
 
-Use the same document-order algorithm in the editor, converters, renderer, and Markdown exporter:
+Use the same document-order algorithm in the editor, converters, and renderer:
 
 1. Canonicalize IDs and bases with the context and two-pass rules above.
 2. Build the same logical list tree used by the PT → PM converter, then traverse ordered-list nodes in document order. A segment is a maximal run at one tree position with the same list type, normalized identity, depth, and parent context; a non-list block, different ID/type, or context change ends it. Keep a counter per continuity scope: `listId`, nesting depth, and parent list-item context.
@@ -126,11 +127,7 @@ Third-party Portable Text renderers may ignore the additive fields and restart s
 
 ## Markdown boundary
 
-Markdown has no portable logical-list identity, so this conversion is intentionally lossy.
-
-- Portable Text to Markdown computes effective starts. Emit the actual effective number on every direct item marker in a numbered segment (`3.`, `4.`, …), preserving nested indentation and calculating nested groups independently. Insert a blank line between adjacent independent numbered segments at the same tree position so EmDash re-import does not merge them into one run. CommonMark itself treats blank-separated items as one loose list, so an external Markdown renderer may still coalesce adjacent independent runs; preserving that distinction portably would require a hidden separator, which is a stated non-goal.
-- Markdown to Portable Text captures the first numeric marker of each contiguous numbered run as its base and assigns a fresh ID to that run. A blank line or intervening non-list block starts a new independent group; conversion does not guess that separated runs were once related.
-- Do not add hidden metadata comments. A PT → Markdown → PT round trip preserves visible starts but not continuity relationships, so later edits to an earlier segment cannot renumber a formerly related later segment.
+Markdown has no portable logical-list identity. Keep the existing lossy import/export behavior and do not synthesize `listId` or `listStart`. Supporting continuity through Markdown is deferred because nested-list boundaries cannot reliably distinguish an independent root list from a continuation without non-portable metadata.
 
 ## Compatibility and rollout
 
@@ -155,7 +152,7 @@ Unit and integration tests must cover:
 - Legacy content, missing keys, overlong/empty IDs, IDs reused across root/nested contexts, conflicting bases, non-integer/negative starts, and overflow never throw or emit invalid HTML; editor normalization deterministically repairs incompatible duplicate contexts.
 - The admin editor and inline visual editor produce equivalent Portable Text.
 - Astro output contains the expected separate `<ol>` elements and later `start` value, separates adjacent different-ID lists at root and nested levels in both `html` and `direct` nesting modes, does not mutate its input, and honors a user `components.list.number` override.
-- Markdown asserts the exact source marker of every direct and nested numbered item and verifies that EmDash re-import separates blank-line and intervening-block boundaries. A CommonMark fixture documents that an external renderer may coalesce adjacent independent runs; cross-segment identity remains intentionally lossy.
+- Markdown import does not synthesize continuity metadata from ambiguous nested and root list sequences.
 - New controls are localized, keyboard-accessible, and usable in Arabic/RTL.
 - Existing bullet-list, list-nesting, and blockquote-grouping suites remain green; query-count snapshots do not change.
 
@@ -176,8 +173,8 @@ The PR should contain three reviewable commits. Each commit must keep types, tes
    - Add admin Continue/Restart controls with Lingui/Kumo and editor, collaboration, undo/redo, copy/paste, and RTL tests.
 
 3. **`fix(core): render continued ordered-list segments`**
-   - Add render preprocessing, identity-aware list-tree construction, `OrderedList.astro`, and Markdown behavior.
-   - Add Astro and Markdown tests, patch changesets for both packages, and verify query-count snapshots are unchanged.
+   - Add render preprocessing, identity-aware list-tree construction, and `OrderedList.astro`.
+   - Add Astro tests, patch changesets for both packages, and verify query-count snapshots are unchanged.
 
 ## Acceptance criteria
 

--- a/docs/technical-specs/issue-2344-numbered-list-continuity.md
+++ b/docs/technical-specs/issue-2344-numbered-list-continuity.md
@@ -1,6 +1,6 @@
 # Numbered-list continuity across blocks
 
-Status: Proposed  
+Status: Proposed
 Issue: [#2344](https://github.com/emdash-cms/emdash/issues/2344)
 
 ## Summary

--- a/docs/technical-specs/issue-2344-numbered-list-continuity.md
+++ b/docs/technical-specs/issue-2344-numbered-list-continuity.md
@@ -1,0 +1,184 @@
+# Numbered-list continuity across blocks
+
+Status: Proposed  
+Issue: [#2344](https://github.com/emdash-cms/emdash/issues/2344)
+
+## Summary
+
+EmDash currently serializes every ordered-list segment as a flat run of Portable Text blocks. When a paragraph, image, code block, or plugin block separates two runs, both the editor and frontend create a new `<ol>` starting at 1. The editor also drops TipTap's existing `orderedList.attrs.start` during Portable Text conversion.
+
+Add a persistent logical-list identity and base start to numbered Portable Text blocks. The editor will preserve that identity when a list is split, derive each segment's visible start from preceding segments, and expose explicit Continue numbering and Restart numbering actions. The frontend will render each segment as a semantic `<ol start="…">`. This is additive, requires no database migration, and leaves legacy content unchanged until it is edited.
+
+## Goals
+
+- Preserve numbering when arbitrary top-level blocks split an ordered list.
+- Recalculate later segment starts after items are inserted, deleted, or moved.
+- Preserve explicitly started lists, such as a list beginning at 2.
+- Keep independent and nested ordered lists independent.
+- Round-trip the behavior through the admin editor, inline visual editor, Portable Text, frontend rendering, and Markdown conversion where the format permits it.
+- Remain backward-compatible with existing Portable Text and third-party renderers.
+
+## Non-goals
+
+- Do not make arbitrary blocks children of a single `<li>`. That requires a future structured rich-list block rather than flat Portable Text.
+- Do not rewrite existing content automatically or infer author intent across legacy separated lists.
+- Do not store Markdown-only hidden comments or add a database migration.
+- Do not change bullet-list behavior.
+- Do not change the Gutenberg importer or its output-only Portable Text types. It remains a legacy metadata-free producer; imported runs acquire identity when subsequently edited in EmDash.
+
+## Data model
+
+Add two optional fields to the core converter, core client, admin editor, and inline editor Portable Text block shapes used by this feature:
+
+```ts
+interface PortableTextTextBlock {
+	// Existing fields omitted.
+	listItem?: "bullet" | "number";
+	level?: number;
+	listId?: string;
+	listStart?: number;
+}
+```
+
+For numbered blocks:
+
+- `listId` identifies one logical ordered list across non-adjacent segments. Generate IDs with `crypto.randomUUID()` when an author creates or pastes a list.
+- `listStart` is the logical list's base start, repeated on every numbered block carrying that `listId`. It is not the later segment's derived start.
+- The visible start of each segment is derived from its base plus the number of preceding direct items with the same `listId`.
+
+Apply the same validation contract in each conversion/rendering path. Core code uses one helper for its converters, inline editor, renderer, and Markdown client; the admin keeps a small local equivalent because `emdash` already depends on `@emdash-cms/admin` and the reverse dependency would be circular. Exercise both helpers with the same table of test vectors.
+
+- A valid `listId` is a trimmed, non-empty string of at most 128 characters. Treat any other value as absent and never emit it into HTML.
+- A valid `listStart` is an integer from 1 through 2,147,483,647, matching the positive range consistently representable by `HTMLOListElement.start`. The derived `base + precedingDirectItemCount` must remain in that range; otherwise treat that malformed group's effective start as 1 rather than relying on browser-specific clamping.
+- One `listId` may belong to only one nesting depth and parent context. If malformed input reuses it in an incompatible context, the first context keeps it and editor normalization deterministically assigns each later context a bounded replacement ID derived from the original ID and structural context; read-only conversion/rendering treats those contexts as separate without mutating stored input.
+- Resolve malformed conflicting `listStart` values with a two-pass scan per continuity scope: the first valid value in document order is that scope's canonical base; use 1 if none is valid. Saving rewrites every member to the canonical ID and base.
+- Ignore both fields on bullet blocks.
+
+Legacy numbered runs without a valid `listId` remain independent and start at 1. When loaded into an editor, derive a deterministic, document-scoped ID for each contiguous run from its run-start index, level, and first block `_key` when present. Do not use randomness for this fallback: two collaboration peers loading the same legacy value must create identical documents. The next save persists valid metadata. Separated legacy runs are not joined unless the author chooses Continue numbering.
+
+### Numbering algorithm
+
+Use the same document-order algorithm in the editor, converters, renderer, and Markdown exporter:
+
+1. Canonicalize IDs and bases with the context and two-pass rules above.
+2. Build the same logical list tree used by the PT → PM converter, then traverse ordered-list nodes in document order. A segment is a maximal run at one tree position with the same list type, normalized identity, depth, and parent context; a non-list block, different ID/type, or context change ends it. Keep a counter per continuity scope: `listId`, nesting depth, and parent list-item context.
+3. The first segment starts at the canonical base. Each later segment starts at `base + precedingDirectItemCount`.
+4. Increase the counter by the segment's direct `listItem` child count. Nested list items belong to their own list node and never increment an ancestor or sibling group's counter.
+
+For example, list A with two items, an image, then two more items renders with starts 1 and 3. Inserting an item into its first segment changes the second start to 4 without rewriting a fixed continuation value.
+
+## Editor behavior
+
+Replace StarterKit's ordered-list extension in both editors with package-local EmDash ordered-list extensions that implement the same contract. They cannot import one implementation without creating the existing `emdash` → `@emdash-cms/admin` dependency in reverse, so keep the core-inline and admin implementations small and lock them to the same behavioral fixtures. Retain TipTap's existing `start` attribute and add editor-only `listId` and `listStart` node attributes. Disable only `orderedList` in StarterKit to avoid duplicate node registrations.
+
+The extension owns these behaviors:
+
+- Creating a list with the toolbar, slash command, or `1.` input rule creates a fresh ID with base 1.
+- An `N.` input rule creates a fresh ID with base `N`.
+- Splitting a list around a paragraph or block preserves the original ID and base on both ordered-list nodes.
+- Continue numbering adopts the nearest preceding compatible ordered list's ID and base. Compatibility means the same nesting depth and the same parent `listItem` node; all document-root lists share one root context. Within that context only, rewrite the current segment and every later segment with its old ID, so its existing tail stays together. Disable the action if the selection spans more than one segment, no compatible predecessor exists, or the predecessor already has the same ID. Unrelated nested lists must not be linked.
+- Restart numbering assigns a fresh ID and base 1 to the segment containing the selection head and every later segment with its old ID in the same context. Disable it when the selection spans more than one segment. Earlier segments retain the old identity, making the current position the start of a new logical-list tail.
+- Adjacent ordered-list nodes with the same ID, base, depth, and parent context merge into one node. Different IDs do not merge.
+- A deterministic `appendTransaction` normalizer computes each ordered-list node's effective TipTap `start` attribute using the numbering algorithm and canonicalizes repeated `listStart` values. It must produce no transaction when the document is already normalized.
+- Random IDs are created only by user actions and paste handling. Never generate randomness in legacy conversion or the replicated normalizer; collaboration peers must derive the same normalized document.
+
+Copy/paste and movement have different identity semantics:
+
+- A custom ProseMirror clipboard serializer/parser carries source identity, logical base, and the first copied item's displayed ordinal in private `data-emdash-*` attributes in editor clipboard HTML. These attributes are accepted only by the editor parser, remapped before insertion, and never emitted by frontend rendering. This preserves metadata across an HTML clipboard round trip without depending on process-local slice objects.
+- A paste remaps every distinct incoming continuity scope to a fresh ID while preserving relationships among segments in that pasted slice. The first pasted segment's effective incoming `start`, not its repeated source `listStart`, becomes the new base and is stamped across the remapped group. Thus copying only a continuation displayed as item 3 pastes an independent list starting at 3 rather than 1. A clipboard slice beginning partway through a segment must likewise use the first copied item's displayed number. External lists without metadata receive fresh IDs per contiguous ordered-list run and preserve a valid HTML/TipTap start as their base.
+- An internal drag/move retains IDs only when its destination has the same depth and parent context. A context-changing move remaps the moved scope to a fresh ID whose base is its pre-move effective start; segments left in the source context retain their old ID.
+- Undo/redo restores IDs, bases, and derived starts as one user-visible operation.
+
+Expose Continue numbering and Restart numbering in the admin editor's ordered-list controls. Use Kumo components and Lingui for labels, descriptions, tooltips, and accessibility text; use logical Tailwind classes and verify the controls in an RTL locale. Continue is disabled when no compatible preceding list exists. Register the underlying commands in the inline visual editor as well, but do not introduce a second settings UI there; its existing create/split/save flows must still preserve continuity.
+
+## Portable Text conversion
+
+Update all three conversion implementations: the reusable core converters, the admin editor's local converters, and the inline visual editor's local converters.
+
+ProseMirror to Portable Text:
+
+- Read `listId` and logical `listStart` from each ordered-list node.
+- If an ordered-list node predates the extension, create a deterministic document-scoped ID from its structural position during serialization and use its valid TipTap `start` as the base when `listStart` is absent. This preserves explicitly started PM documents and makes the failing `start: 2` fixture meaningful.
+- Stamp both values on every numbered block produced from that node, including the blocks representing its direct items at the current level.
+- When descending into a nested ordered list, use that nested node's own metadata. Never copy the parent's identity into the nested group.
+- Do not write the effective TipTap `start` as `listStart`; persist the group base.
+
+Portable Text to ProseMirror:
+
+- Group a numbered run by list type, level/tree position, and canonical `listId`, not merely adjacency and `listItem` type.
+- Construct each ordered-list node with `listId`, canonical `listStart`, and the algorithm's effective `start`.
+- Use a deterministic key-derived ID for a legacy contiguous run where possible. Preserve its current start-at-1 behavior.
+- Preserve existing mixed bullet/number nesting rules and apply numbered metadata only to the ordered nodes at each nesting level.
+
+The first regression test must demonstrate the current failure: a ProseMirror ordered list with `start: 2` loses its start after PM → PT → PM. Make that test fail before implementing the conversion fix.
+
+## Frontend rendering
+
+On the static-render branch of `PortableText.astro`, deep-clone the JSON-shaped value before preprocessing and `groupBlockquoteRuns`; never mutate the caller's array, blocks, nested children, or mark definitions. The preprocessor canonicalizes metadata and counts numbered segments. The edit branch continues to pass the original value to `InlineEditor`, which performs its own conversion.
+
+`astro-portabletext` normally builds an internal `@list` tree by comparing only `level` and `listItem`, which would merge different IDs. Before rendering, build the complete `@list` tree for both bullet and numbered blocks using the caller's requested `listNestingMode` (`html` by default or `direct`) and the toolkit's semantics for that mode, plus one numbered-list rule: two numbered blocks match the same list node only when their canonical scoped identity also matches. Construct identity-aware nodes at every nesting depth, attach the derived effective start directly to each numbered `@list` node, and pass this tree to `astro-portabletext`; because it is already nested, the toolkit does not regroup the children. Adjacent same-ID runs merge, while different IDs remain separate even when nested.
+
+Add an EmDash `OrderedList.astro` component under `emdashComponents.list.number`. It reads the validated effective start from the `@list` node and renders `<ol start={start}>` when the start is not 1, otherwise a normal `<ol>`. It must forward the remaining safe component attributes and slot content. The identity-aware tree is render-only and never enters editor values or serialization.
+
+Component merge order remains EmDash defaults, then plugin components, then user components. A user's `components.list.number` override therefore continues to take priority over `OrderedList.astro`.
+
+Third-party Portable Text renderers may ignore the additive fields and restart separated segments at 1. That is an intentional graceful-degradation boundary; the stored content remains valid Portable Text.
+
+## Markdown boundary
+
+Markdown has no portable logical-list identity, so this conversion is intentionally lossy.
+
+- Portable Text to Markdown computes effective starts. Emit the actual effective number on every direct item marker in a numbered segment (`3.`, `4.`, …), preserving nested indentation and calculating nested groups independently. Insert a blank line between adjacent independent numbered segments at the same tree position so EmDash re-import does not merge them into one run. CommonMark itself treats blank-separated items as one loose list, so an external Markdown renderer may still coalesce adjacent independent runs; preserving that distinction portably would require a hidden separator, which is a stated non-goal.
+- Markdown to Portable Text captures the first numeric marker of each contiguous numbered run as its base and assigns a fresh ID to that run. A blank line or intervening non-list block starts a new independent group; conversion does not guess that separated runs were once related.
+- Do not add hidden metadata comments. A PT → Markdown → PT round trip preserves visible starts but not continuity relationships, so later edits to an earlier segment cannot renumber a formerly related later segment.
+
+## Compatibility and rollout
+
+- The fields are optional and additive; no database migration is required.
+- Existing content renders and edits as it does today. Authors can repair a separated legacy list with Continue numbering.
+- The change performs only in-memory document traversal and adds no database queries or logged-out-route round trips.
+- Add patch changesets for `emdash` and `@emdash-cms/admin`. User-facing release notes should say that numbered lists retain numbering across intervening content blocks.
+
+## Test plan
+
+Unit and integration tests must cover:
+
+- PM → PT → PM preserves a list explicitly starting at 2.
+- A 1/2/3 list split around a plain paragraph, formatted paragraph, code block, image, and representative plugin block continues at the correct value after save/reload.
+- Inserting or deleting an earlier item renumbers every later segment with the same ID.
+- A later independent list still starts at 1; adjacent same-ID runs merge and adjacent different-ID root runs stay separate.
+- Typed `2.` persists base 2; Continue and Restart produce the expected identities and starts, are disabled for multi-segment selections, and Continue is disabled for an already-linked predecessor.
+- Nested ordered lists have independent counters; mixed bullet/number nesting still round-trips without changing structure.
+- Copy/paste remaps identities, preserves relationships within the pasted slice, keeps a continuation-only or partial-list copy's displayed start, and does not join the source.
+- A same-context drag/move retains identity; a cross-context move gets a fresh identity and preserves its pre-move displayed start without rewriting the source scope.
+- Undo/redo and two collaboration peers converge without normalization loops or random-ID divergence.
+- Legacy content, missing keys, overlong/empty IDs, IDs reused across root/nested contexts, conflicting bases, non-integer/negative starts, and overflow never throw or emit invalid HTML; editor normalization deterministically repairs incompatible duplicate contexts.
+- The admin editor and inline visual editor produce equivalent Portable Text.
+- Astro output contains the expected separate `<ol>` elements and later `start` value, separates adjacent different-ID lists at root and nested levels in both `html` and `direct` nesting modes, does not mutate its input, and honors a user `components.list.number` override.
+- Markdown asserts the exact source marker of every direct and nested numbered item and verifies that EmDash re-import separates blank-line and intervening-block boundaries. A CommonMark fixture documents that an external renderer may coalesce adjacent independent runs; cross-segment identity remains intentionally lossy.
+- New controls are localized, keyboard-accessible, and usable in Arabic/RTL.
+- Existing bullet-list, list-nesting, and blockquote-grouping suites remain green; query-count snapshots do not change.
+
+Run the repository-required checks after each implementation commit: `pnpm lint:quick`, the affected Vitest suites, and package `pnpm typecheck`; then run formatting, full relevant tests, changeset validation, and `pnpm lint:json | jq '.diagnostics | length'` before the PR.
+
+## Implementation sequence
+
+The PR should contain three reviewable commits. Each commit must keep types, tests, and runtime code internally consistent.
+
+1. **`fix(portable-text): preserve logical numbered-list identity`**
+   - Add the optional block fields, core and admin validation/canonicalization helpers, shared test vectors, and numbering algorithm.
+   - Update the core, admin, and inline PM/PT conversion paths.
+   - Add the minimal EmDash ordered-list schema extension in both editors, declare `listId`/`listStart`, and disable StarterKit's duplicate ordered-list node so commit 1 can load and save the new attributes without stripping them.
+   - Add failing-first converter, legacy, malformed-input, and nesting tests.
+
+2. **`fix(editor): retain numbering when ordered lists are split`**
+   - Complete the EmDash ordered-list extension with the deterministic normalizer, identity-aware commands, paste remapping, and context-aware drag behavior in both editors.
+   - Add admin Continue/Restart controls with Lingui/Kumo and editor, collaboration, undo/redo, copy/paste, and RTL tests.
+
+3. **`fix(core): render continued ordered-list segments`**
+   - Add render preprocessing, identity-aware list-tree construction, `OrderedList.astro`, and Markdown behavior.
+   - Add Astro and Markdown tests, patch changesets for both packages, and verify query-count snapshots are unchanged.
+
+## Acceptance criteria
+
+The PR is complete when an author can create items 1 and 2, insert any supported top-level block, continue with items 3 and 4, save, reload, edit an earlier item, and see the same correct numbering in the admin editor, inline editor, and rendered Astro page. The stored blocks share one stable `listId` and base, independent lists do not join, legacy content remains readable, and all tests and repository checks above pass.

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -57,6 +57,7 @@
     "@tiptap/extension-dropcursor": "catalog:",
     "@tiptap/extension-focus": "catalog:",
     "@tiptap/extension-link": "catalog:",
+    "@tiptap/extension-list": "catalog:",
     "@tiptap/extension-node-range": "catalog:",
     "@tiptap/extension-placeholder": "catalog:",
     "@tiptap/extension-subscript": "catalog:",

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -124,6 +124,7 @@ import { HeadingDropdownMenu } from "./editor/HeadingDropdownMenu";
 import { HtmlBlockExtension } from "./editor/HtmlBlockNode";
 import { ImageExtension } from "./editor/ImageNode";
 import { MarkdownLinkExtension } from "./editor/MarkdownLinkExtension";
+import { EmDashOrderedList } from "./editor/ordered-list";
 import {
 	type PluginBlockDef,
 	PluginBlockExtension,
@@ -163,6 +164,8 @@ interface PortableTextTextBlock {
 	style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
 	listItem?: "bullet" | "number";
 	level?: number;
+	listId?: string;
+	listStart?: number;
 	children: PortableTextSpan[];
 	markDefs?: PortableTextMarkDef[];
 	textAlign?: "left" | "center" | "right" | "justify";
@@ -249,6 +252,64 @@ function sanitizeGalleryImages(value: unknown, withKeys = false): GalleryImage[]
 const attrStr = (v: unknown): string | undefined => (typeof v === "string" && v ? v : undefined);
 const attrNum = (v: unknown): number | undefined => (typeof v === "number" && v ? v : undefined);
 
+const MAX_ORDERED_LIST_START = 2_147_483_647;
+
+type OrderedListMetadata = { listId: string; listStart: number };
+type OrderedListCounter = OrderedListMetadata & { count: number };
+
+function normalizeListId(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim();
+	return normalized.length > 0 && normalized.length <= 128 ? normalized : undefined;
+}
+
+function normalizeListStart(value: unknown): number | undefined {
+	return typeof value === "number" &&
+		Number.isInteger(value) &&
+		value >= 1 &&
+		value <= MAX_ORDERED_LIST_START
+		? value
+		: undefined;
+}
+
+function deriveLegacyListId(seed: string): string {
+	const readable = `legacy:${seed}`;
+	if (readable.length <= 128) return readable;
+	let hash = 2_166_136_261;
+	for (let i = 0; i < seed.length; i++) {
+		hash ^= seed.charCodeAt(i);
+		hash = Math.imul(hash, 16_777_619);
+	}
+	return `legacy:${seed.slice(0, 96)}:${(hash >>> 0).toString(36)}:${seed.length.toString(36)}`;
+}
+
+function readOrderedListMetadata(
+	attrs: Record<string, unknown> | undefined,
+	fallbackId: string,
+): OrderedListMetadata {
+	return {
+		listId: normalizeListId(attrs?.listId) ?? deriveLegacyListId(fallbackId),
+		listStart: normalizeListStart(attrs?.listStart) ?? normalizeListStart(attrs?.start) ?? 1,
+	};
+}
+
+function takeOrderedListStart(
+	counters: Map<string, OrderedListCounter>,
+	metadata: OrderedListMetadata,
+	directItemCount: number,
+): number {
+	const current = counters.get(metadata.listId);
+	const listStart = current?.listStart ?? metadata.listStart;
+	const count = current?.count ?? 0;
+	const start = normalizeListStart(listStart + count) ?? 1;
+	counters.set(metadata.listId, {
+		...metadata,
+		listStart,
+		count: count + directItemCount,
+	});
+	return start;
+}
+
 // ProseMirror to Portable Text converter
 function prosemirrorToPortableText(doc: {
 	type: string;
@@ -266,8 +327,8 @@ function prosemirrorToPortableText(doc: {
 
 	const blocks: PortableTextBlock[] = [];
 
-	for (const node of doc.content) {
-		const converted = convertPMNode(node);
+	for (let i = 0; i < doc.content.length; i++) {
+		const converted = convertPMNode(doc.content[i]!, `root:${i}`);
 		if (converted) {
 			if (Array.isArray(converted)) {
 				blocks.push(...converted);
@@ -280,13 +341,16 @@ function prosemirrorToPortableText(doc: {
 	return blocks;
 }
 
-function convertPMNode(node: {
-	type: string;
-	attrs?: Record<string, unknown>;
-	content?: unknown[];
-	marks?: unknown[];
-	text?: string;
-}): PortableTextBlock | PortableTextBlock[] | null {
+function convertPMNode(
+	node: {
+		type: string;
+		attrs?: Record<string, unknown>;
+		content?: unknown[];
+		marks?: unknown[];
+		text?: string;
+	},
+	path: string,
+): PortableTextBlock | PortableTextBlock[] | null {
 	switch (node.type) {
 		case "paragraph": {
 			const { children, markDefs } = convertInlineContent(node.content || []);
@@ -325,10 +389,10 @@ function convertPMNode(node: {
 		}
 
 		case "bulletList":
-			return convertList(node.content || [], "bullet");
+			return convertList(node.content || [], "bullet", 1, node.attrs, path);
 
 		case "orderedList":
-			return convertList(node.content || [], "number");
+			return convertList(node.content || [], "number", 1, node.attrs, path);
 
 		case "blockquote": {
 			const blocks: PortableTextTextBlock[] = [];
@@ -505,17 +569,23 @@ function convertList(
 	items: unknown[],
 	listItem: "bullet" | "number",
 	level = 1,
+	attrs?: Record<string, unknown>,
+	path = `list:${level}`,
 ): PortableTextTextBlock[] {
 	const blocks: PortableTextTextBlock[] = [];
 	const typedItems = items as Array<{ type: string; content?: unknown[] }>;
+	const metadata = listItem === "number" ? readOrderedListMetadata(attrs, path) : undefined;
 
-	for (const item of typedItems) {
+	for (let itemIndex = 0; itemIndex < typedItems.length; itemIndex++) {
+		const item = typedItems[itemIndex]!;
 		if (item.type === "listItem") {
 			const listItemContent = (item.content || []) as Array<{
 				type: string;
+				attrs?: Record<string, unknown>;
 				content?: unknown[];
 			}>;
-			for (const child of listItemContent) {
+			for (let childIndex = 0; childIndex < listItemContent.length; childIndex++) {
+				const child = listItemContent[childIndex]!;
 				if (child.type === "paragraph") {
 					const { children, markDefs } = convertInlineContent(child.content || []);
 					if (children.length > 0) {
@@ -525,14 +595,31 @@ function convertList(
 							style: "normal",
 							listItem,
 							level,
+							...metadata,
 							children,
 							markDefs: markDefs.length > 0 ? markDefs : undefined,
 						});
 					}
 				} else if (child.type === "bulletList") {
-					blocks.push(...convertList(child.content || [], "bullet", level + 1));
+					blocks.push(
+						...convertList(
+							child.content || [],
+							"bullet",
+							level + 1,
+							child.attrs,
+							`${path}:${itemIndex}:${childIndex}`,
+						),
+					);
 				} else if (child.type === "orderedList") {
-					blocks.push(...convertList(child.content || [], "number", level + 1));
+					blocks.push(
+						...convertList(
+							child.content || [],
+							"number",
+							level + 1,
+							child.attrs,
+							`${path}:${itemIndex}:${childIndex}`,
+						),
+					);
 				}
 			}
 		}
@@ -662,6 +749,8 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 	}
 
 	const content: unknown[] = [];
+	const counters = new Map<string, OrderedListCounter>();
+	const canonicalStarts = collectCanonicalStarts(blocks);
 	let i = 0;
 
 	while (i < blocks.length) {
@@ -670,6 +759,8 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 		if (isTextBlock(block) && block.listItem) {
 			const listBlocks: PortableTextTextBlock[] = [];
 			const listType = block.listItem;
+			const runStart = i;
+			const rootId = listType === "number" ? normalizeListId(block.listId) : undefined;
 
 			// A list "run" is a level=1 anchor block plus everything that nests
 			// under it (level > 1) or repeats it at the same root level/type.
@@ -678,7 +769,13 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 				const current = blocks[i]!;
 				if (!isTextBlock(current) || !current.listItem) break;
 				const level = current.level || 1;
-				if (level > 1 || current.listItem === listType) {
+				const currentId =
+					current.listItem === "number" ? normalizeListId(current.listId) : undefined;
+				const sameRootIdentity =
+					listType !== "number" ||
+					level > 1 ||
+					(rootId ? currentId === rootId : currentId === undefined);
+				if (level > 1 || (current.listItem === listType && sameRootIdentity)) {
 					listBlocks.push(current);
 					i++;
 				} else {
@@ -686,7 +783,9 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 				}
 			}
 
-			content.push(convertPTList(listBlocks, listType));
+			content.push(
+				convertPTList(listBlocks, listType, counters, canonicalStarts, `root:${runStart}`),
+			);
 		} else {
 			const converted = convertPTBlock(block);
 			if (converted) {
@@ -700,6 +799,45 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 		type: "doc",
 		content: content.length > 0 ? content : [{ type: "paragraph" }],
 	};
+}
+
+function collectCanonicalStarts(blocks: PortableTextBlock[]): Map<string, number> {
+	const starts = new Map<string, number>();
+	for (const block of blocks) {
+		if (!isTextBlock(block) || block.listItem !== "number") continue;
+		const listId = normalizeListId(block.listId);
+		const listStart = normalizeListStart(block.listStart);
+		if (listId && listStart !== undefined && !starts.has(listId)) {
+			starts.set(listId, listStart);
+		}
+	}
+	return starts;
+}
+
+function getListMetadata(
+	item: PortableTextTextBlock,
+	canonicalStarts: Map<string, number>,
+	fallbackSeed: string,
+): OrderedListMetadata {
+	const listId = normalizeListId(item.listId) ?? deriveLegacyListId(fallbackSeed);
+	return {
+		listId,
+		listStart: canonicalStarts.get(listId) ?? normalizeListStart(item.listStart) ?? 1,
+	};
+}
+
+function belongsToNestedGroup(
+	item: PortableTextTextBlock,
+	minLevel: number,
+	parentListType: "bullet" | "number",
+	anchorType: "bullet" | "number",
+	anchorId: string | undefined,
+): boolean {
+	if ((item.level || 2) > minLevel) return true;
+	if ((item.listItem || parentListType) !== anchorType) return false;
+	if (anchorType !== "number") return true;
+	const itemId = normalizeListId(item.listId);
+	return anchorId ? itemId === anchorId : itemId === undefined;
 }
 
 function convertPTBlock(block: PortableTextBlock): unknown {
@@ -918,7 +1056,13 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 	}
 }
 
-function convertPTList(items: PortableTextTextBlock[], listType: "bullet" | "number"): unknown {
+function convertPTList(
+	items: PortableTextTextBlock[],
+	listType: "bullet" | "number",
+	counters: Map<string, OrderedListCounter>,
+	canonicalStarts: Map<string, number>,
+	context: string,
+): unknown {
 	// Group items into root-level items (level === 1) and their nested
 	// descendants (level > 1). For each root item, all subsequent items with
 	// level > 1 belong to its nested subtree — recurse on them with level
@@ -937,17 +1081,43 @@ function convertPTList(items: PortableTextTextBlock[], listType: "bullet" | "num
 				nestedItems.push(items[i]!);
 				i++;
 			}
-			rootItems.push(convertPTListItem(item, nestedItems, listType));
+			rootItems.push(
+				convertPTListItem(
+					item,
+					nestedItems,
+					listType,
+					counters,
+					canonicalStarts,
+					`${context}:${rootItems.length}`,
+				),
+			);
 		} else {
 			// Orphan nested item with no preceding level=1 anchor — treat as root
 			// so we don't drop content.
-			rootItems.push(convertPTListItem(item, [], listType));
+			rootItems.push(
+				convertPTListItem(
+					item,
+					[],
+					listType,
+					counters,
+					canonicalStarts,
+					`${context}:${rootItems.length}`,
+				),
+			);
 			i++;
 		}
 	}
 
+	const firstItem = items[0]!;
+	const metadata =
+		listType === "number"
+			? getListMetadata(firstItem, canonicalStarts, `${context}:${firstItem._key}`)
+			: undefined;
+	const start = metadata ? takeOrderedListStart(counters, metadata, rootItems.length) : undefined;
+
 	return {
 		type: listType === "bullet" ? "bulletList" : "orderedList",
+		attrs: metadata ? { ...metadata, start } : undefined,
 		content: rootItems,
 	};
 }
@@ -956,6 +1126,9 @@ function convertPTListItem(
 	item: PortableTextTextBlock,
 	nestedItems: PortableTextTextBlock[],
 	parentListType: "bullet" | "number",
+	counters: Map<string, OrderedListCounter>,
+	canonicalStarts: Map<string, number>,
+	context: string,
 ): unknown {
 	const content: unknown[] = [];
 
@@ -984,6 +1157,8 @@ function convertPTListItem(
 		let j = 0;
 		while (j < nestedItems.length) {
 			const anchorType: "bullet" | "number" = nestedItems[j]!.listItem || parentListType;
+			const anchorId =
+				anchorType === "number" ? normalizeListId(nestedItems[j]!.listId) : undefined;
 			const nestedGroup: PortableTextTextBlock[] = [];
 
 			do {
@@ -991,8 +1166,7 @@ function convertPTListItem(
 				j++;
 			} while (
 				j < nestedItems.length &&
-				((nestedItems[j]!.level || 2) > minLevel ||
-					(nestedItems[j]!.listItem || parentListType) === anchorType)
+				belongsToNestedGroup(nestedItems[j]!, minLevel, parentListType, anchorType, anchorId)
 			);
 
 			if (nestedGroup.length > 0) {
@@ -1000,7 +1174,15 @@ function convertPTListItem(
 					...ni,
 					level: (ni.level || 2) - 1,
 				}));
-				content.push(convertPTList(adjustedGroup, anchorType));
+				content.push(
+					convertPTList(
+						adjustedGroup,
+						anchorType,
+						counters,
+						canonicalStarts,
+						`${context}:nested:${j - nestedGroup.length}`,
+					),
+				);
 			}
 		}
 	}
@@ -2547,6 +2729,7 @@ export function PortableTextEditor({
 				codeBlock: false,
 				// Replaced with CodeMarkExtension so inline code can combine with link/etc.
 				code: false,
+				orderedList: false,
 				// StarterKit v3 includes Link and Underline
 				link: {
 					openOnClick: false,
@@ -2557,6 +2740,7 @@ export function PortableTextEditor({
 				},
 				underline: {},
 			}),
+			EmDashOrderedList,
 			CodeMarkExtension,
 			CodeBlockExtension,
 			HtmlBlockExtension,

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -255,7 +255,13 @@ const attrNum = (v: unknown): number | undefined => (typeof v === "number" && v 
 const MAX_ORDERED_LIST_START = 2_147_483_647;
 
 type OrderedListMetadata = { listId: string; listStart: number };
-type OrderedListCounter = OrderedListMetadata & { count: number };
+type PortableTextProseMirrorNode = {
+	type: string;
+	attrs?: Record<string, unknown>;
+	content?: PortableTextProseMirrorNode[];
+	marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
+	text?: string;
+};
 
 function normalizeListId(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
@@ -293,21 +299,111 @@ function readOrderedListMetadata(
 	};
 }
 
-function takeOrderedListStart(
-	counters: Map<string, OrderedListCounter>,
-	metadata: OrderedListMetadata,
-	directItemCount: number,
-): number {
-	const current = counters.get(metadata.listId);
-	const listStart = current?.listStart ?? metadata.listStart;
-	const count = current?.count ?? 0;
-	const start = normalizeListStart(listStart + count) ?? 1;
-	counters.set(metadata.listId, {
-		...metadata,
-		listStart,
-		count: count + directItemCount,
+function clonePortableTextProseMirrorNode(
+	node: PortableTextProseMirrorNode,
+): PortableTextProseMirrorNode {
+	return {
+		...node,
+		attrs: node.attrs ? { ...node.attrs } : undefined,
+		content: node.content?.map(clonePortableTextProseMirrorNode),
+		marks: node.marks?.map((mark) => ({
+			...mark,
+			attrs: mark.attrs ? { ...mark.attrs } : undefined,
+		})),
+	};
+}
+
+function normalizeOrderedListJson(doc: { type: "doc"; content: PortableTextProseMirrorNode[] }): {
+	type: "doc";
+	content: PortableTextProseMirrorNode[];
+} {
+	type Descriptor = {
+		node: PortableTextProseMirrorNode;
+		path: string;
+		depth: number;
+		context: string;
+	};
+	const normalized = {
+		...doc,
+		content: doc.content.map(clonePortableTextProseMirrorNode),
+	};
+	const lists: Descriptor[] = [];
+	const visit = (
+		node: PortableTextProseMirrorNode,
+		path: string,
+		depth: number,
+		context: string,
+	) => {
+		if (node.type === "orderedList") lists.push({ node, path, depth, context });
+		for (const [index, child] of (node.content ?? []).entries()) {
+			const childPath = `${path}:${index}`;
+			visit(
+				child,
+				childPath,
+				depth + 1,
+				child.type === "listItem" ? `listItem:${childPath}` : context,
+			);
+		}
+	};
+	for (const [index, node] of normalized.content.entries()) {
+		visit(node, `root:${index}`, 0, "root");
+	}
+
+	const canonicalBySourceScope = new Map<string, string>();
+	const assignedIds = new Set<string>();
+	const descriptors = lists.map((list) => {
+		const sourceId =
+			normalizeListId(list.node.attrs?.listId) ??
+			deriveLegacyListId(`pm-json:${list.path}:${list.depth}:${list.context}`);
+		const scope = JSON.stringify([list.depth, list.context]);
+		const sourceScope = JSON.stringify([sourceId, scope]);
+		let listId = canonicalBySourceScope.get(sourceScope);
+		if (!listId) {
+			if (!assignedIds.has(sourceId)) {
+				listId = sourceId;
+			} else {
+				let attempt = 0;
+				do {
+					const suffix = `:${attempt.toString(36)}`;
+					const base = deriveLegacyListId(`repair:${sourceId}:${scope}`);
+					listId = `${base.slice(0, 128 - suffix.length)}${suffix}`;
+					attempt++;
+				} while (assignedIds.has(listId));
+			}
+			canonicalBySourceScope.set(sourceScope, listId);
+			assignedIds.add(listId);
+		}
+		return {
+			...list,
+			listId,
+			scopeKey: JSON.stringify([listId, list.depth, list.context]),
+		};
 	});
-	return start;
+
+	const bases = new Map<string, number>();
+	for (const list of descriptors) {
+		const listStart = normalizeListStart(list.node.attrs?.listStart);
+		if (listStart !== undefined && !bases.has(list.scopeKey)) {
+			bases.set(list.scopeKey, listStart);
+		}
+	}
+	for (const list of descriptors) {
+		if (!bases.has(list.scopeKey)) {
+			bases.set(list.scopeKey, normalizeListStart(list.node.attrs?.start) ?? 1);
+		}
+	}
+
+	const counts = new Map<string, number>();
+	for (const list of descriptors) {
+		const listStart = bases.get(list.scopeKey)!;
+		const count = counts.get(list.scopeKey) ?? 0;
+		const start = normalizeListStart(listStart + count) ?? 1;
+		const directItemCount =
+			list.node.content?.filter((node) => node.type === "listItem").length ?? 0;
+		counts.set(list.scopeKey, count + directItemCount);
+		list.node.attrs = { ...list.node.attrs, listId: list.listId, listStart, start };
+	}
+	return normalized;
 }
 
 // ProseMirror to Portable Text converter
@@ -749,8 +845,6 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 	}
 
 	const content: unknown[] = [];
-	const counters = new Map<string, OrderedListCounter>();
-	const canonicalStarts = collectCanonicalStarts(blocks);
 	let i = 0;
 
 	while (i < blocks.length) {
@@ -783,9 +877,7 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 				}
 			}
 
-			content.push(
-				convertPTList(listBlocks, listType, counters, canonicalStarts, `root:${runStart}`),
-			);
+			content.push(convertPTList(listBlocks, listType, `root:${runStart}`));
 		} else {
 			const converted = convertPTBlock(block);
 			if (converted) {
@@ -795,34 +887,23 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 		}
 	}
 
-	return {
+	return normalizeOrderedListJson({
 		type: "doc",
-		content: content.length > 0 ? content : [{ type: "paragraph" }],
-	};
-}
-
-function collectCanonicalStarts(blocks: PortableTextBlock[]): Map<string, number> {
-	const starts = new Map<string, number>();
-	for (const block of blocks) {
-		if (!isTextBlock(block) || block.listItem !== "number") continue;
-		const listId = normalizeListId(block.listId);
-		const listStart = normalizeListStart(block.listStart);
-		if (listId && listStart !== undefined && !starts.has(listId)) {
-			starts.set(listId, listStart);
-		}
-	}
-	return starts;
+		content: (content.length > 0
+			? content
+			: [{ type: "paragraph" }]) as PortableTextProseMirrorNode[],
+	});
 }
 
 function getListMetadata(
 	item: PortableTextTextBlock,
-	canonicalStarts: Map<string, number>,
 	fallbackSeed: string,
-): OrderedListMetadata {
+): { listId: string; listStart?: number } {
 	const listId = normalizeListId(item.listId) ?? deriveLegacyListId(fallbackSeed);
+	const listStart = normalizeListStart(item.listStart);
 	return {
 		listId,
-		listStart: canonicalStarts.get(listId) ?? normalizeListStart(item.listStart) ?? 1,
+		...(listStart === undefined ? {} : { listStart }),
 	};
 }
 
@@ -1059,8 +1140,6 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 function convertPTList(
 	items: PortableTextTextBlock[],
 	listType: "bullet" | "number",
-	counters: Map<string, OrderedListCounter>,
-	canonicalStarts: Map<string, number>,
 	context: string,
 ): unknown {
 	// Group items into root-level items (level === 1) and their nested
@@ -1082,42 +1161,23 @@ function convertPTList(
 				i++;
 			}
 			rootItems.push(
-				convertPTListItem(
-					item,
-					nestedItems,
-					listType,
-					counters,
-					canonicalStarts,
-					`${context}:${rootItems.length}`,
-				),
+				convertPTListItem(item, nestedItems, listType, `${context}:${rootItems.length}`),
 			);
 		} else {
 			// Orphan nested item with no preceding level=1 anchor — treat as root
 			// so we don't drop content.
-			rootItems.push(
-				convertPTListItem(
-					item,
-					[],
-					listType,
-					counters,
-					canonicalStarts,
-					`${context}:${rootItems.length}`,
-				),
-			);
+			rootItems.push(convertPTListItem(item, [], listType, `${context}:${rootItems.length}`));
 			i++;
 		}
 	}
 
 	const firstItem = items[0]!;
 	const metadata =
-		listType === "number"
-			? getListMetadata(firstItem, canonicalStarts, `${context}:${firstItem._key}`)
-			: undefined;
-	const start = metadata ? takeOrderedListStart(counters, metadata, rootItems.length) : undefined;
+		listType === "number" ? getListMetadata(firstItem, `${context}:${firstItem._key}`) : undefined;
 
 	return {
 		type: listType === "bullet" ? "bulletList" : "orderedList",
-		attrs: metadata ? { ...metadata, start } : undefined,
+		attrs: metadata ? { ...metadata, start: metadata.listStart ?? 1 } : undefined,
 		content: rootItems,
 	};
 }
@@ -1126,8 +1186,6 @@ function convertPTListItem(
 	item: PortableTextTextBlock,
 	nestedItems: PortableTextTextBlock[],
 	parentListType: "bullet" | "number",
-	counters: Map<string, OrderedListCounter>,
-	canonicalStarts: Map<string, number>,
 	context: string,
 ): unknown {
 	const content: unknown[] = [];
@@ -1175,13 +1233,7 @@ function convertPTListItem(
 					level: (ni.level || 2) - 1,
 				}));
 				content.push(
-					convertPTList(
-						adjustedGroup,
-						anchorType,
-						counters,
-						canonicalStarts,
-						`${context}:nested:${j - nestedGroup.length}`,
-					),
+					convertPTList(adjustedGroup, anchorType, `${context}:nested:${j - nestedGroup.length}`),
 				);
 			}
 		}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -3730,6 +3730,7 @@ function EditorToolbar({
 		editor,
 		selector: (ctx) => {
 			const textAlignment = getSelectionTextAlignment(ctx.editor);
+			const isOrderedList = ctx.editor.isActive("orderedList");
 			return {
 				isBold: ctx.editor.isActive("bold"),
 				isItalic: ctx.editor.isActive("italic"),
@@ -3739,7 +3740,9 @@ function EditorToolbar({
 				isSuperscript: ctx.editor.isActive("superscript"),
 				isCode: ctx.editor.isActive("code"),
 				isBulletList: ctx.editor.isActive("bulletList"),
-				isOrderedList: ctx.editor.isActive("orderedList"),
+				isOrderedList,
+				canContinueOrderedList: isOrderedList && ctx.editor.can().continueOrderedList(),
+				canRestartOrderedList: isOrderedList && ctx.editor.can().restartOrderedList(),
 				isBlockquote: ctx.editor.isActive("blockquote"),
 				isCodeBlock: ctx.editor.isActive("codeBlock"),
 				isAlignLeft: textAlignment === "left",
@@ -3938,6 +3941,24 @@ function EditorToolbar({
 				>
 					<ListNumbers className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
+				{editorState.isOrderedList && (
+					<>
+						<ToolbarButton
+							onClick={() => editor.chain().focus().continueOrderedList().run()}
+							disabled={!editorState.canContinueOrderedList}
+							title={t`Continue numbering`}
+						>
+							<ArrowUUpRight className="h-4 w-4 rtl:-scale-x-100" aria-hidden="true" />
+						</ToolbarButton>
+						<ToolbarButton
+							onClick={() => editor.chain().focus().restartOrderedList().run()}
+							disabled={!editorState.canRestartOrderedList}
+							title={t`Restart numbering`}
+						>
+							<ArrowUUpLeft className="h-4 w-4 rtl:-scale-x-100" aria-hidden="true" />
+						</ToolbarButton>
+					</>
+				)}
 				<ToolbarButton
 					onClick={() => editor.chain().focus().toggleBlockquote().run()}
 					active={editorState.isBlockquote}

--- a/packages/admin/src/components/editor/ordered-list.ts
+++ b/packages/admin/src/components/editor/ordered-list.ts
@@ -72,6 +72,10 @@ function collectLists(doc: ProseMirrorNode): ListDescriptor[] {
 				break;
 			}
 		}
+		if (contextPos === null && resolved.depth > 0) {
+			contextPos = resolved.before(resolved.depth);
+			context = `${resolved.node(resolved.depth).type.name}:${contextPos}`;
+		}
 		lists.push({ node, pos, depth: resolved.depth, context, contextPos });
 	});
 	return lists;

--- a/packages/admin/src/components/editor/ordered-list.ts
+++ b/packages/admin/src/components/editor/ordered-list.ts
@@ -1,0 +1,17 @@
+import { OrderedList } from "@tiptap/extension-list";
+
+export const EmDashOrderedList = OrderedList.extend({
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			listId: {
+				default: null,
+				rendered: false,
+			},
+			listStart: {
+				default: null,
+				rendered: false,
+			},
+		};
+	},
+});

--- a/packages/admin/src/components/editor/ordered-list.ts
+++ b/packages/admin/src/components/editor/ordered-list.ts
@@ -1,17 +1,509 @@
+import { mergeAttributes, wrappingInputRule } from "@tiptap/core";
 import { OrderedList } from "@tiptap/extension-list";
+import { Fragment, type Node as ProseMirrorNode, Slice } from "@tiptap/pm/model";
+import { Plugin, Selection, type EditorState, type Transaction } from "@tiptap/pm/state";
+import { canJoin, dropPoint } from "@tiptap/pm/transform";
+import type { EditorView } from "@tiptap/pm/view";
+
+const ORDERED_LIST_INPUT_REGEX = /^(\d+)\.\s$/;
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		orderedListContinuity: {
+			continueOrderedList: () => ReturnType;
+			restartOrderedList: () => ReturnType;
+		};
+	}
+}
+
+const MAX_START = 2_147_483_647;
+const normalizeId = (value: unknown): string | undefined => {
+	if (typeof value !== "string") return undefined;
+	const id = value.trim();
+	return id.length > 0 && id.length <= 128 ? id : undefined;
+};
+const normalizeStart = (value: unknown): number | undefined =>
+	typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= MAX_START
+		? value
+		: undefined;
+const legacyId = (seed: string): string => {
+	const readable = `legacy:${seed}`;
+	if (readable.length <= 128) return readable;
+	let hash = 2_166_136_261;
+	for (let i = 0; i < seed.length; i++) {
+		hash ^= seed.charCodeAt(i);
+		hash = Math.imul(hash, 16_777_619);
+	}
+	return `legacy:${seed.slice(0, 96)}:${(hash >>> 0).toString(36)}:${seed.length.toString(36)}`;
+};
+const createId = (): string =>
+	globalThis.crypto?.randomUUID?.() ??
+	`list-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+const createRepairId = (sourceId: string, scope: string, attempt: number): string => {
+	const base = legacyId(`repair:${sourceId}:${scope}`);
+	const suffix = `:${attempt.toString(36)}`;
+	return `${base.slice(0, 128 - suffix.length)}${suffix}`;
+};
+
+interface ListDescriptor {
+	node: ProseMirrorNode;
+	pos: number;
+	depth: number;
+	context: string;
+	contextPos: number | null;
+}
+
+export interface OrderedListNormalization {
+	pos: number;
+	attrs: Record<string, unknown>;
+}
+
+function collectLists(doc: ProseMirrorNode): ListDescriptor[] {
+	const lists: ListDescriptor[] = [];
+	doc.descendants((node, pos) => {
+		if (node.type.name !== "orderedList") return;
+		const resolved = doc.resolve(pos);
+		let context = "root";
+		let contextPos: number | null = null;
+		for (let depth = resolved.depth; depth > 0; depth--) {
+			if (resolved.node(depth).type.name === "listItem") {
+				contextPos = resolved.before(depth);
+				context = `listItem:${contextPos}`;
+				break;
+			}
+		}
+		lists.push({ node, pos, depth: resolved.depth, context, contextPos });
+	});
+	return lists;
+}
+
+export function normalizeOrderedListDocument(doc: ProseMirrorNode): OrderedListNormalization[] {
+	const canonicalBySourceScope = new Map<string, string>();
+	const assignedCanonicalIds = new Set<string>();
+	const lists = collectLists(doc).map((list) => {
+		const sourceId =
+			normalizeId(list.node.attrs.listId) ??
+			legacyId(`pm:${list.pos}:${list.depth}:${list.context}`);
+		const scope = JSON.stringify([list.depth, list.context]);
+		const sourceScope = JSON.stringify([sourceId, scope]);
+		let listId = canonicalBySourceScope.get(sourceScope);
+		if (!listId) {
+			if (!assignedCanonicalIds.has(sourceId)) {
+				listId = sourceId;
+			} else {
+				let attempt = 0;
+				do {
+					listId = createRepairId(sourceId, scope, attempt++);
+				} while (assignedCanonicalIds.has(listId));
+			}
+			canonicalBySourceScope.set(sourceScope, listId);
+			assignedCanonicalIds.add(listId);
+		}
+		return {
+			...list,
+			listId,
+			scopeKey: JSON.stringify([listId, list.depth, list.context]),
+		};
+	});
+	const bases = new Map<string, number>();
+	for (const list of lists) {
+		const start = normalizeStart(list.node.attrs.listStart);
+		if (start !== undefined && !bases.has(list.scopeKey)) bases.set(list.scopeKey, start);
+	}
+	for (const list of lists) {
+		if (!bases.has(list.scopeKey))
+			bases.set(list.scopeKey, normalizeStart(list.node.attrs.start) ?? 1);
+	}
+	const counts = new Map<string, number>();
+	const changes: OrderedListNormalization[] = [];
+	for (const list of lists) {
+		const listStart = bases.get(list.scopeKey)!;
+		const count = counts.get(list.scopeKey) ?? 0;
+		const start = normalizeStart(listStart + count) ?? 1;
+		counts.set(list.scopeKey, count + list.node.childCount);
+		if (
+			list.node.attrs.listId !== list.listId ||
+			list.node.attrs.listStart !== listStart ||
+			list.node.attrs.start !== start
+		) {
+			changes.push({
+				pos: list.pos,
+				attrs: { ...list.node.attrs, listId: list.listId, listStart, start },
+			});
+		}
+	}
+	return changes;
+}
+
+function normalizeTransaction(state: EditorState): Transaction | null {
+	const changes = normalizeOrderedListDocument(state.doc);
+	if (changes.length === 0) {
+		const lists = collectLists(state.doc);
+		const hasJoin = lists.some((list, index) => {
+			const next = lists[index + 1];
+			return (
+				next !== undefined &&
+				next.pos === list.pos + list.node.nodeSize &&
+				next.depth === list.depth &&
+				next.context === list.context &&
+				normalizeId(next.node.attrs.listId) === normalizeId(list.node.attrs.listId) &&
+				normalizeStart(next.node.attrs.listStart) === normalizeStart(list.node.attrs.listStart)
+			);
+		});
+		if (!hasJoin) return null;
+	}
+	const transaction = state.tr;
+	for (const change of changes) transaction.setNodeMarkup(change.pos, undefined, change.attrs);
+	const normalizedLists = collectLists(transaction.doc);
+	const joinPositions = normalizedLists.flatMap((list, index) => {
+		const next = normalizedLists[index + 1];
+		return next !== undefined &&
+			next.pos === list.pos + list.node.nodeSize &&
+			next.depth === list.depth &&
+			next.context === list.context &&
+			normalizeId(next.node.attrs.listId) === normalizeId(list.node.attrs.listId) &&
+			normalizeStart(next.node.attrs.listStart) === normalizeStart(list.node.attrs.listStart)
+			? [next.pos]
+			: [];
+	});
+	for (const pos of joinPositions.toReversed()) {
+		if (canJoin(transaction.doc, pos)) transaction.join(pos);
+	}
+	if (!transaction.docChanged) return null;
+	return transaction;
+}
+
+function remapPaste(slice: Slice): Slice {
+	const identities = new Map<string, { listId: string; listStart: number }>();
+	let missingIndex = 0;
+	const mapFragment = (fragment: Fragment, depth: number, parentContext: string): Fragment => {
+		const children: ProseMirrorNode[] = [];
+		fragment.forEach((node, _offset, index) => {
+			const childContext =
+				node.type.name === "listItem" ? `${parentContext}/listItem:${index}` : parentContext;
+			const content = mapFragment(node.content, depth + 1, childContext);
+			if (node.type.name !== "orderedList") {
+				children.push(node.copy(content));
+				return;
+			}
+			const sourceId = normalizeId(node.attrs.listId) ?? `missing:${missingIndex++}`;
+			const scope = JSON.stringify([sourceId, depth, parentContext]);
+			let identity = identities.get(scope);
+			if (!identity) {
+				identity = {
+					listId: createId(),
+					listStart: normalizeStart(node.attrs.start) ?? normalizeStart(node.attrs.listStart) ?? 1,
+				};
+				identities.set(scope, identity);
+			}
+			children.push(
+				node.type.create(
+					{ ...node.attrs, ...identity, start: identity.listStart },
+					content,
+					node.marks,
+				),
+			);
+		});
+		return Fragment.fromArray(children);
+	};
+	return new Slice(mapFragment(slice.content, 0, "root"), slice.openStart, slice.openEnd);
+}
+
+function sliceHasOrderedList(slice: Slice): boolean {
+	let found = false;
+	slice.content.descendants((node) => {
+		if (node.type.name !== "orderedList") return true;
+		found = true;
+		return false;
+	});
+	return found;
+}
+
+function displayedStartAtSelection(
+	state: EditorState,
+): { listId: string; listStart: number } | null {
+	const current = collectLists(state.doc).findLast(
+		(list) =>
+			state.selection.from >= list.pos && state.selection.from <= list.pos + list.node.nodeSize,
+	);
+	if (!current) return null;
+	const listId = normalizeId(current.node.attrs.listId);
+	const start = normalizeStart(current.node.attrs.start);
+	if (!listId || start === undefined) return null;
+	let precedingItems = 0;
+	current.node.forEach((child, offset) => {
+		if (current.pos + 1 + offset + child.nodeSize <= state.selection.from) precedingItems++;
+	});
+	return { listId, listStart: normalizeStart(start + precedingItems) ?? 1 };
+}
+
+function rewriteSliceIdentity(
+	slice: Slice,
+	sourceId: string,
+	listId: string,
+	listStart: number,
+): Slice {
+	const mapFragment = (fragment: Fragment): Fragment => {
+		const children: ProseMirrorNode[] = [];
+		fragment.forEach((node) => {
+			const content = mapFragment(node.content);
+			children.push(
+				node.type.name === "orderedList" && normalizeId(node.attrs.listId) === sourceId
+					? node.type.create(
+							{ ...node.attrs, listId, listStart, start: listStart },
+							content,
+							node.marks,
+						)
+					: node.copy(content),
+			);
+		});
+		return Fragment.fromArray(children);
+	};
+	return new Slice(mapFragment(slice.content), slice.openStart, slice.openEnd);
+}
+
+function prepareCopy(slice: Slice, state: EditorState): Slice {
+	const selected = displayedStartAtSelection(state);
+	if (!selected) return slice;
+	let updated = false;
+	const mapFragment = (fragment: Fragment): Fragment => {
+		const children: ProseMirrorNode[] = [];
+		fragment.forEach((node) => {
+			const isFirstSelectedList =
+				!updated &&
+				node.type.name === "orderedList" &&
+				normalizeId(node.attrs.listId) === selected.listId;
+			if (isFirstSelectedList) updated = true;
+			const content = mapFragment(node.content);
+			if (isFirstSelectedList) {
+				children.push(
+					node.type.create({ ...node.attrs, start: selected.listStart }, content, node.marks),
+				);
+			} else {
+				children.push(node.copy(content));
+			}
+		});
+		return Fragment.fromArray(children);
+	};
+	return new Slice(mapFragment(slice.content), slice.openStart, slice.openEnd);
+}
+
+function remapMove(slice: Slice, state: EditorState): Slice {
+	const selected = displayedStartAtSelection(state);
+	if (!selected) return slice;
+	return rewriteSliceIdentity(slice, selected.listId, createId(), selected.listStart);
+}
+
+function selectedList(
+	state: EditorState,
+): { current: ListDescriptor; lists: ListDescriptor[] } | null {
+	const lists = collectLists(state.doc);
+	const current = lists.findLast(
+		(list) =>
+			state.selection.from >= list.pos && state.selection.to <= list.pos + list.node.nodeSize,
+	);
+	if (!current) return null;
+	const intersecting = lists.filter(
+		(list) =>
+			list.depth === current.depth &&
+			list.context === current.context &&
+			state.selection.from < list.pos + list.node.nodeSize &&
+			state.selection.to > list.pos,
+	);
+	return intersecting.length === 1 ? { current, lists } : null;
+}
+
+function rewriteTail(
+	state: EditorState,
+	dispatch: ((transaction: Transaction) => void) | undefined,
+	mode: "continue" | "restart",
+): boolean {
+	const selected = selectedList(state);
+	if (!selected) return false;
+	const { current, lists } = selected;
+	const currentId = normalizeId(current.node.attrs.listId);
+	if (!currentId) return false;
+	const compatible = lists.filter(
+		(list) => list.depth === current.depth && list.context === current.context,
+	);
+	const predecessor = compatible.findLast((list) => list.pos < current.pos);
+	const predecessorId = predecessor ? normalizeId(predecessor.node.attrs.listId) : undefined;
+	if (mode === "continue" && (!predecessorId || predecessorId === currentId)) return false;
+	if (!dispatch) return true;
+	const listId = mode === "continue" ? predecessorId! : createId();
+	const listStart =
+		mode === "continue" ? (normalizeStart(predecessor!.node.attrs.listStart) ?? 1) : 1;
+	const transaction = state.tr;
+	for (const list of compatible) {
+		if (list.pos < current.pos || normalizeId(list.node.attrs.listId) !== currentId) continue;
+		transaction.setNodeMarkup(list.pos, undefined, { ...list.node.attrs, listId, listStart });
+	}
+	dispatch(transaction);
+	return true;
+}
+
+function buildDropTransaction(
+	state: EditorState,
+	slice: Slice,
+	insertPos: number,
+	deleteSource: boolean,
+): { transaction: Transaction; from: number; to: number } | null {
+	const transaction = state.tr;
+	if (deleteSource) transaction.deleteSelection();
+	const from = transaction.mapping.map(insertPos);
+	const beforeInsert = transaction.doc;
+	transaction.replaceRange(from, from, slice);
+	if (transaction.doc.eq(beforeInsert)) return null;
+	let to = from;
+	transaction.mapping.maps.at(-1)?.forEach((_oldFrom, _oldTo, _newFrom, newTo) => {
+		to = Math.max(to, newTo);
+	});
+	return { transaction, from, to };
+}
+
+function handleMovedDrop(
+	view: EditorView,
+	event: DragEvent,
+	slice: Slice,
+	moved: boolean,
+): boolean {
+	if (!sliceHasOrderedList(slice)) return false;
+	const eventPos = view.posAtCoords({ left: event.clientX, top: event.clientY });
+	if (!eventPos) return false;
+	const insertPos = dropPoint(view.state.doc, eventPos.pos, slice) ?? eventPos.pos;
+	if (!moved) {
+		const dropped = buildDropTransaction(view.state, remapPaste(slice), insertPos, false);
+		if (!dropped) return false;
+		const selectionPos = Math.min(dropped.to, dropped.transaction.doc.content.size);
+		dropped.transaction.setSelection(
+			Selection.near(dropped.transaction.doc.resolve(selectionPos), -1),
+		);
+		view.focus();
+		view.dispatch(dropped.transaction.setMeta("uiEvent", "drop").scrollIntoView());
+		return true;
+	}
+	const selected = selectedList(view.state);
+	if (!selected) return false;
+	const preview = buildDropTransaction(view.state, slice, insertPos, true);
+	if (!preview) return false;
+	const sourceContextPos = selected.current.contextPos;
+	const mappedSourceContextPos =
+		sourceContextPos === null ? null : preview.transaction.mapping.map(sourceContextPos, 1);
+	const remainsInContext = collectLists(preview.transaction.doc).some(
+		(list) =>
+			list.pos < preview.to &&
+			list.pos + list.node.nodeSize > preview.from &&
+			list.depth === selected.current.depth &&
+			list.contextPos === mappedSourceContextPos,
+	);
+	if (remainsInContext) return false;
+	const remapped = remapMove(slice, view.state);
+	if (remapped === slice) return false;
+	const dropped = buildDropTransaction(view.state, remapped, insertPos, true);
+	if (!dropped) return false;
+	const selectionPos = Math.min(dropped.to, dropped.transaction.doc.content.size);
+	dropped.transaction.setSelection(
+		Selection.near(dropped.transaction.doc.resolve(selectionPos), -1),
+	);
+	view.focus();
+	view.dispatch(dropped.transaction.setMeta("uiEvent", "drop").scrollIntoView());
+	return true;
+}
 
 export const EmDashOrderedList = OrderedList.extend({
 	addAttributes() {
+		const parent = this.parent?.() ?? {};
 		return {
-			...this.parent?.(),
+			...parent,
+			start: {
+				...parent.start,
+				parseHTML: (element) =>
+					normalizeStart(Number(element.dataset.emdashListFirst)) ??
+					normalizeStart(Number(element.getAttribute("start"))) ??
+					1,
+			},
 			listId: {
 				default: null,
+				parseHTML: (element) => normalizeId(element.dataset.emdashListId) ?? null,
 				rendered: false,
 			},
 			listStart: {
 				default: null,
+				parseHTML: (element) => normalizeStart(Number(element.dataset.emdashListStart)) ?? null,
 				rendered: false,
 			},
 		};
+	},
+	renderHTML({ HTMLAttributes, node }) {
+		const { start: _start, ...withoutStart } = HTMLAttributes;
+		const start = normalizeStart(node.attrs.start) ?? 1;
+		const continuity = {
+			"data-emdash-list-id": normalizeId(node.attrs.listId),
+			"data-emdash-list-start": normalizeStart(node.attrs.listStart),
+			"data-emdash-list-first": start,
+		};
+		return start === 1
+			? ["ol", mergeAttributes(this.options.HTMLAttributes, withoutStart, continuity), 0]
+			: [
+					"ol",
+					mergeAttributes(this.options.HTMLAttributes, { ...withoutStart, start }, continuity),
+					0,
+				];
+	},
+	addCommands() {
+		return {
+			toggleOrderedList:
+				() =>
+				({ commands, chain }) =>
+					this.editor.isActive(this.name)
+						? commands.toggleList(this.name, this.options.itemTypeName, this.options.keepMarks)
+						: chain()
+								.toggleList(this.name, this.options.itemTypeName, this.options.keepMarks)
+								.updateAttributes(this.name, { listId: createId(), listStart: 1 })
+								.run(),
+			continueOrderedList:
+				() =>
+				({ state, dispatch }) =>
+					rewriteTail(state, dispatch, "continue"),
+			restartOrderedList:
+				() =>
+				({ state, dispatch }) =>
+					rewriteTail(state, dispatch, "restart"),
+		};
+	},
+	addInputRules() {
+		return [
+			wrappingInputRule({
+				find: ORDERED_LIST_INPUT_REGEX,
+				type: this.type,
+				getAttributes: (match) => {
+					const listStart = normalizeStart(Number(match[1])) ?? 1;
+					return { start: listStart, listStart, listId: createId() };
+				},
+				joinPredicate: () => false,
+			}),
+		];
+	},
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				appendTransaction: (_transactions, _oldState, newState) => normalizeTransaction(newState),
+				props: {
+					transformCopied: (slice, view) => prepareCopy(slice, view.state),
+					handleDrop: handleMovedDrop,
+					handlePaste(view, _event, slice) {
+						if (!sliceHasOrderedList(slice)) return false;
+						view.dispatch(
+							view.state.tr
+								.replaceSelection(remapPaste(slice))
+								.setMeta("paste", true)
+								.setMeta("uiEvent", "paste")
+								.scrollIntoView(),
+						);
+						return true;
+					},
+				},
+			}),
+		];
 	},
 });

--- a/packages/admin/tests/components/PortableTextEditor.list.test.ts
+++ b/packages/admin/tests/components/PortableTextEditor.list.test.ts
@@ -10,6 +10,8 @@ type ListBlock = {
 	style: "normal";
 	listItem: "bullet" | "number";
 	level: number;
+	listId?: string;
+	listStart?: number;
 	children: Array<{ _type: "span"; text: string }>;
 };
 
@@ -186,6 +188,7 @@ describe("ProseMirror → PortableText: nested list level", () => {
 
 type PMList = {
 	type: "bulletList" | "orderedList";
+	attrs?: Record<string, unknown>;
 	content: Array<{
 		type: "listItem";
 		content: Array<{ type: string; content?: unknown[] }>;
@@ -370,5 +373,92 @@ describe("Round-trip: PT → PM → PT preserves nested list level", () => {
 			["number", 2, "Nested"],
 			["bullet", 1, "Sibling"],
 		]);
+	});
+});
+
+describe("numbered-list continuity metadata", () => {
+	it("preserves an explicit ordered-list start", () => {
+		const portableText = _prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "orderedList",
+					attrs: { start: 2 },
+					content: [
+						{
+							type: "listItem",
+							content: [{ type: "paragraph", content: [{ type: "text", text: "Second" }] }],
+						},
+					],
+				},
+			],
+		}).filter(isListBlock);
+
+		expect(portableText[0]).toMatchObject({ listStart: 2 });
+		expect(portableText[0]?.listId).toBeTruthy();
+
+		const list = findFirstList(_portableTextToProsemirror(portableText));
+		expect(list?.attrs).toMatchObject({
+			start: 2,
+			listStart: 2,
+			listId: portableText[0]?.listId,
+		});
+	});
+
+	it.each([
+		{ listId: "  valid  ", listStart: 2, expectedId: "valid", expectedStart: 2 },
+		{ listId: " ", listStart: 0, expectedStart: 1 },
+		{ listId: "x".repeat(129), listStart: 2_147_483_648, expectedStart: 1 },
+		{
+			listId: "maximum",
+			listStart: 2_147_483_647,
+			expectedId: "maximum",
+			expectedStart: 2_147_483_647,
+		},
+	])("normalizes numbered-list metadata %#", ({ listId, listStart, expectedId, expectedStart }) => {
+		const list = findFirstList(
+			_portableTextToProsemirror([
+				{
+					...pt("number", 1, "Item"),
+					listId,
+					listStart,
+				},
+			]),
+		);
+
+		expect(list?.attrs?.start).toBe(expectedStart);
+		expect(list?.attrs?.listStart).toBe(expectedStart);
+		if (expectedId) {
+			expect(list?.attrs?.listId).toBe(expectedId);
+		} else {
+			expect(typeof list?.attrs?.listId).toBe("string");
+			expect(list?.attrs?.listId).not.toBe(listId);
+		}
+	});
+
+	it("derives a continuation start across an intervening block", () => {
+		const numbered = (key: string, text: string) => ({
+			...pt("number" as const, 1, text),
+			_key: key,
+			listId: "shared-list",
+			listStart: 1,
+		});
+		const doc = _portableTextToProsemirror([
+			numbered("one", "One"),
+			numbered("two", "Two"),
+			{
+				_type: "block",
+				_key: "between",
+				style: "normal",
+				children: [{ _type: "span", _key: "between-span", text: "Between" }],
+			},
+			numbered("three", "Three"),
+		]);
+		const lists = (doc.content as Array<{ type?: string }>).filter(
+			(node) => node.type === "orderedList",
+		) as PMList[];
+
+		expect(lists.map((list) => list.attrs?.start)).toEqual([1, 3]);
+		expect(lists.map((list) => list.attrs?.listId)).toEqual(["shared-list", "shared-list"]);
 	});
 });

--- a/packages/admin/tests/components/PortableTextEditor.list.test.ts
+++ b/packages/admin/tests/components/PortableTextEditor.list.test.ts
@@ -461,4 +461,108 @@ describe("numbered-list continuity metadata", () => {
 		expect(lists.map((list) => list.attrs?.start)).toEqual([1, 3]);
 		expect(lists.map((list) => list.attrs?.listId)).toEqual(["shared-list", "shared-list"]);
 	});
+
+	it("uses a later valid base when an earlier segment has no base", () => {
+		const first = { ...pt("number", 1, "Five"), listId: "shared-list" };
+		const second = {
+			...pt("number", 1, "Six"),
+			listId: "shared-list",
+			listStart: 5,
+		};
+		const doc = _portableTextToProsemirror([
+			first,
+			{
+				_type: "block",
+				_key: "between",
+				style: "normal",
+				children: [{ _type: "span", _key: "between-span", text: "Between" }],
+			},
+			second,
+		]);
+		const lists = (doc.content as Array<{ type?: string }>).filter(
+			(node) => node.type === "orderedList",
+		) as PMList[];
+
+		expect(lists.map((list) => list.attrs?.listStart)).toEqual([5, 5]);
+		expect(lists.map((list) => list.attrs?.start)).toEqual([5, 6]);
+	});
+
+	it("keeps a reused root and nested identity in separate numbering scopes", () => {
+		const withMetadata = (key: string, text: string, level: number, listStart: number) => ({
+			...pt("number", level, text),
+			_key: key,
+			listId: "shared-list",
+			listStart,
+		});
+		const doc = _portableTextToProsemirror([
+			withMetadata("root", "Root", 1, 1),
+			withMetadata("nested", "Nested", 2, 5),
+			withMetadata("root-two", "Root two", 1, 1),
+		]);
+		const outer = findFirstList(doc);
+		const nested = getNestedList(outer!.content[0]!);
+
+		expect(outer?.attrs).toMatchObject({ listId: "shared-list", listStart: 1, start: 1 });
+		expect(nested?.attrs).toMatchObject({ listStart: 5, start: 5 });
+		expect(nested?.attrs?.listId).not.toBe("shared-list");
+	});
+
+	it("survives save and reload across every supported top-level separator", () => {
+		const numberedList = (label: string, start: number) => ({
+			type: "orderedList",
+			attrs: { start, listStart: 1, listId: "shared-list" },
+			content: [
+				{
+					type: "listItem",
+					content: [{ type: "paragraph", content: [{ type: "text", text: label }] }],
+				},
+			],
+		});
+		const portableText = _prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				numberedList("One", 1),
+				{ type: "paragraph", content: [{ type: "text", text: "Plain" }] },
+				numberedList("Two", 2),
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "Formatted", marks: [{ type: "bold" }] }],
+				},
+				numberedList("Three", 3),
+				{ type: "codeBlock", attrs: { language: "ts" }, content: [{ type: "text", text: "x" }] },
+				numberedList("Four", 4),
+				{ type: "image", attrs: { src: "/image.png", mediaId: "image" } },
+				numberedList("Five", 5),
+				{
+					type: "pluginBlock",
+					attrs: { blockType: "embed", id: "plugin", data: { title: "Plugin" } },
+				},
+				numberedList("Six", 6),
+			],
+		});
+		const numberedBlocks = portableText.filter(
+			(block): block is ListBlock => isListBlock(block) && block.listItem === "number",
+		);
+		expect(numberedBlocks.map((block) => [block.listId, block.listStart])).toEqual(
+			Array.from({ length: 6 }, () => ["shared-list", 1]),
+		);
+
+		const reloaded = _portableTextToProsemirror(portableText);
+		const rootNodes = reloaded.content as Array<{ type?: string; attrs?: Record<string, unknown> }>;
+		const lists = rootNodes.filter((node) => node.type === "orderedList");
+		expect(lists.map((list) => list.attrs?.start)).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(rootNodes.map((node) => node.type)).toEqual([
+			"orderedList",
+			"paragraph",
+			"orderedList",
+			"paragraph",
+			"orderedList",
+			"codeBlock",
+			"orderedList",
+			"image",
+			"orderedList",
+			"pluginBlock",
+			"orderedList",
+		]);
+	});
 });

--- a/packages/admin/tests/editor/ordered-list.test.ts
+++ b/packages/admin/tests/editor/ordered-list.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { Editor, type JSONContent } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	EmDashOrderedList,
+	normalizeOrderedListDocument,
+} from "../../src/components/editor/ordered-list";
+
+const editors: Editor[] = [];
+
+function list(attrs: Record<string, unknown>, labels: string[]): JSONContent {
+	return {
+		type: "orderedList",
+		attrs,
+		content: labels.map((label) => ({
+			type: "listItem",
+			content: [{ type: "paragraph", content: [{ type: "text", text: label }] }],
+		})),
+	};
+}
+
+function createEditor(content: JSONContent): Editor {
+	const editor = new Editor({
+		element: document.createElement("div"),
+		extensions: [StarterKit.configure({ orderedList: false }), EmDashOrderedList],
+		content,
+	});
+	editors.push(editor);
+	return editor;
+}
+
+function orderedNodes(editor: Editor) {
+	const nodes: Array<{ attrs: Record<string, unknown>; pos: number }> = [];
+	editor.state.doc.descendants((node, pos) => {
+		if (node.type.name === "orderedList") nodes.push({ attrs: node.attrs, pos });
+	});
+	return nodes;
+}
+
+afterEach(() => {
+	for (const editor of editors.splice(0)) editor.destroy();
+});
+
+describe("admin EmDashOrderedList", () => {
+	it("derives continuation starts with the core extension contract", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["One", "Two"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 1, listStart: 1, listId: "shared" }, ["Three"]),
+			],
+		});
+
+		expect(normalizeOrderedListDocument(editor.state.doc)[0]?.attrs.start).toBe(3);
+	});
+
+	it("continues and restarts a selected list tail", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "first" }, ["One"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 1, listStart: 1, listId: "second" }, ["Independent"]),
+			],
+		});
+		let lists = orderedNodes(editor);
+		editor.commands.setTextSelection(lists[1]!.pos + 2);
+		expect(editor.commands.continueOrderedList()).toBe(true);
+		lists = orderedNodes(editor);
+		expect(lists.map((node) => node.attrs.start)).toEqual([1, 2]);
+
+		editor.commands.setTextSelection(lists[1]!.pos + 2);
+		expect(editor.commands.restartOrderedList()).toBe(true);
+		lists = orderedNodes(editor);
+		expect(lists[1]!.attrs.listId).not.toBe("first");
+		expect(lists[1]!.attrs.start).toBe(1);
+	});
+});

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -590,9 +590,6 @@ describe("Formatting Button Toggle States", () => {
 			await expect.element(restartButton).toBeVisible();
 			expect(continueButton.element().hasAttribute("disabled")).toBe(false);
 			expect(restartButton.element().hasAttribute("disabled")).toBe(false);
-			expect(continueButton.element().querySelector("svg")?.classList).toContain(
-				"rtl:-scale-x-100",
-			);
 
 			continueButton.element().click();
 			await vi.waitFor(() => {

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -548,6 +548,66 @@ describe("Formatting Button Toggle States", () => {
 		});
 	});
 
+	it("continues or restarts the selected numbered-list segment in RTL", async () => {
+		const previousDir = document.documentElement.dir;
+		document.documentElement.dir = "rtl";
+		try {
+			const { screen, editor } = await renderEditor({
+				value: [
+					{
+						_type: "block",
+						_key: "one",
+						style: "normal",
+						listItem: "number",
+						level: 1,
+						listId: "first",
+						listStart: 1,
+						children: [{ _type: "span", _key: "s1", text: "One" }],
+					},
+					{
+						_type: "block",
+						_key: "between",
+						style: "normal",
+						children: [{ _type: "span", _key: "s2", text: "Between" }],
+					},
+					{
+						_type: "block",
+						_key: "independent",
+						style: "normal",
+						listItem: "number",
+						level: 1,
+						listId: "second",
+						listStart: 1,
+						children: [{ _type: "span", _key: "s3", text: "Independent" }],
+					},
+				],
+			});
+			editor.commands.setTextSelection(getTextPosition(editor, "Independent"));
+
+			const continueButton = getToolbarButton(screen, "Continue numbering");
+			const restartButton = getToolbarButton(screen, "Restart numbering");
+			await expect.element(continueButton).toBeVisible();
+			await expect.element(restartButton).toBeVisible();
+			expect(continueButton.element().hasAttribute("disabled")).toBe(false);
+			expect(restartButton.element().hasAttribute("disabled")).toBe(false);
+			expect(continueButton.element().querySelector("svg")?.classList).toContain(
+				"rtl:-scale-x-100",
+			);
+
+			continueButton.element().click();
+			await vi.waitFor(() => {
+				const starts: number[] = [];
+				editor.state.doc.descendants((node) => {
+					if (node.type.name === "orderedList") starts.push(node.attrs.start);
+				});
+				expect(starts).toEqual([1, 2]);
+				expect(continueButton.element().hasAttribute("disabled")).toBe(true);
+			});
+		} finally {
+			document.documentElement.dir = previousDir;
+		}
+	});
+
 	it("Quote: click toggles aria-pressed to true", async () => {
 		const { screen, editor } = await renderEditor();
 		editor.commands.focus();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -223,6 +223,7 @@
     "@tiptap/extension-focus": "catalog:",
     "@tiptap/extension-image": "catalog:",
     "@tiptap/extension-link": "catalog:",
+    "@tiptap/extension-list": "catalog:",
     "@tiptap/extension-placeholder": "catalog:",
     "@tiptap/extension-text-align": "catalog:",
     "@tiptap/extension-typography": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -228,6 +228,7 @@
     "@tiptap/extension-text-align": "catalog:",
     "@tiptap/extension-typography": "catalog:",
     "@tiptap/extension-underline": "catalog:",
+    "@tiptap/pm": "catalog:",
     "@tiptap/react": "catalog:",
     "@tiptap/starter-kit": "catalog:",
     "@tiptap/suggestion": "catalog:",

--- a/packages/core/src/client/portable-text.ts
+++ b/packages/core/src/client/portable-text.ts
@@ -7,6 +7,9 @@
  *   Tier 3: Unknown blocks <-> opaque HTML comment fences (preserved, not editable)
  */
 
+import { normalizeListId, normalizeListStart } from "../content/converters/numbered-list.js";
+import { getNumberedListOrdinals } from "../content/portable-text-lists.js";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -55,6 +58,7 @@ interface ParsedInline {
  */
 export function portableTextToMarkdown(blocks: PortableTextBlock[]): string {
 	const lines: string[] = [];
+	const ordinals = getNumberedListOrdinals(blocks);
 	let prevWasList = false;
 
 	for (let i = 0; i < blocks.length; i++) {
@@ -62,13 +66,16 @@ export function portableTextToMarkdown(blocks: PortableTextBlock[]): string {
 
 		if (block._type === "block") {
 			const isList = !!block.listItem;
+			const previous = blocks[i - 1];
+			const independentNumberedRun =
+				isList && previous ? startsIndependentNumberedRun(previous, block) : false;
 
 			// Blank line between non-contiguous block types
-			if (i > 0 && (!isList || !prevWasList)) {
+			if (i > 0 && (!isList || !prevWasList || independentNumberedRun)) {
 				lines.push("");
 			}
 
-			lines.push(renderStandardBlock(block));
+			lines.push(renderStandardBlock(block, ordinals.get(block)));
 			prevWasList = isList;
 		} else if (block._type === "code") {
 			if (i > 0) lines.push("");
@@ -95,13 +102,22 @@ export function portableTextToMarkdown(blocks: PortableTextBlock[]): string {
 	return lines.join("\n") + "\n";
 }
 
-function renderStandardBlock(block: PortableTextBlock): string {
+function startsIndependentNumberedRun(
+	previous: PortableTextBlock,
+	current: PortableTextBlock,
+): boolean {
+	if (previous.listItem !== "number" || current.listItem !== "number") return false;
+	if ((previous.level ?? 1) !== (current.level ?? 1)) return false;
+	return normalizeListId(previous.listId) !== normalizeListId(current.listId);
+}
+
+function renderStandardBlock(block: PortableTextBlock, ordinal?: number): string {
 	const text = renderSpans(block.children ?? [], block.markDefs ?? []);
 
 	// List items
 	if (block.listItem) {
 		const indent = "  ".repeat(Math.max(0, (block.level ?? 1) - 1));
-		const marker = block.listItem === "number" ? "1." : "-";
+		const marker = block.listItem === "number" ? `${ordinal ?? 1}.` : "-";
 		return `${indent}${marker} ${text}`;
 	}
 
@@ -169,7 +185,7 @@ function renderSpans(spans: PortableTextSpan[], markDefs: MarkDef[]): string {
 const OPAQUE_FENCE_PATTERN = /^<!--ec:block (.+) -->$/;
 const HEADING_PATTERN = /^(#{1,6})\s+(.+)$/;
 const UNORDERED_LIST_PATTERN = /^(\s*)[-*+]\s+(.+)$/;
-const ORDERED_LIST_PATTERN = /^(\s*)\d+\.\s+(.+)$/;
+const ORDERED_LIST_PATTERN = /^(\s*)(\d+)\.\s+(.+)$/;
 const IMAGE_PATTERN = /^!\[([^\]]*)\]\(([^)]+)\)$/;
 const INLINE_MARKDOWN_PATTERN =
 	/(\*\*(.+?)\*\*)|(_(.+?)_)|(`(.+?)`)|(\[(.+?)\]\((.+?)\))|(~~(.+?)~~)/g;
@@ -181,6 +197,14 @@ const INLINE_MARKDOWN_PATTERN =
 export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 	const blocks: PortableTextBlock[] = [];
 	const lines = markdown.split("\n");
+	const orderedGroups = new Map<string, { listId: string; listStart: number }>();
+	const lastListItems = new Map<number, string>();
+	const lastListTypes = new Map<number, string>();
+	const resetListState = () => {
+		orderedGroups.clear();
+		lastListItems.clear();
+		lastListTypes.clear();
+	};
 	let i = 0;
 
 	while (i < lines.length) {
@@ -189,6 +213,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		// Opaque fence
 		const opaqueMatch = line.match(OPAQUE_FENCE_PATTERN);
 		if (opaqueMatch) {
+			resetListState();
 			try {
 				blocks.push(JSON.parse(opaqueMatch[1]) as PortableTextBlock);
 			} catch {
@@ -200,6 +225,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 
 		// Code fence
 		if (line.startsWith("```")) {
+			resetListState();
 			const lang = line.slice(3).trim();
 			const codeLines: string[] = [];
 			i++;
@@ -219,6 +245,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 
 		// Blank line
 		if (line.trim() === "") {
+			resetListState();
 			i++;
 			continue;
 		}
@@ -226,6 +253,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		// Heading
 		const headingMatch = line.match(HEADING_PATTERN);
 		if (headingMatch) {
+			resetListState();
 			blocks.push(makeBlock(headingMatch[2], `h${headingMatch[1].length}`));
 			i++;
 			continue;
@@ -233,6 +261,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 
 		// Blockquote
 		if (line.startsWith("> ")) {
+			resetListState();
 			blocks.push(makeBlock(line.slice(2), "blockquote"));
 			i++;
 			continue;
@@ -242,7 +271,16 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		const ulMatch = line.match(UNORDERED_LIST_PATTERN);
 		if (ulMatch) {
 			const level = Math.floor(ulMatch[1].length / 2) + 1;
-			blocks.push(makeListBlock(ulMatch[2], "bullet", level));
+			for (const itemLevel of lastListItems.keys()) {
+				if (itemLevel > level) lastListItems.delete(itemLevel);
+			}
+			for (const typeLevel of lastListTypes.keys()) {
+				if (typeLevel > level) lastListTypes.delete(typeLevel);
+			}
+			const block = makeListBlock(ulMatch[2], "bullet", level);
+			blocks.push(block);
+			lastListItems.set(level, block._key!);
+			lastListTypes.set(level, "bullet");
 			i++;
 			continue;
 		}
@@ -251,7 +289,34 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		const olMatch = line.match(ORDERED_LIST_PATTERN);
 		if (olMatch) {
 			const level = Math.floor(olMatch[1].length / 2) + 1;
-			blocks.push(makeListBlock(olMatch[2], "number", level));
+			for (const itemLevel of lastListItems.keys()) {
+				if (itemLevel > level) lastListItems.delete(itemLevel);
+			}
+			for (const typeLevel of lastListTypes.keys()) {
+				if (typeLevel > level) lastListTypes.delete(typeLevel);
+			}
+			let parentContext = "root";
+			for (let parentLevel = level - 1; parentLevel >= 1; parentLevel--) {
+				const parent = lastListItems.get(parentLevel);
+				if (!parent) continue;
+				parentContext = parent;
+				break;
+			}
+			const groupKey = JSON.stringify([level, parentContext]);
+			let group = orderedGroups.get(groupKey);
+			if (!group || lastListTypes.get(level) !== "number") {
+				group = {
+					listId: createListId(),
+					listStart: normalizeListStart(Number(olMatch[2])) ?? 1,
+				};
+				orderedGroups.set(groupKey, group);
+			}
+			const block = makeListBlock(olMatch[3], "number", level);
+			block.listId = group.listId;
+			block.listStart = group.listStart;
+			blocks.push(block);
+			lastListItems.set(level, block._key!);
+			lastListTypes.set(level, "number");
 			i++;
 			continue;
 		}
@@ -259,6 +324,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		// Image
 		const imgMatch = line.match(IMAGE_PATTERN);
 		if (imgMatch) {
+			resetListState();
 			blocks.push({
 				_type: "image",
 				_key: generateKey(),
@@ -270,6 +336,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		}
 
 		// Paragraph
+		resetListState();
 		blocks.push(makeBlock(line));
 		i++;
 	}
@@ -297,6 +364,13 @@ function makeListBlock(text: string, listItem: string, level: number): PortableT
 		markDefs,
 		children: spans,
 	};
+}
+
+function createListId(): string {
+	return (
+		globalThis.crypto?.randomUUID?.() ??
+		`list-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+	);
 }
 
 /**

--- a/packages/core/src/client/portable-text.ts
+++ b/packages/core/src/client/portable-text.ts
@@ -7,9 +7,6 @@
  *   Tier 3: Unknown blocks <-> opaque HTML comment fences (preserved, not editable)
  */
 
-import { normalizeListId, normalizeListStart } from "../content/converters/numbered-list.js";
-import { getNumberedListOrdinals } from "../content/portable-text-lists.js";
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -21,8 +18,6 @@ export interface PortableTextBlock {
 	style?: string;
 	level?: number;
 	listItem?: string;
-	listId?: string;
-	listStart?: number;
 	markDefs?: MarkDef[];
 	children?: PortableTextSpan[];
 	[key: string]: unknown;
@@ -58,7 +53,6 @@ interface ParsedInline {
  */
 export function portableTextToMarkdown(blocks: PortableTextBlock[]): string {
 	const lines: string[] = [];
-	const ordinals = getNumberedListOrdinals(blocks);
 	let prevWasList = false;
 
 	for (let i = 0; i < blocks.length; i++) {
@@ -66,16 +60,13 @@ export function portableTextToMarkdown(blocks: PortableTextBlock[]): string {
 
 		if (block._type === "block") {
 			const isList = !!block.listItem;
-			const previous = blocks[i - 1];
-			const independentNumberedRun =
-				isList && previous ? startsIndependentNumberedRun(previous, block) : false;
 
 			// Blank line between non-contiguous block types
-			if (i > 0 && (!isList || !prevWasList || independentNumberedRun)) {
+			if (i > 0 && (!isList || !prevWasList)) {
 				lines.push("");
 			}
 
-			lines.push(renderStandardBlock(block, ordinals.get(block)));
+			lines.push(renderStandardBlock(block));
 			prevWasList = isList;
 		} else if (block._type === "code") {
 			if (i > 0) lines.push("");
@@ -102,22 +93,13 @@ export function portableTextToMarkdown(blocks: PortableTextBlock[]): string {
 	return lines.join("\n") + "\n";
 }
 
-function startsIndependentNumberedRun(
-	previous: PortableTextBlock,
-	current: PortableTextBlock,
-): boolean {
-	if (previous.listItem !== "number" || current.listItem !== "number") return false;
-	if ((previous.level ?? 1) !== (current.level ?? 1)) return false;
-	return normalizeListId(previous.listId) !== normalizeListId(current.listId);
-}
-
-function renderStandardBlock(block: PortableTextBlock, ordinal?: number): string {
+function renderStandardBlock(block: PortableTextBlock): string {
 	const text = renderSpans(block.children ?? [], block.markDefs ?? []);
 
 	// List items
 	if (block.listItem) {
 		const indent = "  ".repeat(Math.max(0, (block.level ?? 1) - 1));
-		const marker = block.listItem === "number" ? `${ordinal ?? 1}.` : "-";
+		const marker = block.listItem === "number" ? "1." : "-";
 		return `${indent}${marker} ${text}`;
 	}
 
@@ -185,7 +167,7 @@ function renderSpans(spans: PortableTextSpan[], markDefs: MarkDef[]): string {
 const OPAQUE_FENCE_PATTERN = /^<!--ec:block (.+) -->$/;
 const HEADING_PATTERN = /^(#{1,6})\s+(.+)$/;
 const UNORDERED_LIST_PATTERN = /^(\s*)[-*+]\s+(.+)$/;
-const ORDERED_LIST_PATTERN = /^(\s*)(\d+)\.\s+(.+)$/;
+const ORDERED_LIST_PATTERN = /^(\s*)\d+\.\s+(.+)$/;
 const IMAGE_PATTERN = /^!\[([^\]]*)\]\(([^)]+)\)$/;
 const INLINE_MARKDOWN_PATTERN =
 	/(\*\*(.+?)\*\*)|(_(.+?)_)|(`(.+?)`)|(\[(.+?)\]\((.+?)\))|(~~(.+?)~~)/g;
@@ -197,14 +179,6 @@ const INLINE_MARKDOWN_PATTERN =
 export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 	const blocks: PortableTextBlock[] = [];
 	const lines = markdown.split("\n");
-	const orderedGroups = new Map<string, { listId: string; listStart: number }>();
-	const lastListItems = new Map<number, string>();
-	const lastListTypes = new Map<number, string>();
-	const resetListState = () => {
-		orderedGroups.clear();
-		lastListItems.clear();
-		lastListTypes.clear();
-	};
 	let i = 0;
 
 	while (i < lines.length) {
@@ -213,7 +187,6 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		// Opaque fence
 		const opaqueMatch = line.match(OPAQUE_FENCE_PATTERN);
 		if (opaqueMatch) {
-			resetListState();
 			try {
 				blocks.push(JSON.parse(opaqueMatch[1]) as PortableTextBlock);
 			} catch {
@@ -225,7 +198,6 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 
 		// Code fence
 		if (line.startsWith("```")) {
-			resetListState();
 			const lang = line.slice(3).trim();
 			const codeLines: string[] = [];
 			i++;
@@ -245,7 +217,6 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 
 		// Blank line
 		if (line.trim() === "") {
-			resetListState();
 			i++;
 			continue;
 		}
@@ -253,7 +224,6 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		// Heading
 		const headingMatch = line.match(HEADING_PATTERN);
 		if (headingMatch) {
-			resetListState();
 			blocks.push(makeBlock(headingMatch[2], `h${headingMatch[1].length}`));
 			i++;
 			continue;
@@ -261,7 +231,6 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 
 		// Blockquote
 		if (line.startsWith("> ")) {
-			resetListState();
 			blocks.push(makeBlock(line.slice(2), "blockquote"));
 			i++;
 			continue;
@@ -271,16 +240,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		const ulMatch = line.match(UNORDERED_LIST_PATTERN);
 		if (ulMatch) {
 			const level = Math.floor(ulMatch[1].length / 2) + 1;
-			for (const itemLevel of lastListItems.keys()) {
-				if (itemLevel > level) lastListItems.delete(itemLevel);
-			}
-			for (const typeLevel of lastListTypes.keys()) {
-				if (typeLevel > level) lastListTypes.delete(typeLevel);
-			}
-			const block = makeListBlock(ulMatch[2], "bullet", level);
-			blocks.push(block);
-			lastListItems.set(level, block._key!);
-			lastListTypes.set(level, "bullet");
+			blocks.push(makeListBlock(ulMatch[2], "bullet", level));
 			i++;
 			continue;
 		}
@@ -289,34 +249,7 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		const olMatch = line.match(ORDERED_LIST_PATTERN);
 		if (olMatch) {
 			const level = Math.floor(olMatch[1].length / 2) + 1;
-			for (const itemLevel of lastListItems.keys()) {
-				if (itemLevel > level) lastListItems.delete(itemLevel);
-			}
-			for (const typeLevel of lastListTypes.keys()) {
-				if (typeLevel > level) lastListTypes.delete(typeLevel);
-			}
-			let parentContext = "root";
-			for (let parentLevel = level - 1; parentLevel >= 1; parentLevel--) {
-				const parent = lastListItems.get(parentLevel);
-				if (!parent) continue;
-				parentContext = parent;
-				break;
-			}
-			const groupKey = JSON.stringify([level, parentContext]);
-			let group = orderedGroups.get(groupKey);
-			if (!group || lastListTypes.get(level) !== "number") {
-				group = {
-					listId: createListId(),
-					listStart: normalizeListStart(Number(olMatch[2])) ?? 1,
-				};
-				orderedGroups.set(groupKey, group);
-			}
-			const block = makeListBlock(olMatch[3], "number", level);
-			block.listId = group.listId;
-			block.listStart = group.listStart;
-			blocks.push(block);
-			lastListItems.set(level, block._key!);
-			lastListTypes.set(level, "number");
+			blocks.push(makeListBlock(olMatch[2], "number", level));
 			i++;
 			continue;
 		}
@@ -324,7 +257,6 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		// Image
 		const imgMatch = line.match(IMAGE_PATTERN);
 		if (imgMatch) {
-			resetListState();
 			blocks.push({
 				_type: "image",
 				_key: generateKey(),
@@ -336,7 +268,6 @@ export function markdownToPortableText(markdown: string): PortableTextBlock[] {
 		}
 
 		// Paragraph
-		resetListState();
 		blocks.push(makeBlock(line));
 		i++;
 	}
@@ -364,13 +295,6 @@ function makeListBlock(text: string, listItem: string, level: number): PortableT
 		markDefs,
 		children: spans,
 	};
-}
-
-function createListId(): string {
-	return (
-		globalThis.crypto?.randomUUID?.() ??
-		`list-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
-	);
 }
 
 /**

--- a/packages/core/src/client/portable-text.ts
+++ b/packages/core/src/client/portable-text.ts
@@ -18,6 +18,8 @@ export interface PortableTextBlock {
 	style?: string;
 	level?: number;
 	listItem?: string;
+	listId?: string;
+	listStart?: number;
 	markDefs?: MarkDef[];
 	children?: PortableTextSpan[];
 	[key: string]: unknown;

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -27,11 +27,10 @@ import { createPortal } from "react-dom";
 
 import {
 	deriveLegacyListId,
+	normalizeProseMirrorOrderedListJson,
 	normalizeListId,
 	normalizeListStart,
 	readOrderedListMetadata,
-	takeOrderedListStart,
-	type OrderedListCounter,
 } from "../content/converters/numbered-list.js";
 import { computeThumbnailSize } from "../media/thumbnail.js";
 import { CodeMarkExtension } from "./code-mark.js";
@@ -168,9 +167,9 @@ function convertPMNode(node: PMNode, path: string): PTBlock | PTBlock[] | null {
 			};
 		}
 		case "bulletList":
-			return convertPMList(node.content || [], "bullet", undefined);
+			return convertPMList(node.content || [], "bullet", 1, node.attrs, path);
 		case "orderedList":
-			return convertPMList(node.content || [], "number", readOrderedListMetadata(node.attrs, path));
+			return convertPMList(node.content || [], "number", 1, node.attrs, path);
 		case "blockquote": {
 			const blocks: PTTextBlock[] = [];
 			for (const child of node.content || []) {
@@ -259,12 +258,17 @@ function convertPMNode(node: PMNode, path: string): PTBlock | PTBlock[] | null {
 function convertPMList(
 	items: PMNode[],
 	listItem: "bullet" | "number",
-	metadata: { listId: string; listStart: number } | undefined,
+	level: number,
+	attrs: Record<string, unknown> | undefined,
+	path: string,
 ): PTTextBlock[] {
 	const blocks: PTTextBlock[] = [];
-	for (const item of items) {
+	const metadata = listItem === "number" ? readOrderedListMetadata(attrs, path) : undefined;
+	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+		const item = items[itemIndex]!;
 		if (item.type === "listItem") {
-			for (const child of item.content || []) {
+			for (let childIndex = 0; childIndex < (item.content?.length ?? 0); childIndex++) {
+				const child = item.content![childIndex]!;
 				if (child.type === "paragraph") {
 					const { children, markDefs } = convertInline(child.content || []);
 					if (children.length > 0) {
@@ -273,12 +277,23 @@ function convertPMList(
 							_key: k(),
 							style: "normal",
 							listItem,
-							level: 1,
+							level,
 							...metadata,
 							children,
 							markDefs: markDefs.length > 0 ? markDefs : undefined,
 						});
 					}
+				} else if (child.type === "bulletList" || child.type === "orderedList") {
+					const childListItem = child.type === "bulletList" ? "bullet" : "number";
+					blocks.push(
+						...convertPMList(
+							child.content || [],
+							childListItem,
+							level + 1,
+							child.attrs,
+							`${path}:${itemIndex}:${childIndex}`,
+						),
+					);
 				}
 			}
 		}
@@ -362,17 +377,7 @@ function convertPMMark(
 function portableTextToPM(blocks: PTBlock[]): JSONContent {
 	if (!blocks || blocks.length === 0) return { type: "doc", content: [{ type: "paragraph" }] };
 
-	const content: JSONContent[] = [];
-	const counters = new Map<string, OrderedListCounter>();
-	const canonicalStarts = new Map<string, number>();
-	for (const block of blocks) {
-		if (!isPTTextBlock(block) || block.listItem !== "number") continue;
-		const listId = normalizeListId(block.listId);
-		const listStart = normalizeListStart(block.listStart);
-		if (listId && listStart !== undefined && !canonicalStarts.has(listId)) {
-			canonicalStarts.set(listId, listStart);
-		}
-	}
+	const content: PMNode[] = [];
 	let i = 0;
 
 	while (i < blocks.length) {
@@ -388,20 +393,19 @@ function portableTextToPM(blocks: PTBlock[]): JSONContent {
 			const rootId = listType === "number" ? normalizeListId(block.listId) : undefined;
 			while (i < blocks.length) {
 				const cur = blocks[i];
-				const currentId =
-					cur && isPTTextBlock(cur) && cur.listItem === "number"
-						? normalizeListId(cur.listId)
-						: undefined;
+				if (!cur || !isPTTextBlock(cur) || !cur.listItem) break;
+				const level = cur.level || 1;
+				const currentId = cur.listItem === "number" ? normalizeListId(cur.listId) : undefined;
 				const sameIdentity =
-					listType !== "number" || (rootId ? currentId === rootId : currentId === undefined);
-				if (cur && isPTTextBlock(cur) && cur.listItem === listType && sameIdentity) {
+					listType !== "number" ||
+					level > 1 ||
+					(rootId ? currentId === rootId : currentId === undefined);
+				if (level > 1 || (cur.listItem === listType && sameIdentity)) {
 					listBlocks.push(cur);
 					i++;
 				} else break;
 			}
-			content.push(
-				convertPTList(listBlocks, listType, counters, canonicalStarts, `root:${runStart}`),
-			);
+			content.push(convertPTList(listBlocks, listType, `root:${runStart}`));
 		} else if (
 			isPTTextBlock(block) &&
 			block.style === "blockquote" &&
@@ -443,10 +447,13 @@ function portableTextToPM(blocks: PTBlock[]): JSONContent {
 		}
 	}
 
-	return { type: "doc", content: content.length > 0 ? content : [{ type: "paragraph" }] };
+	return normalizeProseMirrorOrderedListJson({
+		type: "doc",
+		content: content.length > 0 ? content : [{ type: "paragraph" }],
+	});
 }
 
-function convertPTBlock(block: PTBlock): JSONContent | null {
+function convertPTBlock(block: PTBlock): PMNode | null {
 	if (isPTTextBlock(block)) {
 		const { style = "normal", children, markDefs = [], textAlign } = block;
 		const pmContent = convertPTSpans(children, markDefs);
@@ -569,38 +576,115 @@ function convertPTBlock(block: PTBlock): JSONContent | null {
 function convertPTList(
 	items: PTTextBlock[],
 	listType: "bullet" | "number",
-	counters: Map<string, OrderedListCounter>,
-	canonicalStarts: Map<string, number>,
 	context: string,
-): JSONContent {
+): PMNode {
+	const rootItems: PMNode[] = [];
+	let index = 0;
+
+	while (index < items.length) {
+		const item = items[index]!;
+		const level = item.level || 1;
+		if (level === 1) {
+			const nestedItems: PTTextBlock[] = [];
+			index++;
+			while (index < items.length && (items[index]!.level || 1) > 1) {
+				nestedItems.push(items[index]!);
+				index++;
+			}
+			rootItems.push(
+				convertPTListItem(item, nestedItems, listType, `${context}:${rootItems.length}`),
+			);
+		} else {
+			rootItems.push(convertPTListItem(item, [], listType, `${context}:${rootItems.length}`));
+			index++;
+		}
+	}
+
 	const firstItem = items[0]!;
 	const listId =
 		normalizeListId(firstItem.listId) ?? deriveLegacyListId(`${context}:${firstItem._key}`);
+	const listStart = normalizeListStart(firstItem.listStart);
 	const metadata =
 		listType === "number"
 			? {
 					listId,
-					listStart: canonicalStarts.get(listId) ?? normalizeListStart(firstItem.listStart) ?? 1,
+					...(listStart === undefined ? {} : { listStart }),
 				}
 			: undefined;
-	const start = metadata ? takeOrderedListStart(counters, metadata, items.length) : undefined;
 	return {
 		type: listType === "bullet" ? "bulletList" : "orderedList",
-		attrs: metadata ? { ...metadata, start } : undefined,
-		content: items.map((item) => ({
-			type: "listItem",
-			content: [
-				{
-					type: "paragraph",
-					content: convertPTSpans(item.children, item.markDefs || []),
-				},
-			],
-		})),
+		attrs: metadata ? { ...metadata, start: metadata.listStart ?? 1 } : undefined,
+		content: rootItems,
 	};
 }
 
-function convertPTSpans(spans: PTSpan[], markDefs: PTMarkDef[]): JSONContent[] {
-	const nodes: JSONContent[] = [];
+function belongsToNestedPTGroup(
+	item: PTTextBlock,
+	minLevel: number,
+	parentListType: "bullet" | "number",
+	anchorType: "bullet" | "number",
+	anchorId: string | undefined,
+): boolean {
+	if ((item.level || 2) > minLevel) return true;
+	if ((item.listItem || parentListType) !== anchorType) return false;
+	if (anchorType !== "number") return true;
+	const itemId = normalizeListId(item.listId);
+	return anchorId ? itemId === anchorId : itemId === undefined;
+}
+
+function convertPTListItem(
+	item: PTTextBlock,
+	nestedItems: PTTextBlock[],
+	parentListType: "bullet" | "number",
+	context: string,
+): PMNode {
+	const content: PMNode[] = [
+		{
+			type: "paragraph",
+			content: convertPTSpans(item.children, item.markDefs || []),
+		},
+	];
+
+	if (nestedItems.length > 0) {
+		let minLevel = Infinity;
+		for (const nestedItem of nestedItems) {
+			const level = nestedItem.level || 2;
+			if (level < minLevel) minLevel = level;
+		}
+
+		let index = 0;
+		while (index < nestedItems.length) {
+			const groupStart = index;
+			const anchorType = nestedItems[index]!.listItem || parentListType;
+			const anchorId =
+				anchorType === "number" ? normalizeListId(nestedItems[index]!.listId) : undefined;
+			const nestedGroup: PTTextBlock[] = [];
+			do {
+				nestedGroup.push(nestedItems[index]!);
+				index++;
+			} while (
+				index < nestedItems.length &&
+				belongsToNestedPTGroup(nestedItems[index]!, minLevel, parentListType, anchorType, anchorId)
+			);
+
+			content.push(
+				convertPTList(
+					nestedGroup.map((nestedItem) => ({
+						...nestedItem,
+						level: (nestedItem.level || 2) - 1,
+					})),
+					anchorType,
+					`${context}:nested:${groupStart}`,
+				),
+			);
+		}
+	}
+
+	return { type: "listItem", content };
+}
+
+function convertPTSpans(spans: PTSpan[], markDefs: PTMarkDef[]): PMNode[] {
+	const nodes: PMNode[] = [];
 	const mdMap = new Map(markDefs.map((md) => [md._key, md]));
 
 	for (const span of spans) {
@@ -610,7 +694,7 @@ function convertPTSpans(spans: PTSpan[], markDefs: PTMarkDef[]): JSONContent[] {
 			const text = parts[i];
 			if (text && text.length > 0) {
 				const marks = convertPTMarks(span.marks || [], mdMap);
-				const node: JSONContent = {
+				const node: PMNode = {
 					type: "text",
 					text,
 				};

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -25,9 +25,18 @@ import Suggestion from "@tiptap/suggestion";
 import * as React from "react";
 import { createPortal } from "react-dom";
 
+import {
+	deriveLegacyListId,
+	normalizeListId,
+	normalizeListStart,
+	readOrderedListMetadata,
+	takeOrderedListStart,
+	type OrderedListCounter,
+} from "../content/converters/numbered-list.js";
 import { computeThumbnailSize } from "../media/thumbnail.js";
 import { CodeMarkExtension } from "./code-mark.js";
 import { InlineCodeBlockExtension } from "./inline-code-block.js";
+import { EmDashOrderedList } from "./ordered-list.js";
 
 // ── Portable Text types ────────────────────────────────────────────
 
@@ -50,6 +59,8 @@ interface PTTextBlock {
 	style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
 	listItem?: "bullet" | "number";
 	level?: number;
+	listId?: string;
+	listStart?: number;
 	children: PTSpan[];
 	markDefs?: PTMarkDef[];
 	textAlign?: "left" | "center" | "right" | "justify";
@@ -106,8 +117,8 @@ function attrNum(attrs: Record<string, unknown> | undefined, key: string): numbe
 function pmToPortableText(doc: PMNode): PTBlock[] {
 	if (!doc || doc.type !== "doc" || !doc.content) return [];
 	const blocks: PTBlock[] = [];
-	for (const node of doc.content) {
-		const r = convertPMNode(node);
+	for (let i = 0; i < doc.content.length; i++) {
+		const r = convertPMNode(doc.content[i]!, `root:${i}`);
 		if (r) {
 			if (Array.isArray(r)) blocks.push(...r);
 			else blocks.push(r);
@@ -116,7 +127,7 @@ function pmToPortableText(doc: PMNode): PTBlock[] {
 	return blocks;
 }
 
-function convertPMNode(node: PMNode): PTBlock | PTBlock[] | null {
+function convertPMNode(node: PMNode, path: string): PTBlock | PTBlock[] | null {
 	switch (node.type) {
 		case "paragraph": {
 			const { children, markDefs } = convertInline(node.content || []);
@@ -157,9 +168,9 @@ function convertPMNode(node: PMNode): PTBlock | PTBlock[] | null {
 			};
 		}
 		case "bulletList":
-			return convertPMList(node.content || [], "bullet");
+			return convertPMList(node.content || [], "bullet", undefined);
 		case "orderedList":
-			return convertPMList(node.content || [], "number");
+			return convertPMList(node.content || [], "number", readOrderedListMetadata(node.attrs, path));
 		case "blockquote": {
 			const blocks: PTTextBlock[] = [];
 			for (const child of node.content || []) {
@@ -245,7 +256,11 @@ function convertPMNode(node: PMNode): PTBlock | PTBlock[] | null {
 	}
 }
 
-function convertPMList(items: PMNode[], listItem: "bullet" | "number"): PTTextBlock[] {
+function convertPMList(
+	items: PMNode[],
+	listItem: "bullet" | "number",
+	metadata: { listId: string; listStart: number } | undefined,
+): PTTextBlock[] {
 	const blocks: PTTextBlock[] = [];
 	for (const item of items) {
 		if (item.type === "listItem") {
@@ -259,6 +274,7 @@ function convertPMList(items: PMNode[], listItem: "bullet" | "number"): PTTextBl
 							style: "normal",
 							listItem,
 							level: 1,
+							...metadata,
 							children,
 							markDefs: markDefs.length > 0 ? markDefs : undefined,
 						});
@@ -347,6 +363,16 @@ function portableTextToPM(blocks: PTBlock[]): JSONContent {
 	if (!blocks || blocks.length === 0) return { type: "doc", content: [{ type: "paragraph" }] };
 
 	const content: JSONContent[] = [];
+	const counters = new Map<string, OrderedListCounter>();
+	const canonicalStarts = new Map<string, number>();
+	for (const block of blocks) {
+		if (!isPTTextBlock(block) || block.listItem !== "number") continue;
+		const listId = normalizeListId(block.listId);
+		const listStart = normalizeListStart(block.listStart);
+		if (listId && listStart !== undefined && !canonicalStarts.has(listId)) {
+			canonicalStarts.set(listId, listStart);
+		}
+	}
 	let i = 0;
 
 	while (i < blocks.length) {
@@ -358,14 +384,24 @@ function portableTextToPM(blocks: PTBlock[]): JSONContent {
 		if (isPTTextBlock(block) && block.listItem) {
 			const listBlocks: PTTextBlock[] = [];
 			const listType = block.listItem;
+			const runStart = i;
+			const rootId = listType === "number" ? normalizeListId(block.listId) : undefined;
 			while (i < blocks.length) {
 				const cur = blocks[i];
-				if (cur && isPTTextBlock(cur) && cur.listItem === listType) {
+				const currentId =
+					cur && isPTTextBlock(cur) && cur.listItem === "number"
+						? normalizeListId(cur.listId)
+						: undefined;
+				const sameIdentity =
+					listType !== "number" || (rootId ? currentId === rootId : currentId === undefined);
+				if (cur && isPTTextBlock(cur) && cur.listItem === listType && sameIdentity) {
 					listBlocks.push(cur);
 					i++;
 				} else break;
 			}
-			content.push(convertPTList(listBlocks, listType));
+			content.push(
+				convertPTList(listBlocks, listType, counters, canonicalStarts, `root:${runStart}`),
+			);
 		} else if (
 			isPTTextBlock(block) &&
 			block.style === "blockquote" &&
@@ -530,9 +566,27 @@ function convertPTBlock(block: PTBlock): JSONContent | null {
 	};
 }
 
-function convertPTList(items: PTTextBlock[], listType: "bullet" | "number"): JSONContent {
+function convertPTList(
+	items: PTTextBlock[],
+	listType: "bullet" | "number",
+	counters: Map<string, OrderedListCounter>,
+	canonicalStarts: Map<string, number>,
+	context: string,
+): JSONContent {
+	const firstItem = items[0]!;
+	const listId =
+		normalizeListId(firstItem.listId) ?? deriveLegacyListId(`${context}:${firstItem._key}`);
+	const metadata =
+		listType === "number"
+			? {
+					listId,
+					listStart: canonicalStarts.get(listId) ?? normalizeListStart(firstItem.listStart) ?? 1,
+				}
+			: undefined;
+	const start = metadata ? takeOrderedListStart(counters, metadata, items.length) : undefined;
 	return {
 		type: listType === "bullet" ? "bulletList" : "orderedList",
+		attrs: metadata ? { ...metadata, start } : undefined,
 		content: items.map((item) => ({
 			type: "listItem",
 			content: [
@@ -1945,7 +1999,9 @@ export function InlinePortableTextEditor({
 				codeBlock: false,
 				// Replaced with CodeMarkExtension so inline code can combine with link/etc.
 				code: false,
+				orderedList: false,
 			}),
+			EmDashOrderedList,
 			CodeMarkExtension,
 			InlineCodeBlockExtension,
 			Image.extend({

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -415,7 +415,7 @@ function portableTextToPM(blocks: PTBlock[]): JSONContent {
 			// PT is flat, so a multi-paragraph quote is stored as a run of
 			// blockquote-styled blocks. Mirrors the grouping in
 			// content/converters/portable-text-to-prosemirror.ts; without it
-			// merges revert on reload in the inline editor too (#1884).
+			// merges revert on reload in the inline editor too.
 			const quoteBlocks: PTTextBlock[] = [];
 			while (i < blocks.length) {
 				const cur = blocks[i];
@@ -2007,7 +2007,7 @@ export function InlinePortableTextEditor({
 		async (options?: { keepalive?: boolean }) => {
 			// A pagehide flush must not be skipped: an in-flight blur save is
 			// cancelled by the navigation, so the keepalive request is the only
-			// one that can still land (#1582).
+			// one that can still land.
 			if (savingRef.current && !options?.keepalive) return;
 
 			const current = JSON.stringify(getBlocks());
@@ -2052,8 +2052,8 @@ export function InlinePortableTextEditor({
 	// Flush unsaved edits when the page goes away (browser back/forward,
 	// link click, tab close). The blur handler doesn't cover this: unload
 	// doesn't reliably fire React blur, and a plain fetch started during
-	// unload is cancelled by the navigation — edits were silently lost
-	// (#1582). `keepalive` lets the PUT outlive the page.
+	// unload is cancelled by the navigation — edits were silently lost.
+	// `keepalive` lets the PUT outlive the page.
 	// Caveat: keepalive caps the body at 64KB — a very long document
 	// can still be lost on unload. Upgrade path: debounced autosave
 	// while typing (like the admin editor) so unload flushes are rare.

--- a/packages/core/src/components/OrderedList.astro
+++ b/packages/core/src/components/OrderedList.astro
@@ -1,0 +1,14 @@
+---
+import type { List, Props as ComponentProps } from "astro-portabletext/types";
+import { normalizeListStart } from "../content/converters/numbered-list.js";
+
+type OrderedListNode = List & { start?: unknown };
+type Props = ComponentProps<OrderedListNode>;
+
+const { node, index: _index, isInline: _isInline, ...attrs } = Astro.props;
+const start = normalizeListStart(node.start) ?? 1;
+---
+
+<ol {...attrs} start={start === 1 ? undefined : start}>
+	<slot />
+</ol>

--- a/packages/core/src/components/PortableText.astro
+++ b/packages/core/src/components/PortableText.astro
@@ -50,7 +50,7 @@ const mergedComponents = userComponents
 
 // A multi-paragraph quote is stored as consecutive blockquote-styled blocks
 // (Portable Text is flat); merge each run into one blockquoteGroup node so
-// it renders as a single <blockquote> instead of several (#1884).
+// it renders as a single <blockquote> instead of several.
 let renderValue = value;
 if (!editMeta) {
 	const cloned = clonePortableTextValue(Array.isArray(value) ? value : value ? [value] : []);

--- a/packages/core/src/components/PortableText.astro
+++ b/packages/core/src/components/PortableText.astro
@@ -17,6 +17,10 @@ import {
 	mergeComponents,
 	type PortableTextProps,
 } from "astro-portabletext";
+import {
+	buildPortableTextListTree,
+	clonePortableTextValue,
+} from "../content/portable-text-lists.js";
 import { getEditMeta } from "../query.js";
 // @ts-ignore - virtual module
 import { pluginBlockComponents } from "virtual:emdash/block-components";
@@ -28,7 +32,12 @@ export interface Props extends Omit<PortableTextProps, "value"> {
 	value: PortableTextProps["value"];
 }
 
-const { value, components: userComponents, ...rest } = Astro.props;
+const {
+	value,
+	components: userComponents,
+	listNestingMode = "html",
+	...rest
+} = Astro.props;
 
 // Check for edit metadata (attached as non-enumerable property by query functions)
 const editMeta = getEditMeta(value);
@@ -42,7 +51,15 @@ const mergedComponents = userComponents
 // A multi-paragraph quote is stored as consecutive blockquote-styled blocks
 // (Portable Text is flat); merge each run into one blockquoteGroup node so
 // it renders as a single <blockquote> instead of several (#1884).
-const renderValue = Array.isArray(value) ? groupBlockquoteRuns(value) : value;
+let renderValue = value;
+if (!editMeta) {
+	const cloned = clonePortableTextValue(Array.isArray(value) ? value : value ? [value] : []);
+	const grouped = groupBlockquoteRuns(cloned);
+	renderValue = buildPortableTextListTree(
+		grouped as Array<Record<string, unknown>>,
+		listNestingMode,
+	) as typeof value;
+}
 ---
 
 {editMeta ? (
@@ -53,5 +70,10 @@ const renderValue = Array.isArray(value) ? groupBlockquoteRuns(value) : value;
 		field={editMeta.field}
 	/>
 ) : (
-	<BasePortableText value={renderValue} components={mergedComponents} {...rest} />
+	<BasePortableText
+		value={renderValue}
+		components={mergedComponents}
+		listNestingMode={listNestingMode}
+		{...rest}
+	/>
 )}

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -50,7 +50,6 @@ export { default as Buttons } from "./Buttons.astro";
 export { default as Cover } from "./Cover.astro";
 export { default as File } from "./File.astro";
 export { default as Pullquote } from "./Pullquote.astro";
-export { default as OrderedList } from "./OrderedList.astro";
 
 // Mark components
 export { default as Superscript } from "./marks/Superscript.astro";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -50,6 +50,7 @@ export { default as Buttons } from "./Buttons.astro";
 export { default as Cover } from "./Cover.astro";
 export { default as File } from "./File.astro";
 export { default as Pullquote } from "./Pullquote.astro";
+export { default as OrderedList } from "./OrderedList.astro";
 
 // Mark components
 export { default as Superscript } from "./marks/Superscript.astro";
@@ -73,6 +74,7 @@ import HtmlBlockComponent from "./HtmlBlock.astro";
 // Pre-configured components object for PortableText
 import ImageComponent from "./Image.astro";
 import { emdashMarkComponents } from "./marks.js";
+import OrderedListComponent from "./OrderedList.astro";
 import PullquoteComponent from "./Pullquote.astro";
 import TableComponent from "./Table.astro";
 
@@ -88,6 +90,9 @@ import TableComponent from "./Table.astro";
  */
 export const emdashComponents = {
 	block: BlockComponent,
+	list: {
+		number: OrderedListComponent,
+	},
 	type: {
 		blockquoteGroup: BlockquoteGroupComponent,
 		image: ImageComponent,

--- a/packages/core/src/components/ordered-list.ts
+++ b/packages/core/src/components/ordered-list.ts
@@ -1,17 +1,545 @@
+import { mergeAttributes, wrappingInputRule } from "@tiptap/core";
 import { OrderedList } from "@tiptap/extension-list";
+import { Fragment, type Node as ProseMirrorNode, Slice } from "@tiptap/pm/model";
+import { Plugin, Selection, type EditorState, type Transaction } from "@tiptap/pm/state";
+import { canJoin, dropPoint } from "@tiptap/pm/transform";
+import type { EditorView } from "@tiptap/pm/view";
+
+import {
+	deriveLegacyListId,
+	normalizeListId,
+	normalizeListStart,
+} from "../content/converters/numbered-list.js";
+
+const ORDERED_LIST_INPUT_REGEX = /^(\d+)\.\s$/;
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		orderedListContinuity: {
+			continueOrderedList: () => ReturnType;
+			restartOrderedList: () => ReturnType;
+		};
+	}
+}
+
+interface OrderedListDescriptor {
+	node: ProseMirrorNode;
+	pos: number;
+	depth: number;
+	context: string;
+	contextPos: number | null;
+}
+
+export interface OrderedListNormalization {
+	pos: number;
+	attrs: Record<string, unknown>;
+}
+
+function createListId(): string {
+	return (
+		globalThis.crypto?.randomUUID?.() ??
+		`list-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+	);
+}
+
+function createRepairId(sourceId: string, scope: string, attempt: number): string {
+	const base = deriveLegacyListId(`repair:${sourceId}:${scope}`);
+	const suffix = `:${attempt.toString(36)}`;
+	return `${base.slice(0, 128 - suffix.length)}${suffix}`;
+}
+
+function collectOrderedLists(doc: ProseMirrorNode): OrderedListDescriptor[] {
+	const lists: OrderedListDescriptor[] = [];
+	doc.descendants((node, pos) => {
+		if (node.type.name !== "orderedList") return;
+		const resolved = doc.resolve(pos);
+		let context = "root";
+		let contextPos: number | null = null;
+		for (let depth = resolved.depth; depth > 0; depth--) {
+			if (resolved.node(depth).type.name === "listItem") {
+				contextPos = resolved.before(depth);
+				context = `listItem:${contextPos}`;
+				break;
+			}
+		}
+		lists.push({ node, pos, depth: resolved.depth, context, contextPos });
+	});
+	return lists;
+}
+
+export function normalizeOrderedListDocument(doc: ProseMirrorNode): OrderedListNormalization[] {
+	const lists = collectOrderedLists(doc);
+	const canonicalBySourceScope = new Map<string, string>();
+	const assignedCanonicalIds = new Set<string>();
+	const prepared = lists.map((list) => {
+		const sourceId =
+			normalizeListId(list.node.attrs.listId) ??
+			deriveLegacyListId(`pm:${list.pos}:${list.depth}:${list.context}`);
+		const scope = JSON.stringify([list.depth, list.context]);
+		const sourceScope = JSON.stringify([sourceId, scope]);
+		let listId = canonicalBySourceScope.get(sourceScope);
+		if (!listId) {
+			if (!assignedCanonicalIds.has(sourceId)) {
+				listId = sourceId;
+			} else {
+				let attempt = 0;
+				do {
+					listId = createRepairId(sourceId, scope, attempt++);
+				} while (assignedCanonicalIds.has(listId));
+			}
+			canonicalBySourceScope.set(sourceScope, listId);
+			assignedCanonicalIds.add(listId);
+		}
+		return {
+			...list,
+			listId,
+			scopeKey: JSON.stringify([listId, list.depth, list.context]),
+		};
+	});
+
+	const bases = new Map<string, number>();
+	for (const list of prepared) {
+		const listStart = normalizeListStart(list.node.attrs.listStart);
+		if (listStart !== undefined && !bases.has(list.scopeKey)) {
+			bases.set(list.scopeKey, listStart);
+		}
+	}
+	for (const list of prepared) {
+		if (!bases.has(list.scopeKey)) {
+			bases.set(list.scopeKey, normalizeListStart(list.node.attrs.start) ?? 1);
+		}
+	}
+
+	const counts = new Map<string, number>();
+	const changes: OrderedListNormalization[] = [];
+	for (const list of prepared) {
+		const listStart = bases.get(list.scopeKey)!;
+		const count = counts.get(list.scopeKey) ?? 0;
+		const start = normalizeListStart(listStart + count) ?? 1;
+		counts.set(list.scopeKey, count + list.node.childCount);
+		if (
+			list.node.attrs.listId !== list.listId ||
+			list.node.attrs.listStart !== listStart ||
+			list.node.attrs.start !== start
+		) {
+			changes.push({
+				pos: list.pos,
+				attrs: { ...list.node.attrs, listId: list.listId, listStart, start },
+			});
+		}
+	}
+	return changes;
+}
+
+function applyNormalization(state: EditorState): Transaction | null {
+	const changes = normalizeOrderedListDocument(state.doc);
+	if (changes.length === 0) {
+		const lists = collectOrderedLists(state.doc);
+		const hasJoin = lists.some((list, index) => {
+			const next = lists[index + 1];
+			return (
+				next !== undefined &&
+				next.pos === list.pos + list.node.nodeSize &&
+				next.depth === list.depth &&
+				next.context === list.context &&
+				normalizeListId(next.node.attrs.listId) === normalizeListId(list.node.attrs.listId) &&
+				normalizeListStart(next.node.attrs.listStart) ===
+					normalizeListStart(list.node.attrs.listStart)
+			);
+		});
+		if (!hasJoin) return null;
+	}
+	const transaction = state.tr;
+	for (const change of changes) {
+		transaction.setNodeMarkup(change.pos, undefined, change.attrs);
+	}
+	const normalizedLists = collectOrderedLists(transaction.doc);
+	const joinPositions = normalizedLists.flatMap((list, index) => {
+		const next = normalizedLists[index + 1];
+		return next !== undefined &&
+			next.pos === list.pos + list.node.nodeSize &&
+			next.depth === list.depth &&
+			next.context === list.context &&
+			normalizeListId(next.node.attrs.listId) === normalizeListId(list.node.attrs.listId) &&
+			normalizeListStart(next.node.attrs.listStart) ===
+				normalizeListStart(list.node.attrs.listStart)
+			? [next.pos]
+			: [];
+	});
+	for (const pos of joinPositions.toReversed()) {
+		if (canJoin(transaction.doc, pos)) transaction.join(pos);
+	}
+	if (!transaction.docChanged) return null;
+	return transaction;
+}
+
+export function remapPastedSlice(slice: Slice): Slice {
+	const identities = new Map<string, { listId: string; listStart: number }>();
+	let missingIndex = 0;
+	const mapFragment = (fragment: Fragment, depth: number, parentContext: string): Fragment => {
+		const children: ProseMirrorNode[] = [];
+		fragment.forEach((node, _offset, index) => {
+			const childContext =
+				node.type.name === "listItem" ? `${parentContext}/listItem:${index}` : parentContext;
+			const content = mapFragment(node.content, depth + 1, childContext);
+			if (node.type.name !== "orderedList") {
+				children.push(node.copy(content));
+				return;
+			}
+			const sourceId = normalizeListId(node.attrs.listId) ?? `missing:${missingIndex++}`;
+			const scope = JSON.stringify([sourceId, depth, parentContext]);
+			let identity = identities.get(scope);
+			if (!identity) {
+				identity = {
+					listId: createListId(),
+					listStart:
+						normalizeListStart(node.attrs.start) ?? normalizeListStart(node.attrs.listStart) ?? 1,
+				};
+				identities.set(scope, identity);
+			}
+			children.push(
+				node.type.create(
+					{ ...node.attrs, ...identity, start: identity.listStart },
+					content,
+					node.marks,
+				),
+			);
+		});
+		return Fragment.fromArray(children);
+	};
+	return new Slice(mapFragment(slice.content, 0, "root"), slice.openStart, slice.openEnd);
+}
+
+function sliceHasOrderedList(slice: Slice): boolean {
+	let found = false;
+	slice.content.descendants((node) => {
+		if (node.type.name !== "orderedList") return true;
+		found = true;
+		return false;
+	});
+	return found;
+}
+
+function displayedStartAtSelection(
+	state: EditorState,
+): { listId: string; listStart: number } | null {
+	const current = collectOrderedLists(state.doc).findLast(
+		(list) =>
+			state.selection.from >= list.pos && state.selection.from <= list.pos + list.node.nodeSize,
+	);
+	if (!current) return null;
+	const listId = normalizeListId(current.node.attrs.listId);
+	const start = normalizeListStart(current.node.attrs.start);
+	if (!listId || start === undefined) return null;
+	let precedingItems = 0;
+	current.node.forEach((child, offset) => {
+		if (current.pos + 1 + offset + child.nodeSize <= state.selection.from) precedingItems++;
+	});
+	return {
+		listId,
+		listStart: normalizeListStart(start + precedingItems) ?? 1,
+	};
+}
+
+function rewriteSliceIdentity(
+	slice: Slice,
+	sourceId: string,
+	listId: string,
+	listStart: number,
+): Slice {
+	const mapFragment = (fragment: Fragment): Fragment => {
+		const children: ProseMirrorNode[] = [];
+		fragment.forEach((node) => {
+			const content = mapFragment(node.content);
+			children.push(
+				node.type.name === "orderedList" && normalizeListId(node.attrs.listId) === sourceId
+					? node.type.create(
+							{ ...node.attrs, listId, listStart, start: listStart },
+							content,
+							node.marks,
+						)
+					: node.copy(content),
+			);
+		});
+		return Fragment.fromArray(children);
+	};
+	return new Slice(mapFragment(slice.content), slice.openStart, slice.openEnd);
+}
+
+export function prepareCopiedSlice(slice: Slice, state: EditorState): Slice {
+	const selected = displayedStartAtSelection(state);
+	if (!selected) return slice;
+	let updated = false;
+	const mapFragment = (fragment: Fragment): Fragment => {
+		const children: ProseMirrorNode[] = [];
+		fragment.forEach((node) => {
+			const isFirstSelectedList =
+				!updated &&
+				node.type.name === "orderedList" &&
+				normalizeListId(node.attrs.listId) === selected.listId;
+			if (isFirstSelectedList) updated = true;
+			const content = mapFragment(node.content);
+			if (isFirstSelectedList) {
+				children.push(
+					node.type.create({ ...node.attrs, start: selected.listStart }, content, node.marks),
+				);
+			} else {
+				children.push(node.copy(content));
+			}
+		});
+		return Fragment.fromArray(children);
+	};
+	return new Slice(mapFragment(slice.content), slice.openStart, slice.openEnd);
+}
+
+export function remapMovedSlice(slice: Slice, state: EditorState): Slice {
+	const selected = displayedStartAtSelection(state);
+	if (!selected) return slice;
+	return rewriteSliceIdentity(slice, selected.listId, createListId(), selected.listStart);
+}
+
+function findCurrentList(state: EditorState): {
+	current: OrderedListDescriptor;
+	lists: OrderedListDescriptor[];
+} | null {
+	const lists = collectOrderedLists(state.doc);
+	const current = lists.findLast(
+		(list) =>
+			state.selection.from >= list.pos && state.selection.to <= list.pos + list.node.nodeSize,
+	);
+	if (!current) return null;
+	const intersecting = lists.filter(
+		(list) =>
+			list.depth === current.depth &&
+			list.context === current.context &&
+			state.selection.from < list.pos + list.node.nodeSize &&
+			state.selection.to > list.pos,
+	);
+	return intersecting.length === 1 ? { current, lists } : null;
+}
+
+function rewriteListTail(
+	state: EditorState,
+	dispatch: ((transaction: Transaction) => void) | undefined,
+	mode: "continue" | "restart",
+): boolean {
+	const selected = findCurrentList(state);
+	if (!selected) return false;
+	const { current, lists } = selected;
+	const currentId = normalizeListId(current.node.attrs.listId);
+	if (!currentId) return false;
+	const compatible = lists.filter(
+		(list) => list.depth === current.depth && list.context === current.context,
+	);
+	const predecessor = compatible.findLast((list) => list.pos < current.pos);
+	const predecessorId = predecessor ? normalizeListId(predecessor.node.attrs.listId) : undefined;
+	if (mode === "continue" && (!predecessorId || predecessorId === currentId)) {
+		return false;
+	}
+	if (!dispatch) return true;
+	const listId = mode === "continue" ? predecessorId! : createListId();
+	const listStart =
+		mode === "continue" ? (normalizeListStart(predecessor!.node.attrs.listStart) ?? 1) : 1;
+	const transaction = state.tr;
+	for (const list of compatible) {
+		if (list.pos < current.pos || normalizeListId(list.node.attrs.listId) !== currentId) continue;
+		transaction.setNodeMarkup(list.pos, undefined, {
+			...list.node.attrs,
+			listId,
+			listStart,
+		});
+	}
+	dispatch(transaction);
+	return true;
+}
+
+function buildDropTransaction(
+	state: EditorState,
+	slice: Slice,
+	insertPos: number,
+	deleteSource: boolean,
+): { transaction: Transaction; from: number; to: number } | null {
+	const transaction = state.tr;
+	if (deleteSource) transaction.deleteSelection();
+	const from = transaction.mapping.map(insertPos);
+	const beforeInsert = transaction.doc;
+	transaction.replaceRange(from, from, slice);
+	if (transaction.doc.eq(beforeInsert)) return null;
+	let to = from;
+	transaction.mapping.maps.at(-1)?.forEach((_oldFrom, _oldTo, _newFrom, newTo) => {
+		to = Math.max(to, newTo);
+	});
+	return { transaction, from, to };
+}
+
+function handleMovedListDrop(
+	view: EditorView,
+	event: DragEvent,
+	slice: Slice,
+	moved: boolean,
+): boolean {
+	if (!sliceHasOrderedList(slice)) return false;
+	const eventPos = view.posAtCoords({ left: event.clientX, top: event.clientY });
+	if (!eventPos) return false;
+	const insertPos = dropPoint(view.state.doc, eventPos.pos, slice) ?? eventPos.pos;
+	if (!moved) {
+		const dropped = buildDropTransaction(view.state, remapPastedSlice(slice), insertPos, false);
+		if (!dropped) return false;
+		const selectionPos = Math.min(dropped.to, dropped.transaction.doc.content.size);
+		dropped.transaction.setSelection(
+			Selection.near(dropped.transaction.doc.resolve(selectionPos), -1),
+		);
+		view.focus();
+		view.dispatch(dropped.transaction.setMeta("uiEvent", "drop").scrollIntoView());
+		return true;
+	}
+	const selected = findCurrentList(view.state);
+	if (!selected) return false;
+	const preview = buildDropTransaction(view.state, slice, insertPos, true);
+	if (!preview) return false;
+	const sourceContextPos = selected.current.contextPos;
+	const mappedSourceContextPos =
+		sourceContextPos === null ? null : preview.transaction.mapping.map(sourceContextPos, 1);
+	const remainsInContext = collectOrderedLists(preview.transaction.doc).some(
+		(list) =>
+			list.pos < preview.to &&
+			list.pos + list.node.nodeSize > preview.from &&
+			list.depth === selected.current.depth &&
+			list.contextPos === mappedSourceContextPos,
+	);
+	if (remainsInContext) return false;
+	const remapped = remapMovedSlice(slice, view.state);
+	if (remapped === slice) return false;
+	const dropped = buildDropTransaction(view.state, remapped, insertPos, true);
+	if (!dropped) return false;
+	const selectionPos = Math.min(dropped.to, dropped.transaction.doc.content.size);
+	dropped.transaction.setSelection(
+		Selection.near(dropped.transaction.doc.resolve(selectionPos), -1),
+	);
+	view.focus();
+	view.dispatch(dropped.transaction.setMeta("uiEvent", "drop").scrollIntoView());
+	return true;
+}
 
 export const EmDashOrderedList = OrderedList.extend({
 	addAttributes() {
+		const parent = this.parent?.() ?? {};
 		return {
-			...this.parent?.(),
+			...parent,
+			start: {
+				...parent.start,
+				parseHTML: (element) =>
+					normalizeListStart(Number(element.dataset.emdashListFirst)) ??
+					normalizeListStart(Number(element.getAttribute("start"))) ??
+					1,
+			},
 			listId: {
 				default: null,
+				parseHTML: (element) => normalizeListId(element.dataset.emdashListId) ?? null,
 				rendered: false,
 			},
 			listStart: {
 				default: null,
+				parseHTML: (element) => normalizeListStart(Number(element.dataset.emdashListStart)) ?? null,
 				rendered: false,
 			},
 		};
+	},
+
+	renderHTML({ HTMLAttributes, node }) {
+		const { start: _start, ...attributesWithoutStart } = HTMLAttributes;
+		const start = normalizeListStart(node.attrs.start) ?? 1;
+		const continuityAttributes = {
+			"data-emdash-list-id": normalizeListId(node.attrs.listId),
+			"data-emdash-list-start": normalizeListStart(node.attrs.listStart),
+			"data-emdash-list-first": start,
+		};
+		return start === 1
+			? [
+					"ol",
+					mergeAttributes(
+						this.options.HTMLAttributes,
+						attributesWithoutStart,
+						continuityAttributes,
+					),
+					0,
+				]
+			: [
+					"ol",
+					mergeAttributes(
+						this.options.HTMLAttributes,
+						{ ...attributesWithoutStart, start },
+						continuityAttributes,
+					),
+					0,
+				];
+	},
+
+	addCommands() {
+		return {
+			toggleOrderedList:
+				() =>
+				({ commands, chain }) => {
+					if (this.editor.isActive(this.name)) {
+						return commands.toggleList(
+							this.name,
+							this.options.itemTypeName,
+							this.options.keepMarks,
+						);
+					}
+					return chain()
+						.toggleList(this.name, this.options.itemTypeName, this.options.keepMarks)
+						.updateAttributes(this.name, {
+							listId: createListId(),
+							listStart: 1,
+						})
+						.run();
+				},
+			continueOrderedList:
+				() =>
+				({ state, dispatch }) =>
+					rewriteListTail(state, dispatch, "continue"),
+			restartOrderedList:
+				() =>
+				({ state, dispatch }) =>
+					rewriteListTail(state, dispatch, "restart"),
+		};
+	},
+
+	addInputRules() {
+		return [
+			wrappingInputRule({
+				find: ORDERED_LIST_INPUT_REGEX,
+				type: this.type,
+				getAttributes: (match) => {
+					const listStart = normalizeListStart(Number(match[1])) ?? 1;
+					return { start: listStart, listStart, listId: createListId() };
+				},
+				joinPredicate: () => false,
+			}),
+		];
+	},
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				appendTransaction: (_transactions, _oldState, newState) => applyNormalization(newState),
+				props: {
+					transformCopied: (slice, view) => prepareCopiedSlice(slice, view.state),
+					handleDrop: handleMovedListDrop,
+					handlePaste(view, _event, slice) {
+						if (!sliceHasOrderedList(slice)) return false;
+						view.dispatch(
+							view.state.tr
+								.replaceSelection(remapPastedSlice(slice))
+								.setMeta("paste", true)
+								.setMeta("uiEvent", "paste")
+								.scrollIntoView(),
+						);
+						return true;
+					},
+				},
+			}),
+		];
 	},
 });

--- a/packages/core/src/components/ordered-list.ts
+++ b/packages/core/src/components/ordered-list.ts
@@ -62,6 +62,10 @@ function collectOrderedLists(doc: ProseMirrorNode): OrderedListDescriptor[] {
 				break;
 			}
 		}
+		if (contextPos === null && resolved.depth > 0) {
+			contextPos = resolved.before(resolved.depth);
+			context = `${resolved.node(resolved.depth).type.name}:${contextPos}`;
+		}
 		lists.push({ node, pos, depth: resolved.depth, context, contextPos });
 	});
 	return lists;

--- a/packages/core/src/components/ordered-list.ts
+++ b/packages/core/src/components/ordered-list.ts
@@ -1,0 +1,17 @@
+import { OrderedList } from "@tiptap/extension-list";
+
+export const EmDashOrderedList = OrderedList.extend({
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			listId: {
+				default: null,
+				rendered: false,
+			},
+			listStart: {
+				default: null,
+				rendered: false,
+			},
+		};
+	},
+});

--- a/packages/core/src/content/converters/numbered-list.ts
+++ b/packages/core/src/content/converters/numbered-list.ts
@@ -7,10 +7,6 @@ export interface OrderedListMetadata {
 	listStart: number;
 }
 
-export interface OrderedListCounter extends OrderedListMetadata {
-	count: number;
-}
-
 export function normalizeListId(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const normalized = value.trim();
@@ -45,24 +41,6 @@ export function readOrderedListMetadata(
 		listId: normalizeListId(attrs?.listId) ?? deriveLegacyListId(fallbackId),
 		listStart: normalizeListStart(attrs?.listStart) ?? normalizeListStart(attrs?.start) ?? 1,
 	};
-}
-
-export function takeOrderedListStart(
-	counters: Map<string, OrderedListCounter>,
-	metadata: OrderedListMetadata,
-	directItemCount: number,
-): number {
-	const current = counters.get(metadata.listId);
-	const listStart = current?.listStart ?? metadata.listStart;
-	const count = current?.count ?? 0;
-	const derived = listStart + count;
-	const start = normalizeListStart(derived) ?? 1;
-	counters.set(metadata.listId, {
-		listId: metadata.listId,
-		listStart,
-		count: count + directItemCount,
-	});
-	return start;
 }
 
 interface ProseMirrorListDescriptor {

--- a/packages/core/src/content/converters/numbered-list.ts
+++ b/packages/core/src/content/converters/numbered-list.ts
@@ -1,0 +1,64 @@
+export const MAX_ORDERED_LIST_START = 2_147_483_647;
+
+export interface OrderedListMetadata {
+	listId: string;
+	listStart: number;
+}
+
+export interface OrderedListCounter extends OrderedListMetadata {
+	count: number;
+}
+
+export function normalizeListId(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim();
+	return normalized.length > 0 && normalized.length <= 128 ? normalized : undefined;
+}
+
+export function normalizeListStart(value: unknown): number | undefined {
+	return typeof value === "number" &&
+		Number.isInteger(value) &&
+		value >= 1 &&
+		value <= MAX_ORDERED_LIST_START
+		? value
+		: undefined;
+}
+
+export function deriveLegacyListId(seed: string): string {
+	const readable = `legacy:${seed}`;
+	if (readable.length <= 128) return readable;
+	let hash = 2_166_136_261;
+	for (let i = 0; i < seed.length; i++) {
+		hash ^= seed.charCodeAt(i);
+		hash = Math.imul(hash, 16_777_619);
+	}
+	return `legacy:${seed.slice(0, 96)}:${(hash >>> 0).toString(36)}:${seed.length.toString(36)}`;
+}
+
+export function readOrderedListMetadata(
+	attrs: Record<string, unknown> | undefined,
+	fallbackId: string,
+): OrderedListMetadata {
+	return {
+		listId: normalizeListId(attrs?.listId) ?? deriveLegacyListId(fallbackId),
+		listStart: normalizeListStart(attrs?.listStart) ?? normalizeListStart(attrs?.start) ?? 1,
+	};
+}
+
+export function takeOrderedListStart(
+	counters: Map<string, OrderedListCounter>,
+	metadata: OrderedListMetadata,
+	directItemCount: number,
+): number {
+	const current = counters.get(metadata.listId);
+	const listStart = current?.listStart ?? metadata.listStart;
+	const count = current?.count ?? 0;
+	const derived = listStart + count;
+	const start = normalizeListStart(derived) ?? 1;
+	counters.set(metadata.listId, {
+		listId: metadata.listId,
+		listStart,
+		count: count + directItemCount,
+	});
+	return start;
+}

--- a/packages/core/src/content/converters/numbered-list.ts
+++ b/packages/core/src/content/converters/numbered-list.ts
@@ -1,3 +1,5 @@
+import type { ProseMirrorDocument, ProseMirrorNode } from "./types.js";
+
 export const MAX_ORDERED_LIST_START = 2_147_483_647;
 
 export interface OrderedListMetadata {
@@ -61,4 +63,108 @@ export function takeOrderedListStart(
 		count: count + directItemCount,
 	});
 	return start;
+}
+
+interface ProseMirrorListDescriptor {
+	node: ProseMirrorNode;
+	path: string;
+	depth: number;
+	context: string;
+}
+
+function collectProseMirrorOrderedLists(doc: ProseMirrorDocument): ProseMirrorListDescriptor[] {
+	const lists: ProseMirrorListDescriptor[] = [];
+	const visit = (node: ProseMirrorNode, path: string, depth: number, context: string) => {
+		if (node.type === "orderedList") lists.push({ node, path, depth, context });
+		for (const [index, child] of (node.content ?? []).entries()) {
+			const childPath = `${path}:${index}`;
+			visit(
+				child,
+				childPath,
+				depth + 1,
+				child.type === "listItem" ? `listItem:${childPath}` : context,
+			);
+		}
+	};
+	for (const [index, node] of doc.content.entries()) {
+		visit(node, `root:${index}`, 0, "root");
+	}
+	return lists;
+}
+
+function cloneProseMirrorNode(node: ProseMirrorNode): ProseMirrorNode {
+	return {
+		...node,
+		attrs: node.attrs ? { ...node.attrs } : undefined,
+		content: node.content?.map(cloneProseMirrorNode),
+		marks: node.marks?.map((mark) => ({
+			...mark,
+			attrs: mark.attrs ? { ...mark.attrs } : undefined,
+		})),
+	};
+}
+
+function createRepairId(sourceId: string, scope: string, attempt: number): string {
+	const base = deriveLegacyListId(`repair:${sourceId}:${scope}`);
+	const suffix = `:${attempt.toString(36)}`;
+	return `${base.slice(0, 128 - suffix.length)}${suffix}`;
+}
+
+export function normalizeProseMirrorOrderedListJson(doc: ProseMirrorDocument): ProseMirrorDocument {
+	const normalized = {
+		...doc,
+		content: doc.content.map(cloneProseMirrorNode),
+	};
+	const canonicalBySourceScope = new Map<string, string>();
+	const assignedCanonicalIds = new Set<string>();
+	const lists = collectProseMirrorOrderedLists(normalized).map((list) => {
+		const sourceId =
+			normalizeListId(list.node.attrs?.listId) ??
+			deriveLegacyListId(`pm-json:${list.path}:${list.depth}:${list.context}`);
+		const scope = JSON.stringify([list.depth, list.context]);
+		const sourceScope = JSON.stringify([sourceId, scope]);
+		let listId = canonicalBySourceScope.get(sourceScope);
+		if (!listId) {
+			if (!assignedCanonicalIds.has(sourceId)) {
+				listId = sourceId;
+			} else {
+				let attempt = 0;
+				do {
+					listId = createRepairId(sourceId, scope, attempt++);
+				} while (assignedCanonicalIds.has(listId));
+			}
+			canonicalBySourceScope.set(sourceScope, listId);
+			assignedCanonicalIds.add(listId);
+		}
+		return {
+			...list,
+			listId,
+			scopeKey: JSON.stringify([listId, list.depth, list.context]),
+		};
+	});
+
+	const bases = new Map<string, number>();
+	for (const list of lists) {
+		const listStart = normalizeListStart(list.node.attrs?.listStart);
+		if (listStart !== undefined && !bases.has(list.scopeKey)) {
+			bases.set(list.scopeKey, listStart);
+		}
+	}
+	for (const list of lists) {
+		if (!bases.has(list.scopeKey)) {
+			bases.set(list.scopeKey, normalizeListStart(list.node.attrs?.start) ?? 1);
+		}
+	}
+
+	const counts = new Map<string, number>();
+	for (const list of lists) {
+		const listStart = bases.get(list.scopeKey)!;
+		const count = counts.get(list.scopeKey) ?? 0;
+		const start = normalizeListStart(listStart + count) ?? 1;
+		const directItemCount =
+			list.node.content?.filter((node) => node.type === "listItem").length ?? 0;
+		counts.set(list.scopeKey, count + directItemCount);
+		list.node.attrs = { ...list.node.attrs, listId: list.listId, listStart, start };
+	}
+	return normalized;
 }

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -7,11 +7,9 @@
 import { sanitizeGalleryImages } from "./gallery.js";
 import {
 	deriveLegacyListId,
+	normalizeProseMirrorOrderedListJson,
 	normalizeListId,
 	normalizeListStart,
-	takeOrderedListStart,
-	type OrderedListCounter,
-	type OrderedListMetadata,
 } from "./numbered-list.js";
 import type {
 	ProseMirrorDocument,
@@ -38,8 +36,6 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 	}
 
 	const content: ProseMirrorNode[] = [];
-	const counters = new Map<string, OrderedListCounter>();
-	const canonicalStarts = collectCanonicalStarts(blocks);
 	let i = 0;
 
 	while (i < blocks.length) {
@@ -79,9 +75,7 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 				}
 			}
 
-			content.push(
-				convertList(listBlocks, listType, counters, canonicalStarts, `root:${runStart}`),
-			);
+			content.push(convertList(listBlocks, listType, `root:${runStart}`));
 		} else if (isTextBlock(block) && block.style === "blockquote") {
 			// Collect a blockquote "run": Portable Text is flat, so a
 			// multi-paragraph quote is stored as consecutive blocks with
@@ -122,34 +116,21 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 		}
 	}
 
-	return {
+	return normalizeProseMirrorOrderedListJson({
 		type: "doc",
 		content: content.length > 0 ? content : [{ type: "paragraph" }],
-	};
-}
-
-function collectCanonicalStarts(blocks: PortableTextBlock[]): Map<string, number> {
-	const starts = new Map<string, number>();
-	for (const block of blocks) {
-		if (!isTextBlock(block) || block.listItem !== "number") continue;
-		const listId = normalizeListId(block.listId);
-		const listStart = normalizeListStart(block.listStart);
-		if (listId && listStart !== undefined && !starts.has(listId)) {
-			starts.set(listId, listStart);
-		}
-	}
-	return starts;
+	});
 }
 
 function getListMetadata(
 	item: PortableTextTextBlock,
-	canonicalStarts: Map<string, number>,
 	fallbackSeed: string,
-): OrderedListMetadata {
+): { listId: string; listStart?: number } {
 	const listId = normalizeListId(item.listId) ?? deriveLegacyListId(fallbackSeed);
+	const listStart = normalizeListStart(item.listStart);
 	return {
 		listId,
-		listStart: canonicalStarts.get(listId) ?? normalizeListStart(item.listStart) ?? 1,
+		...(listStart === undefined ? {} : { listStart }),
 	};
 }
 
@@ -308,8 +289,6 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 function convertList(
 	items: PortableTextTextBlock[],
 	listType: "bullet" | "number",
-	counters: Map<string, OrderedListCounter>,
-	canonicalStarts: Map<string, number>,
 	context: string,
 ): ProseMirrorNode {
 	// Group items by level
@@ -331,40 +310,21 @@ function convertList(
 			}
 
 			rootItems.push(
-				convertListItem(
-					item,
-					nestedItems,
-					listType,
-					counters,
-					canonicalStarts,
-					`${context}:${rootItems.length}`,
-				),
+				convertListItem(item, nestedItems, listType, `${context}:${rootItems.length}`),
 			);
 		} else {
 			// Orphan nested item - treat as root
-			rootItems.push(
-				convertListItem(
-					item,
-					[],
-					listType,
-					counters,
-					canonicalStarts,
-					`${context}:${rootItems.length}`,
-				),
-			);
+			rootItems.push(convertListItem(item, [], listType, `${context}:${rootItems.length}`));
 			i++;
 		}
 	}
 
 	const metadata =
-		listType === "number"
-			? getListMetadata(items[0], canonicalStarts, `${context}:${items[0]._key}`)
-			: undefined;
-	const start = metadata ? takeOrderedListStart(counters, metadata, rootItems.length) : undefined;
+		listType === "number" ? getListMetadata(items[0], `${context}:${items[0]._key}`) : undefined;
 
 	return {
 		type: listType === "bullet" ? "bulletList" : "orderedList",
-		attrs: metadata ? { ...metadata, start } : undefined,
+		attrs: metadata ? { ...metadata, start: metadata.listStart ?? 1 } : undefined,
 		content: rootItems,
 	};
 }
@@ -376,8 +336,6 @@ function convertListItem(
 	item: PortableTextTextBlock,
 	nestedItems: PortableTextTextBlock[],
 	parentListType: "bullet" | "number",
-	counters: Map<string, OrderedListCounter>,
-	canonicalStarts: Map<string, number>,
 	context: string,
 ): ProseMirrorNode {
 	const content: ProseMirrorNode[] = [];
@@ -427,13 +385,7 @@ function convertListItem(
 					level: (ni.level || 2) - 1,
 				}));
 				content.push(
-					convertList(
-						adjustedGroup,
-						anchorType,
-						counters,
-						canonicalStarts,
-						`${context}:nested:${j - nestedGroup.length}`,
-					),
+					convertList(adjustedGroup, anchorType, `${context}:nested:${j - nestedGroup.length}`),
 				);
 			}
 		}

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -5,6 +5,14 @@
  */
 
 import { sanitizeGalleryImages } from "./gallery.js";
+import {
+	deriveLegacyListId,
+	normalizeListId,
+	normalizeListStart,
+	takeOrderedListStart,
+	type OrderedListCounter,
+	type OrderedListMetadata,
+} from "./numbered-list.js";
 import type {
 	ProseMirrorDocument,
 	ProseMirrorNode,
@@ -30,6 +38,8 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 	}
 
 	const content: ProseMirrorNode[] = [];
+	const counters = new Map<string, OrderedListCounter>();
+	const canonicalStarts = collectCanonicalStarts(blocks);
 	let i = 0;
 
 	while (i < blocks.length) {
@@ -48,12 +58,20 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 			// child).
 			const listBlocks: PortableTextTextBlock[] = [];
 			const listType = block.listItem;
+			const runStart = i;
+			const rootId = listType === "number" ? normalizeListId(block.listId) : undefined;
 
 			while (i < blocks.length) {
 				const current = blocks[i];
 				if (!isTextBlock(current) || !current.listItem) break;
 				const level = current.level || 1;
-				if (level > 1 || current.listItem === listType) {
+				const currentId =
+					current.listItem === "number" ? normalizeListId(current.listId) : undefined;
+				const sameRootIdentity =
+					listType !== "number" ||
+					level > 1 ||
+					(rootId ? currentId === rootId : currentId === undefined);
+				if (level > 1 || (current.listItem === listType && sameRootIdentity)) {
 					listBlocks.push(current);
 					i++;
 				} else {
@@ -61,7 +79,9 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 				}
 			}
 
-			content.push(convertList(listBlocks, listType));
+			content.push(
+				convertList(listBlocks, listType, counters, canonicalStarts, `root:${runStart}`),
+			);
 		} else if (isTextBlock(block) && block.style === "blockquote") {
 			// Collect a blockquote "run": Portable Text is flat, so a
 			// multi-paragraph quote is stored as consecutive blocks with
@@ -106,6 +126,45 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 		type: "doc",
 		content: content.length > 0 ? content : [{ type: "paragraph" }],
 	};
+}
+
+function collectCanonicalStarts(blocks: PortableTextBlock[]): Map<string, number> {
+	const starts = new Map<string, number>();
+	for (const block of blocks) {
+		if (!isTextBlock(block) || block.listItem !== "number") continue;
+		const listId = normalizeListId(block.listId);
+		const listStart = normalizeListStart(block.listStart);
+		if (listId && listStart !== undefined && !starts.has(listId)) {
+			starts.set(listId, listStart);
+		}
+	}
+	return starts;
+}
+
+function getListMetadata(
+	item: PortableTextTextBlock,
+	canonicalStarts: Map<string, number>,
+	fallbackSeed: string,
+): OrderedListMetadata {
+	const listId = normalizeListId(item.listId) ?? deriveLegacyListId(fallbackSeed);
+	return {
+		listId,
+		listStart: canonicalStarts.get(listId) ?? normalizeListStart(item.listStart) ?? 1,
+	};
+}
+
+function belongsToNestedGroup(
+	item: PortableTextTextBlock,
+	minLevel: number,
+	parentListType: "bullet" | "number",
+	anchorType: "bullet" | "number",
+	anchorId: string | undefined,
+): boolean {
+	if ((item.level || 2) > minLevel) return true;
+	if ((item.listItem || parentListType) !== anchorType) return false;
+	if (anchorType !== "number") return true;
+	const itemId = normalizeListId(item.listId);
+	return anchorId ? itemId === anchorId : itemId === undefined;
 }
 
 /**
@@ -249,6 +308,9 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 function convertList(
 	items: PortableTextTextBlock[],
 	listType: "bullet" | "number",
+	counters: Map<string, OrderedListCounter>,
+	canonicalStarts: Map<string, number>,
+	context: string,
 ): ProseMirrorNode {
 	// Group items by level
 	const rootItems: ProseMirrorNode[] = [];
@@ -268,16 +330,41 @@ function convertList(
 				i++;
 			}
 
-			rootItems.push(convertListItem(item, nestedItems, listType));
+			rootItems.push(
+				convertListItem(
+					item,
+					nestedItems,
+					listType,
+					counters,
+					canonicalStarts,
+					`${context}:${rootItems.length}`,
+				),
+			);
 		} else {
 			// Orphan nested item - treat as root
-			rootItems.push(convertListItem(item, [], listType));
+			rootItems.push(
+				convertListItem(
+					item,
+					[],
+					listType,
+					counters,
+					canonicalStarts,
+					`${context}:${rootItems.length}`,
+				),
+			);
 			i++;
 		}
 	}
 
+	const metadata =
+		listType === "number"
+			? getListMetadata(items[0], canonicalStarts, `${context}:${items[0]._key}`)
+			: undefined;
+	const start = metadata ? takeOrderedListStart(counters, metadata, rootItems.length) : undefined;
+
 	return {
 		type: listType === "bullet" ? "bulletList" : "orderedList",
+		attrs: metadata ? { ...metadata, start } : undefined,
 		content: rootItems,
 	};
 }
@@ -289,6 +376,9 @@ function convertListItem(
 	item: PortableTextTextBlock,
 	nestedItems: PortableTextTextBlock[],
 	parentListType: "bullet" | "number",
+	counters: Map<string, OrderedListCounter>,
+	canonicalStarts: Map<string, number>,
+	context: string,
 ): ProseMirrorNode {
 	const content: ProseMirrorNode[] = [];
 
@@ -319,6 +409,7 @@ function convertListItem(
 		let j = 0;
 		while (j < nestedItems.length) {
 			const anchorType: "bullet" | "number" = nestedItems[j].listItem || parentListType;
+			const anchorId = anchorType === "number" ? normalizeListId(nestedItems[j].listId) : undefined;
 			const nestedGroup: PortableTextTextBlock[] = [];
 
 			do {
@@ -326,8 +417,7 @@ function convertListItem(
 				j++;
 			} while (
 				j < nestedItems.length &&
-				((nestedItems[j].level || 2) > minLevel ||
-					(nestedItems[j].listItem || parentListType) === anchorType)
+				belongsToNestedGroup(nestedItems[j], minLevel, parentListType, anchorType, anchorId)
 			);
 
 			if (nestedGroup.length > 0) {
@@ -336,7 +426,15 @@ function convertListItem(
 					...ni,
 					level: (ni.level || 2) - 1,
 				}));
-				content.push(convertList(adjustedGroup, anchorType));
+				content.push(
+					convertList(
+						adjustedGroup,
+						anchorType,
+						counters,
+						canonicalStarts,
+						`${context}:nested:${j - nestedGroup.length}`,
+					),
+				);
 			}
 		}
 	}

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -82,7 +82,7 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 			// style "blockquote" (that's what the Gutenberg importer emits
 			// and what prosemirrorToPortableText serializes back to).
 			// Without this grouping each paragraph became its own quote
-			// node, and editor merges reverted on reload (#1884).
+			// node, and editor merges reverted on reload.
 			const quoteBlocks: PortableTextTextBlock[] = [];
 			while (i < blocks.length) {
 				const current = blocks[i];

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -37,8 +37,8 @@ export function prosemirrorToPortableText(doc: ProseMirrorDocument): PortableTex
 
 	const blocks: PortableTextBlock[] = [];
 
-	for (let i = 0; i < doc.content.length; i++) {
-		const converted = convertNode(doc.content[i]!, `root:${i}`);
+	for (const [i, node] of doc.content.entries()) {
+		const converted = convertNode(node, `root:${i}`);
 		if (converted) {
 			if (Array.isArray(converted)) {
 				blocks.push(...converted);
@@ -184,8 +184,7 @@ function convertList(
 	const blocks: PortableTextTextBlock[] = [];
 	const metadata = listItem === "number" ? readOrderedListMetadata(node.attrs, path) : undefined;
 
-	for (let i = 0; i < (node.content || []).length; i++) {
-		const item = node.content![i]!;
+	for (const [i, item] of (node.content ?? []).entries()) {
 		if (item.type === "listItem") {
 			const itemBlocks = convertListItem(item, listItem, 1, `${path}:${i}`, metadata);
 			blocks.push(...itemBlocks);
@@ -207,8 +206,7 @@ function convertListItem(
 ): PortableTextTextBlock[] {
 	const blocks: PortableTextTextBlock[] = [];
 
-	for (let i = 0; i < (item.content || []).length; i++) {
-		const child = item.content![i]!;
+	for (const [i, child] of (item.content ?? []).entries()) {
 		if (child.type === "paragraph") {
 			const { children, markDefs } = convertInlineContent(child.content || []);
 
@@ -246,8 +244,7 @@ function convertListItemNested(
 	const blocks: PortableTextTextBlock[] = [];
 	const metadata = listItem === "number" ? readOrderedListMetadata(node.attrs, path) : undefined;
 
-	for (let i = 0; i < (node.content || []).length; i++) {
-		const item = node.content![i]!;
+	for (const [i, item] of (node.content ?? []).entries()) {
 		if (item.type === "listItem") {
 			blocks.push(...convertListItem(item, listItem, level, `${path}:${i}`, metadata));
 		}

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -5,6 +5,7 @@
  */
 
 import { sanitizeGalleryImages } from "./gallery.js";
+import { readOrderedListMetadata, type OrderedListMetadata } from "./numbered-list.js";
 import type {
 	ProseMirrorDocument,
 	ProseMirrorNode,
@@ -36,8 +37,8 @@ export function prosemirrorToPortableText(doc: ProseMirrorDocument): PortableTex
 
 	const blocks: PortableTextBlock[] = [];
 
-	for (const node of doc.content) {
-		const converted = convertNode(node);
+	for (let i = 0; i < doc.content.length; i++) {
+		const converted = convertNode(doc.content[i]!, `root:${i}`);
 		if (converted) {
 			if (Array.isArray(converted)) {
 				blocks.push(...converted);
@@ -53,7 +54,10 @@ export function prosemirrorToPortableText(doc: ProseMirrorDocument): PortableTex
 /**
  * Convert a single ProseMirror node to Portable Text block(s)
  */
-function convertNode(node: ProseMirrorNode): PortableTextBlock | PortableTextBlock[] | null {
+function convertNode(
+	node: ProseMirrorNode,
+	path: string,
+): PortableTextBlock | PortableTextBlock[] | null {
 	switch (node.type) {
 		case "paragraph":
 			return convertParagraph(node);
@@ -62,10 +66,10 @@ function convertNode(node: ProseMirrorNode): PortableTextBlock | PortableTextBlo
 			return convertHeading(node);
 
 		case "bulletList":
-			return convertList(node, "bullet");
+			return convertList(node, "bullet", path);
 
 		case "orderedList":
-			return convertList(node, "number");
+			return convertList(node, "number", path);
 
 		case "blockquote":
 			return convertBlockquote(node);
@@ -175,12 +179,15 @@ function convertHeading(node: ProseMirrorNode): PortableTextTextBlock | null {
 function convertList(
 	node: ProseMirrorNode,
 	listItem: "bullet" | "number",
+	path: string,
 ): PortableTextTextBlock[] {
 	const blocks: PortableTextTextBlock[] = [];
+	const metadata = listItem === "number" ? readOrderedListMetadata(node.attrs, path) : undefined;
 
-	for (const item of node.content || []) {
+	for (let i = 0; i < (node.content || []).length; i++) {
+		const item = node.content![i]!;
 		if (item.type === "listItem") {
-			const itemBlocks = convertListItem(item, listItem, 1);
+			const itemBlocks = convertListItem(item, listItem, 1, `${path}:${i}`, metadata);
 			blocks.push(...itemBlocks);
 		}
 	}
@@ -195,10 +202,13 @@ function convertListItem(
 	item: ProseMirrorNode,
 	listItem: "bullet" | "number",
 	level: number,
+	path: string,
+	metadata?: OrderedListMetadata,
 ): PortableTextTextBlock[] {
 	const blocks: PortableTextTextBlock[] = [];
 
-	for (const child of item.content || []) {
+	for (let i = 0; i < (item.content || []).length; i++) {
+		const child = item.content![i]!;
 		if (child.type === "paragraph") {
 			const { children, markDefs } = convertInlineContent(child.content || []);
 
@@ -209,14 +219,15 @@ function convertListItem(
 					style: "normal",
 					listItem,
 					level,
+					...metadata,
 					children,
 					markDefs: markDefs.length > 0 ? markDefs : undefined,
 				});
 			}
 		} else if (child.type === "bulletList") {
-			blocks.push(...convertListItemNested(child, "bullet", level + 1));
+			blocks.push(...convertListItemNested(child, "bullet", level + 1, `${path}:${i}`));
 		} else if (child.type === "orderedList") {
-			blocks.push(...convertListItemNested(child, "number", level + 1));
+			blocks.push(...convertListItemNested(child, "number", level + 1, `${path}:${i}`));
 		}
 	}
 
@@ -230,12 +241,15 @@ function convertListItemNested(
 	node: ProseMirrorNode,
 	listItem: "bullet" | "number",
 	level: number,
+	path: string,
 ): PortableTextTextBlock[] {
 	const blocks: PortableTextTextBlock[] = [];
+	const metadata = listItem === "number" ? readOrderedListMetadata(node.attrs, path) : undefined;
 
-	for (const item of node.content || []) {
+	for (let i = 0; i < (node.content || []).length; i++) {
+		const item = node.content![i]!;
 		if (item.type === "listItem") {
-			blocks.push(...convertListItem(item, listItem, level));
+			blocks.push(...convertListItem(item, listItem, level, `${path}:${i}`, metadata));
 		}
 	}
 

--- a/packages/core/src/content/converters/types.ts
+++ b/packages/core/src/content/converters/types.ts
@@ -41,6 +41,8 @@ export interface PortableTextTextBlock {
 	style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
 	listItem?: "bullet" | "number";
 	level?: number;
+	listId?: string;
+	listStart?: number;
 	children: PortableTextSpan[];
 	markDefs?: PortableTextMarkDef[];
 	textAlign?: "left" | "center" | "right" | "justify";

--- a/packages/core/src/content/portable-text-lists.ts
+++ b/packages/core/src/content/portable-text-lists.ts
@@ -203,16 +203,3 @@ export function buildPortableTextListTree(
 ): PortableTextNode[] {
 	return preprocessLists(blocks, mode).tree;
 }
-
-export function getNumberedListOrdinals(blocks: PortableTextNode[]): Map<PortableTextNode, number> {
-	const { descriptors } = preprocessLists(blocks, "direct");
-	const ordinals = new Map<PortableTextNode, number>();
-	for (const descriptor of descriptors) {
-		if (descriptor.node.listItem !== "number") continue;
-		const start = descriptor.node.start ?? 1;
-		for (let index = 0; index < descriptor.directItems.length; index++) {
-			ordinals.set(descriptor.directItems[index].original, normalizeListStart(start + index) ?? 1);
-		}
-	}
-	return ordinals;
-}

--- a/packages/core/src/content/portable-text-lists.ts
+++ b/packages/core/src/content/portable-text-lists.ts
@@ -1,0 +1,218 @@
+import {
+	deriveLegacyListId,
+	normalizeListId,
+	normalizeListStart,
+} from "./converters/numbered-list.js";
+
+type ListNestingMode = "html" | "direct";
+type PortableTextNode = Record<string, unknown>;
+
+interface PortableTextListBlock extends PortableTextNode {
+	_type: "block";
+	children: unknown[];
+	level?: number;
+	listId?: unknown;
+	listItem: string;
+	listStart?: unknown;
+}
+
+export interface PortableTextListNode extends PortableTextNode {
+	_type: "@list";
+	_key: string;
+	children: PortableTextNode[];
+	level: number;
+	listItem: string;
+	mode: ListNestingMode;
+	start?: number;
+}
+
+interface ListDescriptor {
+	node: PortableTextListNode;
+	directItems: Array<{
+		original: PortableTextListBlock;
+		rendered: PortableTextListBlock;
+	}>;
+	level: number;
+	parentContext: string;
+	sourceId: string | undefined;
+	segment: number;
+}
+
+interface ParentItem {
+	context: string;
+	list: ListDescriptor;
+	rendered: PortableTextListBlock;
+}
+
+function isListBlock(node: PortableTextNode): node is PortableTextListBlock {
+	return (
+		node._type === "block" && typeof node.listItem === "string" && Array.isArray(node.children)
+	);
+}
+
+function readLevel(value: unknown): number {
+	return typeof value === "number" && Number.isInteger(value) && value >= 1 ? value : 1;
+}
+
+function findParentItem(items: Map<number, ParentItem>, level: number): ParentItem | undefined {
+	let nearestLevel = 0;
+	let nearest: ParentItem | undefined;
+	for (const [candidate, item] of items) {
+		if (candidate < level && candidate > nearestLevel) {
+			nearestLevel = candidate;
+			nearest = item;
+		}
+	}
+	return nearest;
+}
+
+function matchesList(
+	descriptor: ListDescriptor | undefined,
+	listItem: string,
+	sourceId: string | undefined,
+	parentContext: string,
+): descriptor is ListDescriptor {
+	return (
+		descriptor !== undefined &&
+		descriptor.node.listItem === listItem &&
+		descriptor.parentContext === parentContext &&
+		(listItem !== "number" || descriptor.sourceId === sourceId)
+	);
+}
+
+function buildListTree(
+	blocks: PortableTextNode[],
+	mode: ListNestingMode,
+): { tree: PortableTextNode[]; descriptors: ListDescriptor[] } {
+	const tree: PortableTextNode[] = [];
+	const descriptors: ListDescriptor[] = [];
+	const activeLists = new Map<number, ListDescriptor>();
+	const lastItems = new Map<number, ParentItem>();
+	let segment = 0;
+
+	for (let index = 0; index < blocks.length; index++) {
+		const block = blocks[index];
+		if (!isListBlock(block)) {
+			tree.push(block);
+			activeLists.clear();
+			lastItems.clear();
+			continue;
+		}
+
+		const level = readLevel(block.level);
+		for (const activeLevel of activeLists.keys()) {
+			if (activeLevel > level) activeLists.delete(activeLevel);
+		}
+		for (const itemLevel of lastItems.keys()) {
+			if (itemLevel > level) lastItems.delete(itemLevel);
+		}
+
+		const parent = findParentItem(lastItems, level);
+		const parentContext = parent?.context ?? "root";
+		const sourceId = block.listItem === "number" ? normalizeListId(block.listId) : undefined;
+		let descriptor = activeLists.get(level);
+		if (!matchesList(descriptor, block.listItem, sourceId, parentContext)) {
+			const node: PortableTextListNode = {
+				_type: "@list",
+				_key: `${typeof block._key === "string" ? block._key : index}-parent`,
+				children: [],
+				level,
+				listItem: block.listItem,
+				mode,
+			};
+			descriptor = {
+				node,
+				directItems: [],
+				level,
+				parentContext,
+				sourceId,
+				segment: segment++,
+			};
+			descriptors.push(descriptor);
+			activeLists.set(level, descriptor);
+			if (!parent) {
+				tree.push(node);
+			} else if (mode === "direct") {
+				parent.list.node.children.push(node);
+			} else {
+				parent.rendered.children.push(node);
+			}
+		}
+
+		const rendered = { ...block, children: [...block.children] };
+		descriptor.node.children.push(rendered);
+		descriptor.directItems.push({ original: block, rendered });
+		lastItems.set(level, {
+			context: `${parentContext}/item:${index}`,
+			list: descriptor,
+			rendered,
+		});
+	}
+
+	return { tree, descriptors };
+}
+
+function applyNumbering(descriptors: ListDescriptor[]): void {
+	const bases = new Map<string, number>();
+	const scopeKeys = new Map<ListDescriptor, string>();
+	for (const descriptor of descriptors) {
+		if (descriptor.node.listItem !== "number") continue;
+		const identity =
+			descriptor.sourceId ??
+			deriveLegacyListId(
+				`render:${descriptor.segment}:${descriptor.level}:${descriptor.parentContext}`,
+			);
+		const scope = JSON.stringify([identity, descriptor.level, descriptor.parentContext]);
+		scopeKeys.set(descriptor, scope);
+		if (!descriptor.sourceId || bases.has(scope)) continue;
+		for (const { original } of descriptor.directItems) {
+			const base = normalizeListStart(original.listStart);
+			if (base === undefined) continue;
+			bases.set(scope, base);
+			break;
+		}
+	}
+
+	const counts = new Map<string, number>();
+	for (const descriptor of descriptors) {
+		if (descriptor.node.listItem !== "number") continue;
+		const scope = scopeKeys.get(descriptor)!;
+		const base = bases.get(scope) ?? 1;
+		const count = counts.get(scope) ?? 0;
+		descriptor.node.start = normalizeListStart(base + count) ?? 1;
+		counts.set(scope, count + descriptor.directItems.length);
+	}
+}
+
+function preprocessLists(
+	blocks: PortableTextNode[],
+	mode: ListNestingMode,
+): { tree: PortableTextNode[]; descriptors: ListDescriptor[] } {
+	const result = buildListTree(blocks, mode);
+	applyNumbering(result.descriptors);
+	return result;
+}
+
+export function clonePortableTextValue<T>(value: T): T {
+	return structuredClone(value);
+}
+
+export function buildPortableTextListTree(
+	blocks: PortableTextNode[],
+	mode: ListNestingMode = "html",
+): PortableTextNode[] {
+	return preprocessLists(blocks, mode).tree;
+}
+
+export function getNumberedListOrdinals(blocks: PortableTextNode[]): Map<PortableTextNode, number> {
+	const { descriptors } = preprocessLists(blocks, "direct");
+	const ordinals = new Map<PortableTextNode, number>();
+	for (const descriptor of descriptors) {
+		if (descriptor.node.listItem !== "number") continue;
+		const start = descriptor.node.start ?? 1;
+		for (let index = 0; index < descriptor.directItems.length; index++) {
+			ordinals.set(descriptor.directItems[index].original, normalizeListStart(start + index) ?? 1);
+		}
+	}
+	return ordinals;
+}

--- a/packages/core/tests/repro/fixtures/CustomOrderedList.astro
+++ b/packages/core/tests/repro/fixtures/CustomOrderedList.astro
@@ -1,0 +1,7 @@
+---
+const { node } = Astro.props;
+---
+
+<ol data-custom-list="true" data-start={node.start}>
+	<slot />
+</ol>

--- a/packages/core/tests/repro/portable-text-numbered-list.render.test.ts
+++ b/packages/core/tests/repro/portable-text-numbered-list.render.test.ts
@@ -1,0 +1,85 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it } from "vitest";
+
+import PortableText from "../../src/components/PortableText.astro";
+import CustomOrderedList from "./fixtures/CustomOrderedList.astro";
+
+function item(key: string, text: string, level: number, listId: string, listStart: number) {
+	return {
+		_type: "block",
+		_key: key,
+		style: "normal",
+		listItem: "number",
+		level,
+		listId,
+		listStart,
+		markDefs: [],
+		children: [{ _type: "span", _key: `${key}-span`, text, marks: [] }],
+	};
+}
+
+const paragraph = {
+	_type: "block",
+	_key: "between",
+	style: "normal",
+	markDefs: [{ _key: "link", _type: "link", href: "https://example.com" }],
+	children: [{ _type: "span", _key: "between-span", text: "Between", marks: ["link"] }],
+};
+
+async function render(value: unknown[], props: Record<string, unknown> = {}) {
+	const container = await AstroContainer.create();
+	return container.renderToString(PortableText, { props: { value, ...props } });
+}
+
+function orderedListTags(html: string): string[] {
+	return html.match(/<ol\b[^>]*>/g) ?? [];
+}
+
+describe("PortableText numbered-list rendering", () => {
+	it("renders continuation segments with semantic starts without mutating input", async () => {
+		const value = [
+			item("one", "One", 1, "shared", 1),
+			item("two", "Two", 1, "shared", 1),
+			paragraph,
+			item("three", "Three", 1, "shared", 1),
+			item("four", "Four", 1, "shared", 1),
+		];
+		const before = structuredClone(value);
+		const html = await render(value);
+		const lists = orderedListTags(html);
+
+		expect(lists).toHaveLength(2);
+		expect(lists[0]).not.toContain("start=");
+		expect(lists[1]).toContain('start="3"');
+		expect(value).toEqual(before);
+	});
+
+	it.each(["html", "direct"] as const)(
+		"keeps independent root and nested identities separate in %s mode",
+		async (listNestingMode) => {
+			const value = [
+				item("root", "Root", 1, "root", 1),
+				item("nested-a", "Nested A", 2, "nested-a", 2),
+				item("nested-b", "Nested B", 2, "nested-b", 7),
+				item("root-two", "Root two", 1, "root", 1),
+				item("other", "Other", 1, "other", 4),
+			];
+			const html = await render(value, { listNestingMode });
+			const lists = orderedListTags(html);
+
+			expect(lists).toHaveLength(4);
+			expect(lists.filter((tag) => tag.includes('start="2"'))).toHaveLength(1);
+			expect(lists.filter((tag) => tag.includes('start="7"'))).toHaveLength(1);
+			expect(lists.filter((tag) => tag.includes('start="4"'))).toHaveLength(1);
+		},
+	);
+
+	it("keeps a user numbered-list component override", async () => {
+		const html = await render([item("three", "Three", 1, "shared", 3)], {
+			components: { list: { number: CustomOrderedList } },
+		});
+
+		expect(html).toContain('data-custom-list="true"');
+		expect(html).toContain('data-start="3"');
+	});
+});

--- a/packages/core/tests/unit/client/portable-text.test.ts
+++ b/packages/core/tests/unit/client/portable-text.test.ts
@@ -147,7 +147,116 @@ describe("portableTextToMarkdown", () => {
 				children: [{ _type: "span", text: "Second", marks: [] }],
 			},
 		];
-		expect(portableTextToMarkdown(blocks)).toBe("1. First\n1. Second\n");
+		expect(portableTextToMarkdown(blocks)).toBe("1. First\n2. Second\n");
+	});
+
+	it("emits exact continuation and nested item markers", () => {
+		const blocks: PortableTextBlock[] = [
+			{
+				_type: "block",
+				listItem: "number",
+				level: 1,
+				listId: "root",
+				listStart: 3,
+				children: [{ _type: "span", text: "Three" }],
+			},
+			{
+				_type: "block",
+				listItem: "number",
+				level: 2,
+				listId: "nested",
+				listStart: 8,
+				children: [{ _type: "span", text: "Nested eight" }],
+			},
+			{
+				_type: "block",
+				listItem: "number",
+				level: 2,
+				listId: "nested",
+				listStart: 8,
+				children: [{ _type: "span", text: "Nested nine" }],
+			},
+			{
+				_type: "block",
+				listItem: "number",
+				level: 1,
+				listId: "root",
+				listStart: 3,
+				children: [{ _type: "span", text: "Four" }],
+			},
+		];
+
+		expect(portableTextToMarkdown(blocks)).toBe(
+			"3. Three\n  8. Nested eight\n  9. Nested nine\n4. Four\n",
+		);
+	});
+
+	it("separates adjacent independent numbered runs for EmDash re-import", () => {
+		const blocks: PortableTextBlock[] = [
+			{
+				_type: "block",
+				listItem: "number",
+				level: 1,
+				listId: "first",
+				listStart: 1,
+				children: [{ _type: "span", text: "First" }],
+			},
+			{
+				_type: "block",
+				listItem: "number",
+				level: 1,
+				listId: "second",
+				listStart: 4,
+				children: [{ _type: "span", text: "Fourth" }],
+			},
+		];
+		const markdown = portableTextToMarkdown(blocks);
+		const imported = markdownToPortableText(markdown);
+
+		expect(markdown).toBe("1. First\n\n4. Fourth\n");
+		expect(imported[0].listId).not.toBe(imported[1].listId);
+		expect(imported.map((block) => block.listStart)).toEqual([1, 4]);
+	});
+
+	it("preserves visible continuation starts but not identity through Markdown", () => {
+		const blocks: PortableTextBlock[] = [
+			{
+				_type: "block",
+				listItem: "number",
+				level: 1,
+				listId: "shared",
+				listStart: 1,
+				children: [{ _type: "span", text: "One" }],
+			},
+			{
+				_type: "block",
+				listItem: "number",
+				level: 1,
+				listId: "shared",
+				listStart: 1,
+				children: [{ _type: "span", text: "Two" }],
+			},
+			{
+				_type: "block",
+				style: "normal",
+				children: [{ _type: "span", text: "Between" }],
+			},
+			{
+				_type: "block",
+				listItem: "number",
+				level: 1,
+				listId: "shared",
+				listStart: 1,
+				children: [{ _type: "span", text: "Three" }],
+			},
+		];
+		const markdown = portableTextToMarkdown(blocks);
+		const imported = markdownToPortableText(markdown);
+
+		expect(markdown).toBe("1. One\n2. Two\n\nBetween\n\n3. Three\n");
+		expect(imported[0].listId).toBe(imported[1].listId);
+		expect(imported[3].listId).not.toBe(imported[1].listId);
+		expect(imported[3].listStart).toBe(3);
 	});
 
 	it("converts code blocks", () => {
@@ -304,6 +413,17 @@ describe("markdownToPortableText", () => {
 		expect(blocks).toHaveLength(2);
 		expect(blocks[0].listItem).toBe("number");
 		expect(blocks[1].listItem).toBe("number");
+		expect(blocks[0].listId).toBe(blocks[1].listId);
+		expect(blocks.map((block) => block.listStart)).toEqual([1, 1]);
+	});
+
+	it("preserves ordered starts and separates blank or block boundaries", () => {
+		const blocks = markdownToPortableText("3. Three\n4. Four\n\n8. Eight\nBetween\n2. Two\n");
+
+		expect(blocks.map((block) => block.listStart)).toEqual([3, 3, 8, undefined, 2]);
+		expect(blocks[0].listId).toBe(blocks[1].listId);
+		expect(blocks[2].listId).not.toBe(blocks[1].listId);
+		expect(blocks[4].listId).not.toBe(blocks[2].listId);
 	});
 
 	it("converts code fences", () => {

--- a/packages/core/tests/unit/client/portable-text.test.ts
+++ b/packages/core/tests/unit/client/portable-text.test.ts
@@ -147,51 +147,10 @@ describe("portableTextToMarkdown", () => {
 				children: [{ _type: "span", text: "Second", marks: [] }],
 			},
 		];
-		expect(portableTextToMarkdown(blocks)).toBe("1. First\n2. Second\n");
+		expect(portableTextToMarkdown(blocks)).toBe("1. First\n1. Second\n");
 	});
 
-	it("emits exact continuation and nested item markers", () => {
-		const blocks: PortableTextBlock[] = [
-			{
-				_type: "block",
-				listItem: "number",
-				level: 1,
-				listId: "root",
-				listStart: 3,
-				children: [{ _type: "span", text: "Three" }],
-			},
-			{
-				_type: "block",
-				listItem: "number",
-				level: 2,
-				listId: "nested",
-				listStart: 8,
-				children: [{ _type: "span", text: "Nested eight" }],
-			},
-			{
-				_type: "block",
-				listItem: "number",
-				level: 2,
-				listId: "nested",
-				listStart: 8,
-				children: [{ _type: "span", text: "Nested nine" }],
-			},
-			{
-				_type: "block",
-				listItem: "number",
-				level: 1,
-				listId: "root",
-				listStart: 3,
-				children: [{ _type: "span", text: "Four" }],
-			},
-		];
-
-		expect(portableTextToMarkdown(blocks)).toBe(
-			"3. Three\n  8. Nested eight\n  9. Nested nine\n4. Four\n",
-		);
-	});
-
-	it("separates adjacent independent numbered runs for EmDash re-import", () => {
+	it("does not synthesize continuity metadata across a lossy Markdown boundary", () => {
 		const blocks: PortableTextBlock[] = [
 			{
 				_type: "block",
@@ -199,64 +158,32 @@ describe("portableTextToMarkdown", () => {
 				level: 1,
 				listId: "first",
 				listStart: 1,
-				children: [{ _type: "span", text: "First" }],
+				children: [{ _type: "span", text: "One" }],
+			},
+			{
+				_type: "block",
+				listItem: "number",
+				level: 2,
+				listId: "nested",
+				listStart: 1,
+				children: [{ _type: "span", text: "Nested" }],
 			},
 			{
 				_type: "block",
 				listItem: "number",
 				level: 1,
 				listId: "second",
-				listStart: 4,
-				children: [{ _type: "span", text: "Fourth" }],
+				listStart: 1,
+				children: [{ _type: "span", text: "Other" }],
 			},
 		];
-		const markdown = portableTextToMarkdown(blocks);
-		const imported = markdownToPortableText(markdown);
+		const imported = markdownToPortableText(portableTextToMarkdown(blocks));
 
-		expect(markdown).toBe("1. First\n\n4. Fourth\n");
-		expect(imported[0].listId).not.toBe(imported[1].listId);
-		expect(imported.map((block) => block.listStart)).toEqual([1, 4]);
-	});
-
-	it("preserves visible continuation starts but not identity through Markdown", () => {
-		const blocks: PortableTextBlock[] = [
-			{
-				_type: "block",
-				listItem: "number",
-				level: 1,
-				listId: "shared",
-				listStart: 1,
-				children: [{ _type: "span", text: "One" }],
-			},
-			{
-				_type: "block",
-				listItem: "number",
-				level: 1,
-				listId: "shared",
-				listStart: 1,
-				children: [{ _type: "span", text: "Two" }],
-			},
-			{
-				_type: "block",
-				style: "normal",
-				children: [{ _type: "span", text: "Between" }],
-			},
-			{
-				_type: "block",
-				listItem: "number",
-				level: 1,
-				listId: "shared",
-				listStart: 1,
-				children: [{ _type: "span", text: "Three" }],
-			},
-		];
-		const markdown = portableTextToMarkdown(blocks);
-		const imported = markdownToPortableText(markdown);
-
-		expect(markdown).toBe("1. One\n2. Two\n\nBetween\n\n3. Three\n");
-		expect(imported[0].listId).toBe(imported[1].listId);
-		expect(imported[3].listId).not.toBe(imported[1].listId);
-		expect(imported[3].listStart).toBe(3);
+		expect(imported.map((block) => [block.listId, block.listStart])).toEqual([
+			[undefined, undefined],
+			[undefined, undefined],
+			[undefined, undefined],
+		]);
 	});
 
 	it("converts code blocks", () => {
@@ -413,17 +340,6 @@ describe("markdownToPortableText", () => {
 		expect(blocks).toHaveLength(2);
 		expect(blocks[0].listItem).toBe("number");
 		expect(blocks[1].listItem).toBe("number");
-		expect(blocks[0].listId).toBe(blocks[1].listId);
-		expect(blocks.map((block) => block.listStart)).toEqual([1, 1]);
-	});
-
-	it("preserves ordered starts and separates blank or block boundaries", () => {
-		const blocks = markdownToPortableText("3. Three\n4. Four\n\n8. Eight\nBetween\n2. Two\n");
-
-		expect(blocks.map((block) => block.listStart)).toEqual([3, 3, 8, undefined, 2]);
-		expect(blocks[0].listId).toBe(blocks[1].listId);
-		expect(blocks[2].listId).not.toBe(blocks[1].listId);
-		expect(blocks[4].listId).not.toBe(blocks[2].listId);
 	});
 
 	it("converts code fences", () => {

--- a/packages/core/tests/unit/components/inline-portable-text-list.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-list.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	_pmToPortableText as pmToPortableText,
+	_portableTextToPM as portableTextToPM,
+} from "../../../src/components/InlinePortableTextEditor.js";
+
+type PMNode = {
+	type?: string;
+	attrs?: Record<string, unknown>;
+	content?: PMNode[];
+};
+
+function numbered(key: string, text: string, level: number, listStart: number) {
+	return {
+		_type: "block" as const,
+		_key: key,
+		style: "normal" as const,
+		listItem: "number" as const,
+		level,
+		listId: "shared",
+		listStart,
+		children: [{ _type: "span" as const, _key: `${key}-span`, text }],
+	};
+}
+
+function collectOrderedLists(node: PMNode): PMNode[] {
+	const lists: PMNode[] = [];
+	if (node.type === "orderedList") lists.push(node);
+	for (const child of node.content ?? []) lists.push(...collectOrderedLists(child));
+	return lists;
+}
+
+describe("inline Portable Text list conversion", () => {
+	it("preserves nested list structure in both directions", () => {
+		const pm = portableTextToPM([
+			numbered("root", "Root", 1, 1),
+			numbered("nested", "Nested", 2, 5),
+			numbered("root-two", "Root two", 1, 1),
+		]);
+		const lists = collectOrderedLists(pm);
+
+		expect(lists).toHaveLength(2);
+		expect(lists.map((list) => list.attrs?.listStart)).toEqual([1, 5]);
+		expect(lists.map((list) => list.attrs?.start)).toEqual([1, 5]);
+		expect(lists[0]?.attrs?.listId).toBe("shared");
+		expect(lists[1]?.attrs?.listId).not.toBe("shared");
+
+		const portableText = pmToPortableText(pm) as Array<{
+			listItem?: string;
+			level?: number;
+			children?: Array<{ text?: string }>;
+		}>;
+		expect(
+			portableText.map((block) => [block.listItem, block.level, block.children?.[0]?.text]),
+		).toEqual([
+			["number", 1, "Root"],
+			["number", 2, "Nested"],
+			["number", 1, "Root two"],
+		]);
+	});
+
+	it("does not drop nested ProseMirror lists when saving", () => {
+		const portableText = pmToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{ type: "paragraph", content: [{ type: "text", text: "Root" }] },
+								{
+									type: "orderedList",
+									attrs: { listId: "nested", listStart: 3, start: 3 },
+									content: [
+										{
+											type: "listItem",
+											content: [
+												{
+													type: "paragraph",
+													content: [{ type: "text", text: "Nested" }],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		}) as Array<{
+			listItem?: string;
+			level?: number;
+			listId?: string;
+			listStart?: number;
+			children?: Array<{ text?: string }>;
+		}>;
+
+		expect(
+			portableText.map((block) => [
+				block.listItem,
+				block.level,
+				block.listId,
+				block.listStart,
+				block.children?.[0]?.text,
+			]),
+		).toEqual([
+			["bullet", 1, undefined, undefined, "Root"],
+			["number", 2, "nested", 3, "Nested"],
+		]);
+	});
+
+	it("preserves continuity across supported top-level separators", () => {
+		const blocks = [
+			numbered("one", "One", 1, 1),
+			{
+				_type: "block" as const,
+				_key: "plain",
+				style: "normal" as const,
+				children: [{ _type: "span" as const, _key: "plain-span", text: "Plain" }],
+			},
+			numbered("two", "Two", 1, 1),
+			{
+				_type: "block" as const,
+				_key: "formatted",
+				style: "normal" as const,
+				children: [
+					{
+						_type: "span" as const,
+						_key: "formatted-span",
+						text: "Formatted",
+						marks: ["strong"],
+					},
+				],
+			},
+			numbered("three", "Three", 1, 1),
+			{ _type: "code", _key: "code", code: "x", language: "ts" },
+			numbered("four", "Four", 1, 1),
+			{
+				_type: "image",
+				_key: "image",
+				asset: { _ref: "image", url: "/image.png" },
+			},
+			numbered("five", "Five", 1, 1),
+			{ _type: "embed", _key: "plugin", id: "plugin", title: "Plugin" },
+			numbered("six", "Six", 1, 1),
+		];
+		const pm = portableTextToPM(blocks);
+		const rootNodes = pm.content as PMNode[];
+		const lists = rootNodes.filter((node) => node.type === "orderedList");
+
+		expect(lists.map((list) => list.attrs?.start)).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(rootNodes.map((node) => node.type)).toEqual([
+			"orderedList",
+			"paragraph",
+			"orderedList",
+			"paragraph",
+			"orderedList",
+			"codeBlock",
+			"orderedList",
+			"image",
+			"orderedList",
+			"pluginBlock",
+			"orderedList",
+		]);
+
+		const roundTripped = pmToPortableText(pm) as Array<{
+			listItem?: string;
+			listId?: string;
+			listStart?: number;
+		}>;
+		expect(
+			roundTripped
+				.filter((block) => block.listItem === "number")
+				.map((block) => [block.listId, block.listStart]),
+		).toEqual(Array.from({ length: 6 }, () => ["shared", 1]));
+	});
+});

--- a/packages/core/tests/unit/components/ordered-list.test.ts
+++ b/packages/core/tests/unit/components/ordered-list.test.ts
@@ -90,6 +90,53 @@ describe("EmDashOrderedList", () => {
 		expect(lists[1]!.attrs.start).toBe(1);
 	});
 
+	it("disables continuity commands for linked or multi-segment selections", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["One"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 2, listStart: 1, listId: "shared" }, ["Two"]),
+			],
+		});
+		const lists = orderedNodes(editor);
+		editor.commands.setTextSelection(lists[1]!.pos + 2);
+		expect(editor.can().continueOrderedList()).toBe(false);
+
+		editor.commands.setTextSelection({
+			from: lists[0]!.pos + 2,
+			to: lists[1]!.pos + 2,
+		});
+		expect(editor.can().continueOrderedList()).toBe(false);
+		expect(editor.can().restartOrderedList()).toBe(false);
+	});
+
+	it("renumbers later segments after direct items are inserted or deleted", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["One", "Two"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 3, listStart: 1, listId: "shared" }, ["Three"]),
+			],
+		});
+		let first = orderedNodes(editor)[0]!;
+		let firstNode = editor.state.doc.nodeAt(first.pos)!;
+		const inserted = firstNode.child(0).copy(firstNode.child(0).content);
+		editor.view.dispatch(editor.state.tr.insert(first.pos + firstNode.nodeSize - 1, inserted));
+		expect(orderedNodes(editor).map((node) => node.attrs.start)).toEqual([1, 4]);
+
+		first = orderedNodes(editor)[0]!;
+		firstNode = editor.state.doc.nodeAt(first.pos)!;
+		let lastOffset = 0;
+		firstNode.forEach((_child, offset, index) => {
+			if (index === firstNode.childCount - 1) lastOffset = offset;
+		});
+		const from = first.pos + 1 + lastOffset;
+		editor.view.dispatch(editor.state.tr.delete(from, from + firstNode.lastChild!.nodeSize));
+		expect(orderedNodes(editor).map((node) => node.attrs.start)).toEqual([1, 3]);
+	});
+
 	it("gives a newly toggled list a stable identity", () => {
 		const editor = createEditor({
 			type: "doc",
@@ -100,6 +147,18 @@ describe("EmDashOrderedList", () => {
 		expect(typeof attrs.listId).toBe("string");
 		expect(attrs.listStart).toBe(1);
 		expect(attrs.start).toBe(1);
+	});
+
+	it("creates an explicitly started list from a numeric input rule", () => {
+		const editor = createEditor({ type: "doc", content: [{ type: "paragraph" }] });
+		const { from, to } = editor.state.selection;
+		const handled = editor.view.someProp("handleTextInput", (handler) =>
+			handler(editor.view, from, to, "2. "),
+		);
+
+		expect(handled).toBe(true);
+		expect(orderedNodes(editor)[0]?.attrs).toMatchObject({ start: 2, listStart: 2 });
+		expect(typeof orderedNodes(editor)[0]?.attrs.listId).toBe("string");
 	});
 
 	it("restarts a standalone explicitly started list", () => {
@@ -211,6 +270,24 @@ describe("EmDashOrderedList", () => {
 		expect(second.listId).toBe(first.listId);
 		expect(first.listStart).toBe(3);
 		expect(second.listStart).toBe(3);
+	});
+
+	it("assigns independent identities to external list runs", () => {
+		const editor = createEditor({ type: "doc", content: [{ type: "paragraph" }] });
+		const slice = Slice.fromJSON(editor.schema, {
+			content: [
+				list({ start: 7 }, ["Seven"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 9 }, ["Nine"]),
+			],
+			openStart: 0,
+			openEnd: 0,
+		});
+
+		const pasted = remapPastedSlice(slice).content.toJSON() as JSONContent[];
+		expect(pasted[0]?.attrs).toMatchObject({ start: 7, listStart: 7 });
+		expect(pasted[2]?.attrs).toMatchObject({ start: 9, listStart: 9 });
+		expect(pasted[0]?.attrs?.listId).not.toBe(pasted[2]?.attrs?.listId);
 	});
 
 	it("does not intercept a paste without an ordered list", () => {

--- a/packages/core/tests/unit/components/ordered-list.test.ts
+++ b/packages/core/tests/unit/components/ordered-list.test.ts
@@ -90,6 +90,26 @@ describe("EmDashOrderedList", () => {
 		expect(lists[1]!.attrs.start).toBe(1);
 	});
 
+	it("keeps lists in separate blockquotes independent", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				{
+					type: "blockquote",
+					content: [list({ start: 1, listStart: 1, listId: "first" }, ["One"])],
+				},
+				{
+					type: "blockquote",
+					content: [list({ start: 1, listStart: 1, listId: "second" }, ["Independent"])],
+				},
+			],
+		});
+		const lists = orderedNodes(editor);
+		editor.commands.setTextSelection(lists[1]!.pos + 2);
+
+		expect(editor.can().continueOrderedList()).toBe(false);
+	});
+
 	it("disables continuity commands for linked or multi-segment selections", () => {
 		const editor = createEditor({
 			type: "doc",

--- a/packages/core/tests/unit/components/ordered-list.test.ts
+++ b/packages/core/tests/unit/components/ordered-list.test.ts
@@ -1,0 +1,476 @@
+// @vitest-environment jsdom
+
+import { Editor, type JSONContent } from "@tiptap/core";
+import { type Node as ProseMirrorNode, Slice } from "@tiptap/pm/model";
+import { NodeSelection } from "@tiptap/pm/state";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	EmDashOrderedList,
+	normalizeOrderedListDocument,
+	prepareCopiedSlice,
+	remapMovedSlice,
+	remapPastedSlice,
+} from "../../../src/components/ordered-list.js";
+
+const editors: Editor[] = [];
+
+function list(attrs: Record<string, unknown>, labels: string[]): JSONContent {
+	return {
+		type: "orderedList",
+		attrs,
+		content: labels.map((label) => ({
+			type: "listItem",
+			content: [{ type: "paragraph", content: [{ type: "text", text: label }] }],
+		})),
+	};
+}
+
+function createEditor(content: JSONContent): Editor {
+	const editor = new Editor({
+		element: document.createElement("div"),
+		extensions: [StarterKit.configure({ orderedList: false }), EmDashOrderedList],
+		content,
+	});
+	editors.push(editor);
+	return editor;
+}
+
+function orderedNodes(editor: Editor): Array<{ attrs: Record<string, unknown>; pos: number }> {
+	const nodes: Array<{ attrs: Record<string, unknown>; pos: number }> = [];
+	editor.state.doc.descendants((node, pos) => {
+		if (node.type.name === "orderedList") nodes.push({ attrs: node.attrs, pos });
+	});
+	return nodes;
+}
+
+afterEach(() => {
+	for (const editor of editors.splice(0)) editor.destroy();
+});
+
+describe("EmDashOrderedList", () => {
+	it("normalizes separated segments deterministically", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["One", "Two"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 1, listStart: 1, listId: "shared" }, ["Three"]),
+			],
+		});
+
+		const changes = normalizeOrderedListDocument(editor.state.doc);
+		expect(changes).toHaveLength(1);
+		expect(changes[0]?.attrs.start).toBe(3);
+	});
+
+	it("continues and restarts the selected list tail", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "first" }, ["One"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 1, listStart: 1, listId: "second" }, ["Independent"]),
+			],
+		});
+		let lists = orderedNodes(editor);
+		editor.commands.setTextSelection(lists[1]!.pos + 2);
+		expect(editor.can().continueOrderedList()).toBe(true);
+		expect(editor.commands.continueOrderedList()).toBe(true);
+		lists = orderedNodes(editor);
+		expect(lists.map((node) => node.attrs.listId)).toEqual(["first", "first"]);
+		expect(lists.map((node) => node.attrs.start)).toEqual([1, 2]);
+
+		editor.commands.setTextSelection(lists[1]!.pos + 2);
+		expect(editor.can().restartOrderedList()).toBe(true);
+		expect(editor.commands.restartOrderedList()).toBe(true);
+		lists = orderedNodes(editor);
+		expect(lists[1]!.attrs.listId).not.toBe("first");
+		expect(lists[1]!.attrs.start).toBe(1);
+	});
+
+	it("gives a newly toggled list a stable identity", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [{ type: "paragraph", content: [{ type: "text", text: "Item" }] }],
+		});
+		expect(editor.commands.toggleOrderedList()).toBe(true);
+		const attrs = orderedNodes(editor)[0]!.attrs;
+		expect(typeof attrs.listId).toBe("string");
+		expect(attrs.listStart).toBe(1);
+		expect(attrs.start).toBe(1);
+	});
+
+	it("restarts a standalone explicitly started list", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [list({ start: 2, listStart: 2, listId: "started-at-two" }, ["Two"])],
+		});
+		const selected = orderedNodes(editor)[0]!;
+		editor.commands.setTextSelection(selected.pos + 2);
+		expect(editor.commands.restartOrderedList()).toBe(true);
+		const attrs = orderedNodes(editor)[0]!.attrs;
+		expect(attrs.listId).not.toBe("started-at-two");
+		expect(attrs.listStart).toBe(1);
+		expect(attrs.start).toBe(1);
+	});
+
+	it("never emits malformed list metadata into editor HTML", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [list({ start: -5, listStart: 0, listId: " ".repeat(129) }, ["One"])],
+		});
+		const html = editor.getHTML();
+		expect(html).not.toContain('start="-5"');
+		expect(html).not.toContain("data-emdash-list-id");
+		expect(html).not.toContain("data-emdash-list-start");
+		expect(html).toContain('data-emdash-list-first="1"');
+	});
+
+	it("repairs a malformed cross-context identity using its canonical base", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["Root"]),
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{ type: "paragraph", content: [{ type: "text", text: "Parent" }] },
+								list({ start: 3, listStart: 1, listId: "shared" }, ["Moved continuation"]),
+							],
+						},
+					],
+				},
+			],
+		});
+
+		const changes = normalizeOrderedListDocument(editor.state.doc);
+		const nestedChange = changes.find((change) => change.attrs.listId !== "shared");
+		expect(nestedChange?.attrs.listStart).toBe(1);
+		expect(nestedChange?.attrs.start).toBe(1);
+	});
+
+	it("avoids collisions with deterministic repair identities", () => {
+		const initial = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["Root"]),
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{ type: "paragraph", content: [{ type: "text", text: "Parent" }] },
+								list({ start: 1, listStart: 1, listId: "shared" }, ["Nested"]),
+							],
+						},
+					],
+				},
+			],
+		});
+		const repairId = normalizeOrderedListDocument(initial.state.doc).find(
+			(change) => change.attrs.listId !== "shared",
+		)?.attrs.listId;
+		expect(typeof repairId).toBe("string");
+
+		const editor = createEditor({
+			...initial.getJSON(),
+			content: [
+				...initial.getJSON().content!,
+				{ type: "paragraph", content: [{ type: "text", text: "Boundary" }] },
+				list({ start: 1, listStart: 1, listId: repairId }, ["Collision"]),
+			],
+		});
+		const ids = normalizeOrderedListDocument(editor.state.doc)
+			.map((change) => change.attrs.listId)
+			.filter((id) => id !== "shared");
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it("pastes a continuation as an independent list at its displayed start", () => {
+		const editor = createEditor({ type: "doc", content: [{ type: "paragraph" }] });
+		const slice = Slice.fromJSON(editor.schema, {
+			content: [
+				list({ start: 3, listStart: 1, listId: "source" }, ["Three"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 4, listStart: 1, listId: "source" }, ["Four"]),
+			],
+			openStart: 0,
+			openEnd: 0,
+		});
+
+		const pasted = remapPastedSlice(slice).content.toJSON() as JSONContent[];
+		const first = pasted[0]!.attrs!;
+		const second = pasted[2]!.attrs!;
+		expect(first.listId).not.toBe("source");
+		expect(second.listId).toBe(first.listId);
+		expect(first.listStart).toBe(3);
+		expect(second.listStart).toBe(3);
+	});
+
+	it("does not intercept a paste without an ordered list", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [{ type: "paragraph", content: [{ type: "text", text: "Existing" }] }],
+		});
+		const slice = Slice.fromJSON(editor.schema, {
+			content: [{ type: "paragraph", content: [{ type: "text", text: "Pasted" }] }],
+			openStart: 0,
+			openEnd: 0,
+		});
+		const before = editor.getJSON();
+		const handled = editor.view.someProp("handlePaste", (handler) =>
+			handler(editor.view, {} as ClipboardEvent, slice),
+		);
+		expect(handled).toBeUndefined();
+		expect(editor.getJSON()).toEqual(before);
+	});
+
+	it("copies a partial list from its first selected item's displayed ordinal", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [list({ start: 1, listStart: 1, listId: "source" }, ["One", "Two", "Three"])],
+		});
+		const selected = orderedNodes(editor)[0]!;
+		const orderedList = editor.state.doc.nodeAt(selected.pos)!;
+		let secondOffset = 0;
+		orderedList.forEach((_child, offset, index) => {
+			if (index === 1) secondOffset = offset;
+		});
+		const from = selected.pos + 1 + secondOffset + 2;
+		editor.commands.setTextSelection({ from, to: from + 3 });
+		const copied = prepareCopiedSlice(editor.state.selection.content(), editor.state);
+		let copiedList: ProseMirrorNode | undefined;
+		copied.content.descendants((node) => {
+			if (!copiedList && node.type.name === "orderedList") copiedList = node;
+		});
+		expect(copiedList?.attrs.start).toBe(2);
+		expect(copiedList?.attrs.listStart).toBe(1);
+
+		const pasted = remapPastedSlice(copied);
+		let pastedList: ProseMirrorNode | undefined;
+		pasted.content.descendants((node) => {
+			if (!pastedList && node.type.name === "orderedList") pastedList = node;
+		});
+		expect(pastedList?.attrs.listStart).toBe(2);
+	});
+
+	it("keeps split segments related when a partial copy spans a boundary", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "source" }, ["One", "Two"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 3, listStart: 1, listId: "source" }, ["Three"]),
+			],
+		});
+		const lists = orderedNodes(editor);
+		const firstList = editor.state.doc.nodeAt(lists[0]!.pos)!;
+		let secondOffset = 0;
+		firstList.forEach((_child, offset, index) => {
+			if (index === 1) secondOffset = offset;
+		});
+		const from = lists[0]!.pos + 1 + secondOffset + 2;
+		const to = lists[1]!.pos + 4;
+		editor.commands.setTextSelection({ from, to });
+		const copied = prepareCopiedSlice(editor.state.selection.content(), editor.state);
+		const pasted = remapPastedSlice(copied);
+		const pastedLists: ProseMirrorNode[] = [];
+		pasted.content.descendants((node) => {
+			if (node.type.name === "orderedList") pastedLists.push(node);
+		});
+		expect(pastedLists).toHaveLength(2);
+		expect(pastedLists.map((node) => node.attrs.listId)).toEqual([
+			pastedLists[0]!.attrs.listId,
+			pastedLists[0]!.attrs.listId,
+		]);
+		expect(pastedLists.map((node) => node.attrs.listStart)).toEqual([2, 2]);
+	});
+
+	it("gives a context-changing move a fresh identity at its displayed start", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "source" }, ["One", "Two"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 3, listStart: 1, listId: "source" }, ["Three"]),
+			],
+		});
+		const selected = orderedNodes(editor)[1]!;
+		editor.commands.setTextSelection(selected.pos + 2);
+		const nodeSize = editor.state.doc.nodeAt(selected.pos)!.nodeSize;
+		const moved = remapMovedSlice(
+			editor.state.doc.slice(selected.pos, selected.pos + nodeSize),
+			editor.state,
+		);
+		let movedList: ProseMirrorNode | undefined;
+		moved.content.descendants((node) => {
+			if (!movedList && node.type.name === "orderedList") movedList = node;
+		});
+		expect(movedList?.attrs.listId).not.toBe("source");
+		expect(movedList?.attrs.listStart).toBe(3);
+		expect(movedList?.attrs.start).toBe(3);
+	});
+
+	it("merges adjacent segments with the same identity", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["One"]),
+				list({ start: 2, listStart: 1, listId: "shared" }, ["Two"]),
+			],
+		});
+		editor.view.dispatch(editor.state.tr);
+		const lists = orderedNodes(editor);
+		expect(lists).toHaveLength(1);
+		expect(editor.state.doc.nodeAt(lists[0]!.pos)?.childCount).toBe(2);
+	});
+
+	it("undoes and redoes a restart with the same identity", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [list({ start: 1, listStart: 1, listId: "source" }, ["One"])],
+		});
+		const selected = orderedNodes(editor)[0]!;
+		editor.commands.setTextSelection(selected.pos + 2);
+		expect(editor.commands.restartOrderedList()).toBe(true);
+		const restartedId = orderedNodes(editor)[0]!.attrs.listId;
+		expect(restartedId).not.toBe("source");
+		expect(editor.commands.undo()).toBe(true);
+		expect(orderedNodes(editor)[0]!.attrs.listId).toBe("source");
+		expect(editor.commands.redo()).toBe(true);
+		expect(orderedNodes(editor)[0]!.attrs.listId).toBe(restartedId);
+	});
+
+	it("undoes an adjacent-segment merge with the boundary deletion", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "shared" }, ["One"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Boundary" }] },
+				list({ start: 2, listStart: 1, listId: "shared" }, ["Two"]),
+			],
+		});
+		const first = orderedNodes(editor)[0]!;
+		const boundaryPos = first.pos + editor.state.doc.nodeAt(first.pos)!.nodeSize;
+		const boundarySize = editor.state.doc.nodeAt(boundaryPos)!.nodeSize;
+		expect(editor.commands.deleteRange({ from: boundaryPos, to: boundaryPos + boundarySize })).toBe(
+			true,
+		);
+		expect(orderedNodes(editor)).toHaveLength(1);
+		expect(editor.commands.undo()).toBe(true);
+		expect(orderedNodes(editor)).toHaveLength(2);
+		expect(editor.state.doc.nodeAt(boundaryPos)?.textContent).toBe("Boundary");
+	});
+
+	it("normalizes identically on two collaboration peers and then stabilizes", () => {
+		const content: JSONContent = {
+			type: "doc",
+			content: [
+				list({ start: 1 }, ["One"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 1 }, ["Independent"]),
+			],
+		};
+		const first = createEditor(content);
+		const second = createEditor(content);
+		first.view.dispatch(first.state.tr.setMeta("remote", true));
+		second.view.dispatch(second.state.tr.setMeta("remote", true));
+		expect(first.getJSON()).toEqual(second.getJSON());
+		expect(normalizeOrderedListDocument(first.state.doc)).toEqual([]);
+		const normalized = first.getJSON();
+		first.view.dispatch(first.state.tr.setMeta("remote", true));
+		expect(first.getJSON()).toEqual(normalized);
+	});
+
+	it("remaps an actual cross-context drop but leaves same-context drops to ProseMirror", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "source" }, ["One", "Two"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 3, listStart: 1, listId: "source" }, ["Three"]),
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [{ type: "paragraph", content: [{ type: "text", text: "Target" }] }],
+						},
+					],
+				},
+			],
+		});
+		const source = orderedNodes(editor)[1]!;
+		editor.view.dispatch(
+			editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, source.pos)),
+		);
+		const slice = editor.state.selection.content();
+		let targetPos = 0;
+		editor.state.doc.descendants((node, pos) => {
+			if (node.type.name === "listItem" && node.textContent === "Target") {
+				targetPos = pos + node.nodeSize - 1;
+				return false;
+			}
+			return true;
+		});
+		vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: targetPos, inside: -1 });
+		const dropEvent = { clientX: 0, clientY: 0 } as DragEvent;
+		const handled = editor.view.someProp("handleDrop", (handler) =>
+			handler(editor.view, dropEvent, slice, true),
+		);
+		expect(handled).toBe(true);
+		const lists = orderedNodes(editor);
+		expect(lists).toHaveLength(2);
+		expect(lists[0]!.attrs.listId).toBe("source");
+		expect(lists[1]!.attrs.listId).not.toBe("source");
+		expect(lists[1]!.attrs.listStart).toBe(3);
+		expect(lists[1]!.attrs.start).toBe(3);
+
+		const moved = lists[1]!;
+		editor.view.dispatch(
+			editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, moved.pos)),
+		);
+		const nestedSlice = editor.state.selection.content();
+		vi.mocked(editor.view.posAtCoords).mockReturnValue({ pos: moved.pos, inside: -1 });
+		const sameContextHandled = editor.view.someProp("handleDrop", (handler) =>
+			handler(editor.view, dropEvent, nestedSlice, true),
+		);
+		expect(sameContextHandled).toBeUndefined();
+	});
+
+	it("remaps an ordered-list drag copy without changing the source", () => {
+		const editor = createEditor({
+			type: "doc",
+			content: [
+				list({ start: 1, listStart: 1, listId: "source" }, ["One", "Two"]),
+				{ type: "paragraph", content: [{ type: "text", text: "Between" }] },
+				list({ start: 3, listStart: 1, listId: "source" }, ["Three"]),
+			],
+		});
+		const source = orderedNodes(editor)[1]!;
+		editor.view.dispatch(
+			editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, source.pos)),
+		);
+		const copied = prepareCopiedSlice(editor.state.selection.content(), editor.state);
+		vi.spyOn(editor.view, "posAtCoords").mockReturnValue({
+			pos: editor.state.doc.content.size,
+			inside: -1,
+		});
+		const handled = editor.view.someProp("handleDrop", (handler) =>
+			handler(editor.view, { clientX: 0, clientY: 0 } as DragEvent, copied, false),
+		);
+		expect(handled).toBe(true);
+		const lists = orderedNodes(editor);
+		expect(lists).toHaveLength(3);
+		expect(lists.slice(0, 2).map((node) => node.attrs.listId)).toEqual(["source", "source"]);
+		expect(lists[2]!.attrs.listId).not.toBe("source");
+		expect(lists[2]!.attrs.listStart).toBe(3);
+		expect(lists[2]!.attrs.start).toBe(3);
+	});
+});

--- a/packages/core/tests/unit/content/portable-text-lists.test.ts
+++ b/packages/core/tests/unit/content/portable-text-lists.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
 	buildPortableTextListTree,
 	clonePortableTextValue,
-	getNumberedListOrdinals,
 } from "../../../src/content/portable-text-lists.js";
 
 function item(
@@ -137,17 +136,5 @@ describe("numbered list preprocessing", () => {
 
 		expect(value[0].children[0].text).toBe("Between");
 		expect(value[0].markDefs[0].href).toBe("https://example.com");
-	});
-
-	it("computes exact direct-item ordinals independently for nested groups", () => {
-		const rootOne = item("one", "One", "number", 1, "root", 3);
-		const nestedOne = item("nested-one", "Nested one", "number", 2, "nested", 8);
-		const nestedTwo = item("nested-two", "Nested two", "number", 2, "nested", 8);
-		const rootTwo = item("two", "Two", "number", 1, "root", 3);
-		const ordinals = getNumberedListOrdinals([rootOne, nestedOne, nestedTwo, rootTwo]);
-
-		expect([rootOne, nestedOne, nestedTwo, rootTwo].map((block) => ordinals.get(block))).toEqual([
-			3, 8, 9, 4,
-		]);
 	});
 });

--- a/packages/core/tests/unit/content/portable-text-lists.test.ts
+++ b/packages/core/tests/unit/content/portable-text-lists.test.ts
@@ -108,6 +108,17 @@ describe("buildPortableTextListTree", () => {
 		expect(lists.map((list) => list.start)).toEqual([2, 4, 2_147_483_647, 1]);
 	});
 
+	it("uses a later segment's base when the first segment has no listStart", () => {
+		const value = [
+			item("one", "One", "number", 1, "shared", undefined),
+			paragraph,
+			item("two", "Two", "number", 1, "shared", 5),
+		];
+		const lists = collectLists(buildPortableTextListTree(value, "direct"));
+
+		expect(lists.map((list) => list.start)).toEqual([5, 6]);
+	});
+
 	it("handles sparse untrusted nesting levels in bounded work", () => {
 		const value = [
 			item("root", "Root", "number", 1, "root", 1),

--- a/packages/core/tests/unit/content/portable-text-lists.test.ts
+++ b/packages/core/tests/unit/content/portable-text-lists.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	buildPortableTextListTree,
+	clonePortableTextValue,
+	getNumberedListOrdinals,
+} from "../../../src/content/portable-text-lists.js";
+
+function item(
+	key: string,
+	text: string,
+	listItem: "bullet" | "number",
+	level: number,
+	listId?: string,
+	listStart?: number,
+) {
+	return {
+		_type: "block",
+		_key: key,
+		style: "normal",
+		listItem,
+		level,
+		listId,
+		listStart,
+		markDefs: [],
+		children: [{ _type: "span", _key: `${key}-span`, text, marks: [] }],
+	};
+}
+
+const paragraph = {
+	_type: "block",
+	_key: "between",
+	style: "normal",
+	markDefs: [],
+	children: [{ _type: "span", _key: "between-span", text: "Between", marks: [] }],
+};
+
+function collectLists(value: unknown): Array<Record<string, unknown>> {
+	const lists: Array<Record<string, unknown>> = [];
+	const visit = (node: unknown) => {
+		if (!node || typeof node !== "object") return;
+		const record = node as Record<string, unknown>;
+		if (record._type === "@list") lists.push(record);
+		if (Array.isArray(record.children)) record.children.forEach(visit);
+	};
+	if (Array.isArray(value)) value.forEach(visit);
+	else visit(value);
+	return lists;
+}
+
+describe("buildPortableTextListTree", () => {
+	it.each(["html", "direct"] as const)(
+		"continues a numbered identity across a non-list block in %s mode",
+		(mode) => {
+			const value = [
+				item("one", "One", "number", 1, "shared", 1),
+				item("two", "Two", "number", 1, "shared", 1),
+				paragraph,
+				item("three", "Three", "number", 1, "shared", 1),
+			];
+			const before = structuredClone(value);
+			const tree = buildPortableTextListTree(value, mode);
+			const lists = collectLists(tree);
+
+			expect(lists.map((list) => list.start)).toEqual([1, 3]);
+			expect(value).toEqual(before);
+		},
+	);
+
+	it.each(["html", "direct"] as const)(
+		"keeps adjacent independent identities separate at root and nested levels in %s mode",
+		(mode) => {
+			const value = [
+				item("root", "Root", "number", 1, "root", 1),
+				item("nested-a", "Nested A", "number", 2, "nested-a", 2),
+				item("nested-b", "Nested B", "number", 2, "nested-b", 7),
+				item("root-two", "Root two", "number", 1, "root", 1),
+				item("other", "Other", "number", 1, "other", 4),
+			];
+			const lists = collectLists(buildPortableTextListTree(value, mode));
+
+			expect(lists.map((list) => list.start)).toEqual([1, 2, 7, 4]);
+		},
+	);
+
+	it("uses separate counters when a malformed identity is reused across contexts", () => {
+		const value = [
+			item("root", "Root", "number", 1, "shared", 1),
+			item("nested", "Nested", "number", 2, "shared", 5),
+			item("root-two", "Root two", "number", 1, "shared", 1),
+		];
+		const lists = collectLists(buildPortableTextListTree(value, "direct"));
+
+		expect(lists.map((list) => list.start)).toEqual([1, 5]);
+	});
+
+	it("uses the first valid base and falls back to one on overflow", () => {
+		const value = [
+			item("one", "One", "number", 1, "shared", undefined),
+			item("two", "Two", "number", 1, "shared", 2),
+			paragraph,
+			item("three", "Three", "number", 1, "shared", 99),
+			item("max", "Max", "number", 1, "max", 2_147_483_647),
+			paragraph,
+			item("overflow", "Overflow", "number", 1, "max", 2_147_483_647),
+		];
+		const lists = collectLists(buildPortableTextListTree(value, "direct"));
+
+		expect(lists.map((list) => list.start)).toEqual([2, 4, 2_147_483_647, 1]);
+	});
+
+	it("handles sparse untrusted nesting levels in bounded work", () => {
+		const value = [
+			item("root", "Root", "number", 1, "root", 1),
+			item("deep", "Deep", "number", Number.MAX_SAFE_INTEGER, "deep", 1),
+		];
+		const lists = collectLists(buildPortableTextListTree(value, "direct"));
+
+		expect(lists.map((list) => [list.level, list.start])).toEqual([
+			[1, 1],
+			[Number.MAX_SAFE_INTEGER, 1],
+		]);
+	});
+});
+
+describe("numbered list preprocessing", () => {
+	it("deep-clones nested Portable Text data", () => {
+		const value = [
+			{
+				...paragraph,
+				markDefs: [{ _key: "link", _type: "link", href: "https://example.com" }],
+			},
+		];
+		const clone = clonePortableTextValue(value);
+		(clone[0].children[0] as { text: string }).text = "Changed";
+		(clone[0].markDefs[0] as { href: string }).href = "https://changed.example";
+
+		expect(value[0].children[0].text).toBe("Between");
+		expect(value[0].markDefs[0].href).toBe("https://example.com");
+	});
+
+	it("computes exact direct-item ordinals independently for nested groups", () => {
+		const rootOne = item("one", "One", "number", 1, "root", 3);
+		const nestedOne = item("nested-one", "Nested one", "number", 2, "nested", 8);
+		const nestedTwo = item("nested-two", "Nested two", "number", 2, "nested", 8);
+		const rootTwo = item("two", "Two", "number", 1, "root", 3);
+		const ordinals = getNumberedListOrdinals([rootOne, nestedOne, nestedTwo, rootTwo]);
+
+		expect([rootOne, nestedOne, nestedTwo, rootTwo].map((block) => ordinals.get(block))).toEqual([
+			3, 8, 9, 4,
+		]);
+	});
+});

--- a/packages/core/tests/unit/converters/numbered-list-continuity.test.ts
+++ b/packages/core/tests/unit/converters/numbered-list-continuity.test.ts
@@ -53,6 +53,16 @@ function orderedLists(doc: ProseMirrorDocument): ProseMirrorNode[] {
 	return doc.content.filter((node) => node.type === "orderedList");
 }
 
+function allOrderedLists(doc: ProseMirrorDocument): ProseMirrorNode[] {
+	const lists: ProseMirrorNode[] = [];
+	const visit = (node: ProseMirrorNode) => {
+		if (node.type === "orderedList") lists.push(node);
+		node.content?.forEach(visit);
+	};
+	doc.content.forEach(visit);
+	return lists;
+}
+
 describe("numbered-list Portable Text conversion", () => {
 	it("keeps the inline and reusable legacy identities equivalent", () => {
 		const blocks: PortableTextBlock[] = [
@@ -150,6 +160,30 @@ describe("numbered-list Portable Text conversion", () => {
 		const lists = orderedLists(portableTextToProsemirror(blocks));
 		expect(lists.map((list) => list.attrs?.listStart)).toEqual([5, 5]);
 		expect(lists.map((list) => list.attrs?.start)).toEqual([5, 6]);
+	});
+
+	it("uses a later valid base when an earlier segment has no base", () => {
+		const blocks: PortableTextBlock[] = [
+			{ ...ptListItem("a", "Five", "list-a"), listStart: undefined },
+			paragraph("aside", "Between"),
+			ptListItem("b", "Six", "list-a", 5),
+		];
+
+		const lists = orderedLists(portableTextToProsemirror(blocks));
+		expect(lists.map((list) => list.attrs?.listStart)).toEqual([5, 5]);
+		expect(lists.map((list) => list.attrs?.start)).toEqual([5, 6]);
+	});
+
+	it("keeps a reused root and nested identity in separate numbering scopes", () => {
+		const root = ptListItem("root", "Root", "shared", 1);
+		const nested = { ...ptListItem("nested", "Nested", "shared", 5), level: 2 };
+		const rootTwo = ptListItem("root-two", "Root two", "shared", 1);
+		const lists = allOrderedLists(portableTextToProsemirror([root, nested, rootTwo]));
+
+		expect(lists).toHaveLength(2);
+		expect(lists.map((list) => list.attrs?.listStart)).toEqual([1, 5]);
+		expect(lists.map((list) => list.attrs?.start)).toEqual([1, 5]);
+		expect(lists[1]?.attrs?.listId).not.toBe("shared");
 	});
 
 	it("bounds and canonicalizes untrusted metadata", () => {

--- a/packages/core/tests/unit/converters/numbered-list-continuity.test.ts
+++ b/packages/core/tests/unit/converters/numbered-list-continuity.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import { _portableTextToPM as inlinePortableTextToPM } from "../../../src/components/InlinePortableTextEditor.js";
+import {
+	MAX_ORDERED_LIST_START,
+	normalizeListId,
+	normalizeListStart,
+} from "../../../src/content/converters/numbered-list.js";
+import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
+import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
+import type {
+	PortableTextBlock,
+	PortableTextTextBlock,
+	ProseMirrorDocument,
+	ProseMirrorNode,
+} from "../../../src/content/converters/types.js";
+
+function listItem(text: string): ProseMirrorNode {
+	return {
+		type: "listItem",
+		content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+	};
+}
+
+function ptListItem(
+	key: string,
+	text: string,
+	listId: string,
+	listStart = 1,
+): PortableTextTextBlock {
+	return {
+		_type: "block",
+		_key: key,
+		style: "normal",
+		listItem: "number",
+		level: 1,
+		listId,
+		listStart,
+		children: [{ _type: "span", _key: `${key}-span`, text }],
+	};
+}
+
+function paragraph(key: string, text: string): PortableTextTextBlock {
+	return {
+		_type: "block",
+		_key: key,
+		style: "normal",
+		children: [{ _type: "span", _key: `${key}-span`, text }],
+	};
+}
+
+function orderedLists(doc: ProseMirrorDocument): ProseMirrorNode[] {
+	return doc.content.filter((node) => node.type === "orderedList");
+}
+
+describe("numbered-list Portable Text conversion", () => {
+	it("keeps the inline and reusable legacy identities equivalent", () => {
+		const blocks: PortableTextBlock[] = [
+			{
+				_type: "block",
+				_key: "legacy-item",
+				style: "normal",
+				listItem: "number",
+				level: 1,
+				children: [{ _type: "span", _key: "legacy-span", text: "Legacy" }],
+			},
+		];
+		const inline = inlinePortableTextToPM(blocks) as ProseMirrorDocument;
+		const reusable = portableTextToProsemirror(blocks);
+
+		expect(allOrderedLists(inline)[0]?.attrs?.listId).toBe(
+			allOrderedLists(reusable)[0]?.attrs?.listId,
+		);
+	});
+
+	it("preserves an explicitly started ProseMirror list through PT", () => {
+		const original: ProseMirrorDocument = {
+			type: "doc",
+			content: [
+				{
+					type: "orderedList",
+					attrs: { start: 2 },
+					content: [listItem("Second"), listItem("Third")],
+				},
+			],
+		};
+
+		const portableText = prosemirrorToPortableText(original) as PortableTextTextBlock[];
+		expect(portableText).toHaveLength(2);
+		expect(portableText[0]?.listStart).toBe(2);
+		expect(portableText[0]?.listId).toBeTruthy();
+		expect(portableText[1]?.listId).toBe(portableText[0]?.listId);
+
+		const roundTripped = portableTextToProsemirror(portableText);
+		expect(orderedLists(roundTripped)[0]?.attrs).toMatchObject({
+			start: 2,
+			listStart: 2,
+			listId: portableText[0]?.listId,
+		});
+	});
+
+	it("derives the later start for separated segments with one identity", () => {
+		const blocks: PortableTextBlock[] = [
+			ptListItem("a1", "One", "list-a"),
+			ptListItem("a2", "Two", "list-a"),
+			paragraph("aside", "Between"),
+			ptListItem("a3", "Three", "list-a"),
+			ptListItem("a4", "Four", "list-a"),
+		];
+
+		const lists = orderedLists(portableTextToProsemirror(blocks));
+		expect(lists).toHaveLength(2);
+		expect(lists[0]?.attrs).toMatchObject({ start: 1, listStart: 1, listId: "list-a" });
+		expect(lists[1]?.attrs).toMatchObject({ start: 3, listStart: 1, listId: "list-a" });
+	});
+
+	it("does not merge adjacent numbered runs with different identities", () => {
+		const blocks: PortableTextBlock[] = [
+			ptListItem("a", "First", "list-a"),
+			ptListItem("b", "Independent", "list-b"),
+		];
+
+		const lists = orderedLists(portableTextToProsemirror(blocks));
+		expect(lists).toHaveLength(2);
+		expect(lists.map((list) => list.attrs?.listId)).toEqual(["list-a", "list-b"]);
+		expect(lists.map((list) => list.attrs?.start)).toEqual([1, 1]);
+	});
+
+	it("keeps legacy separated runs independent", () => {
+		const blocks: PortableTextBlock[] = [
+			{ ...ptListItem("a", "One", "unused"), listId: undefined, listStart: undefined },
+			paragraph("aside", "Between"),
+			{ ...ptListItem("b", "One again", "unused"), listId: undefined, listStart: undefined },
+		];
+
+		const lists = orderedLists(portableTextToProsemirror(blocks));
+		expect(lists).toHaveLength(2);
+		expect(lists[0]?.attrs?.start).toBe(1);
+		expect(lists[1]?.attrs?.start).toBe(1);
+		expect(lists[0]?.attrs?.listId).not.toBe(lists[1]?.attrs?.listId);
+	});
+
+	it("uses the first valid base for conflicting metadata", () => {
+		const blocks: PortableTextBlock[] = [
+			ptListItem("a", "Five", "list-a", 5),
+			paragraph("aside", "Between"),
+			ptListItem("b", "Six", "list-a", 99),
+		];
+
+		const lists = orderedLists(portableTextToProsemirror(blocks));
+		expect(lists.map((list) => list.attrs?.listStart)).toEqual([5, 5]);
+		expect(lists.map((list) => list.attrs?.start)).toEqual([5, 6]);
+	});
+
+	it("bounds and canonicalizes untrusted metadata", () => {
+		expect(normalizeListId("  list-a  ")).toBe("list-a");
+		expect(normalizeListId(" ")).toBeUndefined();
+		expect(normalizeListId("x".repeat(129))).toBeUndefined();
+		expect(normalizeListStart(1)).toBe(1);
+		expect(normalizeListStart(MAX_ORDERED_LIST_START)).toBe(MAX_ORDERED_LIST_START);
+		expect(normalizeListStart(0)).toBeUndefined();
+		expect(normalizeListStart(1.5)).toBeUndefined();
+		expect(normalizeListStart(MAX_ORDERED_LIST_START + 1)).toBeUndefined();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,6 +1197,9 @@ importers:
       '@tiptap/extension-link':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
+      '@tiptap/extension-list':
+        specifier: 'catalog:'
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-node-range':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
@@ -1716,6 +1719,9 @@ importers:
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extension-link':
+        specifier: 'catalog:'
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
+      '@tiptap/extension-list':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-placeholder':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1736,6 +1736,9 @@ importers:
       '@tiptap/extension-underline':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
+      '@tiptap/pm':
+        specifier: 'catalog:'
+        version: 3.20.0
       '@tiptap/react':
         specifier: 'catalog:'
         version: 3.20.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -128,6 +128,7 @@ catalog:
   "@tiptap/extension-focus": ^3.20.0
   "@tiptap/extension-image": ^3.20.0
   "@tiptap/extension-link": ^3.20.0
+  "@tiptap/extension-list": ^3.20.0
   "@tiptap/extension-node-range": ^3.20.0
   "@tiptap/extension-placeholder": ^3.20.0
   "@tiptap/extension-subscript": ^3.20.0


### PR DESCRIPTION
## What does this PR do?

Preserves ordered-list numbering when paragraphs, images, code blocks, or plugin blocks separate list segments. It stores a stable logical list identity in Portable Text, derives later segment starts after edits, adds Continue/Restart controls, and renders semantic `<ol start>` values in Astro.

Independent, nested, legacy, blockquote, and table-cell lists remain isolated. Markdown import/export remains intentionally lossy and does not synthesize continuity metadata.

Closes #2344

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a — this is a bug fix for #2344

Scoped `emdash` and `@emdash-cms/admin` typechecks pass. Quick lint reports zero diagnostics, and type-aware lint passes for every changed production TypeScript file. Full-workspace `pnpm typecheck` and `pnpm lint` were not run in the linked worktree, so those boxes remain unchecked for CI.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5.6 Sol) with independent GPT-5.6 Terra adversarial reviewers

## Screenshots / test output

- 35 core editor/converter tests pass.
- 4 Astro rendering tests pass, including semantic continuation starts, immutability, nesting modes, and component overrides.
- 21 admin Chromium tests pass.
- Focused RTL Continue/Restart Chromium test passes.
- A temporary real-Chromium acceptance harness verified Continue/Restart, undo/redo, save/reload, earlier-item insertion/deletion renumbering, and independent/nested/legacy/blockquote/table-cell isolation; the harness was removed after verification.
- Core and admin scoped typechecks pass.
- Changed-file formatting, quick lint, relevant type-aware lint, changeset validation, and `git diff --check` pass.
- Query-count snapshots are unchanged.

Three independent final adversarial reviews found no reproducible functional bugs and recommended merging.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://issue-2344-numbered-list-continuity-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `issue-2344-numbered-list-continuity`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
