### PR TITLE
fix(bot): bake Chrome into the sandbox image at build time

### DIFF
--- a/infra/emdash-bot/Dockerfile
+++ b/infra/emdash-bot/Dockerfile
@@ -1,8 +1,7 @@
 # Container image for the emdash-bot investigate agent's sandbox.
 #
-# Phase 0 (this spike): minimal. Node 22 + pnpm + git, so the agent can clone
-# the repo and run JS commands. No browser yet — Chromium + agent-browser land
-# in Phase 2 once we know the simpler agent path works end-to-end.
+# Node 22 + pnpm + git for repo installs and JS commands, plus agent-browser
+# with a pre-baked Chrome for the browser-driven repro skills.
 #
 # Multi-stage build: copy Node from the official Node Slim image rather than
 # downloading it inside the cloudflare/sandbox base. The sandbox base ships
@@ -24,6 +23,15 @@ RUN npm install -g pnpm@11.1.3 bgproc@0.3.0 agent-browser@0.30.1 \
     && pnpm --version \
     && bgproc --version || true \
     && agent-browser --version || true
+
+# Bake Chrome at build time. At runtime the sandbox egress allowlist only
+# passes GitHub/npm hosts, so `agent-browser install` (Chrome for Testing,
+# served from Google hosts) can never succeed inside a running container --
+# the browser must already be in the image. The Chrome version is pinned by
+# the image build: agent-browser 0.30.1 fetches the stable channel at build
+# time and the daemon auto-detects the single baked copy under
+# /root/.agent-browser/browsers.
+RUN agent-browser install
 
 FROM cloudflare/sandbox:0.12.1
 
@@ -78,6 +86,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=node-source /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-source /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node-source /usr/local/include/node /usr/local/include/node
+
+# The Chrome that `agent-browser install` baked in the source stage. The
+# daemon looks here first, so no runtime download is ever attempted.
+COPY --from=node-source /root/.agent-browser /root/.agent-browser
 
 # Recreate the CLI symlinks the slim image had (Docker COPY flattens symlinks
 # to file copies). Then chmod the .cjs/.js entry points so they're executable.


### PR DESCRIPTION
## What does this PR do?

Bakes Chrome into the emdash-bot sandbox image at build time so the
browser-driven repro skills (`repro-admin`, `repro-public`) can actually launch
a browser.

At runtime the sandbox egress allowlist only passes GitHub/npm hosts, so
`agent-browser install` — which fetches Chrome for Testing from Google hosts —
can never succeed inside a running container. During eval run 8 this blocked
browser verification on two cases (#1272, #1124): the agent got as far as
needing the UI and died on "Chrome install failed" SSL errors from the
intercepting proxy.

The fix follows the image's existing multi-stage pattern (all TLS work happens
in the `node-source` stage, which has a working CA bundle): run
`agent-browser install` there and `COPY` the resulting
`/root/.agent-browser` cache into the final image. The daemon auto-detects the
baked copy, so the repro skills need no changes and no runtime download is
ever attempted. The Chrome version is pinned by the image build (agent-browser
0.30.1, Chrome for Testing stable at build time — currently 151.0.7922.77).

Verified locally in the built container (linux/amd64 under Rosetta):
`agent-browser doctor` reports 8 pass / 0 warn / 0 fail including its live
headless-launch test ("Headless launch + about:blank in 3.84s"), and an
`open` → `get text` → `close` round-trip renders and reads a page against the
baked Chrome with no network install attempt.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (n/a — Dockerfile-only change; verified by a live browser-launch test in the built container, which CI cannot run)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no UI change)
- [ ] I have added a changeset (n/a — infra worker image, not a published package)
- [ ] New features link to an approved Discussion (n/a — not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

`agent-browser doctor` inside the built image:

```
Launch test
  pass  Headless launch + about:blank in 3.84s

Summary: 8 pass, 0 warn, 0 fail
```

`open` / `get text` round-trip:

```
$ agent-browser open "data:text/html,<h1 id=t>baked-chrome-works</h1>"
✓
$ agent-browser get text "#t"
baked-chrome-works
$ agent-browser close
✓ Browser closed
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://bot-sandbox-baked-chrome-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `bot/sandbox-baked-chrome`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
