### PR TITLE
fix(skills): correct the Block Kit examples that break the admin page

### DIFF
--- a/packages/blocks/tests/skill-examples.test.ts
+++ b/packages/blocks/tests/skill-examples.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { validateBlocks } from "../src/validation.js";
+
+const REFERENCE_PATH = fileURLToPath(
+	new URL("../../../skills/creating-plugins/references/block-kit.md", import.meta.url),
+);
+
+type Example = {
+	name: string;
+	section: string;
+	source: string;
+};
+
+const TO_BLOCKS: Record<string, (example: unknown) => unknown[]> = {
+	"Block Syntax": (example) => [example],
+	"Conditional Fields": (example) => [
+		{
+			type: "form",
+			block_id: "example",
+			fields: [example],
+			submit: { label: "Save", action_id: "save" },
+		},
+	],
+	"Button Confirmations": (example) => [{ type: "actions", elements: [example] }],
+};
+
+function extractJsonExamples(markdown: string): Example[] {
+	const examples: Example[] = [];
+	const lines = markdown.split("\n");
+
+	let section = "";
+	let heading = "";
+	let fence: string[] | null = null;
+	let fenceLine = 0;
+
+	for (const [index, line] of lines.entries()) {
+		if (fence) {
+			if (line.startsWith("```")) {
+				examples.push({
+					name: `${heading} (line ${fenceLine})`,
+					section,
+					source: fence.join("\n"),
+				});
+				fence = null;
+			} else {
+				fence.push(line);
+			}
+			continue;
+		}
+
+		if (line.startsWith("## ")) {
+			section = line.slice(3).trim();
+			heading = section;
+		} else if (line.startsWith("### ")) {
+			heading = line.slice(4).trim();
+		} else if (line.trim() === "```json") {
+			fence = [];
+			fenceLine = index + 2;
+		}
+	}
+
+	return examples;
+}
+
+const examples = extractJsonExamples(readFileSync(REFERENCE_PATH, "utf8"));
+
+describe("block kit reference examples", () => {
+	it("finds JSON examples in the reference", () => {
+		expect(examples.length).toBeGreaterThan(0);
+	});
+
+	it.each(examples.map((example) => [example.name, example] as const))("%s", (_name, example) => {
+		const toBlocks = TO_BLOCKS[example.section];
+		if (!toBlocks) {
+			throw new Error(
+				`Section "${example.section}" holds a JSON example but has no entry in TO_BLOCKS`,
+			);
+		}
+
+		expect(validateBlocks(toBlocks(JSON.parse(example.source)))).toEqual({
+			valid: true,
+			errors: [],
+		});
+	});
+});

