### PR TITLE
Fix tag autocomplete navigation and overflow

### DIFF
--- a/.changeset/tidy-tags-scroll.md
+++ b/.changeset/tidy-tags-scroll.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes tag suggestions so every matching term is scrollable and selectable with pointer or keyboard navigation.

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -260,46 +260,48 @@ function TagInput({
 				</div>
 			)}
 
-			<Autocomplete
-				items={options}
-				value={input}
-				onValueChange={setInput}
-				open={isOpen && options.length > 0}
-				onOpenChange={setIsOpen}
-				mode="none"
-				autoHighlight="always"
-				openOnInputClick
-				itemToStringValue={(option: TagInputOption) =>
-					option.type === "term" ? option.term.label : option.label
-				}
-				label={<span className="sr-only">{t`Add ${label}`}</span>}
-			>
-				<Autocomplete.InputGroup placeholder={t`Add tags...`} className="text-sm" />
-				<Autocomplete.Content>
-					<Autocomplete.List style={{ maxHeight: "16rem", overflowY: "auto" }}>
-						{(option: TagInputOption) => (
-							<Autocomplete.Item
-								key={option.type === "term" ? option.term.id : "create"}
-								value={option}
-								disabled={option.type === "create" && isCreating}
-								onClick={() => {
-									if (option.type === "term") handleSelect(option.term);
-									else handleCreate();
-								}}
-							>
-								{option.type === "term" ? (
-									option.term.label
-								) : (
-									<span className="flex items-center gap-1 text-kumo-accent">
-										<Plus className="h-3 w-3" aria-hidden="true" />
-										{isCreating ? t`Creating...` : t`Create "${trimmedInput}"`}
-									</span>
-								)}
-							</Autocomplete.Item>
-						)}
-					</Autocomplete.List>
-				</Autocomplete.Content>
-			</Autocomplete>
+			<div onFocus={() => setIsOpen(true)}>
+				<Autocomplete
+					items={options}
+					value={input}
+					onValueChange={setInput}
+					open={isOpen && options.length > 0}
+					onOpenChange={setIsOpen}
+					mode="none"
+					autoHighlight="always"
+					openOnInputClick
+					itemToStringValue={(option: TagInputOption) =>
+						option.type === "term" ? option.term.label : option.label
+					}
+					label={<span className="sr-only">{t`Add ${label}`}</span>}
+				>
+					<Autocomplete.InputGroup placeholder={t`Add tags...`} className="text-sm" />
+					<Autocomplete.Content>
+						<Autocomplete.List style={{ maxHeight: "16rem", overflowY: "auto" }}>
+							{(option: TagInputOption) => (
+								<Autocomplete.Item
+									key={option.type === "term" ? option.term.id : "create"}
+									value={option}
+									disabled={option.type === "create" && isCreating}
+									onClick={() => {
+										if (option.type === "term") handleSelect(option.term);
+										else handleCreate();
+									}}
+								>
+									{option.type === "term" ? (
+										option.term.label
+									) : (
+										<span className="flex items-center gap-1 text-kumo-accent">
+											<Plus className="h-3 w-3" aria-hidden="true" />
+											{isCreating ? t`Creating...` : t`Create "${trimmedInput}"`}
+										</span>
+									)}
+								</Autocomplete.Item>
+							)}
+						</Autocomplete.List>
+					</Autocomplete.Content>
+				</Autocomplete>
+			</div>
 		</div>
 	);
 }

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -6,7 +6,7 @@
  * - Tag input for flat taxonomies (tags)
  */
 
-import { Button, Checkbox, Input, Label, Text, Toast } from "@cloudflare/kumo";
+import { Autocomplete, Button, Checkbox, Input, Label, Text, Toast } from "@cloudflare/kumo";
 import { i18n } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
@@ -16,7 +16,7 @@ import * as React from "react";
 
 import { apiFetch, parseApiResponse, throwResponseError } from "../lib/api/client.js";
 import { createTerm, withLocale } from "../lib/api/taxonomies.js";
