### PR TITLE
Fix taxonomy filter detection across collections

### DIFF
--- a/.changeset/calm-taxonomy-filters.md
+++ b/.changeset/calm-taxonomy-filters.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes live collection filters so taxonomy names attached only to other collections no longer override matching content fields.

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -293,37 +293,55 @@ function getTableName(type: string): string {
 }
 
 /**
- * Cache for taxonomy names (only used for the primary database).
+ * Cache for taxonomy names by collection (only used for the primary database).
  * Skipped when a per-request DB override is active (e.g. preview mode)
  * because the override DB may have different taxonomies.
  */
-let taxonomyNames: Set<string> | null = null;
+let taxonomyNamesByCollection: Map<string, Set<string>> | null = null;
 
 /**
- * Get all taxonomy names (cached for the primary DB, bypassed only when
- * the per-request DB is an isolated instance — playground / DO preview).
- * Plain D1 Sessions routing shares schema with the singleton, so the
- * module-scoped cache stays valid.
+ * Get taxonomy names attached to a collection (cached for the primary DB,
+ * bypassed only when the per-request DB is an isolated instance — playground /
+ * DO preview). Plain D1 Sessions routing shares schema with the singleton, so
+ * the module-scoped cache stays valid.
  */
-async function getTaxonomyNames(db: Kysely<Database>): Promise<Set<string>> {
+async function getTaxonomyNames(db: Kysely<Database>, collection: string): Promise<Set<string>> {
 	const hasIsolatedDb = getRequestContext()?.dbIsIsolated === true;
 
-	if (!hasIsolatedDb && taxonomyNames) {
-		return taxonomyNames;
+	if (!hasIsolatedDb && taxonomyNamesByCollection) {
+		return taxonomyNamesByCollection.get(collection) ?? new Set();
 	}
 
 	try {
-		const defs = await db.selectFrom("_emdash_taxonomy_defs").select("name").execute();
-		const names = new Set(defs.map((d) => d.name));
-		if (!hasIsolatedDb) {
-			taxonomyNames = names;
+		const defs = await db
+			.selectFrom("_emdash_taxonomy_defs")
+			.select(["name", "collections"])
+			.execute();
+		const namesByCollection = new Map<string, Set<string>>();
+		for (const def of defs) {
+			let collections: unknown;
+			try {
+				collections = JSON.parse(def.collections ?? "[]");
+			} catch {
+				continue;
+			}
+			if (!Array.isArray(collections)) continue;
+			for (const attachedCollection of collections) {
+				if (typeof attachedCollection !== "string") continue;
+				const names = namesByCollection.get(attachedCollection) ?? new Set<string>();
+				names.add(def.name);
+				namesByCollection.set(attachedCollection, names);
+			}
 		}
-		return names;
+		if (!hasIsolatedDb) {
+			taxonomyNamesByCollection = namesByCollection;
+		}
+		return namesByCollection.get(collection) ?? new Set();
 	} catch {
 		// Table doesn't exist yet, return empty set
 		const empty = new Set<string>();
 		if (!hasIsolatedDb) {
-			taxonomyNames = empty;
+			taxonomyNamesByCollection = new Map();
 		}
 		return empty;
 	}
@@ -338,7 +356,7 @@ async function getTaxonomyNames(db: Kysely<Database>): Promise<Set<string>> {
  * isolate-wide taxonomy-defs cache in `taxonomies/index.ts`.
  */
 export function resetTaxonomyNamesCache(): void {
-	taxonomyNames = null;
+	taxonomyNamesByCollection = null;
 }
 
 /**
@@ -1153,7 +1171,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 				const fieldFilters: Record<string, WhereValue> = {};
 
 				if (where && Object.keys(where).length > 0) {
-					const taxNames = await getTaxonomyNames(db);
+					const taxNames = await getTaxonomyNames(db, type);
 
 					for (const [key, value] of Object.entries(where)) {
 						if (value == null) continue;

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -294,22 +294,40 @@ function getTableName(type: string): string {
 
 /**
  * Cache for taxonomy names by collection (only used for the primary database).
- * Skipped when a per-request DB override is active (e.g. preview mode)
+ * Stored on globalThis so Vite SSR chunk duplication cannot create independent
+ * caches. Skipped when a per-request DB override is active (e.g. preview mode)
  * because the override DB may have different taxonomies.
  */
-let taxonomyNamesByCollection: Map<string, Set<string>> | null = null;
+interface TaxonomyNamesHolder {
+	cache: Map<string, Set<string>> | null;
+}
+
+const TAXONOMY_NAMES_CACHE_KEY = Symbol.for("emdash:taxonomy-names");
+const taxonomyNamesStore = globalThis as Record<symbol, unknown>;
+const taxonomyNamesHolder: TaxonomyNamesHolder =
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern (see taxonomies/index.ts)
+	(taxonomyNamesStore[TAXONOMY_NAMES_CACHE_KEY] as TaxonomyNamesHolder | undefined) ??
+	(() => {
+		const holder: TaxonomyNamesHolder = { cache: null };
+		taxonomyNamesStore[TAXONOMY_NAMES_CACHE_KEY] = holder;
+		return holder;
+	})();
+
+function setTaxonomyNamesCache(cache: Map<string, Set<string>> | null): void {
+	taxonomyNamesHolder.cache = cache;
+}
 
 /**
  * Get taxonomy names attached to a collection (cached for the primary DB,
  * bypassed only when the per-request DB is an isolated instance — playground /
  * DO preview). Plain D1 Sessions routing shares schema with the singleton, so
- * the module-scoped cache stays valid.
+ * the isolate-wide cache stays valid.
  */
 async function getTaxonomyNames(db: Kysely<Database>, collection: string): Promise<Set<string>> {
 	const hasIsolatedDb = getRequestContext()?.dbIsIsolated === true;
 
-	if (!hasIsolatedDb && taxonomyNamesByCollection) {
-		return taxonomyNamesByCollection.get(collection) ?? new Set();
+	if (!hasIsolatedDb && taxonomyNamesHolder.cache) {
+		return taxonomyNamesHolder.cache.get(collection) ?? new Set();
 	}
 
 	try {
@@ -334,21 +352,22 @@ async function getTaxonomyNames(db: Kysely<Database>, collection: string): Promi
 			}
 		}
 		if (!hasIsolatedDb) {
-			taxonomyNamesByCollection = namesByCollection;
+			setTaxonomyNamesCache(namesByCollection);
 		}
 		return namesByCollection.get(collection) ?? new Set();
-	} catch {
-		// Table doesn't exist yet, return empty set
+	} catch (error) {
+		if (!isMissingTableError(error) && !isMissingColumnError(error)) throw error;
+
 		const empty = new Set<string>();
 		if (!hasIsolatedDb) {
-			taxonomyNamesByCollection = new Map();
+			setTaxonomyNamesCache(new Map());
 		}
 		return empty;
 	}
 }
 
 /**
- * Reset the module-scoped taxonomy-names cache.
+ * Reset the isolate-wide taxonomy-names cache.
  *
  * Called from `invalidateTaxonomyDefsCache()` so that creating or seeding a
  * taxonomy definition is reflected within the current isolate instead of
@@ -356,7 +375,7 @@ async function getTaxonomyNames(db: Kysely<Database>, collection: string): Promi
  * isolate-wide taxonomy-defs cache in `taxonomies/index.ts`.
  */
 export function resetTaxonomyNamesCache(): void {
-	taxonomyNamesByCollection = null;
+	setTaxonomyNamesCache(null);
 }
 
 /**

--- a/packages/core/tests/integration/loader-taxonomy-pivot-plan.test.ts
+++ b/packages/core/tests/integration/loader-taxonomy-pivot-plan.test.ts
@@ -21,7 +21,7 @@ import { runMigrations } from "../../src/database/migrations/runner.js";
 import { ContentRepository } from "../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
 import type { Database as DatabaseSchema } from "../../src/database/types.js";
-import { emdashLoader } from "../../src/loader.js";
+import { emdashLoader, resetTaxonomyNamesCache } from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
 import { SchemaRegistry } from "../../src/schema/registry.js";
 
@@ -48,6 +48,12 @@ beforeEach(async () => {
 
 	// Deliberately no ANALYZE: matches D1, which never maintains sqlite_stat1.
 	await runMigrations(db);
+	await db
+		.updateTable("_emdash_taxonomy_defs")
+		.set({ collections: JSON.stringify(["post"]) })
+		.where("name", "in", ["category", "tag"])
+		.execute();
+	resetTaxonomyNamesCache();
 	const registry = new SchemaRegistry(db);
 	await registry.createCollection({ slug: "post", label: "Posts", labelSingular: "Post" });
 	await registry.createField("post", { slug: "title", label: "Title", type: "string" });

--- a/packages/core/tests/unit/loader-byline-filter.test.ts
+++ b/packages/core/tests/unit/loader-byline-filter.test.ts
@@ -4,7 +4,7 @@ import { it, expect, beforeEach, afterEach } from "vitest";
 import { handleContentCreate } from "../../src/api/index.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
 import type { Database } from "../../src/database/types.js";
-import { emdashLoader } from "../../src/loader.js";
+import { emdashLoader, resetTaxonomyNamesCache } from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
 import { SchemaRegistry } from "../../src/schema/registry.js";
 import {
@@ -24,6 +24,12 @@ describeEachDialect("Loader byline credit filter", (dialectName: DialectName) =>
 		ctx = await setupForDialectWithCollections(dialectName);
 		db = ctx.db;
 		creditSeq = 0;
+		await db
+			.updateTable("_emdash_taxonomy_defs")
+			.set({ collections: JSON.stringify(["post"]) })
+			.where("name", "in", ["category", "tag"])
+			.execute();
+		resetTaxonomyNamesCache();
 		// Add a 'series' field so we can test byline + field combinations.
 		const registry = new SchemaRegistry(db);
 		await registry.createField("post", {

--- a/packages/core/tests/unit/loader-field-filters.test.ts
+++ b/packages/core/tests/unit/loader-field-filters.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { handleContentCreate } from "../../src/api/index.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
 import type { Database } from "../../src/database/types.js";
-import { emdashLoader } from "../../src/loader.js";
+import { emdashLoader, resetTaxonomyNamesCache } from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
 import { SchemaRegistry } from "../../src/schema/registry.js";
 import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
@@ -14,6 +14,12 @@ describe("Loader field filters", () => {
 
 	beforeEach(async () => {
 		db = await setupTestDatabaseWithCollections();
+		await db
+			.updateTable("_emdash_taxonomy_defs")
+			.set({ collections: JSON.stringify(["post"]) })
+			.where("name", "in", ["category", "tag"])
+			.execute();
+		resetTaxonomyNamesCache();
 		// Add a 'series' field to the post collection for field filtering tests
 		const registry = new SchemaRegistry(db);
 		await registry.createField("post", {

--- a/packages/core/tests/unit/loader-taxonomy-filter.test.ts
+++ b/packages/core/tests/unit/loader-taxonomy-filter.test.ts
@@ -140,6 +140,42 @@ describeEachDialect("Loader taxonomy term filter", (dialectName: DialectName) =>
 		expect(result.entries[0]!.data.title).toBe("News Page");
 	});
 
+	it("surfaces an unexpected definition-query failure without poisoning the cache", async () => {
+		const news = await term("category", "news");
+		const post = await createPost("In News");
+		await tag(post.id, news);
+
+		let failNextQuery = true;
+		const flakyDb = db.withPlugin({
+			transformQuery(args) {
+				if (failNextQuery) {
+					failNextQuery = false;
+					throw new Error("temporary database outage");
+				}
+				return args.node;
+			},
+			async transformResult(args) {
+				return args.result;
+			},
+		});
+		const loader = emdashLoader();
+		const loadWithFlakyDb = () =>
+			runWithContext({ editMode: false, db: flakyDb }, () =>
+				loader.loadCollection!({
+					filter: { type: "post", where: { category: "news" } },
+				}),
+			);
+
+		const failed = await loadWithFlakyDb();
+		expect(failed).toMatchObject({
+			error: { message: "Failed to load collection: temporary database outage" },
+		});
+		const recovered = await loadWithFlakyDb();
+
+		expect(recovered.entries).toHaveLength(1);
+		expect(recovered.entries[0]!.data.title).toBe("In News");
+	});
+
 	it("ANDs across two taxonomies — only entries tagged in BOTH match (#1479)", async () => {
 		const news = await term("category", "news");
 		const featured = await term("tag", "featured");

--- a/packages/core/tests/unit/loader-taxonomy-filter.test.ts
+++ b/packages/core/tests/unit/loader-taxonomy-filter.test.ts
@@ -4,8 +4,9 @@ import { it, expect, beforeEach, afterEach } from "vitest";
 import { handleContentCreate } from "../../src/api/index.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
 import type { Database } from "../../src/database/types.js";
-import { emdashLoader } from "../../src/loader.js";
+import { emdashLoader, resetTaxonomyNamesCache } from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
+import { SchemaRegistry } from "../../src/schema/registry.js";
 import {
 	describeEachDialect,
 	setupForDialectWithCollections,
@@ -23,6 +24,12 @@ describeEachDialect("Loader taxonomy term filter", (dialectName: DialectName) =>
 		ctx = await setupForDialectWithCollections(dialectName);
 		db = ctx.db;
 		termSeq = 0;
+		await db
+			.updateTable("_emdash_taxonomy_defs")
+			.set({ collections: JSON.stringify(["post"]) })
+			.where("name", "in", ["category", "tag"])
+			.execute();
+		resetTaxonomyNamesCache();
 	});
 
 	afterEach(async () => {
@@ -92,7 +99,7 @@ describeEachDialect("Loader taxonomy term filter", (dialectName: DialectName) =>
 		return id;
 	}
 
-	it("filters by a single taxonomy term", async () => {
+	it("filters by a taxonomy attached to the queried collection", async () => {
 		const news = await term("category", "news");
 		const a = await createPost("In News");
 		await createPost("Untagged");
@@ -102,6 +109,35 @@ describeEachDialect("Loader taxonomy term filter", (dialectName: DialectName) =>
 
 		expect(result.entries).toHaveLength(1);
 		expect(result.entries[0]!.data.title).toBe("In News");
+	});
+
+	it("treats a taxonomy name attached to another collection as an ordinary field", async () => {
+		const registry = new SchemaRegistry(db);
+		await registry.createField("page", {
+			slug: "category",
+			label: "Category",
+			type: "string",
+		});
+		const matching = await handleContentCreate(db, "page", {
+			data: { title: "News Page", category: "news" },
+			status: "published",
+		});
+		if (!matching.success) throw new Error("Failed to create page");
+		const other = await handleContentCreate(db, "page", {
+			data: { title: "Other Page", category: "other" },
+			status: "published",
+		});
+		if (!other.success) throw new Error("Failed to create page");
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "page", where: { category: "news" } },
+			}),
+		);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0]!.data.title).toBe("News Page");
 	});
 
 	it("ANDs across two taxonomies — only entries tagged in BOTH match (#1479)", async () => {

--- a/packages/core/tests/unit/loader-taxonomy-pivot.test.ts
+++ b/packages/core/tests/unit/loader-taxonomy-pivot.test.ts
@@ -20,7 +20,11 @@ import { afterEach, beforeEach, expect, it } from "vitest";
 import { ContentRepository } from "../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
 import type { Database } from "../../src/database/types.js";
-import { buildTaxonomyPivotQuery, emdashLoader } from "../../src/loader.js";
+import {
+	buildTaxonomyPivotQuery,
+	emdashLoader,
+	resetTaxonomyNamesCache,
+} from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
 import {
 	describeEachDialect,
@@ -40,6 +44,12 @@ describeEachDialect("Loader taxonomy pivot-drive", (dialectName: DialectName) =>
 	beforeEach(async () => {
 		ctx = await setupForDialectWithCollections(dialectName);
 		db = ctx.db;
+		await db
+			.updateTable("_emdash_taxonomy_defs")
+			.set({ collections: JSON.stringify(["post"]) })
+			.where("name", "in", ["category", "tag"])
+			.execute();
+		resetTaxonomyNamesCache();
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- schema vs Database type
 		content = new ContentRepository(db as any);
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- schema vs Database type

--- a/scripts/query-counts.queries.d1.json
+++ b/scripts/query-counts.queries.d1.json
@@ -26,7 +26,7 @@
 	},
 	"GET /category/development (cold)": {
 		"select \"a\".\"id\" as \"a_id\", \"a\".\"name\" as \"a_name\", \"a\".\"label\" as \"a_label\", \"a\".\"description\" as \"a_description\", \"w\".\"id\" as \"w_id\", \"w\".\"type\" as \"w_type\", \"w\".\"title\" as \"w_title\", \"w\".\"content\" as \"w_content\", \"w\".\"menu_name\" as \"w_menu_name\", \"w\".\"component_id\" as \"w_component_id\", \"w\".\"component_props\" as \"w_component_props\", \"w\".\"area_id\" as \"w_area_id\", \"w\".\"sort_order\" as \"w_sort_order\", \"w\".\"created_at\" as \"w_created_at\" from \"_emdash_widget_areas\" as \"a\" left join \"_emdash_widgets\" as \"w\" on \"w\".\"area_id\" = \"a\".\"id\" where \"a\".\"name\" = ? order by \"w\".\"sort_order\" asc": 1,
-		"select \"name\" from \"_emdash_taxonomy_defs\"": 1,
+		"select \"name\", \"collections\" from \"_emdash_taxonomy_defs\"": 1,
 		"select \"name\", \"value\" from \"options\" where \"name\" in (...)": 2,
 		"select \"name\", \"value\" from \"options\" where name LIKE ? ESCAPE '\\'": 1,
 		"select \"plugin_id\", \"status\" from \"_plugin_state\"": 1,
@@ -256,7 +256,7 @@
 	},
 	"GET /tag/webdev (cold)": {
 		"select \"a\".\"id\" as \"a_id\", \"a\".\"name\" as \"a_name\", \"a\".\"label\" as \"a_label\", \"a\".\"description\" as \"a_description\", \"w\".\"id\" as \"w_id\", \"w\".\"type\" as \"w_type\", \"w\".\"title\" as \"w_title\", \"w\".\"content\" as \"w_content\", \"w\".\"menu_name\" as \"w_menu_name\", \"w\".\"component_id\" as \"w_component_id\", \"w\".\"component_props\" as \"w_component_props\", \"w\".\"area_id\" as \"w_area_id\", \"w\".\"sort_order\" as \"w_sort_order\", \"w\".\"created_at\" as \"w_created_at\" from \"_emdash_widget_areas\" as \"a\" left join \"_emdash_widgets\" as \"w\" on \"w\".\"area_id\" = \"a\".\"id\" where \"a\".\"name\" = ? order by \"w\".\"sort_order\" asc": 1,
-		"select \"name\" from \"_emdash_taxonomy_defs\"": 1,
+		"select \"name\", \"collections\" from \"_emdash_taxonomy_defs\"": 1,
 		"select \"name\", \"value\" from \"options\" where \"name\" in (...)": 2,
 		"select \"name\", \"value\" from \"options\" where name LIKE ? ESCAPE '\\'": 1,
 		"select \"plugin_id\", \"status\" from \"_plugin_state\"": 1,

--- a/scripts/query-counts.queries.sqlite.json
+++ b/scripts/query-counts.queries.sqlite.json
@@ -17,7 +17,7 @@
 	},
 	"GET /category/development (cold)": {
 		"select \"a\".\"id\" as \"a_id\", \"a\".\"name\" as \"a_name\", \"a\".\"label\" as \"a_label\", \"a\".\"description\" as \"a_description\", \"w\".\"id\" as \"w_id\", \"w\".\"type\" as \"w_type\", \"w\".\"title\" as \"w_title\", \"w\".\"content\" as \"w_content\", \"w\".\"menu_name\" as \"w_menu_name\", \"w\".\"component_id\" as \"w_component_id\", \"w\".\"component_props\" as \"w_component_props\", \"w\".\"area_id\" as \"w_area_id\", \"w\".\"sort_order\" as \"w_sort_order\", \"w\".\"created_at\" as \"w_created_at\" from \"_emdash_widget_areas\" as \"a\" left join \"_emdash_widgets\" as \"w\" on \"w\".\"area_id\" = \"a\".\"id\" where \"a\".\"name\" = ? order by \"w\".\"sort_order\" asc": 1,
-		"select \"name\" from \"_emdash_taxonomy_defs\"": 1,
+		"select \"name\", \"collections\" from \"_emdash_taxonomy_defs\"": 1,
 		"select \"value\" from \"options\" where \"name\" = ?": 1,
 		"select * from \"_emdash_menu_items\" where \"menu_id\" = ? order by \"sort_order\" asc": 1,
 		"select * from \"_emdash_menus\" where \"name\" = ? order by \"locale\" asc": 1,


### PR DESCRIPTION
## What does this PR do?

Scopes live-loader taxonomy filter detection to taxonomy definitions attached to the queried collection. A taxonomy name used only by another collection can no longer hijack an ordinary content-field filter.

The existing cold taxonomy-definition query now reads attachment metadata and builds a cached collection-to-name map, so this does not add a logged-out query round trip.

Closes #2357

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI changes or user-visible strings.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No visual changes.

Validation:

- `pnpm --filter emdash exec vitest run tests/unit/loader-taxonomy-filter.test.ts tests/unit/loader-field-filters.test.ts tests/unit/loader-taxonomy-pivot.test.ts` — 42 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:quick`
- `pnpm lint:json | jq '.diagnostics | length'` — 0 diagnostics
- `pnpm format`
