### PR TITLE
docs: correct the auto-selection note for the Cloudflare email provider

### DIFF
--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -330,9 +330,12 @@ the provider under **Settings → Email**.
 | `binding` | `string`                     | `"EMAIL"`    | Name of the `send_email` binding in `wrangler.jsonc`.                 |
 
 <Aside type="note">
-	BCC and attachments are out of scope (not modeled in EmDash's `EmailMessage`),
-	and the provider is never auto-selected — you must choose it under Settings →
-	Email.
+	BCC and attachments are out of scope (not modeled in EmDash's `EmailMessage`).
+	After you activate the plugin under **Admin → Extensions**, EmDash selects it
+	automatically if it is the only active email provider; with more than one,
+	choose the one you want under **Settings → Email**. Under `astro dev` the
+	built-in console provider counts as a second provider, so in dev you always
+	pick there.
 </Aside>
 
 ## Environment Variables


### PR DESCRIPTION
## What does this PR do?

The Cloudflare deployment guide states about `cloudflareEmail()`:

> the provider is never auto-selected — you must choose it under Settings → Email.

That does not match the runtime. `resolveExclusiveHooks` (`packages/core/src/plugins/hooks.ts`) auto-selects any exclusive-hook provider that is the sole active one — on plugin activation and on runtime init — and `createPlugin()` in `packages/cloudflare/src/plugins/cloudflare-email.ts` registers a plain `exclusive: true` hook with no opt-out, so it takes the generic route. The behavior is already asserted by the existing tests (`tests/unit/plugins/exclusive-hooks.test.ts` → "auto-selects single active provider"; `packages/cloudflare/tests/plugins-cloudflare-email.test.ts` → "returns a resolved plugin with an exclusive email:deliver hook").

On a stock Workers deployment this is the common case, not a corner: the built-in dev console provider is `import.meta.env.DEV`-gated (`emdash-runtime.ts`), so in production a single configured mail plugin is the *only* provider and gets selected without any visit to Settings → Email — which matches what we observe on a production site. The "you must choose" experience comes from `astro dev`, where the console stub is a second provider. As written, the note makes operators either conclude mail isn't wired up when it already is, or trust that an unselected provider cannot send when it can.

This PR rewrites the note to describe the actual behavior, including the dev/prod difference. Docs only — the auto-selection itself is consistent with every other exclusive hook and worth keeping.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a, docs-only change
- [ ] `pnpm lint` passes — n/a, docs-only change
- [ ] `pnpm test` passes — n/a, docs-only change; the behavior described is covered by existing tests named above
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes — n/a
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a
- [ ] I have added a changeset — n/a, no published package changed
- [ ] New features link to an approved Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5

## Screenshots / test output

n/a