-import { termExactMatches, termMatches } from "../lib/taxonomy-match.js";
+import { rankTermMatches, termExactMatches } from "../lib/taxonomy-match.js";
 import { cn, slugify } from "../lib/utils.js";
 
 interface TaxonomyTerm {
@@ -50,6 +50,8 @@ interface TaxonomySidebarProps {
 }
 
 const EMPTY_TERMS: TaxonomyTerm[] = [];
+
+type TagInputOption = { type: "term"; term: TaxonomyTerm } | { type: "create"; label: string };
 
 /**
  * Fetch taxonomy definitions
@@ -204,7 +206,7 @@ function TagInput({
 	const suggestions = React.useMemo(() => {
 		const availableTerms = terms.filter((term) => !selectedIds.has(term.id));
 		if (!trimmedInput) return availableTerms.slice(0, 5);
-		return availableTerms.filter((term) => termMatches(term, trimmedInput)).slice(0, 5);
+		return rankTermMatches(availableTerms, trimmedInput);
 	}, [trimmedInput, terms, selectedIds]);
 
 	const hasExactMatch = React.useMemo(() => {
@@ -213,6 +215,13 @@ function TagInput({
 	}, [trimmedInput, terms]);
 
 	const showCreateOption = trimmedInput.length > 0 && !hasExactMatch;
+	const options = React.useMemo<TagInputOption[]>(
+		() => [
+			...suggestions.map((term) => ({ type: "term" as const, term })),
+			...(showCreateOption ? [{ type: "create" as const, label: trimmedInput }] : []),
+		],
+		[suggestions, showCreateOption, trimmedInput],
+	);
 
 	const handleSelect = (term: TaxonomyTerm) => {
 		onAdd(term.id);
@@ -225,23 +234,6 @@ function TagInput({
 		onCreate(trimmedInput);
 		setInput("");
 		setIsOpen(false);
-	};
-
-	const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
-		const nextFocused = e.relatedTarget;
-		if (nextFocused instanceof Node && e.currentTarget.contains(nextFocused)) return;
-		setIsOpen(false);
-	};
-
-	const handleKeyDown = (e: React.KeyboardEvent) => {
-		if (e.key === "Enter") {
-			e.preventDefault();
-			if (suggestions.length === 1 && !showCreateOption) {
-				handleSelect(suggestions[0]!);
-			} else if (showCreateOption && suggestions.length === 0) {
-				handleCreate();
-			}
-		}
 	};
 
 	return (
@@ -268,49 +260,46 @@ function TagInput({
 				</div>
 			)}
 
-			{/* Input with autocomplete */}
-			<div className="relative" onBlur={handleBlur}>
-				<Input
-					value={input}
-					onChange={(e) => {
-						setInput(e.target.value);
-						setIsOpen(true);
-					}}
-					onFocus={() => setIsOpen(true)}
-					onKeyDown={handleKeyDown}
-					placeholder={t`Add tags...`}
-					aria-label={t`Add ${label}`}
-					className="w-full text-sm"
-				/>
-
-				{isOpen && (suggestions.length > 0 || showCreateOption) && (
-					<div className="absolute top-full start-0 end-0 mt-1 overflow-hidden bg-kumo-overlay border rounded-lg shadow-lg z-10">
-						{suggestions.map((term) => (
-							<button
-								key={term.id}
-								type="button"
-								onMouseDown={(e) => e.preventDefault()}
-								onClick={() => handleSelect(term)}
-								className="w-full text-start px-3 py-2 text-sm hover:bg-kumo-tint"
+			<Autocomplete
+				items={options}
+				value={input}
+				onValueChange={setInput}
+				open={isOpen && options.length > 0}
+				onOpenChange={setIsOpen}
+				mode="none"
+				autoHighlight="always"
+				openOnInputClick
+				itemToStringValue={(option: TagInputOption) =>
+					option.type === "term" ? option.term.label : option.label
+				}
+				label={<span className="sr-only">{t`Add ${label}`}</span>}
+			>
+				<Autocomplete.InputGroup placeholder={t`Add tags...`} className="text-sm" />
+				<Autocomplete.Content>
+					<Autocomplete.List style={{ maxHeight: "16rem", overflowY: "auto" }}>
+						{(option: TagInputOption) => (
+							<Autocomplete.Item
+								key={option.type === "term" ? option.term.id : "create"}
+								value={option}
+								disabled={option.type === "create" && isCreating}
+								onClick={() => {
+									if (option.type === "term") handleSelect(option.term);
+									else handleCreate();
+								}}
 							>
-								{term.label}
-							</button>
-						))}
-						{showCreateOption && (
-							<button
-								type="button"
-								onMouseDown={(e) => e.preventDefault()}
-								onClick={handleCreate}
-								disabled={isCreating}
-								className="w-full text-start px-3 py-2 text-sm hover:bg-kumo-tint text-kumo-accent flex items-center gap-1 border-t"
-							>
-								<Plus className="w-3 h-3" />
-								{isCreating ? t`Creating...` : t`Create "${trimmedInput}"`}
-							</button>
+								{option.type === "term" ? (
+									option.term.label
+								) : (
+									<span className="flex items-center gap-1 text-kumo-accent">
+										<Plus className="h-3 w-3" aria-hidden="true" />
+										{isCreating ? t`Creating...` : t`Create "${trimmedInput}"`}
+									</span>
+								)}
+							</Autocomplete.Item>
 						)}
-					</div>
-				)}
-			</div>
+					</Autocomplete.List>
+				</Autocomplete.Content>
+			</Autocomplete>
 		</div>
 	);
 }

