### PR TITLE
revert: flue-review Workers trace collection (#2372) — reviews hang in hydrating

### DIFF
--- a/infra/flue-review/wrangler.jsonc
+++ b/infra/flue-review/wrangler.jsonc
@@ -114,10 +114,5 @@
 	},
 	"observability": {
 		"enabled": true,
-		// Workers runtime spans only until the app is on Flue 2, which is the
-		// floor for automatic agent-turn/model/tool trace emission.
-		"traces": {
-			"enabled": true,
-		},
 	},
 }


### PR DESCRIPTION
## What does this PR do?

Reverts #2372 (`observability.traces.enabled` on `emdash-flue-review`) to restore the PR review bot.

Evidence: flue-review redeployed with traces at 12:35 UTC today; **every review attempted since then has hung silently in the `hydrating` stage** until the watchdog kills it — the five bot-nextgen stack PRs on un-draft, a solo re-trigger of #2375, and its automatic stale-run retry (three attempts on one PR, all identical). No successful review has completed on the traced build; the last successes were all pre-deploy. Hydration is the reviewer's most I/O-intense phase (bulk R2/DO workspace writes), consistent with per-operation trace instrumentation as the mechanism. Live-tail transcript of the failure sequence available.

This restores the pre-#2372 config while the interaction is investigated (likely re-land shape: `head_sampling_rate` or a workaround for the hydration hot path). The bot being down blocks all PR review flow, so this is proposed for direct maintainer merge — the bot cannot review its own resuscitation.

Verification after merge + Workers Builds deploy: re-apply `bot:review` on #2375; the review should progress past `Preparing PR` within a few minutes.

Closes #

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — n/a, config-only revert
- [x] `pnpm lint` passes — n/a, config-only
- [x] `pnpm test` passes — n/a, config-only
- [x] `pnpm format` has been run — n/a, pure revert
- [x] I have added/updated tests for my changes — n/a
- [x] User-visible strings in the admin UI are wrapped for translation — n/a
- [x] I have added a changeset — n/a, infra worker
- [x] New features link to an approved Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

Watchdog signature on all failed runs: `The review stopped reporting progress while in the 'hydrating' stage.`

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://revert-flue-review-traces-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `revert/flue-review-traces`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
