### PR TITLE
fix(core): let sites override the collection sitemap route

### DIFF
--- a/.changeset/sitemap-collection-route-override.md
+++ b/.changeset/sitemap-collection-route-override.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Skips the default `/sitemap-[collection].xml` route injection when the host site defines its own, matching the existing behaviour for `robots.txt` and `sitemap.xml`.

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -842,10 +842,12 @@ export function injectCoreRoutes(
 		});
 	}
 
-	injectRoute({
-		pattern: "/sitemap-[collection].xml",
-		entrypoint: resolveRoute("sitemap-[collection].xml.ts"),
-	});
+	if (!options.srcDir || !hasUserDefinedPublicRoute(options.srcDir, "sitemap-[collection].xml")) {
+		injectRoute({
+			pattern: "/sitemap-[collection].xml",
+			entrypoint: resolveRoute("sitemap-[collection].xml.ts"),
+		});
+	}
 
 	if (!options.srcDir || !hasUserDefinedPublicRoute(options.srcDir, "robots.txt")) {
 		injectRoute({

--- a/packages/core/tests/unit/astro/routes.test.ts
+++ b/packages/core/tests/unit/astro/routes.test.ts
@@ -111,6 +111,21 @@ describe("core media route injection", () => {
 		);
 	});
 
+	it("skips the collection sitemap route when the site defines its own", async () => {
+		await withTempSrcDir(
+			{
+				"pages/sitemap-[collection].xml.ts": "export const GET = () => new Response('');",
+			},
+			(srcDir) => {
+				const routes = collectRoutePatterns(srcDir);
+
+				expect(routes).not.toContain("/sitemap-[collection].xml");
+				expect(routes).toContain("/sitemap.xml");
+				expect(routes).toContain("/robots.txt");
+			},
+		);
+	});
+
 	it("detects index route files for root public route overrides", async () => {
 		await withTempSrcDir(
 			{


### PR DESCRIPTION

## What does this PR do?

#1386 added a `hasUserDefinedPublicRoute()` guard so a site's own `robots.txt` and `sitemap.xml` route files suppress the injected defaults — but left `/sitemap-[collection].xml` unguarded. It is injected unconditionally, so a site that ships its own `sitemap-[collection].xml.ts` gets Astro's duplicate-route warning ("A dynamic SSR route cannot be defined more than once"), and which handler answers rests on route-precedence luck. Astro has announced the collision will become a hard error in a future version.

Of the three SEO routes this is also the only one that serves content data (every published entry of every SEO-enabled collection, with a public cache header) — so it is the one a site is most likely to need to replace or close, e.g. a non-public deployment behind auth, or the per-collection customisations described in #1089.

This PR applies the same guard to the third route. `existsSync` treats the square brackets as literal path characters, so `hasUserDefinedPublicRoute()` needs no change. Sites without their own file see no difference; sites with one now get a clean override instead of a warning and undefined precedence.

The existing "skips root SEO routes that are defined by the site" test keeps asserting that a site-defined `sitemap.xml.ts` alone does **not** suppress the collection route; the new test covers the collection-specific override. The new test fails on the unpatched source.

Closes #1089 — #1386 implemented its Option C for two of the three routes; this covers the remaining one, which the issue lists as use case 3. With it, all three injected SEO routes can be replaced by shipping a route file, with no `node_modules` patching. (An explicit config option, the issue's Option A, would still be a reasonable follow-up, but is a design decision beyond this fix.)

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — `tests/unit/astro/routes.test.ts`, 9/9
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no admin UI change)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (drafted and reviewed in separate sessions)

## Screenshots / test output

New test against the unpatched source (proves it can fail):

```
FAIL tests/unit/astro/routes.test.ts > core media route injection > skips the collection sitemap route when the site defines its own
Tests  1 failed | 8 passed (9)
```

With the fix:

```
Tests  9 passed (9)
```
