### PR TITLE
i18n(de): complete German translations

### DIFF
--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -37,7 +37,7 @@ msgstr " (ausgewählt)"
 
 #: packages/admin/src/routes/bylines.tsx:706
 msgid "-- Select --"
-msgstr ""
+msgstr "-- Auswählen --"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
@@ -86,7 +86,7 @@ msgstr "{0, plural, one {# Kollektion} other {# Kollektionen}}"
 #. placeholder {0}: result.comments.imported
 #: packages/admin/src/components/WordPressImport.tsx:2263
 msgid "{0, plural, one {# comment imported} other {# comments imported}}"
-msgstr ""
+msgstr "{0, plural, one {# Kommentar importiert} other {# Kommentare importiert}}"
 
 #. placeholder {0}: result.affected
 #: packages/admin/src/router.tsx:1493
@@ -111,7 +111,7 @@ msgstr "{0, plural, one {# Inhaltselement importiert} other {# Inhaltselemente i
 #. placeholder {0}: selectedItems.length
 #: packages/admin/src/components/MediaPickerModal.tsx:787
 msgid "{0, plural, one {# item selected} other {# items selected}}"
-msgstr ""
+msgstr "{0, plural, one {# Element ausgewählt} other {# Elemente ausgewählt}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
@@ -123,7 +123,7 @@ msgstr "{0, plural, one {# Element} other {# Elemente}}"
 #. placeholder {0}: mcpTools.length
 #: packages/admin/src/components/PluginManager.tsx:420
 msgid "{0, plural, one {# MCP tool} other {# MCP tools}}"
-msgstr ""
+msgstr "{0, plural, one {# MCP-Tool} other {# MCP-Tools}}"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2279
@@ -138,7 +138,7 @@ msgstr "{0, plural, one {# Mediendatei importiert} other {# Mediendateien import
 #. placeholder {0}: result.menus.created
 #: packages/admin/src/components/WordPressImport.tsx:2255
 msgid "{0, plural, one {# menu imported} other {# menus imported}}"
-msgstr ""
+msgstr "{0, plural, one {# Menü importiert} other {# Menüs importiert}}"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1903
@@ -174,12 +174,12 @@ msgstr "{0, plural, one {# übersprungen (bereits vorhanden)} other {# überspru
 #. placeholder {0}: result.taxonomyAssignments
 #: packages/admin/src/components/WordPressImport.tsx:2247
 msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
-msgstr ""
+msgstr "{0, plural, one {# Taxonomie-Zuordnung} other {# Taxonomie-Zuordnungen}}"
 
 #. placeholder {0}: result.taxonomiesCreated.length
 #: packages/admin/src/components/WordPressImport.tsx:2239
 msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
-msgstr ""
+msgstr "{0, plural, one {# Taxonomie erstellt} other {# Taxonomien erstellt}}"
 
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:585
@@ -189,19 +189,19 @@ msgstr "{0, plural, one {Feld} other {Felder}}"
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:179
 msgid "{0, plural, one {Media file} other {Media files}}"
-msgstr ""
+msgstr "{0, plural, one {Mediendatei} other {Mediendateien}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:183
 msgid "{0, plural, one {User} other {Users}}"
-msgstr ""
+msgstr "{0, plural, one {Benutzer} other {Benutzer}}"
 
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
 #. placeholder {2}: m.host
 #: packages/admin/src/components/RegistryPluginDetail.tsx:636
 msgid "{0} {1} required — you have {2}."
-msgstr ""
+msgstr "{0} {1} erforderlich — du hast {2}."
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-2xl font-semibold leading-tight">{t`Menus`}</h1> <p className="mt-1 text-sm leading-5 text-pretty text-kumo-subtle"> {t`Manage navigation menus for your site`} </p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
@@ -212,12 +212,12 @@ msgstr "{0} • {1}"
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:425
 msgid "{0} banner"
-msgstr ""
+msgstr "Banner von {0}"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:228
 msgid "{0} can't be moved here — its parent has no translation in this locale, so this list isn't the group it belongs to."
-msgstr ""
+msgstr "{0} kann nicht hierher verschoben werden — das übergeordnete Element hat keine Übersetzung in dieser Sprache, diese Liste ist also nicht die Gruppe, zu der es gehört."
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1303
@@ -237,7 +237,7 @@ msgstr "{0} wurde entfernt"
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:437
 msgid "{0} icon"
-msgstr ""
+msgstr "Icon von {0}"
 
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:213
@@ -263,17 +263,17 @@ msgstr "{0} Elemente werden importiert"
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:537
 msgid "{0} of {total} could not be deleted"
-msgstr ""
+msgstr "{0} von {total} konnten nicht gelöscht werden"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:493
 msgid "{0} of {total} could not be published"
-msgstr ""
+msgstr "{0} von {total} konnten nicht publiziert werden"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:516
 msgid "{0} of {total} could not be updated"
