### PR TITLE
fix: prevent unsupported Portable Text mark loss

### DIFF
--- a/.changeset/safe-portable-text-marks.md
+++ b/.changeset/safe-portable-text-marks.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fixes Portable Text editing so content with unsupported marks is blocked with a clear error instead of silently losing those marks.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -73,6 +73,7 @@ function serializeEditorState(input: {
 }
 
 import type { ContentSeoInput } from "../lib/api";
+import { findUnsupportedPortableTextMarks } from "../lib/portable-text-marks.js";
 import { MediaPickerModal } from "./MediaPickerModal";
 import {
 	PortableTextEditor,
@@ -381,6 +382,19 @@ export function ContentEditor({
 	}, [item?.updatedAt, itemDataString, item?.slug, item?.status]);
 
 	const activeBylines = isNew ? (selectedBylines ?? []) : internalBylines;
+	const unsupportedPortableTextMarks = React.useMemo(() => {
+		const unsupported = new Set<string>();
+		for (const [name, field] of Object.entries(fields)) {
+			if (field.kind !== "portableText" || field.widget) continue;
+			const value = formData[name];
+			if (!Array.isArray(value)) continue;
+			for (const mark of findUnsupportedPortableTextMarks(value)) {
+				unsupported.add(mark);
+			}
+		}
+		return [...unsupported].toSorted();
+	}, [fields, formData]);
+	const hasUnsupportedPortableTextMarks = unsupportedPortableTextMarks.length > 0;
 
 	const handleBylinesChange = React.useCallback(
 		(next: BylineCreditInput[]) => {
@@ -409,6 +423,7 @@ export function ContentEditor({
 	const saveFeedbackActive = isSaveFeedbackActive ?? isSaving;
 	const autosaveFeedbackActive = isAutosaveFeedbackActive ?? isAutosaving;
 	const isContentOperationPending = Boolean(isSaving);
+	const isContentSaveBlocked = isContentOperationPending || hasUnsupportedPortableTextMarks;
 
 	// Autosave with debounce
 	// Track pending autosave to cancel on manual save
@@ -442,7 +457,7 @@ export function ContentEditor({
 
 	React.useEffect(() => {
 		// Don't autosave for new items (no ID yet) or if autosave isn't configured
-		if (isNew || !onAutosave || !item?.id) {
+		if (isNew || !onAutosave || !item?.id || hasUnsupportedPortableTextMarks) {
 			return;
 		}
 
@@ -492,12 +507,13 @@ export function ContentEditor({
 		activeBylines,
 		bylinesTouched,
 		hasInvalidUrls,
+		hasUnsupportedPortableTextMarks,
 	]);
 
 	// Cancel pending autosave on manual save
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
-		if (hasInvalidUrls(formData)) return;
+		if (hasInvalidUrls(formData) || hasUnsupportedPortableTextMarks) return;
 		// Cancel pending autosave
 		if (autosaveTimeoutRef.current) {
 			clearTimeout(autosaveTimeoutRef.current);
@@ -678,7 +694,7 @@ export function ContentEditor({
 												type="submit"
 												isDirty={isDirty}
 												isSaving={Boolean(saveFeedbackActive || autosaveFeedbackActive)}
-												disabled={isContentOperationPending}
+												disabled={isContentSaveBlocked}
 											/>
 											{liveViewUrl && (
 												<LinkButton
@@ -720,7 +736,7 @@ export function ContentEditor({
 										size="sm"
 										isDirty={isDirty}
 										isSaving={Boolean(saveFeedbackActive || autosaveFeedbackActive)}
-										disabled={isContentOperationPending}
+										disabled={isContentSaveBlocked}
 									/>
 									{liveViewUrl && (
 										<LinkButton
@@ -829,7 +845,7 @@ export function ContentEditor({
 							isDirty={isDirty}
 							isSaving={Boolean(saveFeedbackActive)}
 							isAutosaving={autosaveFeedbackActive}
-							saveDisabled={isContentOperationPending}
+							saveDisabled={isContentSaveBlocked}
 							isLive={isLive}
 							hasPendingChanges={hasPendingChanges}
 							liveViewUrl={liveViewUrl}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2625,6 +2625,7 @@ export function PortableTextEditor({
 	// Multi-select media picker state (for gallery insertion)
 	const [galleryPickerOpen, setGalleryPickerOpen] = React.useState(false);
 	const [conversionErrorMarks, setConversionErrorMarks] = React.useState<string[]>([]);
+	const [sectionInsertErrorMarks, setSectionInsertErrorMarks] = React.useState<string[]>([]);
 
 	// Plugin block insertion/editing state
 	const [pluginBlockModal, setPluginBlockModal] = React.useState<PluginBlockDef | null>(null);
@@ -3293,11 +3294,12 @@ export function PortableTextEditor({
 				({ content: prosemirrorContent } = portableTextToProsemirror(ptContent));
 			} catch (error) {
 				if (error instanceof UnsupportedPortableTextMarksError) {
-					setConversionErrorMarks(error.marks);
+					setSectionInsertErrorMarks(error.marks);
 					return;
 				}
 				throw error;
 			}
+			setSectionInsertErrorMarks([]);
 
 			const insertPos = pendingBlockInsertPosRef.current;
 			const chain = editor.chain().focus();
@@ -3343,6 +3345,32 @@ export function PortableTextEditor({
 
 	return (
 		<div ref={floatingRootRef} className="relative min-w-0" data-emdash-editor-floating-root>
+			{sectionInsertErrorMarks.length > 0 && (
+				<div
+					role="alert"
+					className="mb-3 flex items-start justify-between gap-4 rounded-lg border border-kumo-error bg-kumo-error/10 p-4 text-start"
+				>
+					<div className="min-w-0">
+						<p className="font-medium text-kumo-error">{t`Could not insert section`}</p>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							<Trans>
+								This section contains unsupported Portable Text marks:{" "}
+								<code dir="auto">{sectionInsertErrorMarks.join(", ")}</code>. Update the section
+								before inserting it.
+							</Trans>
+						</p>
+					</div>
+					<Button
+						type="button"
+						variant="ghost"
+						shape="square"
+						onClick={() => setSectionInsertErrorMarks([])}
+						aria-label={t`Dismiss section error`}
+					>
+						<X className="h-4 w-4" aria-hidden="true" />
+					</Button>
+				</div>
+			)}
 			<EditorBubbleMenu
 				editor={editor}
 				appendTo={appendBubbleMenu}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -43,7 +43,7 @@ import type { Element } from "@emdash-cms/blocks";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg, plural } from "@lingui/core/macro";
 import { useLingui as useLinguiContext } from "@lingui/react";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import {
 	TextB,
 	TextItalic,
@@ -113,6 +113,12 @@ import * as React from "react";
 
 import type { MediaItem } from "../lib/api";
 import type { Section } from "../lib/api";
+import {
+	UnsupportedPortableTextMarksError,
+	assertPortableTextMarksSupported,
+	assertProseMirrorMarksSupported,
+	findUnsupportedPortableTextMarks,
+} from "../lib/portable-text-marks.js";
 import { cn } from "../lib/utils";
 import { CaretNext } from "./ArrowIcons.js";
 import { BlockKitMediaPickerField } from "./BlockKitMediaPickerField";
@@ -421,6 +427,7 @@ function prosemirrorToPortableText(doc: {
 	if (!doc || doc.type !== "doc" || !doc.content) {
 		return [];
 	}
+	assertProseMirrorMarksSupported(doc);
 
 	const blocks: PortableTextBlock[] = [];
 
@@ -797,6 +804,10 @@ function convertMark(
 		case "strike":
 		case "strikethrough":
 			return "strike-through";
+		case "subscript":
+			return "subscript";
+		case "superscript":
+			return "superscript";
 		case "code":
 			return "code";
 		case "link": {
@@ -816,7 +827,7 @@ function convertMark(
 			return key;
 		}
 		default:
-			return mark.type;
+			throw new UnsupportedPortableTextMarksError([mark.type]);
 	}
 }
 
@@ -844,6 +855,7 @@ function portableTextToProsemirror(blocks: PortableTextBlock[]): {
 			content: [{ type: "paragraph" }],
 		};
 	}
+	assertPortableTextMarksSupported(blocks);
 
 	const content: unknown[] = [];
 	let i = 0;
@@ -1315,6 +1327,10 @@ function convertPTMarks(marks: string[], markDefs: Map<string, PortableTextMarkD
 							target: markDef.blank ? "_blank" : null,
 						},
 					});
+				} else {
+					throw new UnsupportedPortableTextMarksError([
+						typeof markDef?._type === "string" ? markDef._type : mark,
+					]);
 				}
 				break;
 			}
@@ -2608,6 +2624,7 @@ export function PortableTextEditor({
 
 	// Multi-select media picker state (for gallery insertion)
 	const [galleryPickerOpen, setGalleryPickerOpen] = React.useState(false);
+	const [conversionErrorMarks, setConversionErrorMarks] = React.useState<string[]>([]);
 
 	// Plugin block insertion/editing state
 	const [pluginBlockModal, setPluginBlockModal] = React.useState<PluginBlockDef | null>(null);
@@ -2758,8 +2775,19 @@ export function PortableTextEditor({
 	};
 
 	// Convert initial value to ProseMirror format
+	const initialUnsupportedMarks = React.useMemo(
+		() => findUnsupportedPortableTextMarks(value || []),
+		[],
+	);
+	const unsupportedMarks = React.useMemo(
+		() => [...new Set([...initialUnsupportedMarks, ...conversionErrorMarks])].toSorted(),
+		[conversionErrorMarks, initialUnsupportedMarks],
+	);
 	const initialContent = React.useMemo(
-		() => portableTextToProsemirror(value || []),
+		() =>
+			initialUnsupportedMarks.length > 0
+				? { type: "doc" as const, content: [{ type: "paragraph" }] }
+				: portableTextToProsemirror(value || []),
 		[], // Only compute once on mount
 	);
 
@@ -2849,7 +2877,7 @@ export function PortableTextEditor({
 	const editor = useEditor({
 		extensions,
 		content: initialContent as Parameters<typeof useEditor>[0]["content"],
-		editable,
+		editable: editable && unsupportedMarks.length === 0,
 		immediatelyRender: true,
 		editorProps,
 		onUpdate: ({ editor: updatedEditor }) => {
@@ -2858,8 +2886,16 @@ export function PortableTextEditor({
 				const doc = updatedEditor.getJSON();
 				// TipTap's getJSON() returns JSONContent which is structurally compatible
 				const pmDoc = doc as Parameters<typeof prosemirrorToPortableText>[0];
-				const portableText = prosemirrorToPortableText(pmDoc);
-				cb(portableText);
+				try {
+					const portableText = prosemirrorToPortableText(pmDoc);
+					cb(portableText);
+				} catch (error) {
+					if (error instanceof UnsupportedPortableTextMarksError) {
+						setConversionErrorMarks(error.marks);
+						return;
+					}
+					throw error;
+				}
 			}
 		},
 	});
@@ -3038,14 +3074,14 @@ export function PortableTextEditor({
 	// reference before TipTap destroys the instance (e.g. when keying by item.id
 	// to switch translations).
 	React.useEffect(() => {
-		if (editor && onEditorReady) {
+		if (editor && onEditorReady && unsupportedMarks.length === 0) {
 			onEditorReady(editor);
 			return () => {
 				onEditorReady(null);
 			};
 		}
 		return undefined;
-	}, [editor, onEditorReady]);
+	}, [editor, onEditorReady, unsupportedMarks.length]);
 
 	React.useEffect(() => {
 		const viewport = window.visualViewport;
@@ -3252,7 +3288,16 @@ export function PortableTextEditor({
 			const ptContent = Array.isArray(section.content)
 				? (section.content as PortableTextBlock[])
 				: [];
-			const { content: prosemirrorContent } = portableTextToProsemirror(ptContent);
+			let prosemirrorContent: unknown[];
+			try {
+				({ content: prosemirrorContent } = portableTextToProsemirror(ptContent));
+			} catch (error) {
+				if (error instanceof UnsupportedPortableTextMarksError) {
+					setConversionErrorMarks(error.marks);
+					return;
+				}
+				throw error;
+			}
 
 			const insertPos = pendingBlockInsertPosRef.current;
 			const chain = editor.chain().focus();
@@ -3265,6 +3310,28 @@ export function PortableTextEditor({
 		},
 		[editor],
 	);
+
+	if (unsupportedMarks.length > 0) {
+		const markList = unsupportedMarks.join(", ");
+		return (
+			<div
+				role="alert"
+				className={cn(
+					className,
+					"rounded-lg border border-kumo-error bg-kumo-error/10 p-4 text-start",
+				)}
+				aria-labelledby={ariaLabelledby}
+			>
+				<p className="font-medium text-kumo-error">{t`This content cannot be edited safely`}</p>
+				<p className="mt-1 text-sm text-kumo-subtle">
+					<Trans>
+						This field contains unsupported Portable Text marks: <code dir="auto">{markList}</code>.
+						Remove them through the API before editing or saving this content.
+					</Trans>
+				</p>
+			</div>
+		);
+	}
 
 	if (!editor) {
 		return (

--- a/packages/admin/src/lib/portable-text-marks.ts
+++ b/packages/admin/src/lib/portable-text-marks.ts
@@ -1,0 +1,129 @@
+const SUPPORTED_PORTABLE_TEXT_DECORATORS = new Set([
+	"strong",
+	"em",
+	"underline",
+	"strike-through",
+	"subscript",
+	"superscript",
+	"code",
+]);
+
+const SUPPORTED_PROSEMIRROR_MARKS = new Set([
+	"bold",
+	"strong",
+	"italic",
+	"em",
+	"underline",
+	"strike",
+	"strikethrough",
+	"subscript",
+	"superscript",
+	"code",
+	"link",
+]);
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectPortableTextMarks(
+	value: unknown,
+	inheritedMarkDefs: ReadonlyMap<string, UnknownRecord>,
+	unsupported: Set<string>,
+): void {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectPortableTextMarks(item, inheritedMarkDefs, unsupported);
+		}
+		return;
+	}
+	if (!isRecord(value)) return;
+
+	let markDefs: ReadonlyMap<string, UnknownRecord> = inheritedMarkDefs;
+	if (Array.isArray(value.markDefs)) {
+		const localMarkDefs = new Map(inheritedMarkDefs);
+		for (const markDef of value.markDefs) {
+			if (isRecord(markDef) && typeof markDef._key === "string") {
+				localMarkDefs.set(markDef._key, markDef);
+			}
+		}
+		markDefs = localMarkDefs;
+	}
+
+	if (value._type === "span" && Array.isArray(value.marks)) {
+		for (const mark of value.marks) {
+			if (typeof mark !== "string" || SUPPORTED_PORTABLE_TEXT_DECORATORS.has(mark)) continue;
+			const markDef = markDefs.get(mark);
+			if (markDef?._type === "link") continue;
+			unsupported.add(typeof markDef?._type === "string" ? markDef._type : mark);
+		}
+	}
+
+	for (const [key, child] of Object.entries(value)) {
+		if (key !== "markDefs") {
+			collectPortableTextMarks(child, markDefs, unsupported);
+		}
+	}
+}
+
+function collectProseMirrorMarks(value: unknown, unsupported: Set<string>): void {
+	if (!isRecord(value)) return;
+	if (Array.isArray(value.marks)) {
+		for (const mark of value.marks) {
+			if (
+				isRecord(mark) &&
+				typeof mark.type === "string" &&
+				!SUPPORTED_PROSEMIRROR_MARKS.has(mark.type)
+			) {
+				unsupported.add(mark.type);
+			}
+		}
+	}
+	if (Array.isArray(value.content)) {
+		for (const child of value.content) {
+			collectProseMirrorMarks(child, unsupported);
+		}
+	}
+}
+
+export class UnsupportedPortableTextMarksError extends Error {
+	readonly marks: string[];
+
+	constructor(marks: Iterable<string>) {
+		const sortedMarks = [...new Set(marks)].toSorted();
+		super(`Unsupported Portable Text marks: ${sortedMarks.join(", ")}`);
+		this.name = "UnsupportedPortableTextMarksError";
+		this.marks = sortedMarks;
+	}
+}
+
+export function findUnsupportedPortableTextMarks(blocks: unknown[]): string[] {
+	const unsupported = new Set<string>();
+	for (const block of blocks) {
+		if (isRecord(block) && (block._type === "block" || block._type === "table")) {
+			collectPortableTextMarks(block, new Map(), unsupported);
+		}
+	}
+	return [...unsupported].toSorted();
+}
+
+export function assertPortableTextMarksSupported(blocks: unknown[]): void {
+	const unsupported = findUnsupportedPortableTextMarks(blocks);
+	if (unsupported.length > 0) {
+		throw new UnsupportedPortableTextMarksError(unsupported);
+	}
+}
+
+export function assertProseMirrorMarksSupported(document: unknown): void {
+	const unsupported = new Set<string>();
+	if (isRecord(document) && Array.isArray(document.content)) {
+		for (const node of document.content) {
+			collectProseMirrorMarks(node, unsupported);
+		}
+	}
+	if (unsupported.size > 0) {
+		throw new UnsupportedPortableTextMarksError(unsupported);
+	}
+}

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -226,6 +226,48 @@ describe("ContentEditor", () => {
 		expect(portableTextProps.current?.placeholder).toBe("Start writing, or type '/' for commands");
 	});
 
+	it("blocks manual save and autosave while a Portable Text field has unsupported marks", async () => {
+		vi.useFakeTimers();
+		try {
+			const onSave = vi.fn();
+			const onAutosave = vi.fn();
+			const item = makeItem({
+				data: {
+					title: "My Post",
+					content: [
+						{
+							_type: "block",
+							_key: "b1",
+							style: "normal",
+							children: [{ _type: "span", _key: "s1", text: "Unsafe", marks: ["accent"] }],
+						},
+					],
+				},
+			});
+			const screen = await renderEditor({
+				isNew: false,
+				item,
+				fields: {
+					title: { kind: "string", label: "Title" },
+					content: { kind: "portableText", label: "Content" },
+				},
+				onSave,
+				onAutosave,
+			});
+
+			await screen.getByLabelText("Title").fill("Changed title");
+			const saveButton = screen.getByRole("button", { name: "Save" }).first();
+
+			await expect.element(saveButton).toBeDisabled();
+			await vi.advanceTimersByTimeAsync(2500);
+			expect(onAutosave).not.toHaveBeenCalled();
+			saveButton.element().click();
+			expect(onSave).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("uses one label and spacing rhythm across editor field types", async () => {
 		const screen = await renderEditor({
 			isNew: false,

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -14,6 +14,8 @@ import type { PluginBlockDef } from "../../src/components/PortableTextEditor";
 import {
 	_buildPluginBlockFormValues,
 	_hasPluginBlockFormData,
+	_portableTextToProsemirror,
+	_prosemirrorToPortableText,
 	PortableTextEditor,
 } from "../../src/components/PortableTextEditor";
 import { render } from "../utils/render";
@@ -297,6 +299,98 @@ describe("plugin block helpers", () => {
 // =============================================================================
 
 describe("Portable Text ↔ ProseMirror conversion", () => {
+	it("rejects mixed unsupported decorators across nested and spanning text", () => {
+		const blocks = [
+			{
+				_type: "block" as const,
+				_key: "quote",
+				style: "blockquote" as const,
+				children: [
+					{ _type: "span" as const, _key: "s1", text: "Brand", marks: ["strong", "accent"] },
+					{ _type: "span" as const, _key: "s2", text: " voice", marks: ["accent", "em"] },
+				],
+			},
+			{
+				_type: "block" as const,
+				_key: "nested-list",
+				style: "normal" as const,
+				listItem: "bullet" as const,
+				level: 2,
+				children: [
+					{ _type: "span" as const, _key: "s3", text: "Muted", marks: ["subtle", "code"] },
+				],
+			},
+		];
+
+		expect(() => _portableTextToProsemirror(blocks)).toThrow(/accent.*subtle/);
+	});
+
+	it("rejects unsupported markDefs annotations by type", () => {
+		const annotationKey = "annotation-9f31";
+		const blocks = [
+			textBlock("Highlighted", {
+				marks: ["strong", annotationKey],
+				markDefs: [{ _type: "brandColor", _key: annotationKey, token: "accent" }],
+			}),
+		];
+
+		let conversionError: Error | undefined;
+		try {
+			_portableTextToProsemirror(blocks);
+		} catch (error) {
+			conversionError = error as Error;
+		}
+		expect(conversionError?.message).toContain("brandColor");
+		expect(conversionError?.message).not.toContain("annotation-9f31");
+	});
+
+	it("rejects unsupported marks in nested outbound ProseMirror content", () => {
+		const document = {
+			type: "doc",
+			content: [
+				{
+					type: "blockquote",
+					content: [
+						{
+							type: "paragraph",
+							content: [
+								{
+									type: "text",
+									text: "Mixed",
+									marks: [{ type: "bold" }, { type: "accent" }],
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		expect(() => _prosemirrorToPortableText(document)).toThrow(/accent/);
+	});
+
+	it("blocks the editor with a localized mark-specific alert in RTL layouts", async () => {
+		const onChange = vi.fn();
+		const onEditorReady = vi.fn();
+		const screen = await render(
+			<div dir="rtl">
+				<PortableTextEditor
+					value={[textBlock("Unsafe", { marks: ["strong", "accent"] })]}
+					onChange={onChange}
+					onEditorReady={onEditorReady}
+				/>
+			</div>,
+		);
+		const alert = screen.getByRole("alert");
+
+		await expect.element(alert).toBeInTheDocument();
+		expect(alert.element()).toHaveTextContent("accent");
+		expect(getComputedStyle(alert.element()).direction).toBe("rtl");
+		expect(document.querySelector(".ProseMirror")).toBeNull();
+		expect(onChange).not.toHaveBeenCalled();
+		expect(onEditorReady).not.toHaveBeenCalledWith(expect.anything());
+	});
+
 	it("renders a paragraph from PT value", async () => {
 		await render(<PortableTextEditor value={[textBlock("Hello world")]} />);
 		const pm = await waitForEditor();

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -28,8 +28,12 @@ vi.mock("../../src/components/MediaPickerModal", () => ({
 	MediaPickerModal: () => null,
 }));
 
+const sectionPickerProps: { current: Record<string, any> | null } = { current: null };
 vi.mock("../../src/components/SectionPickerModal", () => ({
-	SectionPickerModal: () => null,
+	SectionPickerModal: (props: Record<string, any>) => {
+		sectionPickerProps.current = props;
+		return null;
+	},
 }));
 
 vi.mock("../../src/components/editor/DragHandleWrapper", () => ({
@@ -389,6 +393,37 @@ describe("Portable Text ↔ ProseMirror conversion", () => {
 		expect(document.querySelector(".ProseMirror")).toBeNull();
 		expect(onChange).not.toHaveBeenCalled();
 		expect(onEditorReady).not.toHaveBeenCalledWith(expect.anything());
+	});
+
+	it("keeps safe content editable when an unsupported section is rejected", async () => {
+		const onChange = vi.fn();
+		const { screen, editor, pm } = await renderAndGetEditor({
+			value: [textBlock("Safe content")],
+			onChange,
+		});
+		const unsafeSection = {
+			id: "section-1",
+			slug: "unsafe-section",
+			title: "Unsafe section",
+			keywords: [],
+			content: [textBlock("Unsafe insert", { marks: ["accent"] })],
+			source: "user",
+			createdAt: "2026-08-16T00:00:00.000Z",
+			updatedAt: "2026-08-16T00:00:00.000Z",
+		};
+
+		await React.act(async () => {
+			sectionPickerProps.current?.onSelect(unsafeSection);
+		});
+
+		const alert = screen.getByRole("alert");
+		await expect.element(alert).toBeInTheDocument();
+		expect(alert.element()).toHaveTextContent("accent");
+		expect(document.querySelector(".ProseMirror")).toBe(pm);
+		expect(editor.getText()).toBe("Safe content");
+
+		typeIntoEditor(editor, " still editable");
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled(), { timeout: 2000 });
 	});
 
 	it("renders a paragraph from PT value", async () => {

--- a/packages/core/src/content/converters/mark-safety.ts
+++ b/packages/core/src/content/converters/mark-safety.ts
@@ -1,0 +1,120 @@
+import type { PortableTextBlock, ProseMirrorDocument, ProseMirrorNode } from "./types.js";
+
+const SUPPORTED_PORTABLE_TEXT_DECORATORS = new Set([
+	"strong",
+	"em",
+	"underline",
+	"strike-through",
+	"subscript",
+	"superscript",
+	"code",
+]);
+
+const SUPPORTED_PROSEMIRROR_MARKS = new Set([
+	"bold",
+	"strong",
+	"italic",
+	"em",
+	"underline",
+	"strike",
+	"strikethrough",
+	"subscript",
+	"superscript",
+	"code",
+	"link",
+]);
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectPortableTextMarks(
+	value: unknown,
+	inheritedMarkDefs: ReadonlyMap<string, UnknownRecord>,
+	unsupported: Set<string>,
+): void {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectPortableTextMarks(item, inheritedMarkDefs, unsupported);
+		}
+		return;
+	}
+	if (!isRecord(value)) return;
+
+	let markDefs: ReadonlyMap<string, UnknownRecord> = inheritedMarkDefs;
+	if (Array.isArray(value.markDefs)) {
+		const localMarkDefs = new Map(inheritedMarkDefs);
+		for (const markDef of value.markDefs) {
+			if (isRecord(markDef) && typeof markDef._key === "string") {
+				localMarkDefs.set(markDef._key, markDef);
+			}
+		}
+		markDefs = localMarkDefs;
+	}
+
+	if (value._type === "span" && Array.isArray(value.marks)) {
+		for (const mark of value.marks) {
+			if (typeof mark !== "string" || SUPPORTED_PORTABLE_TEXT_DECORATORS.has(mark)) continue;
+			const markDef = markDefs.get(mark);
+			if (markDef?._type === "link") continue;
+			unsupported.add(typeof markDef?._type === "string" ? markDef._type : mark);
+		}
+	}
+
+	for (const [key, child] of Object.entries(value)) {
+		if (key !== "markDefs") {
+			collectPortableTextMarks(child, markDefs, unsupported);
+		}
+	}
+}
+
+function collectProseMirrorMarks(node: ProseMirrorNode, unsupported: Set<string>): void {
+	for (const mark of node.marks ?? []) {
+		if (!SUPPORTED_PROSEMIRROR_MARKS.has(mark.type)) {
+			unsupported.add(mark.type);
+		}
+	}
+	for (const child of node.content ?? []) {
+		collectProseMirrorMarks(child, unsupported);
+	}
+}
+
+export class UnsupportedPortableTextMarksError extends Error {
+	readonly marks: string[];
+
+	constructor(marks: Iterable<string>) {
+		const sortedMarks = [...new Set(marks)].toSorted();
+		super(`Unsupported Portable Text marks: ${sortedMarks.join(", ")}`);
+		this.name = "UnsupportedPortableTextMarksError";
+		this.marks = sortedMarks;
+	}
+}
+
+export function findUnsupportedPortableTextMarks(blocks: PortableTextBlock[]): string[] {
+	const unsupported = new Set<string>();
+	for (const block of blocks) {
+		if (block._type === "block" || block._type === "table") {
+			collectPortableTextMarks(block, new Map(), unsupported);
+		}
+	}
+	return [...unsupported].toSorted();
+}
+
+export function assertPortableTextMarksSupported(blocks: PortableTextBlock[]): void {
+	const unsupported = findUnsupportedPortableTextMarks(blocks);
+	if (unsupported.length > 0) {
+		throw new UnsupportedPortableTextMarksError(unsupported);
+	}
+}
+
+export function assertProseMirrorMarksSupported(document: ProseMirrorDocument): void {
+	const unsupported = new Set<string>();
+	for (const node of document.content) {
+		collectProseMirrorMarks(node, unsupported);
+	}
+	if (unsupported.size > 0) {
+		throw new UnsupportedPortableTextMarksError(unsupported);
+	}
+}

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -6,6 +6,10 @@
 
 import { sanitizeGalleryImages } from "./gallery.js";
 import {
+	UnsupportedPortableTextMarksError,
+	assertPortableTextMarksSupported,
+} from "./mark-safety.js";
+import {
 	deriveLegacyListId,
 	normalizeProseMirrorOrderedListJson,
 	normalizeListId,
@@ -34,6 +38,7 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 			content: [{ type: "paragraph" }],
 		};
 	}
+	assertPortableTextMarksSupported(blocks);
 
 	const content: ProseMirrorNode[] = [];
 	let i = 0;
@@ -466,6 +471,14 @@ function convertMarks(
 				pmMarks.push({ type: "strike" });
 				break;
 
+			case "subscript":
+				pmMarks.push({ type: "subscript" });
+				break;
+
+			case "superscript":
+				pmMarks.push({ type: "superscript" });
+				break;
+
 			case "code":
 				pmMarks.push({ type: "code" });
 				break;
@@ -473,22 +486,18 @@ function convertMarks(
 			default: {
 				// Check if it's a mark definition reference
 				const markDef = markDefs.get(mark);
-				if (markDef) {
-					if (markDef._type === "link") {
-						pmMarks.push({
-							type: "link",
-							attrs: {
-								href: markDef.href,
-								target: markDef.blank ? "_blank" : null,
-							},
-						});
-					} else {
-						// Unknown mark def type - preserve attrs
-						pmMarks.push({
-							type: markDef._type,
-							attrs: markDef,
-						});
-					}
+				if (markDef?._type === "link") {
+					pmMarks.push({
+						type: "link",
+						attrs: {
+							href: markDef.href,
+							target: markDef.blank ? "_blank" : null,
+						},
+					});
+				} else {
+					throw new UnsupportedPortableTextMarksError([
+						typeof markDef?._type === "string" ? markDef._type : mark,
+					]);
 				}
 				break;
 			}

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -5,6 +5,10 @@
  */
 
 import { sanitizeGalleryImages } from "./gallery.js";
+import {
+	UnsupportedPortableTextMarksError,
+	assertProseMirrorMarksSupported,
+} from "./mark-safety.js";
 import { readOrderedListMetadata, type OrderedListMetadata } from "./numbered-list.js";
 import type {
 	ProseMirrorDocument,
@@ -34,6 +38,7 @@ export function prosemirrorToPortableText(doc: ProseMirrorDocument): PortableTex
 	if (!doc || doc.type !== "doc" || !doc.content) {
 		return [];
 	}
+	assertProseMirrorMarksSupported(doc);
 
 	const blocks: PortableTextBlock[] = [];
 
@@ -435,6 +440,12 @@ function convertMark(
 		case "strikethrough":
 			return "strike-through";
 
+		case "subscript":
+			return "subscript";
+
+		case "superscript":
+			return "superscript";
+
 		case "code":
 			return "code";
 
@@ -460,7 +471,6 @@ function convertMark(
 		}
 
 		default:
-			// Unknown mark - preserve as-is
-			return mark.type;
+			throw new UnsupportedPortableTextMarksError([mark.type]);
 	}
 }

--- a/packages/core/tests/unit/converters/unsupported-portable-text-marks.test.ts
+++ b/packages/core/tests/unit/converters/unsupported-portable-text-marks.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
+import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
+import type {
+	PortableTextTextBlock,
+	ProseMirrorDocument,
+} from "../../../src/content/converters/types.js";
+
+describe("unsupported Portable Text marks (core converters)", () => {
+	it("rejects every unsupported decorator spanning nested blocks without dropping supported marks", () => {
+		const blocks: PortableTextTextBlock[] = [
+			{
+				_type: "block",
+				_key: "quote",
+				style: "blockquote",
+				children: [
+					{ _type: "span", _key: "s1", text: "Brand", marks: ["strong", "accent"] },
+					{ _type: "span", _key: "s2", text: " voice", marks: ["accent", "em"] },
+				],
+			},
+			{
+				_type: "block",
+				_key: "nested-list",
+				style: "normal",
+				listItem: "bullet",
+				level: 2,
+				children: [{ _type: "span", _key: "s3", text: "Muted", marks: ["subtle", "code"] }],
+			},
+		];
+
+		expect(() => portableTextToProsemirror(blocks)).toThrow(/accent.*subtle/);
+	});
+
+	it("rejects unsupported markDefs annotations by type instead of their opaque keys", () => {
+		const blocks: PortableTextTextBlock[] = [
+			{
+				_type: "block",
+				_key: "b1",
+				style: "normal",
+				markDefs: [{ _type: "brandColor", _key: "annotation-9f31", token: "accent" }],
+				children: [
+					{
+						_type: "span",
+						_key: "s1",
+						text: "Highlighted",
+						marks: ["strong", "annotation-9f31"],
+					},
+				],
+			},
+		];
+
+		let conversionError: Error | undefined;
+		try {
+			portableTextToProsemirror(blocks);
+		} catch (error) {
+			conversionError = error as Error;
+		}
+		expect(conversionError?.message).toContain("brandColor");
+		expect(conversionError?.message).not.toContain("annotation-9f31");
+	});
+
+	it("rejects unsupported ProseMirror marks anywhere in the outbound document", () => {
+		const document: ProseMirrorDocument = {
+			type: "doc",
+			content: [
+				{
+					type: "blockquote",
+					content: [
+						{
+							type: "paragraph",
+							content: [
+								{
+									type: "text",
+									text: "Mixed",
+									marks: [{ type: "bold" }, { type: "accent" }],
+								},
+								{
+									type: "text",
+									text: " marks",
+									marks: [{ type: "italic" }, { type: "subtle" }],
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		expect(() => prosemirrorToPortableText(document)).toThrow(/accent.*subtle/);
+	});
+
+	it("round-trips every supported decorator and link annotation", () => {
+		const blocks: PortableTextTextBlock[] = [
+			{
+				_type: "block",
+				_key: "b1",
+				style: "normal",
+				markDefs: [{ _type: "link", _key: "link-1", href: "https://example.com" }],
+				children: [
+					{
+						_type: "span",
+						_key: "s1",
+						text: "Supported",
+						marks: [
+							"strong",
+							"em",
+							"underline",
+							"strike-through",
+							"subscript",
+							"superscript",
+							"code",
+							"link-1",
+						],
+					},
+				],
+			},
+		];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(blocks));
+		const block = roundTripped[0] as PortableTextTextBlock;
+		const spanMarks = block.children[0]?.marks ?? [];
+		const linkDef = block.markDefs?.find((markDef) => markDef._type === "link");
+
+		expect(spanMarks).toEqual(
+			expect.arrayContaining([
+				"strong",
+				"em",
+				"underline",
+				"strike-through",
+				"subscript",
+				"superscript",
+				"code",
+			]),
+		);
+		expect(linkDef).toMatchObject({ _type: "link", href: "https://example.com" });
+		expect(spanMarks).toContain(linkDef?._key);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Prevents unsupported Portable Text decorators and `markDefs` annotations from being silently discarded by either the core or admin converters. The admin now replaces the unsafe editing surface with a localized error naming the unsupported marks and blocks manual save and autosave until the content is made safe through the API.

The regression coverage includes nested and spanning marks, mixed supported and unsupported marks, annotations, supported-mark round trips, autosave suppression, and the error UI in an RTL browser layout. This intentionally does not add a mark registration API; that remains separate follow-up work.

Closes #2430

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this is a bug fix scoped by the maintainer decision in #2430.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- `pnpm typecheck` — all 31 package typechecks passed
- `pnpm lint` — passed with warnings denied
- `pnpm --silent lint:json | jq '.diagnostics | length'` — `0`
- `pnpm --filter emdash exec vitest run tests/unit/converters` — 10 files, 47 tests passed
- `pnpm --filter @emdash-cms/admin exec vitest run tests/editor/PortableTextEditor.test.tsx tests/components/ContentEditor.test.tsx` — 2 browser-test files, 140 tests passed
- RTL behavior is covered by the browser test that renders the blocking alert in an inherited RTL direction and verifies the unsafe editor is unavailable.
