### PR TITLE
fix(core): keep Hyperdrive pool alive through layout prefetch

### DIFF
--- a/.changeset/fix-hyperdrive-prefetch-teardown.md
+++ b/.changeset/fix-hyperdrive-prefetch-teardown.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes Hyperdrive requests leaving request-scoped pool teardown pending when background layout prefetch outlives the response.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -60,7 +60,11 @@ import type { PublishedRef } from "../scheduled-publish.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 import { createInitLock, type InitLock, initWithLock } from "../utils/init-lock.js";
 import type { EmDashConfig } from "./integration/runtime.js";
-import { ASTRO_COOKIES_SYMBOL, finishScoped } from "./middleware/scoped-db.js";
+import {
+	ASTRO_COOKIES_SYMBOL,
+	deferScopedCloseUntilSettled,
+	finishScoped,
+} from "./middleware/scoped-db.js";
 import { wrapBodyForStreamMetrics } from "./middleware/stream-end-metrics.js";
 import { prefetchLayoutData } from "./prefetch.js";
 import { createPublicPluginApiRouteHandler } from "./public-plugin-api-routes.js";
@@ -678,10 +682,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					//    pointless on synchronous local SQLite.
 					//  - HTML navigations only -- feeds/sitemaps/JSON don't render the
 					//    layout, so prefetching their chrome is pure waste.
-					//  - via after(): it runs immediately (still warms the render) but
-					//    hands the promise to waitUntil, so the surplus warm-up (chrome a
-					//    given page doesn't render) is kept alive past the response rather
-					//    than erroring on workerd as orphaned request I/O.
+					//  - the work starts immediately, then after() keeps both it and the
+					//    request-scoped connection alive until the response also finishes.
 					// Gate on the CLIENT'S PREFERRED type (leading media range), not a
 					// substring -- browser navigations lead with `text/html`, while feed
 					// readers lead with `application/rss+xml` etc. and only list
@@ -691,11 +693,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
 						.trim()
 						.startsWith("text/html");
 					return runWithContext(ctx, async () => {
-						if (acceptsHtml) after(() => prefetchLayoutData());
+						const scopedLifecycle = acceptsHtml
+							? deferScopedCloseUntilSettled(anonScoped, prefetchLayoutData(), after)
+							: anonScoped;
 						// commit() persists per-request state (e.g. the D1 bookmark cookie)
 						// before the response is returned, even if render throws; close()
 						// (connection teardown) is deferred to stream-end. See finishScoped.
-						return finishScoped(anonScoped, runAnon);
+						return finishScoped(scopedLifecycle, runAnon);
 					});
 				}
 				return runAnon();

--- a/packages/core/src/astro/middleware/scoped-db.ts
+++ b/packages/core/src/astro/middleware/scoped-db.ts
@@ -16,6 +16,43 @@
  */
 export const ASTRO_COOKIES_SYMBOL = Symbol.for("astro.cookies");
 
