### PR TITLE
fix(core): let the configured siteUrl steer outbound email links

### DIFF
--- a/.changeset/fix-site-base-url-config.md
+++ b/.changeset/fix-site-base-url-config.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes outbound email links (magic link, invites, signup confirmation, account recovery, comment notifications) ignoring the configured `siteUrl`. The configured origin — `siteUrl` in the integration options or the `EMDASH_SITE_URL`/`SITE_URL` environment variables — now takes precedence over the origin stored during setup, so a site set up on a temporary domain no longer needs a manual database edit to correct its email links.

--- a/packages/core/src/api/public-url.ts
+++ b/packages/core/src/api/public-url.ts
@@ -10,7 +10,7 @@
  */
 
 /** Minimal config shape — avoids importing the full EmDashConfig type tree. */
-interface SiteUrlConfig {
+export interface SiteUrlConfig {
 	siteUrl?: string;
 }
 
@@ -74,7 +74,19 @@ function getEnvSiteUrl(): string | undefined {
  * @returns Origin string, e.g. `"https://mysite.example.com"`
  */
 export function getPublicOrigin(url: URL, config?: SiteUrlConfig): string {
-	return config?.siteUrl || getEnvSiteUrl() || url.origin;
+	return getConfiguredOrigin(config) || url.origin;
+}
+
+/**
+ * Return the operator-configured public origin, if any.
+ *
+ * The first two steps of {@link getPublicOrigin}'s resolution —
+ * `config.siteUrl`, then the `EMDASH_SITE_URL`/`SITE_URL` env vars — without
+ * the request-URL fallback. For callers that have a more trustworthy fallback
+ * than the request (e.g. the stored setup origin used for outbound emails).
+ */
+export function getConfiguredOrigin(config?: SiteUrlConfig): string | undefined {
+	return config?.siteUrl || getEnvSiteUrl() || undefined;
 }
 
 /**

--- a/packages/core/src/api/site-url.ts
+++ b/packages/core/src/api/site-url.ts
@@ -1,19 +1,29 @@
 /**
  * Resolve the canonical site base URL for use in outbound links (emails, etc.).
  *
- * Uses the stored `emdash:site_url` (set during setup on the real domain)
- * so that Host header spoofing in later requests cannot redirect users to
- * attacker-controlled domains.
- *
- * Falls back to the request URL only if no stored value exists (pre-setup).
+ * Precedence mirrors `getPublicOrigin`: the operator-configured origin
+ * (`config.siteUrl`, then the `EMDASH_SITE_URL`/`SITE_URL` env vars) wins,
+ * then the stored `emdash:site_url` option (written once during setup on the
+ * real domain), and only before setup completes does the request URL fill in.
+ * A configured or stored value always beats the request, so Host header
+ * spoofing cannot redirect users to attacker-controlled domains.
  */
 
 import type { Kysely } from "kysely";
 
 import { OptionsRepository } from "../database/repositories/options.js";
 import type { Database } from "../database/types.js";
+import { getConfiguredOrigin, type SiteUrlConfig } from "./public-url.js";
 
-export async function getSiteBaseUrl(db: Kysely<Database>, request: Request): Promise<string> {
+export async function getSiteBaseUrl(
+	db: Kysely<Database>,
+	request: Request,
+	config?: SiteUrlConfig,
+): Promise<string> {
+	const configured = getConfiguredOrigin(config);
+	if (configured) {
+		return `${configured}/_emdash`;
+	}
 	const options = new OptionsRepository(db);
 	const storedUrl = await options.get<string>("emdash:site_url");
 	if (storedUrl) {

--- a/packages/core/src/astro/routes/api/admin/comments/[id]/status.ts
+++ b/packages/core/src/astro/routes/api/admin/comments/[id]/status.ts
@@ -93,7 +93,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		// Send notification when a comment is newly approved
 		if (newStatus === "approved" && previousStatus !== "approved" && emdash.email) {
 			try {
-				const adminBaseUrl = await getSiteBaseUrl(emdash.db, request);
+				const adminBaseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 				const content = await lookupContentAuthor(emdash.db, updated.collection, updated.contentId);
 				if (content?.author) {
 					await sendCommentNotification({

--- a/packages/core/src/astro/routes/api/admin/users/[id]/send-recovery.ts
+++ b/packages/core/src/astro/routes/api/admin/users/[id]/send-recovery.ts
@@ -51,7 +51,7 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
 			);
 		}
 
-		// Build config using stored site URL (not request Host header)
+		// Build config using the configured site URL, stored option as fallback (not request Host header)
 		const options = new OptionsRepository(emdash.db);
 		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 		const siteName = (await options.get<string>("emdash:site_title")) ?? "EmDash";

--- a/packages/core/src/astro/routes/api/admin/users/[id]/send-recovery.ts
+++ b/packages/core/src/astro/routes/api/admin/users/[id]/send-recovery.ts
@@ -53,7 +53,7 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
 
 		// Build config using stored site URL (not request Host header)
 		const options = new OptionsRepository(emdash.db);
-		const baseUrl = await getSiteBaseUrl(emdash.db, request);
+		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 		const siteName = (await options.get<string>("emdash:site_title")) ?? "EmDash";
 
 		const config: MagicLinkConfig = {

--- a/packages/core/src/astro/routes/api/auth/invite/index.ts
+++ b/packages/core/src/astro/routes/api/auth/invite/index.ts
@@ -47,7 +47,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const siteName = (await options.get<string>("emdash:site_title")) || "EmDash";
 
 		// Use stored site URL to prevent Host header spoofing in invite emails
-		const baseUrl = await getSiteBaseUrl(emdash.db, request);
+		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 
 		// Build email sender from the plugin pipeline (if available)
 		const emailSend = emdash.email?.isAvailable()

--- a/packages/core/src/astro/routes/api/auth/invite/index.ts
+++ b/packages/core/src/astro/routes/api/auth/invite/index.ts
@@ -46,7 +46,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const options = new OptionsRepository(emdash.db);
 		const siteName = (await options.get<string>("emdash:site_title")) || "EmDash";
 
-		// Use stored site URL to prevent Host header spoofing in invite emails
+		// Use the configured site URL (stored option as fallback) to prevent Host header spoofing in invite emails
 		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 
 		// Build email sender from the plugin pipeline (if available)

--- a/packages/core/src/astro/routes/api/auth/magic-link/send.ts
+++ b/packages/core/src/astro/routes/api/auth/magic-link/send.ts
@@ -57,7 +57,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 			);
 		}
 
-		// Build magic link config using stored site URL (not request Host header)
+		// Build magic link config using the configured site URL, stored option as fallback (not request Host header)
 		const options = new OptionsRepository(emdash.db);
 		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 		const siteName = (await options.get<string>("emdash:site_title")) ?? "EmDash";

--- a/packages/core/src/astro/routes/api/auth/magic-link/send.ts
+++ b/packages/core/src/astro/routes/api/auth/magic-link/send.ts
@@ -59,7 +59,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
 		// Build magic link config using stored site URL (not request Host header)
 		const options = new OptionsRepository(emdash.db);
-		const baseUrl = await getSiteBaseUrl(emdash.db, request);
+		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 		const siteName = (await options.get<string>("emdash:site_title")) ?? "EmDash";
 
 		const config: MagicLinkConfig = {

--- a/packages/core/src/astro/routes/api/auth/signup/request.ts
+++ b/packages/core/src/astro/routes/api/auth/signup/request.ts
@@ -68,7 +68,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const options = new OptionsRepository(emdash.db);
 		const siteName = (await options.get<string>("emdash:site_title")) || "EmDash";
 
-		// Use stored site URL to prevent Host header spoofing in signup emails
+		// Use the configured site URL (stored option as fallback) to prevent Host header spoofing in signup emails
 		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 
 		// Request signup - this handles all checks internally and fails silently

--- a/packages/core/src/astro/routes/api/auth/signup/request.ts
+++ b/packages/core/src/astro/routes/api/auth/signup/request.ts
@@ -69,7 +69,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const siteName = (await options.get<string>("emdash:site_title")) || "EmDash";
 
 		// Use stored site URL to prevent Host header spoofing in signup emails
-		const baseUrl = await getSiteBaseUrl(emdash.db, request);
+		const baseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 
 		// Request signup - this handles all checks internally and fails silently
 		// if domain not allowed or user exists (to prevent enumeration)

--- a/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
+++ b/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
@@ -302,7 +302,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		// isolate terminates after the response).
 		if (result.comment.status === "approved" && emdash.email && contentAuthor) {
 			try {
-				const adminBaseUrl = await getSiteBaseUrl(emdash.db, request);
+				const adminBaseUrl = await getSiteBaseUrl(emdash.db, request, emdash.config);
 				await sendCommentNotification({
 					email: emdash.email,
 					comment: result.comment,

--- a/packages/core/tests/integration/api/site-url.test.ts
+++ b/packages/core/tests/integration/api/site-url.test.ts
@@ -1,0 +1,67 @@
+/**
+ * getSiteBaseUrl precedence: configured origin → stored setup origin →
+ * request URL. The configured origin is what `siteUrl` in the integration
+ * options resolves to; the stored `emdash:site_url` option is written once
+ * during setup; the request URL only fills in before setup completes and
+ * must never override either of the other two (Host-spoofing lock).
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getPublicOrigin } from "../../../src/api/public-url.js";
+import { getSiteBaseUrl } from "../../../src/api/site-url.js";
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+const SETUP_ORIGIN = "https://my-site.workers.dev";
+const REAL_ORIGIN = "https://real.example";
+const REQUEST_URL = `${REAL_ORIGIN}/_emdash/api/auth/magic-link/send`;
+
+describe("getSiteBaseUrl", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("configured siteUrl beats the stored setup origin", async () => {
+		// Setup ran on a throwaway origin; the operator has since configured
+		// the real one. Email links must follow the config, like every other
+		// origin-dependent feature does via getPublicOrigin.
+		await new OptionsRepository(db).set("emdash:site_url", SETUP_ORIGIN);
+		const config = { siteUrl: REAL_ORIGIN };
+		const request = new Request(REQUEST_URL, { method: "POST" });
+
+		expect(getPublicOrigin(new URL(request.url), config)).toBe(REAL_ORIGIN);
+		expect(await getSiteBaseUrl(db, request, config)).toBe(`${REAL_ORIGIN}/_emdash`);
+	});
+
+	it("falls back to the stored setup origin when nothing is configured", async () => {
+		await new OptionsRepository(db).set("emdash:site_url", SETUP_ORIGIN);
+		const request = new Request(REQUEST_URL, { method: "POST" });
+
+		expect(await getSiteBaseUrl(db, request)).toBe(`${SETUP_ORIGIN}/_emdash`);
+	});
+
+	it("stored origin is not overridden by the request host", async () => {
+		// The Host-spoofing lock: a stored value always beats the request.
+		await new OptionsRepository(db).set("emdash:site_url", SETUP_ORIGIN);
+		const spoofed = new Request("https://attacker.example/_emdash/api/auth/magic-link/send", {
+			method: "POST",
+		});
+
+		expect(await getSiteBaseUrl(db, spoofed)).toBe(`${SETUP_ORIGIN}/_emdash`);
+	});
+
+	it("derives from the request only before setup has stored an origin", async () => {
+		const request = new Request(REQUEST_URL, { method: "POST" });
+
+		expect(await getSiteBaseUrl(db, request)).toBe(`${REAL_ORIGIN}/_emdash`);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`getSiteBaseUrl` — the only origin source for magic-link, invite, signup-confirmation, recovery and comment-notification emails — read only the stored `emdash:site_url` option. That option is written **once**, by the setup wizard (`setIfAbsent`, deliberately, as the Host-spoofing lock), and Admin → Settings writes the different key `site:url`. So a site that completed setup on a throwaway origin (a `*.workers.dev` preview URL, a staging host) kept mailing that origin forever: the operator sets `siteUrl` in the integration options as the docs prescribe ("the single option for the public origin"), every other origin-dependent feature follows `getPublicOrigin` to the new host — and email links still point at the dead one. The only remedy was a manual `UPDATE options …` against the production database. We hit exactly this on a production site.

This PR gives `getSiteBaseUrl` the same precedence as `getPublicOrigin`: configured origin (`config.siteUrl`, then `EMDASH_SITE_URL`/`SITE_URL`) → stored setup origin → request URL (pre-setup only). The request still never overrides a configured or stored value, so the anti-spoofing property is unchanged. As a side effect, deployments with a configured `siteUrl` skip the options query on the email path entirely.

Changes:
- `api/public-url.ts`: extract `getConfiguredOrigin(config)` (config → env, no request fallback); `getPublicOrigin` now uses it — no behavior change there.
- `api/site-url.ts`: accept an optional `config` and apply it first.
- All six call sites pass `emdash.config` (they already have it in scope).
- New test `tests/integration/api/site-url.test.ts` covering the four precedence cases, including a regression guard for the Host-spoofing lock. The first test fails on `main`.

An alternative fix would be re-syncing the stored option at runtime init when `config.siteUrl` is set — happy to rework in that direction if you prefer it; this variant is the smaller diff and matches the documented "single option" contract.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (core package, `tsc --noEmit`)
- [x] `pnpm lint` passes (`lint:json` → 0 diagnostics)
- [x] `pnpm test` passes (targeted: `tests/integration/api/site-url.test.ts`, `tests/integration/astro/setup-site-url-lock.test.ts`, `tests/integration/auth`, `tests/integration/comments`, `tests/unit/plugins/email-pipeline.test.ts` — 227 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI change
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5

## Screenshots / test output

```
 Test Files  2 passed (2)
      Tests  8 passed (8)   # site-url.test.ts + setup-site-url-lock.test.ts

 Test Files  10 passed (10)
      Tests  219 passed (219)  # integration/auth, integration/comments, email-pipeline
```

On main, the new precedence test fails with:

```
AssertionError: expected 'https://my-site.workers.dev/_emdash' to be 'https://real.example/_emdash'
```