### PR TITLE
feat(core): expose outer user middleware hook

### DIFF
--- a/.changeset/outer-user-middleware.md
+++ b/.changeset/outer-user-middleware.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds `middleware.outer` configuration for returning responses before EmDash initializes and finalizing fully mutated responses after rendering.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -104,6 +104,56 @@ objectCache: memoryCache();
 
 See [Object Cache](/deployment/object-cache/) for setup and options.
 
+### `middleware.outer`
+
+**Optional.** Registers an Astro middleware module outside the complete EmDash middleware stack. Use it for request gates or full-response caches that must avoid runtime and database initialization on a hit, or for response headers that depend on EmDash's final HTML.
+
+```js title="astro.config.mjs"
+emdash({
+	middleware: {
+		outer: "./src/outer-middleware.ts",
+	},
+});
+```
+
+The execution order is:
+
+1. The outer middleware runs up to `await next()`.
+2. EmDash initializes its runtime and database, then runs setup, authentication, and request-context middleware.
+3. The Astro route renders.
+4. EmDash applies response mutations, including visual-editing HTML and security/timing headers.
+5. `next()` resolves to the outer middleware with that final response.
+
+Before calling `next()`, the middleware has the normal Astro request and platform execution context, but `locals.emdash`, `locals.user`, the database, and request-scoped EmDash state are unavailable. An early `Response` skips EmDash entirely, so it must include any security and cache headers it needs. After `next()` resolves, it is safe to finalize CSP nonces, cache the complete body, or set `Content-Length`. If the middleware changes the body, remove or recompute any existing `Content-Length` header.
+
+The hook uses Astro's middleware API on both Node and Cloudflare. This minimal Cloudflare Cache API example caches only anonymous HTML responses and returns hits before EmDash initialization:
+
+```ts title="src/outer-middleware.ts"
+import { waitUntil } from "cloudflare:workers";
+import { defineMiddleware } from "astro:middleware";
+
+export const onRequest = defineMiddleware(async ({ request }, next) => {
+	if (request.method !== "GET" || request.headers.has("cookie")) {
+		return next();
+	}
+
+	const cacheKey = new Request(request.url, { method: "GET" });
+	const cached = await caches.default.match(cacheKey);
+	if (cached) return cached;
+
+	const response = await next();
+	const isHtml = response.headers.get("content-type")?.includes("text/html");
+	const isPrivate = response.headers.get("cache-control")?.includes("no-store");
+	if (response.ok && isHtml && !isPrivate) {
+		waitUntil(caches.default.put(cacheKey, response.clone()));
+	}
+
+	return response;
+});
+```
+
+On Node, use the same middleware shape with a Node-compatible cache such as Redis. Cache keys and bypass rules must include every request property that changes the rendered response.
+
 ### `plugins`
 
 **Optional.** Array of EmDash plugins. The following example registers one plugin:

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -106,7 +106,7 @@ See [Object Cache](/deployment/object-cache/) for setup and options.
 
 ### `middleware.outer`
 
