### PR TITLE
fix(flue-review): cap tar entry size and honor pax linkpath overrides

### DIFF
--- a/infra/flue-review/.flue/lib/untar.ts
+++ b/infra/flue-review/.flue/lib/untar.ts
@@ -13,6 +13,8 @@ export interface UntarTarget {
 /** Ceiling on a single entry's declared size; content is buffered in DO memory. */
 const MAX_ENTRY_SIZE = 64 * 1024 * 1024;
 
+const OCTAL_FIELD = /^[0-7]*$/;
+
 function stripRoot(name: string): string | undefined {
 	const slash = name.indexOf("/");
 	if (slash === -1) return undefined;
@@ -95,12 +97,16 @@ export async function untarInto(
 
 		const rawName = readCString(header.subarray(0, 100));
 		const prefix = readCString(header.subarray(345, 500));
-		const size = parseInt(readCString(header.subarray(124, 136)).trim() || "0", 8);
+		const sizeField = readCString(header.subarray(124, 136)).trim();
+		if (!OCTAL_FIELD.test(sizeField)) {
+			throw new Error(`tar entry size is not octal ("${sizeField}"): ${rawName}`);
+		}
+		const size = sizeField ? parseInt(sizeField, 8) : 0;
 		// Mode bytes (100-108) are ignored: the workspace has no chmod and the
 		// reviewer never executes files.
 		const type = String.fromCharCode(header[156] ?? 48);
 
-		if (!Number.isFinite(size) || size < 0 || size > MAX_ENTRY_SIZE) {
+		if (size > MAX_ENTRY_SIZE) {
 			throw new Error(`tar entry size out of range (${size} bytes): ${rawName}`);
 		}
 		const padded = Math.ceil(size / 512) * 512;

--- a/infra/flue-review/.flue/lib/untar.ts
+++ b/infra/flue-review/.flue/lib/untar.ts
@@ -10,6 +10,9 @@ export interface UntarTarget {
 	writeFileBytes(path: string, content: Uint8Array): Promise<void>;
 }
 
+/** Ceiling on a single entry's declared size; content is buffered in DO memory. */
+const MAX_ENTRY_SIZE = 64 * 1024 * 1024;
+
 function stripRoot(name: string): string | undefined {
 	const slash = name.indexOf("/");
 	if (slash === -1) return undefined;
@@ -38,9 +41,9 @@ function normalizeSegments(path: string): string[] | undefined {
 /**
  * Untar a ustar stream into `destDir`, stripping the archive's single
  * top-level directory. Handles regular files, directories, symlinks, GNU
- * longname ('L') and pax ('x') path overrides. One entry's content is
- * buffered at a time. Rejects any entry path or symlink target that would
- * resolve outside `destDir`.
+ * longname/longlink ('L'/'K') and pax ('x') path/linkpath overrides. One
+ * entry's content is buffered at a time, capped at MAX_ENTRY_SIZE. Rejects
+ * any entry path or symlink target that would resolve outside `destDir`.
  */
 export async function untarInto(
 	target: UntarTarget,
@@ -52,7 +55,9 @@ export async function untarInto(
 	let files = 0;
 	let bytes = 0;
 	let pendingLongName: string | undefined;
+	let pendingLongLink: string | undefined;
 	let pendingPaxPath: string | undefined;
+	let pendingPaxLink: string | undefined;
 	const dirsMade = new Set<string>();
 
 	const append = (chunk: Uint8Array) => {
@@ -94,8 +99,10 @@ export async function untarInto(
 		// Mode bytes (100-108) are ignored: the workspace has no chmod and the
 		// reviewer never executes files.
 		const type = String.fromCharCode(header[156] ?? 48);
-		const linkTarget = readCString(header.subarray(157, 257));
 
+		if (!Number.isFinite(size) || size < 0 || size > MAX_ENTRY_SIZE) {
+			throw new Error(`tar entry size out of range (${size} bytes): ${rawName}`);
+		}
 		const padded = Math.ceil(size / 512) * 512;
 		if (!(await need(padded)) && size > 0) {
 			throw new Error(`tar truncated: needed ${padded} bytes for entry ${rawName}`);
@@ -107,22 +114,30 @@ export async function untarInto(
 			pendingLongName = readCString(content);
 			continue;
 		}
+		if (type === "K") {
+			pendingLongLink = readCString(content);
+			continue;
+		}
 		if (type === "x" || type === "g") {
 			// pax records: "<len> key=value\n"
 			const text = decoder.decode(content);
 			for (const line of text.split("\n")) {
 				const eq = line.indexOf("=");
-				if (eq > 0 && line.slice(line.indexOf(" ") + 1, eq) === "path") {
-					pendingPaxPath = line.slice(eq + 1);
-				}
+				if (eq <= 0) continue;
+				const key = line.slice(line.indexOf(" ") + 1, eq);
+				if (key === "path") pendingPaxPath = line.slice(eq + 1);
+				else if (key === "linkpath") pendingPaxLink = line.slice(eq + 1);
 			}
 			continue;
 		}
 
 		const fullName =
 			pendingPaxPath ?? pendingLongName ?? (prefix ? `${prefix}/${rawName}` : rawName);
+		const linkTarget = pendingPaxLink ?? pendingLongLink ?? readCString(header.subarray(157, 257));
 		pendingLongName = undefined;
+		pendingLongLink = undefined;
 		pendingPaxPath = undefined;
+		pendingPaxLink = undefined;
 
 		if (fullName.startsWith("/")) {
 			throw new Error(`tar entry path is absolute: ${fullName}`);

--- a/infra/flue-review/.flue/sandboxes/cloudflare-shell.ts
+++ b/infra/flue-review/.flue/sandboxes/cloudflare-shell.ts
@@ -237,7 +237,7 @@ function instrumentR2(bucket: R2Bucket): R2Bucket {
 			console.log(JSON.stringify({ message: "r2 op start", id, method, key }));
 			try {
 				// oxlint-disable-next-line typescript/no-unsafe-type-assertion
-				const result = await (bucket as unknown as Record<string, Function>)[method](...args);
+				const result = await (bucket as unknown as Record<string, Function>)[method]!(...args);
 				console.log(JSON.stringify({ message: "r2 op end", id, method, key, ms: Date.now() - t0 }));
 				return result;
 			} catch (error) {

--- a/infra/flue-review/test/untar.test.ts
+++ b/infra/flue-review/test/untar.test.ts
@@ -170,6 +170,16 @@ describe("untarInto", () => {
 		expect(r.symlinks.size).toBe(0);
 	});
 
+	it("rejects entries whose size field is not strictly octal", async () => {
+		for (const sizeField of ["10x", "size!", "-0000001"]) {
+			const block = header({ name: "repo-abc/bad.bin" });
+			block.set(encoder.encode(sizeField), 124);
+			const r = recorder();
+			await expect(untarInto(r.target, tarball([block]), "/repo")).rejects.toThrow(/not octal/);
+			expect(r.files.size).toBe(0);
+		}
+	});
+
 	it("rejects entries whose declared size exceeds the cap", async () => {
 		const r = recorder();
 		await expect(

--- a/infra/flue-review/test/untar.test.ts
+++ b/infra/flue-review/test/untar.test.ts
@@ -126,6 +126,62 @@ describe("untarInto", () => {
 		expect(r.files.has("/repo/ignored-name.txt")).toBe(false);
 	});
 
+	it("applies pax linkpath and GNU longlink overrides to symlink targets", async () => {
+		const longTarget = `deep/${"d/".repeat(40)}target.txt`;
+		const paxBody = `linkpath=${longTarget}\n`;
+		const paxLen = String(paxBody.length + 3).length + 1 + paxBody.length;
+		const paxBytes = encoder.encode(`${paxLen} ${paxBody}`);
+		const longLinkBytes = encoder.encode(longTarget);
+		const r = recorder();
+		await untarInto(
+			r.target,
+			tarball([
+				header({ name: "repo-abc/PaxHeader", type: "x", size: paxBytes.length }),
+				contentBlocks(paxBytes),
+				header({ name: "repo-abc/pax-link", type: "2", linkTarget: "short" }),
+				header({ name: "repo-abc/@LongLink", type: "K", size: longLinkBytes.length }),
+				contentBlocks(longLinkBytes),
+				header({ name: "repo-abc/gnu-link", type: "2", linkTarget: "short" }),
+				header({ name: "repo-abc/plain-link", type: "2", linkTarget: "short" }),
+			]),
+			"/repo",
+		);
+		expect(r.symlinks.get("/repo/pax-link")).toBe(longTarget);
+		expect(r.symlinks.get("/repo/gnu-link")).toBe(longTarget);
+		expect(r.symlinks.get("/repo/plain-link")).toBe("short");
+	});
+
+	it("rejects pax linkpath targets that escape the destination", async () => {
+		const paxBody = "linkpath=../../etc/passwd\n";
+		const paxLen = String(paxBody.length + 3).length + 1 + paxBody.length;
+		const paxBytes = encoder.encode(`${paxLen} ${paxBody}`);
+		const r = recorder();
+		await expect(
+			untarInto(
+				r.target,
+				tarball([
+					header({ name: "repo-abc/PaxHeader", type: "x", size: paxBytes.length }),
+					contentBlocks(paxBytes),
+					header({ name: "repo-abc/evil", type: "2", linkTarget: "harmless" }),
+				]),
+				"/repo",
+			),
+		).rejects.toThrow(/escapes the destination/);
+		expect(r.symlinks.size).toBe(0);
+	});
+
+	it("rejects entries whose declared size exceeds the cap", async () => {
+		const r = recorder();
+		await expect(
+			untarInto(
+				r.target,
+				tarball([header({ name: "repo-abc/huge.bin", size: 128 * 1024 * 1024 })]),
+				"/repo",
+			),
+		).rejects.toThrow(/size out of range/);
+		expect(r.files.size).toBe(0);
+	});
+
 	it("joins the ustar prefix field with the name", async () => {
 		const r = recorder();
 		await untarInto(


### PR DESCRIPTION
## What does this PR do?

Closes the two remaining findings from the review of #2386 on the flue-review untar parser:

- **Entry size cap.** The parser buffers one entry's content at a time in Durable Object memory and previously trusted the declared `size` field unconditionally, so a malformed or hostile header could trigger an unbounded allocation. Entries larger than 64 MiB (or with a non-numeric/negative size field) are now rejected.
- **pax `linkpath` support.** Only the pax `path` keyword was parsed, so a symlink whose target exceeds the 100-byte ustar `linkname` field would have been silently truncated. The parser now honors pax `linkpath` and the GNU `K` long-linkname record, and applies the same escape validation to overridden targets.

Also fixes a one-line `noUncheckedIndexedAccess` violation in the R2 instrumentation that surfaced when running `tsc --noEmit` against freshly generated worker types.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Changeset and i18n are n/a: this touches only the private `infra/flue-review` worker, no published package or admin UI. Typecheck was run for `infra/flue-review` (`tsc --noEmit`); tests are the flue-review vitest suite (49 passing, including new cases for the size cap, pax `linkpath` override, escaping `linkpath` targets, and GNU `K` records).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

```
 Test Files  5 passed (5)
      Tests  49 passed (49)
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-flue-review-untar-size-cap-linkpath-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/flue-review-untar-size-cap-linkpath`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
