### PR TITLE
Fix runtime validation for repeater fields

### DIFF
--- a/.changeset/quiet-otters-validate.md
+++ b/.changeset/quiet-otters-validate.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes content saves accepting repeater values that violate item limits or nested field requirements.

--- a/packages/core/src/schema/zod-generator.ts
+++ b/packages/core/src/schema/zod-generator.ts
@@ -1,7 +1,7 @@
 import { z, type ZodTypeAny } from "zod";
 
 import { hashString } from "../utils/hash.js";
-import type { Field, FieldType, CollectionWithFields } from "./types.js";
+import type { CollectionWithFields, Field, FieldType, RepeaterSubField } from "./types.js";
 
 /** Pattern to split on underscores, hyphens, and spaces for PascalCase conversion */
 const PASCAL_CASE_SPLIT_PATTERN = /[_\-\s]+/;
@@ -58,7 +58,7 @@ export function generateFieldSchema(field: Field): ZodTypeAny {
 /**
  * Get base Zod schema for a field type
  */
-function getBaseSchema(type: FieldType, field: Field): ZodTypeAny {
+function getBaseSchema(type: FieldType, field: Pick<Field, "validation">): ZodTypeAny {
 	switch (type) {
 		case "url":
 			return z.string().url();
@@ -113,6 +113,9 @@ function getBaseSchema(type: FieldType, field: Field): ZodTypeAny {
 			}
 			return z.array(z.string());
 		}
+
+		case "repeater":
+			return z.array(generateRepeaterRowSchema(field.validation?.subFields ?? []));
 
 		case "portableText":
 			// Portable Text is an array of blocks. We require `_type` because
@@ -175,6 +178,29 @@ function getBaseSchema(type: FieldType, field: Field): ZodTypeAny {
 	}
 }
 
+function generateRepeaterRowSchema(
+	subFields: readonly RepeaterSubField[],
+): z.ZodObject<Record<string, ZodTypeAny>> {
+	const shape: Record<string, ZodTypeAny> = {};
+
+	for (const subField of subFields) {
+		let schema = getBaseSchema(subField.type, {
+			validation: subField.options ? { options: subField.options } : undefined,
+		});
+
+		if (subField.required && schema instanceof z.ZodString) {
+			schema = schema.min(1, "required (empty value not allowed)");
+		}
+		if (!subField.required) {
+			schema = schema.nullish();
+		}
+
+		shape[subField.slug] = schema;
+	}
+
+	return z.object(shape).passthrough();
+}
+
 /**
  * Apply validation rules to a schema
  */
@@ -207,6 +233,17 @@ function applyValidation(schema: ZodTypeAny, field: Field): ZodTypeAny {
 			numSchema = numSchema.max(validation.max);
 		}
 		return numSchema;
+	}
+
+	if (field.type === "repeater" && schema instanceof z.ZodArray) {
+		let arraySchema = schema;
+		if (validation.minItems !== undefined) {
+			arraySchema = arraySchema.min(validation.minItems);
+		}
+		if (validation.maxItems !== undefined) {
+			arraySchema = arraySchema.max(validation.maxItems);
+		}
+		return arraySchema;
 	}
 
 	return schema;

--- a/packages/core/tests/integration/content/repeater-validation.test.ts
+++ b/packages/core/tests/integration/content/repeater-validation.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import type { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { createTestRuntime } from "../../utils/mcp-runtime.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+const requiredValues = {
+	name: "First row",
+	details: "Required details",
+};
+
+const invalidRepeaterValues: Array<{ name: string; rows: unknown[] }> = [
+	{ name: "below minItems", rows: [] },
+	{
+		name: "above maxItems",
+		rows: [requiredValues, requiredValues, requiredValues],
+	},
+	{
+		name: "missing a required nested key",
+		rows: [{ name: "Missing details" }],
+	},
+	{
+		name: "containing a blank required nested string",
+		rows: [{ name: "", details: "Present" }],
+	},
+	{
+		name: "containing blank required nested text",
+		rows: [{ name: "Present", details: "" }],
+	},
+	{
+		name: "containing the wrong nested type",
+		rows: [{ ...requiredValues, count: "two" }],
+	},
+];
+
+const validRows = [
+	{
+		...requiredValues,
+		website: "https://example.com",
+		amount: 1.5,
+		count: 2,
+		active: true,
+		startsAt: "2026-08-13T12:00:00Z",
+		category: "news",
+		futureField: { preserved: true },
+	},
+	{
+		name: "Optional values",
+		details: "May be omitted or null",
+		website: null,
+		count: null,
+	},
+];
+
+describeEachDialect("repeater runtime validation", (dialect) => {
+	let ctx: DialectTestContext;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		const registry = new SchemaRegistry(ctx.db);
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", {
+			slug: "rows",
+			label: "Rows",
+			type: "repeater",
+			required: true,
+			validation: {
+				minItems: 1,
+				maxItems: 2,
+				subFields: [
+					{ slug: "name", type: "string", label: "Name", required: true },
+					{ slug: "details", type: "text", label: "Details", required: true },
+					{ slug: "website", type: "url", label: "Website" },
+					{ slug: "amount", type: "number", label: "Amount" },
+					{ slug: "count", type: "integer", label: "Count" },
+					{ slug: "active", type: "boolean", label: "Active" },
+					{ slug: "startsAt", type: "datetime", label: "Starts at" },
+					{
+						slug: "category",
+						type: "select",
+						label: "Category",
+						options: ["news", "guide"],
+					},
+				],
+			},
+		});
+		runtime = createTestRuntime(ctx.db);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it.each(invalidRepeaterValues)("rejects create values $name", async ({ rows }) => {
+		const result = await runtime.handleContentCreate("posts", {
+			slug: "invalid-create",
+			data: { rows },
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.code).toBe("VALIDATION_ERROR");
+	});
+
+	it.each(invalidRepeaterValues)("rejects update values $name", async ({ rows }) => {
+		const created = await runtime.handleContentCreate("posts", {
+			slug: "update-target",
+			data: { rows: [requiredValues] },
+		});
+		expect(created.success).toBe(true);
+		if (!created.success) return;
+
+		const result = await runtime.handleContentUpdate("posts", created.data.item.id, {
+			data: { rows },
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.code).toBe("VALIDATION_ERROR");
+	});
+
+	it("accepts valid create values, nullish optional fields, and unknown row keys", async () => {
+		const result = await runtime.handleContentCreate("posts", {
+			slug: "valid-create",
+			data: { rows: validRows },
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.item.data.rows).toEqual(validRows);
+	});
+
+	it("accepts valid update values, omitted optional fields, and unknown row keys", async () => {
+		const created = await runtime.handleContentCreate("posts", {
+			slug: "valid-update",
+			data: { rows: [requiredValues] },
+		});
+		expect(created.success).toBe(true);
+		if (!created.success) return;
+
+		const result = await runtime.handleContentUpdate("posts", created.data.item.id, {
+			data: { rows: validRows },
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.item.data.rows).toEqual(validRows);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Enforces registered repeater schemas during runtime content validation. Repeater rows now use the existing scalar schemas for nested fields, reject missing or empty required values, and enforce `minItems`/`maxItems` on both create and update while preserving unknown row keys for forward compatibility.

Adds behavioral regressions for invalid bounds, required nested values, nested types, optional values, valid values, and unknown row keys across both save paths.

Closes #2378

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Internationalization is not applicable because this change adds no admin UI or user-visible UI strings. A feature Discussion is not applicable because this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No screenshots are applicable; this has no visual changes.

- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter emdash test --run tests/integration/content/repeater-validation.test.ts tests/unit/schema/zod-generator.test.ts` → 41 passed
