### PR TITLE
fix(core): bound revision cleanup work

### DIFF
--- a/.changeset/fix-cron-revision-row-reads.md
+++ b/.changeset/fix-cron-revision-row-reads.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes scheduled maintenance reading the entire revision history on every cron invocation.

--- a/packages/core/src/after.ts
+++ b/packages/core/src/after.ts
@@ -16,6 +16,9 @@
  * `after()`, which they don't during type-checking.
  */
 
+import { trackDeferredTask } from "./deferred-tasks.js";
+import { getRequestContext } from "./request-context.js";
+
 export type WaitUntilFn = (promise: Promise<unknown>) => void;
 
 // Resolves to the host's waitUntil if the adapter provided one, or
@@ -45,11 +48,13 @@ waitUntilReady.catch(() => {});
  * that care about errors should handle them inside `fn`.
  */
 export function after(fn: () => void | Promise<void>): void {
-	const promise = Promise.resolve()
+	const task = Promise.resolve()
 		.then(fn)
 		.catch((error) => {
 			console.error("[emdash] deferred task failed:", error);
 		});
+	const requestTask = getRequestContext()?.deferredTasks?.track(task) ?? task;
+	const promise = trackDeferredTask(requestTask);
 
 	// Defer the lifetime-extender handoff to the microtask that resolves
 	// waitUntilReady. On workerd this is effectively instant (the virtual

--- a/packages/core/src/api/handlers/revision.ts
+++ b/packages/core/src/api/handlers/revision.ts
@@ -4,6 +4,7 @@
 
 import type { Kysely } from "kysely";
 
+import { after } from "../../after.js";
 import { ContentRepository } from "../../database/repositories/content.js";
 import { RevisionRepository, type Revision } from "../../database/repositories/revision.js";
 import { withTransaction } from "../../database/transaction.js";
@@ -115,7 +116,7 @@ export async function handleRevisionRestore(
 		// Atomically update content and create a new revision to record the restore.
 		// If either operation fails, neither is committed (on engines that support
 		// transactions; on D1, withTransaction falls back to sequential execution).
-		const item = await withTransaction(db, async (trx) => {
+		const { item, queuedRevisionId } = await withTransaction(db, async (trx) => {
 			const trxContentRepo = new ContentRepository(trx);
 			const trxRevisionRepo = new RevisionRepository(trx);
 
@@ -124,19 +125,32 @@ export async function handleRevisionRestore(
 				slug: typeof _slug === "string" ? _slug : undefined,
 			});
 
-			await trxRevisionRepo.create({
+			const queuedRevision = await trxRevisionRepo.create({
 				collection: revision.collection,
 				entryId: revision.entryId,
 				data: revision.data,
 				authorId: callerUserId,
 			});
 
-			return updated;
+			return { item: updated, queuedRevisionId: queuedRevision.id };
 		});
 
-		// Fire-and-forget: prune old revisions to prevent unbounded growth
 		const pruneRepo = new RevisionRepository(db);
-		void pruneRepo.pruneOldRevisions(revision.collection, revision.entryId, 50).catch(() => {});
+		after(async () => {
+			try {
+				await pruneRepo.pruneQueuedEntry(
+					revision.collection,
+					revision.entryId,
+					queuedRevisionId,
+					50,
+				);
+			} catch (error) {
+				console.error(
+					`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
+					error,
+				);
+			}
+		});
 
 		return {
 			success: true,

--- a/packages/core/src/api/handlers/revision.ts
+++ b/packages/core/src/api/handlers/revision.ts
@@ -4,7 +4,6 @@
 
 import type { Kysely } from "kysely";
 
-import { after } from "../../after.js";
 import { ContentRepository } from "../../database/repositories/content.js";
 import { RevisionRepository, type Revision } from "../../database/repositories/revision.js";
 import { withTransaction } from "../../database/transaction.js";
@@ -136,21 +135,14 @@ export async function handleRevisionRestore(
 		});
 
 		const pruneRepo = new RevisionRepository(db);
-		after(async () => {
-			try {
-				await pruneRepo.pruneQueuedEntry(
-					revision.collection,
-					revision.entryId,
-					queuedRevisionId,
-					50,
-				);
-			} catch (error) {
-				console.error(
-					`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
-					error,
-				);
-			}
-		});
+		try {
+			await pruneRepo.pruneQueuedEntry(revision.collection, revision.entryId, queuedRevisionId, 50);
+		} catch (error) {
+			console.error(
+				`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
+				error,
+			);
+		}
 
 		return {
 			success: true,

--- a/packages/core/src/api/handlers/revision.ts
+++ b/packages/core/src/api/handlers/revision.ts
@@ -4,6 +4,7 @@
 
 import type { Kysely } from "kysely";
 
+import { after } from "../../after.js";
 import { ContentRepository } from "../../database/repositories/content.js";
 import { RevisionRepository, type Revision } from "../../database/repositories/revision.js";
 import { withTransaction } from "../../database/transaction.js";
@@ -135,14 +136,21 @@ export async function handleRevisionRestore(
 		});
 
 		const pruneRepo = new RevisionRepository(db);
-		try {
-			await pruneRepo.pruneQueuedEntry(revision.collection, revision.entryId, queuedRevisionId, 50);
-		} catch (error) {
-			console.error(
-				`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
-				error,
-			);
-		}
+		after(async () => {
+			try {
+				await pruneRepo.pruneQueuedEntry(
+					revision.collection,
+					revision.entryId,
+					queuedRevisionId,
+					50,
+				);
+			} catch (error) {
+				console.error(
+					`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
+					error,
+				);
+			}
+		});
 
 		return {
 			success: true,

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -366,7 +366,7 @@ async function runOutsideRequest<T>(
 		// outside a request. Any close-less scope created above is discarded.
 		return fn(runtime);
 	}
-	const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle(scoped);
+	const { closed, deferredTasks, lifecycle } = coordinateScopedDbLifecycle(scoped);
 
 	const parent = getRequestContext();
 	const ctx = parent
@@ -392,6 +392,9 @@ async function runOutsideRequest<T>(
 		} catch (error) {
 			console.error("[emdash] event-scoped db close failed:", error);
 		}
+		// An event handler's returned promise owns its lifetime; unlike an HTTP
+		// response, there is no later stream completion to anchor adapter teardown.
+		await closed;
 	}
 }
 

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -63,7 +63,7 @@ import { createInitLock, type InitLock, initWithLock } from "../utils/init-lock.
 import type { EmDashConfig } from "./integration/runtime.js";
 import {
 	ASTRO_COOKIES_SYMBOL,
-	deferScopedCloseUntilSettled,
+	coordinateScopedDbLifecycle,
 	finishScoped,
 } from "./middleware/scoped-db.js";
 import { wrapBodyForStreamMetrics } from "./middleware/stream-end-metrics.js";
@@ -366,23 +366,29 @@ async function runOutsideRequest<T>(
 		// outside a request. Any close-less scope created above is discarded.
 		return fn(runtime);
 	}
+	const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle(scoped);
 
 	const parent = getRequestContext();
 	const ctx = parent
-		? { ...parent, db: scoped.db }
-		: { editMode: false, db: scoped.db, metrics: createRequestMetrics(performance.now()) };
+		? { ...parent, db: scoped.db, deferredTasks }
+		: {
+				editMode: false,
+				db: scoped.db,
+				metrics: createRequestMetrics(performance.now()),
+				deferredTasks,
+			};
 	try {
 		return await runWithContext(ctx, () => fn(runtime));
 	} finally {
 		// Guard both so a throw in teardown can't mask the callback result or
-		// skip close() and leak the connection. Mirrors closeSafely() in scoped-db.ts.
+		// skip lifecycle settlement and leak the connection.
 		try {
-			scoped.commit();
+			lifecycle.commit();
 		} catch (error) {
 			console.error("[emdash] event-scoped db commit failed:", error);
 		}
 		try {
-			scoped.close();
+			lifecycle.close?.();
 		} catch (error) {
 			console.error("[emdash] event-scoped db close failed:", error);
 		}
@@ -687,10 +693,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					return wrapBodyForStreamMetrics(finalizeResponse(response, timings));
 				};
 				if (anonScoped) {
+					const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle(anonScoped);
 					const parent = getRequestContext();
 					const ctx = parent
-						? { ...parent, db: anonScoped.db }
-						: { editMode: false, db: anonScoped.db, metrics };
+						? { ...parent, db: anonScoped.db, deferredTasks }
+						: { editMode: false, db: anonScoped.db, metrics, deferredTasks };
 					// Eagerly warm site-global layout data (menus, widget areas,
 					// taxonomy terms, settings) concurrently so the layout's
 					// per-component reads overlap into ~one wall-clock round trip and
@@ -710,13 +717,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 						.trim()
 						.startsWith("text/html");
 					return runWithContext(ctx, async () => {
-						const scopedLifecycle = acceptsHtml
-							? deferScopedCloseUntilSettled(anonScoped, prefetchLayoutData(), after)
-							: anonScoped;
+						if (acceptsHtml) after(() => prefetchLayoutData());
 						// commit() persists per-request state (e.g. the D1 bookmark cookie)
 						// before the response is returned, even if render throws; close()
-						// (connection teardown) is deferred to stream-end. See finishScoped.
-						return finishScoped(scopedLifecycle, runAnon);
+						// waits for stream-end and request-owned deferred work. See finishScoped.
+						return finishScoped(lifecycle, runAnon);
 					});
 				}
 				return runAnon();
@@ -903,15 +908,16 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			};
 
 			if (scoped) {
+				const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle(scoped);
 				const parent = getRequestContext();
 				const ctx = parent
-					? { ...parent, db: scoped.db }
-					: { editMode: false, db: scoped.db, metrics };
+					? { ...parent, db: scoped.db, deferredTasks }
+					: { editMode: false, db: scoped.db, metrics, deferredTasks };
 				return runWithContext(ctx, () =>
 					// commit() persists per-request state (e.g. the D1 bookmark cookie)
 					// before the response returns, even if render throws; close()
-					// (connection teardown) is deferred to stream-end. See finishScoped.
-					finishScoped(scoped, renderAndFinalize),
+					// waits for stream-end and request-owned deferred work. See finishScoped.
+					finishScoped(lifecycle, renderAndFinalize),
 				);
 			}
 

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -392,8 +392,6 @@ async function runOutsideRequest<T>(
 		} catch (error) {
 			console.error("[emdash] event-scoped db close failed:", error);
 		}
-		// An event handler's returned promise owns its lifetime; unlike an HTTP
-		// response, there is no later stream completion to anchor adapter teardown.
 		await closed;
 	}
 }

--- a/packages/core/src/astro/middleware/scoped-db.ts
+++ b/packages/core/src/astro/middleware/scoped-db.ts
@@ -6,6 +6,9 @@
  * request-scoped db adapter's lifecycle around the response.
  */
 
+import { createDeferredTaskTracker } from "../../deferred-tasks.js";
+import type { DeferredTaskTracker } from "../../deferred-tasks.js";
+
 /**
  * Astro attaches AstroCookies to outgoing responses via a well-known global
  * symbol. Cloning a Response (`new Response(body, init)`) drops non-header
@@ -21,36 +24,25 @@ interface ScopedDbLifecycle {
 	close?: () => void;
 }
 
-type DeferredTaskScheduler = (task: () => void | Promise<void>) => void;
+/** Hold the real adapter close behind both response and deferred-task completion. */
+export function coordinateScopedDbLifecycle(scoped: ScopedDbLifecycle): {
+	deferredTasks?: DeferredTaskTracker;
+	lifecycle: ScopedDbLifecycle;
+} {
+	if (!scoped.close) return { lifecycle: scoped };
 
-/**
- * Keep teardown alive while both the response and request-owned background
- * work finish. The returned close callback only signals response completion;
- * the adapter's real close runs afterward inside the deferred task.
- */
-export function deferScopedCloseUntilSettled(
-	scoped: ScopedDbLifecycle,
-	pending: Promise<unknown>,
-	defer: DeferredTaskScheduler,
-): ScopedDbLifecycle {
-	if (!scoped.close) {
-		defer(async () => {
-			await pending;
-		});
-		return scoped;
-	}
-
-	let settleResponse!: () => void;
-	const responseSettled = new Promise<void>((resolve) => {
-		settleResponse = resolve;
-	});
 	const close = scoped.close;
-	defer(async () => {
-		await Promise.allSettled([pending, responseSettled]);
-		close();
+	const deferredTasks = createDeferredTaskTracker(() => {
+		try {
+			close();
+		} catch (error) {
+			console.error("[emdash] request-scoped db close failed:", error);
+		}
 	});
-
-	return { commit: scoped.commit, close: settleResponse };
+	return {
+		deferredTasks,
+		lifecycle: { commit: scoped.commit, close: deferredTasks.settle },
+	};
 }
 
 /**
@@ -99,9 +91,9 @@ export function wrapResponseForScopedClose(response: Response, close: () => void
  * Run the request body under a request-scoped db, then settle its lifecycle:
  * `commit()` runs before the response is returned (so per-request state like a
  * D1 bookmark cookie is persisted in the headers, even if render throws), while
- * `close()` (if any) is deferred to stream-end so a connection-backed adapter
- * isn't torn down mid-render. On error the connection is closed immediately
- * before rethrowing so it never leaks.
+ * `close()` (if any) is deferred to lifecycle settlement so a
+ * connection-backed adapter isn't torn down mid-render or mid-task. On error
+ * the lifecycle is settled before rethrowing so it never leaks.
  *
  * On the error path both `commit()` and `close()` are defended: a throw from
  * either is logged and swallowed so it can't replace the propagating render

--- a/packages/core/src/astro/middleware/scoped-db.ts
+++ b/packages/core/src/astro/middleware/scoped-db.ts
@@ -26,6 +26,7 @@ interface ScopedDbLifecycle {
 
 /** Hold the real adapter close behind both response and deferred-task completion. */
 export function coordinateScopedDbLifecycle(scoped: ScopedDbLifecycle): {
+	closed?: Promise<void>;
 	deferredTasks?: DeferredTaskTracker;
 	lifecycle: ScopedDbLifecycle;
 } {
@@ -40,6 +41,7 @@ export function coordinateScopedDbLifecycle(scoped: ScopedDbLifecycle): {
 		}
 	});
 	return {
+		closed: deferredTasks.settled,
 		deferredTasks,
 		lifecycle: { commit: scoped.commit, close: deferredTasks.settle },
 	};

--- a/packages/core/src/cleanup.ts
+++ b/packages/core/src/cleanup.ts
@@ -10,7 +10,7 @@
  */
 
 import { createKyselyAdapter, type AuthTables } from "@emdash-cms/auth/adapters/kysely";
-import { sql, type Kysely } from "kysely";
+import type { Kysely } from "kysely";
 
 import { cleanupExpiredChallenges } from "./auth/challenge-store.js";
 import { MediaRepository } from "./database/repositories/media.js";
@@ -36,11 +36,8 @@ export interface CleanupResult {
 	mediaUsageOrphanOccurrences: number;
 }
 
-/** Max revisions to keep per entry during periodic pruning */
 const REVISION_KEEP_COUNT = 50;
-
-/** Only prune entries that exceed this threshold */
-const REVISION_PRUNE_THRESHOLD = REVISION_KEEP_COUNT;
+const REVISION_PRUNE_BATCH_SIZE = 10;
 
 /**
  * Run all system cleanup tasks.
@@ -136,9 +133,8 @@ export async function runSystemCleanup(
 		console.error("[cleanup] Failed to clean media upload attempts:", error);
 	}
 
-	// 5. Revision pruning -- trim entries with excessive revision counts
 	try {
-		result.revisionsPruned = await pruneExcessiveRevisions(db);
+		result.revisionsPruned = await pruneQueuedRevisions(db);
 	} catch (error) {
 		console.error("[cleanup] Failed to prune revisions:", error);
 	}
@@ -155,31 +151,24 @@ export async function runSystemCleanup(
 	return result;
 }
 
-/**
- * Find entries with more than REVISION_PRUNE_THRESHOLD revisions and prune
- * them down to REVISION_KEEP_COUNT.
- */
-async function pruneExcessiveRevisions(db: Kysely<Database>): Promise<number> {
-	const entries = await sql<{ collection: string; entry_id: string }>`
-		SELECT collection, entry_id
-		FROM revisions
-		GROUP BY collection, entry_id
-		HAVING COUNT(*) > ${REVISION_PRUNE_THRESHOLD}
-	`.execute(db);
-
-	if (entries.rows.length === 0) return 0;
-
+async function pruneQueuedRevisions(db: Kysely<Database>): Promise<number> {
+	const queued = await db
+		.selectFrom("_emdash_revision_prune_queue")
+		.selectAll()
+		.orderBy("revision_id")
+		.limit(REVISION_PRUNE_BATCH_SIZE)
+		.execute();
 	const revisionRepo = new RevisionRepository(db);
 	let totalPruned = 0;
 
-	for (const row of entries.rows) {
+	for (const row of queued) {
 		try {
-			const pruned = await revisionRepo.pruneOldRevisions(
+			totalPruned += await revisionRepo.pruneQueuedEntry(
 				row.collection,
 				row.entry_id,
+				row.revision_id,
 				REVISION_KEEP_COUNT,
 			);
-			totalPruned += pruned;
 		} catch (error) {
 			console.error(
 				`[cleanup] Failed to prune revisions for ${row.collection}/${row.entry_id}:`,

--- a/packages/core/src/cleanup.ts
+++ b/packages/core/src/cleanup.ts
@@ -42,8 +42,8 @@ const REVISION_PRUNE_BATCH_SIZE = 10;
 /**
  * Run all system cleanup tasks.
  *
- * Safe to call frequently -- each task is a single DELETE with a WHERE clause,
- * so repeated calls with nothing to clean are cheap (no-op queries).
+ * Safe to call frequently -- each subsystem tolerates repeated calls, and
+ * repeated calls with nothing to clean are cheap.
  *
  * @param db - The database instance
  * @param storage - Optional storage backend for deleting orphaned files.

--- a/packages/core/src/database/migrations/059_revision_prune_queue.ts
+++ b/packages/core/src/database/migrations/059_revision_prune_queue.ts
@@ -1,0 +1,36 @@
+import { sql, type Kysely } from "kysely";
+
+const REVISION_KEEP_COUNT = 50;
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	await db.schema
+		.createTable("_emdash_revision_prune_queue")
+		.ifNotExists()
+		.addColumn("collection", "text", (column) => column.notNull())
+		.addColumn("entry_id", "text", (column) => column.notNull())
+		.addColumn("revision_id", "text", (column) => column.notNull())
+		.addPrimaryKeyConstraint("revision_prune_queue_pk", ["collection", "entry_id"])
+		.execute();
+
+	await db.schema
+		.createIndex("idx_revision_prune_queue_revision_id")
+		.ifNotExists()
+		.on("_emdash_revision_prune_queue")
+		.column("revision_id")
+		.execute();
+
+	await sql`
+		INSERT INTO _emdash_revision_prune_queue (collection, entry_id, revision_id)
+		SELECT collection, entry_id, MAX(id)
+		FROM revisions
+		WHERE true
+		GROUP BY collection, entry_id
+		HAVING COUNT(*) > ${REVISION_KEEP_COUNT}
+		ON CONFLICT (collection, entry_id)
+		DO UPDATE SET revision_id = excluded.revision_id
+	`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema.dropTable("_emdash_revision_prune_queue").ifExists().execute();
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -61,6 +61,7 @@ import * as m055 from "./055_content_translation_group_locale_index.js";
 import * as m056 from "./056_taxonomy_term_sort_order.js";
 import * as m057 from "./057_collection_hidden.js";
 import * as m058 from "./058_collection_sort_order.js";
+import * as m059 from "./059_revision_prune_queue.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -120,6 +121,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"056_taxonomy_term_sort_order": m056,
 	"057_collection_hidden": m057,
 	"058_collection_sort_order": m058,
+	"059_revision_prune_queue": m059,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/src/database/repositories/revision.ts
+++ b/packages/core/src/database/repositories/revision.ts
@@ -51,6 +51,26 @@ export class RevisionRepository {
 		if (!revision) {
 			throw new Error("Failed to create revision");
 		}
+
+		try {
+			await this.db
+				.insertInto("_emdash_revision_prune_queue")
+				.values({
+					collection: input.collection,
+					entry_id: input.entryId,
+					revision_id: id,
+				})
+				.onConflict((conflict) =>
+					conflict.columns(["collection", "entry_id"]).doUpdateSet({ revision_id: id }),
+				)
+				.execute();
+		} catch (error) {
+			console.error(
+				`[revisions] Failed to queue revision pruning for ${input.collection}/${input.entryId}:`,
+				error,
+			);
+		}
+
 		return revision;
 	}
 
@@ -133,6 +153,19 @@ export class RevisionRepository {
 			.where("entry_id", "=", entryId)
 			.executeTakeFirst();
 
+		try {
+			await this.db
+				.deleteFrom("_emdash_revision_prune_queue")
+				.where("collection", "=", collection)
+				.where("entry_id", "=", entryId)
+				.execute();
+		} catch (error) {
+			console.error(
+				`[revisions] Failed to clear queued revision pruning for ${collection}/${entryId}:`,
+				error,
+			);
+		}
+
 		return Number(result.numDeletedRows ?? 0);
 	}
 
@@ -170,6 +203,22 @@ export class RevisionRepository {
 		`.execute(this.db);
 
 		return Number(result.numAffectedRows ?? 0);
+	}
+
+	async pruneQueuedEntry(
+		collection: string,
+		entryId: string,
+		queuedRevisionId: string,
+		keepCount: number,
+	): Promise<number> {
+		const pruned = await this.pruneOldRevisions(collection, entryId, keepCount);
+		await this.db
+			.deleteFrom("_emdash_revision_prune_queue")
+			.where("collection", "=", collection)
+			.where("entry_id", "=", entryId)
+			.where("revision_id", "=", queuedRevisionId)
+			.execute();
+		return pruned;
 	}
 
 	async deleteIfUnreferenced(

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -13,6 +13,12 @@ export interface RevisionTable {
 	created_at: Generated<string>;
 }
 
+export interface RevisionPruneQueueTable {
+	collection: string;
+	entry_id: string;
+	revision_id: string;
+}
+
 export interface TaxonomyTable {
 	id: string;
 	name: string;
@@ -505,6 +511,7 @@ export interface SectionTable {
 // Note: ec_* content tables are dynamic and not part of this type
 export interface Database {
 	revisions: RevisionTable;
+	_emdash_revision_prune_queue: RevisionPruneQueueTable;
 	taxonomies: TaxonomyTable;
 	content_taxonomies: ContentTaxonomyTable;
 	_emdash_taxonomy_defs: TaxonomyDefTable;

--- a/packages/core/src/deferred-tasks.ts
+++ b/packages/core/src/deferred-tasks.ts
@@ -1,4 +1,5 @@
 export interface DeferredTaskTracker {
+	settled: Promise<void>;
 	track<T>(promise: Promise<T>): Promise<T>;
 	settle(): void;
 }
@@ -36,14 +37,23 @@ export function createDeferredTaskTracker(onSettled: () => void): DeferredTaskTr
 	let pending = 0;
 	let responseSettled = false;
 	let completed = false;
+	let resolveSettled!: () => void;
+	const settled = new Promise<void>((resolve) => {
+		resolveSettled = resolve;
+	});
 
 	const completeIfSettled = () => {
 		if (completed || !responseSettled || pending > 0) return;
 		completed = true;
-		onSettled();
+		try {
+			onSettled();
+		} finally {
+			resolveSettled();
+		}
 	};
 
 	return {
+		settled,
 		track<T>(promise: Promise<T>): Promise<T> {
 			pending++;
 			return promise.finally(() => {

--- a/packages/core/src/deferred-tasks.ts
+++ b/packages/core/src/deferred-tasks.ts
@@ -1,0 +1,61 @@
+export interface DeferredTaskTracker {
+	track<T>(promise: Promise<T>): Promise<T>;
+	settle(): void;
+}
+
+// Test database teardown uses this process-local registry to drain tasks that
+// run without request middleware. Keep it on globalThis so duplicated SSR
+// chunks and their test helpers observe the same task set.
+const DEFERRED_TASKS_KEY = Symbol.for("emdash:deferred-tasks");
+
+const deferredTasks: Set<Promise<unknown>> =
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern
+	((globalThis as Record<symbol, unknown>)[DEFERRED_TASKS_KEY] as
+		| Set<Promise<unknown>>
+		| undefined) ??
+	(() => {
+		const tasks = new Set<Promise<unknown>>();
+		(globalThis as Record<symbol, unknown>)[DEFERRED_TASKS_KEY] = tasks;
+		return tasks;
+	})();
+
+export function trackDeferredTask<T>(promise: Promise<T>): Promise<T> {
+	let tracked!: Promise<T>;
+	tracked = promise.finally(() => deferredTasks.delete(tracked));
+	deferredTasks.add(tracked);
+	return tracked;
+}
+
+export async function waitForDeferredTasks(): Promise<void> {
+	while (deferredTasks.size > 0) {
+		await Promise.allSettled(deferredTasks);
+	}
+}
+
+export function createDeferredTaskTracker(onSettled: () => void): DeferredTaskTracker {
+	let pending = 0;
+	let responseSettled = false;
+	let completed = false;
+
+	const completeIfSettled = () => {
+		if (completed || !responseSettled || pending > 0) return;
+		completed = true;
+		onSettled();
+	};
+
+	return {
+		track<T>(promise: Promise<T>): Promise<T> {
+			pending++;
+			return promise.finally(() => {
+				// A task may register another after() call before it settles. The
+				// counter therefore reaches zero only after the full task chain ends.
+				pending--;
+				completeIfSettled();
+			});
+		},
+		settle(): void {
+			responseSettled = true;
+			completeIfSettled();
+		},
+	};
+}

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2973,7 +2973,16 @@ export class EmDashRuntime {
 							);
 						}
 					} else {
-						void revisionRepo.pruneOldRevisions(collection, resolvedId, 50).catch(() => {});
+						after(async () => {
+							try {
+								await revisionRepo.pruneQueuedEntry(collection, resolvedId, revision.id, 50);
+							} catch (error) {
+								console.error(
+									`[revisions] Failed to prune revisions for ${collection}/${resolvedId}:`,
+									error,
+								);
+							}
+						});
 					}
 					break;
 				}
@@ -3426,10 +3435,21 @@ export class EmDashRuntime {
 				throw error;
 			}
 
-			// Fire-and-forget: prune old revisions to prevent unbounded growth
-			void revisionRepo
-				.pruneOldRevisions(revision.collection, revision.entryId, 50)
-				.catch(() => {});
+			after(async () => {
+				try {
+					await revisionRepo.pruneQueuedEntry(
+						revision.collection,
+						revision.entryId,
+						newDraft.id,
+						50,
+					);
+				} catch (error) {
+					console.error(
+						`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
+						error,
+					);
+				}
+			});
 
 			// Return the freshly-fetched item with the new draft hydrated
 			// onto `data`. Without this the response would echo the live

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2973,16 +2973,14 @@ export class EmDashRuntime {
 							);
 						}
 					} else {
-						after(async () => {
-							try {
-								await revisionRepo.pruneQueuedEntry(collection, resolvedId, revision.id, 50);
-							} catch (error) {
-								console.error(
-									`[revisions] Failed to prune revisions for ${collection}/${resolvedId}:`,
-									error,
-								);
-							}
-						});
+						try {
+							await revisionRepo.pruneQueuedEntry(collection, resolvedId, revision.id, 50);
+						} catch (error) {
+							console.error(
+								`[revisions] Failed to prune revisions for ${collection}/${resolvedId}:`,
+								error,
+							);
+						}
 					}
 					break;
 				}
@@ -3435,21 +3433,14 @@ export class EmDashRuntime {
 				throw error;
 			}
 
-			after(async () => {
-				try {
-					await revisionRepo.pruneQueuedEntry(
-						revision.collection,
-						revision.entryId,
-						newDraft.id,
-						50,
-					);
-				} catch (error) {
-					console.error(
-						`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
-						error,
-					);
-				}
-			});
+			try {
+				await revisionRepo.pruneQueuedEntry(revision.collection, revision.entryId, newDraft.id, 50);
+			} catch (error) {
+				console.error(
+					`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
+					error,
+				);
+			}
 
 			// Return the freshly-fetched item with the new draft hydrated
 			// onto `data`. Without this the response would echo the live

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2973,14 +2973,16 @@ export class EmDashRuntime {
 							);
 						}
 					} else {
-						try {
-							await revisionRepo.pruneQueuedEntry(collection, resolvedId, revision.id, 50);
-						} catch (error) {
-							console.error(
-								`[revisions] Failed to prune revisions for ${collection}/${resolvedId}:`,
-								error,
-							);
-						}
+						after(async () => {
+							try {
+								await revisionRepo.pruneQueuedEntry(collection, resolvedId, revision.id, 50);
+							} catch (error) {
+								console.error(
+									`[revisions] Failed to prune revisions for ${collection}/${resolvedId}:`,
+									error,
+								);
+							}
+						});
 					}
 					break;
 				}
@@ -3433,14 +3435,21 @@ export class EmDashRuntime {
 				throw error;
 			}
 
-			try {
-				await revisionRepo.pruneQueuedEntry(revision.collection, revision.entryId, newDraft.id, 50);
-			} catch (error) {
-				console.error(
-					`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
-					error,
-				);
-			}
+			after(async () => {
+				try {
+					await revisionRepo.pruneQueuedEntry(
+						revision.collection,
+						revision.entryId,
+						newDraft.id,
+						50,
+					);
+				} catch (error) {
+					console.error(
+						`[revisions] Failed to prune revisions for ${revision.collection}/${revision.entryId}:`,
+						error,
+					);
+				}
+			});
 
 			// Return the freshly-fetched item with the new draft hydrated
 			// onto `data`. Without this the response would echo the live

--- a/packages/core/src/request-context.ts
+++ b/packages/core/src/request-context.ts
@@ -20,6 +20,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 import type { QueryRecorder } from "./database/instrumentation.js";
+import type { DeferredTaskTracker } from "./deferred-tasks.js";
 
 /**
  * Lightweight always-on counters surfaced in Server-Timing.
@@ -102,6 +103,8 @@ export interface EmDashRequestContext {
 	 * and `requestCached`.
 	 */
 	metrics?: RequestMetrics;
+	/** Deferred work that owns resources scoped to this request. */
+	deferredTasks?: DeferredTaskTracker;
 }
 
 const ALS_KEY = Symbol.for("emdash:request-context");

--- a/packages/core/tests/integration/content/revision-retention.test.ts
+++ b/packages/core/tests/integration/content/revision-retention.test.ts
@@ -1,0 +1,73 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { deferred } = vi.hoisted(() => ({ deferred: [] as Array<() => void | Promise<void>> }));
+vi.mock("../../../src/after.js", () => ({
+	after: (fn: () => void | Promise<void>) => {
+		deferred.push(fn);
+	},
+}));
+vi.mock(
+	"virtual:emdash/object-cache",
+	() => ({ createObjectCache: undefined, objectCacheConfig: {} }),
+	{ virtual: true },
+);
+
+import { RevisionRepository } from "../../../src/database/repositories/revision.js";
+import type { Database } from "../../../src/database/types.js";
+import type { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { createTestRuntime } from "../../utils/mcp-runtime.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+async function flushDeferred(): Promise<void> {
+	const tasks = deferred.splice(0);
+	for (const task of tasks) await task();
+}
+
+describe("revision retention without scheduled cleanup", () => {
+	let db: Kysely<Database>;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		deferred.length = 0;
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		runtime = createTestRuntime(db);
+	});
+
+	afterEach(async () => {
+		deferred.length = 0;
+		await teardownTestDatabase(db);
+	});
+
+	it("bounds history through request-lifetime work without a scheduled tick", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			data: { title: "Initial" },
+			slug: "bounded-history",
+		});
+		expect(created.success).toBe(true);
+		const entryId = created.data!.item.id;
+		const revisions = new RevisionRepository(db);
+
+		for (let index = 0; index < 50; index++) {
+			await revisions.create({
+				collection: "posts",
+				entryId,
+				data: { title: `Version ${index}` },
+			});
+		}
+
+		const saved = await runtime.handleContentUpdate("posts", entryId, {
+			data: { title: "Version 50" },
+		});
+		expect(saved.success).toBe(true);
+		expect(await revisions.countByEntry("posts", entryId)).toBe(51);
+
+		await flushDeferred();
+
+		expect(await revisions.countByEntry("posts", entryId)).toBe(50);
+	});
+});

--- a/packages/core/tests/integration/content/revision-retention.test.ts
+++ b/packages/core/tests/integration/content/revision-retention.test.ts
@@ -20,11 +20,6 @@ import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { createTestRuntime } from "../../utils/mcp-runtime.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
 
-async function flushDeferred(): Promise<void> {
-	const tasks = deferred.splice(0);
-	for (const task of tasks) await task();
-}
-
 describe("revision retention without scheduled cleanup", () => {
 	let db: Kysely<Database>;
 	let runtime: EmDashRuntime;
@@ -43,7 +38,7 @@ describe("revision retention without scheduled cleanup", () => {
 		await teardownTestDatabase(db);
 	});
 
-	it("bounds history through request-lifetime work without a scheduled tick", async () => {
+	it("bounds history before an update returns without a scheduled tick", async () => {
 		const created = await runtime.handleContentCreate("posts", {
 			data: { title: "Initial" },
 			slug: "bounded-history",
@@ -64,10 +59,6 @@ describe("revision retention without scheduled cleanup", () => {
 			data: { title: "Version 50" },
 		});
 		expect(saved.success).toBe(true);
-		expect(await revisions.countByEntry("posts", entryId)).toBe(51);
-
-		await flushDeferred();
-
 		expect(await revisions.countByEntry("posts", entryId)).toBe(50);
 	});
 });

--- a/packages/core/tests/integration/content/revision-retention.test.ts
+++ b/packages/core/tests/integration/content/revision-retention.test.ts
@@ -20,6 +20,11 @@ import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { createTestRuntime } from "../../utils/mcp-runtime.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
 
+async function flushDeferred(): Promise<void> {
+	const tasks = deferred.splice(0);
+	for (const task of tasks) await task();
+}
+
 describe("revision retention without scheduled cleanup", () => {
 	let db: Kysely<Database>;
 	let runtime: EmDashRuntime;
@@ -38,7 +43,7 @@ describe("revision retention without scheduled cleanup", () => {
 		await teardownTestDatabase(db);
 	});
 
-	it("bounds history before an update returns without a scheduled tick", async () => {
+	it("bounds history through request-lifetime work without a scheduled tick", async () => {
 		const created = await runtime.handleContentCreate("posts", {
 			data: { title: "Initial" },
 			slug: "bounded-history",
@@ -59,6 +64,10 @@ describe("revision retention without scheduled cleanup", () => {
 			data: { title: "Version 50" },
 		});
 		expect(saved.success).toBe(true);
+		expect(await revisions.countByEntry("posts", entryId)).toBe(51);
+
+		await flushDeferred();
+
 		expect(await revisions.countByEntry("posts", entryId)).toBe(50);
 	});
 });

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -145,6 +145,7 @@ describe("Database Migrations (Integration)", () => {
 			"056_taxonomy_term_sort_order",
 			"057_collection_hidden",
 			"058_collection_sort_order",
+			"059_revision_prune_queue",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/unit/after.test.ts
+++ b/packages/core/tests/unit/after.test.ts
@@ -11,6 +11,7 @@ vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual
 // behaviors that don't need a real waitUntil: the callback fires,
 // errors don't escape, and the caller doesn't block.
 import { after } from "../../src/after.js";
+import { waitForDeferredTasks } from "../../src/deferred-tasks.js";
 
 describe("after()", () => {
 	it("runs the callback", async () => {
@@ -52,5 +53,25 @@ describe("after()", () => {
 		});
 		// after() returned already — the callback hasn't completed.
 		expect(ran).toBe(false);
+	});
+
+	it("exposes deferred work for lifecycle teardown", async () => {
+		let settle!: () => void;
+		let completed = false;
+		after(async () => {
+			await new Promise<void>((resolve) => {
+				settle = resolve;
+			});
+			completed = true;
+		});
+		await Promise.resolve();
+
+		const drained = waitForDeferredTasks();
+		await Promise.resolve();
+		expect(completed).toBe(false);
+
+		settle();
+		await drained;
+		expect(completed).toBe(true);
 	});
 });

--- a/packages/core/tests/unit/astro/with-emdash-runtime.test.ts
+++ b/packages/core/tests/unit/astro/with-emdash-runtime.test.ts
@@ -68,6 +68,7 @@ vi.mock("../../../src/object-cache/index.js", async (importOriginal) => ({
 
 import { createRequestScopedDb } from "virtual:emdash/dialect";
 
+import { after } from "../../../src/after.js";
 import { withEmDashRuntime } from "../../../src/astro/middleware.js";
 import { getRequestContext } from "../../../src/request-context.js";
 
@@ -147,6 +148,39 @@ describe("withEmDashRuntime (#1887)", () => {
 		).rejects.toThrow("job failed");
 
 		expect(commit).toHaveBeenCalledTimes(1);
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not finish an event before deferred work releases its scoped db", async () => {
+		let release!: () => void;
+		let returned = false;
+		const close = vi.fn();
+		vi.mocked(createRequestScopedDb).mockReturnValue({
+			db: { _marker: "scoped" } as never,
+			commit: vi.fn(),
+			close,
+		});
+
+		const resultPromise = withEmDashRuntime(async () => {
+			after(
+				() =>
+					new Promise<void>((resolve) => {
+						release = resolve;
+					}),
+			);
+			return "ok";
+		}).then((result) => {
+			returned = true;
+			return result;
+		});
+
+		await vi.waitFor(() => expect(release).toBeTypeOf("function"));
+		await Promise.resolve();
+		expect(returned).toBe(false);
+		expect(close).not.toHaveBeenCalled();
+
+		release();
+		await expect(resultPromise).resolves.toBe("ok");
 		expect(close).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/core/tests/unit/cleanup.test.ts
+++ b/packages/core/tests/unit/cleanup.test.ts
@@ -1,19 +1,12 @@
-/**
- * Tests for the cleanup subsystems.
- *
- * Note: runSystemCleanup() is not tested directly here because it imports
- * from @emdash-cms/auth/adapters/kysely, which requires the auth package to
- * be built. Instead, we test each subsystem independently:
- * - cleanupExpiredChallenges: tested in auth/challenge-store.test.ts
- * - deleteExpiredTokens: tested below using direct DB operations
- * - cleanupPendingUploads: tested below via MediaRepository
- * - pruneOldRevisions: tested below via RevisionRepository
- */
+/** Tests for cleanup subsystems and scheduled cleanup orchestration. */
 
-import type { Kysely } from "kysely";
+import BetterSqlite3 from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
 import { ulid } from "ulidx";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
+import { runSystemCleanup } from "../../src/cleanup.js";
+import { runMigrations } from "../../src/database/migrations/runner.js";
 import { MediaRepository } from "../../src/database/repositories/media.js";
 import { RevisionRepository } from "../../src/database/repositories/revision.js";
 import type { Database } from "../../src/database/types.js";
@@ -129,6 +122,96 @@ describe("Revision Pruning", () => {
 		expect(await revisionRepo.findById(live.id)).not.toBeNull();
 		expect(await revisionRepo.findById(draft.id)).not.toBeNull();
 		expect(await revisionRepo.countByEntry("post", entryId)).toBe(11);
+	});
+});
+
+describe("Scheduled system cleanup", () => {
+	it("prunes revision entries queued by revision writes", async () => {
+		const db = await setupTestDatabaseWithCollections();
+		const revisionRepo = new RevisionRepository(db);
+		const entryId = ulid();
+		const { sql } = await import("kysely");
+
+		try {
+			await sql`
+				INSERT INTO ec_post (id, slug, status, created_at, updated_at, version)
+				VALUES (${entryId}, ${"queued-history"}, ${"draft"}, ${new Date().toISOString()}, ${new Date().toISOString()}, ${1})
+			`.execute(db);
+			for (let i = 0; i < 51; i++) {
+				await revisionRepo.create({
+					collection: "post",
+					entryId,
+					data: { title: `Version ${i + 1}` },
+				});
+			}
+
+			const result = await runSystemCleanup(db);
+
+			expect(result.revisionsPruned).toBe(1);
+			expect(await revisionRepo.countByEntry("post", entryId)).toBe(50);
+			expect(
+				await db.selectFrom("_emdash_revision_prune_queue").select("entry_id").execute(),
+			).toEqual([]);
+		} finally {
+			await db.destroy();
+		}
+	});
+
+	it("processes the oldest queued revision entries first", async () => {
+		const db = await setupTestDatabaseWithCollections();
+		const revisionRepo = new RevisionRepository(db);
+		const { sql } = await import("kysely");
+		const entryIds = ["z-old", ...Array.from({ length: 10 }, (_, index) => `a0${index}`)];
+
+		try {
+			for (const entryId of entryIds) {
+				await sql`
+					INSERT INTO ec_post (id, slug, status, created_at, updated_at, version)
+					VALUES (${entryId}, ${entryId}, ${"draft"}, ${new Date().toISOString()}, ${new Date().toISOString()}, ${1})
+				`.execute(db);
+				await revisionRepo.create({
+					collection: "post",
+					entryId,
+					data: { title: entryId },
+				});
+			}
+
+			await runSystemCleanup(db);
+
+			const remaining = await db
+				.selectFrom("_emdash_revision_prune_queue")
+				.select("entry_id")
+				.execute();
+			expect(remaining).toHaveLength(1);
+			expect(remaining[0]?.entry_id).toMatch(/^a/);
+			expect(remaining).not.toContainEqual({ entry_id: "z-old" });
+		} finally {
+			await db.destroy();
+		}
+	});
+
+	it("does not query the full revision history", async () => {
+		const sqlite = new BetterSqlite3(":memory:");
+		const queries: string[] = [];
+		const db = new Kysely<Database>({
+			dialect: new SqliteDialect({ database: sqlite }),
+			log: (event) => {
+				if (event.level === "query") queries.push(event.query.sql);
+			},
+		});
+
+		try {
+			await runMigrations(db);
+			queries.length = 0;
+			await runSystemCleanup(db);
+
+			const revisionQueries = queries.filter((query) =>
+				/\b(?:from|delete from)\s+["`]?revisions\b/i.test(query),
+			);
+			expect(revisionQueries).toHaveLength(0);
+		} finally {
+			await db.destroy();
+		}
 	});
 });
 

--- a/packages/core/tests/unit/database/migrations/059_revision_prune_queue.test.ts
+++ b/packages/core/tests/unit/database/migrations/059_revision_prune_queue.test.ts
@@ -38,17 +38,6 @@ describe("059_revision_prune_queue migration", () => {
 		`.execute(db);
 		expect(queued.rows).toEqual([{ collection: "post", entry_id: "entry-1", revision_id: "50" }]);
 
-		const plan = await sql<{ detail: string }>`
-			EXPLAIN QUERY PLAN
-			SELECT collection, entry_id, revision_id
-			FROM _emdash_revision_prune_queue
-			ORDER BY revision_id
-			LIMIT 10
-		`.execute(db);
-		expect(plan.rows.map((row) => row.detail).join(" ")).toContain(
-			"USING INDEX idx_revision_prune_queue_revision_id",
-		);
-
 		await down(db);
 	});
 });

--- a/packages/core/tests/unit/database/migrations/059_revision_prune_queue.test.ts
+++ b/packages/core/tests/unit/database/migrations/059_revision_prune_queue.test.ts
@@ -1,0 +1,54 @@
+import BetterSqlite3 from "better-sqlite3";
+import { Kysely, sql, SqliteDialect } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { down, up } from "../../../../src/database/migrations/059_revision_prune_queue.js";
+
+describe("059_revision_prune_queue migration", () => {
+	let db: Kysely<Record<string, never>> | undefined;
+
+	afterEach(async () => {
+		await db?.destroy();
+	});
+
+	it("queues existing excessive histories and can be retried", async () => {
+		const sqlite = new BetterSqlite3(":memory:");
+		sqlite.exec(`
+			CREATE TABLE revisions (
+				id TEXT PRIMARY KEY,
+				collection TEXT NOT NULL,
+				entry_id TEXT NOT NULL
+			)
+		`);
+		const insert = sqlite.prepare(
+			"INSERT INTO revisions (id, collection, entry_id) VALUES (?, ?, ?)",
+		);
+		for (let i = 0; i < 51; i++) insert.run(String(i).padStart(2, "0"), "post", "entry-1");
+
+		db = new Kysely<Record<string, never>>({
+			dialect: new SqliteDialect({ database: sqlite }),
+		});
+
+		await up(db);
+		await up(db);
+
+		const queued = await sql<{ collection: string; entry_id: string; revision_id: string }>`
+			SELECT collection, entry_id, revision_id
+			FROM _emdash_revision_prune_queue
+		`.execute(db);
+		expect(queued.rows).toEqual([{ collection: "post", entry_id: "entry-1", revision_id: "50" }]);
+
+		const plan = await sql<{ detail: string }>`
+			EXPLAIN QUERY PLAN
+			SELECT collection, entry_id, revision_id
+			FROM _emdash_revision_prune_queue
+			ORDER BY revision_id
+			LIMIT 10
+		`.execute(db);
+		expect(plan.rows.map((row) => row.detail).join(" ")).toContain(
+			"USING INDEX idx_revision_prune_queue_revision_id",
+		);
+
+		await down(db);
+	});
+});

--- a/packages/core/tests/unit/middleware/scoped-db.test.ts
+++ b/packages/core/tests/unit/middleware/scoped-db.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
 
+import { after } from "../../../src/after.js";
 import {
 	ASTRO_COOKIES_SYMBOL,
-	deferScopedCloseUntilSettled,
+	coordinateScopedDbLifecycle,
 	finishScoped,
 	wrapResponseForScopedClose,
 } from "../../../src/astro/middleware/scoped-db.js";
+import { runWithContext } from "../../../src/request-context.js";
 
 /** Build a streaming Response whose body emits the given chunks. */
 function streamingResponse(chunks: string[], init?: ResponseInit): Response {
@@ -103,65 +105,113 @@ describe("wrapResponseForScopedClose", () => {
 		expect(wrapped.headers.has("content-length")).toBe(false);
 	});
 });
-
-describe("deferScopedCloseUntilSettled", () => {
-	it("keeps a bodyless response teardown behind in-flight request work", async () => {
+describe("finishScoped", () => {
+	it("keeps a bodyless response connection open for request deferred work", async () => {
 		let settleWork!: () => void;
-		const inFlightWork = new Promise<void>((resolve) => {
-			settleWork = resolve;
-		});
 		const close = vi.fn();
-		let deferredTask!: Promise<void>;
-		const scoped = deferScopedCloseUntilSettled(
-			{ commit: vi.fn(), close },
-			inFlightWork,
-			(task) => {
-				deferredTask = Promise.resolve().then(task);
-			},
-		);
+		const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle({
+			commit: vi.fn(),
+			close,
+		});
 
-		await finishScoped(scoped, async () => new Response(null, { status: 204 }));
+		await runWithContext({ editMode: false, deferredTasks }, async () => {
+			after(async () => {
+				await new Promise<void>((resolve) => {
+					settleWork = resolve;
+				});
+			});
+			await Promise.resolve();
+			await finishScoped(lifecycle, async () => new Response(null, { status: 204 }));
+		});
 
 		expect(close).not.toHaveBeenCalled();
 		settleWork();
-		await deferredTask;
-		expect(close).toHaveBeenCalledTimes(1);
+		await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
 	});
 
-	it("keeps teardown behind a streaming response after request work settles", async () => {
+	it("waits for stream completion after deferred work settles", async () => {
+		let settleWork!: () => void;
 		const close = vi.fn();
-		let deferredTask!: Promise<void>;
-		const scoped = deferScopedCloseUntilSettled(
-			{ commit: vi.fn(), close },
-			Promise.resolve(),
-			(task) => {
-				deferredTask = Promise.resolve().then(task);
-			},
-		);
-
-		const response = await finishScoped(scoped, async () => streamingResponse(["body"]));
-		await Promise.resolve();
-
-		expect(close).not.toHaveBeenCalled();
-		await drain(response);
-		await deferredTask;
-		expect(close).toHaveBeenCalledTimes(1);
-	});
-
-	it("keeps background work deferred for an adapter without teardown", async () => {
-		const scoped = { commit: vi.fn() };
-		let deferredTask!: () => void | Promise<void>;
-
-		const result = deferScopedCloseUntilSettled(scoped, Promise.resolve(), (task) => {
-			deferredTask = task;
+		const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle({
+			commit: vi.fn(),
+			close,
+		});
+		const response = await runWithContext({ editMode: false, deferredTasks }, async () => {
+			after(
+				() =>
+					new Promise<void>((resolve) => {
+						settleWork = resolve;
+					}),
+			);
+			await Promise.resolve();
+			return finishScoped(lifecycle, async () => streamingResponse(["body"]));
 		});
 
-		expect(result).toBe(scoped);
-		await deferredTask();
-	});
-});
+		settleWork();
+		await Promise.resolve();
+		expect(close).not.toHaveBeenCalled();
 
-describe("finishScoped", () => {
+		await drain(response);
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	it("waits for deferred work after the response stream is cancelled", async () => {
+		let settleWork!: () => void;
+		const close = vi.fn();
+		const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle({
+			commit: vi.fn(),
+			close,
+		});
+		const response = await runWithContext({ editMode: false, deferredTasks }, async () => {
+			after(
+				() =>
+					new Promise<void>((resolve) => {
+						settleWork = resolve;
+					}),
+			);
+			await Promise.resolve();
+			return finishScoped(lifecycle, async () => streamingResponse(["body"]));
+		});
+
+		await response.body!.cancel();
+		expect(close).not.toHaveBeenCalled();
+
+		settleWork();
+		await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+	});
+
+	it("waits for nested deferred work after render failure", async () => {
+		let settleNested!: () => void;
+		const close = vi.fn();
+		const renderError = new Error("render failed");
+		const { deferredTasks, lifecycle } = coordinateScopedDbLifecycle({
+			commit: vi.fn(),
+			close,
+		});
+
+		await expect(
+			runWithContext({ editMode: false, deferredTasks }, async () => {
+				after(async () => {
+					after(
+						() =>
+							new Promise<void>((resolve) => {
+								settleNested = resolve;
+							}),
+					);
+				});
+				await Promise.resolve();
+				return finishScoped(lifecycle, async () => {
+					throw renderError;
+				});
+			}),
+		).rejects.toBe(renderError);
+		await vi.waitFor(() => expect(settleNested).toBeTypeOf("function"));
+		expect(close).not.toHaveBeenCalled();
+
+		settleNested();
+		await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+	});
+
 	it("commits then defers close to stream-end for a streaming response", async () => {
 		const order: string[] = [];
 		const commit = vi.fn(() => order.push("commit"));

--- a/packages/core/tests/unit/test-db-deferred-teardown.test.ts
+++ b/packages/core/tests/unit/test-db-deferred-teardown.test.ts
@@ -1,0 +1,29 @@
+import { sql } from "kysely";
+import { expect, it } from "vitest";
+
+import { after } from "../../src/after.js";
+import { setupTestDatabase, teardownTestDatabase } from "../utils/test-db.js";
+
+it("drains deferred database work before test database teardown", async () => {
+	const db = await setupTestDatabase();
+	let release!: () => void;
+	after(async () => {
+		await new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await sql`select 1`.execute(db);
+	});
+	await Promise.resolve();
+
+	let tornDown = false;
+	const teardown = teardownTestDatabase(db).then(() => {
+		tornDown = true;
+		return null;
+	});
+	await Promise.resolve();
+	expect(tornDown).toBe(false);
+
+	release();
+	await teardown;
+	expect(tornDown).toBe(true);
+});

--- a/packages/core/tests/utils/test-db.ts
+++ b/packages/core/tests/utils/test-db.ts
@@ -10,6 +10,7 @@ import { getMigrationStatus, runMigrations } from "../../src/database/migrations
 import type { MigrationStatus } from "../../src/database/migrations/runner.js";
 import { FailFastPostgresDialect } from "../../src/database/pg-migration-lock.js";
 import type { Database as DatabaseSchema } from "../../src/database/types.js";
+import { waitForDeferredTasks } from "../../src/deferred-tasks.js";
 import { SchemaRegistry } from "../../src/schema/registry.js";
 import { resetTaxonomyDefsCacheForTests } from "../../src/taxonomies/index.js";
 
@@ -119,6 +120,7 @@ export async function setupTestDatabaseWithCollections(): Promise<Kysely<Databas
  * Cleanup and destroy a test database
  */
 export async function teardownTestDatabase(db: Kysely<DatabaseSchema>): Promise<void> {
+	await waitForDeferredTasks();
 	await db.destroy();
 }
 
@@ -418,6 +420,7 @@ export async function setupTestPostgresDatabaseWithCollections(): Promise<PgTest
  * Tear down a Postgres test database — drops the schema and closes the pool.
  */
 export async function teardownTestPostgresDatabase(ctx: PgTestContext): Promise<void> {
+	await waitForDeferredTasks();
 	// Destroy the test pool first
 	await ctx.db.destroy();
 


### PR DESCRIPTION
## What does this PR do?

Replaces the scheduled full-table revision-history scan with a durable, bounded pruning queue. Revision writes coalesce pruning work per content entry, while scheduled cleanup processes at most ten oldest entries per invocation as a retry path. A migration queues existing histories over the 50-revision limit once.

Revision-mutating handlers continue to defer their bounded per-entry prune through `after()`. Request-scoped deferred tasks now participate in the database lifecycle, so connection-backed adapters close only after both the response and all request-owned deferred work settle. HTTP responses remain non-blocking through `waitUntil`, while request-free event handlers await their deferred teardown before returning. This covers bodyless and streamed responses, cancellation, render errors, and nested deferred tasks without adding database queries to the logged-out hot path. Direct-runtime tests also drain deferred work before destroying their test database.

This generalized lifecycle coordination replaces the prefetch-specific close deferral merged in #2409. Layout prefetch now uses the common `after()` tracker, and the rebased lifecycle tests retain streamed-response teardown coverage.

Closes #2211

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Admin localization and a feature Discussion are not applicable: this changes background database maintenance and request-resource ownership without adding UI or a feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- Rebased onto `main` after #2280, #2408, and #2409 merged
- Type-aware lint: 0 diagnostics
- Package typecheck passed
- Core build passed
- Exact regression and lifecycle suites: 52/52 passed
- Full core suite before rebase: 5,274 passed; two unrelated existing failures remained (`/var` vs `/private/var` temp-path normalization and taxonomy cursor pagination omitting duplicate-label terms)
- Deferred lifecycle coverage includes bodyless and streamed responses, cancellation, render failure, nested tasks, event completion, and test-database teardown
- SQLite and D1 query-count and SQL snapshots passed unchanged earlier in this PR
- Local D1 migration and Wrangler preview paths passed earlier in this PR

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-issue-2211-cron-row-reads-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/issue-2211-cron-row-reads`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
