### PR TITLE
feat(mcp): add safe schema update tools

### DIFF
--- a/.changeset/add-mcp-schema-updates.md
+++ b/.changeset/add-mcp-schema-updates.md
@@ -2,4 +2,4 @@
 "emdash": minor
 ---
 
-Adds MCP tools for updating collections and fields without deleting and recreating their schemas.
+Adds MCP tools for safely updating collections and fields without deleting and recreating their schemas.

--- a/.changeset/add-mcp-schema-updates.md
+++ b/.changeset/add-mcp-schema-updates.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds MCP tools for updating collections and fields without deleting and recreating their schemas.

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -382,23 +382,23 @@ For `select` and `multiSelect` types, provide allowed values in `validation.opti
 
 #### `schema_update_field`
 
-Update an existing field without deleting its column or stored values. Only provided settings change; omitted settings keep their current values. Type changes are accepted only when the underlying column type remains compatible. Changes that require a physical content migration return `FIELD_TYPE_COLUMN_CHANGE` with migration guidance.
+Update an existing field without deleting its column or stored values. Only provided settings change; omitted settings keep their current values. `string`, `text`, and `slug` may be changed between one another. Other type changes and settings that require content or column migration are rejected with migration guidance. Invalid regular expressions and contradictory validation ranges are rejected before any schema metadata changes.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `collection` | `string` | Yes | Collection containing the field |
 | `fieldSlug` | `string` | Yes | Field slug to update |
 | `label` | `string` | No | New display name |
-| `type` | `string` | No | New field type; must preserve the underlying column type |
-| `required` | `boolean` | No | Whether the field is required |
-| `unique` | `boolean` | No | Whether field values must be unique |
+| `type` | `string` | No | New field type; only `string`, `text`, and `slug` aliases can be changed in place |
+| `required` | `boolean` | No | Whether the field is required; changing it requires a manual content migration |
+| `unique` | `boolean` | No | Whether field values must be unique; changing it requires a manual content migration |
 | `defaultValue` | `any` | No | Default value for new content |
 | `validation` | `object \| null` | No | Validation constraints; `null` clears them |
 | `widget` | `string` | No | Admin editor widget name |
 | `options` | `object` | No | Widget configuration |
 | `sortOrder` | `integer` | No | Field order in the content editor |
 | `searchable` | `boolean` | No | Whether full-text search indexes the field |
-| `translatable` | `boolean` | No | Whether values vary by locale |
+| `translatable` | `boolean` | No | Whether values vary by locale; changing to `false` requires a manual content migration |
 
 **Scope:** `schema:write` | **Minimum role:** Admin
 

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -36,7 +36,7 @@ Tokens are scoped to limit what operations a client can perform. Scopes are requ
 | `media:read` | List and get media items. |
 | `media:write` | Register (create), update, and delete media metadata. |
 | `schema:read` | List collections and get collection schemas. |
-| `schema:write` | Create and delete collections and fields. |
+| `schema:write` | Create, update, and delete collections and fields. |
 | `taxonomies:manage` | Create, update, and delete taxonomy terms. |
 | `menus:manage` | Create, update, and delete navigation menus and their items. |
 | `settings:read` | Read site-wide settings. |
@@ -324,6 +324,27 @@ Create a new content collection. This creates a database table and schema defini
 
 **Scope:** `schema:write` | **Minimum role:** Admin
 
+#### `schema_update_collection`
+
+Update an existing collection without deleting its table, fields, or content. Only provided settings change; omitted settings keep their current values. The collection slug cannot be changed.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | `string` | Yes | Collection slug to update |
+| `label` | `string` | No | New plural display name |
+| `labelSingular` | `string` | No | New singular display name |
+| `description` | `string` | No | New collection description |
+| `icon` | `string` | No | New admin UI icon name |
+| `supports` | `string[]` | No | Complete feature list to enable; omitted preserves the current list |
+| `urlPattern` | `string \| null` | No | New public URL pattern; `null` clears it |
+| `hasSeo` | `boolean` | No | Whether the collection supports SEO metadata |
+| `commentsEnabled` | `boolean` | No | Whether comments are enabled |
+| `commentsModeration` | `string` | No | Moderation policy: `all`, `first_time`, or `none` |
+| `commentsClosedAfterDays` | `integer` | No | Close comments after this many days; `0` keeps them open |
+| `commentsAutoApproveUsers` | `boolean` | No | Automatically approve comments from authenticated users |
+
+**Scope:** `schema:write` | **Minimum role:** Admin
+
 #### `schema_delete_collection`
 
 Delete a collection and its database table. This is irreversible and deletes all content in the collection.
@@ -356,6 +377,28 @@ Add a new field to a collection's schema. This adds a column to the database tab
 Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `portableText`, `image`, `file`, `reference`, `json`, `slug`.
 
 For `select` and `multiSelect` types, provide allowed values in `validation.options`.
+
+**Scope:** `schema:write` | **Minimum role:** Admin
+
+#### `schema_update_field`
+
+Update an existing field without deleting its column or stored values. Only provided settings change; omitted settings keep their current values. Type changes are accepted only when the underlying column type remains compatible. Changes that require a physical content migration return `FIELD_TYPE_COLUMN_CHANGE` with migration guidance.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `collection` | `string` | Yes | Collection containing the field |
+| `fieldSlug` | `string` | Yes | Field slug to update |
+| `label` | `string` | No | New display name |
+| `type` | `string` | No | New field type; must preserve the underlying column type |
+| `required` | `boolean` | No | Whether the field is required |
+| `unique` | `boolean` | No | Whether field values must be unique |
+| `defaultValue` | `any` | No | Default value for new content |
+| `validation` | `object \| null` | No | Validation constraints; `null` clears them |
+| `widget` | `string` | No | Admin editor widget name |
+| `options` | `object` | No | Widget configuration |
+| `sortOrder` | `integer` | No | Field order in the content editor |
+| `searchable` | `boolean` | No | Whether full-text search indexes the field |
+| `translatable` | `boolean` | No | Whether values vary by locale |
 
 **Scope:** `schema:write` | **Minimum role:** Admin
 

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -399,6 +399,7 @@ Update an existing field without deleting its column or stored values. Only prov
 | `options` | `object` | No | Widget configuration |
 | `sortOrder` | `integer` | No | Field order in the content editor |
 | `searchable` | `boolean` | No | Whether full-text search indexes the field |
+| `indexed` | `boolean` | No | Create or remove a physical index for structured sorting |
 | `translatable` | `boolean` | No | Whether values vary by locale; changing to `false` requires a manual content migration |
 
 **Scope:** `schema:write` | **Minimum role:** Admin

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -383,23 +383,23 @@ For `select` and `multiSelect` types, provide allowed values in `validation.opti
 
 #### `schema_update_field`
 
-Update an existing field without deleting its column or stored values. Only provided settings change; omitted settings keep their current values. Type changes are accepted only when the underlying column type remains compatible. Changes that require a physical content migration return `FIELD_TYPE_COLUMN_CHANGE` with migration guidance.
+Update an existing field without deleting its column or stored values. Only provided settings change; omitted settings keep their current values. `string`, `text`, and `slug` may be changed between one another. Other type changes and settings that require content or column migration are rejected with migration guidance. Invalid regular expressions and contradictory validation ranges are rejected before any schema metadata changes.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `collection` | `string` | Yes | Collection containing the field |
 | `fieldSlug` | `string` | Yes | Field slug to update |
 | `label` | `string` | No | New display name |
-| `type` | `string` | No | New field type; must preserve the underlying column type |
-| `required` | `boolean` | No | Whether the field is required |
-| `unique` | `boolean` | No | Whether field values must be unique |
+| `type` | `string` | No | New field type; only `string`, `text`, and `slug` aliases can be changed in place |
+| `required` | `boolean` | No | Whether the field is required; changing it requires a manual content migration |
+| `unique` | `boolean` | No | Whether field values must be unique; changing it requires a manual content migration |
 | `defaultValue` | `any` | No | Default value for new content |
 | `validation` | `object \| null` | No | Validation constraints; `null` clears them |
 | `widget` | `string` | No | Admin editor widget name |
 | `options` | `object` | No | Widget configuration |
 | `sortOrder` | `integer` | No | Field order in the content editor |
 | `searchable` | `boolean` | No | Whether full-text search indexes the field |
-| `translatable` | `boolean` | No | Whether values vary by locale |
+| `translatable` | `boolean` | No | Whether values vary by locale; changing to `false` requires a manual content migration |
 
 **Scope:** `schema:write` | **Minimum role:** Admin
 

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -320,7 +320,7 @@ Create a new content collection. This creates a database table and schema defini
 | `labelSingular` | `string` | No | Singular display name |
 | `description` | `string` | No | Description of this collection |
 | `icon` | `string` | No | Icon name for the admin UI |
-| `supports` | `string[]` | No | Features: `drafts`, `revisions`, `preview`, `scheduling`, `search` (default: `['drafts', 'revisions']`) |
+| `supports` | `string[]` | No | Features: `drafts`, `revisions`, `preview`, `scheduling`, `search`, `seo` (default: `['drafts', 'revisions']`) |
 
 **Scope:** `schema:write` | **Minimum role:** Admin
 
@@ -335,7 +335,7 @@ Update an existing collection without deleting its table, fields, or content. On
 | `labelSingular` | `string` | No | New singular display name |
 | `description` | `string` | No | New collection description |
 | `icon` | `string` | No | New admin UI icon name |
-| `supports` | `string[]` | No | Complete feature list to enable; omitted preserves the current list |
+| `supports` | `string[]` | No | Complete feature list to enable: `drafts`, `revisions`, `preview`, `scheduling`, `search`, `seo`; omitted preserves the current list |
 | `urlPattern` | `string \| null` | No | New public URL pattern; `null` clears it |
 | `hasSeo` | `boolean` | No | Whether the collection supports SEO metadata |
 | `commentsEnabled` | `boolean` | No | Whether comments are enabled |

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -36,7 +36,7 @@ Tokens are scoped to limit what operations a client can perform. Scopes are requ
 | `media:read` | List and get media items. |
 | `media:write` | Register (create), update, and delete media metadata. |
 | `schema:read` | List collections and get collection schemas. |
-| `schema:write` | Create and delete collections and fields. |
+| `schema:write` | Create, update, and delete collections and fields. |
 | `taxonomies:manage` | Create, update, and delete taxonomy terms. |
 | `menus:manage` | Create, update, and delete navigation menus and their items. |
 | `settings:read` | Read site-wide settings. |
@@ -324,6 +324,27 @@ Create a new content collection. This creates a database table and schema defini
 
 **Scope:** `schema:write` | **Minimum role:** Admin
 
