### PR TITLE
docs: document the Cloudflare IMAGES binding behind media transforms

### DIFF
--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -40,6 +40,8 @@ Create `wrangler.jsonc` in your project root with D1 and R2 bindings. Wrangler p
 }
 ```
 
+These are the bindings you configure yourself. The `@astrojs/cloudflare` adapter adds more of its own when it generates the deployed Worker config. One of them is the `IMAGES` binding that media transforms use — see [Image Transformation](#image-transformation).
+
 ## Configure EmDash
 
 Update your Astro configuration to use D1 and R2:
@@ -240,6 +242,33 @@ storage: r2({
 <Aside type="tip">
 	For production, connect a custom domain to your R2 bucket for better URLs and caching control.
 </Aside>
+
+## Image Transformation
+
+EmDash resizes and re-encodes R2 media inside the Worker, through Cloudflare's `IMAGES` binding. The `Image` component from `emdash/ui` and images in rich text both render through the image endpoint EmDash installs under the Cloudflare adapter. For media on the internal `/_emdash/api/media/file/…` route, that endpoint reads the source bytes straight from the R2 binding, without an HTTP fetch. Those transforms keep working behind Cloudflare Access and with `global_fetch_strictly_public`. Media served from a bucket URL — see [Public R2 Access](#public-r2-access) — takes the adapter's own transform endpoint instead, which fetches the file over HTTP before transforming it.
+
+You do not have to declare the binding. `@astrojs/cloudflare` adds it to the Worker config it generates during `astro build`, the same way it adds `cache` for Workers Caching. It does so whenever the runtime image service is `cloudflare-binding`: `imageService` unset, the string itself, or `{ runtime: "cloudflare-binding" }`. Every other value — `"passthrough"`, `"compile"`, `"cloudflare"`, `"custom"` — leaves the binding out. Listing it in your own `wrangler.jsonc` keeps the intent obvious:
+
+```jsonc title="wrangler.jsonc"
+{
+	"images": {
+		"binding": "IMAGES",
+	},
+}
+```
+
+To see what a deploy actually gets, read the generated config rather than `wrangler.jsonc`. A build writes `.wrangler/deploy/config.json`, which points `wrangler deploy` at the merged file (`dist/server/wrangler.json` by default). Look for an `images` entry there.
+
+<Aside type="caution">
+	What a missing binding looks like depends on the media URL. On the internal route the endpoint
+	serves the original file unchanged: pages still render and nothing is logged, but every image is
+	the full-size original rather than a variant scaled to the space it occupies. From a bucket URL
+	the request fails with a 500 instead, because the adapter's transform endpoint calls the binding
+	without a fallback. `imageService: "passthrough"` is the deliberate way out — EmDash then leaves
+	the adapter's passthrough endpoint in place rather than wrapping it.
+</Aside>
+
+Cloudflare bills these transforms as [Images transformations](https://developers.cloudflare.com/images/pricing/#images-transformed). Each unique combination of source image and parameters is billed once per calendar month, and repeat requests within that month are free. The Images Free plan covers 5,000 unique transformations per month. Past that limit, cached transformations are still served, but new ones return a `9422` error and the image request fails.
 
 ## Cloudflare Access Authentication
 

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -252,6 +252,8 @@ const { entry: post } = await getEmDashEntry("posts", Astro.params.slug);
 
 `priority` is for the primary above-the-fold image. It sets `loading="eager"` and `fetchpriority="high"`: `loading` controls whether loading is deferred, and `fetchpriority` gives the browser a priority hint for the request.
 
+EmDash installs an image endpoint that produces the resized variants on request. On Cloudflare Workers that endpoint uses the `IMAGES` binding. [Image Transformation](/deployment/cloudflare/#image-transformation) covers where the binding comes from and what happens when it is absent.
+
 ## Deleting Media
 
 1. Select the file(s) you want to delete


### PR DESCRIPTION
## What does this PR do?

The Cloudflare deployment guide never mentions the `IMAGES` Worker binding, and neither does the media library guide. Media transforms run on that binding. A reader has no way to tell whether their deploy has it, or what a missing binding would look like.

The cause: `packages/cloudflare/src/image-endpoint.ts` resolves the binding per request. When it is absent, internal media URLs stream the original bytes and log nothing — the pages still render, only with images larger than intended. Media served from a bucket URL goes through the adapter's endpoint instead and fails with a 500.

The binding itself needs no configuration. `@astrojs/cloudflare` writes `"images": { "binding": "IMAGES" }` into the Worker config it generates during `astro build`. `wrangler deploy` reads that generated file, not `wrangler.jsonc`, because the build also writes `.wrangler/deploy/config.json` to redirect it there.

This PR adds an `Image Transformation` section to the Cloudflare deployment guide. It states what the binding does, which `imageService` settings make the adapter supply it, how to confirm it in the generated config, what a missing binding looks like on each media path, and how Cloudflare bills the transforms. `Configure Bindings` gets one sentence pointing to that section, and the `Responsive Images` section of the media library guide links to it as well.

Closes #2414

### Details

The issue asks for the binding to be listed next to D1 and R2 in `Configure Bindings`, as a step the reader has to perform. Documenting it that way would be wrong on two counts: the adapter already supplies the binding, and a post-build `wrangler deploy` does not read `wrangler.jsonc`. The new section instead follows the wording the same page already uses for `cache` — the adapter injects it, and listing it yourself keeps the intent obvious.

Verified against this repo's own `templates/starter-cloudflare`, which has no `images` entry in `wrangler.jsonc`:

```
$ npx astro build   # in templates/starter-cloudflare
$ cat .wrangler/deploy/config.json
{"configPath":"../../dist/server/wrangler.json", ...}
$ jq '.images' dist/server/wrangler.json
{ "binding": "IMAGES" }
```

The adapter injects the binding when the runtime image service is `cloudflare-binding` — `imageService` unset, the string itself, or `{ runtime: "cloudflare-binding" }`. `passthrough`, `compile`, `cloudflare` and `custom` all leave it out, so the section names the condition rather than only the passthrough case. With `passthrough`, `resolveImageEndpoint` in `packages/core/src/astro/integration/index.ts` also keeps the adapter's passthrough endpoint in place instead of wrapping it.

The two failure modes differ because the endpoint only reads bytes from R2 for internal media URLs. With a `publicUrl` on the storage adapter, `matchInternalMediaKey` does not match and the request is delegated to `@astrojs/cloudflare/image-transform-endpoint`, which fetches over HTTP and calls `env.IMAGES` unconditionally — a missing binding surfaces as a 500 there, not as an unchanged original.

Docs-only, so there is no changeset (`docs` is in the changeset ignore list) and no test. `npx astro build` in `docs/` completes and the new anchor resolves: `id="image-transformation"` is present in the built page, and the media library page links to it.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes (n/a: docs-only, no TypeScript changed)
- [ ] `pnpm lint` passes (n/a: docs-only, no source changed)
- [ ] `pnpm test` passes (n/a: docs-only; `astro build` in `docs/` passes instead)
- [x] `pnpm format` has been run (`prettier --check` on the two changed `.mdx` files)
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (draft), Claude Fable 5 (review)

Drafted and reviewed with Claude in separate sessions: Claude Opus 5 (draft), Claude Fable 5 (review).

## Screenshots / test output

```
$ npx prettier --check docs/src/content/docs/deployment/cloudflare.mdx docs/src/content/docs/guides/media-library.mdx
Checking formatting...
All matched files use Prettier code style!

$ npx astro build   # in docs/
[build] Server built in 17.96s
[build] Complete!
```
