### PR TITLE
fix(core): admin UI fails to load on Windows in dev mode

### DIFF
--- a/.changeset/fix-admin-windows-lingui-macro.md
+++ b/.changeset/fix-admin-windows-lingui-macro.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the admin UI failing to load in dev mode on Windows (stuck on "Loading EmDash..." with a `babel-plugin-macros` / `process is not defined` console error). The Lingui macro compiler that runs against admin source in local-monorepo dev never matched any files on Windows, so `@lingui/core/macro` imports shipped uncompiled to the browser instead of being transformed away.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import type { AstroConfig } from "astro";
 import type { Plugin } from "vite";
@@ -73,10 +73,21 @@ const LOCALE_MESSAGES_RE = /[/\\]([a-z]{2}(?:-[A-Z]{2})?)[/\\]messages\.mjs$/;
  * @babel/core is dynamically imported from admin's devDependencies —
  * not declared by core, never ships to end users.
  */
-function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plugin {
-	// Resolve @babel/core from admin's devDependencies, not core's.
+export function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plugin {
+	// Resolve @babel/core and the lingui macro plugin from admin's devDependencies,
+	// not core's — and as absolute paths, since Babel's plugin resolution normally
+	// walks up from `filename` (an admin source file aliased into whatever app is
+	// running EmDash, e.g. demos/simple), where these devDependencies aren't reachable.
 	const adminRequire = createRequire(resolve(adminDistPath, "index.js"));
 	const babelCorePath = adminRequire.resolve("@babel/core");
+	const linguiMacroPluginPath = adminRequire.resolve("@lingui/babel-plugin-lingui-macro");
+
+	// Vite normalizes module ids/importers to forward slashes even on Windows,
+	// but `resolve()` returns OS-native (backslash) separators there — compare
+	// against a POSIX-normalized form so this plugin actually matches on Windows.
+	// (A literal backslash replace, not `path.sep`-driven, so this also works
+	// when a Windows-style path is passed on a non-Windows host, e.g. in tests.)
+	const adminSourcePathPosix = adminSourcePath.replaceAll("\\", "/");
 
 	return {
 		name: "emdash-lingui-macro",
@@ -85,18 +96,22 @@ function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plug
 			// Redirect relative locale catalog imports (e.g. ./de/messages.mjs) from
 			// within admin source to the compiled dist/locales/ directory, since
 			// lingui compile only runs during build — not in dev watch mode.
-			if (!importer?.startsWith(adminSourcePath)) return;
+			if (!importer?.startsWith(adminSourcePathPosix)) return;
 			const match = id.match(LOCALE_MESSAGES_RE);
 			if (match?.[1]) {
 				return resolve(adminDistPath, "locales", match[1], "messages.mjs");
 			}
 		},
 		async transform(code, id) {
-			if (!id.startsWith(adminSourcePath) || !code.includes("@lingui")) return;
-			const { transformAsync } = (await import(babelCorePath)) as typeof import("@babel/core");
+			if (!id.startsWith(adminSourcePathPosix) || !code.includes("@lingui")) return;
+			// Dynamic import() requires a file:// URL for absolute paths on Windows —
+			// a raw drive-letter path (e.g. "E:\...") is rejected by the ESM loader.
+			const { transformAsync } = (await import(
+				pathToFileURL(babelCorePath).href
+			)) as typeof import("@babel/core");
 			const result = await transformAsync(code, {
 				filename: id,
-				plugins: ["@lingui/babel-plugin-lingui-macro"],
+				plugins: [linguiMacroPluginPath],
 				parserOpts: { plugins: ["jsx", "typescript"] },
 			});
 			if (!result?.code) return;

--- a/packages/core/tests/unit/astro/vite-config.test.ts
+++ b/packages/core/tests/unit/astro/vite-config.test.ts
@@ -1,10 +1,20 @@
 import { existsSync } from "node:fs";
-import { basename, isAbsolute } from "node:path";
+import { createRequire } from "node:module";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
 
 import type { AstroConfig } from "astro";
 import { describe, expect, it } from "vitest";
 
-import { createViteConfig } from "../../../src/astro/integration/vite-config.js";
+import { createViteConfig, linguiMacroPlugin } from "../../../src/astro/integration/vite-config.js";
+
+// Vite/Rollup type hook fields as `T | { handler: T; order?: ... }`. This
+// plugin always uses the plain-function form, so unwrap that shape to get a
+// directly callable function without pulling in Rollup's types as a dependency.
+function unwrapHook<T>(hook: T | { handler: T } | null | undefined): T {
+	if (hook == null) throw new Error("Hook is not defined");
+	if (typeof hook === "object" && "handler" in hook) return hook.handler;
+	return hook;
+}
 
 describe("createViteConfig admin aliasing", () => {
 	const monorepoDemoRoot = new URL("../../../../../demos/simple/", import.meta.url);
@@ -169,4 +179,77 @@ describe("createViteConfig use-sync-external-store shim aliasing", () => {
 			expect(shimIdx).toBeGreaterThan(indexIdx);
 		});
 	}
+});
+
+// Regression: on Windows, `path.resolve()` returns backslash-separated
+// paths, but Vite always normalizes module ids/importers to forward
+// slashes — even on Windows. `linguiMacroPlugin` used to compare an
+// `adminSourcePath` straight out of `resolve()` against those ids with
+// `id.startsWith(adminSourcePath)`, which is silently always `false` on
+// Windows. The plugin's hooks became permanent no-ops there: Lingui macro
+// calls (`@lingui/core/macro`) shipped uncompiled to the browser, which
+// then failed to hydrate the admin UI entirely (it never got past the
+// "Loading EmDash..." screen). These tests reproduce that mismatch
+// directly, with a synthetic backslash `adminSourcePath` — independent of
+// the host OS running the test — so they fail on the pre-fix
+// `id.startsWith(adminSourcePath)` comparison on any platform, not just
+// Windows CI.
+describe("linguiMacroPlugin Windows path-separator handling", () => {
+	const require = createRequire(import.meta.url);
+	const adminDistPath = dirname(require.resolve("@emdash-cms/admin"));
+	// Derive both separator styles deterministically from the real (OS-native)
+	// path so this test proves the same thing whether it runs on Windows,
+	// macOS, or Linux. `adminSourcePathPosix` stands in for what Vite always
+	// hands hooks (forward slashes); `adminSourcePathWindows` stands in for
+	// what `path.resolve()` returns on win32 (backslashes) — on a real
+	// Windows host these would otherwise be identical and this test would
+	// prove nothing.
+	const adminSourceDirNative = resolve(adminDistPath, "..", "src");
+	const adminSourcePathPosix = adminSourceDirNative.replaceAll("\\", "/");
+	const adminSourcePathWindows = adminSourcePathPosix.replaceAll("/", "\\");
+
+	const plugin = linguiMacroPlugin(adminSourcePathWindows, adminDistPath);
+
+	it("compiles away @lingui macro calls in admin source files", async () => {
+		const id = `${adminSourcePathPosix}/components/Example.tsx`;
+		const code = ['import { t } from "@lingui/core/macro";', "t`Hello`;", ""].join("\n");
+
+		const transform = unwrapHook(plugin.transform);
+		const result = await transform.call(
+			// eslint-disable-next-line typescript/no-unsafe-type-assertion -- test-only stand-in for Rollup's TransformPluginContext, which the hook never touches.
+			{} as never,
+			code,
+			id,
+		);
+
+		expect(result).toBeTruthy();
+		const output = typeof result === "string" ? result : (result?.code ?? "");
+		expect(output).not.toContain("@lingui/core/macro");
+	});
+
+	it("redirects locale catalog imports from admin source to dist/locales", () => {
+		const importer = `${adminSourcePathPosix}/locales/loadMessages.ts`;
+
+		const resolveId = unwrapHook(plugin.resolveId);
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- test-only stand-in for Rollup's PluginContext, which the hook never touches.
+		const resolved = resolveId.call({} as never, "./de/messages.mjs", importer, {
+			attributes: {},
+			isEntry: false,
+		});
+
+		expect(resolved).toBeTruthy();
+		const resolvedPath = typeof resolved === "string" ? resolved : (resolved as { id: string })?.id;
+		expect(resolvedPath).toContain(resolve(adminDistPath, "locales", "de", "messages.mjs"));
+	});
+
+	it("does not match files outside admin source", async () => {
+		const id = `${adminDistPath}/index.js`;
+		const code = 'import { t } from "@lingui/core/macro";';
+
+		const transform = unwrapHook(plugin.transform);
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- test-only stand-in for Rollup's TransformPluginContext, which the hook never touches.
+		const result = await transform.call({} as never, code, id);
+
+		expect(result).toBeFalsy();
+	});
 });


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Fixes the admin UI failing to load in dev mode on Windows — it gets stuck on "Loading EmDash..." forever, with console errors like `Could not resolve "babel-plugin-macros"` and later `process is not defined`.

Root cause: `linguiMacroPlugin` (in `packages/core/src/astro/integration/vite-config.ts`) is a dev-only Vite plugin that compiles away `@lingui/core/macro` calls in admin source files before they reach the browser. It matches files via `id.startsWith(adminSourcePath)`, where `adminSourcePath` comes straight out of `path.resolve()`. On Windows, `resolve()` returns backslash-separated paths, but Vite always normalizes the `id`/`importer` it passes to plugin hooks to forward slashes — even on Windows. So the `startsWith` check is silently always `false` there, the plugin's hooks never fire, and raw `@lingui/core/macro` imports ship to the browser. Vite's dependency optimizer then tries to pre-bundle that module as a real dependency, which fails at runtime (it's only meant to be consumed by a macro loader).

Three fixes, all in the same plugin:

1. Normalize `adminSourcePath` to forward slashes before comparing against Vite's ids/importers (`replaceAll("\\", "/")`, not `path.sep`-driven, so it's also correct — and testable — when a Windows-style path is passed on a non-Windows host).
2. Convert the dynamic `import()` of `@babel/core` to a `file://` URL via `pathToFileURL()` — Node's ESM loader on Windows rejects a raw drive-letter path for dynamic `import()`.
3. Resolve `@lingui/babel-plugin-lingui-macro` to an absolute path via admin's own `node_modules` (same `adminRequire` used for `@babel/core`), instead of passing the bare specifier to Babel, which resolves plugin names starting from the transformed file's directory — outside admin's own dependency tree when EmDash is aliased into a demo/template app.

Verified manually end to end on Windows 11: seeded and ran both `demos/simple` and `templates/marketing`, confirmed the admin dashboard, welcome modal, and content list all render and hydrate correctly after the fix (previously stuck on the loading spinner in both).

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — bug fix

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5 (Claude Code)

## Screenshots / test output

New regression tests in `packages/core/tests/unit/astro/vite-config.test.ts` (`linguiMacroPlugin Windows path-separator handling`) reproduce the mismatch with a synthetic Windows-style path, independent of the host OS running the test — they fail against the pre-fix `linguiMacroPlugin` (in fact fail to even import it, since it wasn't exported) and pass after the fix.

```
✓ linguiMacroPlugin Windows path-separator handling > compiles away @lingui macro calls in admin source files
✓ linguiMacroPlugin Windows path-separator handling > redirects locale catalog imports from admin source to dist/locales
✓ linguiMacroPlugin Windows path-separator handling > does not match files outside admin source
```

Note: this test file has 5 pre-existing, unrelated failures on Windows (`createViteConfig admin aliasing` / `use-sync-external-store shim aliasing` — `TypeError: File URL path must be absolute`, from a synthetic `file:///workspace/emdash-site/` URL that isn't valid on Windows without a drive letter). Left untouched per the "no drive-by fixes" policy; happy to open a separate issue/PR for it if useful.
