### PR TITLE
fix: protect concurrent revisions from queued pruning

### DIFF
--- a/.changeset/safe-revision-pruning.md
+++ b/.changeset/safe-revision-pruning.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes concurrent content saves so revision pruning cannot remove newly created draft revisions.

--- a/packages/core/src/database/repositories/revision.ts
+++ b/packages/core/src/database/repositories/revision.ts
@@ -172,28 +172,39 @@ export class RevisionRepository {
 	/**
 	 * Delete old revisions, keeping the most recent N
 	 */
-	async pruneOldRevisions(collection: string, entryId: string, keepCount: number): Promise<number> {
+	async pruneOldRevisions(
+		collection: string,
+		entryId: string,
+		keepCount: number,
+		throughRevisionId?: string,
+	): Promise<number> {
 		validateIdentifier(collection, "collection");
 		const tableName = `ec_${collection}`;
-		// Get IDs of revisions to keep
-		const keep = await this.db
+		let keepQuery = this.db
 			.selectFrom("revisions")
 			.select("id")
 			.where("collection", "=", collection)
 			.where("entry_id", "=", entryId)
 			.orderBy("created_at", "desc")
 			.orderBy("id", "desc") // ULID tiebreaker
-			.limit(keepCount)
-			.execute();
+			.limit(keepCount);
+
+		if (throughRevisionId) {
+			keepQuery = keepQuery.where("id", "<=", throughRevisionId);
+		}
+
+		const keep = await keepQuery.execute();
 
 		const keepIds = keep.map((r) => r.id);
 
 		if (keepIds.length === 0) return 0;
+		const revisionBoundary = throughRevisionId ? sql`AND id <= ${throughRevisionId}` : sql``;
 
 		const result = await sql`
 			DELETE FROM revisions
 			WHERE collection = ${collection}
 			AND entry_id = ${entryId}
+			${revisionBoundary}
 			AND id NOT IN (${sql.join(keepIds.map((id) => sql`${id}`))})
 			AND NOT EXISTS (
 				SELECT 1 FROM ${sql.ref(tableName)} AS content
@@ -211,7 +222,7 @@ export class RevisionRepository {
 		queuedRevisionId: string,
 		keepCount: number,
 	): Promise<number> {
-		const pruned = await this.pruneOldRevisions(collection, entryId, keepCount);
+		const pruned = await this.pruneOldRevisions(collection, entryId, keepCount, queuedRevisionId);
 		await this.db
 			.deleteFrom("_emdash_revision_prune_queue")
 			.where("collection", "=", collection)

--- a/packages/core/tests/unit/database/repositories/revision-pruning.test.ts
+++ b/packages/core/tests/unit/database/repositories/revision-pruning.test.ts
@@ -1,0 +1,172 @@
+import type {
+	KyselyPlugin,
+	PluginTransformQueryArgs,
+	PluginTransformResultArgs,
+	QueryResult,
+	RootOperationNode,
+	UnknownRow,
+} from "kysely";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { RevisionRepository } from "../../../../src/database/repositories/revision.js";
+import type { DialectTestContext } from "../../../utils/test-db.js";
+import {
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+} from "../../../utils/test-db.js";
+
+class InsertAfterPruneSnapshotPlugin implements KyselyPlugin {
+	readonly #pruneSnapshots = new WeakSet<object>();
+	#inserted = false;
+
+	constructor(private readonly insertRevision: () => Promise<void>) {}
+
+	transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+		if (!this.#inserted && args.node.kind === "SelectQueryNode") {
+			this.#pruneSnapshots.add(args.queryId);
+		}
+		return args.node;
+	}
+
+	async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+		if (this.#pruneSnapshots.has(args.queryId)) {
+			this.#inserted = true;
+			await this.insertRevision();
+		}
+		return args.result;
+	}
+}
+
+describeEachDialect("RevisionRepository pruning", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("does not delete a revision inserted after the queued prune snapshot", async () => {
+		const revisions = new RevisionRepository(ctx.db);
+		const entryId = "concurrent-save";
+		const timestamp = new Date().toISOString();
+		await ctx.db
+			.insertInto("ec_post")
+			.values({
+				id: entryId,
+				slug: entryId,
+				status: "published",
+				created_at: timestamp,
+				updated_at: timestamp,
+				version: 1,
+			})
+			.execute();
+
+		const live = await revisions.create({
+			collection: "post",
+			entryId,
+			data: { title: "Live" },
+		});
+		let queued = live;
+		for (let index = 0; index < 51; index++) {
+			queued = await revisions.create({
+				collection: "post",
+				entryId,
+				data: { title: `History ${index}` },
+			});
+		}
+		await ctx.db
+			.updateTable("ec_post")
+			.set({ live_revision_id: live.id })
+			.where("id", "=", entryId)
+			.execute();
+
+		let concurrentRevisionId: string | undefined;
+		const plugin = new InsertAfterPruneSnapshotPlugin(async () => {
+			const concurrent = await revisions.create({
+				collection: "post",
+				entryId,
+				data: { title: "Concurrent draft" },
+			});
+			concurrentRevisionId = concurrent.id;
+		});
+		const pruning = new RevisionRepository(ctx.db.withPlugin(plugin));
+
+		const pruned = await pruning.pruneQueuedEntry("post", entryId, queued.id, 50);
+
+		expect(pruned).toBe(1);
+		expect(concurrentRevisionId).toBeDefined();
+		expect(await revisions.findById(concurrentRevisionId!)).not.toBeNull();
+		await ctx.db
+			.updateTable("ec_post")
+			.set({ draft_revision_id: concurrentRevisionId })
+			.where("id", "=", entryId)
+			.execute();
+		expect(
+			await ctx.db
+				.selectFrom("ec_post")
+				.select("draft_revision_id")
+				.where("id", "=", entryId)
+				.executeTakeFirst(),
+		).toEqual({ draft_revision_id: concurrentRevisionId });
+		expect(
+			await ctx.db
+				.selectFrom("_emdash_revision_prune_queue")
+				.select("revision_id")
+				.where("collection", "=", "post")
+				.where("entry_id", "=", entryId)
+				.executeTakeFirst(),
+		).toEqual({ revision_id: concurrentRevisionId });
+	});
+
+	it("prunes through the queued revision while preserving referenced live and draft revisions", async () => {
+		const revisions = new RevisionRepository(ctx.db);
+		const entryId = "referenced-revisions";
+		const timestamp = new Date().toISOString();
+		await ctx.db
+			.insertInto("ec_post")
+			.values({
+				id: entryId,
+				slug: entryId,
+				status: "published",
+				created_at: timestamp,
+				updated_at: timestamp,
+				version: 1,
+			})
+			.execute();
+
+		const live = await revisions.create({
+			collection: "post",
+			entryId,
+			data: { title: "Old live" },
+		});
+		const draft = await revisions.create({
+			collection: "post",
+			entryId,
+			data: { title: "Old draft" },
+		});
+		let queued = draft;
+		for (let index = 0; index < 55; index++) {
+			queued = await revisions.create({
+				collection: "post",
+				entryId,
+				data: { title: `History ${index}` },
+			});
+		}
+		await ctx.db
+			.updateTable("ec_post")
+			.set({ live_revision_id: live.id, draft_revision_id: draft.id })
+			.where("id", "=", entryId)
+			.execute();
+
+		const pruned = await revisions.pruneQueuedEntry("post", entryId, queued.id, 10);
+
+		expect(pruned).toBe(45);
+		expect(await revisions.countByEntry("post", entryId)).toBe(12);
+		expect(await revisions.findById(live.id)).not.toBeNull();
+		expect(await revisions.findById(draft.id)).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Bounds queued revision pruning to the monotonic ULID of the revision that queued the work. Both the retention snapshot and deletion ignore later revisions, so a concurrent save cannot lose its newly inserted draft between revision creation and `draft_revision_id` assignment.

Adds a deterministic database-plugin interleaving test that inserts a concurrent revision after the prune keep-list query returns and before deletion begins. The dialect-parametric coverage also verifies retention and protection of referenced live/draft revisions.

Closes #2420

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Localization and a feature Discussion are not applicable because this is a core database bug fix with no user-visible strings or new feature behavior.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No screenshots; this change has no visual surface.

Validated locally:

- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm lint:quick`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `pnpm exec vitest run tests/unit/database/repositories/revision-pruning.test.ts tests/unit/cleanup.test.ts tests/integration/content/revision-retention.test.ts` → 14 tests passed

The new suite uses `describeEachDialect`; SQLite ran locally, and PostgreSQL runs when `EMDASH_TEST_PG` is configured.
