### PR TITLE
fix(core): align MCP taxonomy pagination with manual order

### DIFF
--- a/.changeset/calm-terms-page.md
+++ b/.changeset/calm-terms-page.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes MCP taxonomy term pagination so manually ordered terms are returned without gaps or duplicates.

--- a/packages/core/src/database/repositories/taxonomy.ts
+++ b/packages/core/src/database/repositories/taxonomy.ts
@@ -123,6 +123,36 @@ export interface FindOptions {
 	locale?: string;
 }
 
+export interface TaxonomyManualPageCursor {
+	sortOrder: number;
+	label: string;
+	id: string;
+}
+
+export interface TaxonomyLabelPageCursor {
+	label: string;
+	id: string;
+}
+
+export type TaxonomyPageOptions = FindOptions &
+	(
+		| {
+				order?: "manual";
+				cursor?: TaxonomyManualPageCursor;
+				limit?: number;
+		  }
+		| {
+				order: "label";
+				cursor?: TaxonomyLabelPageCursor;
+				limit?: number;
+		  }
+	);
+
+export interface TaxonomyPage {
+	items: Taxonomy[];
+	hasMore: boolean;
+}
+
 /**
  * Taxonomy repository for categories, tags, and other classification.
  *
@@ -230,8 +260,7 @@ export class TaxonomyRepository {
 	 * `sort_order` carries the manual order set from the admin; it is 0 for
 	 * terms nobody has reordered, so an untouched taxonomy still comes back
 	 * alphabetically. `id asc` is a stable tiebreaker for terms that share both
-	 * — without it the SQL ordering is implementation-defined when they match,
-	 * which breaks keyset pagination over `(label, id)`.
+	 * values. Without it the SQL ordering is implementation-defined when they match.
 	 */
 	async findByName(name: string, options: FindOptions = {}): Promise<Taxonomy[]> {
 		let query = this.db
@@ -254,6 +283,55 @@ export class TaxonomyRepository {
 
 		const rows = await query.execute();
 		return rows.map((row) => this.rowToTaxonomy(row));
+	}
+
+	async findPageByName(name: string, options: TaxonomyPageOptions = {}): Promise<TaxonomyPage> {
+		const limit = Math.max(1, Math.min(options.limit ?? 50, 100));
+		let query = this.db.selectFrom("taxonomies").selectAll().where("name", "=", name);
+
+		if (options.locale !== undefined) query = query.where("locale", "=", options.locale);
+
+		if (options.parentId !== undefined) {
+			query =
+				options.parentId === null
+					? query.where("parent_id", "is", null)
+					: query.where("parent_id", "=", options.parentId);
+		}
+
+		if (options.order === "label") {
+			if (options.cursor) {
+				const cursor = options.cursor;
+				query = query.where((eb) =>
+					eb.or([
+						eb("label", ">", cursor.label),
+						eb.and([eb("label", "=", cursor.label), eb("id", ">", cursor.id)]),
+					]),
+				);
+			}
+			query = query.orderBy("label", "asc").orderBy("id", "asc");
+		} else {
+			if (options.cursor) {
+				const cursor = options.cursor;
+				query = query.where((eb) =>
+					eb.or([
+						eb("sort_order", ">", cursor.sortOrder),
+						eb.and([eb("sort_order", "=", cursor.sortOrder), eb("label", ">", cursor.label)]),
+						eb.and([
+							eb("sort_order", "=", cursor.sortOrder),
+							eb("label", "=", cursor.label),
+							eb("id", ">", cursor.id),
+						]),
+					]),
+				);
+			}
+			query = query.orderBy("sort_order", "asc").orderBy("label", "asc").orderBy("id", "asc");
+		}
+
+		const rows = await query.limit(limit + 1).execute();
+		return {
+			items: rows.slice(0, limit).map((row) => this.rowToTaxonomy(row)),
+			hasMore: rows.length > limit,
+		};
 	}
 
 	/**

--- a/packages/core/src/database/repositories/taxonomy.ts
+++ b/packages/core/src/database/repositories/taxonomy.ts
@@ -129,24 +129,10 @@ export interface TaxonomyManualPageCursor {
 	id: string;
 }
 
-export interface TaxonomyLabelPageCursor {
-	label: string;
-	id: string;
+export interface TaxonomyPageOptions extends FindOptions {
+	cursor?: TaxonomyManualPageCursor;
+	limit?: number;
 }
-
-export type TaxonomyPageOptions = FindOptions &
-	(
-		| {
-				order?: "manual";
-				cursor?: TaxonomyManualPageCursor;
-				limit?: number;
-		  }
-		| {
-				order: "label";
-				cursor?: TaxonomyLabelPageCursor;
-				limit?: number;
-		  }
-	);
 
 export interface TaxonomyPage {
 	items: Taxonomy[];
@@ -298,34 +284,21 @@ export class TaxonomyRepository {
 					: query.where("parent_id", "=", options.parentId);
 		}
 
-		if (options.order === "label") {
-			if (options.cursor) {
-				const cursor = options.cursor;
-				query = query.where((eb) =>
-					eb.or([
-						eb("label", ">", cursor.label),
-						eb.and([eb("label", "=", cursor.label), eb("id", ">", cursor.id)]),
+		if (options.cursor) {
+			const cursor = options.cursor;
+			query = query.where((eb) =>
+				eb.or([
+					eb("sort_order", ">", cursor.sortOrder),
+					eb.and([eb("sort_order", "=", cursor.sortOrder), eb("label", ">", cursor.label)]),
+					eb.and([
+						eb("sort_order", "=", cursor.sortOrder),
+						eb("label", "=", cursor.label),
+						eb("id", ">", cursor.id),
 					]),
-				);
-			}
-			query = query.orderBy("label", "asc").orderBy("id", "asc");
-		} else {
-			if (options.cursor) {
-				const cursor = options.cursor;
-				query = query.where((eb) =>
-					eb.or([
-						eb("sort_order", ">", cursor.sortOrder),
-						eb.and([eb("sort_order", "=", cursor.sortOrder), eb("label", ">", cursor.label)]),
-						eb.and([
-							eb("sort_order", "=", cursor.sortOrder),
-							eb("label", "=", cursor.label),
-							eb("id", ">", cursor.id),
-						]),
-					]),
-				);
-			}
-			query = query.orderBy("sort_order", "asc").orderBy("label", "asc").orderBy("id", "asc");
+				]),
+			);
 		}
+		query = query.orderBy("sort_order", "asc").orderBy("label", "asc").orderBy("id", "asc");
 
 		const rows = await query.limit(limit + 1).execute();
 		return {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -27,10 +27,15 @@ import type { EmDashHandlers } from "../astro/types.js";
 import { hasScope } from "../auth/api-tokens.js";
 import { convertDataForRead, convertDataForWrite } from "../client/portable-text.js";
 import type { FieldSchema } from "../client/portable-text.js";
+import { decodeCursor, encodeCursor, InvalidCursorError } from "../database/repositories/types.js";
+import { decodeBase64, encodeBase64 } from "../utils/base64.js";
 
 const COLLECTION_SLUG_PATTERN = /^[a-z][a-z0-9_]*$/;
 /** http(s) scheme matcher used by `settings_update` URL validation. */
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
+const TAXONOMY_CURSOR_VERSION = 2;
+const MAX_TAXONOMY_CURSOR_LENGTH = 4096;
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
 
 // ---------------------------------------------------------------------------
 // Shared schemas — kept in sync with `api/schemas/settings.ts` (which the
@@ -128,6 +133,69 @@ type ErrorEnvelope = {
 	isError: true;
 	_meta: { code: string; details?: Record<string, unknown> };
 };
+
+type TaxonomyListCursor =
+	| { order: "manual"; sortOrder: number; label: string; id: string }
+	| { order: "label"; label: string; id: string };
+
+function encodeTaxonomyCursor(term: { sortOrder: number; label: string; id: string }): string {
+	return encodeBase64(
+		JSON.stringify({
+			v: TAXONOMY_CURSOR_VERSION,
+			sortOrder: term.sortOrder,
+			label: term.label,
+			id: term.id,
+		}),
+	);
+}
+
+function decodeTaxonomyCursor(cursor: string): TaxonomyListCursor {
+	if (!cursor || cursor.length > MAX_TAXONOMY_CURSOR_LENGTH) {
+		throw new InvalidCursorError(cursor);
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(decodeBase64(cursor));
+	} catch {
+		throw new InvalidCursorError(cursor);
+	}
+
+	if (parsed === null || typeof parsed !== "object") {
+		throw new InvalidCursorError(cursor);
+	}
+
+	const candidate = parsed as Record<string, unknown>;
+	if ("v" in candidate) {
+		const { v, sortOrder, label, id } = candidate;
+		if (
+			v !== TAXONOMY_CURSOR_VERSION ||
+			typeof sortOrder !== "number" ||
+			!Number.isSafeInteger(sortOrder) ||
+			sortOrder < 0 ||
+			sortOrder > POSTGRES_INTEGER_MAX ||
+			typeof label !== "string" ||
+			label.includes("\0") ||
+			typeof id !== "string" ||
+			id.length === 0 ||
+			id.includes("\0")
+		) {
+			throw new InvalidCursorError(cursor);
+		}
+		return {
+			order: "manual",
+			sortOrder,
+			label,
+			id,
+		};
+	}
+
+	const legacy = decodeCursor(cursor);
+	if (legacy.orderValue.includes("\0") || legacy.id.length === 0 || legacy.id.includes("\0")) {
+		throw new InvalidCursorError(cursor);
+	}
+	return { order: "label", label: legacy.orderValue, id: legacy.id };
+}
 
 /**
  * Return a successful tool response with the data as pretty-printed JSON.
@@ -2255,46 +2323,52 @@ export function createMcpServer(
 				if (!taxonomy) return respondError("NOT_FOUND", `Taxonomy '${args.taxonomy}' not found`);
 
 				const { TaxonomyRepository } = await import("../database/repositories/taxonomy.js");
-				const { decodeCursor, encodeCursor, InvalidCursorError } =
-					await import("../database/repositories/types.js");
 				const repo = new TaxonomyRepository(ec.db);
 				const limit = Math.min(args.limit ?? 50, 100);
-				const terms = await repo.findByName(args.taxonomy, { locale: args.locale });
-
-				// Manual keyset pagination over the sorted-by-label results.
-				// Using a base64-encoded `(label, id)` cursor matches the
-				// scheme other list endpoints use and tolerates concurrent
-				// deletion of the cursor-term — the cursor is a position,
-				// not a row reference, so a missing row just means we skip
-				// past it rather than erroring.
-				let startIdx = 0;
+				let cursor: TaxonomyListCursor | undefined;
 				if (args.cursor) {
-					let decoded: { orderValue: string; id: string };
 					try {
-						decoded = decodeCursor(args.cursor);
+						cursor = decodeTaxonomyCursor(args.cursor);
 					} catch (error) {
 						if (error instanceof InvalidCursorError) {
 							return respondError("INVALID_CURSOR", error.message);
 						}
 						throw error;
 					}
-					// Find the first term that sorts strictly after the cursor
-					// position. Stable order is `(label asc, id asc)` so a
-					// `(label, id)` tuple comparison is the keyset.
-					startIdx = terms.findIndex(
-						(t) =>
-							t.label > decoded.orderValue || (t.label === decoded.orderValue && t.id > decoded.id),
-					);
-					if (startIdx < 0) startIdx = terms.length;
 				}
 
-				const page = terms.slice(startIdx, startIdx + limit);
-				const hasMore = startIdx + limit < terms.length;
-				const last = page.at(-1);
-				const nextCursor = hasMore && last ? encodeCursor(last.label, last.id) : undefined;
+				const page =
+					cursor?.order === "label"
+						? await repo.findPageByName(args.taxonomy, {
+								locale: args.locale,
+								limit,
+								order: "label",
+								cursor: { label: cursor.label, id: cursor.id },
+							})
+						: await repo.findPageByName(args.taxonomy, {
+								locale: args.locale,
+								limit,
+								order: "manual",
+								...(cursor
+									? {
+											cursor: {
+												sortOrder: cursor.sortOrder,
+												label: cursor.label,
+												id: cursor.id,
+											},
+										}
+									: {}),
+							});
+				const last = page.items.at(-1);
+				const nextCursor =
+					page.hasMore && last
+						? cursor?.order === "label"
+							? encodeCursor(last.label, last.id)
+							: encodeTaxonomyCursor(last)
+						: undefined;
 
 				return jsonResult({
-					items: page.map((t) => ({
+					items: page.items.map((t) => ({
 						id: t.id,
 						name: t.name,
 						slug: t.slug,

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -27,15 +27,14 @@ import type { EmDashHandlers } from "../astro/types.js";
 import { hasScope } from "../auth/api-tokens.js";
 import { convertDataForRead, convertDataForWrite } from "../client/portable-text.js";
 import type { FieldSchema } from "../client/portable-text.js";
-import { decodeCursor, encodeCursor, InvalidCursorError } from "../database/repositories/types.js";
+import { decodeCursor, InvalidCursorError } from "../database/repositories/types.js";
 import { decodeBase64, encodeBase64 } from "../utils/base64.js";
 
 const COLLECTION_SLUG_PATTERN = /^[a-z][a-z0-9_]*$/;
 /** http(s) scheme matcher used by `settings_update` URL validation. */
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
 const TAXONOMY_CURSOR_VERSION = 2;
-const MAX_TAXONOMY_CURSOR_LENGTH = 4096;
-const POSTGRES_INTEGER_MAX = 2_147_483_647;
+const MAX_TAXONOMY_CURSOR_LENGTH = 2048;
 
 // ---------------------------------------------------------------------------
 // Shared schemas — kept in sync with `api/schemas/settings.ts` (which the
@@ -134,19 +133,19 @@ type ErrorEnvelope = {
 	_meta: { code: string; details?: Record<string, unknown> };
 };
 
-type TaxonomyListCursor =
-	| { order: "manual"; sortOrder: number; label: string; id: string }
-	| { order: "label"; label: string; id: string };
+type TaxonomyListCursor = { id: string };
 
-function encodeTaxonomyCursor(term: { sortOrder: number; label: string; id: string }): string {
-	return encodeBase64(
+function encodeTaxonomyCursor(term: { id: string }): string {
+	const cursor = encodeBase64(
 		JSON.stringify({
 			v: TAXONOMY_CURSOR_VERSION,
-			sortOrder: term.sortOrder,
-			label: term.label,
 			id: term.id,
 		}),
 	);
+	if (cursor.length > MAX_TAXONOMY_CURSOR_LENGTH) {
+		throw new InvalidCursorError(cursor);
+	}
+	return cursor;
 }
 
 function decodeTaxonomyCursor(cursor: string): TaxonomyListCursor {
@@ -167,34 +166,23 @@ function decodeTaxonomyCursor(cursor: string): TaxonomyListCursor {
 
 	const candidate = parsed as Record<string, unknown>;
 	if ("v" in candidate) {
-		const { v, sortOrder, label, id } = candidate;
+		const { v, id } = candidate;
 		if (
 			v !== TAXONOMY_CURSOR_VERSION ||
-			typeof sortOrder !== "number" ||
-			!Number.isSafeInteger(sortOrder) ||
-			sortOrder < 0 ||
-			sortOrder > POSTGRES_INTEGER_MAX ||
-			typeof label !== "string" ||
-			label.includes("\0") ||
 			typeof id !== "string" ||
 			id.length === 0 ||
 			id.includes("\0")
 		) {
 			throw new InvalidCursorError(cursor);
 		}
-		return {
-			order: "manual",
-			sortOrder,
-			label,
-			id,
-		};
+		return { id };
 	}
 
 	const legacy = decodeCursor(cursor);
 	if (legacy.orderValue.includes("\0") || legacy.id.length === 0 || legacy.id.includes("\0")) {
 		throw new InvalidCursorError(cursor);
 	}
-	return { order: "label", label: legacy.orderValue, id: legacy.id };
+	return { id: legacy.id };
 }
 
 /**
@@ -2304,7 +2292,12 @@ export function createMcpServer(
 			inputSchema: z.object({
 				taxonomy: z.string().describe("Taxonomy name (e.g. 'categories', 'tags')"),
 				limit: z.number().int().min(1).max(100).optional().describe("Max items (default 50)"),
-				cursor: z.string().min(1).max(2048).optional().describe("Pagination cursor"),
+				cursor: z
+					.string()
+					.min(1)
+					.max(MAX_TAXONOMY_CURSOR_LENGTH)
+					.optional()
+					.describe("Pagination cursor"),
 				locale: z.string().optional().describe("Filter by locale (omit for all)"),
 			}),
 			annotations: { readOnlyHint: true },
@@ -2337,35 +2330,30 @@ export function createMcpServer(
 					}
 				}
 
-				const page =
-					cursor?.order === "label"
-						? await repo.findPageByName(args.taxonomy, {
-								locale: args.locale,
-								limit,
-								order: "label",
-								cursor: { label: cursor.label, id: cursor.id },
-							})
-						: await repo.findPageByName(args.taxonomy, {
-								locale: args.locale,
-								limit,
-								order: "manual",
-								...(cursor
-									? {
-											cursor: {
-												sortOrder: cursor.sortOrder,
-												label: cursor.label,
-												id: cursor.id,
-											},
-										}
-									: {}),
-							});
+				let pageCursor: { sortOrder: number; label: string; id: string } | undefined;
+				if (cursor) {
+					const cursorTerm = await repo.findById(cursor.id);
+					if (
+						!cursorTerm ||
+						cursorTerm.name !== args.taxonomy ||
+						(args.locale !== undefined && cursorTerm.locale !== args.locale)
+					) {
+						return respondError("INVALID_CURSOR", "Pagination cursor no longer identifies a term");
+					}
+					pageCursor = {
+						sortOrder: cursorTerm.sortOrder,
+						label: cursorTerm.label,
+						id: cursorTerm.id,
+					};
+				}
+
+				const page = await repo.findPageByName(args.taxonomy, {
+					locale: args.locale,
+					limit,
+					...(pageCursor ? { cursor: pageCursor } : {}),
+				});
 				const last = page.items.at(-1);
-				const nextCursor =
-					page.hasMore && last
-						? cursor?.order === "label"
-							? encodeCursor(last.label, last.id)
-							: encodeTaxonomyCursor(last)
-						: undefined;
+				const nextCursor = page.hasMore && last ? encodeTaxonomyCursor(last) : undefined;
 
 				return jsonResult({
 					items: page.items.map((t) => ({

--- a/packages/core/tests/integration/database/taxonomy-repository-pagination.test.ts
+++ b/packages/core/tests/integration/database/taxonomy-repository-pagination.test.ts
@@ -62,7 +62,6 @@ describeEachDialect("TaxonomyRepository pagination", (dialect) => {
 		const page1 = await repo.findPageByName(TAXONOMY, {
 			locale: "en",
 			limit: 2,
-			order: "manual",
 		});
 		expect(page1.items.map((term) => term.slug)).toEqual(["first", "tie-a"]);
 		expect(page1.hasMore).toBe(true);
@@ -72,35 +71,9 @@ describeEachDialect("TaxonomyRepository pagination", (dialect) => {
 		const page2 = await repo.findPageByName(TAXONOMY, {
 			locale: "en",
 			limit: 2,
-			order: "manual",
 			cursor: { sortOrder: last.sortOrder, label: last.label, id: last.id },
 		});
 		expect(page2.items.map((term) => term.slug)).toEqual(["tie-b", "last"]);
-		expect(page2.hasMore).toBe(false);
-	});
-
-	it("continues label-ordered pages after the cursor row is deleted", async () => {
-		await insertTerms([
-			{ id: "term-zulu", slug: "zulu", label: "Zulu", sortOrder: 0 },
-			{ id: "term-alpha", slug: "alpha", label: "Alpha", sortOrder: 1 },
-			{ id: "term-bravo", slug: "bravo", label: "Bravo", sortOrder: 2 },
-		]);
-
-		const page1 = await repo.findPageByName(TAXONOMY, {
-			limit: 1,
-			order: "label",
-			cursor: { label: "Alpha", id: "term-alpha" },
-		});
-		expect(page1.items.map((term) => term.slug)).toEqual(["bravo"]);
-		expect(page1.hasMore).toBe(true);
-
-		await ctx.db.deleteFrom("taxonomies").where("id", "=", "term-bravo").execute();
-		const page2 = await repo.findPageByName(TAXONOMY, {
-			limit: 1,
-			order: "label",
-			cursor: { label: "Bravo", id: "term-bravo" },
-		});
-		expect(page2.items.map((term) => term.slug)).toEqual(["zulu"]);
 		expect(page2.hasMore).toBe(false);
 	});
 
@@ -114,7 +87,7 @@ describeEachDialect("TaxonomyRepository pagination", (dialect) => {
 			})),
 		);
 
-		const page = await repo.findPageByName(TAXONOMY, { limit: 1000, order: "manual" });
+		const page = await repo.findPageByName(TAXONOMY, { limit: 1000 });
 		expect(page.items).toHaveLength(100);
 		expect(page.hasMore).toBe(true);
 	});

--- a/packages/core/tests/integration/database/taxonomy-repository-pagination.test.ts
+++ b/packages/core/tests/integration/database/taxonomy-repository-pagination.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { TaxonomyRepository } from "../../../src/database/repositories/taxonomy.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+const TAXONOMY = "paged_category";
+
+interface TermFixture {
+	id: string;
+	slug: string;
+	label: string;
+	sortOrder: number;
+	locale?: string;
+}
+
+describeEachDialect("TaxonomyRepository pagination", (dialect) => {
+	let ctx: DialectTestContext;
+	let repo: TaxonomyRepository;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		repo = new TaxonomyRepository(ctx.db);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	async function insertTerms(terms: TermFixture[]): Promise<void> {
+		await ctx.db
+			.insertInto("taxonomies")
+			.values(
+				terms.map((term) => ({
+					id: term.id,
+					name: TAXONOMY,
+					slug: term.slug,
+					label: term.label,
+					parent_id: null,
+					data: null,
+					locale: term.locale ?? "en",
+					translation_group: term.id,
+					sort_order: term.sortOrder,
+				})),
+			)
+			.execute();
+	}
+
+	it("pages by sort order, label, and id", async () => {
+		await insertTerms([
+			{ id: "term-z", slug: "first", label: "Zulu", sortOrder: 0 },
+			{ id: "term-b", slug: "tie-b", label: "Alpha", sortOrder: 1 },
+			{ id: "term-a", slug: "tie-a", label: "Alpha", sortOrder: 1 },
+			{ id: "term-c", slug: "last", label: "Bravo", sortOrder: 1 },
+			{ id: "term-fr", slug: "french", label: "Aardvark", sortOrder: 0, locale: "fr" },
+		]);
+
+		const page1 = await repo.findPageByName(TAXONOMY, {
+			locale: "en",
+			limit: 2,
+			order: "manual",
+		});
+		expect(page1.items.map((term) => term.slug)).toEqual(["first", "tie-a"]);
+		expect(page1.hasMore).toBe(true);
+
+		const last = page1.items.at(-1)!;
+		await ctx.db.deleteFrom("taxonomies").where("id", "=", last.id).execute();
+		const page2 = await repo.findPageByName(TAXONOMY, {
+			locale: "en",
+			limit: 2,
+			order: "manual",
+			cursor: { sortOrder: last.sortOrder, label: last.label, id: last.id },
+		});
+		expect(page2.items.map((term) => term.slug)).toEqual(["tie-b", "last"]);
+		expect(page2.hasMore).toBe(false);
+	});
+
+	it("continues label-ordered pages after the cursor row is deleted", async () => {
+		await insertTerms([
+			{ id: "term-zulu", slug: "zulu", label: "Zulu", sortOrder: 0 },
+			{ id: "term-alpha", slug: "alpha", label: "Alpha", sortOrder: 1 },
+			{ id: "term-bravo", slug: "bravo", label: "Bravo", sortOrder: 2 },
+		]);
+
+		const page1 = await repo.findPageByName(TAXONOMY, {
+			limit: 1,
+			order: "label",
+			cursor: { label: "Alpha", id: "term-alpha" },
+		});
+		expect(page1.items.map((term) => term.slug)).toEqual(["bravo"]);
+		expect(page1.hasMore).toBe(true);
+
+		await ctx.db.deleteFrom("taxonomies").where("id", "=", "term-bravo").execute();
+		const page2 = await repo.findPageByName(TAXONOMY, {
+			limit: 1,
+			order: "label",
+			cursor: { label: "Bravo", id: "term-bravo" },
+		});
+		expect(page2.items.map((term) => term.slug)).toEqual(["zulu"]);
+		expect(page2.hasMore).toBe(false);
+	});
+
+	it("caps each page at 100 items", async () => {
+		await insertTerms(
+			Array.from({ length: 101 }, (_, index) => ({
+				id: `term-${String(index).padStart(3, "0")}`,
+				slug: `term-${index}`,
+				label: `Term ${String(index).padStart(3, "0")}`,
+				sortOrder: index,
+			})),
+		);
+
+		const page = await repo.findPageByName(TAXONOMY, { limit: 1000, order: "manual" });
+		expect(page.items).toHaveLength(100);
+		expect(page.hasMore).toBe(true);
+	});
+});

--- a/packages/core/tests/integration/mcp/taxonomy.test.ts
+++ b/packages/core/tests/integration/mcp/taxonomy.test.ts
@@ -17,7 +17,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { handleTaxonomyCreate } from "../../../src/api/handlers/taxonomies.js";
 import { TaxonomyRepository as TaxonomyRepo } from "../../../src/database/repositories/taxonomy.js";
-import { decodeCursor, encodeCursor } from "../../../src/database/repositories/types.js";
+import { encodeCursor } from "../../../src/database/repositories/types.js";
 import type { Database } from "../../../src/database/types.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { decodeBase64, encodeBase64 } from "../../../src/utils/base64.js";
@@ -305,7 +305,7 @@ describe("taxonomy_list_terms", () => {
 		expect(collected.toSorted()).toEqual(slugs.toSorted());
 	});
 
-	it("survives concurrent deletion of the cursor-term", async () => {
+	it("rejects a current cursor after its term is deleted", async () => {
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		for (const slug of ["alpha", "bravo", "charlie", "delta"]) {
 			await harness.client.callTool({
@@ -319,15 +319,14 @@ describe("taxonomy_list_terms", () => {
 			arguments: { taxonomy: "categories", limit: 2 },
 		});
 		const p1 = extractJson<{
-			items: Array<{ slug: string }>;
+			items: Array<{ id: string; slug: string }>;
 			nextCursor?: string;
 		}>(page1);
 		expect(p1.items.map((i) => i.slug)).toEqual(["alpha", "bravo"]);
 		expect(p1.nextCursor).toBeTruthy();
-		expect(JSON.parse(decodeBase64(p1.nextCursor!))).toMatchObject({
+		expect(JSON.parse(decodeBase64(p1.nextCursor!))).toEqual({
 			v: 2,
-			sortOrder: 1,
-			label: "bravo",
+			id: p1.items[1]!.id,
 		});
 
 		const repo = new TaxonomyRepo(db);
@@ -339,15 +338,52 @@ describe("taxonomy_list_terms", () => {
 			name: "taxonomy_list_terms",
 			arguments: { taxonomy: "categories", limit: 2, cursor: p1.nextCursor },
 		});
-		expect(page2.isError, extractText(page2)).toBeFalsy();
-		const p2 = extractJson<{ items: Array<{ slug: string }> }>(page2);
-		expect(p2.items.map((i) => i.slug)).toEqual(["charlie", "delta"]);
+		expect(page2.isError).toBe(true);
+		expect((page2 as { _meta?: { code?: string } })._meta?.code).toBe("INVALID_CURSOR");
 	});
 
-	it("continues legacy label-order cursor chains after cursor-term deletion", async () => {
+	it("rejects a cursor from another taxonomy", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		const repo = new TaxonomyRepo(db);
+		const tag = await repo.create({ name: "tags", slug: "tag", label: "Tag" });
+
+		const result = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: {
+				taxonomy: "categories",
+				cursor: encodeBase64(JSON.stringify({ v: 2, id: tag.id })),
+			},
+		});
+		expect(result.isError).toBe(true);
+		expect((result as { _meta?: { code?: string } })._meta?.code).toBe("INVALID_CURSOR");
+	});
+
+	it("rejects a cursor from another locale", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		const repo = new TaxonomyRepo(db);
+		const french = await repo.create({
+			name: "categories",
+			slug: "bonjour",
+			label: "Bonjour",
+			locale: "fr",
+		});
+
+		const result = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: {
+				taxonomy: "categories",
+				locale: "en",
+				cursor: encodeBase64(JSON.stringify({ v: 2, id: french.id })),
+			},
+		});
+		expect(result.isError).toBe(true);
+		expect((result as { _meta?: { code?: string } })._meta?.code).toBe("INVALID_CURSOR");
+	});
+
+	it("resumes a legacy cursor in manual term order", async () => {
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		for (const [slug, label] of [
-			["zulu", "Zulu"],
+			["charlie", "Charlie"],
 			["alpha", "Alpha"],
 			["bravo", "Bravo"],
 		] as const) {
@@ -365,30 +401,64 @@ describe("taxonomy_list_terms", () => {
 			name: "taxonomy_list_terms",
 			arguments: {
 				taxonomy: "categories",
-				limit: 1,
+				limit: 2,
 				cursor: encodeCursor(alpha.label, alpha.id),
 			},
 		});
-		const p1 = extractJson<{
-			items: Array<{ id: string; slug: string }>;
-			nextCursor?: string;
-		}>(page1);
+		const p1 = extractJson<{ items: Array<{ slug: string }>; nextCursor?: string }>(page1);
 		expect(p1.items.map((item) => item.slug)).toEqual(["bravo"]);
-		expect(p1.nextCursor).toBeTruthy();
-		expect(decodeCursor(p1.nextCursor!)).toEqual({
-			orderValue: "Bravo",
-			id: p1.items[0]!.id,
+		expect(p1.nextCursor).toBeUndefined();
+	});
+
+	it("rejects a legacy cursor after its term is deleted", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		for (const slug of ["alpha", "bravo"]) {
+			await harness.client.callTool({
+				name: "taxonomy_create_term",
+				arguments: { taxonomy: "categories", slug, label: slug },
+			});
+		}
+
+		const repo = new TaxonomyRepo(db);
+		const alpha = await repo.findBySlug("categories", "alpha");
+		if (!alpha) throw new Error("alpha fixture is missing");
+		const cursor = encodeCursor(alpha.label, alpha.id);
+		await db.deleteFrom("taxonomies").where("id", "=", alpha.id).execute();
+
+		const page2 = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: { taxonomy: "categories", limit: 1, cursor },
+		});
+		expect(page2.isError).toBe(true);
+		expect((page2 as { _meta?: { code?: string } })._meta?.code).toBe("INVALID_CURSOR");
+	});
+
+	it("accepts every cursor it emits for a long term label", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		await harness.client.callTool({
+			name: "taxonomy_create_term",
+			arguments: { taxonomy: "categories", slug: "long", label: "x".repeat(1_500) },
+		});
+		await harness.client.callTool({
+			name: "taxonomy_create_term",
+			arguments: { taxonomy: "categories", slug: "last", label: "Last" },
 		});
 
-		await db.deleteFrom("taxonomies").where("id", "=", p1.items[0]!.id).execute();
+		const page1 = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: { taxonomy: "categories", limit: 1 },
+		});
+		const p1 = extractJson<{ items: Array<{ slug: string }>; nextCursor?: string }>(page1);
+		expect(p1.items.map((item) => item.slug)).toEqual(["long"]);
+		expect(p1.nextCursor).toBeTruthy();
 
 		const page2 = await harness.client.callTool({
 			name: "taxonomy_list_terms",
 			arguments: { taxonomy: "categories", limit: 1, cursor: p1.nextCursor },
 		});
-		const p2 = extractJson<{ items: Array<{ slug: string }>; nextCursor?: string }>(page2);
-		expect(p2.items.map((item) => item.slug)).toEqual(["zulu"]);
-		expect(p2.nextCursor).toBeUndefined();
+		expect(page2.isError, extractText(page2)).toBeFalsy();
+		const p2 = extractJson<{ items: Array<{ slug: string }> }>(page2);
+		expect(p2.items.map((item) => item.slug)).toEqual(["last"]);
 	});
 
 	it("malformed cursor returns INVALID_CURSOR", async () => {
@@ -408,12 +478,11 @@ describe("taxonomy_list_terms", () => {
 	});
 
 	it.each([
-		["unknown version", { v: 3, sortOrder: 0, label: "T1", id: "term-1" }],
-		["non-integer sort order", { v: 2, sortOrder: "0", label: "T1", id: "term-1" }],
-		["missing label", { v: 2, sortOrder: 0, id: "term-1" }],
-		["out-of-range sort order", { v: 2, sortOrder: 2_147_483_648, label: "T1", id: "term-1" }],
-		["NUL label", { v: 2, sortOrder: 0, label: "T\0", id: "term-1" }],
-		["NUL id", { v: 2, sortOrder: 0, label: "T1", id: "term\0" }],
+		["unknown version", { v: 3, id: "term-1" }],
+		["missing id", { v: 2 }],
+		["non-string id", { v: 2, id: 1 }],
+		["empty id", { v: 2, id: "" }],
+		["NUL id", { v: 2, id: "term\0" }],
 	])("rejects a cursor with %s", async (_name, payload) => {
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		const result = await harness.client.callTool({

--- a/packages/core/tests/integration/mcp/taxonomy.test.ts
+++ b/packages/core/tests/integration/mcp/taxonomy.test.ts
@@ -16,8 +16,11 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { handleTaxonomyCreate } from "../../../src/api/handlers/taxonomies.js";
+import { TaxonomyRepository as TaxonomyRepo } from "../../../src/database/repositories/taxonomy.js";
+import { decodeCursor, encodeCursor } from "../../../src/database/repositories/types.js";
 import type { Database } from "../../../src/database/types.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { decodeBase64, encodeBase64 } from "../../../src/utils/base64.js";
 import {
 	connectMcpHarness,
 	extractJson,
@@ -240,12 +243,35 @@ describe("taxonomy_list_terms", () => {
 		for (const t of p2.items) expect(p1Slugs).not.toContain(t.slug);
 	});
 
+	it("paginates in manual term order", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		for (const [slug, label] of [
+			["first", "Zulu"],
+			["second", "Alpha"],
+		] as const) {
+			await harness.client.callTool({
+				name: "taxonomy_create_term",
+				arguments: { taxonomy: "categories", slug, label },
+			});
+		}
+
+		const page1 = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: { taxonomy: "categories", limit: 1 },
+		});
+		const p1 = extractJson<{ items: Array<{ slug: string }>; nextCursor?: string }>(page1);
+		expect(p1.items.map((item) => item.slug)).toEqual(["first"]);
+		expect(p1.nextCursor).toBeTruthy();
+
+		const page2 = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: { taxonomy: "categories", limit: 1, cursor: p1.nextCursor },
+		});
+		const p2 = extractJson<{ items: Array<{ slug: string }> }>(page2);
+		expect(p2.items.map((item) => item.slug)).toEqual(["second"]);
+	});
+
 	it("paginates correctly when multiple terms share the same label", async () => {
-		// Keyset pagination over (label, id) needs a stable id tiebreaker
-		// at the SQL layer or tied-label rows can swap order between calls
-		// — producing duplicates or skipped items. Three terms share
-		// label "shared"; pagination must walk through them in a stable
-		// order with no duplicates and no gaps.
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		const slugs = ["shared-1", "shared-2", "shared-3", "unique-a"];
 		for (const slug of slugs) {
@@ -259,11 +285,8 @@ describe("taxonomy_list_terms", () => {
 			});
 		}
 
-		// Walk one item at a time so every cursor transition exercises the
-		// (label, id) keyset.
 		const collected: string[] = [];
 		let cursor: string | undefined;
-		// Hard cap to prevent the test hanging if pagination loops.
 		for (let i = 0; i < 10; i++) {
 			const page = await harness.client.callTool({
 				name: "taxonomy_list_terms",
@@ -279,16 +302,10 @@ describe("taxonomy_list_terms", () => {
 			cursor = data.nextCursor;
 		}
 
-		// Each slug appears exactly once. Order doesn't matter for this
-		// assertion — just no duplicates and no missing entries.
 		expect(collected.toSorted()).toEqual(slugs.toSorted());
 	});
 
 	it("survives concurrent deletion of the cursor-term", async () => {
-		// The base64 keyset cursor encodes a (label, id) position rather
-		// than a row reference, so deleting the cursor-term between pages
-		// must not error — the next page just continues from the next
-		// position in sort order.
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		for (const slug of ["alpha", "bravo", "charlie", "delta"]) {
 			await harness.client.callTool({
@@ -307,20 +324,17 @@ describe("taxonomy_list_terms", () => {
 		}>(page1);
 		expect(p1.items.map((i) => i.slug)).toEqual(["alpha", "bravo"]);
 		expect(p1.nextCursor).toBeTruthy();
+		expect(JSON.parse(decodeBase64(p1.nextCursor!))).toMatchObject({
+			v: 2,
+			sortOrder: 1,
+			label: "bravo",
+		});
 
-		// Delete the cursor-term ('bravo') out of band.
-		const { TaxonomyRepository } = await import("../../../src/database/repositories/taxonomy.js");
-		const repo = new TaxonomyRepository(db);
+		const repo = new TaxonomyRepo(db);
 		const bravo = await repo.findBySlug("categories", "bravo");
-		if (!bravo) throw new Error("bravo missing — fixture broken");
+		if (!bravo) throw new Error("bravo fixture is missing");
 		await db.deleteFrom("taxonomies").where("id", "=", bravo.id).execute();
 
-		// Page 2 must still work and return the items strictly after the
-		// cursor's position. Pre-fix the cursor stored 'bravo's id and
-		// findIndex would have returned -1 → INVALID_CURSOR. Post-fix the
-		// cursor stores ('bravo', '<bravo-id>') and the keyset comparison
-		// finds the first term with (label, id) > ('bravo', '<bravo-id>')
-		// — that's 'charlie'.
 		const page2 = await harness.client.callTool({
 			name: "taxonomy_list_terms",
 			arguments: { taxonomy: "categories", limit: 2, cursor: p1.nextCursor },
@@ -330,6 +344,53 @@ describe("taxonomy_list_terms", () => {
 		expect(p2.items.map((i) => i.slug)).toEqual(["charlie", "delta"]);
 	});
 
+	it("continues legacy label-order cursor chains after cursor-term deletion", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		for (const [slug, label] of [
+			["zulu", "Zulu"],
+			["alpha", "Alpha"],
+			["bravo", "Bravo"],
+		] as const) {
+			await harness.client.callTool({
+				name: "taxonomy_create_term",
+				arguments: { taxonomy: "categories", slug, label },
+			});
+		}
+
+		const repo = new TaxonomyRepo(db);
+		const alpha = await repo.findBySlug("categories", "alpha");
+		if (!alpha) throw new Error("alpha fixture is missing");
+
+		const page1 = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: {
+				taxonomy: "categories",
+				limit: 1,
+				cursor: encodeCursor(alpha.label, alpha.id),
+			},
+		});
+		const p1 = extractJson<{
+			items: Array<{ id: string; slug: string }>;
+			nextCursor?: string;
+		}>(page1);
+		expect(p1.items.map((item) => item.slug)).toEqual(["bravo"]);
+		expect(p1.nextCursor).toBeTruthy();
+		expect(decodeCursor(p1.nextCursor!)).toEqual({
+			orderValue: "Bravo",
+			id: p1.items[0]!.id,
+		});
+
+		await db.deleteFrom("taxonomies").where("id", "=", p1.items[0]!.id).execute();
+
+		const page2 = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: { taxonomy: "categories", limit: 1, cursor: p1.nextCursor },
+		});
+		const p2 = extractJson<{ items: Array<{ slug: string }>; nextCursor?: string }>(page2);
+		expect(p2.items.map((item) => item.slug)).toEqual(["zulu"]);
+		expect(p2.nextCursor).toBeUndefined();
+	});
+
 	it("malformed cursor returns INVALID_CURSOR", async () => {
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		await harness.client.callTool({
@@ -337,9 +398,6 @@ describe("taxonomy_list_terms", () => {
 			arguments: { taxonomy: "categories", slug: "t1", label: "T1" },
 		});
 
-		// taxonomy_list_terms uses a base64 keyset cursor over (label, id).
-		// A completely bogus value fails decodeCursor and surfaces as a
-		// structured INVALID_CURSOR error.
 		const result = await harness.client.callTool({
 			name: "taxonomy_list_terms",
 			arguments: { taxonomy: "categories", cursor: "garbage_cursor_xyz" },
@@ -347,6 +405,39 @@ describe("taxonomy_list_terms", () => {
 		expect(result.isError).toBe(true);
 		const meta = (result as { _meta?: { code?: string } })._meta;
 		expect(meta?.code).toBe("INVALID_CURSOR");
+	});
+
+	it.each([
+		["unknown version", { v: 3, sortOrder: 0, label: "T1", id: "term-1" }],
+		["non-integer sort order", { v: 2, sortOrder: "0", label: "T1", id: "term-1" }],
+		["missing label", { v: 2, sortOrder: 0, id: "term-1" }],
+		["out-of-range sort order", { v: 2, sortOrder: 2_147_483_648, label: "T1", id: "term-1" }],
+		["NUL label", { v: 2, sortOrder: 0, label: "T\0", id: "term-1" }],
+		["NUL id", { v: 2, sortOrder: 0, label: "T1", id: "term\0" }],
+	])("rejects a cursor with %s", async (_name, payload) => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		const result = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: {
+				taxonomy: "categories",
+				cursor: encodeBase64(JSON.stringify(payload)),
+			},
+		});
+		expect(result.isError).toBe(true);
+		expect((result as { _meta?: { code?: string } })._meta?.code).toBe("INVALID_CURSOR");
+	});
+
+	it.each([
+		["NUL label", encodeCursor("T\0", "term-1")],
+		["NUL id", encodeCursor("T1", "term\0")],
+	])("rejects a legacy cursor with %s", async (_name, cursor) => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		const result = await harness.client.callTool({
+			name: "taxonomy_list_terms",
+			arguments: { taxonomy: "categories", cursor },
+		});
+		expect(result.isError).toBe(true);
+		expect((result as { _meta?: { code?: string } })._meta?.code).toBe("INVALID_CURSOR");
 	});
 
 	it("any logged-in user (SUBSCRIBER) can read terms", async () => {

--- a/packages/core/tests/integration/taxonomy-term-order-plan.test.ts
+++ b/packages/core/tests/integration/taxonomy-term-order-plan.test.ts
@@ -124,7 +124,6 @@ it("bounds manual keyset pages while seeking the taxonomy index", async () => {
 	await repo.findPageByName("category", {
 		locale: "en",
 		limit: 2,
-		order: "manual",
 		cursor: {
 			sortOrder: cursor.sortOrder,
 			label: cursor.label,

--- a/packages/core/tests/integration/taxonomy-term-order-plan.test.ts
+++ b/packages/core/tests/integration/taxonomy-term-order-plan.test.ts
@@ -89,12 +89,17 @@ function bindable(p: unknown): unknown {
  * Plan of the last captured query whose SQL matches — the repository's real
  * emitted SQL, so the assertions can't drift from a hand-copied literal.
  */
-function planOf(match: (sql: string) => boolean): string {
+function queryOf(match: (sql: string) => boolean): CapturedQuery {
 	const query = captured.findLast((q) => match(q.sql));
 	expect(query, "expected a matching query to have been emitted").toBeDefined();
+	return query!;
+}
+
+function planOf(match: (sql: string) => boolean): string {
+	const query = queryOf(match);
 	const rows = sqlite
-		.prepare(`EXPLAIN QUERY PLAN ${query!.sql}`)
-		.all(...query!.parameters.map(bindable)) as { detail: string }[];
+		.prepare(`EXPLAIN QUERY PLAN ${query.sql}`)
+		.all(...query.parameters.map(bindable)) as { detail: string }[];
 	return rows.map((r) => r.detail).join("\n");
 }
 
@@ -105,6 +110,32 @@ it("seeks findByName through the composite index rather than scanning the locale
 	const plan = planOf((sql) => sql.includes('"name" = ?') && sql.includes("sort_order"));
 	expect(plan).toContain("idx_taxonomies_name_locale");
 	// The locale-only index reads every term in the locale to filter `name`.
+	expect(plan).not.toContain("idx_taxonomies_locale");
+	expect(plan).not.toContain("SCAN taxonomies");
+	expect(plan).toContain("TEMP B-TREE");
+});
+
+it("bounds manual keyset pages while seeking the taxonomy index", async () => {
+	const terms = await repo.findByName("category", { locale: "en" });
+	const cursor = terms[0]!;
+	const match = (query: string) => query.includes('"sort_order" > ?') && query.includes("limit ?");
+
+	captured = [];
+	await repo.findPageByName("category", {
+		locale: "en",
+		limit: 2,
+		order: "manual",
+		cursor: {
+			sortOrder: cursor.sortOrder,
+			label: cursor.label,
+			id: cursor.id,
+		},
+	});
+
+	const query = queryOf(match);
+	expect(query.parameters.at(-1)).toBe(3);
+	const plan = planOf(match);
+	expect(plan).toContain("idx_taxonomies_name_locale");
 	expect(plan).not.toContain("idx_taxonomies_locale");
 	expect(plan).not.toContain("SCAN taxonomies");
 	expect(plan).toContain("TEMP B-TREE");


### PR DESCRIPTION
## What does this PR do?

Fixes `taxonomy_list_terms` pagination after taxonomy terms gained manual ordering. The tool ordered the first page by `(sort_order, label, id)` but resumed from existing `(label, id)` cursors. When a later manually ordered term sorted earlier by label, the continuation search skipped or repeated terms.

The MCP server now requests bounded `limit + 1` repository pages. Cursors carry only the stable term ID; each continuation resolves that ID to the term's current `(sort_order, label, id)` tuple before resuming the manual keyset query. Legacy cursors remain accepted through the same ID lookup. A deleted term or a cursor from another taxonomy or locale returns `INVALID_CURSOR` so the caller can restart pagination.

Keeping labels out of the cursor also ensures every emitted cursor stays within the shared 2,048-character schema, encoder, and decoder bound, even when a term has a long label.

This returns manually ordered terms without gaps or duplicates and avoids loading an entire taxonomy for each page.

No linked issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no admin UI changes). Do not include `messages.po` changes except in translation PRs; a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: not applicable, this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: Codex (GPT-5)

## Screenshots / test output

Not applicable: this change has no visual output.

- RED on current `main`: a legacy cursor repeated a manually ordered term, a deleted cursor term silently continued, and a 1,500-character label produced a cursor rejected by the tool's own input schema.
- Focused SQLite taxonomy repository, MCP, and query-plan tests: 50 passed.
- Real PostgreSQL taxonomy repository tests: 4 passed.
- Core MCP integration suite: 332 passed.
- Cloudflare taxonomy bridge tests: 9 passed.
- Workerd bridge-handler tests: 29 passed.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm format`: passed.
