### PR TITLE
Document deployment-managed core migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ When writing, revising, or reviewing documentation, load the `writing-emdash-doc
 
 ## Workflow
 
-Run `pnpm lint:json | jq '.diagnostics | length'` before starting and confirm it's clean -- if it's failing after your edits, your changes caused it.
+Before starting any work that involves editing code, run `pnpm lint:json | jq '.diagnostics | length'` and confirm it's clean -- if it's failing after your edits, your changes caused it.
 
 During work:
 
@@ -151,6 +151,12 @@ Migrations live in `packages/core/src/database/migrations/`.
 - **Column types:** SQLite -- `text`, `integer`, `real`, `blob`. Booleans are `integer` defaulting to 0. Timestamps are `text` with ``defaultTo(sql`(datetime('now'))`)``. IDs are `text` primary keys (ULIDs from `ulidx`).
 - **Registration:** Migrations are statically imported in `runner.ts` and added to `StaticMigrationProvider`. Not auto-discovered (Workers bundler compatibility). When adding: create the file, add a static import in `runner.ts`, add it to `getMigrations()`.
 - **Multi-table migrations:** When altering all content tables, query `_emdash_collections` and loop. See `013_scheduled_publishing.ts`.
+
+Published migrations are immutable. Never edit or reorder one that has shipped; add the next monotonically increasing, zero-padded migration as a correction. Write `up` so it can restart after any completed statement, especially on D1 where a lost response can leave an ambiguous outcome.
+
+Preserve expand/deploy/contract compatibility: old application code must tolerate the expanded schema during a rolling deploy, and new code must tolerate incomplete backfills. When a migration changes existing `ec_*` tables, update `SchemaRegistry` so newly created tables receive the same shape. Use parameterized Kysely SQL, validated identifiers, bounded batches, portable dialect behavior, and the repository's index conventions.
+
+Test representative upgrades from existing data, retry after partial completion, every supported dialect, and realistically large data shapes. Add a user-facing changeset for each affected published package.
 
 ## Indexes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Published migrations are immutable. Never edit or reorder one that has shipped; 
 
 Preserve expand/deploy/contract compatibility: old application code must tolerate the expanded schema during a rolling deploy, and new code must tolerate incomplete backfills. When a migration changes existing `ec_*` tables, update `SchemaRegistry` so newly created tables receive the same shape. Use parameterized Kysely SQL, validated identifiers, bounded batches, portable dialect behavior, and the repository's index conventions.
 
-Test representative upgrades from existing data, retry after partial completion, every supported dialect, and realistically large data shapes. Add a user-facing changeset for each affected published package.
+Test representative upgrades from existing data, retry after partial completion, test every supported dialect, and test with realistically large data shapes. Add a user-facing changeset for each affected published package.
 
 ## Indexes
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -220,6 +220,7 @@ export default defineConfig({
 					items: [
 						{ label: "Deploy to Cloudflare", slug: "deployment/cloudflare" },
 						{ label: "Deploy to Node.js", slug: "deployment/nodejs" },
+						{ label: "Core Database Migrations", slug: "deployment/core-migrations" },
 						{ label: "Evolving a Deployed Site", slug: "deployment/schema-evolution" },
 						{ label: "Database Options", slug: "deployment/database" },
 						{ label: "Storage Options", slug: "deployment/storage" },

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -15,7 +15,7 @@ Cloudflare Workers provides a fast, globally distributed runtime for EmDash. Thi
 
 ## Configure Bindings
 
-Create `wrangler.jsonc` in your project root with D1 and R2 bindings. Wrangler provisions both resources on the first deploy if they don't already exist.
+Provision the production D1 database and R2 bucket, then create `wrangler.jsonc` in your project root with bindings for their immutable IDs and names. Database provisioning is separate from applying EmDash's schema migrations.
 
 ```jsonc title="wrangler.jsonc"
 {
@@ -28,6 +28,7 @@ Create `wrangler.jsonc` in your project root with D1 and R2 bindings. Wrangler p
 		{
 			"binding": "DB",
 			"database_name": "emdash-db",
+			"database_id": "00000000-0000-0000-0000-000000000000",
 		},
 	],
 