-msgstr ""
+msgstr "{0} von {total} konnten nicht aktualisiert werden"
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:179
@@ -352,7 +352,7 @@ msgstr "{label} — Übersetzung anzeigen"
 
 #: packages/admin/src/components/ContentList.tsx:934
 msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{matchCount, plural, one {# Element passend zu „{searchQuery}“} other {# Elemente passend zu „{searchQuery}“}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2473
 msgid "{matchedCount} of {totalCount} assigned"
@@ -382,19 +382,19 @@ msgstr "{pluginName} benötigt die folgenden Berechtigungen:"
 #: packages/admin/src/components/PluginSettings.tsx:142
 #: packages/admin/src/components/PluginSettings.tsx:170
 msgid "{pluginName} Settings"
-msgstr ""
+msgstr "{pluginName}-Einstellungen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:298
 msgid "{resultCount, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{resultCount, plural, one {# Element} other {# Elemente}}"
 
 #: packages/admin/src/components/ContentList.tsx:411
 msgid "{selectedCount, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {# ausgewählt} other {# ausgewählt}}"
 
 #: packages/admin/src/components/ContentList.tsx:453
 msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {# Element in den Papierkorb verschieben? Ein späteres Wiederherstellen ist möglich.} other {# Elemente in den Papierkorb verschieben? Ein späteres Wiederherstellen ist möglich.}}"
 
 #: packages/admin/src/components/ContentList.tsx:940
 msgid "{total, plural, one {# item} other {# items}}"
@@ -416,11 +416,11 @@ msgstr "{total, plural, one {Hochladen der Datei ist fehlgeschlagen} other {Hoch
 
 #: packages/admin/src/components/Dashboard.tsx:167
 msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
-msgstr ""
+msgstr "{totalDrafts, plural, one {Entwurf} other {Entwürfe}}"
 
 #: packages/admin/src/components/Dashboard.tsx:173
 msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
-msgstr ""
+msgstr "{totalScheduled, plural, one {Geplant} other {Geplant}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:367
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
@@ -524,11 +524,11 @@ msgstr "404-Fehler"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "410 Content Deleted (Gone)"
-msgstr ""
+msgstr "410 Inhalt gelöscht (Gone)"
 
 #: packages/admin/src/components/Redirects.tsx:161
 msgid "451 Unavailable for legal reasons"
-msgstr ""
+msgstr "451 Aus rechtlichen Gründen nicht verfügbar"
 
 #: packages/admin/src/components/WordPressImport.tsx:1526
 msgid "5. Copy the generated password"
@@ -572,7 +572,7 @@ msgstr "Einladung annehmen"
 
 #: packages/admin/src/routes/byline-schema.tsx:174
 msgid "Access denied"
-msgstr ""
+msgstr "Zugriff verweigert"
 
 #: packages/admin/src/router.tsx:1513
 msgid "Access Denied"
@@ -601,7 +601,7 @@ msgstr "Kontoinformationen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1158
 msgid "ACF Fields"
-msgstr ""
+msgstr "ACF-Felder"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/ContentList.tsx:535
@@ -622,7 +622,7 @@ msgstr "Aktiv"
 #: packages/admin/src/components/MenuEditor.tsx:441
 #: packages/admin/src/components/TaxonomySidebar.tsx:496
 msgid "Add"
-msgstr ""
+msgstr "Hinzufügen"
 
 #. placeholder {0}: field.item_label
 #. placeholder {0}: taxonomyDef.labelSingular || t`Term`
@@ -680,7 +680,7 @@ msgstr "Felder hinzufügen"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr ""
+msgstr "Füge Felder wie „Position“ oder „Pronomen“ hinzu, um jede Autorenzeile anzureichern."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:613
 msgid "Add fields to define the structure of your content"
@@ -696,11 +696,11 @@ msgstr "Erstes Element hinzufügen"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:200
 msgid "Add Images"
-msgstr ""
+msgstr "Bilder hinzufügen"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:247
 msgid "Add images to gallery"
-msgstr ""
+msgstr "Bilder zur Galerie hinzufügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2108
 msgid "Add item"
@@ -782,7 +782,7 @@ msgstr "Zusätzliche Daten, die importiert werden sollen."
 
 #: packages/admin/src/components/WordPressImport.tsx:1483
 msgid "admin"
-msgstr ""
+msgstr "admin"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:101
 #: packages/admin/src/components/Sidebar.tsx:398
@@ -804,16 +804,16 @@ msgstr "Nach dem Senden:"
 
 #: packages/admin/src/components/PluginManager.tsx:543
 msgid "Agent access"
-msgstr ""
+msgstr "Agent-Zugriff"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:335
 msgid "Agent access for {0} has been updated"
-msgstr ""
+msgstr "Agent-Zugriff für {0} wurde aktualisiert"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:139
 msgid "Agent-callable MCP tools"
-msgstr ""
+msgstr "Von Agents aufrufbare MCP-Tools"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4044
 msgid "Align Center"
@@ -830,7 +830,7 @@ msgstr "Rechtsbündig"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
 msgid "Alignment"
-msgstr ""
+msgstr "Ausrichtung"
 
 #: packages/admin/src/components/ContentList.tsx:375
 msgid "All"
@@ -839,7 +839,7 @@ msgstr "Alle"
 #: packages/admin/src/components/ContentList.tsx:785
 #: packages/admin/src/components/ContentList.tsx:789
 msgid "All authors"
-msgstr ""
+msgstr "Alle Autoren"
 
 #: packages/admin/src/routes/bylines.tsx:412
 msgid "All bylines"
@@ -886,7 +886,7 @@ msgstr "Alle Typen"
 
 #: packages/admin/src/components/PluginManager.tsx:545
 msgid "Allow MCP tokens with plugin-tool scope to invoke these routes."
-msgstr ""
+msgstr "Erlaube MCP-Tokens mit dem Scope „plugin-tool“, diese Routen aufzurufen."
 
 #: packages/admin/src/components/Settings.tsx:77
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:150
@@ -991,7 +991,7 @@ msgstr "Ein Fehler ist aufgetreten"
 
 #: packages/admin/src/routes/byline-schema.tsx:272
 msgid "An unexpected error occurred."
-msgstr ""
+msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:251
 msgid "An unknown error occurred"
@@ -1059,7 +1059,7 @@ msgstr "Beliebige JSON-Daten"
 #: packages/admin/src/components/ContentList.tsx:739
 #: packages/admin/src/components/ContentStatusBadge.tsx:65
 msgid "Archived"
-msgstr ""
+msgstr "Archiviert"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 #: packages/admin/src/components/Widgets.tsx:158
@@ -1069,7 +1069,7 @@ msgstr "Archive"
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:375
 msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
-msgstr ""
+msgstr "Möchtest du „{0}“ wirklich löschen? Keine gespeicherten Werte verweisen auf dieses Feld."
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:233
@@ -1095,7 +1095,7 @@ msgstr "Ordne WordPress-Autoren EmDash-Benutzern zu. Beiträge werden der ausgew
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:28
 msgid "Astro"
-msgstr ""
+msgstr "Astro"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 #: packages/admin/src/components/MediaLibrary.tsx:436
@@ -1180,12 +1180,12 @@ msgstr "Automatisch anhand des Namens erstellt (bearbeitbar)"
 #: packages/admin/src/components/settings/BackupSettings.tsx:204
 #: packages/admin/src/components/settings/BackupSettings.tsx:260
 msgid "Automatic Backups"
-msgstr ""
+msgstr "Automatische Backups"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:261
 #: packages/admin/src/components/settings/BackupSettings.tsx:279
 msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
-msgstr ""
+msgstr "Automatische Backups benötigen ein Storage-Backend (R2, S3 oder lokaler Speicher). Konfiguriere Storage in deiner EmDash-Konfiguration, um sie zu aktivieren."
 
 #: packages/admin/src/router.tsx:1013
 msgid "Autosave failed"
@@ -1206,7 +1206,7 @@ msgstr "Verfügbare Widgets"
 #: packages/admin/src/components/BylineAvatarField.tsx:46
 #: packages/admin/src/components/BylineAvatarField.tsx:71
 msgid "Avatar"
-msgstr ""
+msgstr "Avatar"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:266
 #: packages/admin/src/components/MenuEditor.tsx:362
@@ -1257,33 +1257,33 @@ msgstr "Zurück zu Designs"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:214
 msgid "Back up now"
-msgstr ""
+msgstr "Jetzt sichern"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:214
 msgid "Backing up..."
-msgstr ""
+msgstr "Backup läuft..."
 
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:115
 msgid "Backup created: {0}"
-msgstr ""
+msgstr "Backup erstellt: {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:98
 msgid "Backup settings saved"
-msgstr ""
+msgstr "Backup-Einstellungen gespeichert"
 
 #: packages/admin/src/components/Settings.tsx:101
 #: packages/admin/src/components/settings/BackupSettings.tsx:143
 msgid "Backups"
-msgstr ""
+msgstr "Backups"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:238
 msgid "Backups to keep"
-msgstr ""
+msgstr "Aufzubewahrende Backups"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:29
 msgid "Bash"
-msgstr ""
+msgstr "Bash"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:186
 msgid "Before send:"
@@ -1347,11 +1347,11 @@ msgstr "Aufzählungsliste"
 #: packages/admin/src/routes/byline-schema.tsx:218
 #: packages/admin/src/routes/bylines.tsx:383
 msgid "Byline schema"
-msgstr ""
+msgstr "Autorenzeilen-Schema"
 
 #: packages/admin/src/components/Sidebar.tsx:267
 msgid "Byline Schema"
-msgstr ""
+msgstr "Autorenzeilen-Schema"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:613
 #: packages/admin/src/components/ContentSettingsPanel.tsx:616
@@ -1362,15 +1362,15 @@ msgstr "Autorenzeilen"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
-msgstr ""
+msgstr "C"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:32
 msgid "C#"
-msgstr ""
+msgstr "C#"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:31
 msgid "C++"
-msgstr ""
+msgstr "C++"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -1481,11 +1481,11 @@ msgstr "Kategorien ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1146
 msgid "Categories & Tags"
-msgstr ""
+msgstr "Kategorien & Schlagwörter"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
 msgid "Center"
-msgstr ""
+msgstr "Zentriert"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
@@ -1518,7 +1518,7 @@ msgstr "Logo ändern"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:808
 msgid "Changelog"
-msgstr ""
+msgstr "Changelog"
 
 #: packages/admin/src/router.tsx:1064
 msgid "Changes discarded"
@@ -1553,7 +1553,7 @@ msgstr "Überprüfe Authentifizierung..."
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:362
 msgid "Checking how many stored values reference \"{0}\"…"
-msgstr ""
+msgstr "Prüfe, wie viele gespeicherte Werte auf „{0}“ verweisen…"
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
@@ -1565,7 +1565,7 @@ msgstr "Wähle deine bevorzugte Sprache für den Adminbereich"
 
 #: packages/admin/src/components/ContentList.tsx:488
 msgid "Clear"
-msgstr ""
+msgstr "Zurücksetzen"
 
 #: packages/admin/src/components/ContentList.tsx:837
 #: packages/admin/src/components/MediaLibrary.tsx:497
@@ -1576,15 +1576,15 @@ msgstr "Filter zurücksetzen"
 #: packages/admin/src/components/MediaLibrary.tsx:497
 #: packages/admin/src/components/MediaLibrary.tsx:521
 msgid "Clear search"
-msgstr ""
+msgstr "Suche zurücksetzen"
 
 #: packages/admin/src/components/PluginSettings.tsx:354
 msgid "Clear stored value"
-msgstr ""
+msgstr "Gespeicherten Wert löschen"
 
 #: packages/admin/src/components/PluginSettings.tsx:352
 msgid "Clear stored value for {fieldKey}"
-msgstr ""
+msgstr "Gespeicherten Wert für {fieldKey} löschen"
 
 #: packages/admin/src/components/SignupPage.tsx:139
 msgid "Click the link in the email to continue setting up your account."
@@ -1661,7 +1661,7 @@ msgstr "Kommentare schließen nach (Tage)"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:178
 msgid "Close gallery settings"
-msgstr ""
+msgstr "Galerie-Einstellungen schließen"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
@@ -1669,7 +1669,7 @@ msgstr "Panel schließen"
 
 #: packages/admin/src/components/ContentEditor.tsx:1061
 msgid "Close settings"
-msgstr ""
+msgstr "Einstellungen schließen"
 
 #: packages/admin/src/components/ContentTypeList.tsx:356
 #: packages/admin/src/components/PortableTextEditor.tsx:3560
@@ -1713,7 +1713,7 @@ msgstr "Erstellte Kollektionen:"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:185
 msgid "Columns"
-msgstr ""
+msgstr "Spalten"
 
 #: packages/admin/src/components/SectionEditor.tsx:288
 msgid "Comma-separated keywords for search."
@@ -1779,7 +1779,7 @@ msgstr "{0} verbunden"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:185
 msgid "content"
-msgstr ""
+msgstr "Inhalt"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:378
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
@@ -1874,7 +1874,7 @@ msgstr "Import fortsetzen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4001
 msgid "Continue numbering"
-msgstr ""
+msgstr "Nummerierung fortsetzen"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -1920,7 +1920,7 @@ msgstr "Das Kopieren ist nicht automatisch möglich. Bitte markiere die obige UR
 
 #: packages/admin/src/components/Dashboard.tsx:90
 msgid "Could not load dashboard data"
-msgstr ""
+msgstr "Dashboard-Daten konnten nicht geladen werden"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:486
 msgid "Could not load image from URL"
@@ -1932,11 +1932,11 @@ msgstr "WordPress wurde nicht erkannt"
 
 #: packages/admin/src/routes/byline-schema.tsx:268
 msgid "Couldn't load byline fields."
-msgstr ""
+msgstr "Autorenzeilen-Felder konnten nicht geladen werden."
 
 #: packages/admin/src/routes/bylines.tsx:547
 msgid "Couldn't load custom fields."
-msgstr ""
+msgstr "Benutzerdefinierte Felder konnten nicht geladen werden."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:88
 msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
@@ -1944,12 +1944,12 @@ msgstr "\"{draft}\" konnte keinem MIME-Typ zugeordnet werden. Gib den MIME-Typ d
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:929
 msgid "Couldn't search bylines. Please try again."
-msgstr ""
+msgstr "Autorenzeilen konnten nicht durchsucht werden. Bitte versuche es erneut."
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
 msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
-msgstr ""
+msgstr "Es konnte nicht geprüft werden, wie viele Werte auf „{0}“ verweisen. Beim Löschen werden trotzdem alle gespeicherten Werte dieses Felds entfernt — die obige Anzahl konnte aber nicht ermittelt werden."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1049
 msgid "Count"
@@ -2002,7 +2002,7 @@ msgstr "Inhaltstyp erstellen"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Create field"
-msgstr ""
+msgstr "Feld erstellen"
 
 #: packages/admin/src/components/MenuList.tsx:129
 #: packages/admin/src/components/MenuList.tsx:192
@@ -2121,7 +2121,7 @@ msgstr "Erstellt"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:96
 msgid "Created \"{0}\"."
-msgstr ""
+msgstr "„{0}“ erstellt."
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:260
@@ -2153,7 +2153,7 @@ msgstr "Erstellen..."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:33
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:83
 msgid "current"
@@ -2165,7 +2165,7 @@ msgstr "Aktuell"
 
 #: packages/admin/src/components/PluginSettings.tsx:340
 msgid "Currently set — enter a new value to replace"
-msgstr ""
+msgstr "Derzeit gesetzt — neuen Wert eingeben, um ihn zu ersetzen"
 
 #: packages/admin/src/components/Sections.tsx:46
 msgid "Custom"
@@ -2185,11 +2185,11 @@ msgstr "Benutzerdefinierter Abschnitt"
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "Custom Taxonomies"
-msgstr ""
+msgstr "Benutzerdefinierte Taxonomien"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:223
 msgid "Daily automatic backups"
-msgstr ""
+msgstr "Tägliche automatische Backups"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
@@ -2223,7 +2223,7 @@ msgstr "Datums- und Uhrzeitauswahl"
 
 #: packages/admin/src/components/ContentList.tsx:802
 msgid "Date field to filter on"
-msgstr ""
+msgstr "Datumsfeld zum Filtern"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:324
 msgid "Date Format"
@@ -2260,7 +2260,7 @@ msgstr "Erstelle eine neue Taxonomie, um Inhalte zu kategorisieren"
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr ""
+msgstr "Definiere benutzerdefinierte Felder, die auf jeder Autorenzeile gespeichert werden — Position, Pronomen, Social-Media-Handles und mehr."
 
 #: packages/admin/src/components/ContentTypeList.tsx:118
 msgid "Define the structure of your content"
@@ -2333,11 +2333,11 @@ msgstr "{0} entfernen?"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:350
 msgid "Delete backup?"
-msgstr ""
+msgstr "Backup löschen?"
 
 #: packages/admin/src/routes/byline-schema.tsx:358
 msgid "Delete byline field?"
-msgstr ""
+msgstr "Autorenzeilen-Feld löschen?"
 
 #: packages/admin/src/routes/bylines.tsx:622
 msgid "Delete Byline?"
@@ -2367,11 +2367,11 @@ msgstr "Feld entfernen?"
 #: packages/admin/src/components/editor/GalleryNode.tsx:219
 #: packages/admin/src/components/editor/GalleryNode.tsx:220
 msgid "Delete gallery"
-msgstr ""
+msgstr "Galerie löschen"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
 msgid "Delete HTML block"
-msgstr ""
+msgstr "HTML-Block löschen"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:220
 #: packages/admin/src/components/editor/ImageNode.tsx:221
@@ -2436,7 +2436,7 @@ msgstr "Entfernt"
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr ""
+msgstr "Beim Löschen von „{0}“ {1, plural, one {wird auch # gespeicherter Wert} other {werden auch # gespeicherte Werte}} über alle Autorenzeilen hinweg entfernt. Dies kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:409
 #: packages/admin/src/components/ContentTypeEditor.tsx:673
@@ -2455,7 +2455,7 @@ msgstr "Entfernen..."
 
 #: packages/admin/src/routes/byline-schema.tsx:379
 msgid "Deleting…"
-msgstr ""
+msgstr "Lösche…"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
@@ -2516,7 +2516,7 @@ msgstr "Zielpfad"
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:153
 #: packages/admin/src/components/PluginManager.tsx:564
 msgid "Destructive"
-msgstr ""
+msgstr "Destruktiv"
 
 #: packages/admin/src/components/PluginManager.tsx:506
 msgid "details"
@@ -2544,7 +2544,7 @@ msgstr "E-Mail nicht erhalten?"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:34
 msgid "Diff"
-msgstr ""
+msgstr "Diff"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:280
 msgid "Dimensions:"
@@ -2560,7 +2560,7 @@ msgstr "Erweiterung deaktivieren"
 
 #: packages/admin/src/components/PluginManager.tsx:554
 msgid "Disable plugin MCP tools"
-msgstr ""
+msgstr "MCP-Tools der Erweiterung deaktivieren"
 
 #: packages/admin/src/components/Redirects.tsx:507
 msgid "Disable redirect"
@@ -2596,7 +2596,7 @@ msgstr "Deaktivieren..."
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:438
 msgid "Discard"
-msgstr ""
+msgstr "Verwerfen"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:79
 #: packages/admin/src/components/ContentSettingsPanel.tsx:99
@@ -2605,7 +2605,7 @@ msgstr "Änderungen verwerfen"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:436
 msgid "Discard changes?"
-msgstr ""
+msgstr "Änderungen verwerfen?"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:84
 msgid "Discard draft changes?"
@@ -2613,7 +2613,7 @@ msgstr "Änderungen verwerfen?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:439
 msgid "Discarding..."
-msgstr ""
+msgstr "Verwerfe..."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:266
 msgid "Dismiss"
@@ -2621,7 +2621,7 @@ msgstr "Schließen"
 
 #: packages/admin/src/components/Widgets.tsx:127
 msgid "Display a list of recent posts"
-msgstr ""
+msgstr "Zeigt eine Liste der neuesten Beiträge an"
 
 #: packages/admin/src/components/Widgets.tsx:105
 msgid "Display a navigation menu"
@@ -2629,7 +2629,7 @@ msgstr "Ein Navigationsmenü anzeigen"
 
 #: packages/admin/src/components/Widgets.tsx:136
 msgid "Display category list"
-msgstr ""
+msgstr "Zeigt eine Kategorienliste an"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1012
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1074
@@ -2648,7 +2648,7 @@ msgstr "Anzeigegröße"
 
 #: packages/admin/src/components/Widgets.tsx:144
 msgid "Display tag cloud"
-msgstr ""
+msgstr "Zeigt eine Schlagwortwolke an"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
@@ -2665,7 +2665,7 @@ msgstr "Trennlinie"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:35
 msgid "Dockerfile"
-msgstr ""
+msgstr "Dockerfile"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 #: packages/admin/src/components/MediaLibrary.tsx:437
@@ -2704,28 +2704,28 @@ msgstr "Runter"
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:304
 msgid "Download {0}"
-msgstr ""
+msgstr "{0} herunterladen"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:191
 msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
-msgstr ""
+msgstr "Lade ein vollständiges Backup deiner Webseite herunter: alle Inhalte (einschließlich Entwürfen und Papierkorb), Kollektionen, Taxonomien, Menüs, Widgets, Medien-Metadaten und Webseiten-Einstellungen. Benutzerkonten und Secrets sind nie enthalten."
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:195
 msgid "Download backup"
-msgstr ""
+msgstr "Backup herunterladen"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:187
 msgid "Download Backup"
-msgstr ""
+msgstr "Backup herunterladen"
 
 #: packages/admin/src/components/Settings.tsx:102
 #: packages/admin/src/components/settings/BackupSettings.tsx:144
 msgid "Download backups and schedule automatic backups to storage"
-msgstr ""
+msgstr "Backups herunterladen und automatische Backups in den Storage planen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:492
 msgid "Download SBOM"
-msgstr ""
+msgstr "SBOM herunterladen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2126
 msgid "Downloading"
@@ -2747,7 +2747,7 @@ msgstr "Entwürfe"
 
 #: packages/admin/src/components/WordPressImport.tsx:1166
 msgid "Drafts & Private"
-msgstr ""
+msgstr "Entwürfe & private Inhalte"
 
 #: packages/admin/src/components/WordPressImport.tsx:1119
 msgid "Drag and drop or click to browse (.xml)"
@@ -2771,7 +2771,7 @@ msgstr "Ziehen, um {0} neu anzuordnen"
 #: packages/admin/src/components/SortableContentSettingsSections.tsx:215
 #: packages/admin/src/components/SortableContentSettingsSections.tsx:216
 msgid "Drag to reorder {label}"
-msgstr ""
+msgstr "Ziehen, um {label} neu anzuordnen"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:355
 msgid "Drag to reorder block"
@@ -2825,7 +2825,7 @@ msgstr "z. B. MacBook Pro, iPhone"
 #: packages/admin/src/components/Sections.tsx:392
 #: packages/admin/src/components/TranslationsPanel.tsx:93
 msgid "Edit"
-msgstr ""
+msgstr "Bearbeiten"
 
 #. placeholder {0}: block?.label || ""
 #. placeholder {0}: collection.label
@@ -2847,7 +2847,7 @@ msgstr "Feld {0} bearbeiten"
 
 #: packages/admin/src/components/ContentEditor.tsx:649
 msgid "Edit {itemLabel}"
-msgstr ""
+msgstr "{itemLabel} bearbeiten"
 
 #: packages/admin/src/components/ContentList.tsx:1031
 msgid "Edit {title}"
@@ -2859,7 +2859,7 @@ msgstr "Autorenzeile bearbeiten"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "Edit byline field"
-msgstr ""
+msgstr "Autorenzeilen-Feld bearbeiten"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:321
 msgid "Edit Domain"
@@ -2872,7 +2872,7 @@ msgstr "Feld bearbeiten"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryNode.tsx:178
 msgid "Edit image {0}"
-msgstr ""
+msgstr "Bild {0} bearbeiten"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3568
 msgid "Edit link"
@@ -2914,11 +2914,11 @@ msgid ""
 "Editor\n"
 "Reporter\n"
 "Photographer"
-msgstr ""
+msgstr "Redakteur\nReporter\nFotograf"
 
 #: packages/admin/src/components/WordPressImport.tsx:1044
 msgid "em1.…"
-msgstr ""
+msgstr "em1.…"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:62
 #: packages/admin/src/components/Settings.tsx:95
@@ -2986,7 +2986,7 @@ msgstr "EmDash-Exporter-Erweiterung erkannt! Du kannst direkt importieren."
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:160
 msgid "Empty gallery — open settings to add images"
-msgstr ""
+msgstr "Leere Galerie — öffne die Einstellungen, um Bilder hinzuzufügen"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
@@ -3006,7 +3006,7 @@ msgstr "Erweiterung aktivieren"
 
 #: packages/admin/src/components/PluginManager.tsx:555
 msgid "Enable plugin MCP tools"
-msgstr ""
+msgstr "MCP-Tools der Erweiterung aktivieren"
 
 #: packages/admin/src/components/Redirects.tsx:507
 msgid "Enable redirect"
@@ -3040,7 +3040,7 @@ msgstr "E-Mail-Adresse eingeben"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
 msgid "Enter HTML..."
-msgstr ""
+msgstr "HTML eingeben..."
 
 #: packages/admin/src/components/ContentEditor.tsx:1242
 msgid "Enter markdown content..."
@@ -3104,11 +3104,11 @@ msgstr "Alle veröffentlichten Versionen dieser Erweiterung wurden zurückgezoge
 #. placeholder {0}: formData.dateFormat ?? "MMMM d, yyyy"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:327
 msgid "Example: {0} → January 23, 2026"
-msgstr ""
+msgstr "Beispiel: {0} → 23. Januar 2026"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:285
 msgid "example.com"
-msgstr ""
+msgstr "example.com"
 
 #: packages/admin/src/components/WordPressImport.tsx:2010
 msgid "Exists"
@@ -3165,7 +3165,7 @@ msgstr "Hinzufügen der Domain fehlgeschlagen"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:175
 msgid "Failed to add passkey"
-msgstr ""
+msgstr "Hinzufügen des Passkeys fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:413
 msgid "Failed to analyze WordPress site"
@@ -3177,7 +3177,7 @@ msgstr "Kommunikation mit Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:179
 msgid "Failed to confirm upload"
-msgstr ""
+msgstr "Bestätigen des Uploads fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
@@ -3186,7 +3186,7 @@ msgstr "Erstellen des Administrators fehlgeschlagen"
 #: packages/admin/src/components/settings/BackupSettings.tsx:122
 #: packages/admin/src/lib/api/backups.ts:51
 msgid "Failed to create backup"
-msgstr ""
+msgstr "Erstellen des Backups fehlgeschlagen"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1055
 msgid "Failed to create byline"
@@ -3194,15 +3194,15 @@ msgstr "Erstellen der Autorenzeile fehlgeschlagen"
 
 #: packages/admin/src/lib/api/byline-fields.ts:120
 msgid "Failed to create byline field"
-msgstr ""
+msgstr "Erstellen des Autorenzeilen-Felds fehlgeschlagen"
 
 #: packages/admin/src/routes/byline-schema.tsx:102
 msgid "Failed to create field"
-msgstr ""
+msgstr "Erstellen des Felds fehlgeschlagen"
 
 #: packages/admin/src/lib/api/sections.ts:88
 msgid "Failed to create section"
-msgstr ""
+msgstr "Erstellen des Abschnitts fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1714
 msgid "Failed to create some collections"
@@ -3229,7 +3229,7 @@ msgstr "Entfernen der erlaubten Domain fehlgeschlagen"
 
 #: packages/admin/src/lib/api/backups.ts:58
 msgid "Failed to delete backup"
-msgstr ""
+msgstr "Löschen des Backups fehlgeschlagen"
 
 #: packages/admin/src/lib/api/bylines.ts:143
 msgid "Failed to delete byline"
@@ -3237,7 +3237,7 @@ msgstr "Entfernen der Autorenzeile fehlgeschlagen"
 
 #: packages/admin/src/lib/api/byline-fields.ts:143
 msgid "Failed to delete byline field"
-msgstr ""
+msgstr "Löschen des Autorenzeilen-Felds fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:230
 msgid "Failed to delete collection"
@@ -3304,7 +3304,7 @@ msgstr "Deaktivieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/search.ts:32
 msgid "Failed to disable search"
-msgstr ""
+msgstr "Deaktivieren der Suche fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
@@ -3329,7 +3329,7 @@ msgstr "Aktivieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/search.ts:31
 msgid "Failed to enable search"
-msgstr ""
+msgstr "Aktivieren der Suche fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
@@ -3341,11 +3341,11 @@ msgstr "Ausführen des Imports fehlgeschlagen"
 
 #: packages/admin/src/lib/api/client.ts:256
 msgid "Failed to fetch auth mode"
-msgstr ""
+msgstr "Abrufen des Auth-Modus fehlgeschlagen"
 
 #: packages/admin/src/lib/api/backups.ts:37
 msgid "Failed to fetch backup settings"
-msgstr ""
+msgstr "Abrufen der Backup-Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:178
 #: packages/admin/src/lib/api/schema.ts:182
@@ -3354,11 +3354,11 @@ msgstr "Abrufen der Kollektion fehlgeschlagen"
 
 #: packages/admin/src/lib/api/dashboard.ts:42
 msgid "Failed to fetch dashboard stats"
-msgstr ""
+msgstr "Abrufen der Dashboard-Statistiken fehlgeschlagen"
 
 #: packages/admin/src/lib/api/email-settings.ts:34
 msgid "Failed to fetch email settings"
-msgstr ""
+msgstr "Abrufen der E-Mail-Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:109
 msgid "Failed to fetch entry terms"
@@ -3370,15 +3370,15 @@ msgstr "Abrufen des Manifests fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:72
 msgid "Failed to fetch media"
-msgstr ""
+msgstr "Abrufen der Medien fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:85
 msgid "Failed to fetch media item"
-msgstr ""
+msgstr "Abrufen des Medienelements fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:352
 msgid "Failed to fetch media providers"
-msgstr ""
+msgstr "Abrufen der Medienanbieter fehlgeschlagen"
 
 #: packages/admin/src/lib/api/plugins.ts:70
 #: packages/admin/src/lib/api/plugins.ts:74
@@ -3387,15 +3387,15 @@ msgstr "Abrufen der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/plugins.ts:114
 msgid "Failed to fetch plugin settings"
-msgstr ""
+msgstr "Abrufen der Erweiterungs-Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/plugins.ts:56
 msgid "Failed to fetch plugins"
-msgstr ""
+msgstr "Abrufen der Erweiterungen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:382
 msgid "Failed to fetch provider media"
-msgstr ""
+msgstr "Abrufen der Medien vom Anbieter fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:557
 #: packages/admin/src/lib/api/content.ts:562
@@ -3404,15 +3404,15 @@ msgstr "Abrufen der Revision fehlgeschlagen"
 
 #: packages/admin/src/lib/api/sections.ts:76
 msgid "Failed to fetch section"
-msgstr ""
+msgstr "Abrufen des Abschnitts fehlgeschlagen"
 
 #: packages/admin/src/lib/api/sections.ts:68
 msgid "Failed to fetch sections"
-msgstr ""
+msgstr "Abrufen der Abschnitte fehlgeschlagen"
 
 #: packages/admin/src/lib/api/settings.ts:50
 msgid "Failed to fetch settings"
-msgstr ""
+msgstr "Abrufen der Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
@@ -3448,7 +3448,7 @@ msgstr "Abrufen der Registrierungsoptionen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:154
 msgid "Failed to get upload URL"
-msgstr ""
+msgstr "Abrufen der Upload-URL fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:436
 msgid "Failed to import from WordPress"
@@ -3466,7 +3466,7 @@ msgstr "Installieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/byline-fields.ts:98
 msgid "Failed to list byline fields"
-msgstr ""
+msgstr "Auflisten der Autorenzeilen-Felder fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:284
 msgid "Failed to load admin"
@@ -3479,7 +3479,7 @@ msgstr "Laden erlaubter Domains fehlgeschlagen"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:165
 msgid "Failed to load backup settings"
-msgstr ""
+msgstr "Laden der Backup-Einstellungen fehlgeschlagen"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:365
@@ -3505,7 +3505,7 @@ msgstr "Laden der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/components/PluginSettings.tsx:146
 msgid "Failed to load plugin settings"
-msgstr ""
+msgstr "Laden der Erweiterungs-Einstellungen fehlgeschlagen"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:149
@@ -3556,7 +3556,7 @@ msgstr "Publizieren fehlgeschlagen"
 
 #: packages/admin/src/lib/api/byline-fields.ts:106
 msgid "Failed to read byline field usage"
-msgstr ""
+msgstr "Lesen der Nutzung des Autorenzeilen-Felds fehlgeschlagen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:115
 msgid "Failed to remove domain"
@@ -3573,11 +3573,11 @@ msgstr "Umbenennen des Passkeys fehlgeschlagen"
 
 #: packages/admin/src/lib/api/byline-fields.ts:156
 msgid "Failed to reorder byline fields"
-msgstr ""
+msgstr "Neuanordnen der Autorenzeilen-Felder fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:318
 msgid "Failed to reorder content types"
-msgstr ""
+msgstr "Neuanordnen der Inhaltstypen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:301
 #: packages/admin/src/routes/byline-schema.tsx:152
@@ -3617,11 +3617,11 @@ msgstr "Speichern fehlgeschlagen"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:102
 msgid "Failed to save backup settings"
-msgstr ""
+msgstr "Speichern der Backup-Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/routes/byline-schema.tsx:122
 msgid "Failed to save field"
-msgstr ""
+msgstr "Speichern des Felds fehlgeschlagen"
 
 #: packages/admin/src/components/PluginSettings.tsx:74
 #: packages/admin/src/components/settings/GeneralSettings.tsx:77
@@ -3671,7 +3671,7 @@ msgstr "Aufheben der Planung fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:515
 msgid "Failed to update"
-msgstr ""
+msgstr "Aktualisieren fehlgeschlagen"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:369
@@ -3680,7 +3680,7 @@ msgstr "Aktualisieren von {0} fehlgeschlagen"
 
 #: packages/admin/src/lib/api/backups.ts:46
 msgid "Failed to update backup settings"
-msgstr ""
+msgstr "Aktualisieren der Backup-Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1105
 msgid "Failed to update byline"
@@ -3688,7 +3688,7 @@ msgstr "Aktualisieren der Autorenzeile fehlgeschlagen"
 
 #: packages/admin/src/lib/api/byline-fields.ts:135
 msgid "Failed to update byline field"
-msgstr ""
+msgstr "Aktualisieren des Autorenzeilen-Felds fehlgeschlagen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:98
 msgid "Failed to update domain"
@@ -3696,7 +3696,7 @@ msgstr "Aktualisieren der Domain fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:303
 msgid "Failed to update media"
-msgstr ""
+msgstr "Aktualisieren der Medien fehlgeschlagen"
 
 #: packages/admin/src/lib/api/marketplace.ts:232
 #: packages/admin/src/lib/api/registry.ts:776
@@ -3705,19 +3705,19 @@ msgstr "Aktualisieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/plugins.ts:172
 msgid "Failed to update plugin MCP access"
-msgstr ""
+msgstr "Aktualisieren des MCP-Zugriffs der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/plugins.ts:133
 msgid "Failed to update plugin settings"
-msgstr ""
+msgstr "Aktualisieren der Erweiterungs-Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/sections.ts:100
 msgid "Failed to update section"
-msgstr ""
+msgstr "Aktualisieren des Abschnitts fehlgeschlagen"
 
 #: packages/admin/src/lib/api/settings.ts:64
 msgid "Failed to update settings"
-msgstr ""
+msgstr "Aktualisieren der Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:1457
 msgid "Failed to update status"
@@ -3729,11 +3729,11 @@ msgstr "Hochladen der Datei fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:242
 msgid "Failed to upload media"
-msgstr ""
+msgstr "Hochladen der Medien fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:404
 msgid "Failed to upload to provider"
-msgstr ""
+msgstr "Hochladen zum Anbieter fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:248
 msgid "Failed to verify authentication"
@@ -3745,7 +3745,7 @@ msgstr "Verifizieren der Registrierung fehlgeschlagen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:807
 msgid "FAQ"
-msgstr ""
+msgstr "FAQ"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:251
 #: packages/admin/src/components/settings/GeneralSettings.tsx:258
@@ -3758,7 +3758,7 @@ msgstr "Funktion"
 
 #: packages/admin/src/components/WordPressImport.tsx:1148
 msgid "Featured Images"
-msgstr ""
+msgstr "Beitragsbilder"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:440
 #: packages/admin/src/components/ContentTypeList.tsx:187
@@ -3771,11 +3771,11 @@ msgstr "Abrufen von Inhalten über die EmDash-Exporter-API."
 
 #: packages/admin/src/routes/byline-schema.tsx:95
 msgid "Field created"
-msgstr ""
+msgstr "Feld erstellt"
 
 #: packages/admin/src/routes/byline-schema.tsx:133
 msgid "Field deleted"
-msgstr ""
+msgstr "Feld gelöscht"
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
@@ -3791,11 +3791,11 @@ msgstr "Feldnamen können nach der Erstellung nicht mehr geändert werden"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:268
 msgid "Field type cannot be changed after creation."
-msgstr ""
+msgstr "Der Feldtyp kann nach dem Erstellen nicht mehr geändert werden."
 
 #: packages/admin/src/routes/byline-schema.tsx:115
 msgid "Field updated"
-msgstr ""
+msgstr "Feld aktualisiert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:581
 msgid "Fields"
@@ -3834,7 +3834,7 @@ msgstr "Dateien importiert"
 
 #: packages/admin/src/components/ContentList.tsx:781
 msgid "Filter by author"
-msgstr ""
+msgstr "Nach Autor filtern"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:115
 msgid "Filter by capability"
@@ -3884,12 +3884,12 @@ msgstr "Installiere die"
 
 #: packages/admin/src/components/ContentList.tsx:818
 msgid "From date"
-msgstr ""
+msgstr "Startdatum"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
 #: packages/admin/src/components/WordPressImport.tsx:1155
 msgid "Full"
-msgstr ""
+msgstr "Voll"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -3902,12 +3902,12 @@ msgstr "Uneingeschränkter Zugriff"
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:171
 #: packages/admin/src/components/PortableTextEditor.tsx:2687
 msgid "Gallery"
-msgstr ""
+msgstr "Galerie"
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:207
 #: packages/admin/src/components/editor/GalleryNode.tsx:208
 msgid "Gallery settings"
-msgstr ""
+msgstr "Galerie-Einstellungen"
 
 #: packages/admin/src/components/Settings.tsx:48
 msgid "General"
@@ -3935,7 +3935,7 @@ msgstr "Gib diesem Passkey einen Namen, um ihn später leichter wiederzuerkennen
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:36
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: packages/admin/src/components/WordPressImport.tsx:2418
 #: packages/admin/src/router.tsx:2233
@@ -3949,7 +3949,7 @@ msgstr "Google-Verifizierung"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:37
 msgid "GraphQL"
-msgstr ""
+msgstr "GraphQL"
 
 #: packages/admin/src/components/MediaLibrary.tsx:460
 msgid "Grid view"
@@ -3961,7 +3961,7 @@ msgstr "Gruppe (optional)"
 
 #: packages/admin/src/components/Widgets.tsx:162
 msgid "Group by"
-msgstr ""
+msgstr "Gruppieren nach"
 
 #: packages/admin/src/routes/bylines.tsx:555
 msgid "Guest byline"
@@ -3993,24 +3993,24 @@ msgstr "Überschrift 3"
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
 #: packages/admin/src/components/PortableTextEditor.tsx:1387
 msgid "Heading 4"
-msgstr ""
+msgstr "Überschrift 4"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:95
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
 #: packages/admin/src/components/PortableTextEditor.tsx:1397
 msgid "Heading 5"
-msgstr ""
+msgstr "Überschrift 5"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:103
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
 #: packages/admin/src/components/PortableTextEditor.tsx:1407
 msgid "Heading 6"
-msgstr ""
+msgstr "Überschrift 6"
 
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:142
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:158
 msgid "Headings"
-msgstr ""
+msgstr "Überschriften"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
@@ -4064,16 +4064,16 @@ msgstr "Wie ein Anwendungspasswort erstellt wird"
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
 #: packages/admin/src/components/PortableTextEditor.tsx:1457
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
 msgid "HTML source"
-msgstr ""
+msgstr "HTML-Quelltext"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3481
 #: packages/admin/src/components/PortableTextEditor.tsx:4099
 msgid "https://..."
-msgstr ""
+msgstr "https://..."
 
 #: packages/admin/src/components/MenuEditor.tsx:424
 msgid "https://example.com or /about"
@@ -4085,7 +4085,7 @@ msgstr "https://beispiel.de/bild.jpg"
 
 #: packages/admin/src/components/WordPressImport.tsx:1089
 msgid "https://yoursite.com"
-msgstr ""
+msgstr "https://deine-webseite.de"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:243
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:153
@@ -4109,7 +4109,7 @@ msgstr "Bild"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:294
 msgid "Image {0}"
-msgstr ""
+msgstr "Bild {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:205
 msgid "Image from media library"
@@ -4218,7 +4218,7 @@ msgstr "Nach Kollektion importiert"
 #. placeholder {0}: wpImportProgress.comments
 #: packages/admin/src/components/WordPressImport.tsx:903
 msgid "Importing comments... {0}"
-msgstr ""
+msgstr "Importiere Kommentare... {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:920
 msgid "Importing content..."
@@ -4227,12 +4227,12 @@ msgstr "Importiere Inhalte..."
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:901
 msgid "Importing content... {0}"
-msgstr ""
+msgstr "Importiere Inhalte... {0}"
 
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:900
 msgid "Importing content... {0} of {totalSelectedPosts}"
-msgstr ""
+msgstr "Importiere Inhalte... {0} von {totalSelectedPosts}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2139
 msgid "Importing Media"
@@ -4240,7 +4240,7 @@ msgstr "Importiere Medien"
 
 #: packages/admin/src/components/WordPressImport.tsx:904
 msgid "Importing menus and site settings..."
-msgstr ""
+msgstr "Importiere Menüs und Webseiten-Einstellungen..."
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
@@ -4252,7 +4252,7 @@ msgstr "Inkompatibel"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:506
 msgid "Indexed"
-msgstr ""
+msgstr "Indexiert"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3965
 msgid "Inline Code"
@@ -4266,7 +4266,7 @@ msgstr "Einfügen"
 #. placeholder {0}: block?.label || ""
 #: packages/admin/src/components/PortableTextEditor.tsx:1889
 msgid "Insert {0}"
-msgstr ""
+msgstr "{0} einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1438
 msgid "Insert a blockquote"
@@ -4294,20 +4294,20 @@ msgstr "Ein Bild einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2688
 msgid "Insert an image gallery"
-msgstr ""
+msgstr "Eine Bildergalerie einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1717
 msgid "Insert block"
-msgstr ""
+msgstr "Block einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3903
 #: packages/admin/src/components/PortableTextEditor.tsx:3913
 msgid "Insert block after current block"
-msgstr ""
+msgstr "Block nach dem aktuellen Block einfügen"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
 msgid "Insert block below"
-msgstr ""
+msgstr "Block darunter einfügen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:549
 msgid "Insert from URL"
@@ -4320,7 +4320,7 @@ msgstr "Link einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1458
 msgid "Insert raw HTML"
-msgstr ""
+msgstr "Rohes HTML einfügen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:58
 msgid "Insert Section"
@@ -4345,11 +4345,11 @@ msgstr "Installation blockiert"
 
 #: packages/admin/src/components/WordPressImport.tsx:1039
 msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
-msgstr ""
+msgstr "Installiere die EmDash-Exporter-Erweiterung auf deiner WordPress-Webseite und erzeuge einen Schlüssel unter Werkzeuge → EmDash Migration."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:806
 msgid "Installation"
-msgstr ""
+msgstr "Installation"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:263
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:184
@@ -4411,11 +4411,11 @@ msgstr "Lade dein erstes Teammitglied ein"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:97
 msgid "Invoke MCP tools from all enabled plugins"
-msgstr ""
+msgstr "MCP-Tools aller aktivierten Erweiterungen aufrufen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:516
 msgid "Invoke only this plugin's enabled MCP tools"
-msgstr ""
+msgstr "Nur die aktivierten MCP-Tools dieser Erweiterung aufrufen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3525
 #: packages/admin/src/components/PortableTextEditor.tsx:3930
@@ -4447,19 +4447,19 @@ msgstr "Max Mustermann"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:39
 msgid "Java"
-msgstr ""
+msgstr "Java"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:40
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:235
 msgid "Job title"
-msgstr ""
+msgstr "Position"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:246
 msgid "job_title"
-msgstr ""
+msgstr "job_title"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:41
 #: packages/admin/src/components/FieldEditor.tsx:222
@@ -4468,15 +4468,15 @@ msgstr "JSON"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:42
 msgid "JSX"
-msgstr ""
+msgstr "JSX"
 
 #: packages/admin/src/components/WordPressImport.tsx:916
 msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
-msgstr ""
+msgstr "Lass diesen Tab geöffnet. Der Import läuft in kleinen Schritten und kann bei Unterbrechung gefahrlos erneut gestartet werden."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:934
 msgid "Keep typing to narrow down more bylines."
-msgstr ""
+msgstr "Tippe weiter, um die Autorenzeilen weiter einzugrenzen."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283
@@ -4486,7 +4486,7 @@ msgstr "Stichwörter"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:43
 msgid "Kotlin"
-msgstr ""
+msgstr "Kotlin"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:232
 #: packages/admin/src/components/FieldEditor.tsx:411
@@ -4552,7 +4552,7 @@ msgstr "Zuletzt verwendet am {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:337
 msgid "Learn more"
-msgstr ""
+msgstr "Mehr erfahren"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:339
 msgid "Leave blank to use a discoverable passkey."
@@ -4564,7 +4564,7 @@ msgstr "Nicht zugewiesen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
 msgid "Left"
-msgstr ""
+msgstr "Links"
 
 #: packages/admin/src/components/MediaLibrary.tsx:136
 #: packages/admin/src/components/MediaLibrary.tsx:273
@@ -4588,7 +4588,7 @@ msgstr "Hell"
 
 #: packages/admin/src/components/Widgets.tsx:165
 msgid "Limit"
-msgstr ""
+msgstr "Limit"
 
 #: packages/admin/src/components/SignupPage.tsx:258
 msgid "Link expired"
@@ -4647,11 +4647,11 @@ msgstr "Mehr laden"
 
 #: packages/admin/src/router.tsx:2188
 msgid "Loading"
-msgstr ""
+msgstr "Lädt"
 
 #: packages/admin/src/routes/byline-schema.tsx:257
 msgid "Loading byline fields…"
-msgstr ""
+msgstr "Lade Autorenzeilen-Felder…"
 
 #: packages/admin/src/components/ContentTypeList.tsx:198
 msgid "Loading collections..."
@@ -4752,7 +4752,7 @@ msgstr "Seitenverhältnis sperren"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:291
 msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
-msgstr ""
+msgstr "Gesperrt, weil dieses Feld gespeicherte Werte hat. Lösche die Werte (oder das Feld), um das zu ändern."
 
 #: packages/admin/src/components/Header.tsx:109
 msgid "Log out"
@@ -4769,7 +4769,7 @@ msgstr "Logo & Favicon"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:53
 msgid "Long text"
-msgstr ""
+msgstr "Langer Text"
 
 #: packages/admin/src/components/FieldEditor.tsx:156
 #: packages/admin/src/components/FieldEditor.tsx:580
@@ -4835,11 +4835,11 @@ msgstr "Passkeys und Authentifizierung verwalten"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:317
 msgid "Managed by {providerName}"
-msgstr ""
+msgstr "Verwaltet von {providerName}"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:318
 msgid "Managed by an external media provider"
-msgstr ""
+msgstr "Verwaltet von einem externen Medienanbieter"
 
 #: packages/admin/src/components/Redirects.tsx:427
 msgid "Manual"
@@ -4857,11 +4857,11 @@ msgstr "Ordne dem WordPress-Benutzer {0} einen EmDash-Benutzer zu"
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:256
 msgid "Mark {0} as Gone (410)"
-msgstr ""
+msgstr "{0} als Gone (410) markieren"
 
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr ""
+msgstr "Als Gone (410) markieren — signalisiert Suchmaschinen, dass der Inhalt dauerhaft gelöscht wurde"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:502
 msgid "Mark as spam"
@@ -4869,7 +4869,7 @@ msgstr "Als Spam markieren"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:44
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 #: packages/admin/src/components/PluginManager.tsx:206
 msgid "marketplace"
@@ -4896,11 +4896,11 @@ msgstr "Max. Wert"
 
 #: packages/admin/src/components/Widgets.tsx:147
 msgid "Maximum tags"
-msgstr ""
+msgstr "Maximale Anzahl Schlagwörter"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:45
 msgid "MDX"
-msgstr ""
+msgstr "MDX"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2676
 #: packages/admin/src/components/PortableTextEditor.tsx:2691
@@ -5028,7 +5028,7 @@ msgstr "Meta-Titel, Beschreibungen und Bilder für soziale Medien"
 
 #: packages/admin/src/components/WordPressImport.tsx:1051
 msgid "Migration key"
-msgstr ""
+msgstr "Migrationsschlüssel"
 
 #: packages/admin/src/components/FieldEditor.tsx:620
 msgid "Min Items"
@@ -5044,7 +5044,7 @@ msgstr "Min. Wert"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1398
 msgid "Minor section heading"
-msgstr ""
+msgstr "Untergeordnete Abschnittsüberschrift"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:504
 msgid "Moderation"
@@ -5060,15 +5060,15 @@ msgstr "Kollektionsschemata ändern und entfernen"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Monthly"
-msgstr ""
+msgstr "Monatlich"
 
 #: packages/admin/src/components/Widgets.tsx:159
 msgid "Monthly/yearly archives"
-msgstr ""
+msgstr "Monats-/Jahresarchive"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:111
 msgid "More information about {label}"
-msgstr ""
+msgstr "Weitere Informationen zu {label}"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
@@ -5077,12 +5077,12 @@ msgstr "Am beliebtesten"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:439
 msgid "Move \"{0}\" down"
-msgstr ""
+msgstr "„{0}“ nach unten verschieben"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:429
 msgid "Move \"{0}\" up"
-msgstr ""
+msgstr "„{0}“ nach oben verschieben"
 
 #: packages/admin/src/components/ContentList.tsx:1060
 msgid "Move \"{title}\" to trash? You can restore it later."
@@ -5091,22 +5091,22 @@ msgstr "\"{title}\" in den Papierkorb verschieben? Ein späteres Wiederherstelle
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:251
 msgid "Move {0} down"
-msgstr ""
+msgstr "{0} nach unten verschieben"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Move {0} down — unavailable, its parent has no translation in this locale"
-msgstr ""
+msgstr "{0} nach unten verschieben — nicht möglich, das übergeordnete Element hat keine Übersetzung in dieser Sprache"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:238
 msgid "Move {0} up"
-msgstr ""
+msgstr "{0} nach oben verschieben"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:237
 msgid "Move {0} up — unavailable, its parent has no translation in this locale"
-msgstr ""
+msgstr "{0} nach oben verschieben — nicht möglich, das übergeordnete Element hat keine Übersetzung in dieser Sprache"
 
 #: packages/admin/src/components/ContentList.tsx:1051
 msgid "Move {title} to trash"
@@ -5118,7 +5118,7 @@ msgstr "Nach unten verschieben"
 
 #: packages/admin/src/components/ContentList.tsx:446
 msgid "Move to trash"
-msgstr ""
+msgstr "In den Papierkorb verschieben"
 
 #: packages/admin/src/components/ContentList.tsx:473
 #: packages/admin/src/components/ContentList.tsx:1073
@@ -5139,11 +5139,11 @@ msgstr "Nach oben verschieben"
 
 #: packages/admin/src/router.tsx:512
 msgid "Moved {total} items to draft"
-msgstr ""
+msgstr "{total} Elemente zu Entwurf zurückgesetzt"
 
 #: packages/admin/src/router.tsx:533
 msgid "Moved {total} items to trash"
-msgstr ""
+msgstr "{total} Elemente in den Papierkorb verschoben"
 
 #: packages/admin/src/components/FieldEditor.tsx:192
 msgid "Multi Select"
@@ -5209,11 +5209,11 @@ msgstr "{0} erstellen"
 
 #: packages/admin/src/components/ContentEditor.tsx:649
 msgid "New {itemLabel}"
-msgstr ""
+msgstr "{itemLabel} erstellen"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
-msgstr ""
+msgstr "Neues Autorenzeilen-Feld"
 
 #: packages/admin/src/components/WordPressImport.tsx:1982
 msgid "New collection"
@@ -5226,7 +5226,7 @@ msgstr "Neuer Inhaltstyp"
 
 #: packages/admin/src/routes/byline-schema.tsx:224
 msgid "New field"
-msgstr ""
+msgstr "Neues Feld"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:122
 msgid "New public routes"
@@ -5285,7 +5285,7 @@ msgstr "Nein"
 
 #: packages/admin/src/routes/byline-schema.tsx:420
 msgid "No (shared across translations)"
-msgstr ""
+msgstr "Nein (für alle Übersetzungen gemeinsam)"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:454
@@ -5321,7 +5321,7 @@ msgstr "Noch keine freigegebenen Kommentare."
 
 #: packages/admin/src/routes/byline-schema.tsx:291
 msgid "No byline fields yet."
-msgstr ""
+msgstr "Noch keine Autorenzeilen-Felder."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:888
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
@@ -5401,7 +5401,7 @@ msgstr "Keine Überschriften im Dokument"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:205
 msgid "No images in this gallery yet."
-msgstr ""
+msgstr "Noch keine Bilder in dieser Galerie."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:594
 msgid "No installable releases"
@@ -5431,12 +5431,12 @@ msgstr "Keine Treffer"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:931
 msgid "No matching bylines."
-msgstr ""
+msgstr "Keine passenden Autorenzeilen."
 
 #: packages/admin/src/components/MediaLibrary.tsx:489
 #: packages/admin/src/components/MediaLibrary.tsx:517
 msgid "No matching media"
-msgstr ""
+msgstr "Keine passenden Medien"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:264
 msgid "No matching passkey found for this account."
@@ -5453,7 +5453,7 @@ msgstr "Von diesem Anbieter ist kein Medium verfügbar"
 
 #: packages/admin/src/components/MediaLibrary.tsx:540
 msgid "No media available from this provider."
-msgstr ""
+msgstr "Keine Medien von diesem Anbieter verfügbar."
 
 #: packages/admin/src/components/MediaLibrary.tsx:539
 #: packages/admin/src/components/MediaPickerModal.tsx:688
@@ -5479,7 +5479,7 @@ msgstr "Keine Moderation (alle automatisch freigeben)"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "No parent (top level)"
-msgstr ""
+msgstr "Kein übergeordnetes Element (oberste Ebene)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:248
 msgid "No passkeys registered"
@@ -5511,7 +5511,7 @@ msgstr "Keine Vorschau"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:304
 msgid "No public URL available"
-msgstr ""
+msgstr "Keine öffentliche URL verfügbar"
 
 #: packages/admin/src/components/Dashboard.tsx:320
 msgid "No recent activity"
@@ -5529,7 +5529,7 @@ msgstr "Keine Ergebnisse"
 #: packages/admin/src/components/ContentList.tsx:553
 #: packages/admin/src/components/ContentList.tsx:572
 msgid "No results for \"{activeSearch}\""
-msgstr ""
+msgstr "Keine Ergebnisse für „{activeSearch}“"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:178
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
@@ -5580,7 +5580,7 @@ msgstr "Noch keine Widget-Bereiche vorhanden. Erstelle einen, um loszulegen."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
 msgid "None"
-msgstr ""
+msgstr "Keine"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:596
 #: packages/admin/src/components/TaxonomyManager.tsx:605
@@ -5589,11 +5589,11 @@ msgstr "Keine"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:629
 msgid "Not compatible with this environment"
-msgstr ""
+msgstr "Nicht kompatibel mit dieser Umgebung"
 
 #: packages/admin/src/components/PluginSettings.tsx:341
 msgid "Not set"
-msgstr ""
+msgstr "Nicht gesetzt"
 
 #: packages/admin/src/components/FieldEditor.tsx:162
 #: packages/admin/src/components/FieldEditor.tsx:581
@@ -5602,7 +5602,7 @@ msgstr "Zahl"
 
 #: packages/admin/src/components/Widgets.tsx:129
 msgid "Number of posts"
-msgstr ""
+msgstr "Anzahl der Beiträge"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:319
 msgid "Number of posts to show per page on list views"
@@ -5616,7 +5616,7 @@ msgstr "Nummerierte Liste"
 
 #: packages/admin/src/components/WordPressImport.tsx:494
 msgid "OAuth authorization requires HTTPS. Please use manual credentials."
-msgstr ""
+msgstr "OAuth-Autorisierung erfordert HTTPS. Bitte verwende manuelle Anmeldedaten."
 
 #: packages/admin/src/components/SeoImageField.tsx:46
 msgid "OG Image"
@@ -5672,7 +5672,7 @@ msgstr ""
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:385
 msgid "Optional caption"
-msgstr ""
+msgstr "Optionale Bildunterschrift"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
@@ -5707,7 +5707,7 @@ msgstr "Oder wähle per Klick eine Datei aus. Unterstützt .xml-Dateien aus eine
 
 #: packages/admin/src/components/WordPressImport.tsx:1071
 msgid "or connect by URL"
-msgstr ""
+msgstr "oder per URL verbinden"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:97
 #: packages/admin/src/components/LoginPage.tsx:263
@@ -5776,7 +5776,7 @@ msgstr "Teil einer Weiterleitungsschleife"
 
 #: packages/admin/src/components/WordPressImport.tsx:1153
 msgid "Partial"
-msgstr ""
+msgstr "Teilweise"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:324
 msgid "Pass"
@@ -5842,7 +5842,7 @@ msgstr "Passkeys erfordern HTTPS oder http://localhost (mit deinem Port); dieser
 
 #: packages/admin/src/components/WordPressImport.tsx:1037
 msgid "Paste your migration key"
-msgstr ""
+msgstr "Füge deinen Migrationsschlüssel ein"
 
 #: packages/admin/src/components/Redirects.tsx:225
 msgid "Path"
@@ -5892,7 +5892,7 @@ msgstr "Berechtigungen"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:46
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
@@ -5900,7 +5900,7 @@ msgstr "Wähle eine beliebige Methode, um dein Administratorkonto anzulegen."
 
 #: packages/admin/src/components/Widgets.tsx:154
 msgid "Placeholder text"
-msgstr ""
+msgstr "Platzhaltertext"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:311
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
@@ -5910,7 +5910,7 @@ msgstr "Einfaches"
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:27
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:120
 msgid "Plain text"
-msgstr ""
+msgstr "Einfacher Text"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:166
 msgid "Please ask your administrator to send a new invite."
@@ -5934,11 +5934,11 @@ msgstr "Erweiterung"
 
 #: packages/admin/src/lib/api/plugins.ts:68
 msgid "Plugin \"{pluginId}\" not found"
-msgstr ""
+msgstr "Erweiterung „{pluginId}“ nicht gefunden"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:762
 msgid "Plugin details"
-msgstr ""
+msgstr "Details zur Erweiterung"
 
 #: packages/admin/src/components/PluginManager.tsx:114
 msgid "Plugin disabled"
@@ -5959,15 +5959,15 @@ msgstr "Fehler mit der Erweiterung ({0})"
 
 #: packages/admin/src/components/PluginManager.tsx:334
 msgid "Plugin MCP access updated"
-msgstr ""
+msgstr "MCP-Zugriff der Erweiterung aktualisiert"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
 msgid "Plugin MCP Tools"
-msgstr ""
+msgstr "MCP-Tools der Erweiterung"
 
 #: packages/admin/src/lib/api/marketplace.ts:108
 msgid "Plugin MCP tools require explicit consent"
-msgstr ""
+msgstr "MCP-Tools von Erweiterungen erfordern ausdrückliche Zustimmung"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:123
 msgid "Plugin not found"
@@ -5983,7 +5983,7 @@ msgstr "Erweiterung für deine WordPress-Webseite, um von einem reibungslosen Im
 
 #: packages/admin/src/components/PluginManager.tsx:483
 msgid "Plugin pages"
-msgstr ""
+msgstr "Seiten von Erweiterungen"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "Plugin Permissions"
@@ -6002,7 +6002,7 @@ msgstr "Erweiterung antwortete mit {0}: {text}"
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:511
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:514
 msgid "Plugin tools: {0}"
-msgstr ""
+msgstr "Tools der Erweiterung: {0}"
 
 #: packages/admin/src/components/PluginManager.tsx:323
 msgid "Plugin uninstalled"
@@ -6018,7 +6018,7 @@ msgstr "Erweiterung aktualisiert"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
 msgid "Plugin widget error"
-msgstr ""
+msgstr "Fehler im Erweiterungs-Widget"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:218
 #: packages/admin/src/components/PluginManager.tsx:139
@@ -6031,7 +6031,7 @@ msgstr "Erweiterungen"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:327
 msgid "Point-in-Time Restore"
-msgstr ""
+msgstr "Point-in-Time Restore"
 
 #: packages/admin/src/components/SeoPanel.tsx:220
 msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
@@ -6039,7 +6039,7 @@ msgstr "Leitet Suchmaschinen auf die Originalversion dieser Seite weiter, falls 
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:387
 msgid "Post"
-msgstr ""
+msgstr "Beitrag"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:395
 #: packages/admin/src/components/WordPressImport.tsx:1322
@@ -6048,7 +6048,7 @@ msgstr "Beiträge"
 
 #: packages/admin/src/components/WordPressImport.tsx:1144
 msgid "Posts & Pages"
-msgstr ""
+msgstr "Beiträge & Seiten"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:313
 msgid "Posts Per Page"
@@ -6104,7 +6104,7 @@ msgstr "Hauptnavigation"
 
 #: packages/admin/src/components/ContentStatusBadge.tsx:69
 msgid "Private"
-msgstr ""
+msgstr "Privat"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:167
 msgid "Provider:"
@@ -6123,7 +6123,7 @@ msgstr "Publizieren"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:555
 msgid "Publish date"
-msgstr ""
+msgstr "Publikationsdatum"
 
 #: packages/admin/src/components/ContentList.tsx:747
 #: packages/admin/src/router.tsx:1027
@@ -6137,7 +6137,7 @@ msgstr "Publiziert am {0}"
 
 #: packages/admin/src/router.tsx:489
 msgid "Published {total} items"
-msgstr ""
+msgstr "{total} Elemente publiziert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
@@ -6149,7 +6149,7 @@ msgstr "Publiziert von"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
-msgstr ""
+msgstr "Python"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1004
 msgid "Quick create byline"
@@ -6168,7 +6168,7 @@ msgstr "Zitat"
 
 #: packages/admin/src/components/WordPressImport.tsx:1162
 msgid "Raw meta"
-msgstr ""
+msgstr "Rohe Metadaten"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:67
 msgid "Read collection schemas"
@@ -6198,7 +6198,7 @@ msgstr "Deine Inhalte lesen"
 
 #: packages/admin/src/lib/api/marketplace.ts:281
 msgid "Read your taxonomies and terms"
-msgstr ""
+msgstr "Deine Taxonomien und Begriffe lesen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:310
 msgid "Reading"
@@ -6214,7 +6214,7 @@ msgstr "Neueste Aktivitäten"
 
 #: packages/admin/src/components/Widgets.tsx:126
 msgid "Recent Posts"
-msgstr ""
+msgstr "Neueste Beiträge"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:43
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
@@ -6258,7 +6258,7 @@ msgstr "Das angegebene Favicon ist nicht verfügbar."
 
 #: packages/admin/src/components/Dashboard.tsx:91
 msgid "Refresh the page or try again."
-msgstr ""
+msgstr "Lade die Seite neu oder versuche es erneut."
 
 #: packages/admin/src/components/ContentTypeList.tsx:156
 msgid "Register"
@@ -6339,7 +6339,7 @@ msgstr "Bild entfernen"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:320
 msgid "Remove image {0}"
-msgstr ""
+msgstr "Bild {0} entfernen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
 msgid "Remove Image?"
@@ -6393,12 +6393,12 @@ msgstr "Passkey umbenennen"
 
 #: packages/admin/src/components/ContentTypeList.tsx:174
 msgid "Reorder"
-msgstr ""
+msgstr "Neu anordnen"
 
 #. placeholder {0}: collection.label
 #: packages/admin/src/components/ContentTypeList.tsx:281
 msgid "Reorder {0}"
-msgstr ""
+msgstr "{0} neu anordnen"
 
 #: packages/admin/src/components/FieldEditor.tsx:240
 msgid "Repeater"
@@ -6411,7 +6411,7 @@ msgstr "Wiederholbare Gruppe von Feldern"
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:363
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:396
 msgid "Replace image"
-msgstr ""
+msgstr "Bild ersetzen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
@@ -6433,7 +6433,7 @@ msgstr "Einen neuen Link anfragen"
 
 #: packages/admin/src/lib/api/client.ts:227
 msgid "Request failed"
-msgstr ""
+msgstr "Anfrage fehlgeschlagen"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:280
 #: packages/admin/src/components/ContentTypeEditor.tsx:730
@@ -6472,7 +6472,7 @@ msgstr "Original wiederherstellen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4008
 msgid "Restart numbering"
-msgstr ""
+msgstr "Nummerierung neu beginnen"
 
 #: packages/admin/src/components/RevisionHistory.tsx:238
 msgid "Restore"
@@ -6547,7 +6547,7 @@ msgstr "Token widerrufen"
 #. placeholder {0}: token.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:391
 msgid "Revoke token {0}"
-msgstr ""
+msgstr "Token {0} widerrufen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:413
 msgid "Revoke?"
@@ -6571,7 +6571,7 @@ msgstr "Rich-Text-Editor"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
 msgid "Right"
-msgstr ""
+msgstr "Rechts"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:322
@@ -6581,7 +6581,7 @@ msgstr "Risikobewertung: {0}/100"
 #: packages/admin/src/components/settings/SeoSettings.tsx:255
 #: packages/admin/src/components/settings/SeoSettings.tsx:258
 msgid "robots.txt"
-msgstr ""
+msgstr "robots.txt"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:164
 #: packages/admin/src/components/users/UserDetail.tsx:169
@@ -6603,15 +6603,15 @@ msgstr "Rollenbezeichnung"
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:149
 #: packages/admin/src/components/PluginManager.tsx:568
 msgid "Route: {0} · Permission: {1}"
-msgstr ""
+msgstr "Route: {0} · Berechtigung: {1}"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
-msgstr ""
+msgstr "Ruby"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:49
 msgid "Rust"
-msgstr ""
+msgstr "Rust"
 
 #: packages/admin/src/components/MenuEditor.tsx:430
 #: packages/admin/src/components/MenuEditor.tsx:432
@@ -6644,7 +6644,7 @@ msgstr "Alt-Text speichern"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Save changes"
-msgstr ""
+msgstr "Änderungen speichern"
 
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Save Changes"
@@ -6670,7 +6670,7 @@ msgstr "Gespeichert"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:116
 msgid "Saved \"{0}\"."
-msgstr ""
+msgstr "„{0}“ gespeichert."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1111
 #: packages/admin/src/components/FieldEditor.tsx:660
@@ -6689,16 +6689,16 @@ msgstr "Speichern..."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Saving…"
-msgstr ""
+msgstr "Speichere…"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:482
 msgid "SBOM"
-msgstr ""
+msgstr "SBOM"
 
 #. placeholder {0}: sbom.format
 #: packages/admin/src/components/RegistryPluginDetail.tsx:480
 msgid "SBOM · {0}"
-msgstr ""
+msgstr "SBOM · {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:523
 msgid "Schedule"
@@ -6775,7 +6775,7 @@ msgstr "Bildschirmfotos"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:50
 msgid "SCSS"
-msgstr ""
+msgstr "SCSS"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 #: packages/admin/src/components/Settings.tsx:140
@@ -6797,7 +6797,7 @@ msgstr "{0} durchsuchen..."
 #: packages/admin/src/components/MediaLibrary.tsx:415
 #: packages/admin/src/components/MediaPickerModal.tsx:626
 msgid "Search by filename..."
-msgstr ""
+msgstr "Nach Dateiname suchen..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
@@ -6810,7 +6810,7 @@ msgstr "Autorenzeilen durchsuchen"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:904
 msgid "Search bylines to add..."
-msgstr ""
+msgstr "Autorenzeilen zum Hinzufügen suchen..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:164
 msgid "Search comments"
@@ -6835,7 +6835,7 @@ msgstr "Suchmaschinenoptimierung und Verifizierung"
 
 #: packages/admin/src/components/Widgets.tsx:152
 msgid "Search form"
-msgstr ""
+msgstr "Suchformular"
 
 #: packages/admin/src/components/MediaLibrary.tsx:416
 #: packages/admin/src/components/MediaPickerModal.tsx:627
@@ -6889,7 +6889,7 @@ msgstr "Durchsuchbar"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:909
 msgid "Searching..."
-msgstr ""
+msgstr "Suche..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2702
 msgid "Section"
@@ -6996,7 +6996,7 @@ msgstr "{label} auswählen"
 
 #: packages/admin/src/components/ContentList.tsx:985
 msgid "Select {title}"
-msgstr ""
+msgstr "{title} auswählen"
 
 #: packages/admin/src/components/Widgets.tsx:956
 msgid "Select a component..."
@@ -7012,7 +7012,7 @@ msgstr "Alle auswählen"
 
 #: packages/admin/src/components/ContentList.tsx:504
 msgid "Select all on this page"
-msgstr ""
+msgstr "Alle auf dieser Seite auswählen"
 
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:457
@@ -7042,7 +7042,7 @@ msgstr "Datei auswählen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3347
 msgid "Select Gallery Images"
-msgstr ""
+msgstr "Galeriebilder auswählen"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:186
 msgid "Select image"
@@ -7083,7 +7083,7 @@ msgstr "Wähle..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1733
 msgid "Selected {selectedItemTitle}"
-msgstr ""
+msgstr "{selectedItemTitle} ausgewählt"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:795
 msgid "Selected:"
@@ -7176,7 +7176,7 @@ msgstr "Auf 0 setzen, um Kommentare nie automatisch zu schließen."
 
 #: packages/admin/src/components/ContentList.tsx:432
 msgid "Set to draft"
-msgstr ""
+msgstr "Auf Entwurf setzen"
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
@@ -7221,11 +7221,11 @@ msgstr "Teile diesen Link mit dem eingeladenen Benutzer"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:294
 msgid "Shared across all translations of the same byline."
-msgstr ""
+msgstr "Für alle Übersetzungen derselben Autorenzeile gemeinsam."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:52
 msgid "Short text"
-msgstr ""
+msgstr "Kurzer Text"
 
 #: packages/admin/src/components/FieldEditor.tsx:150
 #: packages/admin/src/components/FieldEditor.tsx:579
@@ -7234,23 +7234,23 @@ msgstr "Kurztext"
 
 #: packages/admin/src/components/Widgets.tsx:146
 msgid "Show count"
-msgstr ""
+msgstr "Anzahl anzeigen"
 
 #: packages/admin/src/components/Widgets.tsx:131
 msgid "Show date"
-msgstr ""
+msgstr "Datum anzeigen"
 
 #: packages/admin/src/components/Widgets.tsx:139
 msgid "Show hierarchy"
-msgstr ""
+msgstr "Hierarchie anzeigen"
 
 #: packages/admin/src/components/Widgets.tsx:138
 msgid "Show post count"
-msgstr ""
+msgstr "Beitragsanzahl anzeigen"
 
 #: packages/admin/src/components/Widgets.tsx:130
 msgid "Show thumbnails"
-msgstr ""
+msgstr "Vorschaubilder anzeigen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:275
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:282
@@ -7323,7 +7323,7 @@ msgstr "Webseiten-Identität"
 
 #: packages/admin/src/components/WordPressImport.tsx:2270
 msgid "site identity applied (title, tagline, logo)"
-msgstr ""
+msgstr "Webseiten-Identität übernommen (Titel, Slogan, Logo)"
 
 #: packages/admin/src/components/Settings.tsx:49
 #: packages/admin/src/components/settings/GeneralSettings.tsx:119
@@ -7354,7 +7354,7 @@ msgstr "Webseiten-URL"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:330
 msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
-msgstr ""
+msgstr "Webseiten auf Cloudflare D1 können die Datenbank zusätzlich mit D1 Time Travel auf jede Minute der letzten 30 Tage zurücksetzen — immer aktiv, keine Einrichtung nötig."
 
 #: packages/admin/src/components/MediaLibrary.tsx:588
 msgid "Size"
@@ -7395,7 +7395,7 @@ msgstr "Slug wurde in Zwischenablage kopiert"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:251
 msgid "Slugs cannot be changed after the field is created."
-msgstr ""
+msgstr "Slugs können nach dem Erstellen des Felds nicht mehr geändert werden."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1378
 msgid "Small section heading"
@@ -7403,11 +7403,11 @@ msgstr "Eine kleine Abschnittsüberschrift einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1388
 msgid "Smaller section heading"
-msgstr ""
+msgstr "Kleinere Abschnittsüberschrift"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1408
 msgid "Smallest section heading"
-msgstr ""
+msgstr "Kleinste Abschnittsüberschrift"
 
 #: packages/admin/src/components/Settings.tsx:54
 #: packages/admin/src/components/settings/SocialSettings.tsx:89
@@ -7478,7 +7478,7 @@ msgstr "Tabellendokumente"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:51
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1922
 msgid "Start Import"
@@ -7488,7 +7488,7 @@ msgstr "Import starten"
 #: packages/admin/src/components/PortableTextEditor.tsx:2563
 #: packages/admin/src/components/PortableTextEditor.tsx:2564
 msgid "Start writing, or type '/' for commands"
-msgstr ""
+msgstr "Beginne zu schreiben oder tippe '/' für Befehle"
 
 #: packages/admin/src/components/ContentList.tsx:518
 #: packages/admin/src/components/ContentSettingsPanel.tsx:469
@@ -7504,19 +7504,19 @@ msgstr "Statuscode"
 
 #: packages/admin/src/components/Dashboard.tsx:367
 msgid "Status: {status}"
-msgstr ""
+msgstr "Status: {status}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:205
 msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
-msgstr ""
+msgstr "Speichere ein tägliches Backup im Storage-Bucket deiner Webseite. Alte Backups werden automatisch entfernt."
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:270
 msgid "Stored Backups"
-msgstr ""
+msgstr "Gespeicherte Backups"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:293
 msgid "Stored per locale — each translation of a byline gets its own value."
-msgstr ""
+msgstr "Je Sprache gespeichert — jede Übersetzung einer Autorenzeile erhält ihren eigenen Wert."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3539
 #: packages/admin/src/components/PortableTextEditor.tsx:3944
@@ -7529,7 +7529,7 @@ msgstr "Struktur"
 
 #: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Structured"
-msgstr ""
+msgstr "Strukturiert"
 
 #: packages/admin/src/components/FieldEditor.tsx:523
 msgid "Sub-Fields"
@@ -7543,20 +7543,20 @@ msgstr "Abonnent"
 #: packages/admin/src/components/PortableTextEditor.tsx:3546
 #: packages/admin/src/components/PortableTextEditor.tsx:3951
 msgid "Subscript"
-msgstr ""
+msgstr "Tiefgestellt"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3553
 #: packages/admin/src/components/PortableTextEditor.tsx:3958
 msgid "Superscript"
-msgstr ""
+msgstr "Hochgestellt"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:52
 msgid "Svelte"
-msgstr ""
+msgstr "Svelte"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:53
 msgid "Swift"
-msgstr ""
+msgstr "Swift"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
@@ -7584,7 +7584,7 @@ msgstr "Tabelle"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3628
 msgid "Table controls"
-msgstr ""
+msgstr "Tabellensteuerung"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:173
 #: packages/admin/src/components/SetupWizard.tsx:127
@@ -7698,7 +7698,7 @@ msgstr "Diese Seite existiert nicht."
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
 msgid "The plugin field widget failed to render."
-msgstr ""
+msgstr "Das Feld-Widget der Erweiterung konnte nicht dargestellt werden."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:185
 msgid "The public URL of your site (used for canonical links and sitemaps)"
@@ -7748,7 +7748,7 @@ msgstr "Designs"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:141
 msgid "These tools remain disabled after installation until you explicitly enable agent access."
-msgstr ""
+msgstr "Diese Tools bleiben nach der Installation deaktiviert, bis du den Agent-Zugriff ausdrücklich aktivierst."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:370
 msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
@@ -7756,7 +7756,7 @@ msgstr "Diese Kollektion ist im Code definiert. Einige Einstellungen können hie
 
 #: packages/admin/src/components/WordPressImport.tsx:1059
 msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
-msgstr ""
+msgstr "Das sieht nicht nach einem gültigen Migrationsschlüssel aus. Erzeuge in der Erweiterung einen neuen und füge die vollständige Zeichenkette beginnend mit „em1.“ ein."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:461
 msgid "This field does not accept {sniffedMime} files."
@@ -7790,11 +7790,11 @@ msgstr "Dieser Passkey ist bereits mit diesem Gerät registriert."
 #. placeholder {0}: archiveToDelete?.name ?? ""
 #: packages/admin/src/components/settings/BackupSettings.tsx:351
 msgid "This permanently deletes {0} from storage."
-msgstr ""
+msgstr "Dies löscht {0} dauerhaft aus dem Storage."
 
 #: packages/admin/src/components/PluginSettings.tsx:177
 msgid "This plugin has no configurable settings."
-msgstr ""
+msgstr "Diese Erweiterung hat keine konfigurierbaren Einstellungen."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:287
 msgid "This plugin requires no special permissions."
@@ -7810,7 +7810,7 @@ msgstr "Diese Weiterleitungsregel wird endgültig gelöscht."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:631
 msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
-msgstr ""
+msgstr "Dieses Release erfordert eine neuere Umgebung, als deine Webseite derzeit nutzt. Aktualisiere vor der Installation."
 
 #: packages/admin/src/routes/bylines.tsx:623
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
@@ -7893,7 +7893,7 @@ msgstr "Titel-Trennzeichen"
 
 #: packages/admin/src/components/ContentList.tsx:823
 msgid "to"
-msgstr ""
+msgstr "bis"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:483
 msgid "to close"
@@ -7901,7 +7901,7 @@ msgstr "zum Schließen"
 
 #: packages/admin/src/components/ContentList.tsx:827
 msgid "To date"
-msgstr ""
+msgstr "Enddatum"
 
 #: packages/admin/src/components/PluginManager.tsx:208
 msgid "to install plugins, or add them to your astro.config.mjs."
@@ -7931,7 +7931,7 @@ msgstr "Token-Name"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:54
 msgid "TOML"
-msgstr ""
+msgstr "TOML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "Tools → Export"
@@ -7944,7 +7944,7 @@ msgstr "Inhaltsverlauf verfolgen"
 #: packages/admin/src/components/BylineFieldEditor.tsx:287
 #: packages/admin/src/routes/byline-schema.tsx:243
 msgid "Translatable"
-msgstr ""
+msgstr "Übersetzbar"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:266
 #: packages/admin/src/components/TaxonomyManager.tsx:376
@@ -8004,7 +8004,7 @@ msgstr "Boolean-Schalter"
 
 #: packages/admin/src/components/MediaLibrary.tsx:493
 msgid "Try a broader media type or clear your filters."
-msgstr ""
+msgstr "Versuche einen allgemeineren Medientyp oder setze deine Filter zurück."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:691
 msgid "Try a different search term"
@@ -8033,11 +8033,11 @@ msgstr "Versuche es mit einem anderen Code"
 
 #: packages/admin/src/components/MediaLibrary.tsx:518
 msgid "Try another filename or clear your search."
-msgstr ""
+msgstr "Versuche einen anderen Dateinamen oder setze deine Suche zurück."
 
 #: packages/admin/src/components/MediaLibrary.tsx:492
 msgid "Try another filename, or clear your search and filters."
-msgstr ""
+msgstr "Versuche einen anderen Dateinamen oder setze Suche und Filter zurück."
 
 #: packages/admin/src/components/WordPressImport.tsx:1286
 #: packages/admin/src/components/WordPressImport.tsx:1408
@@ -8051,7 +8051,7 @@ msgstr "Mit meinen Daten versuchen"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:55
 msgid "TSX"
-msgstr ""
+msgstr "TSX"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:297
 msgid "Turn into"
@@ -8075,7 +8075,7 @@ msgstr "Typkonflikt ({0})"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:56
 msgid "TypeScript"
-msgstr ""
+msgstr "TypeScript"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:133
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
@@ -8146,7 +8146,7 @@ msgstr "Unbenannter Passkey"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:204
 msgid "Unpublish {itemLabel}"
-msgstr ""
+msgstr "{itemLabel} depublizieren"
 
 #: packages/admin/src/router.tsx:1045
 msgid "Unpublished"
@@ -8200,7 +8200,7 @@ msgstr "Feld aktualisieren"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:573
 msgid "Update publish date"
-msgstr ""
+msgstr "Publikationsdatum aktualisieren"
 
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
@@ -8229,7 +8229,7 @@ msgstr "Aktualisieren auf v{0}"
 #: packages/admin/src/components/ContentSettingsPanel.tsx:589
 #: packages/admin/src/components/RegistryPluginDetail.tsx:501
 msgid "Updated"
-msgstr ""
+msgstr "Aktualisiert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:129
 msgid "Updated At"
@@ -8301,7 +8301,7 @@ msgstr "Bild hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:505
 msgid "Upload images, videos, and documents to keep reusable assets in one place."
-msgstr ""
+msgstr "Lade Bilder, Videos und Dokumente hoch, um wiederverwendbare Assets an einem Ort zu haben."
 
 #: packages/admin/src/components/Dashboard.tsx:129
 msgid "Upload Media"
@@ -8309,7 +8309,7 @@ msgstr "Medien hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:529
 msgid "Upload media to keep reusable assets in one place."
-msgstr ""
+msgstr "Lade Medien hoch, um wiederverwendbare Assets an einem Ort zu haben."
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:356
@@ -8365,7 +8365,7 @@ msgstr "URL-freundliche Kennung (z. B. \"hauptbereich\", \"fusszeile\")"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:295
 msgid "URL:"
-msgstr ""
+msgstr "URL:"
 
 #: packages/admin/src/components/Redirects.tsx:111
 msgid "Use [param] or [...rest] in paths for pattern matching."
@@ -8455,15 +8455,15 @@ msgstr "Verifizierter Herausgeber"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:461
 msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
-msgstr ""
+msgstr "Verifizierter Herausgeber, bestätigt durch Labeller {verifiedLabeller}"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:452
 msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
-msgstr ""
+msgstr "Verifizierter Herausgeber. Ein Labeller ({verifiedLabeller}) hat die Identität dieses Herausgebers bestätigt."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:453
 msgid "Verified publisher. A labeller has confirmed this publisher's identity."
-msgstr ""
+msgstr "Verifizierter Herausgeber. Ein Labeller hat die Identität dieses Herausgebers bestätigt."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:228
 msgid "Verifying your invite..."
@@ -8528,7 +8528,7 @@ msgstr "Besucher, die diese Pfade aufrufen, erhalten eine Fehlermeldung."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:57
 msgid "Vue"
-msgstr ""
+msgstr "Vue"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
@@ -8616,35 +8616,35 @@ msgstr "Ganze Zahl"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:121
 msgid "Why can't this be changed?"
-msgstr ""
+msgstr "Warum kann das nicht geändert werden?"
 
 #: packages/admin/src/components/SeoPanel.tsx:221
 msgid "Why is this important for duplicate pages?"
-msgstr ""
+msgstr "Warum ist das für doppelte Seiten wichtig?"
 
 #: packages/admin/src/components/SeoPanel.tsx:196
 msgid "Why is this important for search result summaries?"
-msgstr ""
+msgstr "Warum ist das für Zusammenfassungen in Suchergebnissen wichtig?"
 
 #: packages/admin/src/components/SeoPanel.tsx:175
 msgid "Why is this important for search result titles?"
-msgstr ""
+msgstr "Warum ist das für Titel in Suchergebnissen wichtig?"
 
 #: packages/admin/src/components/SeoPanel.tsx:240
 msgid "Why is this important for search visibility?"
-msgstr ""
+msgstr "Warum ist das für die Sichtbarkeit in Suchmaschinen wichtig?"
 
 #: packages/admin/src/components/SeoImageField.tsx:44
 msgid "Why is this important for social sharing?"
-msgstr ""
+msgstr "Warum ist das für das Teilen in sozialen Medien wichtig?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:123
 msgid "Why is this important?"
-msgstr ""
+msgstr "Warum ist das wichtig?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
 msgid "Wide"
-msgstr ""
+msgstr "Breit"
 
 #: packages/admin/src/components/Widgets.tsx:802
 #: packages/admin/src/components/Widgets.tsx:817
@@ -8690,7 +8690,7 @@ msgstr "Breite"
 
 #: packages/admin/src/components/PluginSettings.tsx:338
 msgid "Will be cleared on save"
-msgstr ""
+msgstr "Wird beim Speichern geleert"
 
 #: packages/admin/src/components/WordPressImport.tsx:2014
 msgid "Will create"
@@ -8706,7 +8706,7 @@ msgstr "Ohne E-Mail-Anbieter müssen Einladungslinks eigenhändig geteilt werden
 
 #: packages/admin/src/components/WordPressImport.tsx:210
 msgid "WordPress authorization was rejected"
-msgstr ""
+msgstr "WordPress-Autorisierung wurde abgelehnt"
 
 #: packages/admin/src/components/WordPressImport.tsx:1476
 msgid "WordPress Username"
@@ -8714,7 +8714,7 @@ msgstr "WordPress-Benutzername"
 
 #: packages/admin/src/components/ContentList.tsx:410
 msgid "Working on {selectedCount} items…"
-msgstr ""
+msgstr "Bearbeite {selectedCount} Elemente…"
 
 #: packages/admin/src/components/Widgets.tsx:904
 msgid "Write widget content..."
@@ -8726,19 +8726,19 @@ msgstr "WXR-Datei"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:58
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1497
 msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
-msgstr ""
+msgstr "xxxx xxxx xxxx xxxx xxxx xxxx"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:59
 msgid "YAML"
-msgstr ""
+msgstr "YAML"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Yearly"
-msgstr ""
+msgstr "Jährlich"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:420
@@ -8748,7 +8748,7 @@ msgstr "Ja"
 
 #: packages/admin/src/components/WordPressImport.tsx:1160
 msgid "Yoast/RankMath"
-msgstr ""
+msgstr "Yoast/RankMath"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."
@@ -8764,7 +8764,7 @@ msgstr "Du kannst Inhalte, Medien, Menüs und Taxonomien verwalten."
 
 #: packages/admin/src/routes/bylines.tsx:549
 msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
-msgstr ""
+msgstr "Die festen Felder oben kannst du weiterhin bearbeiten. Beim Speichern werden gespeicherte Werte benutzerdefinierter Felder nicht angetastet."
 
 #: packages/admin/src/components/WelcomeModal.tsx:50
 msgid "You can view and contribute to the site."
@@ -8780,7 +8780,7 @@ msgstr "Du hast vollen Zugriff, um diese Webseite einschließlich Benutzern, Ein
 
 #: packages/admin/src/routes/byline-schema.tsx:175
 msgid "You need admin permissions to manage byline schema."
-msgstr ""
+msgstr "Zum Verwalten des Autorenzeilen-Schemas benötigst du Admin-Berechtigungen."
 
 #: packages/admin/src/router.tsx:1514
 msgid "You need Editor permissions to moderate comments."
@@ -8866,7 +8866,7 @@ msgstr "Dein LinkedIn-Profil-Benutzername"
 #: packages/admin/src/components/MediaLibrary.tsx:504
 #: packages/admin/src/components/MediaLibrary.tsx:528
 msgid "Your media library is empty"
-msgstr ""
+msgstr "Deine Medienbibliothek ist leer"
 
 #: packages/admin/src/components/SetupWizard.tsx:209
 msgid "Your Name"
@@ -8892,7 +8892,7 @@ msgstr "Dein Twitter-/X-Benutzername (z. B. @benutzername)"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:437
 msgid "Your unsaved media changes will be lost."
-msgstr ""
+msgstr "Deine ungespeicherten Medienänderungen gehen verloren."
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:2062


### PR DESCRIPTION
## What does this PR do?

Completes the German (`de`) admin catalog: translates the 373 remaining empty `msgstr` entries in `packages/admin/src/locales/de/messages.po` (1942 total, verified against `upstream/main` 4681b490, 2026-08-09; no other German translation PR is open or merged).

German is enabled in the admin locale switcher, so these gaps are user-visible today — and because of the issue described in #2389, entries missing from the compiled catalog can surface as raw ICU strings in production admin builds rather than falling back to English.

Translation notes:

- Established CMS terms that German-speaking editors use in English (*Slug*, *Storage*, *Backup*, *Token*, *Passkey*, *Widget*) are kept in English; UI copy is otherwise idiomatic German, following the catalog's existing conventions: informal address (du-Form), *Erweiterung* (plugin), *Autorenzeile* (byline), *Kollektion* (collection), *Schlagwörter* (tags), *publizieren/depublizieren*, *Herausgeber* (registry publisher) vs. *Anbieter* (provider), German quotation marks („…“).
- Code-block language names (*Go*, *Diff*, *Swift*, …) are intentionally untranslated — they are language identifiers, not UI copy. The msgid `Full` is shared between image alignment and the import-support table, so it is translated as *Voll*, which fits both contexts.
- ICU plural/select syntax and placeholders are preserved unchanged.
- Only `packages/admin/src/locales/de/messages.po` is touched. No changeset: completing an existing enabled locale doesn't change package behavior (same as #1809 for French).

I am a native German speaker and have reviewed all translations in a running demo site (admin UI switched to German), checking context, layout, and tone.

Drafted and reviewed with Claude Fable 5 (separate sessions).

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (verified 2026-08-09 after fresh `pnpm build`)
- [x] `pnpm lint` passes (verified 2026-08-09)
- [x] `pnpm test` passes (or targeted tests for my change) (admin suite: 115 files, 1384 tests green; `msgfmt --check-format` and `pnpm locale:compile` clean)
- [x] `pnpm format` has been run (no changes)
- [ ] I have added/updated tests for my changes (n/a — translation-only change)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (n/a — completing an existing enabled locale; precedent #1809 merged without one)
- [ ] New features link to an approved Discussion: n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (translation draft; human native-speaker review of every string)

## Screenshots / test output


German admin reviewed in a running demo site (`demos/simple`) by a native speaker; screenshots show the WordPress import, backup settings, the byline-field delete dialog (ICU plural, singular branch), and the content list with bulk actions.
<img width="1512" height="949" alt="Screenshot 2026-08-09 at 23 50 21" src="https://github.com/user-attachments/assets/aad49d0e-d87e-4e4f-8ed7-9b17932d0385" />
<img width="1512" height="949" alt="Screenshot 2026-08-09 at 23 51 19" src="https://github.com/user-attachments/assets/5e9133aa-299e-4298-823c-e6fe916cffc7" />
<img width="1512" height="949" alt="Screenshot 2026-08-09 at 23 54 50" src="https://github.com/user-attachments/assets/46771379-4964-4ba7-9e47-a0bcf2375014" />
<img width="1512" height="949" alt="Screenshot 2026-08-10 at 00 05 05" src="https://github.com/user-attachments/assets/946ae883-cafb-40fc-a5e0-39c0d64cd539" />