-**Optional.** Registers an Astro middleware module outside the complete EmDash middleware stack. Use it for request gates or full-response caches that must avoid runtime and database initialization on a hit, or for response headers that depend on EmDash's final HTML.
+**Optional.** Registers an Astro middleware module outside the complete EmDash middleware stack. Because the integration registers it with Astro `order: "pre"`, it also runs before middleware defined in `src/middleware.ts`. Use it for request gates or full-response caches that must avoid runtime and database initialization on a hit, or for response headers that depend on EmDash's final HTML.
 
 ```js title="astro.config.mjs"
 emdash({

--- a/e2e/fixture-cloudflare/astro.config.mjs
+++ b/e2e/fixture-cloudflare/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
 		react(),
 		emdash({
 			database: d1({ binding: "DB" }),
+			middleware: { outer: "./src/outer-middleware.ts" },
 			storage: r2({ binding: "MEDIA" }),
 			plugins: [colorPlugin()],
 			marketplace: marketplaceUrl,

--- a/e2e/fixture-cloudflare/src/outer-middleware.ts
+++ b/e2e/fixture-cloudflare/src/outer-middleware.ts
@@ -1,0 +1,45 @@
+import { defineMiddleware } from "astro:middleware";
+import { getRequestContext } from "emdash/request-context";
+
+const FINALIZER_NONCE = "outer-finalizer";
+
+function preNextState(locals: App.Locals): string {
+	return JSON.stringify({
+		emdash: locals.emdash !== undefined,
+		user: locals.user !== undefined,
+		requestContext: getRequestContext() !== undefined,
+	});
+}
+
+export const onRequest = defineMiddleware(async (context, next) => {
+	const state = preNextState(context.locals);
+
+	if (context.url.pathname === "/outer-cache-hit") {
+		return new Response("cached before EmDash initialization", {
+			headers: {
+				"Content-Type": "text/plain",
+				"X-Outer-Pre-Next-State": state,
+				"X-Outer-Request-Path": context.url.pathname,
+			},
+		});
+	}
+
+	const response = await next();
+	if (context.request.headers.get("X-Outer-Finalize") !== "1") return response;
+
+	const html = (await response.text()).replaceAll(
+		"<script>",
+		`<script nonce="${FINALIZER_NONCE}">`,
+	);
+	const headers = new Headers(response.headers);
+	headers.set("Content-Security-Policy", `script-src 'nonce-${FINALIZER_NONCE}'`);
+	headers.set("Content-Length", String(new TextEncoder().encode(html).byteLength));
+	headers.set("X-Outer-Pre-Next-State", state);
+	headers.set("X-Outer-Saw-Toolbar", String(html.includes('id="emdash-toolbar"')));
+
+	return new Response(html, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+});

--- a/e2e/fixture/astro.config.mjs
+++ b/e2e/fixture/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
 		react(),
 		emdash({
 			database: sqlite({ url: dbUrl }),
+			middleware: { outer: "./src/outer-middleware.ts" },
 			plugins: [colorPlugin()],
 			marketplace: marketplaceUrl,
 			sandboxRunner: marketplaceUrl ? "./noop-sandbox.mjs" : undefined,

--- a/e2e/fixture/src/outer-middleware.ts
+++ b/e2e/fixture/src/outer-middleware.ts
@@ -1,0 +1,45 @@
+import { defineMiddleware } from "astro:middleware";
+import { getRequestContext } from "emdash/request-context";
+
+const FINALIZER_NONCE = "outer-finalizer";
+
+function preNextState(locals: App.Locals): string {
+	return JSON.stringify({
+		emdash: locals.emdash !== undefined,
+		user: locals.user !== undefined,
+		requestContext: getRequestContext() !== undefined,
+	});
+}
+
+export const onRequest = defineMiddleware(async (context, next) => {
+	const state = preNextState(context.locals);
+
+	if (context.url.pathname === "/outer-cache-hit") {
+		return new Response("cached before EmDash initialization", {
+			headers: {
+				"Content-Type": "text/plain",
+				"X-Outer-Pre-Next-State": state,
+				"X-Outer-Request-Path": context.url.pathname,
+			},
+		});
+	}
+
+	const response = await next();
+	if (context.request.headers.get("X-Outer-Finalize") !== "1") return response;
+
+	const html = (await response.text()).replaceAll(
+		"<script>",
+		`<script nonce="${FINALIZER_NONCE}">`,
+	);
+	const headers = new Headers(response.headers);
+	headers.set("Content-Security-Policy", `script-src 'nonce-${FINALIZER_NONCE}'`);
+	headers.set("Content-Length", String(new TextEncoder().encode(html).byteLength));
+	headers.set("X-Outer-Pre-Next-State", state);
+	headers.set("X-Outer-Saw-Toolbar", String(html.includes('id="emdash-toolbar"')));
+
+	return new Response(html, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+});

--- a/e2e/tests/outer-middleware.spec.ts
+++ b/e2e/tests/outer-middleware.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "../fixtures";
+
+const EMPTY_PRE_NEXT_STATE = JSON.stringify({
+	emdash: false,
+	user: false,
+	requestContext: false,
+});
+
+test.describe("outer user middleware", () => {
+	test("returns a cached response before EmDash runtime and database initialization", async ({
+		serverInfo,
+	}) => {
+		const response = await fetch(`${serverInfo.baseUrl}/outer-cache-hit`);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("cached before EmDash initialization");
+		expect(response.headers.get("x-outer-request-path")).toBe("/outer-cache-hit");
+		expect(response.headers.get("x-outer-pre-next-state")).toBe(EMPTY_PRE_NEXT_STATE);
+		expect(response.headers.get("server-timing")).toBeNull();
+		expect(response.headers.get("x-content-type-options")).toBeNull();
+	});
+
+	test("finalizes the fully EmDash-mutated response after next", async ({ serverInfo }) => {
+		const response = await fetch(serverInfo.baseUrl, {
+			headers: {
+				Cookie: serverInfo.sessionCookie,
+				"X-Outer-Finalize": "1",
+			},
+		});
+		const html = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("x-outer-pre-next-state")).toBe(EMPTY_PRE_NEXT_STATE);
+		expect(response.headers.get("x-outer-saw-toolbar")).toBe("true");
+		expect(response.headers.get("server-timing")).toContain("render");
+		expect(response.headers.get("content-security-policy")).toBe(
+			"script-src 'nonce-outer-finalizer'",
+		);
+		expect(response.headers.get("content-length")).toBe(
+			String(new TextEncoder().encode(html).byteLength),
+		);
+		expect(html).toContain('id="emdash-toolbar"');
+		expect(html).toContain('<script nonce="outer-finalizer">');
+	});
+});

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -12,7 +12,7 @@
 
 import { createRequire } from "node:module";
 
-import type { AstroIntegration, AstroIntegrationLogger } from "astro";
+import type { AstroIntegration, AstroIntegrationLogger, AstroIntegrationMiddleware } from "astro";
 
 import { validateAllowedOrigins, validateOriginShape } from "../../auth/allowed-origins.js";
 import { INTERNAL_MEDIA_PREFIX } from "../../media/normalize.js";
@@ -251,6 +251,52 @@ function printDevServerInfo(baseUrl: string, mcpEnabled: boolean): void {
 	console.log(`  ${dim("›")} Dev bypass  ${cyan(devBypassUrl)}`);
 	console.log(`    ${dim("Skips passkey setup/auth and signs you in as a dev admin")}`);
 	console.log("");
+}
+
+export function buildMiddlewareEntries(
+	config: Pick<EmDashConfig, "middleware" | "playground">,
+	root: URL,
+): AstroIntegrationMiddleware[] {
+	const entries: AstroIntegrationMiddleware[] = [];
+
+	if (config.middleware) {
+		const configuredEntrypoint = config.middleware.outer;
+		const entrypoint =
+			typeof configuredEntrypoint === "string" &&
+			(configuredEntrypoint.startsWith("./") || configuredEntrypoint.startsWith("../"))
+				? new URL(configuredEntrypoint, root)
+				: configuredEntrypoint;
+		entries.push({
+			entrypoint,
+			order: "pre",
+		});
+	}
+
+	if (config.playground) {
+		entries.push({
+			entrypoint: config.playground.middlewareEntrypoint,
+			order: "pre",
+		});
+	}
+
+	entries.push(
+		{ entrypoint: "emdash/middleware", order: "pre" },
+		{ entrypoint: "emdash/middleware/redirect", order: "pre" },
+	);
+
+	if (!config.playground) {
+		entries.push(
+			{ entrypoint: "emdash/middleware/setup", order: "pre" },
+			{ entrypoint: "emdash/middleware/auth", order: "pre" },
+		);
+	}
+
+	entries.push(
+		{ entrypoint: "emdash/middleware/media-usage-write-fence", order: "pre" },
+		{ entrypoint: "emdash/middleware/request-context", order: "pre" },
+	);
+
+	return entries;
 }
 
 /**
@@ -543,53 +589,9 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 					injectMcpRoute(injectRoute);
 				}
 
-				// In playground mode, inject the playground middleware FIRST.
-				// It sets up a per-session DO database in ALS before anything
-				// else runs, so the runtime init middleware sees a real DB.
-				if (resolvedConfig.playground) {
-					addMiddleware({
-						entrypoint: resolvedConfig.playground.middlewareEntrypoint,
-						order: "pre",
-					});
+				for (const middleware of buildMiddlewareEntries(resolvedConfig, astroConfig.root)) {
+					addMiddleware(middleware);
 				}
-
-				// Add middleware to provide database and manifest
-				addMiddleware({
-					entrypoint: "emdash/middleware",
-					order: "pre",
-				});
-
-				// Add redirect middleware (runs after runtime init, before setup/auth)
-				addMiddleware({
-					entrypoint: "emdash/middleware/redirect",
-					order: "pre",
-				});
-
-				// Skip setup and auth in playground mode -- the playground middleware
-				// handles session creation and injects an anonymous admin user.
-				if (!resolvedConfig.playground) {
-					addMiddleware({
-						entrypoint: "emdash/middleware/setup",
-						order: "pre",
-					});
-
-					addMiddleware({
-						entrypoint: "emdash/middleware/auth",
-						order: "pre",
-					});
-				}
-
-				addMiddleware({
-					entrypoint: "emdash/middleware/media-usage-write-fence",
-					order: "pre",
-				});
-
-				// Add request context middleware (runs after auth, on ALL routes)
-				// Sets up ALS-based context for query functions (edit mode, preview)
-				addMiddleware({
-					entrypoint: "emdash/middleware/request-context",
-					order: "pre",
-				});
 
 				// Route info is printed with absolute, clickable URLs once the
 				// dev server is listening (see astro:server:setup), since the

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -259,8 +259,14 @@ export function buildMiddlewareEntries(
 ): AstroIntegrationMiddleware[] {
 	const entries: AstroIntegrationMiddleware[] = [];
 
-	if (config.middleware) {
-		const configuredEntrypoint = config.middleware.outer;
+	if (config.middleware !== undefined) {
+		const configuredEntrypoint = config.middleware?.outer;
+		if (
+			(typeof configuredEntrypoint !== "string" && !(configuredEntrypoint instanceof URL)) ||
+			(typeof configuredEntrypoint === "string" && configuredEntrypoint.trim() === "")
+		) {
+			throw new Error("middleware.outer must be a non-empty module specifier string or URL.");
+		}
 		const entrypoint =
 			typeof configuredEntrypoint === "string" &&
 			(configuredEntrypoint.startsWith("./") || configuredEntrypoint.startsWith("../"))

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -479,6 +479,21 @@ export interface EmDashConfig {
 	trustedProxyHeaders?: string[];
 
 	/**
+	 * User middleware that wraps the complete EmDash request pipeline.
+	 *
+	 * Before `next()` it runs before EmDash initializes its runtime or database,
+	 * so `locals.emdash`, the authenticated user, and request-scoped EmDash state
+	 * are unavailable. This allows cached responses and request gates to return
+	 * without paying initialization cost. When it calls `next()`, the resolved
+	 * response includes EmDash HTML injection and all other response mutations,
+	 * allowing the middleware to finalize caching and response headers safely.
+	 */
+	middleware?: {
+		/** Astro middleware module entrypoint. */
+		outer: string | URL;
+	};
+
+	/**
 	 * Enable playground mode for ephemeral "try EmDash" sites.
 	 *
 	 * When set, the integration injects a playground middleware (order: "pre")

--- a/packages/core/tests/unit/astro/integration/middleware-order.test.ts
+++ b/packages/core/tests/unit/astro/integration/middleware-order.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMiddlewareEntries } from "../../../../src/astro/integration/index.js";
+
+const defaultEntries = [
+	{ entrypoint: "emdash/middleware", order: "pre" },
+	{ entrypoint: "emdash/middleware/redirect", order: "pre" },
+	{ entrypoint: "emdash/middleware/setup", order: "pre" },
+	{ entrypoint: "emdash/middleware/auth", order: "pre" },
+	{ entrypoint: "emdash/middleware/media-usage-write-fence", order: "pre" },
+	{ entrypoint: "emdash/middleware/request-context", order: "pre" },
+] as const;
+const root = new URL("file:///project/");
+
+describe("EmDash middleware registration order", () => {
+	it("preserves the existing middleware order when no outer middleware is configured", () => {
+		expect(buildMiddlewareEntries({}, root)).toEqual(defaultEntries);
+	});
+
+	it("registers the user middleware outside the complete EmDash stack", () => {
+		expect(
+			buildMiddlewareEntries(
+				{
+					middleware: { outer: "./src/outer-middleware.ts" },
+				},
+				root,
+			),
+		).toEqual([
+			{ entrypoint: new URL("file:///project/src/outer-middleware.ts"), order: "pre" },
+			...defaultEntries,
+		]);
+	});
+
+	it("preserves package middleware specifiers", () => {
+		expect(
+			buildMiddlewareEntries({ middleware: { outer: "@example/outer-middleware" } }, root),
+		).toEqual([{ entrypoint: "@example/outer-middleware", order: "pre" }, ...defaultEntries]);
+	});
+
+	it("places the outer middleware before the playground database middleware", () => {
+		expect(
+			buildMiddlewareEntries(
+				{
+					middleware: { outer: "./src/outer-middleware.ts" },
+					playground: { middlewareEntrypoint: "playground/middleware" },
+				},
+				root,
+			),
+		).toEqual([
+			{ entrypoint: new URL("file:///project/src/outer-middleware.ts"), order: "pre" },
+			{ entrypoint: "playground/middleware", order: "pre" },
+			{ entrypoint: "emdash/middleware", order: "pre" },
+			{ entrypoint: "emdash/middleware/redirect", order: "pre" },
+			{ entrypoint: "emdash/middleware/media-usage-write-fence", order: "pre" },
+			{ entrypoint: "emdash/middleware/request-context", order: "pre" },
+		]);
+	});
+});

--- a/packages/core/tests/unit/astro/integration/middleware-order.test.ts
+++ b/packages/core/tests/unit/astro/integration/middleware-order.test.ts
@@ -11,6 +11,13 @@ const defaultEntries = [
 	{ entrypoint: "emdash/middleware/request-context", order: "pre" },
 ] as const;
 const root = new URL("file:///project/");
+const invalidMiddleware: Array<[string, unknown]> = [
+	["a missing outer entrypoint", {}],
+	["a null middleware config", null],
+	["an empty entrypoint", { outer: "" }],
+	["a whitespace-only entrypoint", { outer: " " }],
+	["a non-string entrypoint", { outer: 42 }],
+];
 
 describe("EmDash middleware registration order", () => {
 	it("preserves the existing middleware order when no outer middleware is configured", () => {
@@ -35,6 +42,12 @@ describe("EmDash middleware registration order", () => {
 		expect(
 			buildMiddlewareEntries({ middleware: { outer: "@example/outer-middleware" } }, root),
 		).toEqual([{ entrypoint: "@example/outer-middleware", order: "pre" }, ...defaultEntries]);
+	});
+
+	it.each(invalidMiddleware)("rejects %s", (_label, middleware) => {
+		// @ts-expect-error - runtime validation covers untyped JavaScript configuration
+		const build = () => buildMiddlewareEntries({ middleware }, root);
+		expect(build).toThrow("middleware.outer must be a non-empty module specifier string or URL");
 	});
 
 	it("places the outer middleware before the playground database middleware", () => {


### PR DESCRIPTION
## What does this PR do?

Adds `middleware.outer` to register user middleware outside the complete EmDash middleware stack. An early response now skips runtime and database initialization, while `await next()` returns the fully EmDash-mutated response so callers can safely finalize caching, CSP, `Content-Length`, and related headers.

The existing middleware order is unchanged when the option is omitted. Relative entrypoints resolve from the Astro project root, and package specifiers remain supported. Documentation covers execution order, unavailable pre-next state, and a minimal Cloudflare cache example.

Closes #1282

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (N/A: no admin UI strings.)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (N/A: the maintainer approved the acceptance criteria directly in #1282.)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter emdash test --run tests/unit/astro/integration/middleware-order.test.ts tests/unit/astro/request-context-toolbar-mode.test.ts` → 14 tests passed
- `pnpm exec tsgo --noEmit -p e2e/fixture-cloudflare/tsconfig.json`
- Direct Node and Cloudflare/workerd fixture verification covered early return, unavailable pre-next state, final toolbar HTML, nonce CSP, and exact wire/body `Content-Length` (39,578/39,578 bytes on Node; 61,574/61,574 bytes on workerd).
- The focused Playwright wrapper reached setup/seeding locally, but its parent process was terminated during fixture warm-up before assertions. The equivalent checked-in fixture assertions were verified directly on both runtimes above; CI will run the spec through the normal harness.
