### PR TITLE
fix(admin): localize the editor word-count footer

### DIFF
--- a/.changeset/localize-word-count-footer.md
+++ b/.changeset/localize-word-count-footer.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fixes the editor's word-count footer showing English in every admin language. The word, character, and reading-time metrics now go through the translation catalogs and use each language's plural rules.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -41,7 +41,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import type { Element } from "@emdash-cms/blocks";
 import type { MessageDescriptor } from "@lingui/core";
-import { msg } from "@lingui/core/macro";
+import { msg, plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	TextB,
@@ -2486,20 +2486,20 @@ function EditorFooter({ editor }: { editor: Editor }) {
 		},
 	});
 
+	const { t } = useLingui();
 	const readingTime = calculateReadingTime(text);
 
 	return (
 		<div className="border-t px-4 py-2 flex items-center gap-4 text-xs text-kumo-subtle">
-			<span>
-				{words} {words === 1 ? "word" : "words"}
-			</span>
-			<span>
-				{characters} {characters === 1 ? "character" : "characters"}
-			</span>
-			<span>{readingTime} min read</span>
+			<span>{plural(words, { one: "# word", other: "# words" })}</span>
+			<span>{plural(characters, { one: "# character", other: "# characters" })}</span>
+			<span>{t`${readingTime} min read`}</span>
 		</div>
 	);
 }
+
+// Exported for unit testing
+export { EditorFooter as _EditorFooter };
 
 /** Focus mode state for the editor */
 export type FocusMode = "normal" | "spotlight";

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2498,7 +2498,7 @@ function EditorFooter({ editor }: { editor: Editor }) {
 	);
 }
 
-// Exported for unit testing
+export { EditorFooter as _EditorFooter };
 export { EditorFooter as _EditorFooter };
 
 /** Focus mode state for the editor */

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -42,6 +42,7 @@ import { CSS } from "@dnd-kit/utilities";
 import type { Element } from "@emdash-cms/blocks";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg, plural } from "@lingui/core/macro";
+import { useLingui as useLinguiContext } from "@lingui/react";
 import { useLingui } from "@lingui/react/macro";
 import {
 	TextB,
@@ -2486,14 +2487,15 @@ function EditorFooter({ editor }: { editor: Editor }) {
 		},
 	});
 
-	const { t } = useLingui();
+	// Subscribes to locale changes so the plural messages below re-render.
+	useLinguiContext();
 	const readingTime = calculateReadingTime(text);
 
 	return (
 		<div className="border-t px-4 py-2 flex items-center gap-4 text-xs text-kumo-subtle">
 			<span>{plural(words, { one: "# word", other: "# words" })}</span>
 			<span>{plural(characters, { one: "# character", other: "# characters" })}</span>
-			<span>{t`${readingTime} min read`}</span>
+			<span>{plural(readingTime, { one: "# min read", other: "# min read" })}</span>
 		</div>
 	);
 }

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2499,7 +2499,6 @@ function EditorFooter({ editor }: { editor: Editor }) {
 }
 
 export { EditorFooter as _EditorFooter };
-export { EditorFooter as _EditorFooter };
 
 /** Focus mode state for the editor */
 export type FocusMode = "normal" | "spotlight";

