### PR TITLE
feat(ui): scope LiveSearch results to the page locale

### DIFF
--- a/.changeset/live-search-locale.md
+++ b/.changeset/live-search-locale.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds a `locale` prop to `LiveSearch`, forwarded to the search and suggest endpoints. Both already accept a `locale` query parameter, but the component had no way to pass one, so a multilingual site got every entry back once per language — a French visitor searching from a French page saw each result twice, with the second one opening its English page. Pass `locale={Astro.locals.locale}` to scope results to the visitor's language; leaving it unset keeps the current all-locales behaviour.

--- a/.changeset/live-search-locale.md
+++ b/.changeset/live-search-locale.md
@@ -2,4 +2,18 @@
 "emdash": minor
 ---
 
-Adds a `locale` prop to `LiveSearch`, forwarded to the search and suggest endpoints. Both already accept a `locale` query parameter, but the component had no way to pass one, so a multilingual site got every entry back once per language — a French visitor searching from a French page saw each result twice, with the second one opening its English page. Pass `locale={Astro.locals.locale}` to scope results to the visitor's language; leaving it unset keeps the current all-locales behaviour.
+`LiveSearch` now scopes its results to the locale of the page it is used on.
+
+**Behaviour change.** The component reads `Astro.currentLocale` and forwards it as the `locale` query parameter to `/_emdash/api/search` and `/_emdash/api/search/suggest`, which both already filtered on it. Until now the component never sent one, so a translated site got every entry back once per language — a French visitor searching from a French page saw each result twice, the second one opening its English page. Sites with `i18n` configured that relied on searching across every locale will see fewer results than before.
+
+Two ways to opt out: pass an explicit `locale` to search a different one, or `locale={null}` to search across every locale, which is the previous behaviour.
+
+```astro
+<!-- results in the page's own locale (new default) -->
+<LiveSearch collections={["posts", "pages"]} />
+
+<!-- every locale, as before -->
+<LiveSearch collections={["posts", "pages"]} locale={null} />
+```
+
+Sites without Astro's `i18n` configured are unaffected: `Astro.currentLocale` is `undefined` there, so no `locale` parameter is sent and the search still spans everything.

--- a/docs/src/content/docs/themes/creating-themes.mdx
+++ b/docs/src/content/docs/themes/creating-themes.mdx
@@ -543,15 +543,19 @@ import Base from "../layouts/Base.astro";
 
 `LiveSearch` provides debounced instant search with prefix matching, Porter stemming, and highlighted result snippets. Search must be enabled per-collection in the admin UI (Content Types > Edit > Features > Search).
 
-On a multilingual site, pass `locale` so results stay in the visitor's language. Without it every entry comes back once per locale, so a translated site shows each result twice:
+On a multilingual site, results are scoped to the locale of the page the search runs on. The component reads `Astro.currentLocale`, which Astro derives from the URL, and forwards it to the search endpoint — so a translated site returns each entry once, in the visitor's language.
+
+Pass `locale` explicitly to search a different one, or `null` to search across every locale:
 
 ```astro title="src/pages/search.astro"
 <LiveSearch
   placeholder="Search posts and pages..."
   collections={["posts", "pages"]}
-  locale={Astro.locals.locale}
+  locale={null}
 />
 ```
+
+Sites without Astro's [`i18n` configuration](https://docs.astro.build/en/guides/internationalization/) are unaffected: `Astro.currentLocale` is `undefined` there, so no locale is sent and the search spans every entry.
 
 ## Testing Your Theme
 

--- a/docs/src/content/docs/themes/creating-themes.mdx
+++ b/docs/src/content/docs/themes/creating-themes.mdx
@@ -543,6 +543,16 @@ import Base from "../layouts/Base.astro";
 
 `LiveSearch` provides debounced instant search with prefix matching, Porter stemming, and highlighted result snippets. Search must be enabled per-collection in the admin UI (Content Types > Edit > Features > Search).
 
+On a multilingual site, pass `locale` so results stay in the visitor's language. Without it every entry comes back once per locale, so a translated site shows each result twice:
+
+```astro title="src/pages/search.astro"
+<LiveSearch
+  placeholder="Search posts and pages..."
+  collections={["posts", "pages"]}
+  locale={Astro.locals.locale}
+/>
+```
+
 ## Testing Your Theme
 
 1. Create a test project from your theme:

--- a/packages/core/src/components/LiveSearch.astro
+++ b/packages/core/src/components/LiveSearch.astro
@@ -9,6 +9,13 @@
  * <LiveSearch placeholder="Search articles..." collections={["posts", "pages"]} />
  * ```
  *
+ * On a multilingual site, pass `locale` to keep results in the visitor's
+ * language:
+ *
+ * ```astro
+ * <LiveSearch collections={["posts", "pages"]} locale={Astro.locals.locale} />
+ * ```
+ *
  * Customize the result rendering with slots:
  *
  * ```astro
