### PR TITLE
fix(admin): show published content as "Published", not "Publish"

### DIFF
--- a/.changeset/published-status-badge-label.md
+++ b/.changeset/published-status-badge-label.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the status badge and status filter labeling published content "Publish" instead of "Published". Existing translations of "Published" now apply there too.

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -733,7 +733,7 @@ function FilterBar({
 
 	const statusItems: Record<ContentStatusFilter, string> = {
 		all: t`All statuses`,
-		published: t`Publish`,
+		published: t`Published`,
 		draft: t`Draft`,
 		scheduled: t`Scheduled`,
 		archived: t`Archived`,

--- a/packages/admin/src/components/ContentStatusBadge.tsx
+++ b/packages/admin/src/components/ContentStatusBadge.tsx
@@ -56,7 +56,7 @@ function useContentStatusLabel(state: ContentStatusState): string {
 
 	switch (state) {
 		case "published":
-			return t`Publish`;
+			return t`Published`;
 		case "draft":
 			return t`Draft`;
 		case "scheduled":

--- a/packages/admin/src/components/Dashboard.tsx
+++ b/packages/admin/src/components/Dashboard.tsx
@@ -260,7 +260,7 @@ function CollectionList({
 											icon={CONTENT_STATUS_ICONS.published}
 											count={col.published}
 											variant="success"
-											label={t`Publish`}
+											label={t`Published`}
 										/>
 										<CountBadge
 											icon={CONTENT_STATUS_ICONS.draft}

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -161,7 +161,7 @@ describe("ContentList", () => {
 	describe("status badges", () => {
 		it.each([
 			["draft", "Draft"],
-			["published", "Publish"],
+			["published", "Published"],
 			["scheduled", "Scheduled"],
 			["archived", "Archived"],
 		] as const)("shows the normalized %s status with its icon", async (status, label) => {
@@ -245,7 +245,7 @@ describe("ContentList", () => {
 			expect(filter.element().querySelector("svg")).not.toBeNull();
 			await filter.click();
 
-			for (const label of ["Publish", "Draft", "Scheduled", "Archived"]) {
+			for (const label of ["Published", "Draft", "Scheduled", "Archived"]) {
 				const option = screen.getByRole("option", { name: label });
 				await expect.element(option).toBeInTheDocument();
 				expect(option.element().querySelector("svg")).not.toBeNull();

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -158,8 +158,7 @@ describe("ContentSettingsPanel", () => {
 		);
 		const statusRow = screen.getByText("Status", { exact: true }).element().parentElement!;
 
-		expect(statusRow.textContent).toContain("Publish");
-		expect(statusRow.textContent).not.toContain("Published");
+		expect(statusRow.textContent).toContain("Published");
 		expect(statusRow.querySelector("svg")).not.toBeNull();
 	});
 

--- a/packages/admin/tests/components/ContentStatusBadge.test.tsx
+++ b/packages/admin/tests/components/ContentStatusBadge.test.tsx
@@ -9,7 +9,7 @@ import {
 import { render } from "../utils/render";
 
 const statuses: Array<{ state: ContentStatusState; label: string }> = [
-	{ state: "published", label: "Publish" },
+	{ state: "published", label: "Published" },
 	{ state: "draft", label: "Draft" },
 	{ state: "scheduled", label: "Scheduled" },
 	{ state: "archived", label: "Archived" },

--- a/packages/admin/tests/components/Dashboard.test.tsx
+++ b/packages/admin/tests/components/Dashboard.test.tsx
@@ -95,6 +95,19 @@ describe("Dashboard", () => {
 		await expect.element(screen.getByText("Scheduled")).not.toBeInTheDocument();
 	});
 
+	it("labels the published count for screen readers with the state, not the action", async () => {
+		mockFetchDashboardStats.mockResolvedValue(
+			makeStats([
+				{ slug: "pages", label: "Pages", total: 5, published: 2, draft: 3, scheduled: 0 },
+			]),
+		);
+
+		const screen = await render(<Dashboard manifest={manifest} />);
+
+		await expect.element(screen.getByText("Published", { exact: true })).toBeInTheDocument();
+		await expect.element(screen.getByText("Publish", { exact: true })).not.toBeInTheDocument();
+	});
+
 	it("links collection quick actions to new content forms", async () => {
 		mockFetchDashboardStats.mockResolvedValue(makeStats([]));
 


### PR DESCRIPTION
## What does this PR do?

The status badge on published content reads **"Publish"** — the action verb — instead of the state **"Published"**. The same label leaks into the status filter dropdown. In English this reads as an off-by-one-word oddity; in translated locales it becomes plainly wrong, because the action and the state translate differently (German: "Publizieren" vs. "Publiziert", the badge showed "Publizieren").

Cause: `useContentStatusLabel` in `ContentStatusBadge.tsx` returned `` t`Publish` `` for the `published` state, and `statusItems.published` in `ContentList.tsx` did the same. The msgid `Published` already exists in the catalogs and is used correctly elsewhere (publish-success toast, date-field selector) — the badge and filter just didn't use it, so existing translations apply automatically. The `` t`Publish` `` usages on the actual publish *buttons* are correct and stay untouched.

Tests that pinned the old label (`ContentStatusBadge.test.tsx`, `ContentList.test.tsx`, `ContentSettingsPanel.test.tsx`) were updated first and reproduce the bug: they fail on `main` with the `Published` expectation and pass with this fix. No catalog changes are included; the extraction workflow handles usage updates on merge.

For transparency: #2340 unified the previously mixed labels on `Publish` on purpose. This PR keeps that unification but flips it to the state form `Published`, which is what a status badge describes — and what the non-English catalogs already translate as a state.

Follow-up commit per review: the dashboard's published count badge now uses the same state label for its screen-reader text (`Dashboard.tsx`), with a test.

Drafted and reviewed with Claude Fable 5 (separate sessions).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: the three affected admin test files, 85 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion: n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5

## Screenshots / test output

Verified in the running admin (German locale): list badges and the status filter dropdown now show "Publiziert"; drafts, scheduled, archived and the pending-changes companion badge are unchanged.

```
Test Files  3 passed (3)
     Tests  85 passed (85)
```

After the dashboard follow-up, the full admin suite:

```
Test Files  115 passed (115)
     Tests  1385 passed (1385)
```

With the test-expectation change applied on unfixed code, the two `published` label tests fail as expected:

```
Tests  2 failed | 12 passed (14)   # ContentStatusBadge.test.tsx on main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