@@ -44,7 +45,7 @@ These are the bindings you configure yourself. The `@astrojs/cloudflare` adapter
 
 ## Configure EmDash
 
-Update your Astro configuration to use D1 and R2:
+The following Astro configuration uses the D1 and R2 bindings.
 
 ```js title="astro.config.mjs"
 import { defineConfig } from "astro/config";
@@ -66,9 +67,28 @@ export default defineConfig({
 });
 ```
 
-## First Boot
+## Migrate and Deploy
 
-Database migrations run automatically on the first request after deployment, and on every subsequent boot if there's anything new to apply.
+Runtime migrations remain automatic by default. For deployment-managed migrations, build the Worker and inspect the provisioned D1 target using its account and database UUID.
+
+```bash
+pnpm build
+pnpm exec emdash migrate --status --json \
+  --account-id "$CLOUDFLARE_ACCOUNT_ID" \
+  --d1 "$D1_DATABASE_ID"
+```
+
+After reviewing and recording the reported target fingerprint, apply the migrations and deploy the same build.
+
+```bash
+pnpm exec emdash migrate \
+  --account-id "$CLOUDFLARE_ACCOUNT_ID" \
+  --d1 "$D1_DATABASE_ID" \
+  --expected-target-fingerprint "$EMDASH_TARGET_FINGERPRINT"
+pnpm exec wrangler deploy
+```
+
+The migration job requires `CLOUDFLARE_API_TOKEN` with D1 Edit permission. Serialize jobs by account and database UUID. See [Manage Core Database Migrations](/deployment/core-migrations/) for provisioning, CI concurrency, runtime modes, and recovery guidance.
 
 If the database is empty (no collections) and the setup wizard hasn't been completed, EmDash also applies a seed file on first boot. The seed is read at build time from `.emdash/seed.json`, the path in `package.json#emdash.seed`, or `seed/seed.json` — whichever is found first — and inlined into the bundle. If none is present, a built-in default seed is used. Subsequent deploys against an existing database leave its content alone.
 

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -374,7 +374,7 @@ The AI Search plugin indexes published EmDash content and adds smart search inte
 5. Deploy the site:
 
 	```bash
-	pnpm deploy
+	pnpm exec wrangler deploy
 	```
 
 6. Open **Cloudflare AI Search** in the EmDash admin panel, select the collections to index, and click **Sync All Content**.

