### PR TITLE
fix(admin): restore image and HTML toolbar actions

### DIFF
--- a/.changeset/toolbar-block-actions.md
+++ b/.changeset/toolbar-block-actions.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds Image and HTML insertion to the rich-text toolbar while keeping subscript and superscript in the text-selection menu.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1349,6 +1349,12 @@ interface SlashCommandItem {
 	category?: MessageDescriptor | string;
 }
 
+function insertHtmlBlock(editor: Editor, range?: Range) {
+	const chain = editor.chain().focus();
+	if (range) chain.deleteRange(range);
+	chain.insertContent({ type: "htmlBlock", attrs: { html: "" } }).run();
+}
+
 /**
  * Default slash commands for built-in block types
  */
@@ -1459,14 +1465,7 @@ const defaultSlashCommands: SlashCommandItem[] = [
 		description: msg`Insert raw HTML`,
 		icon: BracketsAngle,
 		aliases: ["html", "raw", "markup"],
-		command: ({ editor, range }) => {
-			editor
-				.chain()
-				.focus()
-				.deleteRange(range)
-				.insertContent({ type: "htmlBlock", attrs: { html: "" } })
-				.run();
-		},
+		command: ({ editor, range }) => insertHtmlBlock(editor, range),
 	},
 	{
 		id: "divider",
@@ -2620,6 +2619,10 @@ export function PortableTextEditor({
 	// Section picker state (for inserting sections)
 	const [sectionPickerOpen, setSectionPickerOpen] = React.useState(false);
 	const pendingBlockInsertPosRef = React.useRef<number | null>(null);
+	const openToolbarImagePicker = React.useCallback(() => {
+		pendingBlockInsertPosRef.current = null;
+		setMediaPickerOpen(true);
+	}, []);
 
 	// Slash commands state
 	const [slashMenuState, setSlashMenuStateRaw] = React.useState<SlashMenuState>({
@@ -3304,6 +3307,7 @@ export function PortableTextEditor({
 						focusMode={focusMode}
 						onFocusModeChange={setFocusMode}
 						onInsertBlock={handleTouchInsertBlock}
+						onInsertImage={openToolbarImagePicker}
 					/>
 				)}
 				<div className="relative overflow-visible">
@@ -3766,12 +3770,14 @@ function EditorToolbar({
 	focusMode,
 	onFocusModeChange,
 	onInsertBlock,
+	onInsertImage,
 }: {
 	toolbarRef: React.RefObject<HTMLDivElement | null>;
 	editor: Editor;
 	focusMode: FocusMode;
 	onFocusModeChange: (mode: FocusMode) => void;
 	onInsertBlock: () => void;
+	onInsertImage: () => void;
 }) {
 	const { t } = useLingui();
 	const [showLinkPopover, setShowLinkPopover] = React.useState(false);
@@ -4009,6 +4015,12 @@ function EditorToolbar({
 					title={t`Code Block`}
 				>
 					<CodeBlock className="h-4 w-4" aria-hidden="true" />
+				</ToolbarButton>
+				<ToolbarButton onClick={onInsertImage} title={t`Insert Image`}>
+					<ImageIcon className="h-4 w-4" aria-hidden="true" />
+				</ToolbarButton>
+				<ToolbarButton onClick={() => insertHtmlBlock(editor)} title={t`Insert HTML`}>
+					<BracketsAngle className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
 			</ToolbarGroup>
 

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -3789,8 +3789,6 @@ function EditorToolbar({
 				isItalic: ctx.editor.isActive("italic"),
 				isUnderline: ctx.editor.isActive("underline"),
 				isStrike: ctx.editor.isActive("strike"),
-				isSubscript: ctx.editor.isActive("subscript"),
-				isSuperscript: ctx.editor.isActive("superscript"),
 				isCode: ctx.editor.isActive("code"),
 				isBulletList: ctx.editor.isActive("bulletList"),
 				isOrderedList,
@@ -3945,20 +3943,6 @@ function EditorToolbar({
 					title={t`Strikethrough`}
 				>
 					<TextStrikethrough className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
-				<ToolbarButton
-					onClick={() => editor.chain().focus().toggleSubscript().run()}
-					active={editorState.isSubscript}
-					title={t`Subscript`}
-				>
-					<TextSubscript className="h-4 w-4" aria-hidden="true" />
-				</ToolbarButton>
-				<ToolbarButton
-					onClick={() => editor.chain().focus().toggleSuperscript().run()}
-					active={editorState.isSuperscript}
-					title={t`Superscript`}
-				>
-					<TextSuperscript className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
 				<ToolbarButton
 					onClick={() => editor.chain().focus().toggleCode().run()}

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -782,13 +782,16 @@ describe("Toolbar", () => {
 
 	it("has inline formatting buttons", async () => {
 		const screen = await renderWithToolbar();
-		await expect.element(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Italic" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Underline" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Strikethrough" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Subscript" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Superscript" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("button", { name: "Inline Code" })).toBeInTheDocument();
+		const toolbar = screen.getByRole("toolbar");
+		await expect.element(toolbar.getByRole("button", { name: "Bold" })).toBeInTheDocument();
+		await expect.element(toolbar.getByRole("button", { name: "Italic" })).toBeInTheDocument();
+		await expect.element(toolbar.getByRole("button", { name: "Underline" })).toBeInTheDocument();
+		await expect
+			.element(toolbar.getByRole("button", { name: "Strikethrough" }))
+			.toBeInTheDocument();
+		await expect.element(toolbar.getByRole("button", { name: "Inline Code" })).toBeInTheDocument();
+		expect(toolbar.element().querySelector('[aria-label="Subscript"]')).toBeNull();
+		expect(toolbar.element().querySelector('[aria-label="Superscript"]')).toBeNull();
 	});
 
 	it.each([
@@ -796,10 +799,17 @@ describe("Toolbar", () => {
 		["Superscript", "superscript"],
 	] as const)("persists %s formatting as a Portable Text mark", async (label, mark) => {
 		const onChange = vi.fn();
-		const { screen, editor } = await renderAndGetEditor({ onChange, value: [] });
+		const { editor } = await renderAndGetEditor({ onChange, value: [textBlock("2")] });
+		editor.chain().focus().selectAll().run();
 
-		await screen.getByRole("button", { name: label }).click();
-		typeIntoEditor(editor, "2");
+		let bubbleButton: HTMLButtonElement | null = null;
+		await vi.waitFor(() => {
+			bubbleButton = document.querySelector(
+				`[data-emdash-inline-bubble-menu] [aria-label="${label}"]`,
+			);
+			expect(bubbleButton).toBeTruthy();
+		});
+		bubbleButton!.click();
 
 		await vi.waitFor(() => expect(onChange).toHaveBeenCalled(), { timeout: 2000 });
 		const blocks = onChange.mock.calls.at(-1)![0] as Array<{

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -849,13 +849,11 @@ describe("Toolbar", () => {
 		await expect.element(screen.getByRole("button", { name: "Align Right" })).toBeInTheDocument();
 	});
 
-	it("keeps insertion-only actions out of the formatting toolbar", async () => {
+	it("keeps extended insertion actions out of the formatting toolbar", async () => {
 		const screen = await renderWithToolbar();
 		const toolbar = screen.getByRole("toolbar").element();
 		await expect.element(screen.getByRole("button", { name: "Insert Link" })).toBeInTheDocument();
 		expect(toolbar.querySelector('[aria-label="Insert Table"]')).toBeNull();
-		expect(toolbar.querySelector('[aria-label="Insert Image"]')).toBeNull();
-		expect(toolbar.querySelector('[aria-label="Insert HTML"]')).toBeNull();
 		expect(toolbar.querySelector('[aria-label="Insert Horizontal Rule"]')).toBeNull();
 	});
 

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -7,6 +7,7 @@ import {
 	PortableTextEditor,
 	type PortableTextEditorProps,
 } from "../../src/components/PortableTextEditor";
+import type { MediaItem } from "../../src/lib/api";
 import { render } from "../utils/render.tsx";
 
 // ---------------------------------------------------------------------------
@@ -14,7 +15,38 @@ import { render } from "../utils/render.tsx";
 // ---------------------------------------------------------------------------
 
 vi.mock("../../src/components/MediaPickerModal", () => ({
-	MediaPickerModal: () => null,
+	MediaPickerModal: ({
+		open,
+		onOpenChange,
+		onSelect,
+	}: {
+		open: boolean;
+		onOpenChange: (open: boolean) => void;
+		onSelect: (item: MediaItem) => void;
+	}) =>
+		open ? (
+			<div role="dialog" aria-label="Test image picker">
+				<button
+					type="button"
+					onClick={() =>
+						onSelect({
+							id: "image-1",
+							filename: "diagram.png",
+							mimeType: "image/png",
+							url: "/diagram.png",
+							size: 1024,
+							alt: "Architecture diagram",
+							createdAt: "2026-08-16T00:00:00.000Z",
+						})
+					}
+				>
+					Choose test image
+				</button>
+				<button type="button" onClick={() => onOpenChange(false)}>
+					Cancel image picker
+				</button>
+			</div>
+		) : null,
 }));
 
 vi.mock("../../src/components/SectionPickerModal", () => ({
@@ -50,6 +82,14 @@ vi.mock("../../src/components/editor/ImageNode", async () => {
 		},
 		renderHTML({ HTMLAttributes }) {
 			return ["img", HTMLAttributes];
+		},
+		addCommands() {
+			return {
+				setImage:
+					(options: Record<string, unknown>) =>
+					({ commands }) =>
+						commands.insertContent({ type: this.name, attrs: options }),
+			};
 		},
 	});
 	return { ImageExtension };
@@ -269,13 +309,13 @@ describe("Toolbar Presence and Structure", () => {
 		await expect.element(screen.getByRole("button", { name: "Align Right" })).toBeVisible();
 	});
 
-	it("keeps insertion-only actions in the block menu", async () => {
+	it("exposes core block insertions and keeps extended actions in the block menu", async () => {
 		const { screen } = await renderEditor();
 		const toolbar = screen.getByRole("toolbar", { name: "Text formatting" }).element();
 		await expect.element(screen.getByRole("button", { name: "Insert Link" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Insert Image" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Insert HTML" })).toBeVisible();
 		expect(toolbar.querySelector('[aria-label="Insert Table"]')).toBeNull();
-		expect(toolbar.querySelector('[aria-label="Insert Image"]')).toBeNull();
-		expect(toolbar.querySelector('[aria-label="Insert HTML"]')).toBeNull();
 		expect(toolbar.querySelector('[aria-label="Insert Horizontal Rule"]')).toBeNull();
 	});
 
@@ -360,6 +400,46 @@ describe("Toolbar Presence and Structure", () => {
 		const { screen } = await renderEditor({ minimal: true });
 		const toolbar = screen.container.querySelector('[role="toolbar"]');
 		expect(toolbar).toBeNull();
+	});
+});
+
+// =============================================================================
+// Block insertion
+// =============================================================================
+
+describe("Block insertion", () => {
+	it("leaves content unchanged until an image is selected from the toolbar picker", async () => {
+		const { screen, editor } = await renderEditor();
+		editor.commands.focus("end");
+		const before = editor.getJSON();
+
+		getToolbarButton(screen, "Insert Image").element().click();
+		await screen.getByRole("button", { name: "Cancel image picker" }).click();
+		expect(editor.getJSON()).toEqual(before);
+
+		getToolbarButton(screen, "Insert Image").element().click();
+		await screen.getByRole("button", { name: "Choose test image" }).click();
+		await vi.waitFor(() => {
+			const image = editor.getJSON().content?.find((node) => node.type === "image");
+			expect(image?.attrs).toMatchObject({
+				src: "/diagram.png",
+				alt: "Architecture diagram",
+				mediaId: "image-1",
+				provider: "local",
+			});
+		});
+	});
+
+	it("inserts an empty HTML block from the toolbar", async () => {
+		const { screen, editor } = await renderEditor();
+		editor.commands.focus("end");
+
+		getToolbarButton(screen, "Insert HTML").element().click();
+
+		await vi.waitFor(() => {
+			const htmlBlock = editor.getJSON().content?.find((node) => node.type === "htmlBlock");
+			expect(htmlBlock?.attrs?.html).toBe("");
+		});
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Restores visible Image and HTML block actions to the Portable Text toolbar. To keep the toolbar the same width, Subscript and Superscript remain available in the text-selection bubble menu but no longer occupy fixed-toolbar slots.

Image insertion reuses the existing media picker and clears stale gutter insertion state before opening it. HTML insertion shares the existing transaction used by the slash command.

Closes #2475

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `@emdash-cms/admin`: 1,440 tests passed
- Simple demo production build passed
- Manually verified desktop, narrow, dark, and Arabic/RTL layouts
- Manually verified the real media picker, HTML insertion, and undo flow
