### PR TITLE
fix(plugins): honor locale when creating content

### DIFF
--- a/.changeset/tidy-lions-create-locales.md
+++ b/.changeset/tidy-lions-create-locales.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+"@emdash-cms/cloudflare": patch
+"@emdash-cms/sandbox-workerd": patch
+---
+
+Fixes plugin-created content to use an explicit or configured default locale instead of always falling back to English.

--- a/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
@@ -61,7 +61,7 @@ const post = await ctx.content.create(
 );
 ```
 
-Locale matching is case-insensitive and stores the casing from the site's locale configuration, so `zh-tw` becomes `zh-TW` when that is the configured form. An unconfigured or malformed explicit locale throws. When the option is omitted, EmDash uses the site's configured default locale; sites without i18n configuration retain the `en` default.
+Locale matching is case-insensitive and stores the casing from the site's locale configuration, so `zh-tw` becomes `zh-TW` when that is the configured form. A malformed explicit locale always throws; when i18n is configured, an explicit locale outside the configured locale list also throws. When the option is omitted, EmDash uses the site's configured default locale; sites without i18n configuration retain the `en` default.
 
 ## Network host allowlists
 

--- a/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
@@ -49,6 +49,20 @@ A few things worth knowing:
 - **`network:request:unrestricted` exists for user-configured URLs.** A webhook plugin where the operator types in the destination URL needs to reach hosts that aren't in the manifest. Plugins that always call known APIs should use `network:request` + `allowedHosts`.
 - **`email:send` is gated by configuration, not just the capability.** A plugin can declare `email:send`, but `ctx.email` will only be populated if some other plugin has registered an `email:deliver` transport.
 
+### Creating content in a locale
+
+`ctx.content.create()` accepts an optional third argument for the new entry's locale:
+
+```ts
+const post = await ctx.content.create(
+	"posts",
+	{ title: "繁體中文" },
+	{ locale: "zh-tw" },
+);
+```
+
+Locale matching is case-insensitive and stores the casing from the site's locale configuration, so `zh-tw` becomes `zh-TW` when that is the configured form. An unconfigured or malformed explicit locale throws. When the option is omitted, EmDash uses the site's configured default locale; sites without i18n configuration retain the `en` default.
+
 ## Network host allowlists
 
 Plugins with `network:request` can only fetch hosts listed in `allowedHosts`. Wildcards are supported for subdomains:

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -596,6 +596,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			'"updated_at"',
 			'"version"',
 			'"locale"',
+			'"translation_group"',
 		];
 		const values: unknown[] = [
 			id,
@@ -606,6 +607,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			now,
 			1,
 			locale,
+			id,
 		];
 
 		// Append user data fields (skip system columns, quote identifiers)

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -9,12 +9,13 @@
 
 import type { D1Database } from "@cloudflare/workers-types";
 import { WorkerEntrypoint } from "cloudflare:workers";
-import type { SandboxEmailSendCallback } from "emdash";
+import type { ContentCreateOptions, I18nConfig, SandboxEmailSendCallback } from "emdash";
 import {
 	createSandboxRouteError,
 	getSandboxRouteErrorDetails,
 	ulid,
 	PluginStorageRepository,
+	resolveContentCreateLocale,
 } from "emdash";
 import { Kysely } from "kysely";
 import { D1Dialect } from "kysely-d1";
@@ -42,6 +43,8 @@ const SYSTEM_COLUMNS = new Set([
 	"version",
 	"live_revision_id",
 	"draft_revision_id",
+	"locale",
+	"translation_group",
 ]);
 
 /**
@@ -93,6 +96,7 @@ function rowToContentItem(
 	data: Record<string, unknown>;
 	createdAt: string;
 	updatedAt: string;
+	locale: string;
 } {
 	const data: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(row)) {
@@ -116,6 +120,7 @@ function rowToContentItem(
 		data,
 		createdAt: typeof row.created_at === "string" ? row.created_at : new Date().toISOString(),
 		updatedAt: typeof row.updated_at === "string" ? row.updated_at : new Date().toISOString(),
+		locale: typeof row.locale === "string" ? row.locale : "en",
 	};
 }
 
@@ -201,6 +206,7 @@ export interface PluginBridgeProps {
 	capabilities: string[];
 	allowedHosts: string[];
 	storageCollections: string[];
+	i18nConfig?: I18nConfig | null;
 	/** Per-collection storage config (matches manifest.storage entries) */
 	storageConfig?: Record<
 		string,
@@ -560,12 +566,14 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 	async contentCreate(
 		collection: string,
 		data: Record<string, unknown>,
+		options?: ContentCreateOptions,
 	): Promise<{
 		id: string;
 		type: string;
 		data: Record<string, unknown>;
 		createdAt: string;
 		updatedAt: string;
+		locale: string;
 	}> {
 		const { capabilities } = this.ctx.props;
 		if (!capabilities.includes("content:write")) {
@@ -574,6 +582,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		if (!COLLECTION_NAME_REGEX.test(collection)) {
 			throw new Error(`Invalid collection name: ${collection}`);
 		}
+		const locale = resolveContentCreateLocale(options?.locale, this.ctx.props.i18nConfig ?? null);
 		await this.assertMediaUsageActivationWriteAllowed();
 
 		const id = ulid();
@@ -588,6 +597,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			'"created_at"',
 			'"updated_at"',
 			'"version"',
+			'"locale"',
 		];
 		const values: unknown[] = [
 			id,
@@ -597,6 +607,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			now,
 			now,
 			1,
+			locale,
 		];
 
 		// Append user data fields (skip system columns, quote identifiers)
@@ -624,7 +635,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			.first();
 
 		if (!created) {
-			return { id, type: collection, data: {}, createdAt: now, updatedAt: now };
+			return { id, type: collection, data: {}, createdAt: now, updatedAt: now, locale };
 		}
 		return rowToContentItem(collection, created);
 	}

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -79,13 +79,9 @@ function serializeValue(value: unknown): unknown {
 }
 
 /**
- * Deserialize a row from D1 into a content response shape.
- * Extracts system columns and bundles remaining columns into data.
- */
-/**
  * Deserialize a row from D1 into a ContentItem matching core's plugin API.
  * Extracts system columns, deserializes JSON fields, and returns the
- * canonical shape: { id, type, data, createdAt, updatedAt }.
+ * canonical shape: { id, type, data, createdAt, updatedAt, locale }.
  */
 function rowToContentItem(
 	collection: string,
@@ -482,6 +478,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		data: Record<string, unknown>;
 		createdAt: string;
 		updatedAt: string;
+		locale: string;
 	} | null> {
 		const { capabilities } = this.ctx.props;
 		if (!capabilities.includes("content:read")) {
@@ -516,6 +513,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			data: Record<string, unknown>;
 			createdAt: string;
 			updatedAt: string;
+			locale: string;
 		}>;
 		cursor?: string;
 		hasMore: boolean;
@@ -650,6 +648,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		data: Record<string, unknown>;
 		createdAt: string;
 		updatedAt: string;
+		locale: string;
 	}> {
 		const { capabilities } = this.ctx.props;
 		if (!capabilities.includes("content:write")) {

--- a/packages/cloudflare/src/sandbox/runner.ts
+++ b/packages/cloudflare/src/sandbox/runner.ts
@@ -15,6 +15,7 @@ import { env, exports } from "cloudflare:workers";
 import {
 	createSandboxRouteError,
 	getSandboxRouteErrorEnvelope,
+	getI18nConfig,
 	normalizeCapabilities,
 	type SandboxRunner,
 	type SandboxedPluginInstance,
@@ -23,6 +24,7 @@ import {
 	type SandboxRunnerFactory,
 	type SerializedRequest,
 	type PluginManifest,
+	type I18nConfig,
 } from "emdash";
 
 import { setEmailSendCallback } from "./bridge.js";
@@ -51,6 +53,7 @@ export interface PluginBridgeProps {
 	capabilities: string[];
 	allowedHosts: string[];
 	storageCollections: string[];
+	i18nConfig?: I18nConfig | null;
 	storageConfig?: Record<
 		string,
 		{ indexes?: Array<string | string[]>; uniqueIndexes?: Array<string | string[]> }
@@ -271,6 +274,7 @@ class CloudflareSandboxedPlugin implements SandboxedPluginInstance {
 				capabilities: normalizeCapabilities(this.manifest.capabilities || []),
 				allowedHosts: this.manifest.allowedHosts || [],
 				storageCollections: Object.keys(this.manifest.storage || {}),
+				i18nConfig: getI18nConfig(),
 				storageConfig: this.manifest.storage,
 			},
 		});

--- a/packages/cloudflare/src/sandbox/types.ts
+++ b/packages/cloudflare/src/sandbox/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { D1Database, R2Bucket } from "@cloudflare/workers-types";
+import type { ContentCreateOptions } from "emdash";
 
 /**
  * Environment bindings required for sandbox runner.
@@ -106,6 +107,7 @@ interface BridgeContentItem {
 	data: Record<string, unknown>;
 	createdAt: string;
 	updatedAt: string;
+	locale: string;
 }
 
 /**
@@ -177,7 +179,11 @@ export interface PluginBridgeBinding {
 		collection: string,
 		opts?: { limit?: number; cursor?: string },
 	): Promise<{ items: BridgeContentItem[]; cursor?: string; hasMore: boolean }>;
-	contentCreate(collection: string, data: Record<string, unknown>): Promise<BridgeContentItem>;
+	contentCreate(
+		collection: string,
+		data: Record<string, unknown>,
+		options?: ContentCreateOptions,
+	): Promise<BridgeContentItem>;
 	contentUpdate(
 		collection: string,
 		id: string,

--- a/packages/cloudflare/src/sandbox/wrapper.ts
+++ b/packages/cloudflare/src/sandbox/wrapper.ts
@@ -124,7 +124,7 @@ function createContext(env) {
 	const content = {
 		get: (collection, id) => bridge.contentGet(collection, id),
 		list: (collection, opts) => bridge.contentList(collection, opts),
-		create: (collection, data) => bridge.contentCreate(collection, data),
+		create: (collection, data, options) => bridge.contentCreate(collection, data, options),
 		update: (collection, id, data) => bridge.contentUpdate(collection, id, data),
 		delete: (collection, id) => bridge.contentDelete(collection, id)
 	};

--- a/packages/cloudflare/tests/sandbox/bridge-content-write-fence.test.ts
+++ b/packages/cloudflare/tests/sandbox/bridge-content-write-fence.test.ts
@@ -202,6 +202,8 @@ describe("PluginBridge content write fence", () => {
 
 		expect(insert?.sql).toContain('"locale"');
 		expect(insert?.values).toContain(expected);
+		expect(insert?.sql).toContain('"translation_group"');
+		expect(insert?.values.at(-1)).toBe(insert?.values[0]);
 		expect(created).toMatchObject({ locale: expected });
 	});
 

--- a/packages/cloudflare/tests/sandbox/bridge-content-write-fence.test.ts
+++ b/packages/cloudflare/tests/sandbox/bridge-content-write-fence.test.ts
@@ -17,7 +17,7 @@ const bridgeContext = {
 	props: {
 		pluginId: "test-plugin",
 		pluginVersion: "1.0.0",
-		capabilities: ["content:write"],
+		capabilities: ["content:read", "content:write"],
 		allowedHosts: [],
 		storageCollections: [],
 	},
@@ -34,6 +34,30 @@ function makeBridge(db: unknown, i18nConfig?: { defaultLocale: string; locales: 
 }
 
 describe("PluginBridge content write fence", () => {
+	it("returns locale from content reads", async () => {
+		const db = {
+			prepare() {
+				return {
+					bind() {
+						return this;
+					},
+					async first() {
+						return {
+							id: "post-id",
+							locale: "fr",
+							created_at: "2026-08-16T00:00:00.000Z",
+							updated_at: "2026-08-16T00:00:00.000Z",
+						};
+					},
+				};
+			},
+		};
+
+		const item = await makeBridge(db).contentGet("posts", "post-id");
+
+		expect(item?.locale).toBe("fr");
+	});
+
 	it("rejects content mutations while media usage activation is incomplete", async () => {
 		const queries: string[] = [];
 		const db = {

--- a/packages/cloudflare/tests/sandbox/bridge-content-write-fence.test.ts
+++ b/packages/cloudflare/tests/sandbox/bridge-content-write-fence.test.ts
@@ -23,8 +23,14 @@ const bridgeContext = {
 	},
 };
 
-function makeBridge(db: unknown) {
-	return new PluginBridge(bridgeContext as never, { DB: db } as never);
+function makeBridge(db: unknown, i18nConfig?: { defaultLocale: string; locales: string[] } | null) {
+	return new PluginBridge(
+		{
+			...bridgeContext,
+			props: { ...bridgeContext.props, i18nConfig },
+		} as never,
+		{ DB: db } as never,
+	);
 }
 
 describe("PluginBridge content write fence", () => {
@@ -116,5 +122,75 @@ describe("PluginBridge content write fence", () => {
 		} finally {
 			consoleError.mockRestore();
 		}
+	});
+
+	it.each([
+		{
+			name: "explicit locale",
+			config: { defaultLocale: "en", locales: ["en", "zh-TW"] },
+			options: { locale: "zh-tw" },
+			expected: "zh-TW",
+		},
+		{
+			name: "configured default",
+			config: { defaultLocale: "ja", locales: ["ja"] },
+			options: undefined,
+			expected: "ja",
+		},
+		{
+			name: "no-i18n fallback",
+			config: null,
+			options: undefined,
+			expected: "en",
+		},
+	])("persists the $name", async ({ config, options, expected }) => {
+		const statements: Array<{ sql: string; values: unknown[] }> = [];
+		const db = {
+			prepare(sql: string) {
+				const statement = {
+					values: [] as unknown[],
+					bind(...values: unknown[]) {
+						statement.values = values;
+						statements.push({ sql, values });
+						return statement;
+					},
+					async first() {
+						if (sql.includes("_emdash_media_usage_activation")) {
+							throw new Error("D1_ERROR: no such table: _emdash_media_usage_activation");
+						}
+						return {
+							id: "created-id",
+							locale: expected,
+							created_at: "2026-08-16T00:00:00.000Z",
+							updated_at: "2026-08-16T00:00:00.000Z",
+						};
+					},
+					async run() {
+						return { meta: { changes: 1 } };
+					},
+				};
+				return statement;
+			},
+		};
+
+		const created = await makeBridge(db, config).contentCreate("posts", {}, options);
+		const insert = statements.find(({ sql }) => sql.startsWith("INSERT INTO"));
+
+		expect(insert?.sql).toContain('"locale"');
+		expect(insert?.values).toContain(expected);
+		expect(created).toMatchObject({ locale: expected });
+	});
+
+	it("rejects invalid locale options before querying D1", async () => {
+		const prepare = vi.fn();
+		const bridge = makeBridge({ prepare }, { defaultLocale: "en", locales: ["en", "fr"] });
+
+		await expect(bridge.contentCreate("posts", {}, { locale: "en_US" })).rejects.toThrow(
+			/invalid locale code/i,
+		);
+		await expect(bridge.contentCreate("posts", {}, { locale: "de" })).rejects.toThrow(
+			/not configured/i,
+		);
+		expect(prepare).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/api/schemas/common.ts
+++ b/packages/core/src/api/schemas/common.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { LOCALE_CODE_PATTERN } from "../../i18n/config.js";
+
 // ---------------------------------------------------------------------------
 // Role level
 // ---------------------------------------------------------------------------
@@ -58,7 +60,7 @@ export const httpUrl = z
  * Validation is case-insensitive, but the value is preserved verbatim because the site config, stored
  * `locale` columns, and public query path all keep the raw BCP-47 casing.
  */
-export const localeCode = z.string().regex(/^[a-z]{2,3}(-[a-z0-9]{2,8})*$/i, "Invalid locale code");
+export const localeCode = z.string().regex(LOCALE_CODE_PATTERN, "Invalid locale code");
 
 /** Shared `?locale=xx` query shape for endpoints that filter by locale. */
 export const localeFilterQuery = z

--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -12,6 +12,8 @@ export interface I18nConfig {
 	prefixDefaultLocale?: boolean;
 }
 
+export const LOCALE_CODE_PATTERN = /^[a-z]{2,3}(-[a-z0-9]{2,8})*$/i;
+
 const I18N_CONFIG_KEY = Symbol.for("emdash:i18n-config");
 
 function configStore(): Record<symbol, I18nConfig | null | undefined> {
@@ -41,6 +43,36 @@ export function resolveConfiguredLocale(locale: string): string {
 		config?.locales.find((configured) => configured.toLowerCase() === locale.toLowerCase()) ??
 		locale
 	);
+}
+
+/** Whether a string is a supported BCP 47 locale code. */
+export function isValidLocaleCode(locale: string): boolean {
+	return LOCALE_CODE_PATTERN.test(locale);
+}
+
+/** Resolve the locale for a new content row. */
+export function resolveContentCreateLocale(
+	locale: unknown,
+	config: I18nConfig | null = getI18nConfig(),
+): string {
+	if (locale !== undefined) {
+		if (typeof locale !== "string") {
+			throw new Error("Invalid locale code: expected a string");
+		}
+		if (!isValidLocaleCode(locale)) {
+			throw new Error(`Invalid locale code: "${locale}"`);
+		}
+
+		const configured = config?.locales.find(
+			(candidate) => candidate.toLowerCase() === locale.toLowerCase(),
+		);
+		if (config && !configured) {
+			throw new Error(`Locale "${locale}" is not configured for this site`);
+		}
+		return configured ?? locale;
+	}
+
+	return config?.defaultLocale ?? "en";
 }
 
 /**

--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -45,7 +45,7 @@ export function resolveConfiguredLocale(locale: string): string {
 	);
 }
 
-/** Whether a string is a supported BCP 47 locale code. */
+/** Whether a string matches the locale-code subset accepted by EmDash. */
 export function isValidLocaleCode(locale: string): boolean {
 	return LOCALE_CODE_PATTERN.test(locale);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -144,7 +144,12 @@ export { after } from "./after.js";
 export type { WaitUntilFn } from "./after.js";
 
 // i18n configuration (from Astro config)
-export { getI18nConfig, isI18nEnabled, getFallbackChain } from "./i18n/config.js";
+export {
+	getI18nConfig,
+	isI18nEnabled,
+	getFallbackChain,
+	resolveContentCreateLocale,
+} from "./i18n/config.js";
 export type { I18nConfig } from "./i18n/config.js";
 
 // Visual editing
@@ -249,6 +254,7 @@ export type {
 	StorageCollection,
 	KVAccess,
 	ContentAccess,
+	ContentCreateOptions,
 	MediaAccess,
 	HttpAccess,
 	LogAccess,

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -17,6 +17,7 @@ import { TaxonomyRepository, type Taxonomy } from "../database/repositories/taxo
 import { UserRepository } from "../database/repositories/user.js";
 import { withTransaction } from "../database/transaction.js";
 import type { Database } from "../database/types.js";
+import { resolveContentCreateLocale } from "../i18n/config.js";
 import {
 	resolveAndValidateExternalUrl,
 	SsrfError,
@@ -46,6 +47,7 @@ import type {
 	UserAccess,
 	UserInfo,
 	ContentItem,
+	ContentCreateOptions,
 	ContentItemSeoInput,
 	ContentWriteInput,
 	MediaItem,
@@ -376,7 +378,12 @@ export function createContentAccessWithWrite(
 	return {
 		...readAccess,
 
-		async create(collection: string, data: ContentWriteInput): Promise<ContentItem> {
+		async create(
+			collection: string,
+			data: ContentWriteInput,
+			options?: ContentCreateOptions,
+		): Promise<ContentItem> {
+			const locale = resolveContentCreateLocale(options?.locale);
 			await beforeContentWrite?.();
 			const { fields, seo } = splitSeoFromInput(data);
 			let contentMutated = false;
@@ -391,6 +398,7 @@ export function createContentAccessWithWrite(
 					const item = await trxContentRepo.create({
 						type: collection,
 						data: fields,
+						locale,
 					});
 					contentMutated = true;
 

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -122,6 +122,8 @@ export type {
 	UserInfo,
 	UserAccess,
 	ContentItem,
+	ContentCreateOptions,
+	ContentWriteInput,
 	MediaItem,
 	ContentListOptions,
 	MediaListOptions,

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -251,6 +251,12 @@ export type ContentWriteInput = Record<string, unknown> & {
 	seo?: ContentItemSeoInput;
 };
 
+/** Options accepted by `content.create`. */
+export interface ContentCreateOptions {
+	/** Locale for the new content row. Defaults to the configured site locale, then `en`. */
+	locale?: string;
+}
+
 /**
  * Taxonomy definition returned from the taxonomy API (e.g. "category", "tag").
  */
@@ -299,7 +305,11 @@ export interface ContentAccess {
 	list(collection: string, options?: ContentListOptions): Promise<PaginatedResult<ContentItem>>;
 
 	// Write operations (requires write:content) - optional on interface
-	create?(collection: string, data: ContentWriteInput): Promise<ContentItem>;
+	create?(
+		collection: string,
+		data: ContentWriteInput,
+		options?: ContentCreateOptions,
+	): Promise<ContentItem>;
 	update?(collection: string, id: string, data: ContentWriteInput): Promise<ContentItem>;
 	delete?(collection: string, id: string): Promise<boolean>;
 }
@@ -325,7 +335,11 @@ export interface TaxonomyAccess {
  * Full content access with write operations
  */
 export interface ContentAccessWithWrite extends ContentAccess {
-	create(collection: string, data: ContentWriteInput): Promise<ContentItem>;
+	create(
+		collection: string,
+		data: ContentWriteInput,
+		options?: ContentCreateOptions,
+	): Promise<ContentItem>;
 	update(collection: string, id: string, data: ContentWriteInput): Promise<ContentItem>;
 	delete(collection: string, id: string): Promise<boolean>;
 }

--- a/packages/core/tests/integration/plugins/capabilities.test.ts
+++ b/packages/core/tests/integration/plugins/capabilities.test.ts
@@ -480,6 +480,14 @@ describe("Capability Enforcement Integration (v2)", () => {
 				expect(created.locale).toBe("en");
 			});
 
+			it("persists a valid explicit locale when i18n is not configured", async () => {
+				const access = createContentAccessWithWrite(db);
+
+				const created = await access.create("posts", { title: "日本語" }, { locale: "ja" });
+
+				expect(created.locale).toBe("ja");
+			});
+
 			it("rejects malformed and unconfigured explicit locales", async () => {
 				setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
 				const access = createContentAccessWithWrite(db);

--- a/packages/core/tests/integration/plugins/capabilities.test.ts
+++ b/packages/core/tests/integration/plugins/capabilities.test.ts
@@ -14,6 +14,7 @@ import { runMigrations } from "../../../src/database/migrations/runner.js";
 import { OptionsRepository } from "../../../src/database/repositories/options.js";
 import { UserRepository } from "../../../src/database/repositories/user.js";
 import type { Database as DbSchema } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
 import {
 	PluginContextFactory,
 	createContentAccess,
@@ -147,6 +148,7 @@ describe("Capability Enforcement Integration (v2)", () => {
 	});
 
 	afterEach(async () => {
+		setI18nConfig(null);
 		await db.destroy();
 		sqliteDb.close();
 	});
@@ -438,6 +440,56 @@ describe("Capability Enforcement Integration (v2)", () => {
 				// Verify it was created
 				const found = await access.get("posts", created.id);
 				expect(found).not.toBeNull();
+			});
+
+			it("persists an explicit locale using the configured casing", async () => {
+				setI18nConfig({ defaultLocale: "en", locales: ["en", "zh-TW"] });
+				const access = createContentAccessWithWrite(db);
+
+				const created = await access.create("posts", { title: "繁體中文" }, { locale: "zh-tw" });
+
+				expect(created.locale).toBe("zh-TW");
+				await expect(access.list("posts", { where: { locale: "zh-TW" } })).resolves.toMatchObject({
+					items: [expect.objectContaining({ id: created.id, locale: "zh-TW" })],
+				});
+			});
+
+			it("uses the configured default locale when locale is omitted", async () => {
+				setI18nConfig({ defaultLocale: "ja", locales: ["ja", "en"] });
+				const access = createContentAccessWithWrite(db);
+
+				const created = await access.create("posts", { title: "日本語" });
+
+				expect(created.locale).toBe("ja");
+			});
+
+			it("uses a non-English default on single-locale sites", async () => {
+				setI18nConfig({ defaultLocale: "fr", locales: ["fr"] });
+				const access = createContentAccessWithWrite(db);
+
+				const created = await access.create("posts", { title: "Français" });
+
+				expect(created.locale).toBe("fr");
+			});
+
+			it("retains the en fallback when i18n is not configured", async () => {
+				const access = createContentAccessWithWrite(db);
+
+				const created = await access.create("posts", { title: "English" });
+
+				expect(created.locale).toBe("en");
+			});
+
+			it("rejects malformed and unconfigured explicit locales", async () => {
+				setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
+				const access = createContentAccessWithWrite(db);
+
+				await expect(
+					access.create("posts", { title: "Malformed" }, { locale: "en_US" }),
+				).rejects.toThrow(/invalid locale code/i);
+				await expect(
+					access.create("posts", { title: "Unknown" }, { locale: "de" }),
+				).rejects.toThrow(/not configured/i);
 			});
 		});
 

--- a/packages/workerd/src/sandbox/backing-service.ts
+++ b/packages/workerd/src/sandbox/backing-service.ts
@@ -16,6 +16,8 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+import { getI18nConfig } from "emdash";
+
 import { createBridgeHandler } from "./bridge-handler.js";
 import type { WorkerdSandboxRunner } from "./runner.js";
 
@@ -70,6 +72,7 @@ export function createBackingServiceHandler(runner: WorkerdSandboxRunner): Backi
 					allowedHosts: claims.allowedHosts,
 					storageCollections: claims.storageCollections,
 					storageConfig: runner.getPluginStorageConfig(claims.pluginId, claims.version),
+					i18nConfig: getI18nConfig(),
 					db: runner.db,
 					beforeContentWrite: runner.beforeContentWrite,
 					emailSend: () => runner.emailSend,

--- a/packages/workerd/src/sandbox/bridge-handler.ts
+++ b/packages/workerd/src/sandbox/bridge-handler.ts
@@ -799,6 +799,7 @@ async function contentCreate(
 		created_at: now,
 		updated_at: now,
 		version: 1,
+		translation_group: id,
 	};
 	if (locale !== undefined) values.locale = locale;
 

--- a/packages/workerd/src/sandbox/bridge-handler.ts
+++ b/packages/workerd/src/sandbox/bridge-handler.ts
@@ -704,6 +704,7 @@ async function contentGet(
 	data: Record<string, unknown>;
 	createdAt: string;
 	updatedAt: string;
+	locale: string;
 } | null> {
 	validateCollectionName(collection);
 	const table = `ec_${collection}`;
@@ -732,6 +733,7 @@ async function contentList(
 		data: Record<string, unknown>;
 		createdAt: string;
 		updatedAt: string;
+		locale: string;
 	}>;
 	cursor?: string;
 	hasMore: boolean;
@@ -840,6 +842,7 @@ async function contentUpdate(
 	data: Record<string, unknown>;
 	createdAt: string;
 	updatedAt: string;
+	locale: string;
 }> {
 	validateCollectionName(collection);
 	const table = `ec_${collection}`;

--- a/packages/workerd/src/sandbox/bridge-handler.ts
+++ b/packages/workerd/src/sandbox/bridge-handler.ts
@@ -213,11 +213,13 @@ async function dispatch(
 			return contentDelete(db, requireString(body, "collection"), requireString(body, "id"));
 		case "content/createMany":
 			requireCapability(opts, "write:content");
+			const createManyLocale = resolveContentCreateLocale(undefined, opts.i18nConfig ?? null);
 			await opts.beforeContentWrite?.();
 			return contentCreateMany(
 				db,
 				requireString(body, "collection"),
 				requireRecordArray(body, "items"),
+				createManyLocale,
 			);
 		case "content/updateMany":
 			requireCapability(opts, "write:content");
@@ -924,6 +926,7 @@ async function contentCreateMany(
 	db: Kysely<Database>,
 	collection: string,
 	items: Array<Record<string, unknown>>,
+	locale: string,
 ): Promise<
 	Array<{
 		id: string;
@@ -931,6 +934,7 @@ async function contentCreateMany(
 		data: Record<string, unknown>;
 		createdAt: string;
 		updatedAt: string;
+		locale: string;
 	}>
 > {
 	if (items.length > MAX_BATCH_SIZE) {
@@ -939,7 +943,7 @@ async function contentCreateMany(
 	return db.transaction().execute(async (trx) => {
 		const results = [];
 		for (const data of items) {
-			results.push(await contentCreate(trx, collection, data));
+			results.push(await contentCreate(trx, collection, data, locale));
 		}
 		return results;
 	});
@@ -956,6 +960,7 @@ async function contentUpdateMany(
 		data: Record<string, unknown>;
 		createdAt: string;
 		updatedAt: string;
+		locale: string;
 	}>
 > {
 	if (items.length > MAX_BATCH_SIZE) {

--- a/packages/workerd/src/sandbox/bridge-handler.ts
+++ b/packages/workerd/src/sandbox/bridge-handler.ts
@@ -19,8 +19,9 @@ import {
 	createSandboxRouteErrorEnvelope,
 	createUnrestrictedHttpAccess,
 	PluginStorageRepository,
+	resolveContentCreateLocale,
 } from "emdash";
-import type { Database, SandboxEmailSendCallback } from "emdash";
+import type { Database, I18nConfig, SandboxEmailSendCallback } from "emdash";
 import { sql, type Kysely, type RawBuilder } from "kysely";
 
 /**
@@ -42,6 +43,8 @@ interface ContentTableRow {
 	version: number;
 	live_revision_id: string | null;
 	draft_revision_id: string | null;
+	locale: string;
+	translation_group: string | null;
 	// User-defined fields. kysely.set()/values() accept these because they're
 	// typed as unknown rather than never.
 	[key: string]: unknown;
@@ -78,6 +81,8 @@ const SYSTEM_COLUMNS = new Set([
 	"version",
 	"live_revision_id",
 	"draft_revision_id",
+	"locale",
+	"translation_group",
 ]);
 
 /** Minimal storage interface for media uploads and deletes */
@@ -101,6 +106,7 @@ export interface BridgeHandlerOptions {
 	storageCollections: string[];
 	/** Full storage config (with indexes) for proper query/count delegation */
 	storageConfig?: Record<string, BridgeStorageCollectionConfig>;
+	i18nConfig?: I18nConfig | null;
 	db: Kysely<Database>;
 	beforeContentWrite?: () => Promise<void>;
 	emailSend: () => SandboxEmailSendCallback | null;
@@ -180,8 +186,18 @@ async function dispatch(
 			return contentList(db, requireString(body, "collection"), body);
 		case "content/create":
 			requireCapability(opts, "write:content");
+			const createOptions = optionalRecord(body, "options");
+			const locale = resolveContentCreateLocale(
+				createOptions ? optionalString(createOptions, "locale") : undefined,
+				opts.i18nConfig ?? null,
+			);
 			await opts.beforeContentWrite?.();
-			return contentCreate(db, requireString(body, "collection"), requireRecord(body, "data"));
+			return contentCreate(
+				db,
+				requireString(body, "collection"),
+				requireRecord(body, "data"),
+				locale,
+			);
 		case "content/update":
 			requireCapability(opts, "write:content");
 			await opts.beforeContentWrite?.();
@@ -574,6 +590,7 @@ function rowToContentItem(
 	data: Record<string, unknown>;
 	createdAt: string;
 	updatedAt: string;
+	locale: string;
 } {
 	const data: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(row)) {
@@ -596,6 +613,7 @@ function rowToContentItem(
 		data,
 		createdAt: typeof row.created_at === "string" ? row.created_at : new Date().toISOString(),
 		updatedAt: typeof row.updated_at === "string" ? row.updated_at : new Date().toISOString(),
+		locale: typeof row.locale === "string" ? row.locale : "en",
 	};
 }
 
@@ -751,12 +769,14 @@ async function contentCreate(
 	db: Kysely<Database>,
 	collection: string,
 	data: Record<string, unknown>,
+	locale?: string,
 ): Promise<{
 	id: string;
 	type: string;
 	data: Record<string, unknown>;
 	createdAt: string;
 	updatedAt: string;
+	locale: string;
 }> {
 	validateCollectionName(collection);
 	const table = `ec_${collection}`;
@@ -776,6 +796,7 @@ async function contentCreate(
 		updated_at: now,
 		version: 1,
 	};
+	if (locale !== undefined) values.locale = locale;
 
 	// Add user data fields (skip system columns, validate names)
 	for (const [key, value] of Object.entries(data)) {
@@ -796,7 +817,14 @@ async function contentCreate(
 		.executeTakeFirst();
 
 	if (!created) {
-		return { id, type: collection, data: {}, createdAt: now, updatedAt: now };
+		return {
+			id,
+			type: collection,
+			data: {},
+			createdAt: now,
+			updatedAt: now,
+			locale: locale ?? "en",
+		};
 	}
 	return rowToContentItem(collection, created);
 }

--- a/packages/workerd/src/sandbox/dev-runner.ts
+++ b/packages/workerd/src/sandbox/dev-runner.ts
@@ -23,7 +23,7 @@ import type {
 	SandboxOptions,
 	SerializedRequest,
 } from "emdash";
-import { createSandboxRouteError, getSandboxRouteErrorEnvelope } from "emdash";
+import { createSandboxRouteError, getI18nConfig, getSandboxRouteErrorEnvelope } from "emdash";
 
 const DEFAULT_WALL_TIME_MS = 30_000;
 import type { PluginManifest } from "emdash";
@@ -174,6 +174,7 @@ export class MiniflareDevRunner implements SandboxRunner {
 				allowedHosts: manifest.allowedHosts || [],
 				storageCollections: Object.keys(manifest.storage || {}),
 				storageConfig: manifest.storage,
+				i18nConfig: getI18nConfig(),
 				db: this.options.db,
 				beforeContentWrite: this.options.beforeContentWrite,
 				emailSend: () => this.emailSendCallback,

--- a/packages/workerd/src/sandbox/wrapper.ts
+++ b/packages/workerd/src/sandbox/wrapper.ts
@@ -163,7 +163,7 @@ function createContext() {
 	const content = {
 		get: (collection, id) => bridgeCall("content/get", { collection, id }),
 		list: (collection, opts) => bridgeCall("content/list", { collection, ...opts }),
-		create: (collection, data) => bridgeCall("content/create", { collection, data }),
+		create: (collection, data, options) => bridgeCall("content/create", { collection, data, options }),
 		update: (collection, id, data) => bridgeCall("content/update", { collection, id, data }),
 		delete: (collection, id) => bridgeCall("content/delete", { collection, id }),
 		createMany: (collection, items) => bridgeCall("content/createMany", { collection, items }),

--- a/packages/workerd/test/bridge-handler.test.ts
+++ b/packages/workerd/test/bridge-handler.test.ts
@@ -658,6 +658,7 @@ describe("Bridge Handler Conformance", () => {
 				.addColumn("version", "integer", (col) => col.defaultTo(1))
 				.addColumn("author_id", "text")
 				.addColumn("locale", "text", (col) => col.notNull().defaultTo("en"))
+				.addColumn("translation_group", "text")
 				.execute();
 		});
 

--- a/packages/workerd/test/bridge-handler.test.ts
+++ b/packages/workerd/test/bridge-handler.test.ts
@@ -657,6 +657,7 @@ describe("Bridge Handler Conformance", () => {
 				.addColumn("deleted_at", "text")
 				.addColumn("version", "integer", (col) => col.defaultTo(1))
 				.addColumn("author_id", "text")
+				.addColumn("locale", "text", (col) => col.notNull().defaultTo("en"))
 				.execute();
 		});
 

--- a/packages/workerd/test/plugin-integration.test.ts
+++ b/packages/workerd/test/plugin-integration.test.ts
@@ -80,6 +80,7 @@ async function runMigrations(db: Kysely<any>) {
 		.addColumn("published_at", "text")
 		.addColumn("deleted_at", "text")
 		.addColumn("version", "integer", (col) => col.notNull().defaultTo(1))
+		.addColumn("locale", "text", (col) => col.notNull().defaultTo("en"))
 		.addColumn("title", "text")
 		.addColumn("body", "text")
 		.execute();
@@ -236,7 +237,7 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 	// ── Content lifecycle: create, read, update, soft-delete ─────────────
 
 	describe("content lifecycle (requires read:content + write:content)", () => {
-		function makeWriteHandler() {
+		function makeWriteHandler(i18nConfig?: { defaultLocale: string; locales: string[] } | null) {
 			// Bridge enforces capabilities strictly: write:content does NOT
 			// imply read:content. Plugins that need both must declare both.
 			return createBridgeHandler({
@@ -245,6 +246,7 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 				capabilities: ["read:content", "write:content"],
 				allowedHosts: [],
 				storageCollections: [],
+				i18nConfig,
 				db,
 				emailSend: () => null,
 			});
@@ -301,6 +303,64 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 			});
 			expect(afterDelete.result).toBeNull();
 		});
+
+		it("forwards and normalizes an explicit locale", async () => {
+			const handler = makeWriteHandler({ defaultLocale: "en", locales: ["en", "zh-TW"] });
+
+			const result = await call(handler, "content/create", {
+				collection: "posts",
+				data: { title: "繁體中文" },
+				options: { locale: "zh-tw" },
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.result).toMatchObject({ locale: "zh-TW" });
+			const row = await db
+				.selectFrom("ec_posts" as any)
+				.select("locale" as any)
+				.where("id", "=", (result.result as { id: string }).id)
+				.executeTakeFirstOrThrow();
+			expect(row.locale).toBe("zh-TW");
+		});
+
+		it("uses configured and no-i18n fallbacks when locale is omitted", async () => {
+			const configured = await call(
+				makeWriteHandler({ defaultLocale: "ja", locales: ["ja"] }),
+				"content/create",
+				{ collection: "posts", data: { title: "日本語" } },
+			);
+			const legacy = await call(makeWriteHandler(null), "content/create", {
+				collection: "posts",
+				data: { title: "English" },
+			});
+
+			expect(configured.result).toMatchObject({ locale: "ja" });
+			expect(legacy.result).toMatchObject({ locale: "en" });
+		});
+
+		it("rejects invalid locale options before inserting", async () => {
+			const handler = makeWriteHandler({ defaultLocale: "en", locales: ["en", "fr"] });
+
+			const malformed = await call(handler, "content/create", {
+				collection: "posts",
+				data: { title: "Malformed" },
+				options: { locale: "en_US" },
+			});
+			const unknown = await call(handler, "content/create", {
+				collection: "posts",
+				data: { title: "Unknown" },
+				options: { locale: "de" },
+			});
+
+			expect(malformed.error).toMatch(/invalid locale code/i);
+			expect(unknown.error).toMatch(/not configured/i);
+			expect(
+				await db
+					.selectFrom("ec_posts" as any)
+					.selectAll()
+					.execute(),
+			).toHaveLength(0);
+		});
 	});
 
 	// ── Capability enforcement matches real plugin config ─────────────────
@@ -329,6 +389,7 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 			.addColumn("updated_at", "text", (col) => col.notNull())
 			.addColumn("deleted_at", "text")
 			.addColumn("version", "integer", (col) => col.notNull().defaultTo(1))
+			.addColumn("locale", "text", (col) => col.notNull().defaultTo("en"))
 			.addColumn("title", "text")
 			.execute();
 

--- a/packages/workerd/test/plugin-integration.test.ts
+++ b/packages/workerd/test/plugin-integration.test.ts
@@ -265,9 +265,11 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 				id: string;
 				type: string;
 				data: Record<string, unknown>;
+				locale: string;
 			};
 			expect(created.type).toBe("posts");
 			expect(created.data.title).toBe("New Post");
+			expect(created.locale).toBe("en");
 			expect(created.id).toBeTruthy();
 
 			// Read
@@ -276,8 +278,13 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 				id: created.id,
 			});
 			expect(readResult.error).toBeUndefined();
-			const read = readResult.result as { id: string; data: Record<string, unknown> };
+			const read = readResult.result as {
+				id: string;
+				data: Record<string, unknown>;
+				locale: string;
+			};
 			expect(read.data.title).toBe("New Post");
+			expect(read.locale).toBe("en");
 
 			// Update
 			const updateResult = await call(handler, "content/update", {
@@ -286,8 +293,13 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 				data: { title: "Updated Post" },
 			});
 			expect(updateResult.error).toBeUndefined();
-			const updated = updateResult.result as { id: string; data: Record<string, unknown> };
+			const updated = updateResult.result as {
+				id: string;
+				data: Record<string, unknown>;
+				locale: string;
+			};
 			expect(updated.data.title).toBe("Updated Post");
+			expect(updated.locale).toBe("en");
 
 			// Delete (soft-delete)
 			const deleteResult = await call(handler, "content/delete", {

--- a/packages/workerd/test/plugin-integration.test.ts
+++ b/packages/workerd/test/plugin-integration.test.ts
@@ -81,6 +81,7 @@ async function runMigrations(db: Kysely<any>) {
 		.addColumn("deleted_at", "text")
 		.addColumn("version", "integer", (col) => col.notNull().defaultTo(1))
 		.addColumn("locale", "text", (col) => col.notNull().defaultTo("en"))
+		.addColumn("translation_group", "text")
 		.addColumn("title", "text")
 		.addColumn("body", "text")
 		.execute();
@@ -271,6 +272,13 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 			expect(created.data.title).toBe("New Post");
 			expect(created.locale).toBe("en");
 			expect(created.id).toBeTruthy();
+			await expect(
+				db
+					.selectFrom("ec_posts" as any)
+					.select("translation_group" as any)
+					.where("id", "=", created.id)
+					.executeTakeFirstOrThrow(),
+			).resolves.toEqual({ translation_group: created.id });
 
 			// Read
 			const readResult = await call(handler, "content/get", {
@@ -425,6 +433,7 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 			.addColumn("deleted_at", "text")
 			.addColumn("version", "integer", (col) => col.notNull().defaultTo(1))
 			.addColumn("locale", "text", (col) => col.notNull().defaultTo("en"))
+			.addColumn("translation_group", "text")
 			.addColumn("title", "text")
 			.execute();
 

--- a/packages/workerd/test/plugin-integration.test.ts
+++ b/packages/workerd/test/plugin-integration.test.ts
@@ -350,6 +350,29 @@ describe("Plugin integration: sandboxed-test plugin operations", () => {
 			expect(legacy.result).toMatchObject({ locale: "en" });
 		});
 
+		it("uses the configured default locale for batch creates", async () => {
+			const result = await call(
+				makeWriteHandler({ defaultLocale: "ja", locales: ["ja"] }),
+				"content/createMany",
+				{
+					collection: "posts",
+					items: [{ title: "一" }, { title: "二" }],
+				},
+			);
+
+			expect(result.error).toBeUndefined();
+			expect(result.result).toEqual([
+				expect.objectContaining({ locale: "ja" }),
+				expect.objectContaining({ locale: "ja" }),
+			]);
+			expect(
+				await db
+					.selectFrom("ec_posts" as any)
+					.select("locale" as any)
+					.execute(),
+			).toEqual([{ locale: "ja" }, { locale: "ja" }]);
+		});
+
 		it("rejects invalid locale options before inserting", async () => {
 			const handler = makeWriteHandler({ defaultLocale: "en", locales: ["en", "fr"] });
 


### PR DESCRIPTION
## What does this PR do?

Adds a backward-compatible third `options` argument to `ctx.content.create()` with an optional `locale`. Trusted and sandboxed plugin writes now resolve locale in this order: explicit locale (case-normalized when it matches a configured locale), configured default locale, then `en` when i18n is not configured. Malformed explicit locales are rejected before writes; when i18n is configured, explicit locales outside its locale list are also rejected.

The locale contract is forwarded through both Cloudflare and workerd sandbox bridges, documented for plugin authors, and covered by regression tests for every fallback branch and invalid inputs.

Closes #2487

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no admin UI strings changed). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable; this is a bug fix for #2487.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 Codex

## Screenshots / test output

No visual changes.

Verified locally:

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm format` and `pnpm format:check`
- Core plugin capability + locale schema tests: 131 passed
- Workerd bridge + plugin integration tests: 44 passed
- Cloudflare sandbox bridge tests: 8 passed
