### PR TITLE
fix(loader): expose folded bylines on live entries

### DIFF
--- a/.changeset/live-loader-bylines.md
+++ b/.changeset/live-loader-bylines.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes live-loader entries to expose explicit byline credits through `data.bylines` and `data.byline`.

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -215,6 +215,27 @@ function expandFoldedSeo(row: Record<string, unknown>): void {
 	}
 }
 
+export function creditsFromFoldedBylines(folded: unknown[]) {
+	return folded
+		.map((raw) => {
+			const credit = isPlainObject(raw) ? raw : {};
+			const byline = isPlainObject(credit.byline) ? credit.byline : {};
+			return {
+				roleLabel: typeof credit.roleLabel === "string" ? credit.roleLabel : null,
+				sortOrder: Number(credit.sortOrder ?? 0),
+				source: "explicit" as const,
+				byline: {
+					...byline,
+					isGuest: Boolean(byline.isGuest),
+					// Folded rows contain only byline-table columns. The query wrappers
+					// replace this map through full hydration when custom fields exist.
+					customFields: {},
+				},
+			};
+		})
+		.toSorted((a, b) => a.sortOrder - b.sortOrder);
+}
+
 /**
  * Stash folded hydration JSON (non-enumerable) for the query.ts fast paths.
  * SQLite returns a JSON string (parse it); Postgres returns already-parsed JSON.
@@ -252,18 +273,7 @@ function stashFolded(data: Record<string, unknown>, row: Record<string, unknown>
 
 	const foldedBylines = Reflect.get(data, FOLDED_BYLINES);
 	if (!Array.isArray(foldedBylines)) return;
-	const credits = foldedBylines
-		.map((raw) => {
-			const credit = isPlainObject(raw) ? raw : {};
-			const byline = isPlainObject(credit.byline) ? credit.byline : {};
-			return {
-				roleLabel: typeof credit.roleLabel === "string" ? credit.roleLabel : null,
-				sortOrder: Number(credit.sortOrder ?? 0),
-				source: "explicit" as const,
-				byline: { ...byline, isGuest: Boolean(byline.isGuest), customFields: {} },
-			};
-		})
-		.toSorted((a, b) => a.sortOrder - b.sortOrder);
+	const credits = creditsFromFoldedBylines(foldedBylines);
 	data.bylines = credits;
 	data.byline = credits[0]?.byline ?? null;
 }

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -227,8 +227,7 @@ export function creditsFromFoldedBylines(folded: unknown[]) {
 				byline: {
 					...byline,
 					isGuest: Boolean(byline.isGuest),
-					// Folded rows contain only byline-table columns. The query wrappers
-					// replace this map through full hydration when custom fields exist.
+					// Folded rows omit custom-field values.
 					customFields: {},
 				},
 			};

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -249,6 +249,23 @@ function stashFolded(data: Record<string, unknown>, row: Record<string, unknown>
 			configurable: true,
 		});
 	}
+
+	const foldedBylines = Reflect.get(data, FOLDED_BYLINES);
+	if (!Array.isArray(foldedBylines)) return;
+	const credits = foldedBylines
+		.map((raw) => {
+			const credit = isPlainObject(raw) ? raw : {};
+			const byline = isPlainObject(credit.byline) ? credit.byline : {};
+			return {
+				roleLabel: typeof credit.roleLabel === "string" ? credit.roleLabel : null,
+				sortOrder: Number(credit.sortOrder ?? 0),
+				source: "explicit" as const,
+				byline: { ...byline, isGuest: Boolean(byline.isGuest), customFields: {} },
+			};
+		})
+		.toSorted((a, b) => a.sortOrder - b.sortOrder);
+	data.bylines = credits;
+	data.byline = credits[0]?.byline ?? null;
 }
 
 /** Resolved SEO shape attached to `entry.data.seo`. Mirrors `ContentSeo`. */
@@ -1546,6 +1563,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 						};
 						const revSeo = extractSeo(row);
 						if (revSeo) revEntryData.seo = revSeo;
