### PR TITLE
fix(admin): paginate redirects list

### DIFF
--- a/.changeset/redirects-load-more.md
+++ b/.changeset/redirects-load-more.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the redirects screen so all redirects can be loaded beyond the first 100 results.

--- a/packages/admin/src/components/Redirects.tsx
+++ b/packages/admin/src/components/Redirects.tsx
@@ -65,7 +65,7 @@ function RedirectFormDialog({
 	const createMutation = useMutation({
 		mutationFn: (input: CreateRedirectInput) => createRedirect(input),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["redirects"] });
+			void queryClient.resetQueries({ queryKey: ["redirects"] });
 			onClose();
 		},
 	});
@@ -73,7 +73,7 @@ function RedirectFormDialog({
 	const updateMutation = useMutation({
 		mutationFn: (input: UpdateRedirectInput) => updateRedirect(redirect!.id, input),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["redirects"] });
+			void queryClient.resetQueries({ queryKey: ["redirects"] });
 			onClose();
 		},
 	});
@@ -319,7 +319,7 @@ export function Redirects() {
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => deleteRedirect(id),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["redirects"] });
+			void queryClient.resetQueries({ queryKey: ["redirects"] });
 			setDeleteId(null);
 		},
 	});
@@ -329,10 +329,10 @@ export function Redirects() {
 		mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
 			updateRedirect(id, { enabled }),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["redirects"] });
+			void queryClient.resetQueries({ queryKey: ["redirects"] });
 		},
 		onError: () => {
-			void queryClient.invalidateQueries({ queryKey: ["redirects"] });
+			void queryClient.resetQueries({ queryKey: ["redirects"] });
 		},
 	});
 
@@ -341,7 +341,7 @@ export function Redirects() {
 		mutationFn: (path: string) =>
 			createRedirect({ source: path, destination: "", type: 410, enabled: true }),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["redirects"] });
+			void queryClient.resetQueries({ queryKey: ["redirects"] });
 		},
 	});
 