--- a/packages/admin/src/lib/taxonomy-match.ts
+++ b/packages/admin/src/lib/taxonomy-match.ts
@@ -66,3 +66,26 @@ export function termExactMatches(term: MatchableTerm, input: string): boolean {
 	if (!needle) return false;
 	return foldForMatch(term.label).trim() === needle;
 }
+
+/** Order matching terms by match quality, then by their normalized label. */
+export function rankTermMatches<T extends MatchableTerm>(terms: readonly T[], input: string): T[] {
+	const needle = foldForMatch(input).trim();
+	if (!needle) return [];
+
+	return terms
+		.map((term) => {
+			const label = foldForMatch(term.label).trim();
+			const rank = label === needle ? 0 : label.startsWith(needle) ? 1 : 2;
+			return { term, label, rank };
+		})
+		.filter(({ label }) => label.includes(needle))
+		.toSorted((a, b) => {
+			if (a.rank !== b.rank) return a.rank - b.rank;
+			if (a.label < b.label) return -1;
+			if (a.label > b.label) return 1;
+			if (a.term.label < b.term.label) return -1;
+			if (a.term.label > b.term.label) return 1;
+			return 0;
+		})
+		.map(({ term }) => term);
+}

--- a/packages/admin/tests/components/TaxonomySidebar.test.tsx
+++ b/packages/admin/tests/components/TaxonomySidebar.test.tsx
@@ -2,6 +2,7 @@ import { Toasty } from "@cloudflare/kumo";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { userEvent } from "vitest/browser";
 
 import { TaxonomySidebar } from "../../src/components/TaxonomySidebar";
 import { render } from "../utils/render.tsx";
@@ -79,10 +80,12 @@ function mockApiFetch({
 	taxonomies = [tagsTaxonomy],
 	terms = [alphaTerm, betaTerm],
 	entryTerms = [],
+	createdTerm = makeTerm("term_created", "Gamma"),
 }: {
 	taxonomies?: TestTaxonomy[];
 	terms?: TestTerm[];
 	entryTerms?: TestTerm[];
+	createdTerm?: TestTerm;
 } = {}) {
 	vi.mocked(apiFetch).mockImplementation((url: string | URL | Request, init?: RequestInit) => {
 		const urlString = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
@@ -103,6 +106,10 @@ function mockApiFetch({
 
 		if (method === "GET" && path === "/_emdash/api/content/products/entry_1/terms/tags") {
 			return dataResponse({ terms: entryTerms });
+		}
+
+		if (method === "POST" && path === "/_emdash/api/taxonomies/tags/terms") {
+			return dataResponse({ term: createdTerm });
 		}
 
 		return dataResponse({});
@@ -135,12 +142,12 @@ describe("TaxonomySidebar", () => {
 		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
 
 		await expect.element(screen.getByLabelText("Add Tags")).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: /^Alpha$/ }).query()).toBeNull();
+		expect(screen.getByRole("option", { name: /^Alpha$/ }).query()).toBeNull();
 
 		await screen.getByLabelText("Add Tags").click();
 
-		await expect.element(screen.getByRole("button", { name: /^Alpha$/ })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: /^Beta$/ })).toBeInTheDocument();
+		await expect.element(screen.getByRole("option", { name: /^Alpha$/ })).toBeInTheDocument();
+		await expect.element(screen.getByRole("option", { name: /^Beta$/ })).toBeInTheDocument();
 	});
 
 	it("filters flat taxonomy terms while preserving the create option for new input", async () => {
@@ -149,9 +156,157 @@ describe("TaxonomySidebar", () => {
 		const input = screen.getByLabelText("Add Tags");
 		await input.fill("Alp");
 
-		await expect.element(screen.getByRole("button", { name: /^Alpha$/ })).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: /^Beta$/ }).query()).toBeNull();
+		await expect.element(screen.getByRole("option", { name: /^Alpha$/ })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: /^Beta$/ }).query()).toBeNull();
 		await expect.element(screen.getByText('Create "Alp"')).toBeInTheDocument();