+						stashFolded(revEntryData, row);
 						return {
 							id: revId,
 							slug,

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -27,6 +27,7 @@
 import { encodeCursor } from "./database/repositories/types.js";
 import { getFallbackChain, getI18nConfig, isI18nEnabled } from "./i18n/config.js";
 import {
+	creditsFromFoldedBylines,
 	CURSOR_RAW_VALUES,
 	FOLDED_BYLINES,
 	FOLDED_BYLINES_EXIST,
@@ -1018,17 +1019,7 @@ async function hydrateEntryBylines<D>(type: string, entries: ContentEntry<D>[]):
 			const data = entryData(entry);
 			const folded = Reflect.get(data, FOLDED_BYLINES);
 			const rows = Array.isArray(folded) ? folded : [];
-			const credits = rows
-				.map((raw) => {
-					const b = raw?.byline ?? {};
-					return {
-						roleLabel: raw?.roleLabel ?? null,
-						sortOrder: Number(raw?.sortOrder ?? 0),
-						source: "explicit" as const,
-						byline: { ...b, isGuest: Boolean(b.isGuest), customFields: {} },
-					};
-				})
-				.toSorted((a, b) => a.sortOrder - b.sortOrder);
+			const credits = creditsFromFoldedBylines(rows);
 			return { data, credits };
 		});
 

--- a/packages/core/tests/integration/loader-fold.test.ts
+++ b/packages/core/tests/integration/loader-fold.test.ts
@@ -18,6 +18,7 @@ import type { ContentBylineCredit } from "../../src/database/repositories/types.
 import { setI18nConfig } from "../../src/i18n/config.js";
 import { emdashLoader, FOLDED_BYLINES, FOLDED_TERMS } from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