--- a/skills/creating-plugins/references/block-kit.md
+++ b/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/blank/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/blog/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/marketing/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/portfolio/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {

--- a/templates/starter/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/block-kit.md
@@ -105,7 +105,7 @@ routes: {
 {
 	"type": "section",
 	"text": "Configure your plugin settings below.",
-	"accessory": { "type": "button", "text": "Refresh", "action_id": "refresh" }
+	"accessory": { "type": "button", "label": "Refresh", "action_id": "refresh" }
 }
 ```
 
@@ -132,12 +132,16 @@ routes: {
 ```json
 {
 	"type": "stats",
-	"stats": [
-		{ "label": "Total", "value": "1,234", "trend": "+12%", "trend_direction": "up" },
+	"items": [
+		{ "label": "Total", "value": "1,234", "trend": "up", "description": "+12% vs last week" },
 		{ "label": "Active", "value": "567" }
 	]
 }
 ```
+
+- `items` — the array key is `items`, not `stats`
+- `trend` — `"up"`, `"down"`, or `"neutral"`; renders an arrow icon next to the value
+- `description` — secondary line beneath the value, for context such as "+12% vs last week"
 
 ### Table
 
@@ -149,9 +153,15 @@ routes: {
 		{ "key": "status", "label": "Status" },
 		{ "key": "date", "label": "Date" }
 	],
-	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }]
+	"rows": [{ "name": "Item 1", "status": "Active", "date": "2025-01-01" }],
+	"page_action_id": "browse_items",
+	"empty_text": "No items yet."
 }
 ```
+
+- `page_action_id` — required. The admin sends it as the `block_action` id when the user sorts a column or pages through results.
+- `empty_text` — shown in place of the table when `rows` is empty
+- `next_cursor` — set it to render a "Load more" control
 
 ### Actions
 
@@ -159,8 +169,8 @@ routes: {
 {
 	"type": "actions",
 	"elements": [
-		{ "type": "button", "text": "Save", "action_id": "save", "style": "primary" },
-		{ "type": "button", "text": "Cancel", "action_id": "cancel" }
+		{ "type": "button", "label": "Save", "action_id": "save", "style": "primary" },
+		{ "type": "button", "label": "Cancel", "action_id": "cancel" }
 	]
 }
 ```
@@ -196,11 +206,19 @@ routes: {
 {
 	"type": "columns",
 	"columns": [
-		{ "blocks": [{ "type": "header", "text": "Left" }] },
-		{ "blocks": [{ "type": "header", "text": "Right" }] }
+		[
+			{ "type": "header", "text": "Usage" },
+			{ "type": "meter", "label": "Storage used", "value": 65 }
+		],
+		[
+			{ "type": "header", "text": "Activity" },
+			{ "type": "context", "text": "Last sync 2 hours ago" }
+		]
 	]
 }
 ```
+
+- `columns` — 2 or 3 columns, each one an array of blocks
 
 ### Chart (Timeseries)
 
@@ -395,7 +413,7 @@ return {
 ```json
 {
 	"type": "button",
-	"text": "Delete All",
+	"label": "Delete All",
 	"action_id": "delete_all",
 	"style": "danger",
 	"confirm": {


### PR DESCRIPTION
## What does this PR do?

If you copy the Stats example out of the `creating-plugins` skill, the admin page fails to render. The example puts the stat cards under a `stats` key. `StatsBlockComponent` reads `block.items.map(...)`, so the page crashes with "Cannot read properties of undefined (reading 'map')". The Columns example breaks the same way. It wraps each column in `{ "blocks": [...] }`, and `ColumnsBlockComponent` passes each entry to `BlockRenderer`. `BlockRenderer` calls `.map()` on it.

The cause: the examples in `skills/creating-plugins/references/block-kit.md` describe a shape that `packages/blocks/src/types.ts` never declared. Five of the fourteen block examples disagree with the exported types. `validateBlocks()` rejects all five.

This PR corrects six examples — the five in "Block Syntax", plus the Button Confirmations example further down the file:

- **Stats** — the array key is `items`, not `stats`. `trend` is the enum `"up" | "down" | "neutral"` rather than a percentage string. The "+12%" text moves to `description`, which is the field that `StatItem` provides for it. `trend_direction` does not exist. The example no longer shows it.
- **Table** — adds `page_action_id`. `TableBlock` declares it as required, and the renderer sends it as the `block_action` id when a user sorts a column or loads more rows. The example now also shows `empty_text`, and a bullet documents `next_cursor`.
- **Columns** — each column is an array of blocks (`Block[][]`), not an object with a `blocks` key. Each column in the example now holds two blocks, so the example shows what the nesting is for.
- **Section**, **Actions** and **Button Confirmations** — buttons carry `label`, not `text`. `ButtonElement.label` is required, and the renderer prints `element.label`. The documented shape renders a button with no caption.

Stats, Table and Columns each gain a short bullet list for the fields involved. A reader sees the constraint and does not have to infer it from the sample.

These skill files ship inside every project that `npm create emdash@latest` generates. Coding agents read them. An agent cannot check a rendered page before it ships the plugin. `scripts/sync-template-skills.sh` carries the fix into the nine template copies. The source file and all nine copies are byte-identical.

`packages/blocks/tests/skill-examples.test.ts` keeps the examples from drifting again. It extracts every JSON example from the reference and runs it through `validateBlocks()`. The examples outside "Block Syntax" are elements rather than blocks, so the test wraps each one in the block that carries it: the conditional fields go into a `form`, the Button Confirmations button into an `actions` block. All 17 examples are covered. Restoring the reference to its state on `main` fails six of them. Output below.

Closes #1737

### Details

The docs site is not affected. `docs/src/content/docs/plugins/creating-plugins/block-kit.mdx` carries no per-block JSON examples, so nothing there had to change.

Four of the six corrections go beyond the issue. The issue reports Stats and Table. The validator flagged three more when it ran over all fourteen examples: Section and Actions use `text` for button labels, and Columns uses the wrong nesting. The Button Confirmations example carries the same `text` defect. All six are the same drift in the same file. A fix for only two of them would leave the next copy-paste broken.

The issue also suggests generating the examples from `packages/blocks/src/types.ts`. This PR does not do that. Validating the examples catches the same drift and leaves the reference hand-written, so an author can still show a realistic sample rather than a generated minimum.

`validateBlocks()` runs in the blocks playground and in the package's own tests. It does not guard the admin render path. This PR therefore uses it as a check on the examples. It does not show that the runtime catches a bad block.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) (targeted: `pnpm --filter @emdash-cms/blocks test`, 114 passing)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI change)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) (n/a: skill markdown, its template copies and a test; every template package is in the .changeset ignore list, and the test is excluded from the `@emdash-cms/blocks` build)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (draft), Claude Fable 5 (review)

Drafted and reviewed with Claude in separate sessions: Opus 5 wrote the reference corrections and the test, Fable 5 verified the corrections against the source in a fresh session.

## Screenshots / test output

Every JSON example in the reference, run through `validateBlocks()`:

```
$ pnpm --filter @emdash-cms/blocks exec vitest run tests/skill-examples.test.ts

✓ finds JSON examples in the reference 1ms
✓ Header (line 99) 1ms
✓ Section (line 105) 0ms
✓ Divider (line 115) 0ms
✓ Fields (line 121) 0ms
✓ Stats (line 133) 0ms
✓ Table (line 149) 0ms
✓ Actions (line 169) 0ms
✓ Form (line 181) 0ms
✓ Columns (line 206) 0ms
✓ Chart (Timeseries) (line 226) 0ms
✓ Chart (Custom) (line 269) 0ms
✓ Code (line 295) 0ms
✓ Meter (line 307) 0ms
✓ Banner (line 322) 0ms
✓ Conditional Fields (line 338) 0ms
✓ Conditional Fields (line 346) 0ms
✓ Button Confirmations (line 414) 0ms
Test Files  1 passed (1)
Tests  18 passed (18)
```

With the reference restored to its state on `main`, the six corrected examples fail:

```
✓ finds JSON examples in the reference 1ms
✓ Header (line 99) 1ms
× Section (line 105) 6ms
→ expected { valid: false, errors: [ { …(2) } ] } to deeply equal { valid: true, errors: [] }
✓ Divider (line 115) 0ms
✓ Fields (line 121) 0ms
× Stats (line 133) 1ms
→ expected { valid: false, errors: [ { …(2) } ] } to deeply equal { valid: true, errors: [] }
× Table (line 145) 0ms
→ expected { valid: false, errors: [ { …(2) } ] } to deeply equal { valid: true, errors: [] }
× Actions (line 159) 0ms
→ expected { valid: false, …(1) } to deeply equal { valid: true, errors: [] }
✓ Form (line 171) 0ms
× Columns (line 196) 0ms
→ expected { valid: false, …(1) } to deeply equal { valid: true, errors: [] }
✓ Chart (Timeseries) (line 208) 0ms
✓ Chart (Custom) (line 251) 0ms
✓ Code (line 277) 0ms
✓ Meter (line 289) 0ms
✓ Banner (line 304) 0ms
✓ Conditional Fields (line 320) 0ms
✓ Conditional Fields (line 328) 0ms
× Button Confirmations (line 396) 0ms
→ expected { valid: false, errors: [ { …(2) } ] } to deeply equal { valid: true, errors: [] }
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
Test Files  1 failed (1)
Tests  6 failed | 12 passed (18)
```