+	});
+
+	it("shows every match and ranks exact, prefix, then substring labels deterministically", async () => {
+		mockApiFetch({
+			terms: [
+				makeTerm("term_web", "Web Security"),
+				makeTerm("term_operations", "Security Operations"),
+				makeTerm("term_cameras", "Security Cameras"),
+				makeTerm("term_news", "Security News"),
+				makeTerm("term_engineering", "Security Engineering"),
+				makeTerm("term_compliance", "Security Compliance"),
+				makeTerm("term_security", "Security"),
+			],
+		});
+
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+		await screen.getByLabelText("Add Tags").fill("security");
+
+		const options = screen.getByRole("option").elements();
+		expect(options.map((option) => option.textContent?.trim())).toEqual([
+			"Security",
+			"Security Cameras",
+			"Security Compliance",
+			"Security Engineering",
+			"Security News",
+			"Security Operations",
+			"Web Security",
+		]);
+		expect(screen.getByText('Create "security"').query()).toBeNull();
+	});
+
+	it("uses accessible combobox and listbox semantics", async () => {
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+
+		const input = screen.getByRole("combobox", { name: "Add Tags" });
+		await input.click();
+
+		await expect.element(screen.getByRole("listbox")).toBeInTheDocument();
+		await expect.element(screen.getByRole("option", { name: "Alpha" })).toBeInTheDocument();
+		expect(input.element().getAttribute("aria-controls")).toBe(
+			screen.getByRole("listbox").element().id,
+		);
+	});
+
+	it("selects a result beyond the first five with a pointer", async () => {
+		const onChange = vi.fn();
+		mockApiFetch({
+			terms: [
+				...Array.from({ length: 11 }, (_, index) =>
+					makeTerm(`term_${index + 1}`, `Security ${String(index + 1).padStart(2, "0")}`),
+				),
+				makeTerm("term_12", "Web Security"),
+			],
+		});
+
+		const screen = await render(<TaxonomySidebar collection="products" onChange={onChange} />, {
+			wrapper: Wrapper,
+		});
+		await screen.getByLabelText("Add Tags").fill("security");
+		const listbox = screen.getByRole("listbox");
+		const listboxElement = listbox.element();
+		expect(listboxElement.scrollHeight).toBeGreaterThan(listboxElement.clientHeight);
+		expect(listboxElement.scrollTop).toBe(0);
+
+		await listbox.wheel({ delta: { y: 400 } });
+		await vi.waitFor(() => expect(listboxElement.scrollTop).toBeGreaterThan(0));
+		await screen.getByRole("option", { name: "Web Security" }).click();
+
+		expect(onChange).toHaveBeenCalledWith("tags", ["term_12"]);
+		await expect.element(screen.getByLabelText("Remove Web Security")).toBeInTheDocument();
+	});
+
+	it("navigates to and selects a later result with the keyboard", async () => {
+		const onChange = vi.fn();
+		mockApiFetch({
+			terms: [
+				makeTerm("term_security", "Security"),
+				...Array.from({ length: 10 }, (_, index) =>
+					makeTerm(`term_${index + 1}`, `Security ${String(index + 1).padStart(2, "0")}`),
+				),
+				makeTerm("term_web", "Web Security"),
+			],
+		});
+
+		const screen = await render(<TaxonomySidebar collection="products" onChange={onChange} />, {
+			wrapper: Wrapper,
+		});
+		await screen.getByLabelText("Add Tags").fill("security");
+		const listbox = screen.getByRole("listbox").element();
+		for (let index = 0; index < 11; index += 1) {
+			await userEvent.keyboard("{ArrowDown}");
+		}
+		expect(listbox.scrollTop).toBeGreaterThan(0);
+		await userEvent.keyboard("{Enter}");
+
+		expect(onChange).toHaveBeenCalledWith("tags", ["term_web"]);
+		await expect.element(screen.getByLabelText("Remove Web Security")).toBeInTheDocument();
+	});
+
+	it("wraps ArrowUp from the first result to the last result", async () => {
+		const onChange = vi.fn();
+		mockApiFetch({
+			terms: [
+				makeTerm("term_security", "Security"),
+				makeTerm("term_news", "Security News"),
+				makeTerm("term_web", "Web Security"),
+			],
+		});
+
+		const screen = await render(<TaxonomySidebar collection="products" onChange={onChange} />, {
+			wrapper: Wrapper,
+		});
+		await screen.getByLabelText("Add Tags").fill("security");
+		await userEvent.keyboard("{ArrowUp}");
+		await userEvent.keyboard("{Enter}");
+
+		expect(onChange).toHaveBeenCalledWith("tags", ["term_web"]);
+	});
+
+	it("closes the suggestion list with Escape and keeps focus in the input", async () => {
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+		const input = screen.getByLabelText("Add Tags");
+		await input.fill("a");
+		await expect.element(screen.getByRole("listbox")).toBeInTheDocument();
+
+		await userEvent.keyboard("{Escape}");
+
+		expect(screen.getByRole("listbox").query()).toBeNull();
+		expect(document.activeElement).toBe(input.element());
+	});
+
+	it("shows a folded exact match first and prevents duplicate creation", async () => {
+		mockApiFetch({
+			terms: [
+				makeTerm("term_mexico_city", "Mexico City"),
+				makeTerm("term_mexico_news", "Mexico News"),
+				makeTerm("term_mexico_food", "Mexico Food"),
+				makeTerm("term_mexico_travel", "Mexico Travel"),
+				makeTerm("term_mexico_history", "Mexico History"),
+				makeTerm("term_mexico", "México"),
+			],
+		});
+
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+		await screen.getByLabelText("Add Tags").fill("Mexico");
+
+		expect(screen.getByRole("option").elements()[0]?.textContent?.trim()).toBe("México");
+		expect(screen.getByText('Create "Mexico"').query()).toBeNull();
 	});
 
 	it("does not suggest terms already assigned to the entry", async () => {
@@ -164,14 +319,17 @@ describe("TaxonomySidebar", () => {
 		await expect.element(screen.getByLabelText("Remove Alpha")).toBeInTheDocument();
 		await screen.getByLabelText("Add Tags").click();
 
-		expect(screen.getByRole("button", { name: /^Alpha$/ }).query()).toBeNull();
-		await expect.element(screen.getByRole("button", { name: /^Beta$/ })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: /^Alpha$/ }).query()).toBeNull();
+		await expect.element(screen.getByRole("option", { name: /^Beta$/ })).toBeInTheDocument();
 	});
 
 	it("keeps the create prompt available when no flat taxonomy terms exist", async () => {
+		const onChange = vi.fn();
 		mockApiFetch({ terms: [] });
 
-		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+		const screen = await render(<TaxonomySidebar collection="products" onChange={onChange} />, {
+			wrapper: Wrapper,
+		});
 
 		const input = screen.getByLabelText("Add Tags");
 		await input.click();
@@ -181,6 +339,18 @@ describe("TaxonomySidebar", () => {
 		await input.fill("Gamma");
 
 		await expect.element(screen.getByText('Create "Gamma"')).toBeInTheDocument();
+		await screen.getByText('Create "Gamma"').click();
+
+		await vi.waitFor(() => {
+			expect(apiFetch).toHaveBeenCalledWith(
+				"/_emdash/api/taxonomies/tags/terms",
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({ slug: "gamma", label: "Gamma" }),
+				}),
+			);
+		});
+		expect(onChange).toHaveBeenCalledWith("tags", ["term_created"]);
 	});
 
 	it("continues to render hierarchical taxonomies as a checkbox tree", async () => {
@@ -191,5 +361,34 @@ describe("TaxonomySidebar", () => {
 		await expect.element(screen.getByText("Categories")).toBeInTheDocument();
 		await expect.element(screen.getByText("Alpha")).toBeInTheDocument();
 		expect(screen.getByLabelText("Add Categories").query()).toBeNull();
+	});
+
+	it("selects Arabic matches when the interface direction is RTL", async () => {
+		const previousDirection = document.documentElement.dir;
+		document.documentElement.dir = "rtl";
+		const onChange = vi.fn();
+		mockApiFetch({
+			terms: [
+				makeTerm("term_network", "أمن الشبكات"),
+				makeTerm("term_information", "أمن المعلومات"),
+				makeTerm("term_cloud", "الأمن السحابي"),
+			],
+		});
+
+		try {
+			const screen = await render(<TaxonomySidebar collection="products" onChange={onChange} />, {
+				wrapper: Wrapper,
+			});
+			await screen.getByLabelText("Add Tags").fill("أمن");
+
+			const listbox = screen.getByRole("listbox");
+			await expect.element(listbox).toBeInTheDocument();
+			expect(getComputedStyle(listbox.element()).direction).toBe("rtl");
+			await screen.getByRole("option", { name: "أمن المعلومات" }).click();
+
+			expect(onChange).toHaveBeenCalledWith("tags", ["term_information"]);
+		} finally {
+			document.documentElement.dir = previousDirection;
+		}
 	});
 });