--- a/packages/admin/src/components/Redirects.tsx
+++ b/packages/admin/src/components/Redirects.tsx
@@ -10,7 +10,7 @@ import {
 	WarningCircle,
 	X,
 } from "@phosphor-icons/react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
 import {
@@ -295,15 +295,18 @@ export function Redirects() {
 	const enabledFilter = filterEnabled === "all" ? undefined : filterEnabled === "true";
 	const autoFilter = filterAuto === "all" ? undefined : filterAuto === "true";
 
-	const redirectsQuery = useQuery({
+	const redirectsQuery = useInfiniteQuery({
 		queryKey: ["redirects", debouncedSearch, enabledFilter, autoFilter],
-		queryFn: () =>
+		queryFn: ({ pageParam }) =>
 			fetchRedirects({
 				search: debouncedSearch || undefined,
 				enabled: enabledFilter,
 				auto: autoFilter,
+				cursor: pageParam,
 				limit: 100,
 			}),
+		initialPageParam: undefined as string | undefined,
+		getNextPageParam: (lastPage) => lastPage.nextCursor,
 	});
 
 	const notFoundQuery = useQuery({
@@ -348,8 +351,10 @@ export function Redirects() {
 		setTab("redirects");
 	}
 
-	const redirects = redirectsQuery.data?.items ?? [];
-	const loopRedirectIds = new Set(redirectsQuery.data?.loopRedirectIds ?? []);
+	const redirects = redirectsQuery.data?.pages.flatMap((page) => page.items) ?? [];
+	const loopRedirectIds = new Set(
+		redirectsQuery.data?.pages.flatMap((page) => page.loopRedirectIds ?? []) ?? [],
+	);
 
 	return (
 		<div className="space-y-6">
@@ -380,8 +385,8 @@ export function Redirects() {
 					{t`Redirects`}
 					{redirectsQuery.data && (
 						<Badge variant="secondary" className="ms-2">
-							{redirectsQuery.data.items.length}
-							{redirectsQuery.data.nextCursor ? "+" : ""}
+							{redirects.length}
+							{redirectsQuery.hasNextPage ? "+" : ""}
 						</Badge>
 					)}
 				</button>
@@ -464,86 +469,99 @@ export function Redirects() {
 							<p className="text-sm mt-1">{t`Create redirect rules to manage URL changes.`}</p>
 						</div>
 					) : (
-						<div className="border rounded-lg">
-							<div className="flex items-center gap-4 py-2 px-4 border-b bg-kumo-tint/50 text-sm font-medium text-kumo-subtle">
-								<div className="flex-1">{t`Source`}</div>
-								<div className="w-8 text-center" />
-								<div className="flex-1">{t`Destination`}</div>
-								<div className="w-14 text-center">{t`Code`}</div>
-								<div className="w-16 text-end">{t`Hits`}</div>
-								<div className="w-20 text-center">{t`Status`}</div>
-								<div className="w-20" />
-							</div>
-							{redirects.map((r) => (
-								<div
-									key={r.id}
-									className={cn(
-										"flex items-center gap-4 py-2 px-4 border-b last:border-0 text-sm",
-										!r.enabled && "opacity-50",
-									)}
-								>
-									<div className="flex-1 font-mono text-xs truncate" title={r.source}>
-										{r.source}
-									</div>
-									<div className="w-8 text-center text-kumo-subtle">
-										<ArrowNext size={14} />
-									</div>
-									<div className="flex-1 font-mono text-xs truncate" title={r.destination}>
-										{r.destination}
-									</div>
-									<div className="w-14 text-center">
-										<Badge variant="secondary">{r.type}</Badge>
-									</div>
-									<div className="w-16 text-end tabular-nums text-kumo-subtle">{r.hits}</div>
-									<div className="w-20 text-center">
-										<Switch
-											checked={r.enabled}
-											onCheckedChange={(checked) =>
-												toggleMutation.mutate({
-													id: r.id,
-													enabled: checked,
-												})
-											}
-											aria-label={r.enabled ? t`Disable redirect` : t`Enable redirect`}
-										/>
-									</div>
-									<div className="w-20 flex items-center justify-end gap-1">
-										{loopRedirectIds.has(r.id) && (
-											<span title={t`Part of a redirect loop`} className="me-1 inline-flex">
-												<WarningCircle
-													size={14}
-													weight="fill"
-													className="text-kumo-warning"
-													role="img"
-													aria-label={t`Part of a redirect loop`}
-												/>
-											</span>
-										)}
-										{r.auto && (
-											<Badge variant="outline" className="me-1 text-xs">
-												{t`auto`}
-											</Badge>
-										)}
-										<button
-											onClick={() => setEditRedirect(r)}
-											className="p-1 text-kumo-subtle hover:text-kumo-default"
-											title={t`Edit redirect`}
-											aria-label={t`Edit redirect ${r.source}`}
-										>
-											<PencilSimple size={14} />
-										</button>
-										<button
-											onClick={() => setDeleteId(r.id)}
-											className="p-1 text-kumo-subtle hover:text-kumo-danger"
-											title={t`Delete redirect`}
-											aria-label={t`Delete redirect ${r.source}`}
-										>
-											<Trash size={14} />
-										</button>
-									</div>
+						<>
+							<div className="border rounded-lg">
+								<div className="flex items-center gap-4 py-2 px-4 border-b bg-kumo-tint/50 text-sm font-medium text-kumo-subtle">
+									<div className="flex-1">{t`Source`}</div>
+									<div className="w-8 text-center" />
+									<div className="flex-1">{t`Destination`}</div>
+									<div className="w-14 text-center">{t`Code`}</div>
+									<div className="w-16 text-end">{t`Hits`}</div>
+									<div className="w-20 text-center">{t`Status`}</div>
+									<div className="w-20" />
 								</div>
-							))}
-						</div>
+								{redirects.map((r) => (
+									<div
+										key={r.id}
+										className={cn(
+											"flex items-center gap-4 py-2 px-4 border-b last:border-0 text-sm",
+											!r.enabled && "opacity-50",
+										)}
+									>
+										<div className="flex-1 font-mono text-xs truncate" title={r.source}>
+											{r.source}
+										</div>
+										<div className="w-8 text-center text-kumo-subtle">
+											<ArrowNext size={14} />
+										</div>
+										<div className="flex-1 font-mono text-xs truncate" title={r.destination}>
+											{r.destination}
+										</div>
+										<div className="w-14 text-center">
+											<Badge variant="secondary">{r.type}</Badge>
+										</div>
+										<div className="w-16 text-end tabular-nums text-kumo-subtle">{r.hits}</div>
+										<div className="w-20 text-center">
+											<Switch
+												checked={r.enabled}
+												onCheckedChange={(checked) =>
+													toggleMutation.mutate({
+														id: r.id,
+														enabled: checked,
+													})
+												}
+												aria-label={r.enabled ? t`Disable redirect` : t`Enable redirect`}
+											/>
+										</div>
+										<div className="w-20 flex items-center justify-end gap-1">
+											{loopRedirectIds.has(r.id) && (
+												<span title={t`Part of a redirect loop`} className="me-1 inline-flex">
+													<WarningCircle
+														size={14}
+														weight="fill"
+														className="text-kumo-warning"
+														role="img"
+														aria-label={t`Part of a redirect loop`}
+													/>
+												</span>
+											)}
+											{r.auto && (
+												<Badge variant="outline" className="me-1 text-xs">
+													{t`auto`}
+												</Badge>
+											)}
+											<button
+												onClick={() => setEditRedirect(r)}
+												className="p-1 text-kumo-subtle hover:text-kumo-default"
+												title={t`Edit redirect`}
+												aria-label={t`Edit redirect ${r.source}`}
+											>
+												<PencilSimple size={14} />
+											</button>
+											<button
+												onClick={() => setDeleteId(r.id)}
+												className="p-1 text-kumo-subtle hover:text-kumo-danger"
+												title={t`Delete redirect`}
+												aria-label={t`Delete redirect ${r.source}`}
+											>
+												<Trash size={14} />
+											</button>
+										</div>
+									</div>
+								))}
+							</div>
+							{redirectsQuery.hasNextPage && (
+								<div className="flex justify-center">
+									<Button
+										variant="outline"
+										onClick={() => void redirectsQuery.fetchNextPage()}
+										disabled={redirectsQuery.isFetchingNextPage}
+									>
+										{redirectsQuery.isFetchingNextPage ? t`Loading...` : t`Load more`}
+									</Button>
+								</div>
+							)}
+						</>
 					)}
 				</>
 			)}

--- a/packages/admin/tests/components/Redirects.test.tsx
+++ b/packages/admin/tests/components/Redirects.test.tsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Redirect } from "../../src/lib/api/redirects.js";
+import { render } from "../utils/render.tsx";
+
+vi.mock("../../src/lib/api/redirects.js", () => ({
+	createRedirect: vi.fn(),
+	deleteRedirect: vi.fn(),
+	fetch404Summary: vi.fn().mockResolvedValue([]),
+	fetchRedirects: vi.fn(),
+	updateRedirect: vi.fn(),
+}));
+
+import { Redirects } from "../../src/components/Redirects.js";
+import { fetchRedirects } from "../../src/lib/api/redirects.js";
+
+function makeRedirect(index: number): Redirect {
+	return {
+		id: `redirect-${index}`,
+		source: `/source-${index}`,
+		destination: `/destination-${index}`,
+		type: 301,
+		isPattern: false,
+		enabled: true,
+		hits: 0,
+		lastHitAt: null,
+		groupName: null,
+		auto: false,
+		createdAt: "2026-08-10T00:00:00.000Z",
+		updatedAt: "2026-08-10T00:00:00.000Z",
+	};
+}
+
+describe("Redirects", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(fetchRedirects).mockImplementation(async ({ cursor } = {}) => {
+			if (cursor === "page-2") {
+				return { items: [makeRedirect(101)] };
+			}
+
+			return {
+				items: Array.from({ length: 100 }, (_, index) => makeRedirect(index + 1)),
+				nextCursor: "page-2",
+			};
+		});
+	});
+
+	it("loads redirects beyond the first page", async () => {
+		const screen = await render(<Redirects />);
+
+		await expect.element(screen.getByText("/source-100")).toBeInTheDocument();
+		await screen.getByRole("button", { name: "Load more" }).click();
+
+		await expect.element(screen.getByText("/source-101")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Load more" }).query()).toBeNull();
+		expect(fetchRedirects).toHaveBeenLastCalledWith(
+			expect.objectContaining({ cursor: "page-2", limit: 100 }),
+		);
+	});
+});

--- a/packages/admin/tests/components/Redirects.test.tsx
+++ b/packages/admin/tests/components/Redirects.test.tsx
@@ -12,7 +12,7 @@ vi.mock("../../src/lib/api/redirects.js", () => ({
 }));
 
 import { Redirects } from "../../src/components/Redirects.js";
-import { fetchRedirects } from "../../src/lib/api/redirects.js";
+import { fetchRedirects, updateRedirect } from "../../src/lib/api/redirects.js";
 
 function makeRedirect(index: number): Redirect {
 	return {
@@ -34,6 +34,7 @@ function makeRedirect(index: number): Redirect {
 describe("Redirects", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.mocked(updateRedirect).mockResolvedValue(makeRedirect(1));
 		vi.mocked(fetchRedirects).mockImplementation(async ({ cursor } = {}) => {
 			if (cursor === "page-2") {
 				return { items: [makeRedirect(101)] };
@@ -57,5 +58,18 @@ describe("Redirects", () => {
 		expect(fetchRedirects).toHaveBeenLastCalledWith(
 			expect.objectContaining({ cursor: "page-2", limit: 100 }),
 		);
+	});
+
+	it("restarts pagination after a redirect mutation", async () => {
+		const screen = await render(<Redirects />);
+
+		await expect.element(screen.getByText("/source-100")).toBeInTheDocument();
+		await screen.getByRole("button", { name: "Load more" }).click();
+		await expect.element(screen.getByText("/source-101")).toBeInTheDocument();
+
+		await screen.getByRole("switch", { name: "Disable redirect" }).first().click();
+
+		await expect.element(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+		expect(screen.getByText("/source-101").query()).toBeNull();
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Adds cursor pagination to the redirects admin screen so redirects beyond the first 100 rows are reachable. The screen now appends pages through a localized Kumo “Load more” button and preserves loop indicators across loaded pages.

Closes #2290

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

The new-feature Discussion item is not applicable because this restores access to the API's existing pagination behavior.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- Redirects browser regression: 1/1 passed with 101 rows
- Admin typecheck passed
- Type-aware lint: 0 diagnostics
- Manually verified the 101-row flow in Arabic with `lang="ar"` and `dir="rtl"`; the final row loads and the button disappears
- `pnpm format`

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-2290-redirect-pagination-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/2290-redirect-pagination`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
