### PR TITLE
test(e2e): wait for dashboard metrics before asserting layout

### DIFF
--- a/e2e/tests/accessibility.spec.ts
+++ b/e2e/tests/accessibility.spec.ts
@@ -63,7 +63,7 @@ test.describe("Accessibility Audit", () => {
 			await admin.waitForLoading();
 
 			const metricCards = admin.page.getByTestId("dashboard-metric");
-			expect(await metricCards.count()).toBeGreaterThanOrEqual(3);
+			await expect.poll(() => metricCards.count()).toBeGreaterThanOrEqual(3);
 
 			const layout = await admin.page.locator("main").evaluate((main) => {
 				const textStart = (element: Element) => {
@@ -115,6 +115,7 @@ test.describe("Accessibility Audit", () => {
 		}) => {
 			await admin.goToDashboard();
 			await admin.waitForLoading();
+			await expect(admin.page.getByTestId("dashboard-metric-value").first()).toBeVisible();
 
 			const trackingByLocale = await admin.page.locator("main").evaluate((main) => {
 				const title = main.querySelector("h1");


### PR DESCRIPTION
## What does this PR do?

Fixes a race in the two dashboard layout E2E tests that fails runs on the Cloudflare shard.

Both tests read `dashboard-metric` cards immediately after `admin.waitForLoading()`. That helper only waits for the text `Loading` and for `.animate-spin` to disappear (`e2e/fixtures/admin.ts:171`), but the dashboard renders Kumo `SkeletonLine` placeholders while the `dashboard-stats` query is in flight (`packages/admin/src/components/Dashboard.tsx:133-152`) — the skeleton cards carry no `data-testid`. Neither selector matches, both waits time out silently into `.catch(() => {})`, and the helper returns immediately.

`expect(await metricCards.count())` is a plain assertion rather than a web-first one, so it takes a single snapshot with no retry. When the stats fetch is slow the count is `0`:

```
Error: expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 3
Received:    0
```

The failure artifact's page snapshot confirms the loading state — `main` contained only the `<h1>`, quick-action links, and the "Content"/"Recent Activity" headings.

The fix uses assertions that retry: `expect.poll` for the card count, and a web-first visibility check before the tracking test's `evaluate` (that one throws `Dashboard typography is missing` under the same race).

No product code changes — the dashboard behaves correctly; only the tests were reading it too early.

## Type of change

- [x] Tests

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no UI strings changed
- [ ] I have added a changeset — n/a, test-only change, no published package touched
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

Verified by temporarily delaying the dashboard stats response by 3s locally, which makes the race deterministic.

**Before** (delay, original assertions) — both tests fail, reproducing CI exactly:

```
Error: expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 3
Received:    0
  1 failed
    dashboard card headings and metric values share an inset
```

```
Error: locator.evaluate: Error: Dashboard typography is missing
  1 failed
    dashboard headings keep the font's default tracking across scripts
```

**After** (same 3s delay, with this change) — both pass.

Clean run of all three dashboard tests without the delay:

```
Running 3 tests using 1 worker
[1/3] dashboard should have no WCAG 2.x AA violations
[2/3] dashboard card headings and metric values share an inset
[3/3] dashboard headings keep the font's default tracking across scripts
  3 passed (48.1s)
```

The temporary delay was local-only and is not part of the diff.
