### PR TITLE
chore(flue-review): enable Workers trace collection

### DIFF
--- a/infra/flue-review/wrangler.jsonc
+++ b/infra/flue-review/wrangler.jsonc
@@ -114,5 +114,10 @@
 	},
 	"observability": {
 		"enabled": true,
+		// Workers runtime spans only until the app is on Flue 2, which is the
+		// floor for automatic agent-turn/model/tool trace emission.
+		"traces": {
+			"enabled": true,
+		},
 	},
 }


### PR DESCRIPTION
## What does this PR do?

Enables Workers trace collection on the `emdash-flue-review` worker (`observability.traces.enabled` in its wrangler config), per Cloudflare's agent-tracing launch ([changelog 2026-08-04](https://developers.cloudflare.com/changelog/post/2026-08-04-agent-tracing/)).

What this buys immediately: full runtime waterfalls for every review run — webhook handling, workflow-DO admission, AI-binding calls, GitHub fetches, R2/DO operations — visible in Workers Observability with session-level replay in the Agents dashboard view. The July `FLueError` incident died undiagnosed because run logs were unrecoverable after the fact; traces make that class of failure inspectable.

Scope note: automatic *agent-level* spans (turns, model calls, tool runs) require Flue 2 — this app is on `@flue/runtime` 1.0.0-beta.9, which predates that. Runtime spans still cover the orchestration path end to end. Agent-turn tracing lands whenever flue-review moves to Flue 2, with no further wrangler changes needed (Flue 2 records payloads by default; that upgrade should set `createCloudflareTracing({ content: false })` or confirm PR content is acceptable to store — noted here so it isn't missed later).

No sampling rate is set: the worker's traffic is PR-webhook volume, far under the free tier (200k events/day; tracing is free in beta and folds into Workers Observability pricing from 2026-10-01).

Closes #

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — n/a, config-only change to an infra worker
- [x] `pnpm lint` passes — n/a, config-only
- [x] `pnpm test` passes — n/a, config-only
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes — n/a, config-only
- [x] User-visible strings in the admin UI are wrapped for translation — n/a
- [x] I have added a changeset — n/a, `infra/flue-review` is not a published package
- [x] New features link to an approved Discussion — n/a, chore

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

n/a — verification is post-deploy: traces appear under Workers Observability / the Agents tab for `emdash-flue-review` on the next review run.
