### PR TITLE
fix(core): refresh redirect cache across isolates

### DIFF
--- a/.changeset/fresh-redirect-isolates.md
+++ b/.changeset/fresh-redirect-isolates.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes redirect changes remaining stale across Cloudflare Worker isolates by refreshing cached rules within 30 seconds.

--- a/packages/core/src/astro/middleware/redirect.ts
+++ b/packages/core/src/astro/middleware/redirect.ts
@@ -18,11 +18,7 @@ import { defineMiddleware } from "astro:middleware";
 
 import { RedirectRepository } from "../../database/repositories/redirect.js";
 import { getDb } from "../../loader.js";
-import {
-	getCachedRedirects,
-	matchCachedPatterns,
-	setCachedRedirects,
-} from "../../redirects/cache.js";
+import { loadCachedRedirects, matchCachedPatterns } from "../../redirects/cache.js";
 import { isTerminalStatus } from "../../redirects/status.js";
 
 /** Paths that should never be intercepted by redirects */
@@ -68,11 +64,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		// One query loads both exact and pattern rules into the cache; warm
 		// requests issue zero queries. Empty-redirect sites cache an empty
 		// Map + array, so the next request returns immediately without probing.
-		let cached = getCachedRedirects();
-		if (!cached) {
-			const all = await repo.findAllEnabled();
-			cached = setCachedRedirects(all);
-		}
+		const cached = await loadCachedRedirects(() => repo.findAllEnabled());
 
 		// 1. Exact match (O(1) Map lookup)
 		let exact = cached.exact.get(pathname);