--- a/docs/src/content/docs/deployment/core-migrations.mdx
+++ b/docs/src/content/docs/deployment/core-migrations.mdx
@@ -1,0 +1,193 @@
+---
+title: Manage Core Database Migrations
+description: Run EmDash's internal schema migrations as a serialized deployment step.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+EmDash core migrations update EmDash's own tables and the standard columns on content tables. They do not create, remove, or rename your collections and fields; see [Evolving a Deployed Site](/deployment/schema-evolution/) for content-model changes.
+
+Runtime migration mode defaults to `auto`, so existing deployments keep applying pending core migrations on startup. Deployment-managed migrations let a build migrate its database before new application code receives traffic, then let the runtime verify or trust that deployment step.
+
+## Build, migrate, deploy, check
+
+An Astro build or sync writes `.emdash/migrations.json`. This secret-free manifest records the exact EmDash version, ordered migration set, locale configuration, and adapter migration executor used by that build.
+
+Run these commands from the project whose dependencies produced the manifest. First build and inspect the target.
+
+```bash
+pnpm build
+pnpm exec emdash migrate --status --json
+```
+
+After reviewing the reported target and recording its fingerprint, apply the migrations, deploy, and check the deployed schema.
+
+```bash
+pnpm exec emdash migrate --expected-target-fingerprint "$EMDASH_TARGET_FINGERPRINT"
+pnpm deploy
+pnpm exec emdash migrate --check
+```
+
+`emdash migrate` prints the immutable target before issuing SQL. An interactive, human-readable apply asks for confirmation. Non-interactive apply and every `--json` apply require `--expected-target-fingerprint`; the command fails if it does not match the resolved target.
+
+`--check` never applies migrations and exits non-zero when known migrations are pending or the database contains migration records unknown to the build. The [CLI reference](/reference/cli/#exit-codes) distinguishes pending, unknown, confirmation, interruption, and operational exit codes. The following command inspects all sets without using check's non-zero "work required" exit status.
+
+```bash
+pnpm exec emdash migrate --status --json
+```
+
+Use `--manifest path/to/migrations.json` for a manifest stored elsewhere. For local investigation, `--from-config [--config astro.config.mjs]` explicitly evaluates trusted project configuration without running Astro hooks or starting a server. Deployment pipelines should consume the build manifest.
+
+<Aside type="caution">
+	Keep the manifest and application artifact together. Stale schema versions, migration registries,
+	fingerprints, and executor entrypoints are rejected against the project's installed EmDash package.
+	Artifacts from different builds of the same version can share that identity, so target review and
+	artifact pairing remain deployment safeguards. A global CLI cannot substitute its own registry.
+</Aside>
+
+## Select the database explicitly
+
+The configured adapter contributes secret-free target information to the manifest. Credentials remain in environment variables and are read only by the migration command.
+
+| Adapter | Manifest target | Default credential variable | Useful override |
+| --- | --- | --- | --- |
+| SQLite | Database path or `file:` URL | — | `--database <path>` |
+| libSQL | Public URL | `TURSO_AUTH_TOKEN` | Configure `migrationAuthTokenEnv` |
+| PostgreSQL | Connection variable name | `DATABASE_URL` | `--database-url-env <name>` |
+| Cloudflare D1 | Wrangler binding name | `CLOUDFLARE_API_TOKEN` | `--d1`, `--account-id`, `--wrangler-config`, `--wrangler-env` |
+| Hyperdrive | Primary binding and origin variable name | Binding-specific direct-origin variable | Configure `migrationConnectionStringEnv` |
+
+Relative SQLite paths resolve from the project root, not from the installed EmDash package or the shell's current subdirectory. PostgreSQL, libSQL, and Hyperdrive target labels omit credentials and URL parameters.
+
+## Provision D1 before migrating it
+
+Creating a D1 database and migrating its schema are separate operations. `emdash migrate` never creates a missing database.
+
+<Steps>
+
+1. Provision the database and record its production UUID.
+
+   ```bash
+   pnpm exec wrangler d1 create my-site-production
+   ```
+
+2. Add that UUID to the intended binding and environment in `wrangler.jsonc`.
+
+3. Build the site so the D1 binding is recorded in `.emdash/migrations.json`.
+
+4. Set the account ID and a scoped API token with D1 Edit permission. Inspect the selected target, record its fingerprint, and then migrate it.
+
+   ```bash
+   export CLOUDFLARE_ACCOUNT_ID="..."
+   export CLOUDFLARE_API_TOKEN="..."
+   pnpm exec emdash migrate \
+     --status --json \
+     --wrangler-config wrangler.jsonc \
+     --wrangler-env production
+   pnpm exec emdash migrate \
+     --wrangler-config wrangler.jsonc \
+     --wrangler-env production \
+     --expected-target-fingerprint "$EMDASH_TARGET_FINGERPRINT"
+   ```
+
+</Steps>
+
+You can instead provide `--account-id` with `--d1 <database-uuid-or-name>`. Name lookup must resolve to exactly one database. Preview IDs, placeholder IDs, conflicting accounts, and ambiguous bindings fail closed.
+
+## Serialize D1 migration jobs
+
+D1 does not provide the advisory migration lock used by PostgreSQL. Run at most one migration job for an account and database UUID. The following GitHub Actions workflow keys the concurrency group by both immutable identifiers.
+
+```yaml title=".github/workflows/deploy.yml"
+name: Deploy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: emdash-migrations-${{ vars.CLOUDFLARE_ACCOUNT_ID }}-${{ vars.D1_DATABASE_ID }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Inspect EmDash migration target
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm exec emdash migrate --status --json \
+            --account-id "${{ vars.CLOUDFLARE_ACCOUNT_ID }}" \
+            --d1 "${{ vars.D1_DATABASE_ID }}"
+      - name: Apply EmDash migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          EMDASH_TARGET_FINGERPRINT: ${{ vars.EMDASH_TARGET_FINGERPRINT }}
+        run: |
+          pnpm exec emdash migrate \
+            --account-id "${{ vars.CLOUDFLARE_ACCOUNT_ID }}" \
+            --d1 "${{ vars.D1_DATABASE_ID }}" \
+            --expected-target-fingerprint "$EMDASH_TARGET_FINGERPRINT"
+      - run: pnpm deploy
+      - name: Check EmDash migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm exec emdash migrate --check \
+            --account-id "${{ vars.CLOUDFLARE_ACCOUNT_ID }}" \
+            --d1 "${{ vars.D1_DATABASE_ID }}"
+```
+
+Store the target fingerprint only after reviewing the target printed by `--status`. The fingerprint contains no credential, but it is an important deployment guard against migrating the wrong database.
+
+## Hyperdrive connects to the origin
+
+Hyperdrive's migration executor opens a direct PostgreSQL connection to the origin. It does not send migration traffic through Hyperdrive, use the optional cached binding, or inherit private-network reachability from the Worker.
+
+The deployment runner must be able to reach the origin. Set `migrationConnectionStringEnv` on `hyperdrive()` when the default binding-specific variable is unsuitable, and provide that variable only to the migration job. Keep runtime Hyperdrive credentials and direct-origin deployment credentials separate.
+
+## Adopt runtime enforcement gradually
+
+The following EmDash integration configuration enables runtime enforcement while retaining automatic migrations in development.
+
+```js title="astro.config.mjs"
+emdash({
+	database,
+	migrations: {
+		runtime: "check",
+		dev: "auto",
+	},
+});
+```
+
+- `auto` is the backwards-compatible default. Runtime startup checks and applies pending migrations.
+- `check` performs one directional status query and returns 503 before repositories use an older schema when known migrations are pending. It tolerates records from a newer compatible build during a rolling deployment.
+- `manual` performs no runtime migration or status query. Use it only after the deployment pipeline applies and checks every build reliably.
+
+`EMDASH_MIGRATIONS_MODE` can override the runtime mode when the same artifact is promoted through multiple environments. Setup and development bypass routes obey the effective mode; they cannot silently migrate behind `check` or `manual`.
+
+A conservative rollout is `auto` while introducing the deployment job, then `check` after the job is reliable, then `manual` when an external check is enforced for every deployment.
+
+## Compatibility during rolling deploys
+
+Core migrations follow expand/deploy/contract sequencing. A deployment may temporarily run old and new application isolates against the expanded database, and a backfill may still be in progress. Do not contract a schema until every deployed version has stopped using it.
+
+Unknown applied migration records are tolerated by runtime `check` for this rolling-deployment direction only. The CLI's exact check reports them and apply refuses to mutate, because the database may be newer or may have a divergent migration history.
+
+## Troubleshooting
+
+- **No migration manifest found.** Build or sync the project first. Use `--manifest` for a non-standard artifact location or explicitly choose `--from-config` for local investigation.
+- **The artifact does not match project EmDash.** Rebuild and deploy the application and manifest together. Run the project's CLI instead of a global installation.
+- **The target is missing or ambiguous.** Provision it first, then supply an explicit database path, connection-variable name, D1 selector, or selected Wrangler config and environment. EmDash does not guess from unrelated environment variables or bindings.
+- **The target fingerprint changed.** Stop and review the displayed account, environment, database name, UUID, or path. Update the expected fingerprint only after confirming the intended target.
+- **Unknown migration records are present.** Do not delete the records or rerun apply. Confirm that the application artifact is the intended version and investigate whether a newer or divergent build migrated the database.
+- **A D1 write outcome is ambiguous.** Do not replay the migration command. Run `emdash migrate --status` against the same account and database UUID, inspect the result, and escalate if the migration stopped part-way through.
+- **Hyperdrive cannot connect.** Test reachability from the deployment runner to the PostgreSQL origin and verify the direct-origin variable. Worker-to-Hyperdrive connectivity does not prove the runner can reach the origin.

--- a/docs/src/content/docs/deployment/core-migrations.mdx
+++ b/docs/src/content/docs/deployment/core-migrations.mdx
@@ -24,13 +24,13 @@ After reviewing the reported target and recording its fingerprint, apply the mig
 
 ```bash
 pnpm exec emdash migrate --expected-target-fingerprint "$EMDASH_TARGET_FINGERPRINT"
-pnpm deploy
+pnpm exec wrangler deploy
 pnpm exec emdash migrate --check
 ```
 
 `emdash migrate` prints the immutable target before issuing SQL. An interactive, human-readable apply asks for confirmation. Non-interactive apply and every `--json` apply require `--expected-target-fingerprint`; the command fails if it does not match the resolved target.
 
-`--check` never applies migrations and exits non-zero when known migrations are pending or the database contains migration records unknown to the build. The [CLI reference](/reference/cli/#exit-codes) distinguishes pending, unknown, confirmation, interruption, and operational exit codes. The following command inspects all sets without using check's non-zero "work required" exit status.
+`--check` never applies migrations and exits non-zero when known migrations are pending or the database contains migration records unknown to the build. The [CLI reference](/reference/cli/#emdash-migrate) distinguishes pending, unknown, confirmation, interruption, and operational exit codes. The following command inspects all sets without using check's non-zero "work required" exit status.
 
 ```bash
 pnpm exec emdash migrate --status --json
@@ -136,7 +136,7 @@ jobs:
             --account-id "${{ vars.CLOUDFLARE_ACCOUNT_ID }}" \
             --d1 "${{ vars.D1_DATABASE_ID }}" \
             --expected-target-fingerprint "$EMDASH_TARGET_FINGERPRINT"
-      - run: pnpm deploy
+      - run: pnpm exec wrangler deploy
       - name: Check EmDash migrations
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -169,7 +169,7 @@ emdash({
 ```
 
 - `auto` is the backwards-compatible default. Runtime startup checks and applies pending migrations.
-- `check` performs one directional status query and returns 503 before repositories use an older schema when known migrations are pending. It tolerates records from a newer compatible build during a rolling deployment.
+- `check` performs one directional status query and returns 503 before serving a request when known migrations are pending. It tolerates records from a newer compatible build during a rolling deployment.
 - `manual` performs no runtime migration or status query. Use it only after the deployment pipeline applies and checks every build reliably.
 
 `EMDASH_MIGRATIONS_MODE` can override the runtime mode when the same artifact is promoted through multiple environments. Setup and development bypass routes obey the effective mode; they cannot silently migrate behind `check` or `manual`.

--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -66,8 +66,9 @@ export default defineConfig({
 </Tabs>
 
 <Aside>
-	EmDash runs migrations on D1 automatically on the first request after deployment. Wrangler
-	provisions the D1 database itself on first deploy if it doesn't already exist.
+	EmDash runs core migrations automatically by default on the first request after deployment, or a
+	deployment can apply them from the build manifest before traffic. You must provision the D1
+	database separately; see [Manage Core Database Migrations](/deployment/core-migrations/).
 </Aside>
 
 ### Read Replicas

--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -148,10 +148,11 @@ export default defineConfig({
 
 ### Configuration
 
-| Option      | Type     | Description                                          |
-| ----------- | -------- | ---------------------------------------------------- |
-| `url`       | `string` | Database URL (`libsql://...` or `file:...`)          |
-| `authToken` | `string` | Auth token for remote databases (optional for local) |
+| Option                  | Type     | Description                                                        |
+| ----------------------- | -------- | ------------------------------------------------------------------ |
+| `url`                   | `string` | Database URL (`libsql://...` or `file:...`)                        |
+| `authToken`             | `string` | Runtime auth token for remote databases (optional for local)       |
+| `migrationAuthTokenEnv` | `string` | Migration token variable name (default `TURSO_AUTH_TOKEN`)          |
 
 ### Local Development
 
@@ -211,6 +212,7 @@ database: postgres({
 | `ssl`              | `boolean` | Enable SSL                           |
 | `pool.min`         | `number`  | Minimum pool connections (default 0) |
 | `pool.max`         | `number`  | Maximum pool connections (default 10)|
+| `migrationConnectionStringEnv` | `string` | Migration connection-string variable name (default `DATABASE_URL`) |
 
 ### Database role requirements
 
@@ -358,12 +360,13 @@ wrangler hyperdrive create emdash-db \
 
 ### Configuration
 
-| Option                         | Type     | Default        | Description                                                                                                      |
-| ------------------------------ | -------- | -------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `binding`                      | `string` | `"HYPERDRIVE"` | Primary (caching-disabled) Hyperdrive binding name                                                               |
-| `cachedBinding`                | `string` | —              | Optional caching-enabled binding for anonymous reads (see below)                                                 |
-| `preferUncachedAfterWriteMs`   | `number` | `60000`\*      | After a content publish, prefer `binding` for this many ms on anonymous public reads (match Hyperdrive `max_age`) |
-| `max`                          | `number` | `5`            | Max size of the in-Worker connection pool to Hyperdrive                                                          |
+| Option                         | Type     | Default                                                        | Description                                                                                                      |
+| ------------------------------ | -------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `binding`                      | `string` | `"HYPERDRIVE"`                                                 | Primary (caching-disabled) Hyperdrive binding name                                                               |
+| `cachedBinding`                | `string` | —                                                              | Optional caching-enabled binding for anonymous reads (see below)                                                 |
+| `preferUncachedAfterWriteMs`   | `number` | `60000`\*                                                      | After a content publish, prefer `binding` for this many ms on anonymous public reads (match Hyperdrive `max_age`) |
+| `migrationConnectionStringEnv` | `string` | `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING>`      | Environment variable containing the direct PostgreSQL origin URL for `emdash migrate`                            |
+| `max`                          | `number` | `5`                                                            | Max size of the in-Worker connection pool to Hyperdrive                                                          |
 
 \*Default `60000` applies only when `cachedBinding` is set; ignored otherwise.
 
@@ -401,7 +404,8 @@ This is the [two-configuration pattern](https://developers.cloudflare.com/hyperd
 - **Authenticated requests** (editors, authors) → uncached `binding`.
 - **Mutation requests** (`POST`, `PUT`, `PATCH`, `DELETE`, including anonymous ones) → uncached `binding`.
 - **Any request under `/_emdash`** (admin, setup, auth, internal APIs), even an anonymous `GET` → uncached `binding`.
-- **Migrations and runtime initialization** → always the primary `binding`.
+- **Runtime migrations and cold-start** → always the primary `binding`.
+- **Deployment-managed migrations** → connect directly to the PostgreSQL origin using `migrationConnectionStringEnv`; they never use either Hyperdrive binding.
 
 <Aside>
 	The `/_emdash` carve-out matters: the setup wizard and login-state checks are
@@ -544,9 +548,11 @@ database: sqlite({ url: `file:${process.env.DATABASE_PATH}` });
 
 ## Migrations
 
-EmDash runs migrations automatically on the first request, for every supported dialect (D1, SQLite, libSQL, PostgreSQL). Migrations are bundled with the `emdash` package and embedded into your build.
+EmDash runs core migrations automatically by default for every supported dialect. Astro build and sync also emit a validated, secret-free `.emdash/migrations.json`, which `emdash migrate` can apply before deployment. SQLite, libSQL, PostgreSQL, D1, and the direct PostgreSQL origin behind Hyperdrive have deployment executors.
 
-For PostgreSQL, migrations run through the configured connection; Hyperdrive always uses its primary binding. They run before EmDash finishes runtime initialization and may create tables, indexes, and functions, alter or drop columns and constraints, and update existing rows. A role that can connect and modify rows but does not own the existing EmDash objects is not sufficient. The setup wizard cannot repair missing database privileges because migrations run before setup.
+See [Manage Core Database Migrations](/deployment/core-migrations/) for target credentials, CI serialization, `auto`/`check`/`manual` runtime policy, and recovery from unknown records or ambiguous D1 writes.
+
+For PostgreSQL, runtime migrations run through the configured connection; Hyperdrive runtime migrations always use its primary binding. Deployment-managed Hyperdrive migrations connect directly to the PostgreSQL origin. Core migrations may create tables, indexes, and functions, alter or drop columns and constraints, and update existing rows. A role that can connect and modify rows but does not own the existing EmDash objects is not sufficient. The setup wizard cannot repair missing database privileges because runtime migrations run before setup.
 
 If the database is empty (no collections) and the setup wizard has not been completed, EmDash also applies a seed file on first boot. The seed is read from `.emdash/seed.json`, the path in `package.json#emdash.seed`, or `seed/seed.json` — whichever is found first — and inlined into the build at compile time. If none is present, a built-in default seed is used. Subsequent boots against an existing database leave its content alone.
 

--- a/docs/src/content/docs/deployment/schema-evolution.mdx
+++ b/docs/src/content/docs/deployment/schema-evolution.mdx
@@ -21,10 +21,12 @@ A site goes through four distinct workflows. Each one touches a different layer:
 The seed file only participates in the third row. It is applied once, when the database is empty and the setup wizard has not been completed. Deploying a changed seed file against an existing database does nothing — evolving a live site's schema always happens through the admin panel or the API.
 
 <Aside type="note">
-	Pending core migrations run on the first request after a deploy. They can change EmDash system tables
-	and the physical layout of collection tables, but they do not add or remove your collections, fields,
-	or taxonomies. PostgreSQL deployments must retain the [required schema ownership and
-	permissions](/deployment/database/#database-role-requirements) for these migrations.
+	Core migrations update EmDash's internal tables and the physical layout of collection tables. Runtime
+	migration remains automatic by default, or a deployment can apply the exact build manifest before
+	traffic. Core migrations do not add or remove your collections, fields, or taxonomies. PostgreSQL
+	deployments must retain the [required schema ownership and
+	permissions](/deployment/database/#database-role-requirements). See [Manage Core Database
+	Migrations](/deployment/core-migrations/) for the deployment workflow.
 </Aside>
 
 ## Change the schema in the admin panel

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -43,9 +43,54 @@ These flags are available on commands using the shared remote client:
 
 ## Output
 
-When stdout is a TTY, the CLI pretty-prints results with consola. When piped or when `--json` is set, it outputs raw JSON to stdout — suitable for `jq` or other tools.
+For commands using the shared remote client, stdout is pretty-printed with consola when it is a TTY and becomes raw JSON when piped or when `--json` is set. `emdash migrate` emits JSON only with its explicit `--json` option.
 
 ## Commands
+
+### `emdash migrate`
+
+Check or apply the core migration set emitted by an Astro build.
+
+```bash
+npx emdash migrate [options]
+npx emdash migrate --check [options]
+npx emdash migrate --status --json [options]
+```
+
+By default the command discovers the project root and reads `.emdash/migrations.json`. It validates the manifest against the project's installed EmDash package, resolves the adapter's project-local executor, and prints the immutable target before any SQL.
+
+#### Options
+
+| Option | Description |
+| --- | --- |
+| `--check` | Apply nothing; exit non-zero for pending or unknown migration records |
+| `--status` | Report exact status without applying; exit zero after a successful report |
+| `--json` | Emit the stable migration report as JSON |
+| `--manifest <path>` | Read a non-standard manifest path |
+| `--from-config` | Explicitly evaluate trusted Astro configuration instead of a manifest |
+| `--config <path>` | Astro config path used with `--from-config` |
+| `--expected-target-fingerprint <sha256>` | Required guard for non-interactive apply |
+| `--database <path>` | Override a SQLite path |
+| `--database-url-env <name>` | Override a PostgreSQL connection-variable name |
+| `--d1 <uuid-or-name>` | Select a D1 database explicitly |
+| `--account-id <id>` | Select a Cloudflare account explicitly |
+| `--wrangler-config <path>` | Read D1 binding metadata from an explicit Wrangler config |
+| `--wrangler-env <name>` | Select an environment; requires `--wrangler-config` |
+
+Interactive human-readable apply asks for confirmation. Non-interactive apply and every apply using `--json` require the exact fingerprint printed for the target. There is no `down` or `--dry-run`; use `--check` to determine whether work is required.
+
+#### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success, including a successful `--status` report |
+| `1` | Validation, configuration, target, migration, or cleanup error |
+| `2` | `--check` found pending known migrations |
+| `3` | `--check` found unknown applied records (takes precedence over pending) |
+| `4` | Confirmation missing, declined, or target fingerprint mismatch |
+| `130` | Interrupted after bounded executor cleanup |
+
+See [Manage Core Database Migrations](/deployment/core-migrations/) for deployment order, target credentials, and D1 serialization.
 
 ### `emdash dev` (deprecated)
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -57,7 +57,7 @@ See [Database Options](/deployment/database/) for details.
 
 ### `migrations`
 
-**Optional.** Controls runtime handling of EmDash's internal database migrations. Existing sites default to `{ runtime: "auto" }`.
+**Optional.** Controls runtime handling of EmDash's internal database migrations. Omitting this option defaults to `{ runtime: "auto" }`.
 
 ```js
 migrations: {

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -55,6 +55,19 @@ database: d1({ binding: "DB" });
 
 See [Database Options](/deployment/database/) for details.
 
+### `migrations`
+
+**Optional.** Controls runtime handling of EmDash's internal database migrations. Existing sites default to `{ runtime: "auto" }`.
+
+```js
+migrations: {
+	runtime: "check", // "auto" | "check" | "manual"
+	dev: "auto",     // optional development override
+}
+```
+
+`auto` checks and applies pending migrations, `check` returns 503 when migrations known to the running build are pending, and `manual` performs no runtime migration query. `EMDASH_MIGRATIONS_MODE` overrides the effective runtime mode. See [Manage Core Database Migrations](/deployment/core-migrations/) before adopting `check` or `manual`.
+
 ### `storage`
 
 **Required.** Media storage adapter configuration. Choose one adapter:
@@ -519,10 +532,11 @@ sqlite({ url: "file:./data.db" });
 
 libSQL database. The following example connects to a remote libSQL database:
 
-| Option      | Type     | Description                           |
-| ----------- | -------- | ------------------------------------- |
-| `url`       | `string` | Database URL                          |
-| `authToken` | `string` | Auth token (optional for local files) |
+| Option                  | Type     | Description                                                   |
+| ----------------------- | -------- | ------------------------------------------------------------- |
+| `url`                   | `string` | Database URL                                                  |
+| `authToken`             | `string` | Runtime auth token (optional for local files)                 |
+| `migrationAuthTokenEnv` | `string` | Migration token variable name (default `TURSO_AUTH_TOKEN`)    |
 
 ```js
 libsql({
@@ -546,6 +560,7 @@ PostgreSQL database with connection pooling.
 | `ssl`              | `boolean` | Enable SSL                           |
 | `pool.min`         | `number`  | Minimum pool size (default: 0)       |
 | `pool.max`         | `number`  | Maximum pool size (default: 10)      |
+| `migrationConnectionStringEnv` | `string` | Migration connection-string variable name (default `DATABASE_URL`) |
 
 The following example connects with a connection string:
 
@@ -575,8 +590,10 @@ d1({ binding: "DB", session: "auto" });
 
 When `session` is `"auto"` or `"primary-first"`, EmDash uses the D1 Sessions API to route read queries to nearby replicas. Authenticated users get bookmark-based read-your-writes consistency. See [Database Options — Read Replicas](/deployment/database/#read-replicas) for details.
 
-<Aside type="caution">
-	D1 requires migrations via Wrangler CLI. DDL statements are not allowed at runtime.
+<Aside>
+	D1 core migrations run automatically by default or through the deployment migration manifest.
+	Provision the D1 database separately; see [Manage Core Database
+	Migrations](/deployment/core-migrations/).
 </Aside>
 
 ## Storage adapters


### PR DESCRIPTION
## What does this PR do?

Documents deployment-managed core migrations across database, Cloudflare, CLI, configuration, and schema-evolution guides. It also includes the requested unrelated `AGENTS.md` workflow clarification.

Closes #2276

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/2418

The typecheck and changeset items are not applicable to this documentation-only layer. Quick lint, targeted formatting, and the docs build pass. The i18n item is not applicable because this does not change the admin UI.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Non-visual documentation change. The documentation site builds successfully.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://codex-issue-2276-migrations-docs-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `codex/issue-2276-migrations-docs`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
