### PR TITLE
feat(emdash-bot): reporter-verified pkg.pr.new fix loop (bot next-gen 4/5)

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -55,12 +55,19 @@ const initialDataSchema = v.object({
 	previousBranchSha: v.nullable(v.string()),
 });
 
+const screenshotSchema = v.object({
+	filename: v.pipe(v.string(), v.minLength(1), v.maxLength(80)),
+	description: v.optional(v.string()),
+});
+
 const resultSchema = v.object({
 	skipped: v.optional(v.boolean()),
 	reproduced: v.optional(v.boolean()),
 	fixed: v.optional(v.boolean()),
 	verdict: v.optional(v.picklist(["bug", "intended-behavior", "unclear"])),
 	summary: v.pipe(v.string(), v.minLength(10), v.maxLength(400)),
+	/** Reproduction screenshots pushed to bot/artifacts-<n>, rendered in the ask comment. */
+	screenshots: v.optional(v.array(screenshotSchema)),
 });
 
 const reportedResultSchema = v.object({
@@ -437,6 +444,7 @@ function buildPrompt(input: InvestigateData): string {
 				"- Write tests where they make sense.",
 				"- Touch only files relevant to the issue. Do not bulk-format or modify .github/workflows.",
 				`- When done, commit and push from a container: \`exec\` with target container running \`git checkout -B bot/fix-${input.issueNumber} && git add <files> && git commit -m '<message>' && git push -u origin HEAD --force-with-lease\`.`,
+				`- If you captured reproduction screenshots in \`.bot-artifacts/\`, keep them off the fix branch (\`git reset HEAD .bot-artifacts\` before committing) and push them to an orphan artifacts branch from a scratch tree: copy \`.bot-artifacts\` aside, \`git init -b bot/artifacts-${input.issueNumber}\`, add and commit only \`.bot-artifacts\`, then \`git push -u origin HEAD --force\`. Report each screenshot's basename and a one-line description in \`screenshots\`.`,
 			];
 	const closing = diagnose
 		? "Call report_result exactly once when finished. Do not set fixed; report reproduced and your verdict with the diagnosis in summary."

--- a/infra/emdash-bot/.flue/lib/comments.ts
+++ b/infra/emdash-bot/.flue/lib/comments.ts
@@ -1,4 +1,5 @@
 import type { StateId } from "./machine.js";
+import { artifactsBranch, fixBranch, previewInstallCommand } from "./preview.js";
 import type { Decision } from "./router.js";
 
 export function shouldPostReadonlyReply(dryRun?: boolean): boolean {
@@ -93,4 +94,95 @@ export function renderAgentComment(
 		default:
 			return summary;
 	}
+}
+
+/** A reproduction screenshot the fix agent pushed to the artifacts branch. */
+export interface PreviewScreenshot {
+	filename: string;
+	description?: string;
+}
+
+// Defense in depth on the agent's structured output: only render screenshots
+// whose filename is a plain basename (no path traversal, no URL injection), and
+// escape the markdown metacharacters in the alt text so a description can't
+// break out of the image span.
+const SCREENSHOT_FILENAME_RE = /^[a-zA-Z0-9._-]{1,80}$/;
+const MD_ESCAPE_RE = /([\\[\]()])/g;
+
+function mdEscape(text: string): string {
+	return text.replace(MD_ESCAPE_RE, "\\$1");
+}
+
+/**
+ * Compose the ask comment posted when a candidate fix's preview has published.
+ * The reporter verifies the change against their own site via the pkg.pr.new
+ * install command, then replies to confirm or reject.
+ *
+ * Shape mirrors the gen-1 ask: a hidden `bot-ask` marker (the reply-staleness
+ * anchor), the investigation notes, the full-ref install command, the
+ * reproduction screenshots served from the artifacts branch, and the reporter
+ * ask. Unlike gen-1 there is no "the preview may 404, retry" caveat -- the DO
+ * polled pkg.pr.new to a 200 before posting this, so the URL already resolves.
+ */
+export function renderPreviewReadyAsk(input: {
+	owner: string;
+	repo: string;
+	issueNumber: number;
+	at: string;
+	notes?: string | null;
+	screenshots?: readonly PreviewScreenshot[];
+	reporterLogin?: string | null;
+}): string {
+	const shots = (input.screenshots ?? [])
+		.filter((shot) => SCREENSHOT_FILENAME_RE.test(shot.filename))
+		.map(
+			(shot) =>
+				`![${mdEscape(shot.description ?? shot.filename)}](https://raw.githubusercontent.com/${input.owner}/${input.repo}/${artifactsBranch(input.issueNumber)}/.bot-artifacts/${shot.filename})`,
+		);
+	const reporterAsk = input.reporterLogin
+		? `@${input.reporterLogin} could you try this and reply here with whether it resolves the issue? A simple "yes, fixed" or "no, still broken" is enough.`
+		: "Could the reporter please try this and reply with whether it resolves the issue?";
+	return [
+		`<!-- bot-ask: ${input.at} -->`,
+		"The investigation reproduced this issue and pushed a candidate fix.",
+		"",
+		input.notes?.trim() ?? "",
+		"",
+		"Try the fix against your own site:",
+		"",
+		"```bash",
+		previewInstallCommand(input.issueNumber),
+		"```",
+		"",
+		...(shots.length > 0 ? ["**Screenshots:**", "", shots.join("\n\n"), ""] : []),
+		reporterAsk,
+		"",
+		"<sub>Maintainers can act on the reporter's behalf: `@emdashbot confirm` to accept the fix and open a draft PR, or `@emdashbot reject` (with details) to reap the branch and revise.</sub>",
+		"",
+		`Fix branch: \`${fixBranch(input.issueNumber)}\` · Artifacts branch: \`${artifactsBranch(input.issueNumber)}\``,
+	]
+		.filter((line, index, lines) => !(line === "" && lines[index - 1] === ""))
+		.join("\n");
+}
+
+/**
+ * Body for the draft PR opened when the reporter confirms the fix. References
+ * the issue (so merging closes it), points at the preview the reporter just
+ * verified, and flags that a maintainer must review before merge. The fix run
+ * left a regression test on the branch; the reviewer confirms it on the diff.
+ */
+export function renderDraftPrBody(issueNumber: number): string {
+	return [
+		`Closes #${issueNumber}.`,
+		"",
+		"A candidate fix the reporter confirmed against their own site via the preview build:",
+		"",
+		"```bash",
+		previewInstallCommand(issueNumber),
+		"```",
+		"",
+		"The fix run left a regression test on the branch -- confirm it covers the reported case on review.",
+		"",
+		"<sub>Opened automatically by emdashbot as a draft. A maintainer must review before merge.</sub>",
+	].join("\n");
 }

--- a/infra/emdash-bot/.flue/lib/github-proxy.ts
+++ b/infra/emdash-bot/.flue/lib/github-proxy.ts
@@ -163,8 +163,11 @@ async function hasOnlyBotBranchUpdates(request: Request, issueNumber: number): P
 				if (!PKT_LINE_HEADER.test(header)) return false;
 				const length = Number.parseInt(header, 16);
 				if (length === 0) {
-					const expected = `refs/heads/bot/fix-${issueNumber}`;
-					return refs.length > 0 && refs.every((ref) => ref === expected);
+					const allowed = new Set([
+						`refs/heads/bot/fix-${issueNumber}`,
+						`refs/heads/bot/artifacts-${issueNumber}`,
+					]);
+					return refs.length > 0 && refs.every((ref) => allowed.has(ref));
 				}
 				if (length < 4 || length > MAX_RECEIVE_PACK_COMMAND_BYTES) return false;
 				if (buffer.length - offset < length) break;

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -9,7 +9,14 @@ import { DurableObject } from "cloudflare:workers";
 
 import { Investigate } from "../agents/investigate.js";
 import { classifyComment, type ClassifyResult } from "./classifier-client.js";
-import { renderAgentComment, renderReadonlyReply, shouldPostReadonlyReply } from "./comments.js";
+import {
+	type PreviewScreenshot,
+	renderAgentComment,
+	renderDraftPrBody,
+	renderPreviewReadyAsk,
+	renderReadonlyReply,
+	shouldPostReadonlyReply,
+} from "./comments.js";
 import {
 	addLabels,
 	closePullRequest,
@@ -25,8 +32,10 @@ import {
 	readAppCreds,
 	readRepoContext,
 	removeLabels,
+	type RepoContext,
 } from "./github.js";
 import { STATES, type EventId, type Kind, type StateId } from "./machine.js";
+import { branchesToReap, previewUrl, probePreviewReady } from "./preview.js";
 import {
 	currentState,
 	type Decision,
@@ -97,6 +106,20 @@ export interface NormalizedEvent {
 	readonly dryRun?: boolean;
 	/** Agent's structured summary, surfaced in the post-run comment. */
 	readonly agentSummary?: string;
+	/** Reproduction screenshots the fix run pushed, carried into the ask comment. */
+	readonly agentScreenshots?: readonly PreviewScreenshot[];
+	/**
+	 * Precomposed comment body that replaces the default `renderComment` output
+	 * for this transition. Used for the preview-ready ask, whose body needs data
+	 * (install URL, screenshots, reporter login) the generic renderer lacks.
+	 */
+	readonly commentBodyOverride?: string;
+	/**
+	 * Post the comment BEFORE flipping labels for this transition. The fix-loop
+	 * ask must land first: a failed comment post must not leave the issue labeled
+	 * awaiting-reporter with no ask for the reporter to act on.
+	 */
+	readonly commentFirst?: boolean;
 	/** Internal callback metadata: this event's projection completes the run. */
 	readonly settlesRunId?: string;
 }
@@ -110,6 +133,7 @@ export interface AgentResult {
 	readonly reproduced?: boolean;
 	readonly fixed?: boolean;
 	readonly verdict?: string;
+	readonly screenshots?: readonly PreviewScreenshot[];
 	readonly [key: string]: unknown;
 }
 
@@ -170,12 +194,22 @@ const STORAGE = {
 	pendingDispatch: "o:pendingDispatch",
 	pendingSideEffects: "o:pendingSideEffects",
 	awaitingReporterSince: "o:awaitingReporterSince",
+	previewBuildDeadline: "o:previewBuildDeadline",
+	previewPollNextAt: "o:previewPollNextAt",
+	previewNotes: "o:previewNotes",
+	previewScreenshots: "o:previewScreenshots",
 } as const;
 
 const TICK_INTERVAL_MS = 60 * 60 * 1000;
 /** Reporter-confirmation window for the fix loop. After this, the alarm fires
  * `expire`, which reaps the candidate branch and falls back to `reproduced`. */
 const REPORTER_SILENCE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+/** Overall budget for a candidate preview to publish on pkg.pr.new before we
+ * give up and fire `preview.failed`. Publishing normally lands within ~60s. */
+const PREVIEW_BUILD_TIMEOUT_MS = 10 * 60 * 1000;
+/** First poll waits for the push→publish lag; later polls back off to this. */
+const PREVIEW_POLL_INITIAL_MS = 45 * 1000;
+const PREVIEW_POLL_INTERVAL_MS = 30 * 1000;
 const STALE_RUN_THRESHOLD_MS = 30 * 60 * 1000;
 const DISPATCH_TIMEOUT_MS = 30_000;
 const INBOX_RETRY_MS = 60_000;
@@ -215,6 +249,8 @@ interface PendingSideEffect {
 	readonly commentBody: string;
 	readonly commentMarker: string;
 	readonly commentMayExist: boolean;
+	/** Post the comment before flipping labels (fix-loop ask ordering). */
+	readonly commentFirst?: boolean;
 }
 
 /** Bounded delivery-id dedupe window. */
@@ -403,6 +439,9 @@ export class OrchestratorDO extends DurableObject<Env> {
 		const labels = await this.projectLabels();
 		const agentSummary =
 			typeof input.result?.summary === "string" ? input.result.summary : undefined;
+		const agentScreenshots = Array.isArray(input.result?.screenshots)
+			? input.result.screenshots
+			: undefined;
 		const outcome = await this.processEvent({
 			event,
 			arg: null,
@@ -411,9 +450,30 @@ export class OrchestratorDO extends DurableObject<Env> {
 			needsClassify: false,
 			settlesRunId: input.runId,
 			...(agentSummary ? { agentSummary } : {}),
+			...(agentScreenshots ? { agentScreenshots } : {}),
 		});
 		await this.clearRun(input.runId);
 		return outcome;
+	}
+
+	/**
+	 * Reap the fix loop's branches when the anchoring issue closes. Mirrors
+	 * bot-cleanup.yml's close path: always delete bot/artifacts-<n>, delete
+	 * bot/fix-<n> only when no open PR references it. Does not touch machine
+	 * state -- a closed issue may legitimately keep its in_review/PR state, and
+	 * the branches are a projection we clean up regardless.
+	 */
+	cleanupOnClose(anchorNumber: number): Promise<CleanupOutcome> {
+		return this.runExclusive(() => this.processCleanupOnClose(anchorNumber));
+	}
+
+	private async processCleanupOnClose(anchorNumber: number): Promise<CleanupOutcome> {
+		await this.ctx.storage.put(STORAGE.anchorNumber, anchorNumber);
+		const creds = readAppCreds(this.env);
+		const repo = readRepoContext(this.env);
+		if (!creds || !repo) return { kind: "skipped", reason: "credentials or repository missing" };
+		const error = await this.runReapBranch(creds, repo, anchorNumber);
+		return error ? { kind: "error", error } : { kind: "reaped" };
 	}
 
 	/**
@@ -460,6 +520,14 @@ export class OrchestratorDO extends DurableObject<Env> {
 			recoveryError ??= message;
 			console.error("[orchestrator] reporter-wait expiry failed", { error: message });
 		}
+		let previewPoll: PreviewPollOutcome = "idle";
+		try {
+			previewPoll = await this.pollPreviewBuild(now);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			recoveryError ??= message;
+			console.error("[orchestrator] preview poll failed", { error: message });
+		}
 		const labelDrift = await this.reconcileLabels();
 
 		return {
@@ -470,7 +538,99 @@ export class OrchestratorDO extends DurableObject<Env> {
 			recoveryError,
 			labelDrift,
 			expiredReporterWait,
+			previewPoll,
 		};
+	}
+
+	/**
+	 * Poll pkg.pr.new for the candidate fix's preview while the item sits in
+	 * `preview_building`. One probe per alarm tick (the alarm cadence IS the
+	 * poll interval -- no unbounded loop in the DO). A 200 fires `preview.ready`
+	 * and advances to the reporter ask; exhausting the overall budget fires
+	 * `preview.failed`, which retains the branch and falls back to the diagnosis.
+	 */
+	private async pollPreviewBuild(now: number): Promise<PreviewPollOutcome> {
+		const [state, deadline, nextAt] = await Promise.all([
+			this.ctx.storage.get<StateId>(STORAGE.state),
+			this.ctx.storage.get<number>(STORAGE.previewBuildDeadline),
+			this.ctx.storage.get<number>(STORAGE.previewPollNextAt),
+		]);
+		if (state !== "preview_building" || deadline === undefined) return "idle";
+		if (nextAt !== undefined && now < nextAt) return "waiting";
+		const anchorNumber = await this.ctx.storage.get<number>(STORAGE.anchorNumber);
+		if (anchorNumber === undefined) return "idle";
+
+		const ready = await probePreviewReady(previewUrl(anchorNumber));
+		if (ready) {
+			await this.firePreviewReady(anchorNumber);
+			return "ready";
+		}
+		if (now >= deadline) {
+			await this.firePreviewEvent(anchorNumber, "preview.failed");
+			return "failed";
+		}
+		await this.ctx.storage.put(STORAGE.previewPollNextAt, now + PREVIEW_POLL_INTERVAL_MS);
+		return "polling";
+	}
+
+	/**
+	 * Fire `preview.ready`, composing the ask comment first so it can post ahead
+	 * of the label flip. Composition needs the persisted fix notes/screenshots
+	 * and the reporter's login; without live creds (dev/tests) we still advance
+	 * the state, just without a comment.
+	 */
+	private async firePreviewReady(anchorNumber: number): Promise<void> {
+		const labels = await this.projectLabels();
+		const creds = readAppCreds(this.env);
+		const repo = readRepoContext(this.env);
+		let override: string | undefined;
+		if (creds && repo) {
+			const [notes, screenshots] = await Promise.all([
+				this.ctx.storage.get<string>(STORAGE.previewNotes),
+				this.ctx.storage.get<PreviewScreenshot[]>(STORAGE.previewScreenshots),
+			]);
+			let reporterLogin: string | null = null;
+			try {
+				const token = await this.getInstallationToken(creds);
+				reporterLogin = (await getIssue(token, repo, anchorNumber)).authorLogin;
+			} catch (err) {
+				console.error("[orchestrator] preview ask: reporter lookup failed", err);
+			}
+			override = renderPreviewReadyAsk({
+				owner: repo.owner,
+				repo: repo.repo,
+				issueNumber: anchorNumber,
+				at: new Date().toISOString(),
+				notes,
+				...(screenshots ? { screenshots } : {}),
+				reporterLogin,
+			});
+		}
+		await this.processEvent({
+			event: "preview.ready",
+			arg: null,
+			actor: "system",
+			labels,
+			needsClassify: false,
+			...(override ? { commentBodyOverride: override, commentFirst: true } : {}),
+		});
+	}
+
+	private async firePreviewEvent(anchorNumber: number, event: EventId): Promise<void> {
+		const labels = await this.projectLabels();
+		const commentBodyOverride =
+			event === "preview.failed"
+				? `The preview build for the candidate fix didn't publish within ${Math.round(PREVIEW_BUILD_TIMEOUT_MS / 60_000)} minutes. The diagnosis still holds -- a maintainer can \`@emdashbot fix\` to rebuild the candidate.`
+				: undefined;
+		await this.processEvent({
+			event,
+			arg: null,
+			actor: "system",
+			labels,
+			needsClassify: false,
+			anchorNumber,
+			...(commentBodyOverride ? { commentBodyOverride } : {}),
+		});
 	}
 
 	/**
@@ -554,19 +714,23 @@ export class OrchestratorDO extends DurableObject<Env> {
 	}
 
 	private async armAlarm(): Promise<void> {
-		const [current, runStartedAt, inbox, pendingSideEffects] = await Promise.all([
+		const [current, runStartedAt, inbox, pendingSideEffects, previewPollNextAt] = await Promise.all([
 			this.ctx.storage.getAlarm(),
 			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
 			this.ctx.storage.get<InboxEntry[]>(STORAGE.inbox),
 			this.ctx.storage.get<PendingSideEffect[]>(STORAGE.pendingSideEffects),
+			this.ctx.storage.get<number>(STORAGE.previewPollNextAt),
 		]);
 		const now = Date.now();
-		const desired =
+		let desired =
 			inbox?.length || pendingSideEffects?.length
 				? now + INBOX_RETRY_MS
 				: runStartedAt
 					? Math.max(now + 1_000, runStartedAt + STALE_RUN_THRESHOLD_MS)
 					: now + TICK_INTERVAL_MS;
+		if (previewPollNextAt !== undefined) {
+			desired = Math.min(desired, Math.max(now + 1_000, previewPollNextAt));
+		}
 		if (current === null || current <= now || current > desired) {
 			await this.ctx.storage.setAlarm(desired);
 		}
@@ -968,7 +1132,9 @@ export class OrchestratorDO extends DurableObject<Env> {
 					headBranch,
 					baseBranch: "main",
 					title: `Fix #${anchorNumber}`,
-					body: `Fixes #${anchorNumber}.\n\nAutomated PR opened by emdashbot.`,
+					body: draft
+						? renderDraftPrBody(anchorNumber)
+						: `Fixes #${anchorNumber}.\n\nAutomated PR opened by emdashbot.`,
 					draft,
 				}));
 			await this.ctx.storage.put(STORAGE.prNumber, created.number);
@@ -978,6 +1144,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 		}
 	}
 
+	/**
+	 * Reap the fix loop's bot branches. The artifacts branch is always deleted;
+	 * the fix branch is spared when an open PR references it (deleting the ref
+	 * would silently close that PR). Shared by the reject/expire/decline reap
+	 * edges and the issue-close cleanup path.
+	 */
 	private async runReapBranch(
 		creds: Parameters<typeof mintInstallationToken>[0],
 		repo: Parameters<typeof deleteBranch>[1],
@@ -985,7 +1157,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 	): Promise<string | null> {
 		try {
 			const token = await this.getInstallationToken(creds);
-			await deleteBranch(token, repo, `bot/fix-${anchorNumber}`);
+			const openPr = await getOpenPullRequest(token, repo, `bot/fix-${anchorNumber}`);
+			for (const branch of branchesToReap(anchorNumber, openPr !== null)) {
+				await deleteBranch(token, repo, branch);
+			}
 			return null;
 		} catch (err) {
 			return `reapBranch failed: ${errorMessage(err)}`;
@@ -1038,7 +1213,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 	// ---------------- Side effects (GitHub) ----------------
 
 	private async flushPendingSideEffect(id: string): Promise<void> {
-		let pending = (
+		const pending = (
 			(await this.ctx.storage.get<PendingSideEffect[]>(STORAGE.pendingSideEffects)) ?? []
 		).find((effect) => effect.id === id);
 		if (!pending) return;
@@ -1053,33 +1228,58 @@ export class OrchestratorDO extends DurableObject<Env> {
 		}
 
 		const token = await this.getInstallationToken(creds);
-		await addLabels(token, repo, pending.anchorNumber, pending.addLabels);
-		await removeLabels(token, repo, pending.anchorNumber, pending.removeLabels);
-
-		if (pending.commentBody) {
-			let exists = false;
-			if (pending.commentMayExist) {
-				exists = await hasIssueCommentMarker(
-					token,
-					repo,
-					pending.anchorNumber,
-					pending.commentMarker,
-				);
-			} else {
-				await this.markCommentMayExist(pending.id);
-				pending = { ...pending, commentMayExist: true };
-			}
-			if (!exists) {
-				await postIssueComment(
-					token,
-					repo,
-					pending.anchorNumber,
-					`${pending.commentBody}\n\n${pending.commentMarker}`,
-				);
-			}
+		let current: PendingSideEffect = pending;
+		const applyLabels = () => this.applySideEffectLabels(token, repo, current);
+		const postComment = async () => {
+			current = await this.postSideEffectComment(token, repo, current);
+		};
+		// The fix-loop ask posts first: if it fails, the labels stay put so the
+		// item never advertises awaiting-reporter without an ask on the thread.
+		if (current.commentFirst) {
+			await postComment();
+			await applyLabels();
+		} else {
+			await applyLabels();
+			await postComment();
 		}
 
-		await this.completePendingSideEffect(pending);
+		await this.completePendingSideEffect(current);
+	}
+
+	private async applySideEffectLabels(
+		token: string,
+		repo: RepoContext,
+		pending: PendingSideEffect,
+	): Promise<void> {
+		await addLabels(token, repo, pending.anchorNumber, pending.addLabels);
+		await removeLabels(token, repo, pending.anchorNumber, pending.removeLabels);
+	}
+
+	/** Post the effect's comment at-most-once, returning the effect with the
+	 * marker-may-exist flag persisted so a retry doesn't double-post. */
+	private async postSideEffectComment(
+		token: string,
+		repo: RepoContext,
+		pending: PendingSideEffect,
+	): Promise<PendingSideEffect> {
+		if (!pending.commentBody) return pending;
+		let exists = false;
+		let updated = pending;
+		if (pending.commentMayExist) {
+			exists = await hasIssueCommentMarker(token, repo, pending.anchorNumber, pending.commentMarker);
+		} else {
+			await this.markCommentMayExist(pending.id);
+			updated = { ...pending, commentMayExist: true };
+		}
+		if (!exists) {
+			await postIssueComment(
+				token,
+				repo,
+				pending.anchorNumber,
+				`${pending.commentBody}\n\n${pending.commentMarker}`,
+			);
+		}
+		return updated;
 	}
 
 	private async getInstallationToken(creds: Parameters<typeof mintInstallationToken>[0]) {
@@ -1119,6 +1319,24 @@ export class OrchestratorDO extends DurableObject<Env> {
 					? transaction.put(STORAGE.awaitingReporterSince, Date.now())
 					: transaction.delete(STORAGE.awaitingReporterSince),
 			];
+			if (decision.to === "preview_building") {
+				const startedAt = Date.now();
+				puts.push(
+					transaction.put(STORAGE.previewBuildDeadline, startedAt + PREVIEW_BUILD_TIMEOUT_MS),
+					transaction.put(STORAGE.previewPollNextAt, startedAt + PREVIEW_POLL_INITIAL_MS),
+					transaction.put(STORAGE.previewNotes, input.agentSummary ?? ""),
+					input.agentScreenshots?.length
+						? transaction.put(STORAGE.previewScreenshots, input.agentScreenshots)
+						: transaction.delete(STORAGE.previewScreenshots),
+				);
+			} else {
+				puts.push(
+					transaction.delete(STORAGE.previewBuildDeadline),
+					transaction.delete(STORAGE.previewPollNextAt),
+					transaction.delete(STORAGE.previewNotes),
+					transaction.delete(STORAGE.previewScreenshots),
+				);
+			}
 			const kindLabel = decision.addLabels.find(
 				(label) => label.startsWith("bot:") && label !== decision.addLabel,
 			);
@@ -1155,9 +1373,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 							anchorNumber,
 							addLabels: decision.addLabels,
 							removeLabels: decision.removeLabels,
-							commentBody: renderComment(decision, anchorNumber, input.agentSummary),
+							commentBody:
+								input.commentBodyOverride ??
+								renderComment(decision, anchorNumber, input.agentSummary),
 							commentMarker: `<!-- emdashbot-event:${sideEffectId} -->`,
 							commentMayExist: false,
+							...(input.commentFirst ? { commentFirst: true } : {}),
 						} satisfies PendingSideEffect,
 					]),
 				);
@@ -1246,7 +1467,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 			]);
 			const effect = effects?.[0];
 			if (!effect) return settledRuns;
-			if (!effect.settlesRun && effect.runId === pendingDispatch?.runId) return settledRuns;
+			// Defer only a launch effect belonging to the still-pending dispatch.
+			// A standalone effect (runId undefined) must not be held back -- and
+			// `undefined === pendingDispatch?.runId` when no dispatch is pending
+			// would otherwise wedge it here forever.
+			if (!effect.settlesRun && effect.runId !== undefined && effect.runId === pendingDispatch?.runId)
+				return settledRuns;
 
 			await this.flushPendingSideEffect(effect.id);
 			if (effect.settlesRun && effect.runId) settledRuns.add(effect.runId);
@@ -1439,6 +1665,32 @@ export class OrchestratorDO extends DurableObject<Env> {
 		await this.ctx.storage.put(STORAGE.awaitingReporterSince, since);
 	}
 
+	/** Test-only: force the preview-poll schedule so a tick probes immediately. */
+	async debugSetPreviewPoll(deadline: number, nextAt: number): Promise<void> {
+		await Promise.all([
+			this.ctx.storage.put(STORAGE.previewBuildDeadline, deadline),
+			this.ctx.storage.put(STORAGE.previewPollNextAt, nextAt),
+		]);
+	}
+
+	/** Test-only: seed the installation-token cache so side effects skip the JWT
+	 * mint (which needs a real private key) and go straight to the fake GitHub. */
+	async debugSetTokenCache(token: string, expiresAt: number): Promise<void> {
+		await this.ctx.storage.put<CachedToken>(STORAGE.tokenCache, { token, expiresAt });
+	}
+
+	/** Test-only: land directly in `preview_building` with the ask's persisted
+	 * inputs, so the preview-poll path can be exercised without dispatching the
+	 * (runtime-less in tests) investigate agent through fixing. */
+	async debugPrimePreviewBuilding(anchorNumber: number, notes: string): Promise<void> {
+		await Promise.all([
+			this.ctx.storage.put(STORAGE.state, "preview_building" satisfies StateId),
+			this.ctx.storage.put(STORAGE.kind, "bug" satisfies Kind),
+			this.ctx.storage.put(STORAGE.anchorNumber, anchorNumber),
+			this.ctx.storage.put(STORAGE.previewNotes, notes),
+		]);
+	}
+
 	/** Test-only: inject dispatch recovery state without invoking Flue. */
 	async debugSetPendingDispatch(input: {
 		runId: string;
@@ -1492,6 +1744,10 @@ export type EnqueueOutcome =
 	| { kind: "admitted"; id: string }
 	| { kind: "duplicate"; deliveryId: string };
 
+/** One preview poll's outcome: idle (not building), waiting (before next poll),
+ * polling (probed, not yet published), ready, or failed (budget exhausted). */
+export type PreviewPollOutcome = "idle" | "waiting" | "polling" | "ready" | "failed";
+
 export interface TickOutcome {
 	ranAt: number;
 	processedInboxItem: boolean;
@@ -1500,7 +1756,13 @@ export interface TickOutcome {
 	recoveryError: string | null;
 	labelDrift: { added: number; removed: number } | null;
 	expiredReporterWait: boolean;
+	previewPoll: PreviewPollOutcome;
 }
+
+export type CleanupOutcome =
+	| { kind: "reaped" }
+	| { kind: "skipped"; reason: string }
+	| { kind: "error"; error: string };
 
 class ClassifierProcessingError extends Error {
 	constructor(reason: string) {

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -714,13 +714,15 @@ export class OrchestratorDO extends DurableObject<Env> {
 	}
 
 	private async armAlarm(): Promise<void> {
-		const [current, runStartedAt, inbox, pendingSideEffects, previewPollNextAt] = await Promise.all([
-			this.ctx.storage.getAlarm(),
-			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
-			this.ctx.storage.get<InboxEntry[]>(STORAGE.inbox),
-			this.ctx.storage.get<PendingSideEffect[]>(STORAGE.pendingSideEffects),
-			this.ctx.storage.get<number>(STORAGE.previewPollNextAt),
-		]);
+		const [current, runStartedAt, inbox, pendingSideEffects, previewPollNextAt] = await Promise.all(
+			[
+				this.ctx.storage.getAlarm(),
+				this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
+				this.ctx.storage.get<InboxEntry[]>(STORAGE.inbox),
+				this.ctx.storage.get<PendingSideEffect[]>(STORAGE.pendingSideEffects),
+				this.ctx.storage.get<number>(STORAGE.previewPollNextAt),
+			],
+		);
 		const now = Date.now();
 		let desired =
 			inbox?.length || pendingSideEffects?.length
@@ -1266,7 +1268,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 		let exists = false;
 		let updated = pending;
 		if (pending.commentMayExist) {
-			exists = await hasIssueCommentMarker(token, repo, pending.anchorNumber, pending.commentMarker);
+			exists = await hasIssueCommentMarker(
+				token,
+				repo,
+				pending.anchorNumber,
+				pending.commentMarker,
+			);
 		} else {
 			await this.markCommentMayExist(pending.id);
 			updated = { ...pending, commentMayExist: true };
@@ -1471,7 +1478,11 @@ export class OrchestratorDO extends DurableObject<Env> {
 			// A standalone effect (runId undefined) must not be held back -- and
 			// `undefined === pendingDispatch?.runId` when no dispatch is pending
 			// would otherwise wedge it here forever.
-			if (!effect.settlesRun && effect.runId !== undefined && effect.runId === pendingDispatch?.runId)
+			if (
+				!effect.settlesRun &&
+				effect.runId !== undefined &&
+				effect.runId === pendingDispatch?.runId
+			)
 				return settledRuns;
 
 			await this.flushPendingSideEffect(effect.id);

--- a/infra/emdash-bot/.flue/lib/preview.ts
+++ b/infra/emdash-bot/.flue/lib/preview.ts
@@ -1,0 +1,70 @@
+// pkg.pr.new preview helpers for the fix loop.
+//
+// The worker never publishes to pkg.pr.new -- that authenticates via the
+// pkg-pr-new GitHub App + Actions OIDC and can only run inside GitHub Actions.
+// The worker's job is to push `bot/fix-<n>`; `preview-releases.yml` (unchanged)
+// publishes the preview on that push. What lives here is the reader half: the
+// canonical install URL and a bounded readiness probe the DO alarm polls so the
+// ask comment only advertises a preview that has actually resolved.
+
+const PREVIEW_PROBE_TIMEOUT_MS = 10_000;
+
+/** The fix branch pkg.pr.new keys the preview to. */
+export function fixBranch(issueNumber: number): string {
+	return `bot/fix-${issueNumber}`;
+}
+
+/** The orphan branch holding this issue's reproduction screenshots. */
+export function artifactsBranch(issueNumber: number): string {
+	return `bot/artifacts-${issueNumber}`;
+}
+
+/**
+ * The bot branches to delete when reaping an issue's fix loop. The artifacts
+ * branch is always safe -- it is never a PR head. The fix branch is spared when
+ * an open PR references it: deleting the ref would silently close that PR and
+ * lose the bot's work with no recovery (a maintainer may have closed the issue
+ * while the bot PR was still open). Mirrors bot-cleanup.yml's close guard.
+ */
+export function branchesToReap(issueNumber: number, hasOpenFixPr: boolean): string[] {
+	return hasOpenFixPr
+		? [artifactsBranch(issueNumber)]
+		: [fixBranch(issueNumber), artifactsBranch(issueNumber)];
+}
+
+/**
+ * The pkg.pr.new install URL. pkg.pr.new resolves branches by the FULL ref, so
+ * the `bot/fix-<n>` prefix stays verbatim -- stripping `bot/` produces a URL
+ * that 404s. This same URL is what the readiness probe polls and what the ask
+ * comment advertises, so there is one source of truth.
+ */
+export function previewUrl(issueNumber: number): string {
+	return `https://pkg.pr.new/emdash@${fixBranch(issueNumber)}`;
+}
+
+/** The one-line install command posted in the ask comment. */
+export function previewInstallCommand(issueNumber: number): string {
+	return `npm i ${previewUrl(issueNumber)}`;
+}
+
+/**
+ * Probe pkg.pr.new for a published preview. Returns true on a 2xx, false on
+ * anything else (a 404 while publishing is still in flight, a network error, or
+ * the probe timing out). Never throws: the caller treats false as "not yet" and
+ * retries on the next poll until its overall deadline.
+ */
+export async function probePreviewReady(
+	url: string,
+	fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+	try {
+		const res = await fetchImpl(url, {
+			method: "GET",
+			redirect: "follow",
+			signal: AbortSignal.timeout(PREVIEW_PROBE_TIMEOUT_MS),
+		});
+		return res.ok;
+	} catch {
+		return false;
+	}
+}

--- a/infra/emdash-bot/.flue/lib/webhook.ts
+++ b/infra/emdash-bot/.flue/lib/webhook.ts
@@ -180,6 +180,7 @@ export interface PullRequestReviewCommentEvent {
 
 export type NormalizeResult =
 	| { kind: "dispatch"; anchor: string; event: NormalizedEvent }
+	| { kind: "cleanup"; anchor: string; anchorNumber: number; deliveryId?: string }
 	| { kind: "skip"; reason: string }
 	| { kind: "pong" };
 
@@ -236,6 +237,20 @@ function normalizeIssues(
 	deliveryId?: string,
 ): NormalizeResult {
 	const action = readString(event?.action) ?? "";
+	// A closed issue reaps its fix-loop branches (bot-cleanup.yml's close path).
+	// PR-as-issue closes arrive as pull_request events too; skip them here.
+	if (action === "closed") {
+		const issue = asRecord(event?.issue);
+		const number = readNumber(issue?.number);
+		if (!number) return { kind: "skip", reason: "issues.closed missing issue.number" };
+		if (issue?.pull_request) return { kind: "skip", reason: "issues.closed on a PR-as-issue" };
+		return {
+			kind: "cleanup",
+			anchor: anchorForIssue(number),
+			anchorNumber: number,
+			...(deliveryId ? { deliveryId } : {}),
+		};
+	}
 	if (action !== "opened" && action !== "reopened") {
 		return { kind: "skip", reason: `issues.${action} not handled` };
 	}

--- a/infra/emdash-bot/.flue/routes.ts
+++ b/infra/emdash-bot/.flue/routes.ts
@@ -43,6 +43,21 @@ export function registerCoreRoutes(app: Hono<{ Bindings: Env }>): Hono<{ Binding
 			return c.text(`skipped: ${result.reason}`, 202);
 		}
 
+		// Issue-close cleanup reaps the fix-loop branches directly (a few fast
+		// GitHub calls, well within the ack budget); it is not a machine event,
+		// so it bypasses the DO inbox and runs synchronously.
+		if (result.kind === "cleanup") {
+			const stub = c.env.Orchestrator.getByName(result.anchor);
+			const cleanup = await stub.cleanupOnClose(result.anchorNumber);
+			console.log("[webhook] cleanup", {
+				event: eventType,
+				delivery: deliveryId,
+				anchor: result.anchor,
+				cleanup: cleanup.kind,
+			});
+			return c.json({ anchor: result.anchor, cleanup }, 202);
+		}
+
 		// Persist into the per-anchor OrchestratorDO inbox before acknowledging.
 		// Classification, dispatch, and GitHub effects run from the DO alarm so
 		// GitHub does not time out while the bot performs external work.

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -18,13 +18,14 @@
 // ordering doesn't matter.
 
 import { env } from "cloudflare:workers";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { applyInvestigationResult } from "../../.flue/lib/investigation-result.js";
 import type { NormalizedEvent } from "../../.flue/lib/orchestrator.js";
 
 interface TestEnv {
 	Orchestrator: Env["Orchestrator"];
+	GITHUB_APP_PRIVATE_KEY: string;
 }
 
 const testEnv = env as unknown as TestEnv;
@@ -48,6 +49,13 @@ function makeEvent(overrides: Partial<NormalizedEvent> = {}): NormalizedEvent {
 }
 
 describe("OrchestratorDO (workers-pool)", () => {
+	// The credential-injecting tests below mutate shared env and global fetch;
+	// reset both after every test so nothing leaks into a later case.
+	afterEach(() => {
+		testEnv.GITHUB_APP_PRIVATE_KEY = "";
+		vi.unstubAllGlobals();
+	});
+
 	test("fresh instance starts with no persisted state", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		const state = await stub.getPersistedState();
@@ -503,5 +511,144 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect(persisted.state).toBe("working");
 		const log = await stub.getEventLog();
 		expect(log.length).toBe(1);
+	});
+
+	async function driveToPreviewBuilding(
+		stub: ReturnType<TestEnv["Orchestrator"]["getByName"]>,
+		anchorNumber: number,
+	): Promise<void> {
+		await stub.event(makeEvent({ event: "investigate", arg: "diagnose it", anchorNumber }));
+		await stub.debugSetStaleRun("diag-run", Date.now(), `investigate-${anchorNumber}-diag`, "diagnose");
+		await stub.applyAgentResult({
+			runId: "diag-run",
+			result: { reproduced: true, summary: "Reproduced it." },
+			pushed: false,
+			ok: true,
+		});
+		await stub.event(makeEvent({ event: "fix", arg: "fix it", anchorNumber }));
+		await stub.debugSetStaleRun("fix-run", Date.now(), `investigate-${anchorNumber}-fix`, "fix");
+		await stub.applyAgentResult({
+			runId: "fix-run",
+			result: { fixed: true, summary: "Built a candidate." },
+			pushed: true,
+			ok: true,
+		});
+	}
+
+	test("preview poll advances to awaiting_reporter once pkg.pr.new resolves", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await driveToPreviewBuilding(stub, 42);
+		expect((await stub.getPersistedState()).state).toBe("preview_building");
+
+		vi.stubGlobal("fetch", () => Promise.resolve(new Response("", { status: 200 })));
+		await stub.debugSetPreviewPoll(Date.now() + 60_000, Date.now() - 1_000);
+		const tick = await stub.tick();
+		vi.unstubAllGlobals();
+
+		expect(tick.previewPoll).toBe("ready");
+		expect((await stub.getPersistedState()).state).toBe("awaiting_reporter");
+	});
+
+	test("preview poll gives up and falls back to reproduced past the budget", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await driveToPreviewBuilding(stub, 42);
+
+		vi.stubGlobal("fetch", () => Promise.resolve(new Response("", { status: 404 })));
+		await stub.debugSetPreviewPoll(Date.now() - 1_000, Date.now() - 1_000);
+		const tick = await stub.tick();
+		vi.unstubAllGlobals();
+
+		expect(tick.previewPoll).toBe("failed");
+		expect((await stub.getPersistedState()).state).toBe("reproduced");
+	});
+
+	test("preview poll holds off before the next scheduled probe", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await driveToPreviewBuilding(stub, 42);
+
+		await stub.debugSetPreviewPoll(Date.now() + 60_000, Date.now() + 60_000);
+		const tick = await stub.tick();
+
+		expect(tick.previewPoll).toBe("waiting");
+		expect((await stub.getPersistedState()).state).toBe("preview_building");
+	});
+
+	// Records GitHub side-effect calls in order. `commentStatus` controls whether
+	// the ask comment POST succeeds (201) or fails (500). Fetches to pkg.pr.new
+	// always resolve 200 so the poll fires preview.ready.
+	function githubCallRecorder(
+		calls: string[],
+		commentStatus: number,
+	): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
+		return (input, init) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			const method = (init?.method ?? "GET").toUpperCase();
+			if (url.startsWith("https://pkg.pr.new/")) {
+				return Promise.resolve(new Response("", { status: 200 }));
+			}
+			if (method === "GET" && /\/issues\/\d+$/.test(url)) {
+				return Promise.resolve(
+					new Response(JSON.stringify({ title: "t", body: "b", user: { login: "alice" } }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+			}
+			if (method === "GET" && url.includes("/comments")) {
+				return Promise.resolve(new Response("[]", { status: 200 }));
+			}
+			if (method === "POST" && url.endsWith("/comments")) {
+				calls.push("comment");
+				return Promise.resolve(new Response("{}", { status: commentStatus }));
+			}
+			if (url.includes("/labels")) {
+				calls.push("labels");
+				return Promise.resolve(new Response("[]", { status: 200 }));
+			}
+			return Promise.resolve(new Response("{}", { status: 200 }));
+		};
+	}
+
+	// Credentials are captured at DO construction, so the private key must be set
+	// before getByName -- which means the machine-driven path (investigate/fix)
+	// would try to dispatch the runtime-less agent. These tests prime
+	// preview_building directly to isolate the poll + ask flush.
+	test("the preview ask posts the comment before flipping labels", async () => {
+		const calls: string[] = [];
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		vi.stubGlobal("fetch", githubCallRecorder(calls, 201));
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+		await stub.debugPrimePreviewBuilding(42, "Root cause: the loader drops the locale.");
+
+		await stub.debugSetPreviewPoll(Date.now() + 60_000, Date.now() - 1_000);
+		const tick = await stub.tick();
+		expect(tick.previewPoll).toBe("ready");
+
+		expect(calls[0]).toBe("comment");
+		expect(calls).toContain("labels");
+		expect((await stub.getPersistedState()).state).toBe("awaiting_reporter");
+	});
+
+	test("a failing ask comment leaves the labels unflipped and the effect pending", async () => {
+		const calls: string[] = [];
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		vi.stubGlobal("fetch", githubCallRecorder(calls, 500));
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+		await stub.debugPrimePreviewBuilding(42, "Root cause: the loader drops the locale.");
+
+		await stub.debugSetPreviewPoll(Date.now() + 60_000, Date.now() - 1_000);
+		await stub.tick();
+
+		expect(calls).toContain("comment");
+		expect(calls).not.toContain("labels");
+		expect(await stub.getPendingSideEffectCount()).toBe(1);
+	});
+
+	test("cleanupOnClose is a no-op without live credentials", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		const outcome = await stub.cleanupOnClose(42);
+		expect(outcome.kind).toBe("skipped");
 	});
 });

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -584,7 +584,7 @@ describe("OrchestratorDO (workers-pool)", () => {
 	function githubCallRecorder(
 		calls: string[],
 		commentStatus: number,
-	): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
+	): (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => Promise<Response> {
 		return (input, init) => {
 			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
 			const method = (init?.method ?? "GET").toUpperCase();

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -518,7 +518,12 @@ describe("OrchestratorDO (workers-pool)", () => {
 		anchorNumber: number,
 	): Promise<void> {
 		await stub.event(makeEvent({ event: "investigate", arg: "diagnose it", anchorNumber }));
-		await stub.debugSetStaleRun("diag-run", Date.now(), `investigate-${anchorNumber}-diag`, "diagnose");
+		await stub.debugSetStaleRun(
+			"diag-run",
+			Date.now(),
+			`investigate-${anchorNumber}-diag`,
+			"diagnose",
+		);
 		await stub.applyAgentResult({
 			runId: "diag-run",
 			result: { reproduced: true, summary: "Reproduced it." },

--- a/infra/emdash-bot/tests/integration/webhook.test.ts
+++ b/infra/emdash-bot/tests/integration/webhook.test.ts
@@ -240,6 +240,24 @@ describe("POST /webhook/github (workers-pool)", () => {
 		expect(secondJson.admission.kind).toBe("duplicate");
 	});
 
+	test("issues.closed drives the branch-cleanup path", async () => {
+		const issueNumber = uniqueIssueNumber();
+		const res = await postWebhook({
+			eventType: "issues",
+			delivery: `close-${issueNumber}`,
+			payload: {
+				action: "closed",
+				issue: { number: issueNumber, user: { login: "alice" } },
+				sender: { login: "alice" },
+			},
+		});
+		expect(res.status).toBe(202);
+		const json = (await res.json()) as { anchor: string; cleanup: { kind: string } };
+		expect(json.anchor).toBe(`issue-${issueNumber}`);
+		// No live private key in the test pool, so the reap no-ops but the path runs.
+		expect(json.cleanup.kind).toBe("skipped");
+	});
+
 	test("invalid JSON returns 400", async () => {
 		const body = "{this is not json";
 		const signature = await sign(body);

--- a/infra/emdash-bot/tests/unit/github-proxy.test.ts
+++ b/infra/emdash-bot/tests/unit/github-proxy.test.ts
@@ -102,6 +102,22 @@ describe("gateGithubRequest", () => {
 		).resolves.toMatch(/current issue/);
 	});
 
+	test("allows pushes to the issue's artifacts branch", async () => {
+		const url = "https://github.com/emdash-cms/emdash.git/git-receive-pack";
+		await expect(
+			gate(url, {
+				method: "POST",
+				body: `${pktLine("old new refs/heads/bot/artifacts-123\0 report-status\n")}0000PACKpayload`,
+			}),
+		).resolves.toBeNull();
+		await expect(
+			gate(url, {
+				method: "POST",
+				body: `${pktLine("old new refs/heads/bot/artifacts-456\0 report-status\n")}0000PACKpayload`,
+			}),
+		).resolves.toMatch(/current issue/);
+	});
+
 	test("rejects an unbounded receive-pack command prefix", async () => {
 		const url = "https://github.com/emdash-cms/emdash.git/git-receive-pack";
 		const oversizedPrefix = "f".repeat(64 * 1024);

--- a/infra/emdash-bot/tests/unit/orchestrator-comments.test.ts
+++ b/infra/emdash-bot/tests/unit/orchestrator-comments.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { renderAgentComment, shouldPostReadonlyReply } from "../../.flue/lib/comments.js";
+import {
+	renderAgentComment,
+	renderDraftPrBody,
+	renderPreviewReadyAsk,
+	shouldPostReadonlyReply,
+} from "../../.flue/lib/comments.js";
 import type { Decision } from "../../.flue/lib/router.js";
 
 function fixReadyDecision(): Extract<Decision, { kind: "transition" }> {
@@ -22,6 +27,71 @@ describe("renderAgentComment", () => {
 		const body = renderAgentComment(fixReadyDecision(), 1234, "Fixed the bug.");
 		expect(body).toContain("pnpm add https://pkg.pr.new/emdash-cms/emdash@bot/fix-1234");
 		expect(body).not.toContain("https://pkg.pr.new/emdash@bot/fix-");
+	});
+});
+
+describe("renderPreviewReadyAsk", () => {
+	function ask(overrides: Partial<Parameters<typeof renderPreviewReadyAsk>[0]> = {}): string {
+		return renderPreviewReadyAsk({
+			owner: "emdash-cms",
+			repo: "emdash",
+			issueNumber: 77,
+			at: "2026-08-08T00:00:00Z",
+			notes: "Root cause: the loader drops the locale.",
+			reporterLogin: "alice",
+			...overrides,
+		});
+	}
+
+	test("carries the bot-ask marker, full-ref install URL, notes, and reporter ask", () => {
+		const body = ask();
+		expect(body).toContain("<!-- bot-ask: 2026-08-08T00:00:00Z -->");
+		expect(body).toContain("npm i https://pkg.pr.new/emdash@bot/fix-77");
+		expect(body).toContain("Root cause: the loader drops the locale.");
+		expect(body).toContain("@alice");
+		expect(body).toContain("`bot/fix-77`");
+		expect(body).toContain("`bot/artifacts-77`");
+	});
+
+	test("falls back to a generic ask when the reporter login is unknown", () => {
+		const body = ask({ reporterLogin: null });
+		expect(body).not.toContain("could you try this");
+		expect(body).toContain("Could the reporter please try this");
+	});
+
+	test("renders screenshots from the artifacts branch with escaped alt text", () => {
+		const body = ask({
+			screenshots: [{ filename: "step-1.png", description: "broken [state] (here)" }],
+		});
+		expect(body).toContain(
+			"https://raw.githubusercontent.com/emdash-cms/emdash/bot/artifacts-77/.bot-artifacts/step-1.png",
+		);
+		expect(body).toContain("broken \\[state\\] \\(here\\)");
+	});
+
+	test("drops screenshots whose filename could inject a URL or traverse paths", () => {
+		const body = ask({
+			screenshots: [
+				{ filename: "../../etc/passwd", description: "traversal" },
+				{ filename: "ok.png", description: "kept" },
+			],
+		});
+		expect(body).not.toContain("etc/passwd");
+		expect(body).toContain("/.bot-artifacts/ok.png");
+	});
+
+	test("omits the screenshots block entirely when there are none", () => {
+		expect(ask({ screenshots: [] })).not.toContain("**Screenshots:**");
+	});
+});
+
+describe("renderDraftPrBody", () => {
+	test("closes the issue, links the verified preview, and flags review", () => {
+		const body = renderDraftPrBody(77);
+		expect(body).toContain("Closes #77.");
+		expect(body).toContain("npm i https://pkg.pr.new/emdash@bot/fix-77");
+		expect(body).toContain("regression test");
+		expect(body).toContain("draft");
 	});
 });
 

--- a/infra/emdash-bot/tests/unit/preview.test.ts
+++ b/infra/emdash-bot/tests/unit/preview.test.ts
@@ -31,7 +31,9 @@ describe("branchesToReap", () => {
 describe("probePreviewReady", () => {
 	test("resolves true on a 2xx", async () => {
 		const fake = (() => Promise.resolve(new Response("", { status: 200 }))) as typeof fetch;
-		await expect(probePreviewReady("https://pkg.pr.new/emdash@bot/fix-1", fake)).resolves.toBe(true);
+		await expect(probePreviewReady("https://pkg.pr.new/emdash@bot/fix-1", fake)).resolves.toBe(
+			true,
+		);
 	});
 
 	test("resolves false while the preview is still publishing (404)", async () => {

--- a/infra/emdash-bot/tests/unit/preview.test.ts
+++ b/infra/emdash-bot/tests/unit/preview.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	artifactsBranch,
+	branchesToReap,
+	fixBranch,
+	previewInstallCommand,
+	previewUrl,
+	probePreviewReady,
+} from "../../.flue/lib/preview.js";
+
+describe("preview branch + URL helpers", () => {
+	test("keeps the full bot/fix ref pkg.pr.new resolves by", () => {
+		expect(fixBranch(42)).toBe("bot/fix-42");
+		expect(artifactsBranch(42)).toBe("bot/artifacts-42");
+		expect(previewUrl(42)).toBe("https://pkg.pr.new/emdash@bot/fix-42");
+		expect(previewInstallCommand(42)).toBe("npm i https://pkg.pr.new/emdash@bot/fix-42");
+	});
+});
+
+describe("branchesToReap", () => {
+	test("spares the fix branch when an open PR references it", () => {
+		expect(branchesToReap(42, true)).toEqual(["bot/artifacts-42"]);
+	});
+
+	test("deletes both branches when no PR references the fix branch", () => {
+		expect(branchesToReap(42, false)).toEqual(["bot/fix-42", "bot/artifacts-42"]);
+	});
+});
+
+describe("probePreviewReady", () => {
+	test("resolves true on a 2xx", async () => {
+		const fake = (() => Promise.resolve(new Response("", { status: 200 }))) as typeof fetch;
+		await expect(probePreviewReady("https://pkg.pr.new/emdash@bot/fix-1", fake)).resolves.toBe(true);
+	});
+
+	test("resolves false while the preview is still publishing (404)", async () => {
+		const fake = (() => Promise.resolve(new Response("", { status: 404 }))) as typeof fetch;
+		await expect(probePreviewReady("https://pkg.pr.new/emdash@bot/fix-1", fake)).resolves.toBe(
+			false,
+		);
+	});
+
+	test("resolves false on a network error rather than throwing", async () => {
+		const fake = (() => Promise.reject(new Error("network"))) as typeof fetch;
+		await expect(probePreviewReady("https://pkg.pr.new/emdash@bot/fix-1", fake)).resolves.toBe(
+			false,
+		);
+	});
+});

--- a/infra/emdash-bot/tests/unit/webhook.test.ts
+++ b/infra/emdash-bot/tests/unit/webhook.test.ts
@@ -219,6 +219,30 @@ describe("normalizeWebhook", () => {
 			const r = normalizeWebhook({ eventType: "issues", payload });
 			expect(r.kind).toBe("skip");
 		});
+
+		test("closed reaps the fix-loop branches for that issue", () => {
+			const payload: IssuesEvent = {
+				action: "closed",
+				issue: { number: 7, user: { login: "alice" } },
+				sender: { login: "alice" },
+			};
+			const r = normalizeWebhook({ eventType: "issues", payload });
+			expect(r.kind).toBe("cleanup");
+			if (r.kind === "cleanup") {
+				expect(r.anchor).toBe("issue-7");
+				expect(r.anchorNumber).toBe(7);
+			}
+		});
+
+		test("closed on a PR-as-issue is skipped (handled by pull_request)", () => {
+			const payload: IssuesEvent = {
+				action: "closed",
+				issue: { number: 7, user: { login: "alice" }, pull_request: {} },
+				sender: { login: "alice" },
+			};
+			const r = normalizeWebhook({ eventType: "issues", payload });
+			expect(r.kind).toBe("skip");
+		});
 	});
 
 	describe("pull_request", () => {


### PR DESCRIPTION
## What does this PR do?

Slice 4 of the bot next-gen stack (on #2381). Wires the reporter-verified fix loop onto the machine states from #2376, reusing gen-1's `bot/fix-*` + pkg.pr.new conventions with the worker as orchestrator.

- **Preview flow:** the fix-mode investigation pushes `bot/fix-<n>` (+ orphan `bot/artifacts-<n>` screenshots) through the capability-scoped push proxy; `preview-releases.yml` (untouched — Actions/OIDC is the only pkg.pr.new publisher) builds the package preview; the DO polls the install URL on its existing alarm tick (bounded, 10-min budget as a tunable constant) and only advertises once it resolves — removing gen-1's "if npm i 404s, retry" reporter-facing race.
- **Ask comment:** gen-1's shape (hidden `bot-ask` marker, notes, full-ref `npm i https://pkg.pr.new/emdash@bot/fix-<n>`, screenshots, @reporter), posted comment-first so a failed post can't strand the state; restart-safe via a persisted marker check (no duplicate asks).
- **Confirmation → draft PR** with a useful body (closes-link, verified preview link, regression-test note); **cleanup** gains the open-PR guard on branch reaping (review flag from #2376) and an `issues.closed` path mirroring gen-1's bot-cleanup semantics.
- **Orchestrator bug fixed en route:** the side-effect drain guard matched `undefined === undefined`, deferring standalone effects forever — first reachable here (the ask), but also affecting readonly status replies. Now guarded explicitly; restart idempotency covered by tests.

Adversarially reviewed: single-alarm multiplexing traced (the poll rides the existing tick, earliest-deadline-wins), push-proxy admission HMAC-scoped per issue, injection surfaces validated.

Closes #

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))

> Maintainer-directed: implements the bot next-gen design; no separate Discussion.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — n/a-with-note: same pre-existing `infra/emdash-bot` baseline as the stack; zero new production error classes
- [x] `pnpm lint` passes — oxlint `--type-aware --deny-warnings` exit 0
- [x] `pnpm test` passes — unit 126/126, integration 42/42 (workers pool)
- [x] `pnpm format` has been run — oxfmt (note: `.flue/` is dot-dir-skipped; tab style verified by review)
- [x] I have added/updated tests for my changes — poll success/timeout, comment-first ordering (failed post leaves labels unflipped), open-PR reap guard, ask composition + injection rejection, issues.closed cleanup
- [x] User-visible strings in the admin UI are wrapped for translation — n/a
- [x] I have added a changeset — n/a, unpublished infra worker
- [x] New features link to an approved Discussion — see note above

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code; built and adversarially reviewed by Fable subagents)

## Screenshots / test output

```
unit:        126 passed (126)
integration:  42 passed (42)
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://bot-nextgen-04-fix-loop-wiring-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `bot-nextgen/04-fix-loop-wiring`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