--- a/packages/core/src/redirects/cache.ts
+++ b/packages/core/src/redirects/cache.ts
@@ -76,7 +76,7 @@ export function invalidateRedirectCache(): void {
 /**
  * Get the cached redirects, or null if the cache is cold.
  */
-export function getCachedRedirects(): CachedRedirects | null {
+function getCachedRedirects(): CachedRedirects | null {
 	if (cacheState.redirects && Date.now() >= cacheState.expiresAt) {
 		invalidateRedirectCache();
 	}

--- a/packages/core/src/redirects/cache.ts
+++ b/packages/core/src/redirects/cache.ts
@@ -45,6 +45,7 @@ interface RedirectCacheState {
 }
 
 const REDIRECT_CACHE_TTL_MS = 30_000;
+const REDIRECT_CACHE_MAX_REFRESH_ATTEMPTS = 3;
 const REDIRECT_CACHE_KEY = Symbol.for("emdash:redirect-cache");
 const g = globalThis as Record<symbol, unknown>;
 const cacheState: RedirectCacheState =
@@ -102,15 +103,10 @@ function installCachedRedirects(redirects: CachedRedirects): CachedRedirects {
 	return cacheState.redirects;
 }
 
-export function setCachedRedirects(redirects: Redirect[]): CachedRedirects {
-	invalidateRedirectCache();
-	return installCachedRedirects(compileRedirects(redirects));
-}
-
 export async function loadCachedRedirects(
 	load: () => Promise<Redirect[]>,
 ): Promise<CachedRedirects> {
-	while (true) {
+	for (let attempt = 0; attempt < REDIRECT_CACHE_MAX_REFRESH_ATTEMPTS; attempt++) {
 		const cached = getCachedRedirects();
 		if (cached) return cached;
 
@@ -124,7 +120,13 @@ export async function loadCachedRedirects(
 		if (generation === cacheState.generation) {
 			return installCachedRedirects(loaded);
 		}
+
+		if (attempt === REDIRECT_CACHE_MAX_REFRESH_ATTEMPTS - 1) {
+			return loaded;
+		}
 	}
+
+	throw new Error("Redirect cache refresh exhausted without loading rules");
 }
 
 /**

--- a/packages/core/src/redirects/cache.ts
+++ b/packages/core/src/redirects/cache.ts
@@ -1,19 +1,27 @@
 /**
  * Redirect rule cache.
  *
- * Module-level cache for enabled redirect rules. The middleware populates this
- * on first request; route handlers invalidate it on writes.
+ * Worker-isolate cache for enabled redirect rules. The middleware populates
+ * this on first request; route handlers invalidate it on writes. Cached rules
+ * expire so writes handled by another isolate become visible here too.
  *
  * Both exact-match and pattern rules are loaded from one query and cached
  * together: exact rules indexed by source path in a Map, pattern rules
  * pre-compiled into an array. A single warm request issues zero database
- * queries; a cold isolate issues one.
+ * queries; a cold or expired isolate issues one.
  *
  * This module deliberately has NO Astro imports so it can be safely imported
  * from handlers, seed, CLI, and tests without dragging in `astro:middleware`.
  */
 
+import { after } from "../after.js";
 import type { Redirect } from "../database/repositories/redirect.js";
+import {
+	createSingleFlightCache,
+	type SingleFlightCache,
+	invalidateSingleFlightCache,
+	singleFlightCached,
+} from "../utils/single-flight-cache.js";
 import type { CompiledPattern } from "./patterns.js";
 import { compilePattern, interpolateDestination, matchPattern } from "./patterns.js";
 
@@ -29,33 +37,53 @@ export interface CachedRedirects {
 	patterns: CachedRedirectRule[];
 }
 
-/**
- * Cached enabled redirects.
- * null = not yet populated, object = cached.
- */
-let cachedRedirects: CachedRedirects | null = null;
+interface RedirectCacheState {
+	redirects: CachedRedirects | null;
+	expiresAt: number;
+	generation: number;
+	refresh: SingleFlightCache<CachedRedirects>;
+}
+
+const REDIRECT_CACHE_TTL_MS = 30_000;
+const REDIRECT_CACHE_KEY = Symbol.for("emdash:redirect-cache");
+const g = globalThis as Record<symbol, unknown>;
+const cacheState: RedirectCacheState =
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern (see request-context.ts)
+	(g[REDIRECT_CACHE_KEY] as RedirectCacheState | undefined) ??
+	(() => {
+		const state: RedirectCacheState = {
+			redirects: null,
+			expiresAt: 0,
+			generation: 0,
+			refresh: createSingleFlightCache<CachedRedirects>(),
+		};
+		g[REDIRECT_CACHE_KEY] = state;
+		return state;
+	})();
 
 /**
  * Invalidate the cached redirects (both exact and pattern).
  * Call when redirects are created, updated, or deleted.
  */
 export function invalidateRedirectCache(): void {
-	cachedRedirects = null;
+	cacheState.generation++;
+	cacheState.redirects = null;
+	cacheState.expiresAt = 0;
+	invalidateSingleFlightCache(cacheState.refresh);
 }
 
 /**
  * Get the cached redirects, or null if the cache is cold.
  */
 export function getCachedRedirects(): CachedRedirects | null {
-	return cachedRedirects;
+	if (cacheState.redirects && Date.now() >= cacheState.expiresAt) {
+		invalidateRedirectCache();
+	}
+	return cacheState.redirects;
 }
 
-/**
- * Populate the cache from a list of enabled redirects (both exact and
- * pattern). The caller is responsible for passing only enabled rows — the
- * cache stores them as-is.
- */
-export function setCachedRedirects(redirects: Redirect[]): CachedRedirects {
+/** Compile enabled database rows into the in-memory lookup structures. */
+function compileRedirects(redirects: Redirect[]): CachedRedirects {
 	const exact = new Map<string, Redirect>();
 	const patterns: CachedRedirectRule[] = [];
 	for (const r of redirects) {
@@ -65,8 +93,38 @@ export function setCachedRedirects(redirects: Redirect[]): CachedRedirects {
 			exact.set(r.source, r);
 		}
 	}
-	cachedRedirects = { exact, patterns };
-	return cachedRedirects;
+	return { exact, patterns };
+}
+
+function installCachedRedirects(redirects: CachedRedirects): CachedRedirects {
+	cacheState.redirects = redirects;
+	cacheState.expiresAt = Date.now() + REDIRECT_CACHE_TTL_MS;
+	return cacheState.redirects;
+}
+
+export function setCachedRedirects(redirects: Redirect[]): CachedRedirects {
+	invalidateRedirectCache();
+	return installCachedRedirects(compileRedirects(redirects));
+}
+
+export async function loadCachedRedirects(
+	load: () => Promise<Redirect[]>,
+): Promise<CachedRedirects> {
+	while (true) {
+		const cached = getCachedRedirects();
+		if (cached) return cached;
+
+		const generation = cacheState.generation;
+		const loaded = await singleFlightCached(
+			cacheState.refresh,
+			async () => compileRedirects(await load()),
+			{ anchor: (promise) => after(() => promise), ownerTimeoutMs: 30_000 },
+		);
+
+		if (generation === cacheState.generation) {
+			return installCachedRedirects(loaded);
+		}
+	}
 }
 
 /**

--- a/packages/core/tests/unit/astro/middleware-redirect.test.ts
+++ b/packages/core/tests/unit/astro/middleware-redirect.test.ts
@@ -168,8 +168,8 @@ describe("redirect middleware — issue #808", () => {
 
 	it("refreshes redirect rules after another Worker isolate changes them", async () => {
 		vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+		const findAllEnabled = vi.spyOn(RedirectRepository.prototype, "findAllEnabled");
 		try {
-			const findAllEnabled = vi.spyOn(RedirectRepository.prototype, "findAllEnabled");
 			const repo = new RedirectRepository(db);
 
 			const first = buildContext({ pathname: "/old" });
@@ -203,8 +203,8 @@ describe("redirect middleware — issue #808", () => {
 
 			expect(refreshed.redirect).toHaveBeenCalledWith("/newer", 301);
 			expect(findAllEnabled).toHaveBeenCalledTimes(2);
-			findAllEnabled.mockRestore();
 		} finally {
+			findAllEnabled.mockRestore();
 			vi.useRealTimers();
 		}
 	});
@@ -290,6 +290,43 @@ describe("redirect middleware — issue #808", () => {
 
 			expect(request.redirect).toHaveBeenCalledWith("/newer", 301);
 			expect(findAllEnabled).toHaveBeenCalledTimes(2);
+		} finally {
+			findAllEnabled.mockRestore();
+		}
+	});
+
+	it("bounds refresh retries when writes keep invalidating the cache", async () => {
+		const originalFindAllEnabled = RedirectRepository.prototype.findAllEnabled;
+		let invalidationsRemaining = 3;
+		const findAllEnabled = vi
+			.spyOn(RedirectRepository.prototype, "findAllEnabled")
+			.mockImplementation(async function () {
+				const rows = await originalFindAllEnabled.call(this);
+				if (invalidationsRemaining > 0) {
+					invalidationsRemaining--;
+					invalidateRedirectCache();
+				}
+				return rows;
+			});
+
+		try {
+			const first = buildContext({ pathname: "/old" });
+			await runMiddleware(
+				first.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+
+			expect(first.redirect).toHaveBeenCalledWith("/new", 301);
+			expect(findAllEnabled).toHaveBeenCalledTimes(3);
+
+			const second = buildContext({ pathname: "/old" });
+			await runMiddleware(
+				second.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+
+			expect(second.redirect).toHaveBeenCalledWith("/new", 301);
+			expect(findAllEnabled).toHaveBeenCalledTimes(4);
 		} finally {
 			findAllEnabled.mockRestore();
 		}

--- a/packages/core/tests/unit/astro/middleware-redirect.test.ts
+++ b/packages/core/tests/unit/astro/middleware-redirect.test.ts
@@ -166,6 +166,135 @@ describe("redirect middleware — issue #808", () => {
 		findAllEnabled.mockRestore();
 	});
 
+	it("refreshes redirect rules after another Worker isolate changes them", async () => {
+		vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+		try {
+			const findAllEnabled = vi.spyOn(RedirectRepository.prototype, "findAllEnabled");
+			const repo = new RedirectRepository(db);
+
+			const first = buildContext({ pathname: "/old" });
+			await runMiddleware(
+				first.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+			expect(first.redirect).toHaveBeenCalledWith("/new", 301);
+
+			const existing = await repo.findBySource("/old");
+			expect(existing).not.toBeNull();
+			await repo.update(existing!.id, { destination: "/newer" });
+
+			vi.advanceTimersByTime(29_999);
+
+			const stillCached = buildContext({ pathname: "/old" });
+			await runMiddleware(
+				stillCached.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+			expect(stillCached.redirect).toHaveBeenCalledWith("/new", 301);
+			expect(findAllEnabled).toHaveBeenCalledTimes(1);
+
+			vi.advanceTimersByTime(1);
+
+			const refreshed = buildContext({ pathname: "/old" });
+			await runMiddleware(
+				refreshed.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+
+			expect(refreshed.redirect).toHaveBeenCalledWith("/newer", 301);
+			expect(findAllEnabled).toHaveBeenCalledTimes(2);
+			findAllEnabled.mockRestore();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("coalesces concurrent cache refreshes into one database query", async () => {
+		const originalFindAllEnabled = RedirectRepository.prototype.findAllEnabled;
+		let releaseRefresh!: () => void;
+		const refreshGate = new Promise<void>((resolve) => {
+			releaseRefresh = resolve;
+		});
+		let markRefreshStarted!: () => void;
+		const refreshStarted = new Promise<void>((resolve) => {
+			markRefreshStarted = resolve;
+		});
+		const findAllEnabled = vi
+			.spyOn(RedirectRepository.prototype, "findAllEnabled")
+			.mockImplementation(async function () {
+				markRefreshStarted();
+				await refreshGate;
+				return originalFindAllEnabled.call(this);
+			});
+
+		try {
+			const first = buildContext({ pathname: "/old" });
+			const firstResponse = runMiddleware(
+				first.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+			await refreshStarted;
+
+			const second = buildContext({ pathname: "/old" });
+			const secondResponse = runMiddleware(
+				second.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+
+			releaseRefresh();
+			await Promise.all([firstResponse, secondResponse]);
+
+			expect(findAllEnabled).toHaveBeenCalledTimes(1);
+			expect(first.redirect).toHaveBeenCalledWith("/new", 301);
+			expect(second.redirect).toHaveBeenCalledWith("/new", 301);
+		} finally {
+			findAllEnabled.mockRestore();
+		}
+	});
+
+	it("does not restore stale rules when a write invalidates an in-flight refresh", async () => {
+		const originalFindAllEnabled = RedirectRepository.prototype.findAllEnabled;
+		let releaseRefresh!: () => void;
+		const refreshGate = new Promise<void>((resolve) => {
+			releaseRefresh = resolve;
+		});
+		let markSnapshotLoaded!: () => void;
+		const snapshotLoaded = new Promise<void>((resolve) => {
+			markSnapshotLoaded = resolve;
+		});
+		const findAllEnabled = vi
+			.spyOn(RedirectRepository.prototype, "findAllEnabled")
+			.mockImplementation(async function () {
+				const rows = await originalFindAllEnabled.call(this);
+				markSnapshotLoaded();
+				await refreshGate;
+				return rows;
+			});
+
+		try {
+			const request = buildContext({ pathname: "/old" });
+			const response = runMiddleware(
+				request.context,
+				vi.fn(async () => new Response("not found", { status: 404 })),
+			);
+			await snapshotLoaded;
+
+			const repo = new RedirectRepository(db);
+			const existing = await repo.findBySource("/old");
+			expect(existing).not.toBeNull();
+			await repo.update(existing!.id, { destination: "/newer" });
+			invalidateRedirectCache();
+			releaseRefresh();
+
+			await response;
+
+			expect(request.redirect).toHaveBeenCalledWith("/newer", 301);
+			expect(findAllEnabled).toHaveBeenCalledTimes(2);
+		} finally {
+			findAllEnabled.mockRestore();
+		}
+	});
+
 	it("does not intercept /_emdash routes", async () => {
 		const { context, redirect } = buildContext({ pathname: "/_emdash/admin" });
 


### PR DESCRIPTION
## What does this PR do?

Bounds redirect-rule staleness across Worker isolates to 30 seconds. Expired caches refresh through a cancellation-safe single flight, and a generation check prevents a write from being overwritten by an older in-flight query.

Closes #2286

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- `pnpm --filter emdash exec vitest run tests/unit/astro/middleware-redirect.test.ts` — 12 passed
- `pnpm typecheck` — passed
- `pnpm lint:json` — 0 diagnostics
- `pnpm format` — passed

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-2286-redirect-cache-ttl-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/2286-redirect-cache-ttl`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