+interface ScopedDbLifecycle {
+	commit: () => void;
+	close?: () => void;
+}
+
+type DeferredTaskScheduler = (task: () => void | Promise<void>) => void;
+
+/**
+ * Keep teardown alive while both the response and request-owned background
+ * work finish. The returned close callback only signals response completion;
+ * the adapter's real close runs afterward inside the deferred task.
+ */
+export function deferScopedCloseUntilSettled(
+	scoped: ScopedDbLifecycle,
+	pending: Promise<unknown>,
+	defer: DeferredTaskScheduler,
+): ScopedDbLifecycle {
+	if (!scoped.close) {
+		defer(async () => {
+			await pending;
+		});
+		return scoped;
+	}
+
+	let settleResponse!: () => void;
+	const responseSettled = new Promise<void>((resolve) => {
+		settleResponse = resolve;
+	});
+	const close = scoped.close;
+	defer(async () => {
+		await Promise.allSettled([pending, responseSettled]);
+		close();
+	});
+
+	return { commit: scoped.commit, close: settleResponse };
+}
+
 /**
  * Run a request-scoped db's `close()` once the response body has finished
  * streaming. Astro streams HTML and components issue DB queries during that
@@ -77,7 +114,7 @@ export function wrapResponseForScopedClose(response: Response, close: () => void
  * or mask.
  */
 export async function finishScoped(
-	scoped: { commit: () => void; close?: () => void },
+	scoped: ScopedDbLifecycle,
 	run: () => Promise<Response>,
 ): Promise<Response> {
 	let response: Response;

--- a/packages/core/tests/unit/middleware/scoped-db.test.ts
+++ b/packages/core/tests/unit/middleware/scoped-db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import {
 	ASTRO_COOKIES_SYMBOL,
+	deferScopedCloseUntilSettled,
 	finishScoped,
 	wrapResponseForScopedClose,
 } from "../../../src/astro/middleware/scoped-db.js";
@@ -100,6 +101,43 @@ describe("wrapResponseForScopedClose", () => {
 		const wrapped = wrapResponseForScopedClose(response, close);
 
 		expect(wrapped.headers.has("content-length")).toBe(false);
+	});
+});
+
+describe("deferScopedCloseUntilSettled", () => {
+	it("keeps a bodyless response teardown behind in-flight request work", async () => {
+		let settleWork!: () => void;
+		const inFlightWork = new Promise<void>((resolve) => {
+			settleWork = resolve;
+		});
+		const close = vi.fn();
+		let deferredTask!: Promise<void>;
+		const scoped = deferScopedCloseUntilSettled(
+			{ commit: vi.fn(), close },
+			inFlightWork,
+			(task) => {
+				deferredTask = Promise.resolve().then(task);
+			},
+		);
+
+		await finishScoped(scoped, async () => new Response(null, { status: 204 }));
+
+		expect(close).not.toHaveBeenCalled();
+		settleWork();
+		await deferredTask;
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps background work deferred for an adapter without teardown", async () => {
+		const scoped = { commit: vi.fn() };
+		let deferredTask!: () => void | Promise<void>;
+
+		const result = deferScopedCloseUntilSettled(scoped, Promise.resolve(), (task) => {
+			deferredTask = task;
+		});
+
+		expect(result).toBe(scoped);
+		await deferredTask();
 	});
 });
 

--- a/packages/core/tests/unit/middleware/scoped-db.test.ts
+++ b/packages/core/tests/unit/middleware/scoped-db.test.ts
@@ -128,6 +128,26 @@ describe("deferScopedCloseUntilSettled", () => {
 		expect(close).toHaveBeenCalledTimes(1);
 	});
 
+	it("keeps teardown behind a streaming response after request work settles", async () => {
+		const close = vi.fn();
+		let deferredTask!: Promise<void>;
+		const scoped = deferScopedCloseUntilSettled(
+			{ commit: vi.fn(), close },
+			Promise.resolve(),
+			(task) => {
+				deferredTask = Promise.resolve().then(task);
+			},
+		);
+
+		const response = await finishScoped(scoped, async () => streamingResponse(["body"]));
+		await Promise.resolve();
+
+		expect(close).not.toHaveBeenCalled();
+		await drain(response);
+		await deferredTask;
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
 	it("keeps background work deferred for an adapter without teardown", async () => {
 		const scoped = { commit: vi.fn() };
 		let deferredTask!: () => void | Promise<void>;


### PR DESCRIPTION
## What does this PR do?

Keeps the anonymous request-scoped database alive until both the response body and the concurrent layout prefetch have settled. This prevents Hyperdrive pool shutdown from racing queries that still own pool clients, which left successful Worker invocations pending until `waitUntil()` cancellation.

Closes #2133

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

The i18n and Discussion checklist items are not applicable: this changes no admin UI strings and fixes an existing bug.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Non-visual change. Verified with:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --dir packages/core exec vitest run tests/unit/middleware/scoped-db.test.ts` (18 passed)
- Focused middleware and Hyperdrive tests (28 passed)
- `pnpm build`
- `pnpm format`