--- a/packages/admin/tests/components/PortableTextEditor.footer.test.tsx
+++ b/packages/admin/tests/components/PortableTextEditor.footer.test.tsx
@@ -1,0 +1,58 @@
+import { i18n } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import { screen } from "@testing-library/react";
+import CharacterCount from "@tiptap/extension-character-count";
+import { useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import * as React from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { _EditorFooter, countWords } from "../../src/components/PortableTextEditor";
+import { render } from "../utils/render.tsx";
+
+// The msg macro hashes to the same message id as the corresponding macro call
+// in EditorFooter, so this catalog binds translations for exactly the messages
+// the footer renders.
+const deMessages = {
+	[msg`{words, plural, one {# word} other {# words}}`.id!]:
+		"{words, plural, one {# Wort} other {# Wörter}}",
+	[msg`{characters, plural, one {# character} other {# characters}}`.id!]:
+		"{characters, plural, one {# Zeichen} other {# Zeichen}}",
+	[msg`{readingTime} min read`.id!]: "{readingTime} Min. Lesezeit",
+};
+
+beforeAll(() => {
+	i18n.loadAndActivate({ locale: "de", messages: deMessages });
+});
+
+function FooterHarness({ content }: { content: string }) {
+	const editor = useEditor({
+		extensions: [StarterKit, CharacterCount.configure({ wordCounter: countWords })],
+		content,
+		immediatelyRender: true,
+	});
+
+	if (!editor) return null;
+	return <_EditorFooter editor={editor} />;
+}
+
+describe("EditorFooter localization", () => {
+	it("renders the metrics translated when the active catalog provides them", async () => {
+		void render(<FooterHarness content="<p>Hallo schöne Welt</p>" />);
+
+		await vi.waitFor(() => {
+			expect(screen.getByText("3 Wörter")).toBeTruthy();
+		});
+		expect(screen.getByText("17 Zeichen")).toBeTruthy();
+		expect(screen.getByText("1 Min. Lesezeit")).toBeTruthy();
+	});
+
+	it("uses the catalog's plural rules for the singular branch", async () => {
+		void render(<FooterHarness content="<p>Hallo</p>" />);
+
+		await vi.waitFor(() => {
+			expect(screen.getByText("1 Wort")).toBeTruthy();
+		});
+		expect(screen.getByText("5 Zeichen")).toBeTruthy();
+	});
+});

--- a/packages/admin/tests/components/PortableTextEditor.footer.test.tsx
+++ b/packages/admin/tests/components/PortableTextEditor.footer.test.tsx
@@ -5,7 +5,7 @@ import CharacterCount from "@tiptap/extension-character-count";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import * as React from "react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { _EditorFooter, countWords } from "../../src/components/PortableTextEditor";
 import { render } from "../utils/render.tsx";
@@ -18,7 +18,8 @@ const deMessages = {
 		"{words, plural, one {# Wort} other {# Wörter}}",
 	[msg`{characters, plural, one {# character} other {# characters}}`.id!]:
 		"{characters, plural, one {# Zeichen} other {# Zeichen}}",
-	[msg`{readingTime} min read`.id!]: "{readingTime} Min. Lesezeit",
+	[msg`{readingTime, plural, one {# min read} other {# min read}}`.id!]:
+		"{readingTime, plural, one {# Minute Lesezeit} other {# Min. Lesezeit}}",
 };
 
 beforeAll(() => {
@@ -48,7 +49,7 @@ describe("EditorFooter localization", () => {
 			expect(screen.getByText("3 Wörter")).toBeTruthy();
 		});
 		expect(screen.getByText("17 Zeichen")).toBeTruthy();
-		expect(screen.getByText("1 Min. Lesezeit")).toBeTruthy();
+		expect(screen.getByText("1 Minute Lesezeit")).toBeTruthy();
 	});
 
 	it("uses the catalog's plural rules for the singular branch", async () => {

--- a/packages/admin/tests/components/PortableTextEditor.footer.test.tsx
+++ b/packages/admin/tests/components/PortableTextEditor.footer.test.tsx
@@ -25,6 +25,10 @@ beforeAll(() => {
 	i18n.loadAndActivate({ locale: "de", messages: deMessages });
 });
 
+afterAll(() => {
+	i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
 function FooterHarness({ content }: { content: string }) {
 	const editor = useEditor({
 		extensions: [StarterKit, CharacterCount.configure({ wordCounter: countWords })],


### PR DESCRIPTION
## What does this PR do?

The word-count footer under the Portable Text editor ("1 word · 5 characters · 1 min read") stays English in every locale. Its strings are hard-coded and never reach the translation catalogs. The plural handling is also hand-rolled (`words === 1 ? "word" : "words"`), which breaks for locales with plural rules beyond one/other.

The cause: the footer in `packages/admin/src/components/PortableTextEditor.tsx` renders raw string literals instead of going through Lingui. CONTRIBUTING.md (§ Internationalization) requires all user-facing admin strings to be localized.

The fix wraps the three segments in Lingui `plural()` macros so they reach the catalogs. Each metric keeps its own `<span>` and stays a separate message with a single number slot, matching the existing `# item`/`# items` catalog entries. No `messages.po` changes are included; the extraction workflow adds the new entries on merge.

**Test.** `PortableTextEditor.footer.test.tsx` binds a German test catalog for exactly these three messages and asserts the footer renders the translations, including the singular branch. The test fails on `main` and passes with the fix. (The `msg` macro in the test hashes to the same message ids as the macros in the component. `EditorFooter` is exported as `_EditorFooter`, following the file's existing `_`-prefixed test exports.)

No screenshots: every locale falls back to the English source strings until the new entries are extracted and translated, so a before/after screenshot would show no difference. The browser test covers the change.

Drafted and reviewed with Claude Fable 5 (separate sessions).

## Revisions since this PR was opened

- `ddab38c2` — applies the two review suggestions: the footer test resets the i18n locale in `afterAll`, and the comment on the test-only export is gone.
- `5617449c` — removes a duplicated `_EditorFooter` export that broke the typecheck.
- `7006eebb` — two changes after review feedback. The reading-time segment now uses `plural()` like the other two metrics; a flat `t` string kept translators from branching on number. English keeps the same wording in both branches ("# min read"); the German test catalog uses two different wordings ("1 Minute Lesezeit" / "# Min. Lesezeit"). And `EditorFooter` now subscribes to locale changes via the runtime `useLingui` hook from `@lingui/react`. Without the subscription, the footer kept showing the previous locale after a language switch: on `i18n.activate`, `I18nProvider` swaps its context value but passes `children` through by reference, so React re-renders only components that read `LinguiContext` — and a footer built purely from `@lingui/core/macro` calls reads the global `i18n` instance instead. (The macro of the same name from `@lingui/react/macro` cannot be called bare; it has to bind a variable.)

Verified on `7006eebb`: admin suite 116/116 files and 1386/1386 tests, `pnpm lint:json` 0 diagnostics, `pnpm typecheck` exit 0, `pnpm format` clean.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (exit 0 at `7006eebb`)
- [x] `pnpm lint` passes (`lint:json` 0 diagnostics at `7006eebb`)
- [x] `pnpm test` passes (or targeted tests for my change) (admin suite at `7006eebb`: 116 files, 1386 tests green, including the 2 new ones; new test verified red on `main` before the fix)
- [x] `pnpm format` has been run (no residual changes)
- [x] I have added/updated tests for my changes
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (patch: `emdash`, `@emdash-cms/admin`)
- [ ] New features link to an approved Discussion: n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5

## Screenshots / test output

Covered by the browser test (see above); no visual change until the new catalog entries are extracted and translated.