+import { BylineSchemaRegistry } from "../../src/schema/byline-registry.js";
 import {
 	type DialectTestContext,
 	describeEachDialect,
@@ -164,6 +165,38 @@ describeEachDialect("loader hydration fold", (dialect) => {
 			(entry.data.bylines as ContentBylineCredit[]).map((credit) => credit.byline.displayName),
 		).toEqual(["Grace Hopper", "Ada Lovelace"]);
 		expect(entry.data.byline.displayName).toBe("Grace Hopper");
+	});
+
+	it("uses the folded public shape when byline custom fields are registered", async () => {
+		// eslint-disable-next-line typescript/no-explicit-any -- schema type vs Database type
+		const db = ctx.db as any;
+		const content = new ContentRepository(db);
+		const bylines = new BylineRepository(db);
+		const fields = new BylineSchemaRegistry(ctx.db);
+		await fields.createField({ slug: "job_title", label: "Job title", type: "string" });
+		const author = await bylines.create({
+			displayName: "Ada Lovelace",
+			slug: "ada-custom",
+			customFields: { job_title: "Editor" },
+		});
+		const post = await content.create({
+			type: "post",
+			slug: "custom-fields",
+			data: { title: "Custom fields" },
+			locale: "en",
+		});
+		await bylines.setContentBylines("post", post.id, [
+			{ bylineId: author.id, roleLabel: "Author" },
+		]);
+		expect((await bylines.findById(author.id))?.customFields?.job_title).toBe("Editor");
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db: ctx.db }, () =>
+			loader.loadEntry({ filter: { type: "post", id: "custom-fields" } }),
+		);
+		// eslint-disable-next-line typescript/no-explicit-any -- loader result union
+		const data = (result as any).data as { bylines: ContentBylineCredit[] };
+		expect(data.bylines[0]?.byline.customFields).toEqual({});
 	});
 
 	it("folds terms in the entry's own locale (#1441)", async () => {

--- a/packages/core/tests/integration/loader-fold.test.ts
+++ b/packages/core/tests/integration/loader-fold.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeEach, expect, it } from "vitest";
 
+import { resetBylineFieldDefsCacheForTests } from "../../src/bylines/field-defs-cache.js";
 import { BylineRepository } from "../../src/database/repositories/byline.js";
 import { ContentRepository } from "../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
@@ -44,6 +45,7 @@ describeEachDialect("loader hydration fold", (dialect) => {
 		ctx = await setupForDialectWithCollections(dialect);
 	});
 	afterEach(async () => {
+		resetBylineFieldDefsCacheForTests();
 		await teardownForDialect(ctx);
 	});
 
@@ -174,6 +176,7 @@ describeEachDialect("loader hydration fold", (dialect) => {
 		const bylines = new BylineRepository(db);
 		const fields = new BylineSchemaRegistry(ctx.db);
 		await fields.createField({ slug: "job_title", label: "Job title", type: "string" });
+		resetBylineFieldDefsCacheForTests();
 		const author = await bylines.create({
 			displayName: "Ada Lovelace",
 			slug: "ada-custom",

--- a/packages/core/tests/integration/loader-fold.test.ts
+++ b/packages/core/tests/integration/loader-fold.test.ts
@@ -9,7 +9,6 @@
  * dialects to guard the fold end-to-end.
  */
 
-import { ulid } from "ulidx";
 import { afterEach, beforeEach, expect, it } from "vitest";
 
 import { BylineRepository } from "../../src/database/repositories/byline.js";
@@ -81,22 +80,17 @@ describeEachDialect("loader hydration fold", (dialect) => {
 			slug: "ada",
 			avatarMediaId: "media_ada_avatar",
 		});
-		// _emdash_content_bylines.byline_id stores the byline's translation_group.
-		await db
-			.insertInto("_emdash_content_bylines")
-			.values({
-				id: ulid(),
-				collection_slug: "post",
-				content_id: post.id,
-				byline_id: author.translationGroup,
-				sort_order: 0,
-				role_label: "Author",
-				created_at: new Date().toISOString(),
-			})
-			.execute();
+		const editor = await bylines.create({
+			displayName: "Grace Hopper",
+			slug: "grace",
+		});
+		await bylines.setContentBylines("post", post.id, [
+			{ bylineId: editor.id, roleLabel: "Editor" },
+			{ bylineId: author.id, roleLabel: "Author" },
+		]);
 		const tag = await tax.create({ name: "tag", slug: "news", label: "News", locale: "en" });
 		await tax.attachToEntry("post", post.id, tag.id);
-		return { post, author, tag };
+		return { post, author, editor, tag };
 	}
 
 	function read<T>(data: unknown, sym: symbol): T {
@@ -117,12 +111,48 @@ describeEachDialect("loader hydration fold", (dialect) => {
 		expect(terms[0]).toMatchObject({ name: "tag", slug: "news", label: "News" });
 
 		const credits = read<FoldedByline[]>(data, FOLDED_BYLINES);
-		expect(credits).toHaveLength(1);
-		expect(credits[0]!.roleLabel).toBe("Author");
-		expect(credits[0]!.byline.displayName).toBe("Ada Lovelace");
+		expect(credits).toHaveLength(2);
+		const ada = credits.find((credit) => credit.byline.slug === "ada");
+		expect(ada?.roleLabel).toBe("Author");
+		expect(ada?.byline.displayName).toBe("Ada Lovelace");
 		// avatarMediaId is a required BylineSummary field templates read to render
 		// author avatars; the fold must carry it (regression guard).
-		expect(credits[0]!.byline.avatarMediaId).toBe("media_ada_avatar");
+		expect(ada?.byline.avatarMediaId).toBe("media_ada_avatar");
+
+		const publicCredits = data.bylines as Array<{
+			roleLabel: string | null;
+			sortOrder: number;
+			source: string;
+			byline: { displayName: string; slug: string; isGuest: boolean; customFields: unknown };
+		}>;
+		expect(
+			publicCredits.map((credit) => ({
+				displayName: credit.byline.displayName,
+				roleLabel: credit.roleLabel,
+				sortOrder: credit.sortOrder,
+				source: credit.source,
+				isGuest: credit.byline.isGuest,
+				customFields: credit.byline.customFields,
+			})),
+		).toEqual([
+			{
+				displayName: "Grace Hopper",
+				roleLabel: "Editor",
+				sortOrder: 0,
+				source: "explicit",
+				isGuest: false,
+				customFields: {},
+			},
+			{
+				displayName: "Ada Lovelace",
+				roleLabel: "Author",
+				sortOrder: 1,
+				source: "explicit",
+				isGuest: false,
+				customFields: {},
+			},
+		]);
+		expect(data.byline).toBe(publicCredits[0]!.byline);
 	});
 
 	it("folds bylines + terms into loadCollection", async () => {
@@ -134,15 +164,17 @@ describeEachDialect("loader hydration fold", (dialect) => {
 		// eslint-disable-next-line typescript/no-explicit-any -- loader result union
 		const entry = (result as any).entries[0];
 		expect(read<FoldedTerm[]>(entry.data, FOLDED_TERMS)[0]!.slug).toBe("news");
-		expect(read<FoldedByline[]>(entry.data, FOLDED_BYLINES)[0]!.byline.displayName).toBe(
-			"Ada Lovelace",
-		);
+		expect(
+			(entry.data.bylines as FoldedByline[]).map((credit) => credit.byline.displayName),
+		).toEqual(["Grace Hopper", "Ada Lovelace"]);
+		expect(entry.data.byline.displayName).toBe("Grace Hopper");
 	});
 
 	it("folds terms in the entry's own locale (#1441)", async () => {
 		// eslint-disable-next-line typescript/no-explicit-any -- schema type vs Database type
 		const db = ctx.db as any;
 		const content = new ContentRepository(db);
+		const bylines = new BylineRepository(db);
 		const tax = new TaxonomyRepository(db);
 		setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
 		try {
@@ -168,15 +200,34 @@ describeEachDialect("loader hydration fold", (dialect) => {
 				translationOf: enTag.id,
 			});
 			await tax.attachToEntry("post", fr.id, enTag.id);
+			const enAuthor = await bylines.create({
+				displayName: "English Author",
+				slug: "author",
+				locale: "en",
+			});
+			await bylines.create({
+				displayName: "Auteur français",
+				slug: "auteur",
+				locale: "fr",
+				translationOf: enAuthor.id,
+			});
+			await bylines.setContentBylines("post", fr.id, [
+				{ bylineId: enAuthor.id, roleLabel: "Author" },
+			]);
 
 			const loader = emdashLoader();
 			const result = await runWithContext({ editMode: false, db: ctx.db }, () =>
 				loader.loadEntry({ filter: { type: "post", id: "bonjour", locale: "fr" } }),
 			);
 			// eslint-disable-next-line typescript/no-explicit-any -- loader result union
-			const terms = read<FoldedTerm[]>((result as any).data, FOLDED_TERMS);
+			const data = (result as any).data;
+			const terms = read<FoldedTerm[]>(data, FOLDED_TERMS);
 			expect(terms).toHaveLength(1);
 			expect(terms[0]!.slug).toBe("actualites");
+			expect(data.bylines).toHaveLength(1);
+			expect(data.bylines[0].byline.displayName).toBe("Auteur français");
+			expect(data.bylines[0].byline.locale).toBe("fr");
+			expect(data.byline.displayName).toBe("Auteur français");
 		} finally {
 			setI18nConfig(null);
 		}
@@ -194,5 +245,7 @@ describeEachDialect("loader hydration fold", (dialect) => {
 		const data = (result as any).data as Record<string, unknown>;
 		expect(read<FoldedTerm[]>(data, FOLDED_TERMS)).toEqual([]);
 		expect(read<FoldedByline[]>(data, FOLDED_BYLINES)).toEqual([]);
+		expect(data.bylines).toEqual([]);
+		expect(data.byline).toBeNull();
 	});
 });

--- a/packages/core/tests/integration/loader-fold.test.ts
+++ b/packages/core/tests/integration/loader-fold.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, expect, it } from "vitest";
 import { BylineRepository } from "../../src/database/repositories/byline.js";
 import { ContentRepository } from "../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
+import type { ContentBylineCredit } from "../../src/database/repositories/types.js";
 import { setI18nConfig } from "../../src/i18n/config.js";
 import { emdashLoader, FOLDED_BYLINES, FOLDED_TERMS } from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
@@ -119,12 +120,7 @@ describeEachDialect("loader hydration fold", (dialect) => {
 		// author avatars; the fold must carry it (regression guard).
 		expect(ada?.byline.avatarMediaId).toBe("media_ada_avatar");
 
-		const publicCredits = data.bylines as Array<{
-			roleLabel: string | null;
-			sortOrder: number;
-			source: string;
-			byline: { displayName: string; slug: string; isGuest: boolean; customFields: unknown };
-		}>;
+		const publicCredits = data.bylines as ContentBylineCredit[];
 		expect(
 			publicCredits.map((credit) => ({
 				displayName: credit.byline.displayName,
@@ -165,7 +161,7 @@ describeEachDialect("loader hydration fold", (dialect) => {
 		const entry = (result as any).entries[0];
 		expect(read<FoldedTerm[]>(entry.data, FOLDED_TERMS)[0]!.slug).toBe("news");
 		expect(
-			(entry.data.bylines as FoldedByline[]).map((credit) => credit.byline.displayName),
+			(entry.data.bylines as ContentBylineCredit[]).map((credit) => credit.byline.displayName),
 		).toEqual(["Grace Hopper", "Ada Lovelace"]);
 		expect(entry.data.byline.displayName).toBe("Grace Hopper");
 	});

--- a/packages/core/tests/unit/loader-revision-preview.test.ts
+++ b/packages/core/tests/unit/loader-revision-preview.test.ts
@@ -2,6 +2,7 @@ import type { Kysely } from "kysely";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { handleContentCreate } from "../../src/api/index.js";
+import { BylineRepository } from "../../src/database/repositories/byline.js";
 import { ContentRepository } from "../../src/database/repositories/content.js";
 import { RevisionRepository } from "../../src/database/repositories/revision.js";
 import type { Database } from "../../src/database/types.js";
@@ -117,5 +118,46 @@ describe("Loader revision preview", () => {
 		// System dates from content table, as Date objects
 		expect(data.createdAt).toBeInstanceOf(Date);
 		expect(data.updatedAt).toBeInstanceOf(Date);
+	});
+
+	it("should expose explicit bylines on revision previews", async () => {
+		const post = await createPublishedPost("Original Title");
+		const bylineRepo = new BylineRepository(db);
+		const author = await bylineRepo.create({
+			displayName: "Ada Lovelace",
+			slug: "ada",
+		});
+		await bylineRepo.setContentBylines("post", post.id, [
+			{ bylineId: author.id, roleLabel: "Author" },
+		]);
+		const revision = await revisionRepo.create({
+			collection: "post",
+			entryId: post.id,
+			data: { title: "Revised Title" },
+		});
+
+		const loader = emdashLoader();
+		const entry = await runWithContext({ editMode: true, db }, () =>
+			loader.loadEntry!({
+				filter: { type: "post", id: post.slug!, revisionId: revision.id },
+			}),
+		);
+
+		expect(entry).toBeDefined();
+		expect(entry).not.toHaveProperty("error");
+		const data = (
+			entry as {
+				data: {
+					bylines: Array<{ source: string; byline: { displayName: string } }>;
+					byline: { displayName: string } | null;
+				};
+			}
+		).data;
+		expect(data.bylines).toHaveLength(1);
+		expect(data.bylines[0]).toMatchObject({
+			source: "explicit",
+			byline: { displayName: "Ada Lovelace" },
+		});
+		expect(data.byline).toBe(data.bylines[0]!.byline);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Exposes the explicit byline credits already folded into live-loader content queries through the reserved `entry.data.bylines` and `entry.data.byline` properties.

The loader now maps the existing folded payload to the established public credit shape, preserves `sortOrder`, marks credits as `source: "explicit"`, selects the first ordered credit as the primary byline, and returns `[]` / `null` when no explicit credits exist. Locale filtering remains strict because the mapping reuses the locale-filtered folded rows. No query or logged-out route round trip is added.

Closes #2424

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: this change adds no admin UI or user-facing strings.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: this is an approved bug fix for #2424.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

No visual changes.

- `pnpm --filter emdash exec vitest run tests/integration/loader-fold.test.ts tests/integration/loader-fold-plan.test.ts tests/unit/query-fold-public-shape.test.ts tests/unit/bylines/hydration-empty-table.test.ts tests/unit/loader-revision-preview.test.ts` — 5 files, 13 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with warnings denied
- `pnpm lint:json | jq '.diagnostics | length'` — `0`
- `pnpm format` — completed
- `pnpm query-counts --target sqlite` — count and SQL-text snapshots match
- `pnpm query-counts --target d1 --skip-build --skip-seed` — count and SQL-text snapshots match after the fixture was freshly seeded and built

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://codex-issue-2424-live-loader-bylines-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `codex/issue-2424-live-loader-bylines`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
