### PR TITLE
fix(admin): surface create-content failures as an error toast

### DIFF
--- a/.changeset/content-create-error-toast.md
+++ b/.changeset/content-create-error-toast.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes silent save failures when creating content in the admin: a rejected create — for example a slug that already exists in the collection — now shows a "Failed to save" toast with the server's message instead of doing nothing.

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -4,7 +4,7 @@
  * Defines all admin routes and their components.
  */
 
-import { Button, Loader, Toast } from "@cloudflare/kumo";
+import { Button, Loader, Toast, useKumoToastManager } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import type { QueryClient } from "@tanstack/react-query";
@@ -634,6 +634,8 @@ function ContentNewPage() {
 	const { locale } = useSearch({ from: "/_admin/content/$collection/new" });
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const { t } = useLingui();
+	const toastManager = useKumoToastManager();
 	const [selectedBylines, setSelectedBylines] = React.useState<BylineCreditInput[]>([]);
 
 	const { data: manifest } = useQuery({
@@ -661,6 +663,13 @@ function ContentNewPage() {
 				to: "/content/$collection/$id",
 				params: { collection, id: result.id },
 				search: { locale: result.locale },
+			});
+		},
+		onError: (error) => {
+			toastManager.add({
+				title: t`Failed to save`,
+				description: error instanceof Error ? error.message : t`An error occurred`,
+				variant: "error",
 			});
 		},
 	});

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -493,6 +493,80 @@ describe("ContentNewPage – locale passed to createContent", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: ContentNewPage – a rejected create surfaces an error toast
+// ---------------------------------------------------------------------------
+
+describe("ContentNewPage – create failure surfaces the server's error", () => {
+	let mockFetch: ReturnType<typeof createMockFetch>;
+
+	beforeEach(() => {
+		mockFetch = createMockFetch();
+
+		mockFetch
+			.on("GET", "/_emdash/api/manifest", { data: MANIFEST })
+			.on("GET", "/_emdash/api/auth/me", {
+				data: { id: "user_01", role: 60 },
+			})
+			.on("GET", "/_emdash/api/bylines", { data: { items: [] } })
+			// A canned 409 SLUG_CONFLICT — the response shape the server
+			// returns when the entry's slug is already taken in the
+			// collection (slug derivation itself is server-side and not
+			// exercised here).
+			.on(
+				"POST",
+				"/_emdash/api/content/posts",
+				{
+					success: false,
+					error: {
+						code: "SLUG_CONFLICT",
+						message: "Slug 'test-post' already exists in collection 'posts'",
+					},
+				},
+				409,
+			);
+	});
+
+	afterEach(() => {
+		mockFetch.restore();
+	});
+
+	it("shows a toast with the server's message on a slug conflict (and stays on /new)", async () => {
+		const { router, TestApp } = buildRouter();
+
+		await router.navigate({
+			to: "/content/$collection/new",
+			params: { collection: "posts" },
+			search: { locale: undefined },
+		});
+
+		const screen = await render(<TestApp />);
+
+		await expect
+			.element(screen.getByRole("button", { name: "Save", exact: true }))
+			.toBeInTheDocument();
+
+		await screen.getByRole("button", { name: "Save", exact: true }).click();
+
+		// The UI surfaces WHAT happened — the server's human-readable
+		// conflict message.
+		await expect.element(screen.getByText("Failed to save")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("Slug 'test-post' already exists in collection 'posts'"))
+			.toBeInTheDocument();
+
+		// And with the error affordance: Kumo styles severity off `variant`
+		// (Base UI's `type` is inert for styling), and the toast icon only
+		// renders for a non-default variant.
+		await expect
+			.poll(() => document.querySelectorAll("[data-toast-icon]").length)
+			.toBeGreaterThan(0);
+
+		// And the failed create must not navigate anywhere.
+		expect(router.state.location.pathname).toContain("/content/posts/new");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Tests: ContentEditPage – autosave cache stays in sync
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

A rejected content CREATE (e.g. the 409 `SLUG_CONFLICT` when the auto-generated slug collides with an existing entry) was fully silent: `ContentNewPage.createMutation` has no `onError`, the page has no toast manager, and the `QueryClient` has no global mutation error handler — so the thrown `Error` (which already carries the server's human-readable message, via `throwResponseError`) died in mutation state. The Save button reset and the editor stayed on `/new` with zero feedback.

Every other mutation in `router.tsx` surfaces failures (the edit page's `handleContentUpdateError` → "Failed to save" toast); this adds the equivalent handler to the create mutation. It follows the settings-components pattern (`useKumoToastManager` + `variant: "error"`) rather than `Toast.useToastManager` + `type: "error"`: Kumo styles toast severity off `variant` (danger ring + error icon), while Base UI's `type` field is inert for styling — verified by rendering both. Strings are lingui-wrapped.

The regression test drives the real route with a mocked 409 `SLUG_CONFLICT` response and asserts the toast title, the server's message, the error affordance (the `variant`-driven toast icon — mutation-tested: dropping `variant` fails the test), and that the router stays on `/content/posts/new`. Repro proof: **fails unpatched (1/14), passes patched (14/14)**.

Closes #2365

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`pnpm --filter @emdash-cms/admin typecheck` — tsgo clean)
- [x] `pnpm lint` passes (type-aware oxlint on the changed files — clean; full-workspace lint not runnable on this machine, native build scripts unavailable)
- [x] `pnpm test` passes (or targeted tests for my change) — `packages/admin` `vitest run tests/router.test.tsx`: 14/14
- [x] `pnpm format` has been run (`oxfmt` — no reflow beyond the change)
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

```
❯ |chromium| tests/router.test.tsx (14 tests | 1 failed)   ← unpatched
    × shows a toast with the server's message on a slug conflict (and stays on /new)

❯ |chromium| tests/router.test.tsx (14 tests)              ← patched
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Related follow-up (deliberately NOT in this PR — behavior change): the server's `generateUniqueSlug` auto-suffixing never runs on normal creates because the admin always sends its client-side slug; omitting `slug` when the editor hasn't touched the field would make this collision a non-event. Flagged in #2365 for maintainer input.
