### PR TITLE
test(core): normalize sandbox watch paths on macOS

### DIFF
--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -229,7 +229,9 @@ describe("createVirtualModulesPlugin scheduler wiring", () => {
 
 			expect(source).toContain("export default { hooks: {} };");
 			expect(addWatchFile).toHaveBeenCalledOnce();
-			expect(addWatchFile).toHaveBeenCalledWith(entryPath);
+			// Module resolution canonicalizes macOS' /var -> /private/var symlink.
+			// Compare the physical path so this contract is portable across hosts.
+			expect(addWatchFile).toHaveBeenCalledWith(realpathSync(entryPath));
 		} finally {
 			rmSync(projectRoot, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## What does this PR do?

Normalizes the sandbox plugin watch-path assertion to the physical filesystem path.

On macOS, `os.tmpdir()` returns a path under `/var`, while module resolution canonicalizes the same location under `/private/var`. The test therefore compared two names for the same file and failed even though the plugin watched the correct resolved entry. Comparing physical paths keeps the assertion portable without changing runtime behavior.

Related issue: N/A. This is a test-only portability fix.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). N/A: this PR changes no admin UI or user-visible strings.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package). N/A: test-only changes do not affect a published package.
- [ ] New features link to an approved Discussion. N/A: this PR adds no feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not visual.

Validation:

- Pristine current `main`: the targeted file reproduced the macOS mismatch with 18 tests passing and 1 failing (`/var/...` expected, `/private/var/...` received).
- Updated targeted file: 4 consecutive runs passed, 19 tests each.
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- Full core suite with bounded workers: 430 test files passed, 1 skipped; 5,467 tests passed, 4 skipped.
- Oxfmt and Prettier were run for the changed test file.
