### PR TITLE
test(admin): pick the role option directly to deflake the allowed-domains dialog test

### DIFF
--- a/packages/admin/tests/components/settings/AllowedDomainsSettings.test.tsx
+++ b/packages/admin/tests/components/settings/AllowedDomainsSettings.test.tsx
@@ -174,8 +174,9 @@ describe("AllowedDomainsSettings", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Edit example.com" }));
 		await expect.element(screen.getByRole("heading", { name: "Edit Domain" })).toBeInTheDocument();
 		const roleSelect = screen.getByLabelText("Default Role").element() as HTMLButtonElement;
-		roleSelect.focus();
-		await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+		roleSelect.click();
+		await expect.element(screen.getByRole("option", { name: "Editor" })).toBeVisible();
+		(screen.getByRole("option", { name: "Editor" }).element() as HTMLElement).click();
 
 		await vi.waitFor(() => {
 			expect(mockUpdateAllowedDomain).toHaveBeenCalledWith("example.com", { defaultRole: 40 });


### PR DESCRIPTION
## What does this PR do?

Closes #2387

`AllowedDomainsSettings.test.tsx > updates the default role from the edit dialog`
is flaky on CI — #2387 has the full analysis and a failing run. In short: the
test drives the `Default Role` select blind:

```ts
const roleSelect = screen.getByLabelText("Default Role").element() as HTMLButtonElement;
roleSelect.focus();
await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
```

The option list for this dialog is Subscriber (10) / Contributor (20) /
Author (30) / Editor (40) — `useAllowedDomainsRolesConfig` filters
`ROLE_ENTRIES` to `value <= MAX_SELF_SIGNUP_DEFAULT_ROLE`. The fixture domain
starts at Author (30) and the assertion expects Editor (40), which is exactly
**one** step down the list. The test sends **two** `{ArrowDown}`s — so it
passes only when exactly one keystroke is absorbed by opening the popup *and*
the highlight starts on the currently selected item. When that doesn't hold,
`{Enter}` commits Subscriber (10), the first item in the list — the exact
failure in #2387, and the same flip shows up in the CI history of #2374, where
the admin package is byte-identical across three SHAs yet `Browser Tests` goes
fail/pass/fail (details in
https://github.com/emdash-cms/emdash/pull/2374#issuecomment-5233492508).

**The change:** open the select and click the Editor option directly. Kumo's
`Select.Option` renders Base UI's select item with `role="option"`, so the
option can be addressed by its accessible name. The test awaits the option's
visibility before clicking, which removes the popup-mount race and makes the
test independent of the ordering of `ROLE_ENTRIES`.

### Why not `userEvent.click`, as suggested in #2387

The issue suggests the pattern from `Settings.test.tsx` — `userEvent.click` on
the combobox, then on the option. That pattern works there because the language
combobox sits on the settings page; inside this modal dialog it times out on
the very first click, on the trigger, because Base UI's inert overlay
intercepts the pointer events:

```
TimeoutError: locator.click: Timeout 14813ms exceeded.
  - <div aria-hidden="true" role="presentation" data-base-ui-inert=""></div> intercepts pointer events
```

The clicks are therefore programmatic (`element().click()`), following the
delete-confirmation tests in the same file, which already use a programmatic
`confirmButton.click()` for the same reason. That interception is also the
likely reason this test used blind keyboard navigation in the first place.

On the sweep suggested in #2387: this is the only keyboard-driven `Select`
interaction of this shape in the admin tests. The `{ArrowDown}` uses in
`slash-menu.test.tsx` drive the editor's slash menu, and
`SortableContentSettingsSections.test.tsx` drives drag-reorder — neither is a
`Select`.

### Why there is no failing test in this PR

`CONTRIBUTING.md` asks bug fixes to include a failing test. That does not apply
cleanly here, because the test *is* the defect: it asserts a correct
expectation through an unreliable interaction, and the race cannot be pinned
deterministically without changing the very timing under test. The evidence is
the failing run linked in #2387 and the fail/pass/fail CI history of #2374
across byte-identical admin sources.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — targeted file plus full admin browser suite, see below
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, test-only change
- [ ] I have added a changeset — n/a, test-only change with no user-facing effect
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (diagnosis, draft), Claude Fable 5 (implementation, review pass)

Drafted and reviewed with Claude (Opus 5: diagnosis and draft; Fable 5: implementation and review pass, separate sessions).

## Screenshots / test output

Targeted file, six consecutive green runs during drafting, re-verified in
review (two further targeted runs plus the full admin browser suite):

```
✓ |chromium| tests/components/settings/AllowedDomainsSettings.test.tsx (10 tests)

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

```
 Test Files  115 passed (115)
      Tests  1384 passed (1384)
```

The `userEvent.click` variant from #2387, tried on the same branch, fails
deterministically with the inert-overlay timeout quoted above.
