### PR TITLE
fix: preserve revisionless content on publish

### DIFF
--- a/.changeset/calm-pandas-publish.md
+++ b/.changeset/calm-pandas-publish.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes publishing collections without revision support so current content remains intact.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -88,6 +88,19 @@ async function collectionHasSeo(db: Kysely<Database>, collection: string): Promi
 	return row?.has_seo === 1;
 }
 
+async function collectionSupportsRevisions(
+	db: Kysely<Database>,
+	collection: string,
+): Promise<boolean> {
+	const row = await db
+		.selectFrom("_emdash_collections")
+		.select("supports")
+		.where("slug", "=", collection)
+		.executeTakeFirst();
+	const supports: unknown = row?.supports ? JSON.parse(row.supports) : [];
+	return Array.isArray(supports) && supports.includes("revisions");
+}
+
 /**
  * Hydrate SEO data on a single content item if the collection has SEO enabled.
  */
@@ -1527,6 +1540,7 @@ export async function handleContentPublish(
 		const item = await withTransaction(db, async (trx) => {
 			const repo = new ContentRepository(trx);
 			const resolvedId = (await resolveId(repo, collection, id)) ?? id;
+			const supportsRevisions = await collectionSupportsRevisions(trx, collection);
 
 			// Capture the pre-publish state. For revision-supporting collections a
 			// slug edit is staged as `_slug` in the draft revision and only lands
@@ -1541,6 +1555,7 @@ export async function handleContentPublish(
 				options.publishedAt,
 				options.requireScheduledDue,
 				options.expectedScheduledAt,
+				supportsRevisions,
 			);
 
 			// Leave a 301 behind when publishing changed the slug of an entry that

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -73,6 +73,7 @@ function matchesPublication(
 function matchesLifecyclePublication(
 	observed: ContentItem,
 	existing: ContentItem,
+	liveRevisionId: string,
 	publishedAt: string,
 	updatedAt: string,
 ): boolean {
@@ -80,8 +81,8 @@ function matchesLifecyclePublication(
 		observed.version !== existing.version + 1 ||
 		observed.status !== "published" ||
 		observed.slug !== existing.slug ||
-		observed.liveRevisionId !== existing.liveRevisionId ||
-		observed.draftRevisionId !== existing.draftRevisionId ||
+		observed.liveRevisionId !== liveRevisionId ||
+		observed.draftRevisionId !== null ||
 		observed.scheduledAt !== null ||
 		observed.publishedAt !== publishedAt ||
 		observed.updatedAt !== updatedAt
@@ -1492,62 +1493,97 @@ export class ContentRepository {
 		}
 
 		if (!promoteRevision) {
-			const intendedPublishedAt = publishedAt ?? existing.publishedAt ?? now;
-			const duePredicate = requireDue
-				? sql`AND scheduled_at IS NOT NULL AND scheduled_at <= ${now}`
-				: sql``;
-			let published = false;
+			const revisionRepo = new RevisionRepository(this.db);
+			let provisionalRevisionId: string | null = null;
 			try {
-				const result = await sql`
-					UPDATE ${sql.ref(tableName)}
-					SET status = 'published',
-						scheduled_at = NULL,
-						published_at = ${intendedPublishedAt},
-						updated_at = ${now},
-						version = version + 1
-					WHERE id = ${id}
-					AND deleted_at IS NULL
-					AND version = ${existing.version}
-					AND status = ${existing.status}
-					AND ${nullableColumnMatch("live_revision_id", existing.liveRevisionId)}
-					AND ${nullableColumnMatch("draft_revision_id", existing.draftRevisionId)}
-					AND ${nullableColumnMatch("scheduled_at", existing.scheduledAt)}
-					${duePredicate}
-				`.execute(this.db);
-				published = (result.numAffectedRows ?? 0n) > 0n;
-			} catch (error) {
-				if (isConfirmedStatementFailure(error)) throw error;
-				let observed: ContentItem | null;
+				let liveRevisionId = existing.liveRevisionId;
+				if (!liveRevisionId) {
+					const revision = await revisionRepo.create({
+						collection: type,
+						entryId: id,
+						data: existing.data,
+					});
+					liveRevisionId = revision.id;
+					provisionalRevisionId = revision.id;
+				}
+
+				const intendedPublishedAt = publishedAt ?? existing.publishedAt ?? now;
+				const duePredicate = requireDue
+					? sql`AND scheduled_at IS NOT NULL AND scheduled_at <= ${now}`
+					: sql``;
+				let published = false;
 				try {
-					observed = await this.findById(type, id);
-				} catch (reconciliationError) {
-					throw new Error("Unable to confirm whether content publication completed", {
-						cause: reconciliationError,
-					});
+					const result = await sql`
+						UPDATE ${sql.ref(tableName)}
+						SET live_revision_id = ${liveRevisionId},
+							draft_revision_id = NULL,
+							status = 'published',
+							scheduled_at = NULL,
+							published_at = ${intendedPublishedAt},
+							updated_at = ${now},
+							version = version + 1
+						WHERE id = ${id}
+						AND deleted_at IS NULL
+						AND version = ${existing.version}
+						AND status = ${existing.status}
+						AND ${nullableColumnMatch("live_revision_id", existing.liveRevisionId)}
+						AND ${nullableColumnMatch("draft_revision_id", existing.draftRevisionId)}
+						AND ${nullableColumnMatch("scheduled_at", existing.scheduledAt)}
+						${duePredicate}
+					`.execute(this.db);
+					published = (result.numAffectedRows ?? 0n) > 0n;
+				} catch (error) {
+					if (isConfirmedStatementFailure(error)) throw error;
+					let observed: ContentItem | null;
+					try {
+						observed = await this.findById(type, id);
+					} catch (reconciliationError) {
+						throw new Error("Unable to confirm whether content publication completed", {
+							cause: reconciliationError,
+						});
+					}
+					if (!observed) {
+						throw new Error("Unable to confirm whether content publication completed", {
+							cause: error,
+						});
+					}
+					published = matchesLifecyclePublication(
+						observed,
+						existing,
+						liveRevisionId,
+						intendedPublishedAt,
+						now,
+					);
+					if (!published && matchesPublicationFence(observed, existing)) throw error;
+					if (!published) {
+						throw new Error("Unable to confirm whether content publication completed", {
+							cause: error,
+						});
+					}
 				}
-				if (!observed) {
-					throw new Error("Unable to confirm whether content publication completed", {
-						cause: error,
-					});
-				}
-				published = matchesLifecyclePublication(observed, existing, intendedPublishedAt, now);
-				if (!published && matchesPublicationFence(observed, existing)) throw error;
+
 				if (!published) {
-					throw new Error("Unable to confirm whether content publication completed", {
-						cause: error,
-					});
+					throw requireDue ? new ScheduledNotDueError() : new ContentMutationConflictError();
 				}
-			}
 
-			if (!published) {
-				throw requireDue ? new ScheduledNotDueError() : new ContentMutationConflictError();
+				invalidateCollectionCache(type);
+				await this.restampEntryPivot(type, id);
+				const updated = await this.findById(type, id);
+				if (!updated) throw new Error("Content not found");
+				return updated;
+			} catch (error) {
+				if (provisionalRevisionId) {
+					try {
+						await revisionRepo.deleteIfUnreferenced(type, id, provisionalRevisionId);
+					} catch (cleanupError) {
+						console.error(
+							`[content] Failed to clean up provisional revision ${provisionalRevisionId}:`,
+							cleanupError,
+						);
+					}
+				}
+				throw error;
 			}
-
-			invalidateCollectionCache(type);
-			await this.restampEntryPivot(type, id);
-			const updated = await this.findById(type, id);
-			if (!updated) throw new Error("Content not found");
-			return updated;
 		}
 
 		const revisionRepo = new RevisionRepository(this.db);

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -70,6 +70,30 @@ function matchesPublication(
 	);
 }
 
+function matchesLifecyclePublication(
+	observed: ContentItem,
+	existing: ContentItem,
+	publishedAt: string,
+	updatedAt: string,
+): boolean {
+	if (
+		observed.version !== existing.version + 1 ||
+		observed.status !== "published" ||
+		observed.slug !== existing.slug ||
+		observed.liveRevisionId !== existing.liveRevisionId ||
+		observed.draftRevisionId !== existing.draftRevisionId ||
+		observed.scheduledAt !== null ||
+		observed.publishedAt !== publishedAt ||
+		observed.updatedAt !== updatedAt
+	) {
+		return false;
+	}
+
+	return Object.entries(existing.data).every(([key, value]) =>
+		sameStoredValue(observed.data[key], value),
+	);
+}
+
 function matchesPublicationFence(observed: ContentItem, existing: ContentItem): boolean {
 	return (
 		observed.version === existing.version &&
@@ -1431,6 +1455,8 @@ export class ContentRepository {
 	 * Syncs the draft revision's data into the content table columns so the
 	 * content table always reflects the published version.
 	 * If no draft revision exists, creates one from current data and publishes it.
+	 * When `promoteRevision` is false, publishes the current content-table data
+	 * by changing lifecycle metadata only.
 	 *
 	 * `publishedAt` (optional) overrides the publication timestamp. If omitted,
 	 * the existing `published_at` is preserved (idempotent re-publish keeps the
@@ -1448,6 +1474,7 @@ export class ContentRepository {
 		publishedAt?: string,
 		requireDue = false,
 		expectedScheduledAt?: string,
+		promoteRevision = true,
 	): Promise<ContentItem> {
 		const tableName = getTableName(type);
 		const now = new Date().toISOString();
@@ -1462,6 +1489,65 @@ export class ContentRepository {
 			existing.scheduledAt !== expectedScheduledAt
 		) {
 			throw new ScheduledNotDueError();
+		}
+
+		if (!promoteRevision) {
+			const intendedPublishedAt = publishedAt ?? existing.publishedAt ?? now;
+			const duePredicate = requireDue
+				? sql`AND scheduled_at IS NOT NULL AND scheduled_at <= ${now}`
+				: sql``;
+			let published = false;
+			try {
+				const result = await sql`
+					UPDATE ${sql.ref(tableName)}
+					SET status = 'published',
+						scheduled_at = NULL,
+						published_at = ${intendedPublishedAt},
+						updated_at = ${now},
+						version = version + 1
+					WHERE id = ${id}
+					AND deleted_at IS NULL
+					AND version = ${existing.version}
+					AND status = ${existing.status}
+					AND ${nullableColumnMatch("live_revision_id", existing.liveRevisionId)}
+					AND ${nullableColumnMatch("draft_revision_id", existing.draftRevisionId)}
+					AND ${nullableColumnMatch("scheduled_at", existing.scheduledAt)}
+					${duePredicate}
+				`.execute(this.db);
+				published = (result.numAffectedRows ?? 0n) > 0n;
+			} catch (error) {
+				if (isConfirmedStatementFailure(error)) throw error;
+				let observed: ContentItem | null;
+				try {
+					observed = await this.findById(type, id);
+				} catch (reconciliationError) {
+					throw new Error("Unable to confirm whether content publication completed", {
+						cause: reconciliationError,
+					});
+				}
+				if (!observed) {
+					throw new Error("Unable to confirm whether content publication completed", {
+						cause: error,
+					});
+				}
+				published = matchesLifecyclePublication(observed, existing, intendedPublishedAt, now);
+				if (!published && matchesPublicationFence(observed, existing)) throw error;
+				if (!published) {
+					throw new Error("Unable to confirm whether content publication completed", {
+						cause: error,
+					});
+				}
+			}
+
+			if (!published) {
+				throw requireDue ? new ScheduledNotDueError() : new ContentMutationConflictError();
+			}
+
+			invalidateCollectionCache(type);
+			await this.restampEntryPivot(type, id);
+			const updated = await this.findById(type, id);
+			if (!updated) throw new Error("Content not found");
+			return updated;
 		}
 
 		const revisionRepo = new RevisionRepository(this.db);

--- a/packages/core/tests/integration/mcp/drafts.test.ts
+++ b/packages/core/tests/integration/mcp/drafts.test.ts
@@ -307,6 +307,64 @@ describe("MCP drafts — content_get and content_update round-trip (bug #2)", ()
 	// ----- regression guard: non-revision collection still works -----
 
 	describe("non-revision-supporting collection (regression guard)", () => {
+		it("first publish preserves column data and establishes a live revision marker", async () => {
+			const created = await harness.client.callTool({
+				name: "content_create",
+				arguments: { collection: "page", data: { title: "Current title" } },
+			});
+			const id = extractJson<ItemEnvelope>(created).item.id;
+
+			const published = await harness.client.callTool({
+				name: "content_publish",
+				arguments: { collection: "page", id },
+			});
+			expect(published.isError, extractText(published)).toBeFalsy();
+
+			const got = await harness.client.callTool({
+				name: "content_get",
+				arguments: { collection: "page", id },
+			});
+			const item = extractJson<ItemEnvelope>(got).item;
+			expect(item.status).toBe("published");
+			expect(item.liveRevisionId).toBeTruthy();
+			expect(item.draftRevisionId).toBeNull();
+			expect(readTitle(item)).toBe("Current title");
+		});
+
+		it("first publish ignores an unexpected stale draft pointer", async () => {
+			const created = await harness.client.callTool({
+				name: "content_create",
+				arguments: { collection: "page", data: { title: "Current title" } },
+			});
+			const id = extractJson<ItemEnvelope>(created).item.id;
+			const revisionRepo = new RevisionRepository(db);
+			const staleDraft = await revisionRepo.create({
+				collection: "page",
+				entryId: id,
+				data: { title: "Stale draft" },
+			});
+			await sql`
+				UPDATE ${sql.ref("ec_page")}
+				SET draft_revision_id = ${staleDraft.id}
+				WHERE id = ${id}
+			`.execute(db);
+
+			const published = await harness.client.callTool({
+				name: "content_publish",
+				arguments: { collection: "page", id },
+			});
+			expect(published.isError, extractText(published)).toBeFalsy();
+
+			const item = extractJson<ItemEnvelope>(published).item;
+			expect(item.status).toBe("published");
+			expect(item.liveRevisionId).toBeTruthy();
+			expect(item.liveRevisionId).not.toBe(staleDraft.id);
+			expect(item.draftRevisionId).toBeNull();
+			expect(readTitle(item)).toBe("Current title");
+			const liveRevision = await revisionRepo.findById(item.liveRevisionId!);
+			expect(liveRevision?.data.title).toBe("Current title");
+		});
+
 		it("publishing preserves column data when live_revision_id is stale", async () => {
 			const created = await harness.client.callTool({
 				name: "content_create",
@@ -319,9 +377,15 @@ describe("MCP drafts — content_get and content_update round-trip (bug #2)", ()
 				entryId: id,
 				data: { title: "Stale title" },
 			});
+			const staleDraft = await revisionRepo.create({
+				collection: "page",
+				entryId: id,
+				data: { title: "Stale draft" },
+			});
 			await sql`
 				UPDATE ${sql.ref("ec_page")}
-				SET live_revision_id = ${staleRevision.id}
+				SET live_revision_id = ${staleRevision.id},
+					draft_revision_id = ${staleDraft.id}
 				WHERE id = ${id}
 			`.execute(db);
 
@@ -342,6 +406,7 @@ describe("MCP drafts — content_get and content_update round-trip (bug #2)", ()
 			const item = extractJson<ItemEnvelope>(got).item;
 			expect(item.status).toBe("published");
 			expect(item.liveRevisionId).toBe(staleRevision.id);
+			expect(item.draftRevisionId).toBeNull();
 			expect(readTitle(item)).toBe("Fresh title");
 		});
 

--- a/packages/core/tests/integration/mcp/drafts.test.ts
+++ b/packages/core/tests/integration/mcp/drafts.test.ts
@@ -16,9 +16,10 @@
  */
 
 import { Role } from "@emdash-cms/auth";
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { RevisionRepository } from "../../../src/database/repositories/revision.js";
 import type { Database } from "../../../src/database/types.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import {
@@ -180,21 +181,25 @@ describe("MCP drafts — content_get and content_update round-trip (bug #2)", ()
 			});
 
 			// Update creates a draft revision
-			await harness.client.callTool({
+			const updated = await harness.client.callTool({
 				name: "content_update",
 				arguments: { collection: "post", id, data: { title: "Draft change" } },
 			});
+			const draftRevisionId = extractJson<ItemEnvelope>(updated).item.draftRevisionId;
 
 			// Publish promotes draft to live
-			await harness.client.callTool({
+			const published = await harness.client.callTool({
 				name: "content_publish",
 				arguments: { collection: "post", id },
 			});
+			const publishedItem = extractJson<ItemEnvelope>(published).item;
 
 			const got = await harness.client.callTool({
 				name: "content_get",
 				arguments: { collection: "post", id },
 			});
+			expect(publishedItem.liveRevisionId).toBe(draftRevisionId);
+			expect(publishedItem.draftRevisionId).toBeNull();
 			expect(readTitle(extractJson<ItemEnvelope>(got).item)).toBe("Draft change");
 		});
 
@@ -302,6 +307,44 @@ describe("MCP drafts — content_get and content_update round-trip (bug #2)", ()
 	// ----- regression guard: non-revision collection still works -----
 
 	describe("non-revision-supporting collection (regression guard)", () => {
+		it("publishing preserves column data when live_revision_id is stale", async () => {
+			const created = await harness.client.callTool({
+				name: "content_create",
+				arguments: { collection: "page", data: { title: "Stale title" } },
+			});
+			const id = extractJson<ItemEnvelope>(created).item.id;
+			const revisionRepo = new RevisionRepository(db);
+			const staleRevision = await revisionRepo.create({
+				collection: "page",
+				entryId: id,
+				data: { title: "Stale title" },
+			});
+			await sql`
+				UPDATE ${sql.ref("ec_page")}
+				SET live_revision_id = ${staleRevision.id}
+				WHERE id = ${id}
+			`.execute(db);
+
+			await harness.client.callTool({
+				name: "content_update",
+				arguments: { collection: "page", id, data: { title: "Fresh title" } },
+			});
+			const published = await harness.client.callTool({
+				name: "content_publish",
+				arguments: { collection: "page", id },
+			});
+			expect(published.isError, extractText(published)).toBeFalsy();
+
+			const got = await harness.client.callTool({
+				name: "content_get",
+				arguments: { collection: "page", id },
+			});
+			const item = extractJson<ItemEnvelope>(got).item;
+			expect(item.status).toBe("published");
+			expect(item.liveRevisionId).toBe(staleRevision.id);
+			expect(readTitle(item)).toBe("Fresh title");
+		});
+
 		it("content_update on collection without revisions support reflects on read", async () => {
 			const created = await harness.client.callTool({
 				name: "content_create",


### PR DESCRIPTION
## What does this PR do?

Prevents publishing a collection without `revisions` support from replacing current content-table values with stale data from `live_revision_id`. Revisionless publishing now updates lifecycle metadata only, while revision-enabled collections continue promoting the staged draft revision normally.

Closes #2095

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable; no admin UI changes). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable; this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable; this is a non-visual data-layer fix.

Validation:

- `pnpm lint:json | jq '.diagnostics | length'` — `0`
- `pnpm lint:quick`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter emdash exec vitest run tests/integration/mcp/drafts.test.ts tests/unit/database/repositories/content.test.ts tests/unit/scheduled-publish.test.ts tests/integration/seed-live-revisions.test.ts` — 98 tests passed
