### PR TITLE
fix: generate inline taxonomy slugs server-side

### DIFF
--- a/.changeset/fix-inline-unicode-taxonomies.md
+++ b/.changeset/fix-inline-unicode-taxonomies.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fixes inline taxonomy term creation for Unicode-only labels and adds numeric suffixes when generated term slugs collide.

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -434,7 +434,7 @@ function TermFormDialog({
 	const createMutation = useMutation({
 		mutationFn: () =>
 			createTerm(taxonomyName, {
-				slug,
+				...(autoSlug ? {} : { slug }),
 				label,
 				parentId: parentId || undefined,
 				description: description || undefined,

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -17,7 +17,7 @@ import * as React from "react";
 import { apiFetch, parseApiResponse, throwResponseError } from "../lib/api/client.js";
 import { createTerm, withLocale } from "../lib/api/taxonomies.js";
 import { rankTermMatches, termExactMatches } from "../lib/taxonomy-match.js";
-import { cn, slugify } from "../lib/utils.js";
+import { cn } from "../lib/utils.js";
 
 interface TaxonomyTerm {
 	id: string;
@@ -367,7 +367,6 @@ function TaxonomySection({
 	const createTermMutation = useMutation({
 		mutationFn: (label: string) =>
 			createTerm(taxonomy.name, {
-				slug: slugify(label),
 				label,
 				// Create the term in the entry's locale so it resolves on this entry.
 				...(entryLocale ? { locale: entryLocale } : {}),

--- a/packages/admin/src/lib/api/taxonomies.ts
+++ b/packages/admin/src/lib/api/taxonomies.ts
@@ -71,7 +71,7 @@ export interface CreateTaxonomyInput {
 }
 
 export interface CreateTermInput {
-	slug: string;
+	slug?: string;
 	label: string;
 	parentId?: string;
 	description?: string;

--- a/packages/admin/tests/components/TaxonomyManager.test.tsx
+++ b/packages/admin/tests/components/TaxonomyManager.test.tsx
@@ -2,6 +2,7 @@ import { Toasty } from "@cloudflare/kumo";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { userEvent } from "vitest/browser";
 
 import {
 	getAvailableParentTerms,
@@ -342,6 +343,42 @@ describe("TaxonomyManager", () => {
 		await expect.element(screen.getByLabelText("Slug")).toBeInTheDocument();
 		// The InputArea uses "Description (optional)" as label
 		await expect.element(screen.getByText("Description (optional)")).toBeInTheDocument();
+	});
+
+	it("lets the server derive an auto-generated term slug", async () => {
+		const screen = await render(<TaxonomyManager taxonomyName="categories" />, {
+			wrapper: Wrapper,
+		});
+		await screen.getByRole("button", { name: ADD_CATEGORY_BUTTON_REGEX }).click();
+		await screen.getByLabelText("Name").fill("音楽");
+		await expect.element(screen.getByLabelText("Slug")).toHaveValue("音楽");
+
+		await userEvent.keyboard("{Enter}");
+
+		await vi.waitFor(() => {
+			const call = vi.mocked(apiFetch).mock.calls.find(([, init]) => init?.method === "POST");
+			expect(call).toBeDefined();
+			const body = typeof call?.[1]?.body === "string" ? JSON.parse(call[1].body) : undefined;
+			expect(body).toMatchObject({ label: "音楽" });
+			expect(body).not.toHaveProperty("slug");
+		});
+	});
+
+	it("sends a manually edited term slug", async () => {
+		const screen = await render(<TaxonomyManager taxonomyName="categories" />, {
+			wrapper: Wrapper,
+		});
+		await screen.getByRole("button", { name: ADD_CATEGORY_BUTTON_REGEX }).click();
+		await screen.getByLabelText("Name").fill("Music");
+		await screen.getByLabelText("Slug").fill("custom-music");
+
+		await userEvent.keyboard("{Enter}");
+
+		await vi.waitFor(() => {
+			const call = vi.mocked(apiFetch).mock.calls.find(([, init]) => init?.method === "POST");
+			const body = typeof call?.[1]?.body === "string" ? JSON.parse(call[1].body) : undefined;
+			expect(body).toMatchObject({ label: "Music", slug: "custom-music" });
+		});
 	});
 
 	it("shows parent selector for hierarchical taxonomies", async () => {

--- a/packages/admin/tests/components/TaxonomySidebar.test.tsx
+++ b/packages/admin/tests/components/TaxonomySidebar.test.tsx
@@ -357,11 +357,26 @@ describe("TaxonomySidebar", () => {
 				"/_emdash/api/taxonomies/tags/terms",
 				expect.objectContaining({
 					method: "POST",
-					body: JSON.stringify({ slug: "gamma", label: "Gamma" }),
+					body: JSON.stringify({ label: "Gamma" }),
 				}),
 			);
 		});
 		expect(onChange).toHaveBeenCalledWith("tags", ["term_created"]);
+	});
+
+	it("lets the server derive the slug for an inline Unicode term", async () => {
+		mockApiFetch({ terms: [] });
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+
+		await screen.getByLabelText("Add Tags").fill("音楽");
+		await screen.getByText('Create "音楽"').click();
+
+		await vi.waitFor(() => {
+			const call = vi.mocked(apiFetch).mock.calls.find(([, init]) => init?.method === "POST");
+			expect(call).toBeDefined();
+			const body = typeof call?.[1]?.body === "string" ? JSON.parse(call[1].body) : undefined;
+			expect(body).toEqual({ label: "音楽" });
+		});
 	});
 
 	it("continues to render hierarchical taxonomies as a checkbox tree", async () => {

--- a/packages/core/src/api/handlers/taxonomies.ts
+++ b/packages/core/src/api/handlers/taxonomies.ts
@@ -19,6 +19,15 @@ import { fetchVisibleTermCounts } from "../../taxonomies/term-counts.js";
 import type { ApiResult } from "../types.js";
 
 const NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+const MAX_GENERATED_TERM_SLUG_ATTEMPTS = 16;
+
+function isTermSlugUniqueViolation(error: unknown): boolean {
+	const message = error instanceof Error ? error.message.toLowerCase() : "";
+	return (
+		(message.includes("unique constraint failed") || message.includes("duplicate key")) &&
+		message.includes("slug")
+	);
+}
 
 // ---------------------------------------------------------------------------
 // Response types
@@ -820,6 +829,7 @@ export async function handleTermCreate(
 		translationOf?: string;
 	},
 ): Promise<ApiResult<TermResponse>> {
+	let attemptedSlug = input.slug;
 	try {
 		const locale = resolveConfiguredLocale(input.locale ?? getI18nConfig()?.defaultLocale ?? "en");
 		// Taxonomy definitions are per-locale, but terms can exist in any locale
@@ -829,21 +839,20 @@ export async function handleTermCreate(
 		if (!lookup.success) return lookup;
 
 		const repo = new TaxonomyRepository(db);
-		const generatedSlug = input.slug === undefined;
-		const slug = input.slug ?? (await repo.generateUniqueSlug(taxonomyName, input.label, locale));
 
 		// Coerce empty-string parentId to undefined (treat as "no parent").
 		const parentId =
 			input.parentId === "" || input.parentId === undefined ? undefined : input.parentId;
 
 		// Conflict check is scoped to locale (per-locale slugs are unique).
-		const existing = generatedSlug ? null : await repo.findBySlug(taxonomyName, slug, locale);
+		const existing =
+			input.slug === undefined ? null : await repo.findBySlug(taxonomyName, input.slug, locale);
 		if (existing) {
 			return {
 				success: false,
 				error: {
 					code: "CONFLICT",
-					message: `Term '${slug}' already exists in '${taxonomyName}' (${locale})`,
+					message: `Term '${input.slug}' already exists in '${taxonomyName}' (${locale})`,
 				},
 			};
 		}
@@ -875,15 +884,33 @@ export async function handleTermCreate(
 			return { success: false, error: parentError };
 		}
 
-		const term = await repo.create({
-			name: taxonomyName,
-			slug,
-			label: input.label,
-			parentId: parentId ?? undefined,
-			data: input.description ? { description: input.description } : undefined,
-			locale,
-			translationOf: input.translationOf,
-		});
+		const create = (slug: string) =>
+			repo.create({
+				name: taxonomyName,
+				slug,
+				label: input.label,
+				parentId: parentId ?? undefined,
+				data: input.description ? { description: input.description } : undefined,
+				locale,
+				translationOf: input.translationOf,
+			});
+		let term: Awaited<ReturnType<typeof create>> | undefined;
+		let lastSlugConflict: unknown;
+		if (input.slug !== undefined) {
+			term = await create(input.slug);
+		} else {
+			for (let attempt = 0; attempt < MAX_GENERATED_TERM_SLUG_ATTEMPTS; attempt++) {
+				attemptedSlug = await repo.generateUniqueSlug(taxonomyName, input.label, locale);
+				try {
+					term = await create(attemptedSlug);
+					break;
+				} catch (error) {
+					if (!isTermSlugUniqueViolation(error)) throw error;
+					lastSlugConflict = error;
+				}
+			}
+		}
+		if (!term) throw lastSlugConflict ?? new Error("Failed to create taxonomy term");
 
 		invalidateTermCache();
 
@@ -903,7 +930,16 @@ export async function handleTermCreate(
 				},
 			},
 		};
-	} catch {
+	} catch (error) {
+		if (isTermSlugUniqueViolation(error)) {
+			return {
+				success: false,
+				error: {
+					code: "CONFLICT",
+					message: `Term with slug '${attemptedSlug ?? "(generated)"}' already exists in taxonomy '${taxonomyName}'`,
+				},
+			};
+		}
 		return {
 			success: false,
 			error: { code: "TERM_CREATE_ERROR", message: "Failed to create term" },

--- a/packages/core/src/api/handlers/taxonomies.ts
+++ b/packages/core/src/api/handlers/taxonomies.ts
@@ -812,7 +812,7 @@ export async function handleTermCreate(
 	db: Kysely<Database>,
 	taxonomyName: string,
 	input: {
-		slug: string;
+		slug?: string;
 		label: string;
 		parentId?: string | null;
 		description?: string;
@@ -829,19 +829,21 @@ export async function handleTermCreate(
 		if (!lookup.success) return lookup;
 
 		const repo = new TaxonomyRepository(db);
+		const generatedSlug = input.slug === undefined;
+		const slug = input.slug ?? (await repo.generateUniqueSlug(taxonomyName, input.label, locale));
 
 		// Coerce empty-string parentId to undefined (treat as "no parent").
 		const parentId =
 			input.parentId === "" || input.parentId === undefined ? undefined : input.parentId;
 
 		// Conflict check is scoped to locale (per-locale slugs are unique).
-		const existing = await repo.findBySlug(taxonomyName, input.slug, locale);
+		const existing = generatedSlug ? null : await repo.findBySlug(taxonomyName, slug, locale);
 		if (existing) {
 			return {
 				success: false,
 				error: {
 					code: "CONFLICT",
-					message: `Term '${input.slug}' already exists in '${taxonomyName}' (${locale})`,
+					message: `Term '${slug}' already exists in '${taxonomyName}' (${locale})`,
 				},
 			};
 		}
@@ -875,7 +877,7 @@ export async function handleTermCreate(
 
 		const term = await repo.create({
 			name: taxonomyName,
-			slug: input.slug,
+			slug,
 			label: input.label,
 			parentId: parentId ?? undefined,
 			data: input.description ? { description: input.description } : undefined,

--- a/packages/core/src/api/schemas/taxonomies.ts
+++ b/packages/core/src/api/schemas/taxonomies.ts
@@ -52,7 +52,11 @@ export const updateTaxonomyDefBody = z
 
 export const createTermBody = z
 	.object({
-		slug: z.string().min(1),
+		slug: z
+			.string()
+			.min(1)
+			.optional()
+			.meta({ description: "Term slug. Omit to derive a unique slug from the label." }),
 		label: z.string().min(1),
 		parentId: z.string().nullish(),
 		description: z.string().optional(),

--- a/packages/core/src/database/repositories/taxonomy.ts
+++ b/packages/core/src/database/repositories/taxonomy.ts
@@ -2,6 +2,7 @@ import { sql, type Kysely, type Selectable } from "kysely";
 import { ulid } from "ulidx";
 
 import { invalidateTaxonomyObjectCache } from "../../object-cache/index.js";
+import { slugify } from "../../utils/slugify.js";
 import { withTransaction } from "../transaction.js";
 import type { Database, TaxonomyTable } from "../types.js";
 import { validateIdentifier } from "../validate.js";
@@ -18,6 +19,7 @@ export interface SiblingPosition {
  * statement inside D1's 100-parameter ceiling.
  */
 const GROUPS_PER_UPDATE = 32;
+const NUMERIC_SUFFIX_PATTERN = /^\d+$/;
 
 /** Deal the listed groups back out over the slots they hold, in the order given. */
 function permuteWithinSlots(
@@ -214,6 +216,29 @@ export class TaxonomyRepository {
 		if (locale !== undefined) query = query.where("locale", "=", locale);
 		const row = await query.orderBy("locale", "asc").executeTakeFirst();
 		return row ? this.rowToTaxonomy(row) : null;
+	}
+
+	/** Generate a locale-scoped term slug, adding a numeric suffix when needed. */
+	async generateUniqueSlug(name: string, text: string, locale?: string): Promise<string> {
+		const baseSlug = slugify(text);
+		let query = this.db
+			.selectFrom("taxonomies")
+			.select("slug")
+			.where("name", "=", name)
+			.where((eb) => eb.or([eb("slug", "=", baseSlug), eb("slug", "like", `${baseSlug}-%`)]));
+		if (locale !== undefined) query = query.where("locale", "=", locale);
+		const candidates = await query.execute();
+		if (!candidates.some((candidate) => candidate.slug === baseSlug)) return baseSlug;
+
+		let maxSuffix = 0;
+		const prefix = `${baseSlug}-`;
+		for (const candidate of candidates) {
+			if (!candidate.slug.startsWith(prefix)) continue;
+			const suffix = candidate.slug.slice(prefix.length);
+			if (!NUMERIC_SUFFIX_PATTERN.test(suffix)) continue;
+			maxSuffix = Math.max(maxSuffix, Number.parseInt(suffix, 10));
+		}
+		return `${baseSlug}-${maxSuffix + 1}`;
 	}
 
 	/**

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -2528,7 +2528,11 @@ export function createMcpServer(
 				"new term beneath a chain of 100+ existing ancestors are rejected.",
 			inputSchema: z.object({
 				taxonomy: z.string().describe("Taxonomy name (e.g. 'categories', 'tags')"),
-				slug: z.string().describe("URL-safe identifier for the term"),
+				slug: z
+					.string()
+					.min(1)
+					.optional()
+					.describe("URL identifier for the term; omit to derive it from the label"),
 				label: z.string().describe("Display name"),
 				parentId: z.string().optional().describe("Parent term ID for hierarchical taxonomies"),
 				description: z.string().optional().describe("Description of the term"),

--- a/packages/core/tests/integration/mcp/taxonomy.test.ts
+++ b/packages/core/tests/integration/mcp/taxonomy.test.ts
@@ -550,6 +550,18 @@ describe("taxonomy_create_term", () => {
 		expect(term.label).toBe("Tech");
 	});
 
+	it("derives a Unicode slug when omitted", async () => {
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+		const result = await harness.client.callTool({
+			name: "taxonomy_create_term",
+			arguments: { taxonomy: "tags", label: "音楽" },
+		});
+
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const { term } = extractJson<{ term: { slug: string } }>(result);
+		expect(term.slug).toBe("音楽");
+	});
+
 	it("creates a child term with parentId", async () => {
 		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
 		const parent = await harness.client.callTool({

--- a/packages/core/tests/unit/taxonomies/term-slug-generation.test.ts
+++ b/packages/core/tests/unit/taxonomies/term-slug-generation.test.ts
@@ -1,19 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, expect, it } from "vitest";
 
 import { handleTaxonomyCreate, handleTermCreate } from "../../../src/api/handlers/taxonomies.js";
-import { createTermBody } from "../../../src/api/schemas/taxonomies.js";
 import {
 	describeEachDialect,
 	setupForDialectWithCollections,
 	teardownForDialect,
 	type DialectTestContext,
 } from "../../utils/test-db.js";
-
-describe("taxonomy term create schema", () => {
-	it("allows the server to derive a slug from the label", () => {
-		expect(createTermBody.safeParse({ label: "音楽" }).success).toBe(true);
-	});
-});
 
 describeEachDialect("taxonomy term slug generation", (dialect) => {
 	let ctx: DialectTestContext;
@@ -64,6 +57,20 @@ describeEachDialect("taxonomy term slug generation", (dialect) => {
 		expect(second.success).toBe(true);
 		if (!second.success) return;
 		expect(second.data.term.slug).toBe("音楽-1");
+	});
+
+	it("recovers when concurrent generated slugs collide", async () => {
+		const results = await Promise.all(
+			Array.from({ length: 6 }, () =>
+				handleTermCreate(ctx.db, "tags", { label: "同時", locale: "en" }),
+			),
+		);
+
+		expect(results.every((result) => result.success)).toBe(true);
+		const slugs = results.flatMap((result) => (result.success ? [result.data.term.slug] : []));
+		expect(new Set(slugs)).toEqual(
+			new Set(["同時", "同時-1", "同時-2", "同時-3", "同時-4", "同時-5"]),
+		);
 	});
 
 	it("keeps generated slug uniqueness scoped to the locale", async () => {

--- a/packages/core/tests/unit/taxonomies/term-slug-generation.test.ts
+++ b/packages/core/tests/unit/taxonomies/term-slug-generation.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleTaxonomyCreate, handleTermCreate } from "../../../src/api/handlers/taxonomies.js";
+import { createTermBody } from "../../../src/api/schemas/taxonomies.js";
+import {
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describe("taxonomy term create schema", () => {
+	it("allows the server to derive a slug from the label", () => {
+		expect(createTermBody.safeParse({ label: "音楽" }).success).toBe(true);
+	});
+});
+
+describeEachDialect("taxonomy term slug generation", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+		const created = await handleTaxonomyCreate(ctx.db, {
+			name: "tags",
+			label: "Tags",
+			collections: ["post"],
+		});
+		expect(created.success).toBe(true);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it.each([
+		["مرحبا بالعالم", "مرحبا-بالعالم"],
+		["你好世界", "你好世界"],
+		["Привет мир", "привет-мир"],
+		["שלום עולם", "שלום-עולם"],
+		["สวัสดี โลก", "สวัสดี-โลก"],
+		["Καλημέρα κόσμε", "καλημέρα-κόσμε"],
+		["మేష రాసి", "మేష-రాసి"],
+	])("derives a native-script slug for %s", async (label, expected) => {
+		const result = await handleTermCreate(ctx.db, "tags", { label });
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.term.slug).toBe(expected);
+	});
+
+	it("uses a deterministic fallback for emoji-only labels", async () => {
+		const result = await handleTermCreate(ctx.db, "tags", { label: "🎵🎵" });
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.term.slug).toMatch(/^untitled-[a-z0-9]+$/);
+	});
+
+	it("adds a numeric suffix for generated slug collisions", async () => {
+		const first = await handleTermCreate(ctx.db, "tags", { label: "音楽", locale: "en" });
+		const second = await handleTermCreate(ctx.db, "tags", { label: "音楽", locale: "en" });
+
+		expect(first.success).toBe(true);
+		expect(second.success).toBe(true);
+		if (!second.success) return;
+		expect(second.data.term.slug).toBe("音楽-1");
+	});
+
+	it("keeps generated slug uniqueness scoped to the locale", async () => {
+		const english = await handleTermCreate(ctx.db, "tags", { label: "音楽", locale: "en" });
+		const japanese = await handleTermCreate(ctx.db, "tags", { label: "音楽", locale: "ja" });
+
+		expect(english.success).toBe(true);
+		expect(japanese.success).toBe(true);
+		if (!english.success || !japanese.success) return;
+		expect(english.data.term.slug).toBe("音楽");
+		expect(japanese.data.term.slug).toBe("音楽");
+	});
+
+	it("still rejects a colliding explicit slug", async () => {
+		await handleTermCreate(ctx.db, "tags", { slug: "music", label: "Music" });
+
+		const duplicate = await handleTermCreate(ctx.db, "tags", {
+			slug: "music",
+			label: "Other music",
+		});
+
+		expect(duplicate.success).toBe(false);
+		if (duplicate.success) return;
+		expect(duplicate.error.code).toBe("CONFLICT");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Moves automatic taxonomy-term slug generation to the server for inline creation. When callers omit a slug, the API uses the shared Unicode slug utility from #2505 and resolves collisions against the database with locale-scoped numeric suffixes. Manually supplied slugs remain unchanged and still return a conflict when already taken.

The entry-editor taxonomy sidebar now sends only the label (plus locale), while the taxonomy manager omits the slug only while its slug field remains auto-generated.

Depends on #2505.

Closes #2355

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no new user-visible admin strings.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this fixes #2355 using the maintainer-approved slug policy in #2271.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm --filter @emdash-cms/admin --filter emdash build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter emdash exec vitest run tests/unit/taxonomies/term-slug-generation.test.ts tests/unit/taxonomies/taxonomy-crud.test.ts tests/unit/taxonomies/term-reorder.test.ts tests/integration/taxonomies/taxonomy-locale-terms.test.ts tests/integration/mcp/taxonomy.test.ts` → 122 passed.
- `pnpm --filter @emdash-cms/admin exec vitest run tests/components/TaxonomySidebar.test.tsx tests/components/TaxonomyManager.test.tsx` → 31 passed.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://codex-taxonomy-unicode-slugs-2355-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `codex/taxonomy-unicode-slugs-2355`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