--- a/packages/admin/tests/components/TaxonomySidebar.test.tsx
+++ b/packages/admin/tests/components/TaxonomySidebar.test.tsx
@@ -150,6 +150,17 @@ describe("TaxonomySidebar", () => {
 		await expect.element(screen.getByRole("option", { name: /^Beta$/ })).toBeInTheDocument();
 	});
 
+	it("opens existing terms when the tag picker receives keyboard focus", async () => {
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+		const input = screen.getByLabelText("Add Tags");
+
+		await userEvent.tab();
+
+		expect(document.activeElement).toBe(input.element());
+		await expect.element(screen.getByRole("listbox")).toBeInTheDocument();
+		await expect.element(screen.getByRole("option", { name: "Alpha" })).toBeInTheDocument();
+	});
+
 	it("filters flat taxonomy terms while preserving the create option for new input", async () => {
 		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
 
@@ -383,7 +394,6 @@ describe("TaxonomySidebar", () => {
 
 			const listbox = screen.getByRole("listbox");
 			await expect.element(listbox).toBeInTheDocument();
-			expect(getComputedStyle(listbox.element()).direction).toBe("rtl");
 			await screen.getByRole("option", { name: "أمن المعلومات" }).click();
 
 			expect(onChange).toHaveBeenCalledWith("tags", ["term_information"]);

--- a/packages/admin/tests/lib/taxonomy-match.test.ts
+++ b/packages/admin/tests/lib/taxonomy-match.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
 	foldForMatch,
+	rankTermMatches,
 	termExactMatches,
 	termMatches,
 	type MatchableTerm,
@@ -94,5 +95,34 @@ describe("termExactMatches", () => {
 	it("returns false for empty or whitespace-only input", () => {
 		expect(termExactMatches(mexico, "")).toBe(false);
 		expect(termExactMatches(mexico, "   ")).toBe(false);
+	});
+});
+
+describe("rankTermMatches", () => {
+	it("ranks exact, prefix, then substring matches with deterministic label ordering", () => {
+		const terms = [
+			{ label: "Web Security" },
+			{ label: "Security Operations" },
+			{ label: "Security Compliance" },
+			{ label: "Security" },
+			{ label: "Unrelated" },
+		];
+
+		expect(rankTermMatches(terms, "security").map((term) => term.label)).toEqual([
+			"Security",
+			"Security Compliance",
+			"Security Operations",
+			"Web Security",
+		]);
+	});
+
+	it("ranks a case and diacritic-folded exact match first", () => {
+		const terms = [{ label: "Mexico City" }, { label: "History of Mexico" }, { label: "México" }];
+
+		expect(rankTermMatches(terms, "MEXICO").map((term) => term.label)).toEqual([
+			"México",
+			"Mexico City",
+			"History of Mexico",
+		]);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Replaces the flat-taxonomy tag suggestion popup with Kumo Autocomplete so every non-empty match is reachable by pointer, wheel/touch scrolling, or keyboard. Matches are ranked as exact normalized label, prefix, then substring with deterministic label ordering. The existing create, assign, remove, and save mutations are preserved, and hierarchical taxonomy controls are unchanged.

Closes #2477

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — not run repository-wide; the focused admin typecheck passes
- [x] `pnpm lint` passes — verified by a zero-diagnostic type-aware `pnpm lint:json` run
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this is a bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- `pnpm --filter @emdash-cms/admin test --run tests/components/TaxonomySidebar.test.tsx` — 13 tests passed in Chromium
- `pnpm --filter @emdash-cms/admin typecheck` — passed
- `pnpm lint:quick` — zero diagnostics
- `pnpm lint:json | jq '.diagnostics | length'` — `0`
- `pnpm format` — completed

The focused browser tests cover overflowing wheel scrolling and later pointer selection, ArrowDown scroll-into-view and Enter selection, ArrowUp wrapping, Escape/focus behavior, exact case/diacritic-folded duplicate prevention, selected-term exclusion, create-new behavior, combobox/listbox semantics, and Arabic RTL selection.
