### PR TITLE
fix(editor): protect inline edits from file navigation

### DIFF
--- a/.changeset/safe-inline-file-transfers.md
+++ b/.changeset/safe-inline-file-transfers.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes inline Portable Text editing so dropping or pasting files no longer navigates away from unsaved work and instead explains how to insert images.

--- a/e2e/tests/visual-editing.spec.ts
+++ b/e2e/tests/visual-editing.spec.ts
@@ -202,7 +202,6 @@ test.describe("Inline Editor", () => {
 
 		const editor = page.locator(".emdash-inline-editor");
 		await expect(editor).toBeVisible({ timeout: 15000 });
-		const originalUrl = page.url();
 
 		await editor.locator("p").last().click();
 		await page.keyboard.press("End");
@@ -233,7 +232,6 @@ test.describe("Inline Editor", () => {
 			itemCount: 1,
 			itemKind: "file",
 		});
-		expect(page.url()).toBe(originalUrl);
 		await expect(editor).toContainText("SafeTransferEdits");
 		await expect(page.getByRole("status")).toContainText("Type /image");
 
@@ -247,7 +245,6 @@ test.describe("Inline Editor", () => {
 		});
 
 		expect(pasteResult).toEqual({ defaultPrevented: true, dispatched: false });
-		expect(page.url()).toBe(originalUrl);
 		await expect(editor).toContainText("SafeTransferEdits");
 
 		await editor.locator("p").last().click();

--- a/e2e/tests/visual-editing.spec.ts
+++ b/e2e/tests/visual-editing.spec.ts
@@ -195,6 +195,98 @@ test.describe("Inline Editor", () => {
 		await expect(picker.locator("text=Insert Image")).toBeVisible();
 	});
 
+	test("refuses file drop and paste without losing edits or breaking image insertion", async ({
+		page,
+	}) => {
+		await gotoWithRetry(page, POST_WITH_IMAGE_PATH);
+
+		const editor = page.locator(".emdash-inline-editor");
+		await expect(editor).toBeVisible({ timeout: 15000 });
+		const originalUrl = page.url();
+
+		await editor.locator("p").last().click();
+		await page.keyboard.press("End");
+		await page.keyboard.type(" SafeTransferEdits");
+
+		const dropResult = await editor.evaluate((element) => {
+			const transfer = new DataTransfer();
+			transfer.items.add(new File(["image"], "drop.png", { type: "image/png" }));
+			const event = new DragEvent("drop", {
+				bubbles: true,
+				cancelable: true,
+				dataTransfer: transfer,
+			});
+			const dispatched = element.dispatchEvent(event);
+			return {
+				defaultPrevented: event.defaultPrevented,
+				dispatched,
+				fileCount: event.dataTransfer?.files.length,
+				itemCount: event.dataTransfer?.items.length,
+				itemKind: event.dataTransfer?.items[0]?.kind,
+			};
+		});
+
+		expect(dropResult).toEqual({
+			defaultPrevented: true,
+			dispatched: false,
+			fileCount: 1,
+			itemCount: 1,
+			itemKind: "file",
+		});
+		expect(page.url()).toBe(originalUrl);
+		await expect(editor).toContainText("SafeTransferEdits");
+		await expect(page.getByRole("status")).toContainText("Type /image");
+
+		const pasteResult = await editor.evaluate((element) => {
+			const transfer = new DataTransfer();
+			transfer.items.add(new File(["document"], "paste.pdf", { type: "application/pdf" }));
+			const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+			Object.defineProperty(event, "clipboardData", { value: transfer });
+			const dispatched = element.dispatchEvent(event);
+			return { defaultPrevented: event.defaultPrevented, dispatched };
+		});
+
+		expect(pasteResult).toEqual({ defaultPrevented: true, dispatched: false });
+		expect(page.url()).toBe(originalUrl);
+		await expect(editor).toContainText("SafeTransferEdits");
+
+		await editor.locator("p").last().click();
+		await page.keyboard.press("End");
+		await page.keyboard.press("Enter");
+		await page.keyboard.type("/image");
+		await page.keyboard.press("Enter");
+		await expect(page.locator(".emdash-media-picker")).toBeVisible({ timeout: 5000 });
+	});
+
+	test("shows file-transfer guidance in Arabic with RTL direction", async ({ page }) => {
+		await gotoWithRetry(page, POST_WITH_IMAGE_PATH);
+
+		const editor = page.locator(".emdash-inline-editor");
+		await expect(editor).toBeVisible({ timeout: 15000 });
+		await page.evaluate(() => {
+			document.documentElement.lang = "ar";
+			document.documentElement.dir = "rtl";
+		});
+
+		await editor.evaluate((element) => {
+			const transfer = new DataTransfer();
+			transfer.items.add(new File(["image"], "drop.png", { type: "image/png" }));
+			element.dispatchEvent(
+				new DragEvent("drop", {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer: transfer,
+				}),
+			);
+		});
+
+		const guidance = page.locator(".emdash-inline-editor-guidance");
+		await expect(guidance).toHaveText(
+			"لا يمكن إفلات الملفات أو لصقها هنا. اكتب /image لاختيار صورة من مكتبة الوسائط.",
+		);
+		expect(await guidance.evaluate((element) => getComputedStyle(element).direction)).toBe("rtl");
+	});
+
 	test("media picker shows uploaded images", async ({ page }) => {
 		await gotoWithRetry(page, POST_WITH_IMAGE_PATH);
 

--- a/e2e/tests/visual-editing.spec.ts
+++ b/e2e/tests/visual-editing.spec.ts
@@ -253,7 +253,10 @@ test.describe("Inline Editor", () => {
 			itemKind: "file",
 		});
 		await expect(editor).toContainText("SafeTransferEdits");
-		await expect(page.getByRole("status")).toContainText("Type /image");
+		const guidance = page.getByRole("status");
+		await expect(guidance).toContainText("Type /image");
+		const firstGuidance = await guidance.elementHandle();
+		expect(firstGuidance).not.toBeNull();
 
 		const pasteResult = await editor.evaluate((element) => {
 			const transfer = new DataTransfer();
@@ -266,6 +269,8 @@ test.describe("Inline Editor", () => {
 
 		expect(pasteResult).toEqual({ defaultPrevented: true, dispatched: false });
 		await expect(editor).toContainText("SafeTransferEdits");
+		await expect(guidance).toContainText("Type /image");
+		expect(await firstGuidance!.evaluate((element) => element.isConnected)).toBe(false);
 
 		await editor.locator("p").last().click();
 		await page.keyboard.press("End");

--- a/e2e/tests/visual-editing.spec.ts
+++ b/e2e/tests/visual-editing.spec.ts
@@ -210,6 +210,18 @@ test.describe("Inline Editor", () => {
 		const dropResult = await editor.evaluate((element) => {
 			const transfer = new DataTransfer();
 			transfer.items.add(new File(["image"], "drop.png", { type: "image/png" }));
+			const dragEnter = new DragEvent("dragenter", {
+				bubbles: true,
+				cancelable: true,
+				dataTransfer: transfer,
+			});
+			const dragEnterDispatched = element.dispatchEvent(dragEnter);
+			const dragOver = new DragEvent("dragover", {
+				bubbles: true,
+				cancelable: true,
+				dataTransfer: transfer,
+			});
+			const dragOverDispatched = element.dispatchEvent(dragOver);
 			const event = new DragEvent("drop", {
 				bubbles: true,
 				cancelable: true,
@@ -217,6 +229,10 @@ test.describe("Inline Editor", () => {
 			});
 			const dispatched = element.dispatchEvent(event);
 			return {
+				dragEnterDefaultPrevented: dragEnter.defaultPrevented,
+				dragEnterDispatched,
+				dragOverDefaultPrevented: dragOver.defaultPrevented,
+				dragOverDispatched,
 				defaultPrevented: event.defaultPrevented,
 				dispatched,
 				fileCount: event.dataTransfer?.files.length,
@@ -226,6 +242,10 @@ test.describe("Inline Editor", () => {
 		});
 
 		expect(dropResult).toEqual({
+			dragEnterDefaultPrevented: true,
+			dragEnterDispatched: false,
+			dragOverDefaultPrevented: true,
+			dragOverDispatched: false,
 			defaultPrevented: true,
 			dispatched: false,
 			fileCount: 1,

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2009,10 +2009,16 @@ export function InlinePortableTextEditor({
 
 	// Media picker state
 	const [mediaPickerOpen, setMediaPickerOpen] = React.useState(false);
-	const [unsupportedFileGuidance, setUnsupportedFileGuidance] = React.useState<string | null>(null);
+	const [unsupportedFileGuidance, setUnsupportedFileGuidance] = React.useState<{
+		message: string;
+		version: number;
+	} | null>(null);
 	const showUnsupportedFileGuidance = React.useCallback(() => {
 		const locale = document.documentElement.lang || navigator.language;
-		setUnsupportedFileGuidance(getUnsupportedFileGuidance(locale));
+		setUnsupportedFileGuidance((current) => ({
+			message: getUnsupportedFileGuidance(locale),
+			version: (current?.version ?? 0) + 1,
+		}));
 	}, []);
 	const unsupportedFileHandlers = React.useMemo(
 		() => createUnsupportedFileHandlers(showUnsupportedFileGuidance),
@@ -2251,8 +2257,14 @@ export function InlinePortableTextEditor({
 			<InlineBubbleMenu editor={editor} />
 			<EditorContent editor={editor} />
 			{unsupportedFileGuidance ? (
-				<div className="emdash-inline-editor-guidance" role="status" aria-live="polite" dir="auto">
-					{unsupportedFileGuidance}
+				<div
+					key={unsupportedFileGuidance.version}
+					className="emdash-inline-editor-guidance"
+					role="status"
+					aria-live="polite"
+					dir="auto"
+				>
+					{unsupportedFileGuidance.message}
 				</div>
 			) : null}
 			<InlineSlashMenu

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -102,8 +102,15 @@ function hasTransferredFiles(transfer: DataTransfer | null): boolean {
 }
 
 function createUnsupportedFileHandlers(showGuidance: () => void) {
+	const keepFileDragInEditor = (_view: unknown, event: DragEvent): boolean => {
+		if (!hasTransferredFiles(event.dataTransfer)) return false;
+		event.preventDefault();
+		return true;
+	};
 	return {
 		handleDOMEvents: {
+			dragenter: keepFileDragInEditor,
+			dragover: keepFileDragInEditor,
 			drop: (_view: unknown, event: DragEvent): boolean => {
 				if (!hasTransferredFiles(event.dataTransfer)) return false;
 				event.preventDefault();
@@ -2414,8 +2421,7 @@ export function InlinePortableTextEditor({
 	);
 }
 
-// Test-only exports for unit tests of the conversion functions.
+// Test-only exports for unit tests.
 export { pmToPortableText as _pmToPortableText };
 export { portableTextToPM as _portableTextToPM };
 export { createUnsupportedFileHandlers as _createUnsupportedFileHandlers };
-export { getUnsupportedFileGuidance as _getUnsupportedFileGuidance };

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -85,6 +85,41 @@ function k(): string {
 	return Math.random().toString(36).substring(2, 11);
 }
 
+function getUnsupportedFileGuidance(locale: string): string {
+	if (locale.toLowerCase().startsWith("ar")) {
+		return "لا يمكن إفلات الملفات أو لصقها هنا. اكتب /image لاختيار صورة من مكتبة الوسائط.";
+	}
+	return "Files can’t be dropped or pasted here. Type /image to choose an image from the media library.";
+}
+
+function hasTransferredFiles(transfer: DataTransfer | null): boolean {
+	if (!transfer) return false;
+	if (transfer.files.length > 0) return true;
+	for (let index = 0; index < transfer.items.length; index++) {
+		if (transfer.items[index]?.kind === "file") return true;
+	}
+	return false;
+}
+
+function createUnsupportedFileHandlers(showGuidance: () => void) {
+	return {
+		handleDOMEvents: {
+			drop: (_view: unknown, event: DragEvent): boolean => {
+				if (!hasTransferredFiles(event.dataTransfer)) return false;
+				event.preventDefault();
+				showGuidance();
+				return true;
+			},
+			paste: (_view: unknown, event: ClipboardEvent): boolean => {
+				if (!hasTransferredFiles(event.clipboardData)) return false;
+				event.preventDefault();
+				showGuidance();
+				return true;
+			},
+		},
+	};
+}
+
 // ── ProseMirror → Portable Text ────────────────────────────────────
 
 type PMNode = {
@@ -1967,6 +2002,15 @@ export function InlinePortableTextEditor({
 
 	// Media picker state
 	const [mediaPickerOpen, setMediaPickerOpen] = React.useState(false);
+	const [unsupportedFileGuidance, setUnsupportedFileGuidance] = React.useState<string | null>(null);
+	const showUnsupportedFileGuidance = React.useCallback(() => {
+		const locale = document.documentElement.lang || navigator.language;
+		setUnsupportedFileGuidance(getUnsupportedFileGuidance(locale));
+	}, []);
+	const unsupportedFileHandlers = React.useMemo(
+		() => createUnsupportedFileHandlers(showUnsupportedFileGuidance),
+		[showUnsupportedFileGuidance],
+	);
 
 	// Listen for the slash command's media picker event
 	React.useEffect(() => {
@@ -2132,6 +2176,7 @@ export function InlinePortableTextEditor({
 				class: "prose prose-sm sm:prose-base dark:prose-invert max-w-none emdash-inline-editor",
 				dir: "auto",
 			},
+			...unsupportedFileHandlers,
 		},
 		onUpdate: () => {
 			document.dispatchEvent(new CustomEvent("emdash:save", { detail: { state: "unsaved" } }));
@@ -2198,6 +2243,11 @@ export function InlinePortableTextEditor({
 		<div onBlur={handleBlur}>
 			<InlineBubbleMenu editor={editor} />
 			<EditorContent editor={editor} />
+			{unsupportedFileGuidance ? (
+				<div className="emdash-inline-editor-guidance" role="status" aria-live="polite" dir="auto">
+					{unsupportedFileGuidance}
+				</div>
+			) : null}
 			<InlineSlashMenu
 				state={slashMenuState}
 				onCommand={handleSlashCommand}
@@ -2323,6 +2373,19 @@ export function InlinePortableTextEditor({
 				.emdash-inline-editor:focus {
 					outline: none;
 				}
+				.emdash-inline-editor-guidance {
+					margin-block-start: 0.75rem;
+					padding-block: 0.625rem;
+					padding-inline: 0.875rem;
+					border: 1px solid #bfdbfe;
+					border-radius: 0.5rem;
+					background: #eff6ff;
+					color: #1e3a8a;
+					font-size: 0.875rem;
+					font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+					line-height: 1.4;
+					text-align: start;
+				}
 				.emdash-plugin-block-placeholder {
 					margin: 0.75rem 0;
 					padding: 0.625rem 0.875rem;
@@ -2335,6 +2398,11 @@ export function InlinePortableTextEditor({
 					user-select: none;
 				}
 				@media (prefers-color-scheme: dark) {
+					.emdash-inline-editor-guidance {
+						border-color: #1e40af;
+						background: #172554;
+						color: #dbeafe;
+					}
 					.emdash-plugin-block-placeholder {
 						border-color: #374151;
 						background: #111827;
@@ -2349,3 +2417,5 @@ export function InlinePortableTextEditor({
 // Test-only exports for unit tests of the conversion functions.
 export { pmToPortableText as _pmToPortableText };
 export { portableTextToPM as _portableTextToPM };
+export { createUnsupportedFileHandlers as _createUnsupportedFileHandlers };
+export { getUnsupportedFileGuidance as _getUnsupportedFileGuidance };

--- a/packages/core/tests/unit/components/inline-portable-text-file-transfer.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-file-transfer.test.ts
@@ -2,10 +2,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import {
-	_createUnsupportedFileHandlers as createUnsupportedFileHandlers,
-	_getUnsupportedFileGuidance as getUnsupportedFileGuidance,
-} from "../../../src/components/InlinePortableTextEditor.js";
+import { _createUnsupportedFileHandlers as createUnsupportedFileHandlers } from "../../../src/components/InlinePortableTextEditor.js";
 
 function fileList(...files: File[]): FileList {
 	const list = {
@@ -39,6 +36,19 @@ describe("inline editor file transfers", () => {
 		expect(handlers.handleDOMEvents.drop({} as never, event)).toBe(true);
 		expect(event.preventDefault).toHaveBeenCalledOnce();
 		expect(showGuidance).toHaveBeenCalledOnce();
+	});
+
+	it("keeps file drags inside the editor until they can be refused", () => {
+		const showGuidance = vi.fn();
+		const handlers = createUnsupportedFileHandlers(showGuidance);
+		const dragEnter = dropEvent([new File(["image"], "photo.png", { type: "image/png" })]);
+		const dragOver = dropEvent([new File(["image"], "photo.png", { type: "image/png" })]);
+
+		expect(handlers.handleDOMEvents.dragenter({} as never, dragEnter)).toBe(true);
+		expect(handlers.handleDOMEvents.dragover({} as never, dragOver)).toBe(true);
+		expect(dragEnter.preventDefault).toHaveBeenCalledOnce();
+		expect(dragOver.preventDefault).toHaveBeenCalledOnce();
+		expect(showGuidance).not.toHaveBeenCalled();
 	});
 
 	it("refuses files pasted from the clipboard", () => {
@@ -75,14 +85,5 @@ describe("inline editor file transfers", () => {
 		expect(drop.preventDefault).not.toHaveBeenCalled();
 		expect(paste.preventDefault).not.toHaveBeenCalled();
 		expect(showGuidance).not.toHaveBeenCalled();
-	});
-
-	it("localizes the guidance for an Arabic editing page", () => {
-		expect(getUnsupportedFileGuidance("ar-EG")).toBe(
-			"لا يمكن إفلات الملفات أو لصقها هنا. اكتب /image لاختيار صورة من مكتبة الوسائط.",
-		);
-		expect(getUnsupportedFileGuidance("fr")).toBe(
-			"Files can’t be dropped or pasted here. Type /image to choose an image from the media library.",
-		);
 	});
 });

--- a/packages/core/tests/unit/components/inline-portable-text-file-transfer.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-file-transfer.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	_createUnsupportedFileHandlers as createUnsupportedFileHandlers,
+	_getUnsupportedFileGuidance as getUnsupportedFileGuidance,
+} from "../../../src/components/InlinePortableTextEditor.js";
+
+function fileList(...files: File[]): FileList {
+	const list = {
+		length: files.length,
+		item: (index: number) => files[index] ?? null,
+	} as unknown as FileList;
+	files.forEach((file, index) => Object.defineProperty(list, index, { value: file }));
+	return list;
+}
+
+function dropEvent(files: File[]): DragEvent {
+	return {
+		dataTransfer: { files: fileList(...files), items: { length: 0 } },
+		preventDefault: vi.fn(),
+	} as unknown as DragEvent;
+}
+
+function pasteEvent(files: File[]): ClipboardEvent {
+	return {
+		clipboardData: { files: fileList(...files), items: { length: 0 } },
+		preventDefault: vi.fn(),
+	} as unknown as ClipboardEvent;
+}
+
+describe("inline editor file transfers", () => {
+	it("refuses file drops before the browser can navigate away", () => {
+		const showGuidance = vi.fn();
+		const handlers = createUnsupportedFileHandlers(showGuidance);
+		const event = dropEvent([new File(["image"], "photo.png", { type: "image/png" })]);
+
+		expect(handlers.handleDOMEvents.drop({} as never, event)).toBe(true);
+		expect(event.preventDefault).toHaveBeenCalledOnce();
+		expect(showGuidance).toHaveBeenCalledOnce();
+	});
+
+	it("refuses files pasted from the clipboard", () => {
+		const showGuidance = vi.fn();
+		const handlers = createUnsupportedFileHandlers(showGuidance);
+		const event = pasteEvent([new File(["document"], "notes.pdf", { type: "application/pdf" })]);
+
+		expect(handlers.handleDOMEvents.paste({} as never, event)).toBe(true);
+		expect(event.preventDefault).toHaveBeenCalledOnce();
+		expect(showGuidance).toHaveBeenCalledOnce();
+	});
+
+	it("recognizes an indexed file item when the browser leaves files empty", () => {
+		const showGuidance = vi.fn();
+		const handlers = createUnsupportedFileHandlers(showGuidance);
+		const event = dropEvent([]);
+		Object.defineProperty(event.dataTransfer, "items", {
+			value: { 0: { kind: "file" }, length: 1 },
+		});
+
+		expect(handlers.handleDOMEvents.drop({} as never, event)).toBe(true);
+		expect(event.preventDefault).toHaveBeenCalledOnce();
+		expect(showGuidance).toHaveBeenCalledOnce();
+	});
+
+	it("leaves ordinary editor drop and paste behavior untouched", () => {
+		const showGuidance = vi.fn();
+		const handlers = createUnsupportedFileHandlers(showGuidance);
+		const drop = dropEvent([]);
+		const paste = pasteEvent([]);
+
+		expect(handlers.handleDOMEvents.drop({} as never, drop)).toBe(false);
+		expect(handlers.handleDOMEvents.paste({} as never, paste)).toBe(false);
+		expect(drop.preventDefault).not.toHaveBeenCalled();
+		expect(paste.preventDefault).not.toHaveBeenCalled();
+		expect(showGuidance).not.toHaveBeenCalled();
+	});
+
+	it("localizes the guidance for an Arabic editing page", () => {
+		expect(getUnsupportedFileGuidance("ar-EG")).toBe(
+			"لا يمكن إفلات الملفات أو لصقها هنا. اكتب /image لاختيار صورة من مكتبة الوسائط.",
+		);
+		expect(getUnsupportedFileGuidance("fr")).toBe(
+			"Files can’t be dropped or pasted here. Type /image to choose an image from the media library.",
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Prevents unsupported file drops and clipboard pastes from reaching the browser's default navigation path in the inline Portable Text editor. The editor preserves in-progress edits, announces page-locale guidance to use `/image` and the media library, and leaves ordinary editor transfers and the existing slash-command image picker unchanged. Upload-on-drop remains out of scope.

Closes #2425

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Discussion is not applicable because this is a focused bug fix. Admin Lingui catalogs are not applicable because the affected visual editor is a standalone core component; its new guidance resolves from the editing page language, with Arabic RTL coverage, and this PR does not change `messages.po` files.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- `pnpm build`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format` and `pnpm format:check`
- `pnpm --filter emdash test --run tests/unit/components/inline-portable-text-file-transfer.test.ts` → 5 passed
- Focused Playwright regressions in `e2e/tests/visual-editing.spec.ts` → 2 passed
- Chromium Arabic check: localized guidance computes `direction: rtl` and logical `text-align: start`
