### PR TITLE
perf(core): batch public menu reference resolution

### DIFF
--- a/.changeset/quiet-menus-batch.md
+++ b/.changeset/quiet-menus-batch.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes public menu rendering so content and taxonomy links are resolved in batches instead of issuing database queries for each item.

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -17,6 +17,7 @@ import { resolveLocale, resolveLocaleChain } from "../i18n/resolve.js";
 import { getDb } from "../loader.js";
 import { cachedQuery, CacheNamespace } from "../object-cache/index.js";
 import { requestCached } from "../request-cache.js";
+import { chunks, SQL_BATCH_SIZE } from "../utils/chunks.js";
 import { sanitizeHref } from "../utils/url.js";
 import type { Menu, MenuItem, MenuItemRow } from "./types.js";
 
@@ -135,21 +136,22 @@ async function buildMenuTree(
 	db: Kysely<Database>,
 	locale: string,
 ): Promise<MenuItem[]> {
-	const collectionSlugs = new Set<string>();
-	for (const item of items) {
-		if (item.reference_collection) collectionSlugs.add(item.reference_collection);
-		if (item.type === "page" || item.type === "post") {
-			collectionSlugs.add(item.reference_collection || `${item.type}s`);
-		}
-	}
+	const contentReferences = collectContentReferences(items);
+	const taxonomyReferences = new Set(
+		items.flatMap((item) =>
+			item.type === "taxonomy" && item.reference_id ? [item.reference_id] : [],
+		),
+	);
+	const [urlPatterns, contentLookup, taxonomyLookup] = await Promise.all([
+		contentReferences.size > 0
+			? getCollectionUrlPatterns(db, new Set(contentReferences.keys()))
+			: new Map<string, string | null>(),
+		resolveContentReferences(db, contentReferences, locale),
+		resolveTaxonomyReferences(db, taxonomyReferences, locale),
+	]);
 
-	const urlPatterns =
-		collectionSlugs.size > 0
-			? await getCollectionUrlPatterns(db, collectionSlugs)
-			: new Map<string, string | null>();
-
-	const resolvedItems = await Promise.all(
-		items.map((item) => resolveMenuItem(item, db, urlPatterns, locale)),
+	const resolvedItems = items.map((item) =>
+		resolveMenuItem(item, urlPatterns, contentLookup, taxonomyLookup),
 	);
 	const validItems = resolvedItems.filter((item): item is MenuItem => item !== null);
 
@@ -173,6 +175,44 @@ async function buildMenuTree(
 	}
 
 	return rootItems;
+}
+
+function collectContentReferences(items: MenuItemRow[]): Map<string, Set<string>> {
+	const references = new Map<string, Set<string>>();
+	for (const item of items) {
+		const reference = getContentReference(item);
+		if (!reference) continue;
+		let ids = references.get(reference.collection);
+		if (!ids) {
+			ids = new Set();
+			references.set(reference.collection, ids);
+		}
+		ids.add(reference.id);
+	}
+	return references;
+}
+
+function getContentReference(item: MenuItemRow): { collection: string; id: string } | null {
+	if (item.type === "page" || item.type === "post") {
+		if (!item.reference_id) return null;
+		return {
+			collection: item.reference_collection || `${item.type}s`,
+			id: item.reference_id,
+		};
+	}
+	if (item.type === "collection") {
+		if (!item.reference_collection || !item.reference_id) return null;
+		return { collection: item.reference_collection, id: item.reference_id };
+	}
+	if (
+		item.type !== "custom" &&
+		item.type !== "taxonomy" &&
+		item.reference_collection &&
+		item.reference_id
+	) {
+		return { collection: item.reference_collection, id: item.reference_id };
+	}
+	return null;
 }
 
 /**
@@ -200,77 +240,69 @@ function getCollectionUrlPatterns(
 
 /**
  * Resolve a single menu item's URL. `reference_id` is a translation_group
- * (migration 036 remapped all existing references); we join it against
+ * (migration 036 remapped all existing references); we look it up against
  * the per-locale ec_* row or per-locale taxonomy row.
  */
-async function resolveMenuItem(
+function resolveMenuItem(
 	item: MenuItemRow,
-	db: Kysely<Database>,
 	urlPatterns: Map<string, string | null>,
-	locale: string,
-): Promise<MenuItem | null> {
+	contentLookup: ContentReferenceLookup,
+	taxonomyLookup: TaxonomyReferenceLookup,
+): MenuItem | null {
 	let url: string | null;
 
-	try {
-		switch (item.type) {
-			case "custom":
-				url = item.custom_url || "#";
-				break;
+	switch (item.type) {
+		case "custom":
+			url = item.custom_url || "#";
+			break;
 
-			case "page":
-			case "post":
-				url = await resolveContentUrl(
-					item.reference_collection || `${item.type}s`,
+		case "page":
+		case "post":
+			url = resolveContentUrl(
+				item.reference_collection || `${item.type}s`,
+				item.reference_id,
+				urlPatterns,
+				contentLookup,
+			);
+			if (url === null) return null;
+			break;
+
+		case "taxonomy":
+			url = resolveTaxonomyUrl(item.reference_id, taxonomyLookup);
+			if (url === null) return null;
+			break;
+
+		case "collection":
+			// Two shapes share this type: the admin content picker stores
+			// entries from custom collections as "collection" with a
+			// reference_id, while archive links carry only the collection
+			// slug. Entry references resolve like page/post items.
+			if (!item.reference_collection) return null;
+			if (item.reference_id) {
+				url = resolveContentUrl(
+					item.reference_collection,
 					item.reference_id,
-					db,
 					urlPatterns,
-					locale,
+					contentLookup,
 				);
 				if (url === null) return null;
-				break;
+			} else {
+				url = `/${item.reference_collection}/`;
+			}
+			break;
 
-			case "taxonomy":
-				url = await resolveTaxonomyUrl(item.reference_id, db, locale);
+		default:
+			if (item.reference_collection && item.reference_id) {
+				url = resolveContentUrl(
+					item.reference_collection,
+					item.reference_id,
+					urlPatterns,
+					contentLookup,
+				);
 				if (url === null) return null;
-				break;
-
-			case "collection":
-				// Two shapes share this type: the admin content picker stores
-				// entries from custom collections as "collection" with a
-				// reference_id, while archive links carry only the collection
-				// slug. Entry references resolve like page/post items.
-				if (!item.reference_collection) return null;
-				if (item.reference_id) {
-					url = await resolveContentUrl(
-						item.reference_collection,
-						item.reference_id,
-						db,
-						urlPatterns,
-						locale,
-					);
-					if (url === null) return null;
-				} else {
-					url = `/${item.reference_collection}/`;
-				}
-				break;
-
-			default:
-				if (item.reference_collection && item.reference_id) {
-					url = await resolveContentUrl(
-						item.reference_collection,
-						item.reference_id,
-						db,
-						urlPatterns,
-						locale,
-					);
-					if (url === null) return null;
-				} else {
-					url = "#";
-				}
-		}
-	} catch (error) {
-		console.error(`Failed to resolve menu item ${item.id}:`, error);
-		return null;
+			} else {
+				url = "#";
+			}
 	}
 
 	return {
@@ -296,97 +328,161 @@ function interpolateUrlPattern(pattern: string, slug: string, id: string): strin
 	return pattern.replace(SLUG_PLACEHOLDER, slug).replace(ID_PLACEHOLDER, id);
 }
 
+interface ContentReferenceRow {
+	id: string;
+	slug: string;
+	locale: string;
+	translation_group: string;
+}
+
+interface ResolvedContentReference {
+	id: string;
+	slug: string;
+}
+
+type ContentReferenceLookup = Map<string, Map<string, ResolvedContentReference>>;
+
+async function resolveContentReferences(
+	db: Kysely<Database>,
+	references: Map<string, Set<string>>,
+	locale: string,
+): Promise<ContentReferenceLookup> {
+	const entries = await Promise.all(
+		Array.from(references, async ([collection, referenceGroups]) => {
+			const lookup = new Map<string, ResolvedContentReference>();
+			const localized = new Map<string, ContentReferenceRow>();
+			try {
+				validateIdentifier(collection, "menu item collection");
+				for (const batch of chunks([...referenceGroups], SQL_BATCH_SIZE)) {
+					const result = await sql<ContentReferenceRow>`
+						SELECT id, slug, locale, translation_group
+						FROM ${sql.ref(`ec_${collection}`)}
+						WHERE translation_group IN (${sql.join(batch)})
+					`.execute(db);
+					for (const row of result.rows) {
+						const existing = localized.get(row.translation_group);
+						if (shouldPreferLocalizedRow(row, existing, locale)) {
+							localized.set(row.translation_group, row);
+						}
+					}
+				}
+				for (const [referenceGroup, row] of localized) lookup.set(referenceGroup, row);
+
+				const unresolved = [...referenceGroups].filter((id) => !lookup.has(id));
+				for (const batch of chunks(unresolved, SQL_BATCH_SIZE)) {
+					const result = await sql<ResolvedContentReference>`
+						SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
+						WHERE id IN (${sql.join(batch)})
+					`.execute(db);
+					for (const row of result.rows) lookup.set(row.id, row);
+				}
+			} catch (error) {
+				console.error(`Failed to resolve content URLs for ${collection}:`, error);
+			}
+			return [collection, lookup] as const;
+		}),
+	);
+	return new Map(entries);
+}
+
+function shouldPreferLocalizedRow(
+	candidate: ContentReferenceRow,
+	existing: ContentReferenceRow | undefined,
+	locale: string,
+): boolean {
+	if (!existing) return true;
+	if (candidate.locale === locale) return existing.locale !== locale || candidate.id < existing.id;
+	if (existing.locale === locale) return false;
+	return (
+		candidate.locale < existing.locale ||
+		(candidate.locale === existing.locale && candidate.id < existing.id)
+	);
+}
+
 /**
  * Resolve the URL for a content reference. `referenceGroup` is the content
  * row's translation_group; we look up the row in the requested locale
  * (falling back to the source if no translation exists so the menu link is
  * still clickable).
  */
-async function resolveContentUrl(
+function resolveContentUrl(
 	collection: string,
 	referenceGroup: string | null,
-	db: Kysely<Database>,
 	urlPatterns: Map<string, string | null>,
-	locale: string,
-): Promise<string | null> {
+	contentLookup: ContentReferenceLookup,
+): string | null {
 	if (!referenceGroup) return null;
+	const row = contentLookup.get(collection)?.get(referenceGroup);
+	if (!row) return null;
+	const pattern = urlPatterns.get(collection);
+	if (pattern) return interpolateUrlPattern(pattern, row.slug, row.id);
+	return `/${collection}/${row.slug}`;
+}
 
+interface TaxonomyReferenceRow {
+	id: string;
+	name: string;
+	slug: string;
+	locale: string;
+	translation_group: string;
+}
+
+interface ResolvedTaxonomyReference {
+	name: string;
+	slug: string;
+}
+
+type TaxonomyReferenceLookup = Map<string, ResolvedTaxonomyReference>;
+
+async function resolveTaxonomyReferences(
+	db: Kysely<Database>,
+	referenceGroups: Set<string>,
+	locale: string,
+): Promise<TaxonomyReferenceLookup> {
+	const lookup = new Map<string, ResolvedTaxonomyReference>();
+	const localized = new Map<string, TaxonomyReferenceRow>();
 	try {
-		validateIdentifier(collection, "menu item collection");
-
-		// Try the requested locale first, then any locale (deterministic).
-		let result = await sql<{ id: string; slug: string }>`
-			SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
-			WHERE translation_group = ${referenceGroup} AND locale = ${locale}
-			LIMIT 1
-		`.execute(db);
-		let row = result.rows[0];
-		if (!row) {
-			result = await sql<{ id: string; slug: string }>`
-				SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
-				WHERE translation_group = ${referenceGroup}
-				ORDER BY locale ASC LIMIT 1
-			`.execute(db);
-			row = result.rows[0];
+		for (const batch of chunks([...referenceGroups], SQL_BATCH_SIZE)) {
+			const rows = await db
+				.selectFrom("taxonomies")
+				.select(["id", "name", "slug", "locale", "translation_group"])
+				.where("translation_group", "in", batch)
+				.$narrowType<{ translation_group: string }>()
+				.execute();
+			for (const row of rows) {
+				const existing = localized.get(row.translation_group);
+				if (shouldPreferLocalizedRow(row, existing, locale)) {
+					localized.set(row.translation_group, row);
+				}
+			}
 		}
-		if (!row) {
-			// Legacy rows whose reference_id still points at an id directly
-			// (defensive — migration 036 normalised these, but a row inserted
-			// between migrations could predate the remap).
-			const legacy = await sql<{ id: string; slug: string }>`
-				SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
-				WHERE id = ${referenceGroup} LIMIT 1
-			`.execute(db);
-			row = legacy.rows[0];
-		}
-		if (!row) return null;
+		for (const [referenceGroup, row] of localized) lookup.set(referenceGroup, row);
 
-		const pattern = urlPatterns.get(collection);
-		if (pattern) return interpolateUrlPattern(pattern, row.slug, row.id);
-		return `/${collection}/${row.slug}`;
+		const unresolved = [...referenceGroups].filter((id) => !lookup.has(id));
+		for (const batch of chunks(unresolved, SQL_BATCH_SIZE)) {
+			const rows = await db
+				.selectFrom("taxonomies")
+				.select(["id", "name", "slug"])
+				.where("id", "in", batch)
+				.execute();
+			for (const row of rows) lookup.set(row.id, row);
+		}
 	} catch (error) {
-		console.error(`Failed to resolve content URL for ${collection}/${referenceGroup}:`, error);
-		return null;
+		console.error("Failed to resolve taxonomy URLs:", error);
 	}
+	return lookup;
 }
 
 /**
  * Resolve URL for a taxonomy term reference. `referenceGroup` is the term's
  * translation_group; we pick the row in the active locale (or fall back).
  */
-async function resolveTaxonomyUrl(
+function resolveTaxonomyUrl(
 	referenceGroup: string | null,
-	db: Kysely<Database>,
-	locale: string,
-): Promise<string | null> {
+	taxonomyLookup: TaxonomyReferenceLookup,
+): string | null {
 	if (!referenceGroup) return null;
-
-	let taxonomy = await db
-		.selectFrom("taxonomies")
-		.select(["name", "slug"])
-		.where("translation_group", "=", referenceGroup)
-		.where("locale", "=", locale)
-		.executeTakeFirst();
-
-	if (!taxonomy) {
-		taxonomy = await db
-			.selectFrom("taxonomies")
-			.select(["name", "slug"])
-			.where("translation_group", "=", referenceGroup)
-			.orderBy("locale", "asc")
-			.executeTakeFirst();
-	}
-
-	if (!taxonomy) {
-		// Legacy: id-based reference that predates the migration remap.
-		taxonomy = await db
-			.selectFrom("taxonomies")
-			.select(["name", "slug"])
-			.where("id", "=", referenceGroup)
-			.executeTakeFirst();
-	}
-
+	const taxonomy = taxonomyLookup.get(referenceGroup);
 	if (!taxonomy) return null;
-
 	return `/${taxonomy.name}/${taxonomy.slug}`;
 }

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -366,7 +366,9 @@ async function resolveContentReferences(
 						}
 					}
 				}
-				for (const [referenceGroup, row] of localized) lookup.set(referenceGroup, row);
+				for (const [referenceGroup, row] of localized) {
+					lookup.set(referenceGroup, { id: row.id, slug: row.slug });
+				}
 
 				const unresolved = [...referenceGroups].filter((id) => !lookup.has(id));
 				for (const batch of chunks(unresolved, SQL_BATCH_SIZE)) {
@@ -385,9 +387,14 @@ async function resolveContentReferences(
 	return new Map(entries);
 }
 
+interface LocalizedReference {
+	id: string;
+	locale: string;
+}
+
 function shouldPreferLocalizedRow(
-	candidate: ContentReferenceRow,
-	existing: ContentReferenceRow | undefined,
+	candidate: LocalizedReference,
+	existing: LocalizedReference | undefined,
 	locale: string,
 ): boolean {
 	if (!existing) return true;
@@ -456,7 +463,9 @@ async function resolveTaxonomyReferences(
 				}
 			}
 		}
-		for (const [referenceGroup, row] of localized) lookup.set(referenceGroup, row);
+		for (const [referenceGroup, row] of localized) {
+			lookup.set(referenceGroup, { name: row.name, slug: row.slug });
+		}
 
 		const unresolved = [...referenceGroups].filter((id) => !lookup.has(id));
 		for (const batch of chunks(unresolved, SQL_BATCH_SIZE)) {
@@ -465,7 +474,7 @@ async function resolveTaxonomyReferences(
 				.select(["id", "name", "slug"])
 				.where("id", "in", batch)
 				.execute();
-			for (const row of rows) lookup.set(row.id, row);
+			for (const row of rows) lookup.set(row.id, { name: row.name, slug: row.slug });
 		}
 	} catch (error) {
 		console.error("Failed to resolve taxonomy URLs:", error);

--- a/packages/core/tests/unit/menus/menu-batch-resolution.test.ts
+++ b/packages/core/tests/unit/menus/menu-batch-resolution.test.ts
@@ -1,0 +1,255 @@
+import type {
+	KyselyPlugin,
+	PluginTransformQueryArgs,
+	PluginTransformResultArgs,
+	QueryResult,
+	RootOperationNode,
+	UnknownRow,
+} from "kysely";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { getMenuWithDb } from "../../../src/menus/index.js";
+import {
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+class QueryCountingPlugin implements KyselyPlugin {
+	count = 0;
+
+	transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+		this.count += 1;
+		return args.node;
+	}
+
+	transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+		return Promise.resolve(args.result);
+	}
+}
+
+describeEachDialect("batched menu reference resolution", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+
+		await ctx.db
+			.updateTable("_emdash_collections")
+			.set({ url_pattern: "/pages/{slug}" })
+			.where("slug", "=", "page")
+			.execute();
+		await ctx.db
+			.updateTable("_emdash_collections")
+			.set({ url_pattern: "/articles/{slug}-{id}" })
+			.where("slug", "=", "post")
+			.execute();
+
+		await ctx.db
+			.insertInto("ec_page" as never)
+			.values([
+				{
+					id: "page-local-en",
+					slug: "contact",
+					locale: "en",
+					translation_group: "page-local",
+				},
+				{
+					id: "page-local-fr",
+					slug: "contact-fr",
+					locale: "fr",
+					translation_group: "page-local",
+				},
+				{
+					id: "page-fallback-en",
+					slug: "about",
+					locale: "en",
+					translation_group: "page-fallback",
+				},
+				{
+					id: "page-fallback-es",
+					slug: "acerca-de",
+					locale: "es",
+					translation_group: "page-fallback",
+				},
+				{
+					id: "legacy-page-id",
+					slug: "legacy",
+					locale: "en",
+					translation_group: "legacy-page-group",
+				},
+			] as never)
+			.execute();
+
+		await ctx.db
+			.insertInto("ec_post" as never)
+			.values([
+				{
+					id: "post-local-en",
+					slug: "hello",
+					locale: "en",
+					translation_group: "post-local",
+				},
+				{
+					id: "post-local-fr",
+					slug: "bonjour",
+					locale: "fr",
+					translation_group: "post-local",
+				},
+				{
+					id: "post-fallback-en",
+					slug: "static",
+					locale: "en",
+					translation_group: "post-fallback",
+				},
+				{
+					id: "post-fallback-es",
+					slug: "estatico",
+					locale: "es",
+					translation_group: "post-fallback",
+				},
+			] as never)
+			.execute();
+
+		await ctx.db
+			.insertInto("taxonomies")
+			.values([
+				{
+					id: "taxonomy-local-en",
+					name: "category",
+					slug: "news",
+					label: "News",
+					parent_id: null,
+					data: null,
+					locale: "en",
+					translation_group: "taxonomy-local",
+				},
+				{
+					id: "taxonomy-local-fr",
+					name: "category",
+					slug: "nouvelles",
+					label: "Nouvelles",
+					parent_id: null,
+					data: null,
+					locale: "fr",
+					translation_group: "taxonomy-local",
+				},
+				{
+					id: "taxonomy-fallback-en",
+					name: "tag",
+					slug: "releases",
+					label: "Releases",
+					parent_id: null,
+					data: null,
+					locale: "en",
+					translation_group: "taxonomy-fallback",
+				},
+				{
+					id: "taxonomy-fallback-es",
+					name: "tag",
+					slug: "lanzamientos",
+					label: "Lanzamientos",
+					parent_id: null,
+					data: null,
+					locale: "es",
+					translation_group: "taxonomy-fallback",
+				},
+				{
+					id: "legacy-taxonomy-id",
+					name: "category",
+					slug: "legacy-topic",
+					label: "Legacy topic",
+					parent_id: null,
+					data: null,
+					locale: "en",
+					translation_group: "legacy-taxonomy-group",
+				},
+			])
+			.execute();
+
+		await ctx.db
+			.insertInto("_emdash_menus")
+			.values({ id: "menu-primary-fr", name: "primary", label: "Primary", locale: "fr" })
+			.execute();
+		const contentItems: Array<[string, number, string, string, string, string]> = [
+			["item-page-local", 1, "page", "page", "page-local", "Contact"],
+			["item-page-fallback", 2, "page", "page", "page-fallback", "About"],
+			["item-page-legacy", 3, "page", "page", "legacy-page-id", "Legacy page"],
+			["item-post-local", 4, "post", "post", "post-local", "Bonjour"],
+			["item-post-fallback", 5, "post", "post", "post-fallback", "Static"],
+			["item-collection-entry", 6, "collection", "page", "page-fallback", "Featured page"],
+		];
+		const taxonomyItems: Array<[string, number, string, string]> = [
+			["item-taxonomy-local", 8, "taxonomy-local", "Nouvelles"],
+			["item-taxonomy-fallback", 9, "taxonomy-fallback", "Releases"],
+			["item-taxonomy-legacy", 10, "legacy-taxonomy-id", "Legacy topic"],
+		];
+		await ctx.db
+			.insertInto("_emdash_menu_items")
+			.values([
+				{
+					id: "item-custom",
+					menu_id: "menu-primary-fr",
+					sort_order: 0,
+					type: "custom",
+					custom_url: "https://example.com/docs",
+					label: "Docs",
+					locale: "fr",
+				},
+				...contentItems.map(([id, sortOrder, type, collection, referenceId, label]) => ({
+					id,
+					menu_id: "menu-primary-fr",
+					sort_order: sortOrder,
+					type,
+					reference_collection: collection,
+					reference_id: referenceId,
+					label,
+					locale: "fr",
+				})),
+				{
+					id: "item-collection-archive",
+					menu_id: "menu-primary-fr",
+					sort_order: 7,
+					type: "collection",
+					reference_collection: "page",
+					label: "All pages",
+					locale: "fr",
+				},
+				...taxonomyItems.map(([id, sortOrder, referenceId, label]) => ({
+					id,
+					menu_id: "menu-primary-fr",
+					sort_order: sortOrder,
+					type: "taxonomy",
+					reference_id: referenceId,
+					label,
+					locale: "fr",
+				})),
+			])
+			.execute();
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("resolves mixed locale references with a fixed query budget", async () => {
+		const counter = new QueryCountingPlugin();
+		const menu = await getMenuWithDb("primary", ctx.db.withPlugin(counter), { locale: "fr" });
+
+		expect(menu?.items.map(({ label, url }) => ({ label, url }))).toEqual([
+			{ label: "Docs", url: "https://example.com/docs" },
+			{ label: "Contact", url: "/pages/contact-fr" },
+			{ label: "About", url: "/pages/about" },
+			{ label: "Legacy page", url: "/pages/legacy" },
+			{ label: "Bonjour", url: "/articles/bonjour-post-local-fr" },
+			{ label: "Static", url: "/articles/static-post-fallback-en" },
+			{ label: "Featured page", url: "/pages/about" },
+			{ label: "All pages", url: "/page/" },
+			{ label: "Nouvelles", url: "/category/nouvelles" },
+			{ label: "Releases", url: "/tag/releases" },
+			{ label: "Legacy topic", url: "/category/legacy-topic" },
+		]);
+		expect(counter.count).toBe(8);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Batches public menu content references by collection and taxonomy references into all-locale lookups, then selects the requested locale or deterministic minimum-locale fallback in memory. Only unresolved references pay a batched legacy-ID sweep.

This removes per-item query fan-out while preserving URL patterns, custom URLs, collection entry/archive items, taxonomy URLs, legacy references, and request caching. The mixed page/post/taxonomy regression drops from 20 queries to a fixed budget of 8.

Closes #1189

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

The i18n checklist item is satisfied without catalog changes because this PR has no admin UI strings. The feature/Discussion item is not applicable to this issue-scoped performance improvement.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No visual changes.

- `pnpm exec vitest run tests/unit/menus/menus.test.ts tests/unit/menus/menu-request-cache.test.ts tests/unit/menus/menu-batch-resolution.test.ts --maxWorkers=1` — 53 passed
- `pnpm typecheck` — passed
- `pnpm lint:quick` — 0 diagnostics
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm --filter emdash build` — passed
- `node scripts/query-counts.mjs --target sqlite --skip-seed` — count and SQL snapshots match exactly; no logged-out route increased

The local D1 query-count harness did not reach measurement because its dev-only seed endpoint returned 403. The D1 CI job remains authoritative and will be monitored on this PR.