@@ -26,6 +33,12 @@ export interface Props {
 	placeholder?: string;
 	/** Collections to search (defaults to all searchable collections) */
 	collections?: string[];
+	/**
+	 * Restrict results to one locale, e.g. `Astro.locals.locale`. Left unset,
+	 * the search returns every locale, so a bilingual site shows each entry
+	 * once per language.
+	 */
+	locale?: string;
 	/** Minimum characters before searching (defaults to 2) */
 	minChars?: number;
 	/** Debounce delay in milliseconds (defaults to 300) */
@@ -59,6 +72,7 @@ export interface Props {
 const {
 	placeholder = "Search...",
 	collections,
+	locale = "",
 	minChars = 2,
 	debounce = 300,
 	limit = 10,
@@ -77,6 +91,7 @@ const {
 
 const config = {
 	collections: collections?.join(",") ?? "",
+	locale,
 	minChars,
 	debounce,
 	limit,
@@ -145,6 +160,7 @@ const config = {
 
 	interface Config {
 		collections: string;
+		locale: string;
 		minChars: number;
 		debounce: number;
 		limit: number;
@@ -164,6 +180,7 @@ const config = {
 		private template: HTMLTemplateElement | null = null;
 		private config: Config = {
 			collections: "",
+			locale: "",
 			minChars: 2,
 			debounce: 300,
 			limit: 10,
@@ -362,6 +379,10 @@ const config = {
 
 				if (this.config.collections) {
 					params.set("collections", this.config.collections);
+				}
+
+				if (this.config.locale) {
+					params.set("locale", this.config.locale);
 				}
 
 				const response = await fetch(`${endpoint}?${params}`, {

--- a/packages/core/src/components/LiveSearch.astro
+++ b/packages/core/src/components/LiveSearch.astro
@@ -9,11 +9,13 @@
  * <LiveSearch placeholder="Search articles..." collections={["posts", "pages"]} />
  * ```
  *
- * On a multilingual site, pass `locale` to keep results in the visitor's
- * language:
+ * Results are scoped to the page's locale, taken from `Astro.currentLocale`,
+ * so a translated site returns each entry once, in the language of the page
+ * the visitor searched from. Pass `locale` to override that, or `null` to
+ * search across every locale:
  *
  * ```astro
- * <LiveSearch collections={["posts", "pages"]} locale={Astro.locals.locale} />
+ * <LiveSearch collections={["posts", "pages"]} locale={null} />
  * ```
  *
  * Customize the result rendering with slots:
@@ -34,11 +36,11 @@ export interface Props {
 	/** Collections to search (defaults to all searchable collections) */
 	collections?: string[];
 	/**
-	 * Restrict results to one locale, e.g. `Astro.locals.locale`. Left unset,
-	 * the search returns every locale, so a bilingual site shows each entry
-	 * once per language.
+	 * Locale to restrict results to. Defaults to `Astro.currentLocale`, which
+	 * Astro derives from the URL, so results match the page the search was
+	 * made from. Pass `null` to search across every locale.
 	 */
-	locale?: string;
+	locale?: string | null;
 	/** Minimum characters before searching (defaults to 2) */
 	minChars?: number;
 	/** Debounce delay in milliseconds (defaults to 300) */
@@ -72,7 +74,7 @@ export interface Props {
 const {
 	placeholder = "Search...",
 	collections,
-	locale = "",
+	locale = Astro.currentLocale ?? null,
 	minChars = 2,
 	debounce = 300,
 	limit = 10,
@@ -91,7 +93,7 @@ const {
 
 const config = {
 	collections: collections?.join(",") ?? "",
-	locale,
+	locale: locale ?? "",
 	minChars,
 	debounce,
 	limit,

--- a/packages/core/tests/repro/live-search-locale.render.test.ts
+++ b/packages/core/tests/repro/live-search-locale.render.test.ts
@@ -1,0 +1,33 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it } from "vitest";
+
+import LiveSearch from "../../src/components/LiveSearch.astro";
+
+/**
+ * The serialized config the client script reads. `locale` is sent as a query
+ * parameter only when it is a non-empty string.
+ */
+async function renderConfig(props: Record<string, unknown>) {
+	const container = await AstroContainer.create();
+	const html = await container.renderToString(LiveSearch, { props, locals: {} });
+	const match = html.match(/data-config="([^"]*)"/);
+	if (!match) throw new Error("no data-config on the rendered component");
+	const json = match[1].replaceAll("&#34;", '"').replaceAll("&quot;", '"');
+	return JSON.parse(json) as { locale: string };
+}
+
+describe("LiveSearch locale", () => {
+	it("sends no locale when the site has no i18n configuration", async () => {
+		// The container has no `i18n` config, so `Astro.currentLocale` is
+		// undefined — the same situation as a single-language site.
+		expect((await renderConfig({})).locale).toBe("");
+	});
+
+	it("forwards an explicit locale", async () => {
+		expect((await renderConfig({ locale: "fr" })).locale).toBe("fr");
+	});
+
+	it("sends no locale when passed null, so results span every locale", async () => {
+		expect((await renderConfig({ locale: null })).locale).toBe("");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`/_emdash/api/search` and `/_emdash/api/search/suggest` both filter on a `locale` query parameter, but `LiveSearch` never sent one. On a site with translated content the dropdown returned every entry once per locale.

On my bilingual site (FR canonical, EN under `/en/`), searching `endless` from a French page returned:

```
en  posts  Endless Night: Maeta's dance turn with KAYTRANADA
fr  posts  Endless Night : le virage dance de Maeta avec KAYTRANADA
en  pages  About
fr  pages  À propos de Maeta et le site
```

Half the list is in the wrong language and duplicates the other half. Clicking the English result opens the French page, because the slug redirects to its translation.

**This PR now implements option 2 from [Discussion #2479](https://github.com/emdash-cms/emdash/discussions/2479), per @ascorbic's call** ([comment](https://github.com/emdash-cms/emdash/discussions/2479#discussioncomment-18061500): *"I'd go with 2, and highlight the changed behaviour in the changeset"*). The first revision of this PR added an opt-in `locale` prop; it now defaults to the page's own locale instead.

## Behaviour change

`LiveSearch` reads `Astro.currentLocale` — which Astro derives from the URL — and forwards it to whichever endpoint it is using. Results now match the language of the page the search runs on.

```astro
<!-- results in the page's own locale (new default) -->
<LiveSearch collections={["posts", "pages"]} />

<!-- a specific locale -->
<LiveSearch collections={["posts", "pages"]} locale="fr" />

<!-- every locale — the previous behaviour -->
<LiveSearch collections={["posts", "pages"]} locale={null} />
```

Who is affected:

- **Sites with `i18n` configured** that relied on cross-locale results will get fewer results than before. `locale={null}` restores the old behaviour. This is called out at the top of the changeset.
- **Sites without `i18n`** are unaffected: `Astro.currentLocale` is `undefined` there, so no `locale` parameter is sent and the search still spans everything.

The earlier revision of this PR documented `locale={Astro.locals.locale}`, which was wrong — that is a convention of my own theme's middleware, not an Astro API. @ascorbic caught it in the Discussion; the docs and the component's JSDoc now say `Astro.currentLocale`.

Discussion: https://github.com/emdash-cms/emdash/discussions/2479

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm build` then `pnpm typecheck` pass (0 errors)
- [x] `pnpm lint` passes (`oxlint --type-aware --deny-warnings`, 0 warnings)
- [x] `pnpm test` passes — full `packages/core` suite: **472 files, 5867 tests, 0 failures**, plus `pnpm test:repro` (6 files, 29 tests)
- [x] `pnpm format` has been run (`oxfmt` + `prettier --check` clean on the touched files)
- [x] I have added/updated tests for my changes
- [ ] User-visible strings in the admin UI are wrapped for translation (not applicable — no admin UI strings)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [x] New features link to an approved Discussion — [#2479](https://github.com/emdash-cms/emdash/discussions/2479), where a maintainer picked the design implemented here ([comment](https://github.com/emdash-cms/emdash/discussions/2479#discussioncomment-18061500))

Note on the last box: when this PR was first opened, #2479 had no maintainer response and the box was left unticked with a note saying so. It is ticked now because @ascorbic has since responded twice and chosen this design — not because a link exists.

## Tests

`packages/core/tests/repro/live-search-locale.render.test.ts` renders the component through `AstroContainer` and asserts the serialized config, covering three paths:

- no `i18n` configuration → no locale sent (single-language sites unchanged)
- explicit `locale` prop → forwarded
- `locale={null}` → no locale sent (cross-locale search)

What that test does **not** cover: the `Astro.currentLocale` default itself, since the test container has no `i18n` configuration to derive a locale from. That path is verified on a live bilingual site (FR canonical, EN under `/en/`), where `/` renders `fr` and `/en/…` renders `en`, including under `i18n.routing: "manual"`.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Notes

The branch was rebased onto current `main` (it was 39 commits behind), hence the force-push. The option-2 change is a separate commit on top of the original one, so the diff between the two revisions stays readable.