+#### `schema_update_collection`
+
+Update an existing collection without deleting its table, fields, or content. Only provided settings change; omitted settings keep their current values. The collection slug cannot be changed.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slug` | `string` | Yes | Collection slug to update |
+| `label` | `string` | No | New plural display name |
+| `labelSingular` | `string` | No | New singular display name |
+| `description` | `string` | No | New collection description |
+| `icon` | `string` | No | New admin UI icon name |
+| `supports` | `string[]` | No | Complete feature list to enable; omitted preserves the current list |
+| `urlPattern` | `string \| null` | No | New public URL pattern; `null` clears it |
+| `hasSeo` | `boolean` | No | Whether the collection supports SEO metadata |
+| `commentsEnabled` | `boolean` | No | Whether comments are enabled |
+| `commentsModeration` | `string` | No | Moderation policy: `all`, `first_time`, or `none` |
+| `commentsClosedAfterDays` | `integer` | No | Close comments after this many days; `0` keeps them open |
+| `commentsAutoApproveUsers` | `boolean` | No | Automatically approve comments from authenticated users |
+
+**Scope:** `schema:write` | **Minimum role:** Admin
+
 #### `schema_delete_collection`
 
 Delete a collection and its database table. This is irreversible and deletes all content in the collection.
@@ -357,6 +378,28 @@ Add a new field to a collection's schema. This adds a column to the database tab
 Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `portableText`, `image`, `file`, `reference`, `json`, `slug`.
 
 For `select` and `multiSelect` types, provide allowed values in `validation.options`.
+
+**Scope:** `schema:write` | **Minimum role:** Admin
+
+#### `schema_update_field`
+
+Update an existing field without deleting its column or stored values. Only provided settings change; omitted settings keep their current values. Type changes are accepted only when the underlying column type remains compatible. Changes that require a physical content migration return `FIELD_TYPE_COLUMN_CHANGE` with migration guidance.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `collection` | `string` | Yes | Collection containing the field |
+| `fieldSlug` | `string` | Yes | Field slug to update |
+| `label` | `string` | No | New display name |
+| `type` | `string` | No | New field type; must preserve the underlying column type |
+| `required` | `boolean` | No | Whether the field is required |
+| `unique` | `boolean` | No | Whether field values must be unique |
+| `defaultValue` | `any` | No | Default value for new content |
+| `validation` | `object \| null` | No | Validation constraints; `null` clears them |
+| `widget` | `string` | No | Admin editor widget name |
+| `options` | `object` | No | Widget configuration |
+| `sortOrder` | `integer` | No | Field order in the content editor |
+| `searchable` | `boolean` | No | Whether full-text search indexes the field |
+| `translatable` | `boolean` | No | Whether values vary by locale |
 
 **Scope:** `schema:write` | **Minimum role:** Admin
 

--- a/packages/core/src/api/handlers/schema.ts
+++ b/packages/core/src/api/handlers/schema.ts
@@ -9,6 +9,7 @@ import { invalidateCollectionCache } from "../../object-cache/index.js";
 import {
 	SchemaRegistry,
 	SchemaError,
+	invalidateSchemaCache,
 	type Collection,
 	type Field,
 	type CreateCollectionInput,
@@ -18,6 +19,11 @@ import {
 	type CollectionWithFields,
 } from "../../schema/index.js";
 import type { ApiResult } from "../types.js";
+
+function invalidateFieldCaches(collectionSlug: string): void {
+	invalidateCollectionCache(collectionSlug);
+	invalidateSchemaCache(collectionSlug);
+}
 
 export interface CollectionListResponse {
 	items: Collection[];
@@ -317,7 +323,7 @@ export async function handleSchemaFieldCreate(
 		const item = await registry.createField(collectionSlug, input);
 
 		// Content snapshots embed field values; a column change invalidates them.
-		invalidateCollectionCache(collectionSlug);
+		invalidateFieldCaches(collectionSlug);
 
 		return {
 			success: true,
@@ -357,7 +363,7 @@ export async function handleSchemaFieldUpdate(
 		const registry = new SchemaRegistry(db);
 		const item = await registry.updateField(collectionSlug, fieldSlug, input);
 
-		invalidateCollectionCache(collectionSlug);
+		invalidateFieldCaches(collectionSlug);
 
 		return {
 			success: true,
@@ -396,7 +402,7 @@ export async function handleSchemaFieldDelete(
 		const registry = new SchemaRegistry(db);
 		await registry.deleteField(collectionSlug, fieldSlug);
 
-		invalidateCollectionCache(collectionSlug);
+		invalidateFieldCaches(collectionSlug);
 
 		return {
 			success: true,

--- a/packages/core/src/api/schemas/schema.ts
+++ b/packages/core/src/api/schemas/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { MAX_COLLECTION_LIST_COLUMNS } from "../../schema/types.js";
+import { compileUrlPattern } from "../../schema/url-pattern.js";
 import { slugPattern } from "./common.js";
 
 // ---------------------------------------------------------------------------
@@ -67,6 +68,17 @@ const repeaterSubFieldSchema = z.object({
 	options: z.array(z.string()).optional(),
 });
 
+const urlPatternValue = z.string().superRefine((pattern, ctx) => {
+	try {
+		compileUrlPattern(pattern);
+	} catch {
+		ctx.addIssue({
+			code: "custom",
+			message: "Invalid URL pattern",
+		});
+	}
+});
+
 const fieldValidation = z
 	.object({
 		required: z.boolean().optional(),
@@ -89,6 +101,35 @@ const fieldValidation = z
 			.max(64, "allowedMimeTypes may contain at most 64 entries")
 			.optional(),
 	})
+	.superRefine((validation, ctx) => {
+		for (const [minimum, maximum] of [
+			["min", "max"],
+			["minLength", "maxLength"],
+			["minItems", "maxItems"],
+		] as const) {
+			const minimumValue = validation[minimum];
+			const maximumValue = validation[maximum];
+			if (minimumValue !== undefined && maximumValue !== undefined && minimumValue > maximumValue) {
+				ctx.addIssue({
+					code: "custom",
+					path: [maximum],
+					message: `${maximum} must be greater than or equal to ${minimum}`,
+				});
+			}
+		}
+
+		if (validation.pattern !== undefined) {
+			try {
+				RegExp(validation.pattern);
+			} catch {
+				ctx.addIssue({
+					code: "custom",
+					path: ["pattern"],
+					message: "Invalid validation pattern",
+				});
+			}
+		}
+	})
 	.optional();
 
 const fieldWidgetOptions = z.record(z.string(), z.unknown()).optional();
@@ -103,7 +144,7 @@ export const createCollectionBody = z
 		admin: collectionAdminInputConfig.optional(),
 		supports: z.array(collectionSupportValues).optional(),
 		source: z.string().regex(collectionSourcePattern).optional(),
-		urlPattern: z.string().optional(),
+		urlPattern: urlPatternValue.optional(),
 		hasSeo: z.boolean().optional(),
 		hidden: z.boolean().optional(),
 		sortOrder: z.number().int().nullish(),
@@ -118,7 +159,7 @@ export const updateCollectionBody = z
 		icon: z.string().optional(),
 		admin: collectionAdminInputConfig.optional(),
 		supports: z.array(collectionSupportValues).optional(),
-		urlPattern: z.string().nullish(),
+		urlPattern: urlPatternValue.nullish(),
 		hasSeo: z.boolean().optional(),
 		hidden: z.boolean().optional(),
 		sortOrder: z.number().int().nullish(),

--- a/packages/core/src/api/schemas/schema.ts
+++ b/packages/core/src/api/schemas/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { compileUrlPattern } from "../../schema/url-pattern.js";
 import { slugPattern } from "./common.js";
 
 // ---------------------------------------------------------------------------
@@ -49,6 +50,17 @@ const repeaterSubFieldSchema = z.object({
 	options: z.array(z.string()).optional(),
 });
 
+const urlPatternValue = z.string().superRefine((pattern, ctx) => {
+	try {
+		compileUrlPattern(pattern);
+	} catch {
+		ctx.addIssue({
+			code: "custom",
+			message: "Invalid URL pattern",
+		});
+	}
+});
+
 const fieldValidation = z
 	.object({
 		required: z.boolean().optional(),
@@ -71,6 +83,35 @@ const fieldValidation = z
 			.max(64, "allowedMimeTypes may contain at most 64 entries")
 			.optional(),
 	})
+	.superRefine((validation, ctx) => {
+		for (const [minimum, maximum] of [
+			["min", "max"],
+			["minLength", "maxLength"],
+			["minItems", "maxItems"],
+		] as const) {
+			const minimumValue = validation[minimum];
+			const maximumValue = validation[maximum];
+			if (minimumValue !== undefined && maximumValue !== undefined && minimumValue > maximumValue) {
+				ctx.addIssue({
+					code: "custom",
+					path: [maximum],
+					message: `${maximum} must be greater than or equal to ${minimum}`,
+				});
+			}
+		}
+
+		if (validation.pattern !== undefined) {
+			try {
+				RegExp(validation.pattern);
+			} catch {
+				ctx.addIssue({
+					code: "custom",
+					path: ["pattern"],
+					message: "Invalid validation pattern",
+				});
+			}
+		}
+	})
 	.optional();
 
 const fieldWidgetOptions = z.record(z.string(), z.unknown()).optional();
@@ -84,7 +125,7 @@ export const createCollectionBody = z
 		icon: z.string().optional(),
 		supports: z.array(collectionSupportValues).optional(),
 		source: z.string().regex(collectionSourcePattern).optional(),
-		urlPattern: z.string().optional(),
+		urlPattern: urlPatternValue.optional(),
 		hasSeo: z.boolean().optional(),
 	})
 	.meta({ id: "CreateCollectionBody" });
@@ -96,7 +137,7 @@ export const updateCollectionBody = z
 		description: z.string().optional(),
 		icon: z.string().optional(),
 		supports: z.array(collectionSupportValues).optional(),
-		urlPattern: z.string().nullish(),
+		urlPattern: urlPatternValue.nullish(),
 		hasSeo: z.boolean().optional(),
 		commentsEnabled: z.boolean().optional(),
 		commentsModeration: z.enum(["all", "first_time", "none"]).optional(),

--- a/packages/core/src/api/schemas/schema.ts
+++ b/packages/core/src/api/schemas/schema.ts
@@ -8,7 +8,14 @@ import { slugPattern } from "./common.js";
 // Schema (collections & fields): Input schemas
 // ---------------------------------------------------------------------------
 
-const collectionSupportValues = z.enum(["drafts", "revisions", "preview", "scheduling", "search"]);
+const collectionSupportValues = z.enum([
+	"drafts",
+	"revisions",
+	"preview",
+	"scheduling",
+	"search",
+	"seo",
+]);
 
 const collectionSourcePattern = /^(template:.+|import:.+|manual|discovered|seed)$/;
 

--- a/packages/core/src/astro/routes/api/schema/collections/[slug]/index.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/[slug]/index.ts
@@ -17,7 +17,6 @@ import {
 } from "#api/index.js";
 import { parseBody, parseQuery, isParseError } from "#api/parse.js";
 import { collectionGetQuery, updateCollectionBody } from "#api/schemas.js";
-import type { UpdateCollectionInput } from "#schema/types.js";
 
 export const prerender = false;
 
@@ -53,12 +52,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 	const body = await parseBody(request, updateCollectionBody);
 	if (isParseError(body)) return body;
 
-	const result = await handleSchemaCollectionUpdate(
-		emdash.db,
-		slug,
-		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- parseBody validates via Zod
-		body as UpdateCollectionInput,
-	);
+	const result = await handleSchemaCollectionUpdate(emdash.db, slug, body);
 	emdash.invalidateUrlPatternCache();
 	return unwrapResult(result);
 };

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -20,6 +20,7 @@ import {
 	CONTENT_TYPE_RE,
 	contentBylineInputSchema,
 	contentSeoInput,
+	createCollectionBody,
 	updateCollectionBody,
 	updateFieldBody,
 } from "#api/schemas.js";
@@ -1797,7 +1798,8 @@ export function createMcpServer(
 				"table and schema definition. The slug must be lowercase alphanumeric " +
 				"with underscores, starting with a letter. Supports: 'drafts' (draft/" +
 				"publish workflow), 'revisions' (version history), 'preview' (live " +
-				"preview), 'scheduling' (timed publish), 'search' (full-text indexing).",
+				"preview), 'scheduling' (timed publish), 'search' (full-text indexing), " +
+				"and 'seo' (SEO metadata).",
 			inputSchema: z.object({
 				slug: z
 					.string()
@@ -1807,10 +1809,9 @@ export function createMcpServer(
 				labelSingular: z.string().optional().describe("Singular display name (e.g. 'Blog Post')"),
 				description: z.string().optional().describe("Description of this collection"),
 				icon: z.string().optional().describe("Icon name for the admin UI"),
-				supports: z
-					.array(z.enum(["drafts", "revisions", "preview", "scheduling", "search"]))
-					.optional()
-					.describe("Features to enable (default: ['drafts', 'revisions'])"),
+				supports: createCollectionBody.shape.supports.describe(
+					"Features to enable (default: ['drafts', 'revisions'])",
+				),
 			}),
 		},
 		async (args, extra) => {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -114,7 +114,12 @@ const mediaUsageRepairToolSchema = z
 	});
 
 const schemaUpdateCollectionToolSchema = z.object({
-	slug: z.string().describe("Collection slug to update; the slug itself cannot be changed"),
+	slug: z
+		.string()
+		.min(1)
+		.max(63)
+		.regex(COLLECTION_SLUG_PATTERN, "Invalid collection slug")
+		.describe("Collection slug to update; the slug itself cannot be changed"),
 	label: updateCollectionBody.shape.label.describe("New plural display name"),
 	labelSingular: updateCollectionBody.shape.labelSingular.describe("New singular display name"),
 	description: updateCollectionBody.shape.description.describe("New collection description"),
@@ -143,8 +148,18 @@ const schemaUpdateCollectionToolSchema = z.object({
 });
 
 const schemaUpdateFieldToolSchema = z.object({
-	collection: z.string().describe("Collection slug containing the field"),
-	fieldSlug: z.string().describe("Field slug to update; the slug itself cannot be changed"),
+	collection: z
+		.string()
+		.min(1)
+		.max(63)
+		.regex(COLLECTION_SLUG_PATTERN, "Invalid collection slug")
+		.describe("Collection slug containing the field"),
+	fieldSlug: z
+		.string()
+		.min(1)
+		.max(63)
+		.regex(COLLECTION_SLUG_PATTERN, "Invalid field slug")
+		.describe("Field slug to update; the slug itself cannot be changed"),
 	label: updateFieldBody.shape.label.describe("New display name"),
 	type: updateFieldBody.shape.type.describe(
 		"New field type; only string, text, and slug aliases can be changed in place",

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -168,6 +168,9 @@ const schemaUpdateFieldToolSchema = z.object({
 	translatable: updateFieldBody.shape.translatable.describe(
 		"Whether values vary by locale; changing to false requires a manual content migration",
 	),
+	indexed: updateFieldBody.shape.indexed.describe(
+		"Create or remove a physical index for structured sorting",
+	),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -143,10 +143,14 @@ const schemaUpdateFieldToolSchema = z.object({
 	fieldSlug: z.string().describe("Field slug to update; the slug itself cannot be changed"),
 	label: updateFieldBody.shape.label.describe("New display name"),
 	type: updateFieldBody.shape.type.describe(
-		"New field type; only changes that preserve the underlying column type are allowed",
+		"New field type; only string, text, and slug aliases can be changed in place",
 	),
-	required: updateFieldBody.shape.required.describe("Whether the field is required"),
-	unique: updateFieldBody.shape.unique.describe("Whether field values must be unique"),
+	required: updateFieldBody.shape.required.describe(
+		"Whether the field is required; changing this requires a manual content migration",
+	),
+	unique: updateFieldBody.shape.unique.describe(
+		"Whether field values must be unique; changing this requires a manual content migration",
+	),
 	defaultValue: updateFieldBody.shape.defaultValue.describe("Default value for new content"),
 	validation: updateFieldBody.shape.validation.describe(
 		"Validation constraints; pass null to clear existing constraints",
@@ -158,7 +162,7 @@ const schemaUpdateFieldToolSchema = z.object({
 		"Whether full-text search indexes the field",
 	),
 	translatable: updateFieldBody.shape.translatable.describe(
-		"Whether values vary by locale instead of syncing across a translation group",
+		"Whether values vary by locale; changing to false requires a manual content migration",
 	),
 });
 
@@ -1801,6 +1805,7 @@ export function createMcpServer(
 				"Only provided settings change; omitted settings keep their current values. " +
 				"The collection slug cannot be changed.",
 			inputSchema: schemaUpdateCollectionToolSchema,
+			annotations: { destructiveHint: false },
 		},
 		async (args, extra) => {
 			requireScope(extra, "schema:write");
@@ -1955,9 +1960,10 @@ export function createMcpServer(
 			title: "Update Field",
 			description:
 				"Update an existing field without deleting its column or stored values. Only " +
-				"provided settings change; omitted settings keep their current values. Type " +
-				"changes that require a physical column migration are rejected with migration guidance.",
+				"provided settings change; omitted settings keep their current values. Changes " +
+				"that require a content or column migration are rejected with migration guidance.",
 			inputSchema: schemaUpdateFieldToolSchema,
+			annotations: { destructiveHint: false },
 		},
 		async (args, extra) => {
 			requireScope(extra, "schema:write");

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -20,6 +20,8 @@ import {
 	CONTENT_TYPE_RE,
 	contentBylineInputSchema,
 	contentSeoInput,
+	updateCollectionBody,
+	updateFieldBody,
 } from "#api/schemas.js";
 
 import type { MediaUsageRepairRequest } from "../api/schemas/media-usage.js";
@@ -110,6 +112,59 @@ const mediaUsageRepairToolSchema = z
 			});
 		}
 	});
+
+const schemaUpdateCollectionToolSchema = z.object({
+	slug: z.string().describe("Collection slug to update; the slug itself cannot be changed"),
+	label: updateCollectionBody.shape.label.describe("New plural display name"),
+	labelSingular: updateCollectionBody.shape.labelSingular.describe("New singular display name"),
+	description: updateCollectionBody.shape.description.describe("New collection description"),
+	icon: updateCollectionBody.shape.icon.describe("New admin UI icon name"),
+	supports: updateCollectionBody.shape.supports.describe(
+		"Complete feature list to enable; omit to preserve the current list",
+	),
+	urlPattern: updateCollectionBody.shape.urlPattern.describe(
+		"New public URL pattern; pass null to clear it",
+	),
+	hasSeo: updateCollectionBody.shape.hasSeo.describe(
+		"Whether the collection supports SEO metadata",
+	),
+	commentsEnabled: updateCollectionBody.shape.commentsEnabled.describe(
+		"Whether comments are enabled for this collection",
+	),
+	commentsModeration: updateCollectionBody.shape.commentsModeration.describe(
+		"Comment moderation policy",
+	),
+	commentsClosedAfterDays: updateCollectionBody.shape.commentsClosedAfterDays.describe(
+		"Close comments after this many days; 0 keeps them open",
+	),
+	commentsAutoApproveUsers: updateCollectionBody.shape.commentsAutoApproveUsers.describe(
+		"Whether comments from authenticated users are automatically approved",
+	),
+});
+
+const schemaUpdateFieldToolSchema = z.object({
+	collection: z.string().describe("Collection slug containing the field"),
+	fieldSlug: z.string().describe("Field slug to update; the slug itself cannot be changed"),
+	label: updateFieldBody.shape.label.describe("New display name"),
+	type: updateFieldBody.shape.type.describe(
+		"New field type; only changes that preserve the underlying column type are allowed",
+	),
+	required: updateFieldBody.shape.required.describe("Whether the field is required"),
+	unique: updateFieldBody.shape.unique.describe("Whether field values must be unique"),
+	defaultValue: updateFieldBody.shape.defaultValue.describe("Default value for new content"),
+	validation: updateFieldBody.shape.validation.describe(
+		"Validation constraints; pass null to clear existing constraints",
+	),
+	widget: updateFieldBody.shape.widget.describe("Admin editor widget name"),
+	options: updateFieldBody.shape.options.describe("Widget configuration"),
+	sortOrder: updateFieldBody.shape.sortOrder.describe("Field order in the content editor"),
+	searchable: updateFieldBody.shape.searchable.describe(
+		"Whether full-text search indexes the field",
+	),
+	translatable: updateFieldBody.shape.translatable.describe(
+		"Whether values vary by locale instead of syncing across a translation group",
+	),
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1794,6 +1849,32 @@ export function createMcpServer(
 	);
 
 	server.registerTool(
+		"schema_update_collection",
+		{
+			title: "Update Collection",
+			description:
+				"Update an existing collection without deleting its table, fields, or content. " +
+				"Only provided settings change; omitted settings keep their current values. " +
+				"The collection slug cannot be changed.",
+			inputSchema: schemaUpdateCollectionToolSchema,
+		},
+		async (args, extra) => {
+			requireScope(extra, "schema:write");
+			requireRole(extra, Role.ADMIN);
+			const ec = getEmDash(extra);
+			const { slug, ...input } = args;
+			try {
+				const { handleSchemaCollectionUpdate } = await import("../api/handlers/schema.js");
+				const result = await handleSchemaCollectionUpdate(ec.db, slug, input);
+				if (result.success) ec.invalidateUrlPatternCache();
+				return unwrap(result);
+			} catch (error) {
+				return respondHandlerError(error, "SCHEMA_UPDATE_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
 		"schema_create_field",
 		{
 			title: "Add Field to Collection",
@@ -1922,6 +2003,30 @@ export function createMcpServer(
 				return jsonResult({ deleted: args.fieldSlug, collection: args.collection });
 			} catch (error) {
 				return respondHandlerError(error, "FIELD_DELETE_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
+		"schema_update_field",
+		{
+			title: "Update Field",
+			description:
+				"Update an existing field without deleting its column or stored values. Only " +
+				"provided settings change; omitted settings keep their current values. Type " +
+				"changes that require a physical column migration are rejected with migration guidance.",
+			inputSchema: schemaUpdateFieldToolSchema,
+		},
+		async (args, extra) => {
+			requireScope(extra, "schema:write");
+			requireRole(extra, Role.ADMIN);
+			const ec = getEmDash(extra);
+			const { collection, fieldSlug, ...input } = args;
+			try {
+				const { handleSchemaFieldUpdate } = await import("../api/handlers/schema.js");
+				return unwrap(await handleSchemaFieldUpdate(ec.db, collection, fieldSlug, input));
+			} catch (error) {
+				return respondHandlerError(error, "SCHEMA_FIELD_UPDATE_ERROR");
 			}
 		},
 	);

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -20,6 +20,8 @@ import {
 	CONTENT_TYPE_RE,
 	contentBylineInputSchema,
 	contentSeoInput,
+	updateCollectionBody,
+	updateFieldBody,
 } from "#api/schemas.js";
 
 import type { MediaUsageRepairRequest } from "../api/schemas/media-usage.js";
@@ -106,6 +108,59 @@ const mediaUsageRepairToolSchema = z
 			});
 		}
 	});
+
+const schemaUpdateCollectionToolSchema = z.object({
+	slug: z.string().describe("Collection slug to update; the slug itself cannot be changed"),
+	label: updateCollectionBody.shape.label.describe("New plural display name"),
+	labelSingular: updateCollectionBody.shape.labelSingular.describe("New singular display name"),
+	description: updateCollectionBody.shape.description.describe("New collection description"),
+	icon: updateCollectionBody.shape.icon.describe("New admin UI icon name"),
+	supports: updateCollectionBody.shape.supports.describe(
+		"Complete feature list to enable; omit to preserve the current list",
+	),
+	urlPattern: updateCollectionBody.shape.urlPattern.describe(
+		"New public URL pattern; pass null to clear it",
+	),
+	hasSeo: updateCollectionBody.shape.hasSeo.describe(
+		"Whether the collection supports SEO metadata",
+	),
+	commentsEnabled: updateCollectionBody.shape.commentsEnabled.describe(
+		"Whether comments are enabled for this collection",
+	),
+	commentsModeration: updateCollectionBody.shape.commentsModeration.describe(
+		"Comment moderation policy",
+	),
+	commentsClosedAfterDays: updateCollectionBody.shape.commentsClosedAfterDays.describe(
+		"Close comments after this many days; 0 keeps them open",
+	),
+	commentsAutoApproveUsers: updateCollectionBody.shape.commentsAutoApproveUsers.describe(
+		"Whether comments from authenticated users are automatically approved",
+	),
+});
+
+const schemaUpdateFieldToolSchema = z.object({
+	collection: z.string().describe("Collection slug containing the field"),
+	fieldSlug: z.string().describe("Field slug to update; the slug itself cannot be changed"),
+	label: updateFieldBody.shape.label.describe("New display name"),
+	type: updateFieldBody.shape.type.describe(
+		"New field type; only changes that preserve the underlying column type are allowed",
+	),
+	required: updateFieldBody.shape.required.describe("Whether the field is required"),
+	unique: updateFieldBody.shape.unique.describe("Whether field values must be unique"),
+	defaultValue: updateFieldBody.shape.defaultValue.describe("Default value for new content"),
+	validation: updateFieldBody.shape.validation.describe(
+		"Validation constraints; pass null to clear existing constraints",
+	),
+	widget: updateFieldBody.shape.widget.describe("Admin editor widget name"),
+	options: updateFieldBody.shape.options.describe("Widget configuration"),
+	sortOrder: updateFieldBody.shape.sortOrder.describe("Field order in the content editor"),
+	searchable: updateFieldBody.shape.searchable.describe(
+		"Whether full-text search indexes the field",
+	),
+	translatable: updateFieldBody.shape.translatable.describe(
+		"Whether values vary by locale instead of syncing across a translation group",
+	),
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1738,6 +1793,32 @@ export function createMcpServer(
 	);
 
 	server.registerTool(
+		"schema_update_collection",
+		{
+			title: "Update Collection",
+			description:
+				"Update an existing collection without deleting its table, fields, or content. " +
+				"Only provided settings change; omitted settings keep their current values. " +
+				"The collection slug cannot be changed.",
+			inputSchema: schemaUpdateCollectionToolSchema,
+		},
+		async (args, extra) => {
+			requireScope(extra, "schema:write");
+			requireRole(extra, Role.ADMIN);
+			const ec = getEmDash(extra);
+			const { slug, ...input } = args;
+			try {
+				const { handleSchemaCollectionUpdate } = await import("../api/handlers/schema.js");
+				const result = await handleSchemaCollectionUpdate(ec.db, slug, input);
+				if (result.success) ec.invalidateUrlPatternCache();
+				return unwrap(result);
+			} catch (error) {
+				return respondHandlerError(error, "SCHEMA_UPDATE_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
 		"schema_create_field",
 		{
 			title: "Add Field to Collection",
@@ -1864,6 +1945,30 @@ export function createMcpServer(
 				return jsonResult({ deleted: args.fieldSlug, collection: args.collection });
 			} catch (error) {
 				return respondHandlerError(error, "FIELD_DELETE_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
+		"schema_update_field",
+		{
+			title: "Update Field",
+			description:
+				"Update an existing field without deleting its column or stored values. Only " +
+				"provided settings change; omitted settings keep their current values. Type " +
+				"changes that require a physical column migration are rejected with migration guidance.",
+			inputSchema: schemaUpdateFieldToolSchema,
+		},
+		async (args, extra) => {
+			requireScope(extra, "schema:write");
+			requireRole(extra, Role.ADMIN);
+			const ec = getEmDash(extra);
+			const { collection, fieldSlug, ...input } = args;
+			try {
+				const { handleSchemaFieldUpdate } = await import("../api/handlers/schema.js");
+				return unwrap(await handleSchemaFieldUpdate(ec.db, collection, fieldSlug, input));
+			} catch (error) {
+				return respondHandlerError(error, "SCHEMA_FIELD_UPDATE_ERROR");
 			}
 		},
 	);

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -147,10 +147,14 @@ const schemaUpdateFieldToolSchema = z.object({
 	fieldSlug: z.string().describe("Field slug to update; the slug itself cannot be changed"),
 	label: updateFieldBody.shape.label.describe("New display name"),
 	type: updateFieldBody.shape.type.describe(
-		"New field type; only changes that preserve the underlying column type are allowed",
+		"New field type; only string, text, and slug aliases can be changed in place",
 	),
-	required: updateFieldBody.shape.required.describe("Whether the field is required"),
-	unique: updateFieldBody.shape.unique.describe("Whether field values must be unique"),
+	required: updateFieldBody.shape.required.describe(
+		"Whether the field is required; changing this requires a manual content migration",
+	),
+	unique: updateFieldBody.shape.unique.describe(
+		"Whether field values must be unique; changing this requires a manual content migration",
+	),
 	defaultValue: updateFieldBody.shape.defaultValue.describe("Default value for new content"),
 	validation: updateFieldBody.shape.validation.describe(
 		"Validation constraints; pass null to clear existing constraints",
@@ -162,7 +166,7 @@ const schemaUpdateFieldToolSchema = z.object({
 		"Whether full-text search indexes the field",
 	),
 	translatable: updateFieldBody.shape.translatable.describe(
-		"Whether values vary by locale instead of syncing across a translation group",
+		"Whether values vary by locale; changing to false requires a manual content migration",
 	),
 });
 
@@ -1857,6 +1861,7 @@ export function createMcpServer(
 				"Only provided settings change; omitted settings keep their current values. " +
 				"The collection slug cannot be changed.",
 			inputSchema: schemaUpdateCollectionToolSchema,
+			annotations: { destructiveHint: false },
 		},
 		async (args, extra) => {
 			requireScope(extra, "schema:write");
@@ -2013,9 +2018,10 @@ export function createMcpServer(
 			title: "Update Field",
 			description:
 				"Update an existing field without deleting its column or stored values. Only " +
-				"provided settings change; omitted settings keep their current values. Type " +
-				"changes that require a physical column migration are rejected with migration guidance.",
+				"provided settings change; omitted settings keep their current values. Changes " +
+				"that require a content or column migration are rejected with migration guidance.",
 			inputSchema: schemaUpdateFieldToolSchema,
+			annotations: { destructiveHint: false },
 		},
 		async (args, extra) => {
 			requireScope(extra, "schema:write");

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -41,6 +41,7 @@ import {
 } from "./object-cache/index.js";
 import { requestCached } from "./request-cache.js";
 import { getRequestContext } from "./request-context.js";
+import { compileUrlPattern } from "./schema/url-pattern.js";
 import type { TaxonomyTerm } from "./taxonomies/types.js";
 import { isMissingTableError } from "./utils/db-errors.js";
 import {
@@ -1310,19 +1311,6 @@ export interface ResolvePathResult<T = Record<string, unknown>> {
 	params: Record<string, string>;
 }
 
-/** Matches `{paramName}` placeholders in URL patterns */
-const URL_PARAM_PATTERN = /\{(\w+)\}/g;
-
-/** Convert a URL pattern like "/blog/{slug}" to a regex and param name list */
-function patternToRegex(pattern: string): { regex: RegExp; paramNames: string[] } {
-	const paramNames: string[] = [];
-	const regexStr = pattern.replace(URL_PARAM_PATTERN, (_match, name: string) => {
-		paramNames.push(name);
-		return "([^/]+)";
-	});
-	return { regex: new RegExp(`^${regexStr}$`), paramNames };
-}
-
 /** Cached compiled URL patterns for resolveEmDashPath */
 interface CachedPattern {
 	slug: string;
@@ -1377,7 +1365,7 @@ export async function resolveEmDashPath<T = Record<string, unknown>>(
 		cachedUrlPatterns = [];
 		for (const collection of collections) {
 			if (!collection.urlPattern) continue;
-			const { regex, paramNames } = patternToRegex(collection.urlPattern);
+			const { regex, paramNames } = compileUrlPattern(collection.urlPattern);
 			cachedUrlPatterns.push({ slug: collection.slug, regex, paramNames });
 		}
 	}

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1317,7 +1317,21 @@ interface CachedPattern {
 	regex: RegExp;
 	paramNames: string[];
 }
-let cachedUrlPatterns: CachedPattern[] | null = null;
+
+interface UrlPatternCache {
+	patterns: CachedPattern[] | null;
+}
+
+const URL_PATTERN_CACHE_KEY = Symbol.for("emdash:url-pattern-cache");
+const queryGlobal = globalThis as Record<symbol, unknown>;
+const urlPatternCache: UrlPatternCache =
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern (see request-context.ts)
+	(queryGlobal[URL_PATTERN_CACHE_KEY] as UrlPatternCache | undefined) ??
+	(() => {
+		const cache: UrlPatternCache = { patterns: null };
+		queryGlobal[URL_PATTERN_CACHE_KEY] = cache;
+		return cache;
+	})();
 
 /**
  * Invalidate the cached URL patterns used by resolveEmDashPath.
@@ -1328,7 +1342,7 @@ let cachedUrlPatterns: CachedPattern[] | null = null;
  * every schema-mutation path already routes through here.
  */
 export function invalidateUrlPatternCache(): void {
-	cachedUrlPatterns = null;
+	urlPatternCache.patterns = null;
 	invalidateSchemaObjectCache();
 }
 
@@ -1355,6 +1369,7 @@ export async function resolveEmDashPath<T = Record<string, unknown>>(
 	path: string,
 ): Promise<ResolvePathResult<T> | null> {
 	// Build and cache compiled patterns on first call
+	let cachedUrlPatterns = urlPatternCache.patterns;
 	if (!cachedUrlPatterns) {
 		const { getDb } = await import("./loader.js");
 		const { SchemaRegistry } = await import("./schema/registry.js");
@@ -1368,6 +1383,7 @@ export async function resolveEmDashPath<T = Record<string, unknown>>(
 			const { regex, paramNames } = compileUrlPattern(collection.urlPattern);
 			cachedUrlPatterns.push({ slug: collection.slug, regex, paramNames });
 		}
+		urlPatternCache.patterns = cachedUrlPatterns;
 	}
 
 	for (const pattern of cachedUrlPatterns) {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -40,6 +40,7 @@ import {
 } from "./object-cache/index.js";
 import { requestCached } from "./request-cache.js";
 import { getRequestContext } from "./request-context.js";
+import { compileUrlPattern } from "./schema/url-pattern.js";
 import type { TaxonomyTerm } from "./taxonomies/types.js";
 import { isMissingTableError } from "./utils/db-errors.js";
 import {
@@ -1298,19 +1299,6 @@ export interface ResolvePathResult<T = Record<string, unknown>> {
 	params: Record<string, string>;
 }
 
-/** Matches `{paramName}` placeholders in URL patterns */
-const URL_PARAM_PATTERN = /\{(\w+)\}/g;
-
-/** Convert a URL pattern like "/blog/{slug}" to a regex and param name list */
-function patternToRegex(pattern: string): { regex: RegExp; paramNames: string[] } {
-	const paramNames: string[] = [];
-	const regexStr = pattern.replace(URL_PARAM_PATTERN, (_match, name: string) => {
-		paramNames.push(name);
-		return "([^/]+)";
-	});
-	return { regex: new RegExp(`^${regexStr}$`), paramNames };
-}
-
 /** Cached compiled URL patterns for resolveEmDashPath */
 interface CachedPattern {
 	slug: string;
@@ -1365,7 +1353,7 @@ export async function resolveEmDashPath<T = Record<string, unknown>>(
 		cachedUrlPatterns = [];
 		for (const collection of collections) {
 			if (!collection.urlPattern) continue;
-			const { regex, paramNames } = patternToRegex(collection.urlPattern);
+			const { regex, paramNames } = compileUrlPattern(collection.urlPattern);
 			cachedUrlPatterns.push({ slug: collection.slug, regex, paramNames });
 		}
 	}

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -744,7 +744,11 @@ export class SchemaRegistry {
 			if (input.admin !== undefined) updates.admin_config = JSON.stringify(input.admin);
 			if (input.supports !== undefined) updates.supports = JSON.stringify(input.supports);
 			if (input.urlPattern !== undefined) updates.url_pattern = input.urlPattern;
-			if (input.hasSeo !== undefined) updates.has_seo = input.hasSeo ? 1 : 0;
+			if (input.hasSeo !== undefined) {
+				updates.has_seo = input.hasSeo ? 1 : 0;
+			} else if (input.supports !== undefined) {
+				updates.has_seo = input.supports.includes("seo") ? 1 : 0;
+			}
 			if (input.hidden !== undefined) updates.hidden = input.hidden ? 1 : 0;
 			if (input.sortOrder !== undefined) updates.sort_order = input.sortOrder;
 			if (input.titleField !== undefined) updates.title_field = input.titleField || null;
@@ -762,14 +766,12 @@ export class SchemaRegistry {
 				updates.comments_auto_approve_users = input.commentsAutoApproveUsers ? 1 : 0;
 			}
 
-			if (Object.keys(updates).length > 0) {
-				updates.updated_at = new Date().toISOString();
-				await trx
-					.updateTable("_emdash_collections")
-					.set(updates)
-					.where("id", "=", existing.id)
-					.execute();
-			}
+			updates.updated_at = new Date().toISOString();
+			await trx
+				.updateTable("_emdash_collections")
+				.set(updates)
+				.where("id", "=", existing.id)
+				.execute();
 
 			const row = await trx
 				.selectFrom("_emdash_collections")

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -1,4 +1,11 @@
-import type { ColumnDataType, CreateTableBuilder, Insertable, Kysely, Selectable } from "kysely";
+import type {
+	ColumnDataType,
+	CreateTableBuilder,
+	Insertable,
+	Kysely,
+	Selectable,
+	Updateable,
+} from "kysely";
 import { sql } from "kysely";
 import { ulid } from "ulidx";
 
@@ -59,6 +66,7 @@ const COLUMN_TYPE_TO_DATA_TYPE = {
 	INTEGER: "integer",
 	JSON: "json",
 } satisfies Record<ColumnType, ColumnDataType>;
+const TEXT_ALIAS_FIELD_TYPES: ReadonlySet<FieldType> = new Set(["string", "text", "slug"]);
 
 /** Field types usable as a `titleField` — plain text that reads well as a title. */
 const TITLE_FIELD_TYPES: ReadonlySet<string> = new Set(["string", "text", "slug"]);
@@ -343,11 +351,12 @@ export class SchemaRegistry {
 		collectionId: string,
 		collectionSlug: string,
 		input: { titleField?: string | null; dateField?: string | null },
+		db: Kysely<Database> = this.db,
 	): Promise<void> {
 		const slugs = [input.titleField, input.dateField].filter((slug): slug is string => !!slug);
 		if (slugs.length === 0) return;
 
-		const rows = await this.db
+		const rows = await db
 			.selectFrom("_emdash_fields")
 			.where("collection_id", "=", collectionId)
 			.where("slug", "in", slugs)
@@ -707,86 +716,64 @@ export class SchemaRegistry {
 	 * Update a collection
 	 */
 	async updateCollection(slug: string, input: UpdateCollectionInput): Promise<Collection> {
-		const existing = await this.getCollection(slug);
-		if (!existing) {
-			throw new SchemaError(`Collection "${slug}" not found`, "COLLECTION_NOT_FOUND");
-		}
-
-		// Fields exist by update time, so this is where title/date fields are
-		// strictly validated (fail fast, before opening the transaction).
-		await this.validateTitleDateFields(existing.id, slug, {
-			titleField: input.titleField,
-			dateField: input.dateField,
-		});
-
-		const now = new Date().toISOString();
-
-		// Derive hasSeo from supports array if supports is being updated and hasSeo not explicitly set
-		const supportsArray = input.supports ?? existing.supports;
-		const hasSeo =
-			input.hasSeo !== undefined
-				? input.hasSeo
-				: input.supports !== undefined
-					? supportsArray.includes("seo")
-					: existing.hasSeo;
-
 		return withTransaction(this.db, async (trx) => {
-			await trx
-				.updateTable("_emdash_collections")
-				.set({
-					label: input.label ?? existing.label,
-					label_singular: input.labelSingular ?? existing.labelSingular ?? null,
-					description: input.description ?? existing.description ?? null,
-					icon: input.icon ?? existing.icon ?? null,
-					admin_config:
-						input.admin !== undefined
-							? JSON.stringify(input.admin)
-							: existing.admin
-								? JSON.stringify(existing.admin)
-								: null,
-					supports: input.supports
-						? JSON.stringify(input.supports)
-						: JSON.stringify(existing.supports),
-					url_pattern:
-						input.urlPattern !== undefined
-							? (input.urlPattern ?? null)
-							: (existing.urlPattern ?? null),
-					// `|| null` (not `?? null`): "" clears back to the default.
-					title_field:
-						input.titleField !== undefined
-							? input.titleField || null
-							: (existing.titleField ?? null),
-					date_field:
-						input.dateField !== undefined ? input.dateField || null : (existing.dateField ?? null),
-					has_seo: hasSeo ? 1 : 0,
-					hidden: input.hidden !== undefined ? (input.hidden ? 1 : 0) : existing.hidden ? 1 : 0,
-					sort_order:
-						input.sortOrder !== undefined ? input.sortOrder : (existing.sortOrder ?? null),
-					comments_enabled:
-						input.commentsEnabled !== undefined
-							? input.commentsEnabled
-								? 1
-								: 0
-							: existing.commentsEnabled
-								? 1
-								: 0,
-					comments_moderation: input.commentsModeration ?? existing.commentsModeration,
-					comments_closed_after_days:
-						input.commentsClosedAfterDays !== undefined
-							? input.commentsClosedAfterDays
-							: existing.commentsClosedAfterDays,
-					comments_auto_approve_users:
-						input.commentsAutoApproveUsers !== undefined
-							? input.commentsAutoApproveUsers
-								? 1
-								: 0
-							: existing.commentsAutoApproveUsers
-								? 1
-								: 0,
-					updated_at: now,
-				})
+			const existingRow = await trx
+				.selectFrom("_emdash_collections")
 				.where("slug", "=", slug)
-				.execute();
+				.selectAll()
+				.executeTakeFirst();
+			if (!existingRow) {
+				throw new SchemaError(`Collection "${slug}" not found`, "COLLECTION_NOT_FOUND");
+			}
+			const existing = this.mapCollectionRow(existingRow);
+			await this.validateTitleDateFields(
+				existing.id,
+				slug,
+				{
+					titleField: input.titleField,
+					dateField: input.dateField,
+				},
+				trx,
+			);
+			const updates: Updateable<CollectionTable> = {};
+
+			if (input.label !== undefined) updates.label = input.label;
+			if (input.labelSingular !== undefined) updates.label_singular = input.labelSingular;
+			if (input.description !== undefined) updates.description = input.description;
+			if (input.icon !== undefined) updates.icon = input.icon;
+			if (input.admin !== undefined) updates.admin_config = JSON.stringify(input.admin);
+			if (input.supports !== undefined) updates.supports = JSON.stringify(input.supports);
+			if (input.urlPattern !== undefined) updates.url_pattern = input.urlPattern;
+			if (input.hasSeo !== undefined) {
+				updates.has_seo = input.hasSeo ? 1 : 0;
+			} else if (input.supports !== undefined) {
+				updates.has_seo = input.supports.includes("seo") ? 1 : 0;
+			}
+			if (input.hidden !== undefined) updates.hidden = input.hidden ? 1 : 0;
+			if (input.sortOrder !== undefined) updates.sort_order = input.sortOrder;
+			if (input.titleField !== undefined) updates.title_field = input.titleField || null;
+			if (input.dateField !== undefined) updates.date_field = input.dateField || null;
+			if (input.commentsEnabled !== undefined) {
+				updates.comments_enabled = input.commentsEnabled ? 1 : 0;
+			}
+			if (input.commentsModeration !== undefined) {
+				updates.comments_moderation = input.commentsModeration;
+			}
+			if (input.commentsClosedAfterDays !== undefined) {
+				updates.comments_closed_after_days = input.commentsClosedAfterDays;
+			}
+			if (input.commentsAutoApproveUsers !== undefined) {
+				updates.comments_auto_approve_users = input.commentsAutoApproveUsers ? 1 : 0;
+			}
+
+			if (Object.keys(updates).length > 0) {
+				updates.updated_at = new Date().toISOString();
+				await trx
+					.updateTable("_emdash_collections")
+					.set(updates)
+					.where("id", "=", existing.id)
+					.execute();
+			}
 
 			const row = await trx
 				.selectFrom("_emdash_collections")
@@ -1041,113 +1028,113 @@ export class SchemaRegistry {
 		fieldSlug: string,
 		input: UpdateFieldInput,
 	): Promise<Field> {
-		const field = await this.getField(collectionSlug, fieldSlug);
-		if (!field) {
-			throw new SchemaError(
-				`Field "${fieldSlug}" not found in collection "${collectionSlug}"`,
-				"FIELD_NOT_FOUND",
-			);
-		}
-
-		// `input.validation === undefined` means "no change" (keep existing);
-		// an explicit `null` clears the column.
-		const nextValidation = input.validation === undefined ? field.validation : input.validation;
-
-		// A field-type change is only safe when the underlying column type stays
-		// the same. There is no in-place column migration (only addColumn/
-		// dropColumn), so a change that would alter the SQLite column affinity
-		// (e.g. `text` TEXT -> `portableText` JSON) is rejected rather than
-		// silently rewriting only the metadata — which would leave `column_type`
-		// pointing at a column type the real `ec_*` column doesn't have (#1397).
-		let nextType = field.type;
-		let nextColumnType = field.columnType;
-		if (input.type !== undefined && input.type !== field.type) {
-			const newColumnType = FIELD_TYPE_TO_COLUMN[input.type];
-			if (newColumnType !== field.columnType) {
-				throw new SchemaError(
-					`Cannot change field "${fieldSlug}" in collection "${collectionSlug}" from type ` +
-						`"${field.type}" to "${input.type}": the underlying column type would change from ` +
-						`${field.columnType} to ${newColumnType}, which requires a manual content migration. ` +
-						`Drop and re-create the field, or migrate the column data, before changing its type.`,
-					"FIELD_TYPE_COLUMN_CHANGE",
-				);
-			}
-
-			// A same-column-type change can still break the titleField/dateField
-			// type invariants. Read the collection only when a type change
-			// is actually requested, so the common path pays nothing.
-			const collection = await this.getCollection(collectionSlug);
-			if (collection?.titleField === fieldSlug && !TITLE_FIELD_TYPES.has(input.type)) {
-				throw new SchemaError(
-					`titleField "${fieldSlug}" must stay a text field, not "${input.type}"`,
-					"INVALID_TITLE_FIELD",
-				);
-			}
-			if (collection?.dateField === fieldSlug && input.type !== "datetime") {
-				throw new SchemaError(
-					`dateField "${fieldSlug}" must stay a datetime field, not "${input.type}"`,
-					"INVALID_DATE_FIELD",
-				);
-			}
-
-			nextType = input.type;
-			nextColumnType = newColumnType;
-		}
 		const activeCoverageInvalidated = await invalidateContentMediaUsageSchemaChange(
 			this.db,
 			collectionSlug,
 		);
-
-		const nextIndexed = input.indexed ?? field.indexed;
-		assertIndexableField(nextType, nextIndexed, fieldSlug);
-
 		let schemaMutated = false;
 		try {
 			const updatedField = await withTransaction(this.db, async (trx) => {
-				await trx
-					.updateTable("_emdash_fields")
-					.set({
-						type: nextType,
-						column_type: nextColumnType,
-						label: input.label ?? field.label,
-						required:
-							input.required !== undefined ? (input.required ? 1 : 0) : field.required ? 1 : 0,
-						unique: input.unique !== undefined ? (input.unique ? 1 : 0) : field.unique ? 1 : 0,
-						searchable:
-							input.searchable !== undefined
-								? input.searchable
-									? 1
-									: 0
-								: field.searchable
-									? 1
-									: 0,
-						...(input.indexed === undefined ? {} : { indexed: input.indexed ? 1 : 0 }),
-						translatable:
-							input.translatable !== undefined
-								? input.translatable
-									? 1
-									: 0
-								: field.translatable
-									? 1
-									: 0,
-						default_value:
-							input.defaultValue !== undefined
-								? JSON.stringify(input.defaultValue)
-								: field.defaultValue !== undefined
-									? JSON.stringify(field.defaultValue)
-									: null,
-						validation: nextValidation ? JSON.stringify(nextValidation) : null,
-						widget: input.widget ?? field.widget ?? null,
-						options: input.options
-							? JSON.stringify(input.options)
-							: field.options
-								? JSON.stringify(field.options)
-								: null,
-						sort_order: input.sortOrder ?? field.sortOrder,
-					})
-					.where("id", "=", field.id)
-					.execute();
-				schemaMutated = true;
+				const collectionRow = await trx
+					.selectFrom("_emdash_collections")
+					.where("slug", "=", collectionSlug)
+					.select(["id", "title_field", "date_field"])
+					.executeTakeFirst();
+				const fieldRow = collectionRow
+					? await trx
+							.selectFrom("_emdash_fields")
+							.where("collection_id", "=", collectionRow.id)
+							.where("slug", "=", fieldSlug)
+							.selectAll()
+							.executeTakeFirst()
+					: undefined;
+				if (!fieldRow) {
+					throw new SchemaError(
+						`Field "${fieldSlug}" not found in collection "${collectionSlug}"`,
+						"FIELD_NOT_FOUND",
+					);
+				}
+				const field = this.mapFieldRow(fieldRow);
+				const updates: Updateable<FieldTable> = {};
+				let nextType = field.type;
+
+				if (input.type !== undefined && input.type !== field.type) {
+					const newColumnType = FIELD_TYPE_TO_COLUMN[input.type];
+					if (newColumnType !== field.columnType) {
+						throw new SchemaError(
+							`Cannot change field "${fieldSlug}" in collection "${collectionSlug}" from type ` +
+								`"${field.type}" to "${input.type}": the underlying column type would change from ` +
+								`${field.columnType} to ${newColumnType}, which requires a manual content migration.`,
+							"FIELD_TYPE_COLUMN_CHANGE",
+						);
+					}
+					if (!TEXT_ALIAS_FIELD_TYPES.has(field.type) || !TEXT_ALIAS_FIELD_TYPES.has(input.type)) {
+						throw new SchemaError(
+							`Cannot change field "${fieldSlug}" in collection "${collectionSlug}" from type ` +
+								`"${field.type}" to "${input.type}" without a manual content migration.`,
+							"FIELD_TYPE_CHANGE_REQUIRES_MIGRATION",
+						);
+					}
+					if (collectionRow?.title_field === fieldSlug && !TITLE_FIELD_TYPES.has(input.type)) {
+						throw new SchemaError(
+							`titleField "${fieldSlug}" must stay a text field, not "${input.type}"`,
+							"INVALID_TITLE_FIELD",
+						);
+					}
+					if (collectionRow?.date_field === fieldSlug && input.type !== "datetime") {
+						throw new SchemaError(
+							`dateField "${fieldSlug}" must stay a datetime field, not "${input.type}"`,
+							"INVALID_DATE_FIELD",
+						);
+					}
+					nextType = input.type;
+					updates.type = input.type;
+					updates.column_type = newColumnType;
+				}
+
+				if (input.required !== undefined && input.required !== field.required) {
+					throw new SchemaError(
+						`Changing required for field "${fieldSlug}" requires a manual content migration.`,
+						"FIELD_UPDATE_REQUIRES_MIGRATION",
+					);
+				}
+				if (input.unique !== undefined && input.unique !== field.unique) {
+					throw new SchemaError(
+						`Changing unique for field "${fieldSlug}" requires a manual content migration.`,
+						"FIELD_UPDATE_REQUIRES_MIGRATION",
+					);
+				}
+				if (input.translatable === false && field.translatable) {
+					throw new SchemaError(
+						`Changing field "${fieldSlug}" to non-translatable requires a manual content migration.`,
+						"FIELD_UPDATE_REQUIRES_MIGRATION",
+					);
+				}
+
+				if (input.label !== undefined) updates.label = input.label;
+				if (input.required !== undefined) updates.required = input.required ? 1 : 0;
+				if (input.unique !== undefined) updates.unique = input.unique ? 1 : 0;
+				if (input.searchable !== undefined) updates.searchable = input.searchable ? 1 : 0;
+				if (input.indexed !== undefined) updates.indexed = input.indexed ? 1 : 0;
+				if (input.translatable !== undefined) {
+					updates.translatable = input.translatable ? 1 : 0;
+				}
+				if (input.defaultValue !== undefined) {
+					updates.default_value = JSON.stringify(input.defaultValue);
+				}
+				if (input.validation !== undefined) {
+					updates.validation = input.validation ? JSON.stringify(input.validation) : null;
+				}
+				if (input.widget !== undefined) updates.widget = input.widget;
+				if (input.options !== undefined) updates.options = JSON.stringify(input.options);
+				if (input.sortOrder !== undefined) updates.sort_order = input.sortOrder;
+
+				assertIndexableField(nextType, input.indexed ?? field.indexed, fieldSlug);
+
+				if (Object.keys(updates).length > 0) {
+					await trx.updateTable("_emdash_fields").set(updates).where("id", "=", field.id).execute();
+					schemaMutated = true;
+				}
 
 				if (input.indexed !== undefined) {
 					if (input.indexed) {
@@ -1155,6 +1142,7 @@ export class SchemaRegistry {
 					} else {
 						await this.dropFieldIndex(field.id, trx);
 					}
+					schemaMutated = true;
 				}
 
 				// Read the updated field via trx (not this.db) to avoid connection mutex deadlock
@@ -1173,21 +1161,23 @@ export class SchemaRegistry {
 
 				// If searchable changed, sync FTS state for this collection
 				const searchableChanged =
-					input.searchable !== undefined && input.searchable !== field.searchable;
+					schemaMutated && input.searchable !== undefined && input.searchable !== field.searchable;
 				if (searchableChanged) {
 					await this.syncSearchState(collectionSlug, trx);
 				}
 
 				return updated;
 			});
-			if (activeCoverageInvalidated) {
-				await invalidateContentMediaUsageSchemaChange(this.db, collectionSlug);
-			} else {
-				await markContentMediaUsageCollectionStaleSafely(
-					this.db,
-					collectionSlug,
-					"CONTENT_USAGE_STALE",
-				);
+			if (schemaMutated) {
+				if (activeCoverageInvalidated) {
+					await invalidateContentMediaUsageSchemaChange(this.db, collectionSlug);
+				} else {
+					await markContentMediaUsageCollectionStaleSafely(
+						this.db,
+						collectionSlug,
+						"CONTENT_USAGE_STALE",
+					);
+				}
 			}
 			return updatedField;
 		} catch (error) {

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -1,4 +1,11 @@
-import type { ColumnDataType, CreateTableBuilder, Insertable, Kysely, Selectable } from "kysely";
+import type {
+	ColumnDataType,
+	CreateTableBuilder,
+	Insertable,
+	Kysely,
+	Selectable,
+	Updateable,
+} from "kysely";
 import { sql } from "kysely";
 import { ulid } from "ulidx";
 
@@ -44,6 +51,7 @@ const COLUMN_TYPE_TO_DATA_TYPE = {
 	INTEGER: "integer",
 	JSON: "json",
 } satisfies Record<ColumnType, ColumnDataType>;
+const TEXT_ALIAS_FIELD_TYPES: ReadonlySet<FieldType> = new Set(["string", "text", "slug"]);
 
 /** Valid collection source prefixes/values */
 const VALID_SOURCES: ReadonlySet<string> = new Set(["manual", "discovered", "seed"]);
@@ -384,63 +392,46 @@ export class SchemaRegistry {
 	 * Update a collection
 	 */
 	async updateCollection(slug: string, input: UpdateCollectionInput): Promise<Collection> {
-		const existing = await this.getCollection(slug);
-		if (!existing) {
-			throw new SchemaError(`Collection "${slug}" not found`, "COLLECTION_NOT_FOUND");
-		}
-
-		const now = new Date().toISOString();
-
-		// Derive hasSeo from supports array if supports is being updated and hasSeo not explicitly set
-		const supportsArray = input.supports ?? existing.supports;
-		const hasSeo =
-			input.hasSeo !== undefined
-				? input.hasSeo
-				: input.supports !== undefined
-					? supportsArray.includes("seo")
-					: existing.hasSeo;
-
 		return withTransaction(this.db, async (trx) => {
-			await trx
-				.updateTable("_emdash_collections")
-				.set({
-					label: input.label ?? existing.label,
-					label_singular: input.labelSingular ?? existing.labelSingular ?? null,
-					description: input.description ?? existing.description ?? null,
-					icon: input.icon ?? existing.icon ?? null,
-					supports: input.supports
-						? JSON.stringify(input.supports)
-						: JSON.stringify(existing.supports),
-					url_pattern:
-						input.urlPattern !== undefined
-							? (input.urlPattern ?? null)
-							: (existing.urlPattern ?? null),
-					has_seo: hasSeo ? 1 : 0,
-					comments_enabled:
-						input.commentsEnabled !== undefined
-							? input.commentsEnabled
-								? 1
-								: 0
-							: existing.commentsEnabled
-								? 1
-								: 0,
-					comments_moderation: input.commentsModeration ?? existing.commentsModeration,
-					comments_closed_after_days:
-						input.commentsClosedAfterDays !== undefined
-							? input.commentsClosedAfterDays
-							: existing.commentsClosedAfterDays,
-					comments_auto_approve_users:
-						input.commentsAutoApproveUsers !== undefined
-							? input.commentsAutoApproveUsers
-								? 1
-								: 0
-							: existing.commentsAutoApproveUsers
-								? 1
-								: 0,
-					updated_at: now,
-				})
+			const existingRow = await trx
+				.selectFrom("_emdash_collections")
 				.where("slug", "=", slug)
-				.execute();
+				.selectAll()
+				.executeTakeFirst();
+			if (!existingRow) {
+				throw new SchemaError(`Collection "${slug}" not found`, "COLLECTION_NOT_FOUND");
+			}
+			const existing = this.mapCollectionRow(existingRow);
+			const updates: Updateable<CollectionTable> = {};
+
+			if (input.label !== undefined) updates.label = input.label;
+			if (input.labelSingular !== undefined) updates.label_singular = input.labelSingular;
+			if (input.description !== undefined) updates.description = input.description;
+			if (input.icon !== undefined) updates.icon = input.icon;
+			if (input.supports !== undefined) updates.supports = JSON.stringify(input.supports);
+			if (input.urlPattern !== undefined) updates.url_pattern = input.urlPattern;
+			if (input.hasSeo !== undefined) updates.has_seo = input.hasSeo ? 1 : 0;
+			if (input.commentsEnabled !== undefined) {
+				updates.comments_enabled = input.commentsEnabled ? 1 : 0;
+			}
+			if (input.commentsModeration !== undefined) {
+				updates.comments_moderation = input.commentsModeration;
+			}
+			if (input.commentsClosedAfterDays !== undefined) {
+				updates.comments_closed_after_days = input.commentsClosedAfterDays;
+			}
+			if (input.commentsAutoApproveUsers !== undefined) {
+				updates.comments_auto_approve_users = input.commentsAutoApproveUsers ? 1 : 0;
+			}
+
+			if (Object.keys(updates).length > 0) {
+				updates.updated_at = new Date().toISOString();
+				await trx
+					.updateTable("_emdash_collections")
+					.set(updates)
+					.where("id", "=", existing.id)
+					.execute();
+			}
 
 			const row = await trx
 				.selectFrom("_emdash_collections")
@@ -667,87 +658,92 @@ export class SchemaRegistry {
 		fieldSlug: string,
 		input: UpdateFieldInput,
 	): Promise<Field> {
-		const field = await this.getField(collectionSlug, fieldSlug);
-		if (!field) {
-			throw new SchemaError(
-				`Field "${fieldSlug}" not found in collection "${collectionSlug}"`,
-				"FIELD_NOT_FOUND",
-			);
-		}
-
-		// `input.validation === undefined` means "no change" (keep existing);
-		// an explicit `null` clears the column.
-		const nextValidation = input.validation === undefined ? field.validation : input.validation;
-
-		// A field-type change is only safe when the underlying column type stays
-		// the same. There is no in-place column migration (only addColumn/
-		// dropColumn), so a change that would alter the SQLite column affinity
-		// (e.g. `text` TEXT -> `portableText` JSON) is rejected rather than
-		// silently rewriting only the metadata — which would leave `column_type`
-		// pointing at a column type the real `ec_*` column doesn't have (#1397).
-		let nextType = field.type;
-		let nextColumnType = field.columnType;
-		if (input.type !== undefined && input.type !== field.type) {
-			const newColumnType = FIELD_TYPE_TO_COLUMN[input.type];
-			if (newColumnType !== field.columnType) {
-				throw new SchemaError(
-					`Cannot change field "${fieldSlug}" in collection "${collectionSlug}" from type ` +
-						`"${field.type}" to "${input.type}": the underlying column type would change from ` +
-						`${field.columnType} to ${newColumnType}, which requires a manual content migration. ` +
-						`Drop and re-create the field, or migrate the column data, before changing its type.`,
-					"FIELD_TYPE_COLUMN_CHANGE",
-				);
-			}
-			nextType = input.type;
-			nextColumnType = newColumnType;
-		}
-
 		let schemaMutated = false;
 		try {
 			const updatedField = await withTransaction(this.db, async (trx) => {
-				await trx
-					.updateTable("_emdash_fields")
-					.set({
-						type: nextType,
-						column_type: nextColumnType,
-						label: input.label ?? field.label,
-						required:
-							input.required !== undefined ? (input.required ? 1 : 0) : field.required ? 1 : 0,
-						unique: input.unique !== undefined ? (input.unique ? 1 : 0) : field.unique ? 1 : 0,
-						searchable:
-							input.searchable !== undefined
-								? input.searchable
-									? 1
-									: 0
-								: field.searchable
-									? 1
-									: 0,
-						translatable:
-							input.translatable !== undefined
-								? input.translatable
-									? 1
-									: 0
-								: field.translatable
-									? 1
-									: 0,
-						default_value:
-							input.defaultValue !== undefined
-								? JSON.stringify(input.defaultValue)
-								: field.defaultValue !== undefined
-									? JSON.stringify(field.defaultValue)
-									: null,
-						validation: nextValidation ? JSON.stringify(nextValidation) : null,
-						widget: input.widget ?? field.widget ?? null,
-						options: input.options
-							? JSON.stringify(input.options)
-							: field.options
-								? JSON.stringify(field.options)
-								: null,
-						sort_order: input.sortOrder ?? field.sortOrder,
-					})
-					.where("id", "=", field.id)
-					.execute();
-				schemaMutated = true;
+				const collectionRow = await trx
+					.selectFrom("_emdash_collections")
+					.where("slug", "=", collectionSlug)
+					.select("id")
+					.executeTakeFirst();
+				const fieldRow = collectionRow
+					? await trx
+							.selectFrom("_emdash_fields")
+							.where("collection_id", "=", collectionRow.id)
+							.where("slug", "=", fieldSlug)
+							.selectAll()
+							.executeTakeFirst()
+					: undefined;
+				if (!fieldRow) {
+					throw new SchemaError(
+						`Field "${fieldSlug}" not found in collection "${collectionSlug}"`,
+						"FIELD_NOT_FOUND",
+					);
+				}
+				const field = this.mapFieldRow(fieldRow);
+				const updates: Updateable<FieldTable> = {};
+
+				if (input.type !== undefined && input.type !== field.type) {
+					const newColumnType = FIELD_TYPE_TO_COLUMN[input.type];
+					if (newColumnType !== field.columnType) {
+						throw new SchemaError(
+							`Cannot change field "${fieldSlug}" in collection "${collectionSlug}" from type ` +
+								`"${field.type}" to "${input.type}": the underlying column type would change from ` +
+								`${field.columnType} to ${newColumnType}, which requires a manual content migration.`,
+							"FIELD_TYPE_COLUMN_CHANGE",
+						);
+					}
+					if (!TEXT_ALIAS_FIELD_TYPES.has(field.type) || !TEXT_ALIAS_FIELD_TYPES.has(input.type)) {
+						throw new SchemaError(
+							`Cannot change field "${fieldSlug}" in collection "${collectionSlug}" from type ` +
+								`"${field.type}" to "${input.type}" without a manual content migration.`,
+							"FIELD_TYPE_CHANGE_REQUIRES_MIGRATION",
+						);
+					}
+					updates.type = input.type;
+					updates.column_type = newColumnType;
+				}
+
+				if (input.required !== undefined && input.required !== field.required) {
+					throw new SchemaError(
+						`Changing required for field "${fieldSlug}" requires a manual content migration.`,
+						"FIELD_UPDATE_REQUIRES_MIGRATION",
+					);
+				}
+				if (input.unique !== undefined && input.unique !== field.unique) {
+					throw new SchemaError(
+						`Changing unique for field "${fieldSlug}" requires a manual content migration.`,
+						"FIELD_UPDATE_REQUIRES_MIGRATION",
+					);
+				}
+				if (input.translatable === false && field.translatable) {
+					throw new SchemaError(
+						`Changing field "${fieldSlug}" to non-translatable requires a manual content migration.`,
+						"FIELD_UPDATE_REQUIRES_MIGRATION",
+					);
+				}
+
+				if (input.label !== undefined) updates.label = input.label;
+				if (input.required !== undefined) updates.required = input.required ? 1 : 0;
+				if (input.unique !== undefined) updates.unique = input.unique ? 1 : 0;
+				if (input.searchable !== undefined) updates.searchable = input.searchable ? 1 : 0;
+				if (input.translatable !== undefined) {
+					updates.translatable = input.translatable ? 1 : 0;
+				}
+				if (input.defaultValue !== undefined) {
+					updates.default_value = JSON.stringify(input.defaultValue);
+				}
+				if (input.validation !== undefined) {
+					updates.validation = input.validation ? JSON.stringify(input.validation) : null;
+				}
+				if (input.widget !== undefined) updates.widget = input.widget;
+				if (input.options !== undefined) updates.options = JSON.stringify(input.options);
+				if (input.sortOrder !== undefined) updates.sort_order = input.sortOrder;
+
+				if (Object.keys(updates).length > 0) {
+					await trx.updateTable("_emdash_fields").set(updates).where("id", "=", field.id).execute();
+					schemaMutated = true;
+				}
 
 				// Read the updated field via trx (not this.db) to avoid connection mutex deadlock
 				const updatedRow = await trx
@@ -765,18 +761,20 @@ export class SchemaRegistry {
 
 				// If searchable changed, sync FTS state for this collection
 				const searchableChanged =
-					input.searchable !== undefined && input.searchable !== field.searchable;
+					schemaMutated && input.searchable !== undefined && input.searchable !== field.searchable;
 				if (searchableChanged) {
 					await this.syncSearchState(collectionSlug, trx);
 				}
 
 				return updated;
 			});
-			await markContentMediaUsageCollectionStaleSafely(
-				this.db,
-				collectionSlug,
-				"CONTENT_USAGE_STALE",
-			);
+			if (schemaMutated) {
+				await markContentMediaUsageCollectionStaleSafely(
+					this.db,
+					collectionSlug,
+					"CONTENT_USAGE_STALE",
+				);
+			}
 			return updatedField;
 		} catch (error) {
 			if (schemaMutated) {

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -1108,7 +1108,8 @@ export class SchemaRegistry {
 				if (input.required !== undefined) updates.required = input.required ? 1 : 0;
 				if (input.unique !== undefined) updates.unique = input.unique ? 1 : 0;
 				if (input.searchable !== undefined) updates.searchable = input.searchable ? 1 : 0;
-				if (input.indexed !== undefined) updates.indexed = input.indexed ? 1 : 0;
+				const indexedChanged = input.indexed !== undefined && input.indexed !== field.indexed;
+				if (indexedChanged) updates.indexed = input.indexed ? 1 : 0;
 				if (input.translatable !== undefined) {
 					updates.translatable = input.translatable ? 1 : 0;
 				}
@@ -1123,7 +1124,7 @@ export class SchemaRegistry {
 				if (input.sortOrder !== undefined) updates.sort_order = input.sortOrder;
 
 				assertIndexableField(nextType, input.indexed ?? field.indexed, fieldSlug);
-				if (Object.keys(updates).length === 0 && input.indexed === undefined) return field;
+				if (Object.keys(updates).length === 0) return field;
 
 				activeCoverageInvalidated = await invalidateContentMediaUsageSchemaChange(
 					trx,
@@ -1135,7 +1136,7 @@ export class SchemaRegistry {
 					schemaMutated = true;
 				}
 
-				if (input.indexed !== undefined) {
+				if (indexedChanged) {
 					if (input.indexed) {
 						await this.createFieldIndex(collectionSlug, field.id, fieldSlug, trx);
 					} else {

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -744,11 +744,7 @@ export class SchemaRegistry {
 			if (input.admin !== undefined) updates.admin_config = JSON.stringify(input.admin);
 			if (input.supports !== undefined) updates.supports = JSON.stringify(input.supports);
 			if (input.urlPattern !== undefined) updates.url_pattern = input.urlPattern;
-			if (input.hasSeo !== undefined) {
-				updates.has_seo = input.hasSeo ? 1 : 0;
-			} else if (input.supports !== undefined) {
-				updates.has_seo = input.supports.includes("seo") ? 1 : 0;
-			}
+			if (input.hasSeo !== undefined) updates.has_seo = input.hasSeo ? 1 : 0;
 			if (input.hidden !== undefined) updates.hidden = input.hidden ? 1 : 0;
 			if (input.sortOrder !== undefined) updates.sort_order = input.sortOrder;
 			if (input.titleField !== undefined) updates.title_field = input.titleField || null;
@@ -1028,10 +1024,7 @@ export class SchemaRegistry {
 		fieldSlug: string,
 		input: UpdateFieldInput,
 	): Promise<Field> {
-		const activeCoverageInvalidated = await invalidateContentMediaUsageSchemaChange(
-			this.db,
-			collectionSlug,
-		);
+		let activeCoverageInvalidated = false;
 		let schemaMutated = false;
 		try {
 			const updatedField = await withTransaction(this.db, async (trx) => {
@@ -1130,6 +1123,12 @@ export class SchemaRegistry {
 				if (input.sortOrder !== undefined) updates.sort_order = input.sortOrder;
 
 				assertIndexableField(nextType, input.indexed ?? field.indexed, fieldSlug);
+				if (Object.keys(updates).length === 0 && input.indexed === undefined) return field;
+
+				activeCoverageInvalidated = await invalidateContentMediaUsageSchemaChange(
+					trx,
+					collectionSlug,
+				);
 
 				if (Object.keys(updates).length > 0) {
 					await trx.updateTable("_emdash_fields").set(updates).where("id", "=", field.id).execute();

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -326,13 +326,9 @@ export interface CreateFieldInput {
 export interface UpdateFieldInput {
 	label?: string;
 	/**
-	 * Change the field's type. Only type changes that keep the same underlying
-	 * column type (per `FIELD_TYPE_TO_COLUMN`) are allowed — e.g. `string` to
-	 * `slug` (both TEXT). A change that would alter the column affinity (e.g.
-	 * `text` TEXT to `portableText` JSON) is rejected, because there is no
-	 * in-place column migration and silently rewriting the metadata would
-	 * desync `column_type` from the real `ec_*` column. Omit to keep the
-	 * current type.
+	 * Change the field's type. Only storage-compatible text aliases (`string`,
+	 * `text`, and `slug`) can be changed in place. Other changes require an
+	 * explicit content migration. Omit to keep the current type.
 	 */
 	type?: FieldType;
 	required?: boolean;

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -282,7 +282,7 @@ export interface UpdateCollectionInput {
 	icon?: string;
 	admin?: CollectionAdminConfig;
 	supports?: CollectionSupport[];
-	urlPattern?: string;
+	urlPattern?: string | null;
 	hasSeo?: boolean;
 	/** Omit the auto-generated admin sidebar entry */
 	hidden?: boolean;

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -265,13 +265,9 @@ export interface CreateFieldInput {
 export interface UpdateFieldInput {
 	label?: string;
 	/**
-	 * Change the field's type. Only type changes that keep the same underlying
-	 * column type (per `FIELD_TYPE_TO_COLUMN`) are allowed — e.g. `string` to
-	 * `slug` (both TEXT). A change that would alter the column affinity (e.g.
-	 * `text` TEXT to `portableText` JSON) is rejected, because there is no
-	 * in-place column migration and silently rewriting the metadata would
-	 * desync `column_type` from the real `ec_*` column. Omit to keep the
-	 * current type.
+	 * Change the field's type. Only storage-compatible text aliases (`string`,
+	 * `text`, and `slug`) can be changed in place. Other changes require an
+	 * explicit content migration. Omit to keep the current type.
 	 */
 	type?: FieldType;
 	required?: boolean;

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -231,7 +231,7 @@ export interface UpdateCollectionInput {
 	description?: string;
 	icon?: string;
 	supports?: CollectionSupport[];
-	urlPattern?: string;
+	urlPattern?: string | null;
 	hasSeo?: boolean;
 	commentsEnabled?: boolean;
 	commentsModeration?: "all" | "first_time" | "none";

--- a/packages/core/src/schema/url-pattern.ts
+++ b/packages/core/src/schema/url-pattern.ts
@@ -1,11 +1,33 @@
 const URL_PARAM_PATTERN = /\{(\w+)\}/g;
+const REGEX_SPECIAL_CHARACTERS = /[.*+?^${}()|[\]\\]/g;
+const INVALID_LITERAL_PATTERN = /[{}]/;
+
+function escapeRegex(literal: string): string {
+	return literal.replace(REGEX_SPECIAL_CHARACTERS, "\\$&");
+}
 
 export function compileUrlPattern(pattern: string): { regex: RegExp; paramNames: string[] } {
 	const paramNames: string[] = [];
-	const regexSource = pattern.replace(URL_PARAM_PATTERN, (_match, name: string) => {
+	let regexSource = "";
+	let previousIndex = 0;
+
+	for (const match of pattern.matchAll(URL_PARAM_PATTERN)) {
+		const matchIndex = match.index;
+		const literal = pattern.slice(previousIndex, matchIndex);
+		if (INVALID_LITERAL_PATTERN.test(literal)) throw new Error("Invalid URL pattern placeholder");
+		regexSource += escapeRegex(literal);
+
+		const name = match[1];
 		paramNames.push(name);
-		return "([^/]+)";
-	});
+		regexSource += "([^/]+)";
+		previousIndex = matchIndex + match[0].length;
+	}
+
+	const trailingLiteral = pattern.slice(previousIndex);
+	if (INVALID_LITERAL_PATTERN.test(trailingLiteral)) {
+		throw new Error("Invalid URL pattern placeholder");
+	}
+	regexSource += escapeRegex(trailingLiteral);
 
 	return { regex: new RegExp(`^${regexSource}$`), paramNames };
 }

--- a/packages/core/src/schema/url-pattern.ts
+++ b/packages/core/src/schema/url-pattern.ts
@@ -1,0 +1,11 @@
+const URL_PARAM_PATTERN = /\{(\w+)\}/g;
+
+export function compileUrlPattern(pattern: string): { regex: RegExp; paramNames: string[] } {
+	const paramNames: string[] = [];
+	const regexSource = pattern.replace(URL_PARAM_PATTERN, (_match, name: string) => {
+		paramNames.push(name);
+		return "([^/]+)";
+	});
+
+	return { regex: new RegExp(`^${regexSource}$`), paramNames };
+}

--- a/packages/core/tests/integration/database/media-usage-stale-bypass.test.ts
+++ b/packages/core/tests/integration/database/media-usage-stale-bypass.test.ts
@@ -168,6 +168,7 @@ describeEachDialect("media usage stale marking for bypass writes", (dialect) => 
 			.executeTakeFirstOrThrow();
 
 		await registry.updateField("posts", "hero", {});
+		await registry.updateField("posts", "hero", { indexed: false });
 		await expect(registry.updateField("posts", "hero", { required: true })).rejects.toThrow(
 			/manual content migration/,
 		);

--- a/packages/core/tests/integration/database/media-usage-stale-bypass.test.ts
+++ b/packages/core/tests/integration/database/media-usage-stale-bypass.test.ts
@@ -146,7 +146,7 @@ describeEachDialect("media usage stale marking for bypass writes", (dialect) => 
 		await expectSchemaReconciliation(collectionId, 2);
 
 		await trustCurrentSchema(collectionId);
-		await registry.updateField("posts", "hero", { type: "file" });
+		await registry.updateField("posts", "deck", { type: "text" });
 		await expectSchemaReconciliation(collectionId, 4);
 
 		await trustCurrentSchema(collectionId);
@@ -157,6 +157,28 @@ describeEachDialect("media usage stale marking for bypass writes", (dialect) => 
 			await usageRepo.recordIncrementalSuccess({ collectionId, collectionSlug: "posts" }),
 		).toBe(true);
 		await expectSchemaReconciliation(collectionId, 6);
+	});
+
+	it("keeps active coverage trusted when a field update makes no schema mutation", async () => {
+		const collectionId = await activateCollectionCapture("posts");
+		const statusBefore = await ctx.db
+			.selectFrom("_emdash_media_usage_index_status")
+			.select(["status", "reconciliation_required", "change_epoch", "capture_state"])
+			.where("collection_id", "=", collectionId)
+			.executeTakeFirstOrThrow();
+
+		await registry.updateField("posts", "hero", {});
+		await expect(registry.updateField("posts", "hero", { required: true })).rejects.toThrow(
+			/manual content migration/,
+		);
+
+		await expect(
+			ctx.db
+				.selectFrom("_emdash_media_usage_index_status")
+				.select(["status", "reconciliation_required", "change_epoch", "capture_state"])
+				.where("collection_id", "=", collectionId)
+				.executeTakeFirstOrThrow(),
+		).resolves.toEqual(statusBefore);
 	});
 
 	it("does not mutate schema when active coverage cannot be invalidated", async () => {

--- a/packages/core/tests/integration/mcp/schema.test.ts
+++ b/packages/core/tests/integration/mcp/schema.test.ts
@@ -5,8 +5,10 @@
  *   - schema_list_collections
  *   - schema_get_collection
  *   - schema_create_collection (also bug #11 — supports default)
+ *   - schema_update_collection
  *   - schema_delete_collection
  *   - schema_create_field
+ *   - schema_update_field
  *   - schema_delete_field
  *
  * For each tool: happy path, edge cases (empty, missing, duplicate,
@@ -300,6 +302,159 @@ describe("schema_create_collection", () => {
 });
 
 // ---------------------------------------------------------------------------
+// schema_update_collection
+// ---------------------------------------------------------------------------
+
+describe("schema_update_collection", () => {
+	let db: Kysely<Database>;
+	let harness: McpHarness;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({
+			slug: "post",
+			label: "Posts",
+			labelSingular: "Post",
+			supports: ["drafts", "revisions"],
+		});
+		await registry.createField("post", { slug: "title", label: "Title", type: "string" });
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+	});
+
+	afterEach(async () => {
+		if (harness) await harness.cleanup();
+		await teardownTestDatabase(db);
+	});
+
+	it("updates collection settings without recreating the collection or losing content", async () => {
+		const registry = new SchemaRegistry(db);
+		const before = await registry.getCollectionWithFields("post");
+		await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Kept content" } },
+		});
+
+		const result = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: {
+				slug: "post",
+				label: "Articles",
+				labelSingular: "Article",
+				description: "Long-form writing",
+				supports: ["drafts", "revisions", "preview"],
+				urlPattern: "/articles/{slug}",
+				hasSeo: true,
+				commentsEnabled: true,
+				commentsModeration: "first_time",
+				commentsClosedAfterDays: 30,
+				commentsAutoApproveUsers: true,
+			},
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const { item } = extractJson<{
+			item: {
+				id: string;
+				label: string;
+				labelSingular: string | null;
+				description: string | null;
+				supports: string[];
+				urlPattern: string | null;
+				hasSeo: boolean;
+				commentsEnabled: boolean;
+				commentsModeration: string;
+				commentsClosedAfterDays: number;
+				commentsAutoApproveUsers: boolean;
+			};
+		}>(result);
+		expect(item).toMatchObject({
+			id: before?.id,
+			label: "Articles",
+			labelSingular: "Article",
+			description: "Long-form writing",
+			urlPattern: "/articles/{slug}",
+			hasSeo: true,
+			commentsEnabled: true,
+			commentsModeration: "first_time",
+			commentsClosedAfterDays: 30,
+			commentsAutoApproveUsers: true,
+		});
+		expect(item.supports).toEqual(["drafts", "revisions", "preview"]);
+
+		const clearUrlPattern = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "post", urlPattern: null },
+		});
+		expect(clearUrlPattern.isError, extractText(clearUrlPattern)).toBeFalsy();
+		expect(
+			extractJson<{ item: { urlPattern?: string } }>(clearUrlPattern).item.urlPattern,
+		).toBeUndefined();
+
+		const after = await registry.getCollectionWithFields("post");
+		expect(after?.id).toBe(before?.id);
+		expect(after?.urlPattern).toBeUndefined();
+		expect(after?.fields.map((field) => field.slug)).toContain("title");
+
+		const content = await harness.client.callTool({
+			name: "content_list",
+			arguments: { collection: "post" },
+		});
+		const { items } = extractJson<{ items: Array<{ data: { title?: string } }> }>(content);
+		expect(items.some((entry) => entry.data.title === "Kept content")).toBe(true);
+	});
+
+	it("returns the canonical not-found error", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "missing", label: "Missing" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(extractText(result)).toContain("[COLLECTION_NOT_FOUND]");
+		expect(extractText(result)).toContain('Collection "missing" not found');
+	});
+
+	it("requires the schema:write token scope", async () => {
+		await harness.cleanup();
+		harness = await connectMcpHarness({
+			db,
+			userId: ADMIN_ID,
+			userRole: Role.ADMIN,
+			tokenScopes: ["schema:read"],
+		});
+
+		const result = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "post", label: "Blocked" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(extractText(result)).toContain("[INSUFFICIENT_SCOPE]");
+		expect((await new SchemaRegistry(db).getCollection("post"))?.label).toBe("Posts");
+	});
+
+	it("requires the ADMIN role even with schema:write scope", async () => {
+		await harness.cleanup();
+		harness = await connectMcpHarness({
+			db,
+			userId: EDITOR_ID,
+			userRole: Role.EDITOR,
+			tokenScopes: ["schema:write"],
+		});
+
+		const result = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "post", label: "Blocked" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(extractText(result)).toContain("[INSUFFICIENT_PERMISSIONS]");
+		expect((await new SchemaRegistry(db).getCollection("post"))?.label).toBe("Posts");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // schema_delete_collection
 // ---------------------------------------------------------------------------
 
@@ -569,6 +724,152 @@ describe("schema_create_field", () => {
 		expect(result.isError, extractText(result)).toBeFalsy();
 		const field = extractJson<{ required?: boolean }>(result);
 		expect(field.required).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// schema_update_field
+// ---------------------------------------------------------------------------
+
+describe("schema_update_field", () => {
+	let db: Kysely<Database>;
+	let harness: McpHarness;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "post", label: "Posts" });
+		await registry.createField("post", { slug: "body", label: "Body", type: "text" });
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { body: "Kept body" } },
+		});
+	});
+
+	afterEach(async () => {
+		if (harness) await harness.cleanup();
+		await teardownTestDatabase(db);
+	});
+
+	it("updates field metadata and a storage-compatible type without losing values", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: {
+				collection: "post",
+				fieldSlug: "body",
+				label: "Summary",
+				type: "string",
+				required: true,
+				validation: { minLength: 1, maxLength: 160 },
+				widget: "text",
+				sortOrder: 4,
+				translatable: false,
+			},
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const { item } = extractJson<{
+			item: {
+				slug: string;
+				label: string;
+				type: string;
+				required: boolean;
+				validation: { minLength: number; maxLength: number } | null;
+				widget: string | null;
+				sortOrder: number;
+				translatable: boolean;
+			};
+		}>(result);
+		expect(item).toMatchObject({
+			slug: "body",
+			label: "Summary",
+			type: "string",
+			required: true,
+			validation: { minLength: 1, maxLength: 160 },
+			widget: "text",
+			sortOrder: 4,
+			translatable: false,
+		});
+
+		const content = await harness.client.callTool({
+			name: "content_list",
+			arguments: { collection: "post" },
+		});
+		const { items } = extractJson<{ items: Array<{ data: { body?: string } }> }>(content);
+		expect(items.some((entry) => entry.data.body === "Kept body")).toBe(true);
+	});
+
+	it("rejects a type change that needs a content migration and preserves the field", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: {
+				collection: "post",
+				fieldSlug: "body",
+				type: "portableText",
+			},
+		});
+
+		expect(result.isError).toBe(true);
+		const text = extractText(result);
+		expect(text).toContain("[FIELD_TYPE_COLUMN_CHANGE]");
+		expect(text).toMatch(/manual content migration/i);
+		expect(text).toContain('from type "text" to "portableText"');
+
+		const field = await new SchemaRegistry(db).getField("post", "body");
+		expect(field?.type).toBe("text");
+	});
+
+	it("uses the REST validation contract for update input", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: {
+				collection: "post",
+				fieldSlug: "body",
+				label: "",
+				sortOrder: -1,
+			},
+		});
+
+		expect(result.isError).toBe(true);
+		expect(extractText(result)).toMatch(/invalid|too small|greater than or equal to/i);
+		expect(extractText(result)).not.toMatch(/tool .* not found/i);
+		const field = await new SchemaRegistry(db).getField("post", "body");
+		expect(field?.label).toBe("Body");
+		expect(field?.sortOrder).toBe(0);
+	});
+
+	it("requires schema:write scope and ADMIN role", async () => {
+		await harness.cleanup();
+		harness = await connectMcpHarness({
+			db,
+			userId: EDITOR_ID,
+			userRole: Role.EDITOR,
+			tokenScopes: ["schema:write"],
+		});
+
+		const editorResult = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: { collection: "post", fieldSlug: "body", label: "Blocked" },
+		});
+		expect(editorResult.isError).toBe(true);
+		expect(extractText(editorResult)).toContain("[INSUFFICIENT_PERMISSIONS]");
+
+		await harness.cleanup();
+		harness = await connectMcpHarness({
+			db,
+			userId: ADMIN_ID,
+			userRole: Role.ADMIN,
+			tokenScopes: ["schema:read"],
+		});
+
+		const scopeResult = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: { collection: "post", fieldSlug: "body", label: "Blocked" },
+		});
+		expect(scopeResult.isError).toBe(true);
+		expect(extractText(scopeResult)).toContain("[INSUFFICIENT_SCOPE]");
+		expect((await new SchemaRegistry(db).getField("post", "body"))?.label).toBe("Body");
 	});
 });
 

--- a/packages/core/tests/integration/mcp/schema.test.ts
+++ b/packages/core/tests/integration/mcp/schema.test.ts
@@ -231,6 +231,19 @@ describe("schema_create_collection", () => {
 		expect(created.supports.toSorted()).toEqual(["drafts", "revisions", "scheduling"].toSorted());
 	});
 
+	it("creates a collection with SEO support", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		const result = await harness.client.callTool({
+			name: "schema_create_collection",
+			arguments: { slug: "landing", label: "Landing pages", supports: ["seo"] },
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const created = extractJson<{ supports: string[]; hasSeo: boolean }>(result);
+		expect(created.supports).toEqual(["seo"]);
+		expect(created.hasSeo).toBe(true);
+	});
+
 	it("rejects slug that doesn't match the collection slug pattern", async () => {
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		const result = await harness.client.callTool({

--- a/packages/core/tests/integration/mcp/schema.test.ts
+++ b/packages/core/tests/integration/mcp/schema.test.ts
@@ -428,15 +428,15 @@ describe("schema_update_collection", () => {
 		expect((await new SchemaRegistry(db).getCollection("post"))?.urlPattern).toBeUndefined();
 	});
 
-	it("preserves SEO when supports changes without hasSeo", async () => {
+	it("derives SEO when supports changes without hasSeo", async () => {
 		const result = await harness.client.callTool({
 			name: "schema_update_collection",
 			arguments: { slug: "post", supports: ["drafts", "preview"] },
 		});
 
 		expect(result.isError, extractText(result)).toBeFalsy();
-		expect(extractJson<{ item: { hasSeo: boolean } }>(result).item.hasSeo).toBe(true);
-		expect((await new SchemaRegistry(db).getCollection("post"))?.hasSeo).toBe(true);
+		expect(extractJson<{ item: { hasSeo: boolean } }>(result).item.hasSeo).toBe(false);
+		expect((await new SchemaRegistry(db).getCollection("post"))?.hasSeo).toBe(false);
 	});
 
 	it("preserves concurrent partial collection updates", async () => {

--- a/packages/core/tests/integration/mcp/schema.test.ts
+++ b/packages/core/tests/integration/mcp/schema.test.ts
@@ -420,7 +420,7 @@ describe("schema_update_collection", () => {
 	it("rejects malformed URL patterns without changing the collection", async () => {
 		const result = await harness.client.callTool({
 			name: "schema_update_collection",
-			arguments: { slug: "post", urlPattern: "(" },
+			arguments: { slug: "post", urlPattern: "/articles/{slug" },
 		});
 
 		expect(result.isError).toBe(true);
@@ -437,6 +437,24 @@ describe("schema_update_collection", () => {
 		expect(result.isError, extractText(result)).toBeFalsy();
 		expect(extractJson<{ item: { hasSeo: boolean } }>(result).item.hasSeo).toBe(false);
 		expect((await new SchemaRegistry(db).getCollection("post"))?.hasSeo).toBe(false);
+
+		const enableSeo = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "post", supports: ["drafts", "seo"] },
+		});
+
+		expect(enableSeo.isError, extractText(enableSeo)).toBeFalsy();
+		expect(extractJson<{ item: { hasSeo: boolean } }>(enableSeo).item.hasSeo).toBe(true);
+	});
+
+	it("validates the collection slug before lookup", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "Invalid!", label: "Invalid" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(extractText(result)).toMatch(/invalid collection slug/i);
 	});
 
 	it("preserves concurrent partial collection updates", async () => {
@@ -973,6 +991,21 @@ describe("schema_update_field", () => {
 		const field = await new SchemaRegistry(db).getField("post", "body");
 		expect(field?.label).toBe("Body");
 		expect(field?.sortOrder).toBe(0);
+	});
+
+	it("validates collection and field slugs before lookup", async () => {
+		for (const identifiers of [
+			{ collection: "Invalid!", fieldSlug: "body" },
+			{ collection: "post", fieldSlug: "Invalid!" },
+		]) {
+			const result = await harness.client.callTool({
+				name: "schema_update_field",
+				arguments: { ...identifiers, label: "Invalid" },
+			});
+
+			expect(result.isError).toBe(true);
+			expect(extractText(result)).toMatch(/invalid .* slug/i);
+		}
 	});
 
 	it("requires schema:write scope and ADMIN role", async () => {

--- a/packages/core/tests/integration/mcp/schema.test.ts
+++ b/packages/core/tests/integration/mcp/schema.test.ts
@@ -834,6 +834,26 @@ describe("schema_update_field", () => {
 		expect(items.some((entry) => entry.data.body === "Kept body")).toBe(true);
 	});
 
+	it("updates the structured-sort index", async () => {
+		await new SchemaRegistry(db).createField("post", {
+			slug: "priority",
+			label: "Priority",
+			type: "string",
+		});
+		const result = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: {
+				collection: "post",
+				fieldSlug: "priority",
+				indexed: true,
+			},
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		expect(extractJson<{ item: { indexed: boolean } }>(result).item.indexed).toBe(true);
+		expect((await new SchemaRegistry(db).getField("post", "priority"))?.indexed).toBe(true);
+	});
+
 	it("rejects a type change that needs a content migration and preserves the field", async () => {
 		const result = await harness.client.callTool({
 			name: "schema_update_field",

--- a/packages/core/tests/integration/mcp/schema.test.ts
+++ b/packages/core/tests/integration/mcp/schema.test.ts
@@ -24,6 +24,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { Database } from "../../../src/database/types.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { validateContent } from "../../../src/schema/zod-generator.js";
 import {
 	connectMcpHarness,
 	extractJson,
@@ -317,6 +318,7 @@ describe("schema_update_collection", () => {
 			label: "Posts",
 			labelSingular: "Post",
 			supports: ["drafts", "revisions"],
+			hasSeo: true,
 		});
 		await registry.createField("post", { slug: "title", label: "Title", type: "string" });
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
@@ -413,6 +415,40 @@ describe("schema_update_collection", () => {
 		expect(result.isError).toBe(true);
 		expect(extractText(result)).toContain("[COLLECTION_NOT_FOUND]");
 		expect(extractText(result)).toContain('Collection "missing" not found');
+	});
+
+	it("rejects malformed URL patterns without changing the collection", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "post", urlPattern: "(" },
+		});
+
+		expect(result.isError).toBe(true);
+		expect(extractText(result)).toMatch(/url pattern|regular expression|invalid/i);
+		expect((await new SchemaRegistry(db).getCollection("post"))?.urlPattern).toBeUndefined();
+	});
+
+	it("preserves SEO when supports changes without hasSeo", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_collection",
+			arguments: { slug: "post", supports: ["drafts", "preview"] },
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		expect(extractJson<{ item: { hasSeo: boolean } }>(result).item.hasSeo).toBe(true);
+		expect((await new SchemaRegistry(db).getCollection("post"))?.hasSeo).toBe(true);
+	});
+
+	it("preserves concurrent partial collection updates", async () => {
+		const registry = new SchemaRegistry(db);
+		await Promise.all([
+			registry.updateCollection("post", { label: "Articles" }),
+			registry.updateCollection("post", { description: "Concurrent description" }),
+		]);
+
+		const collection = await registry.getCollection("post");
+		expect(collection?.label).toBe("Articles");
+		expect(collection?.description).toBe("Concurrent description");
 	});
 
 	it("requires the schema:write token scope", async () => {
@@ -760,11 +796,9 @@ describe("schema_update_field", () => {
 				fieldSlug: "body",
 				label: "Summary",
 				type: "string",
-				required: true,
 				validation: { minLength: 1, maxLength: 160 },
 				widget: "text",
 				sortOrder: 4,
-				translatable: false,
 			},
 		});
 
@@ -785,11 +819,11 @@ describe("schema_update_field", () => {
 			slug: "body",
 			label: "Summary",
 			type: "string",
-			required: true,
+			required: false,
 			validation: { minLength: 1, maxLength: 160 },
 			widget: "text",
 			sortOrder: 4,
-			translatable: false,
+			translatable: true,
 		});
 
 		const content = await harness.client.callTool({
@@ -818,6 +852,88 @@ describe("schema_update_field", () => {
 
 		const field = await new SchemaRegistry(db).getField("post", "body");
 		expect(field?.type).toBe("text");
+	});
+
+	it("rejects a semantically incompatible type with the same column affinity", async () => {
+		const result = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: {
+				collection: "post",
+				fieldSlug: "body",
+				type: "datetime",
+			},
+		});
+
+		expect(result.isError).toBe(true);
+		expect(extractText(result)).toContain("[FIELD_TYPE_CHANGE_REQUIRES_MIGRATION]");
+		expect(extractText(result)).toMatch(/manual content migration/i);
+		expect((await new SchemaRegistry(db).getField("post", "body"))?.type).toBe("text");
+	});
+
+	it("rejects field invariant changes that require data or column migration", async () => {
+		for (const change of [{ required: true }, { unique: true }, { translatable: false }]) {
+			const result = await harness.client.callTool({
+				name: "schema_update_field",
+				arguments: { collection: "post", fieldSlug: "body", ...change },
+			});
+			expect(result.isError).toBe(true);
+			expect(extractText(result)).toContain("[FIELD_UPDATE_REQUIRES_MIGRATION]");
+			expect(extractText(result)).toMatch(/manual content migration/i);
+		}
+
+		const field = await new SchemaRegistry(db).getField("post", "body");
+		expect(field).toMatchObject({ required: false, unique: false, translatable: true });
+	});
+
+	it("rejects invalid validation rules without changing the field", async () => {
+		for (const validation of [
+			{ pattern: "[" },
+			{ minLength: 5, maxLength: 1 },
+			{ min: 10, max: 1 },
+			{ minItems: 4, maxItems: 2 },
+		]) {
+			const result = await harness.client.callTool({
+				name: "schema_update_field",
+				arguments: { collection: "post", fieldSlug: "body", validation },
+			});
+			expect(result.isError).toBe(true);
+			expect(extractText(result)).toMatch(/invalid|minimum|maximum|pattern/i);
+		}
+
+		expect((await new SchemaRegistry(db).getField("post", "body"))?.validation).toBeUndefined();
+	});
+
+	it("invalidates the generated content schema after a field update", async () => {
+		const registry = new SchemaRegistry(db);
+		const before = await registry.getCollectionWithFields("post");
+		expect(before).not.toBeNull();
+		expect(validateContent(before!, { body: "primes the cache" }).success).toBe(true);
+
+		const update = await harness.client.callTool({
+			name: "schema_update_field",
+			arguments: {
+				collection: "post",
+				fieldSlug: "body",
+				validation: { maxLength: 1 },
+			},
+		});
+		expect(update.isError, extractText(update)).toBeFalsy();
+
+		const after = await registry.getCollectionWithFields("post");
+		expect(after).not.toBeNull();
+		expect(validateContent(after!, { body: "too long" }).success).toBe(false);
+	});
+
+	it("preserves concurrent partial field updates", async () => {
+		const registry = new SchemaRegistry(db);
+		await Promise.all([
+			registry.updateField("post", "body", { label: "Summary" }),
+			registry.updateField("post", "body", { sortOrder: 7 }),
+		]);
+
+		const field = await registry.getField("post", "body");
+		expect(field?.label).toBe("Summary");
+		expect(field?.sortOrder).toBe(7);
 	});
 
 	it("uses the REST validation contract for update input", async () => {

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -263,12 +263,12 @@ describe("SchemaRegistry", () => {
 
 			const updated = await registry.updateField("posts", "title", {
 				label: "Post Title",
-				required: true,
+				sortOrder: 3,
 				widget: "text",
 			});
 
 			expect(updated.label).toBe("Post Title");
-			expect(updated.required).toBe(true);
+			expect(updated.sortOrder).toBe(3);
 			expect(updated.widget).toBe("text");
 		});
 

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -220,6 +220,19 @@ describe("SchemaRegistry", () => {
 			expect(updated.supports).toEqual(["drafts"]);
 		});
 
+		it("touches updatedAt for an empty update", async () => {
+			await registry.createCollection({ slug: "posts", label: "Posts" });
+			await db
+				.updateTable("_emdash_collections")
+				.set({ updated_at: "2000-01-01T00:00:00.000Z" })
+				.where("slug", "=", "posts")
+				.execute();
+
+			const updated = await registry.updateCollection("posts", {});
+
+			expect(updated.updatedAt).not.toBe("2000-01-01T00:00:00.000Z");
+		});
+
 		it("collections are visible in the sidebar by default", async () => {
 			const collection = await registry.createCollection({ slug: "posts", label: "Posts" });
 

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -562,12 +562,12 @@ describe("SchemaRegistry", () => {
 
 			const updated = await registry.updateField("posts", "title", {
 				label: "Post Title",
-				required: true,
+				sortOrder: 3,
 				widget: "text",
 			});
 
 			expect(updated.label).toBe("Post Title");
-			expect(updated.required).toBe(true);
+			expect(updated.sortOrder).toBe(3);
 			expect(updated.widget).toBe("text");
 		});
 

--- a/packages/core/tests/unit/url-pattern/url-pattern.test.ts
+++ b/packages/core/tests/unit/url-pattern/url-pattern.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { Database } from "../../../src/database/types.js";
 import { getMenuWithDb } from "../../../src/menus/index.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { compileUrlPattern } from "../../../src/schema/url-pattern.js";
 import { applySeed } from "../../../src/seed/apply.js";
 import type { SeedFile } from "../../../src/seed/types.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
@@ -24,6 +25,13 @@ describe("urlPattern", () => {
 	});
 
 	describe("schema registry", () => {
+		it("treats URL-pattern punctuation as literals", () => {
+			const { regex } = compileUrlPattern("/posts/{slug}.html");
+
+			expect(regex.test("/posts/example.html")).toBe(true);
+			expect(regex.test("/posts/exampleXhtml")).toBe(false);
+		});
+
 		it("should store urlPattern on create", async () => {
 			const collection = await registry.createCollection({
 				slug: "pages",

--- a/packages/core/tests/unit/url-pattern/url-pattern.test.ts
+++ b/packages/core/tests/unit/url-pattern/url-pattern.test.ts
@@ -1,15 +1,27 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 import { ulid } from "ulidx";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import type { Database } from "../../../src/database/types.js";
 import { getMenuWithDb } from "../../../src/menus/index.js";
+import { runWithContext } from "../../../src/request-context.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { compileUrlPattern } from "../../../src/schema/url-pattern.js";
 import { applySeed } from "../../../src/seed/apply.js";
 import type { SeedFile } from "../../../src/seed/types.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+vi.mock("astro:content", () => ({
+	getLiveCollection: vi.fn(),
+	getLiveEntry: vi.fn().mockResolvedValue({
+		entry: {
+			id: "example",
+			data: { id: "entry-id", slug: "example", status: "published", locale: "en" },
+		},
+		cacheHint: {},
+	}),
+}));
 
 describe("urlPattern", () => {
 	let db: Kysely<Database>;
@@ -30,6 +42,39 @@ describe("urlPattern", () => {
 
 			expect(regex.test("/posts/example.html")).toBe(true);
 			expect(regex.test("/posts/exampleXhtml")).toBe(false);
+		});
+
+		it("invalidates URL patterns across duplicated query modules", async () => {
+			const firstQueryModule = await import("../../../src/query.js");
+			firstQueryModule.invalidateUrlPatternCache();
+			await registry.createCollection({
+				slug: "posts",
+				label: "Posts",
+				urlPattern: "/old/{slug}",
+			});
+			await sql`
+				INSERT INTO ec_posts (id, slug, status) VALUES (${ulid()}, ${"example"}, ${"published"})
+			`.execute(db);
+			expect(
+				await runWithContext({ editMode: false, db }, () =>
+					firstQueryModule.resolveEmDashPath("/old/example"),
+				),
+			).not.toBeNull();
+
+			await db
+				.updateTable("_emdash_collections")
+				.set({ url_pattern: "/new/{slug}" })
+				.where("slug", "=", "posts")
+				.execute();
+			vi.resetModules();
+			const secondQueryModule = await import("../../../src/query.js");
+			secondQueryModule.invalidateUrlPatternCache();
+
+			expect(
+				await runWithContext({ editMode: false, db }, () =>
+					firstQueryModule.resolveEmDashPath("/new/example"),
+				),
+			).not.toBeNull();
 		});
 
 		it("should store urlPattern on create", async () => {


### PR DESCRIPTION
## What does this PR do?

Adds `schema_update_collection` and `schema_update_field` MCP tools so agents can update existing schemas without deleting tables, columns, content, or stored field values.

Both tools reuse the canonical REST handlers and validation, require `schema:write` plus the Admin role, preserve omitted properties during concurrent partial updates, invalidate affected caches, and return explicit migration errors for changes that cannot be represented safely as metadata-only updates. The MCP reference documents the new surface and migration limits.

Closes #1681

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI strings are changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1876 (also scoped by maintainer-authored 1.0 roadmap issue #1681)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5); RepoPrompt Oracle was used for adversarial review

## Screenshots / test output

No visual changes.

- `pnpm typecheck` — passed
- `pnpm lint:json | jq '.diagnostics | length'` — `0`
- MCP integration and schema registry tests — 374 passed
- Full MCP integration suite — 335 passed
- Workspace build — passed
- Docs build — passed
- Changeset status and `git diff --check` — passed
- Full core suite — 5,188 passed; one unrelated macOS path assertion compares `/var/...` with its `/private/var/...` resolved path
- Package validation — `publint` passed; `attw` 0.18.2 exited with its internal `Cannot read properties of undefined (reading 'filename')` error
