### PR TITLE
fix(scheduler): warn when scheduled maintenance stops

### DIFF
--- a/.changeset/calm-heartbeats-warn.md
+++ b/.changeset/calm-heartbeats-warn.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Adds scheduler heartbeat health to the admin dashboard and warns when scheduled content is overdue because maintenance has never run or has stopped running.

--- a/packages/admin/src/components/Dashboard.tsx
+++ b/packages/admin/src/components/Dashboard.tsx
@@ -61,6 +61,7 @@ export function Dashboard({ manifest }: DashboardProps) {
 
 			{showDashboardData && (
 				<>
+					{stats && <SchedulerWarning stats={stats} />}
 					<SummaryMetrics stats={stats} loading={isLoading} />
 
 					{/* Collections + Recent activity */}
@@ -78,6 +79,39 @@ export function Dashboard({ manifest }: DashboardProps) {
 			{/* Plugin widgets */}
 			<PluginWidgets manifest={manifest} />
 		</div>
+	);
+}
+
+function SchedulerWarning({ stats }: { stats: DashboardStats }) {
+	const { t } = useLingui();
+	const overdueCount = stats.collections.reduce(
+		(sum, collection) => sum + (collection.overdueScheduled ?? 0),
+		0,
+	);
+	if (overdueCount === 0 || !stats.schedulerHealth || stats.schedulerHealth.status === "healthy") {
+		return null;
+	}
+
+	const description =
+		stats.schedulerHealth.status === "unknown"
+			? plural(overdueCount, {
+					one: "One scheduled item is overdue, but no scheduler run has completed. Run `npx emdash doctor` and verify the deployed Cron Trigger.",
+					other:
+						"# scheduled items are overdue, but no scheduler run has completed. Run `npx emdash doctor` and verify the deployed Cron Trigger.",
+				})
+			: plural(overdueCount, {
+					one: "One scheduled item is overdue and the scheduler heartbeat is stale. Run `npx emdash doctor` and verify the deployed Cron Trigger.",
+					other:
+						"# scheduled items are overdue and the scheduler heartbeat is stale. Run `npx emdash doctor` and verify the deployed Cron Trigger.",
+				});
+
+	return (
+		<Banner
+			variant="alert"
+			title={t`Scheduled publishing needs attention`}
+			description={description}
+			role="alert"
+		/>
 	);
 }
 

--- a/packages/admin/src/lib/api/dashboard.ts
+++ b/packages/admin/src/lib/api/dashboard.ts
@@ -14,6 +14,7 @@ export interface CollectionStats {
 	published: number;
 	draft: number;
 	scheduled: number;
+	overdueScheduled?: number;
 }
 
 export interface RecentItem {
@@ -32,6 +33,10 @@ export interface DashboardStats {
 	mediaCount: number;
 	userCount: number;
 	recentItems: RecentItem[];
+	schedulerHealth?: {
+		status: "healthy" | "stale" | "unknown";
+		lastCompletedAt: string | null;
+	};
 }
 
 /**

--- a/packages/admin/tests/components/Dashboard.test.tsx
+++ b/packages/admin/tests/components/Dashboard.test.tsx
@@ -62,6 +62,7 @@ function makeStats(collections: DashboardStats["collections"]): DashboardStats {
 		mediaCount: 0,
 		userCount: 0,
 		recentItems: [],
+		schedulerHealth: { status: "healthy", lastCompletedAt: new Date().toISOString() },
 	};
 }
 
@@ -93,6 +94,100 @@ describe("Dashboard", () => {
 
 		await expect.element(screen.getByText("Media files")).toBeInTheDocument();
 		await expect.element(screen.getByText("Scheduled")).not.toBeInTheDocument();
+	});
+
+	it("warns when scheduled content is overdue and the scheduler has never completed", async () => {
+		const stats = makeStats([
+			{
+				slug: "pages",
+				label: "Pages",
+				total: 1,
+				published: 0,
+				draft: 1,
+				scheduled: 1,
+				overdueScheduled: 1,
+			},
+		]);
+		stats.schedulerHealth = { status: "unknown", lastCompletedAt: null };
+		mockFetchDashboardStats.mockResolvedValue(stats);
+
+		const screen = await render(<Dashboard manifest={manifest} />);
+
+		await expect
+			.element(screen.getByText("Scheduled publishing needs attention"))
+			.toBeInTheDocument();
+		await expect.element(screen.getByText(/no scheduler run has completed/i)).toBeInTheDocument();
+		await expect.element(screen.getByText(/npx emdash doctor/i)).toBeInTheDocument();
+	});
+
+	it("warns when scheduled content is overdue and the heartbeat is stale", async () => {
+		const stats = makeStats([
+			{
+				slug: "pages",
+				label: "Pages",
+				total: 1,
+				published: 0,
+				draft: 1,
+				scheduled: 1,
+				overdueScheduled: 1,
+			},
+		]);
+		stats.schedulerHealth = {
+			status: "stale",
+			lastCompletedAt: "2026-08-16T11:50:00.000Z",
+		};
+		mockFetchDashboardStats.mockResolvedValue(stats);
+
+		const screen = await render(<Dashboard manifest={manifest} />);
+
+		await expect
+			.element(screen.getByText("Scheduled publishing needs attention"))
+			.toBeInTheDocument();
+		await expect.element(screen.getByText(/scheduler heartbeat is stale/i)).toBeInTheDocument();
+	});
+
+	it("does not warn when the scheduler heartbeat is healthy", async () => {
+		mockFetchDashboardStats.mockResolvedValue(
+			makeStats([
+				{
+					slug: "pages",
+					label: "Pages",
+					total: 1,
+					published: 0,
+					draft: 1,
+					scheduled: 1,
+					overdueScheduled: 1,
+				},
+			]),
+		);
+
+		const screen = await render(<Dashboard manifest={manifest} />);
+
+		await expect
+			.element(screen.getByText("Scheduled publishing needs attention"))
+			.not.toBeInTheDocument();
+	});
+
+	it("renders dashboard data from an older API without scheduler health", async () => {
+		const stats = makeStats([
+			{
+				slug: "pages",
+				label: "Pages",
+				total: 1,
+				published: 0,
+				draft: 1,
+				scheduled: 0,
+			},
+		]);
+		stats.schedulerHealth = undefined;
+		mockFetchDashboardStats.mockResolvedValue(stats);
+
+		const screen = await render(<Dashboard manifest={manifest} />);
+
+		await expect.element(screen.getByText("Content")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("Scheduled publishing needs attention"))
+			.not.toBeInTheDocument();
 	});
 
 	it("labels the published count for screen readers with the state, not the action", async () => {

--- a/packages/core/src/api/handlers/dashboard.ts
+++ b/packages/core/src/api/handlers/dashboard.ts
@@ -13,6 +13,7 @@ import { MediaRepository } from "../../database/repositories/media.js";
 import { UserRepository } from "../../database/repositories/user.js";
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
+import { getSchedulerHealth, type SchedulerHealth } from "../../scheduler-health.js";
 import type { ApiResult } from "../types.js";
 
 export interface CollectionStats {
@@ -22,6 +23,7 @@ export interface CollectionStats {
 	published: number;
 	draft: number;
 	scheduled: number;
+	overdueScheduled: number;
 }
 
 export interface RecentItem {
@@ -40,6 +42,7 @@ export interface DashboardStats {
 	mediaCount: number;
 	userCount: number;
 	recentItems: RecentItem[];
+	schedulerHealth: SchedulerHealth;
 }
 
 /**
@@ -50,6 +53,7 @@ export interface DashboardStats {
  */
 export async function handleDashboardStats(
 	db: Kysely<Database>,
+	now = new Date(),
 ): Promise<ApiResult<DashboardStats>> {
 	try {
 		// Discover collections from the system table
@@ -63,7 +67,7 @@ export async function handleDashboardStats(
 		const contentRepo = new ContentRepository(db);
 		const collectionStats: CollectionStats[] = await Promise.all(
 			collections.map(async (col) => {
-				const stats = await contentRepo.getStats(col.slug);
+				const stats = await contentRepo.getStats(col.slug, now);
 				return {
 					slug: col.slug,
 					label: col.label,
@@ -71,6 +75,7 @@ export async function handleDashboardStats(
 					published: stats.published,
 					draft: stats.draft,
 					scheduled: stats.scheduled,
+					overdueScheduled: stats.overdueScheduled,
 				};
 			}),
 		);
@@ -78,7 +83,11 @@ export async function handleDashboardStats(
 		// Media and user counts
 		const mediaRepo = new MediaRepository(db);
 		const userRepo = new UserRepository(db);
-		const [mediaCount, userCount] = await Promise.all([mediaRepo.count(), userRepo.count()]);
+		const [mediaCount, userCount, schedulerHealth] = await Promise.all([
+			mediaRepo.count(),
+			userRepo.count(),
+			getSchedulerHealth(db, now),
+		]);
 
 		// Recent items across all collections (last 10 updated, any status)
 		const recentItems = await fetchRecentItems(db, collections);
@@ -90,6 +99,7 @@ export async function handleDashboardStats(
 				mediaCount,
 				userCount,
 				recentItems,
+				schedulerHealth,
 			},
 		};
 	} catch (error) {

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -1302,8 +1302,16 @@ export class ContentRepository {
 	// get overall statistics for a content type in a single query
 	async getStats(
 		type: string,
-	): Promise<{ total: number; published: number; draft: number; scheduled: number }> {
+		now = new Date(),
+	): Promise<{
+		total: number;
+		published: number;
+		draft: number;
+		scheduled: number;
+		overdueScheduled: number;
+	}> {
 		const tableName = getTableName(type);
+		const nowIso = now.toISOString();
 
 		const result = await this.db
 			.selectFrom(tableName as keyof Database)
@@ -1312,6 +1320,9 @@ export class ContentRepository {
 				eb.fn.sum(eb.case().when("status", "=", "published").then(1).else(0).end()).as("published"),
 				eb.fn.sum(eb.case().when("status", "=", "draft").then(1).else(0).end()).as("draft"),
 				sql<number>`SUM(CASE WHEN scheduled_at IS NOT NULL THEN 1 ELSE 0 END)`.as("scheduled"),
+				sql<number>`SUM(CASE WHEN scheduled_at IS NOT NULL AND scheduled_at <= ${nowIso} THEN 1 ELSE 0 END)`.as(
+					"overdue_scheduled",
+				),
 			])
 			.where("deleted_at" as never, "is", null)
 			.executeTakeFirst();
@@ -1321,6 +1332,7 @@ export class ContentRepository {
 			published: Number(result?.published || 0),
 			draft: Number(result?.draft || 0),
 			scheduled: Number(result?.scheduled || 0),
+			overdueScheduled: Number(result?.overdue_scheduled || 0),
 		};
 	}
 

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -84,7 +84,7 @@ import type {
 	SettingField,
 	UserInfo,
 } from "./plugins/types.js";
-import { recordSchedulerHeartbeat } from "./scheduler-health.js";
+import { recordSchedulerHeartbeatSafely } from "./scheduler-health.js";
 import { MAX_COLLECTION_LIST_COLUMNS, type FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
 import { createInitLock, type InitLock, initWithLock } from "./utils/init-lock.js";
@@ -801,7 +801,7 @@ export class EmDashRuntime {
 
 		// Never throws; no-op unless scheduled backups are enabled and due.
 		await maybeRunScheduledBackup(this.db, this.storage ?? undefined);
-		await recordSchedulerHeartbeat(this.db);
+		await recordSchedulerHeartbeatSafely(this.db);
 
 		return { published };
 	}
@@ -1769,7 +1769,7 @@ export class EmDashRuntime {
 						}
 						// Never throws; no-op unless scheduled backups are enabled and due.
 						await maybeRunScheduledBackup(db, storage ?? undefined);
-						await recordSchedulerHeartbeat(db);
+						await recordSchedulerHeartbeatSafely(db);
 						if (!scheduler.setMediaUsageMaintenance) {
 							try {
 								await runMediaUsageMaintenance();

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -84,6 +84,7 @@ import type {
 	SettingField,
 	UserInfo,
 } from "./plugins/types.js";
+import { recordSchedulerHeartbeat } from "./scheduler-health.js";
 import { MAX_COLLECTION_LIST_COLUMNS, type FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
 import { createInitLock, type InitLock, initWithLock } from "./utils/init-lock.js";
@@ -800,6 +801,7 @@ export class EmDashRuntime {
 
 		// Never throws; no-op unless scheduled backups are enabled and due.
 		await maybeRunScheduledBackup(this.db, this.storage ?? undefined);
+		await recordSchedulerHeartbeat(this.db);
 
 		return { published };
 	}
@@ -1767,6 +1769,7 @@ export class EmDashRuntime {
 						}
 						// Never throws; no-op unless scheduled backups are enabled and due.
 						await maybeRunScheduledBackup(db, storage ?? undefined);
+						await recordSchedulerHeartbeat(db);
 						if (!scheduler.setMediaUsageMaintenance) {
 							try {
 								await runMediaUsageMaintenance();

--- a/packages/core/src/scheduler-health.ts
+++ b/packages/core/src/scheduler-health.ts
@@ -18,6 +18,17 @@ export async function recordSchedulerHeartbeat(
 	await new OptionsRepository(db).set(SCHEDULER_HEARTBEAT_OPTION, completedAt.toISOString());
 }
 
+export async function recordSchedulerHeartbeatSafely(
+	db: Kysely<Database>,
+	completedAt = new Date(),
+): Promise<void> {
+	try {
+		await recordSchedulerHeartbeat(db, completedAt);
+	} catch (error) {
+		console.error("[scheduler] Failed to record heartbeat:", error);
+	}
+}
+
 export async function getSchedulerHealth(
 	db: Kysely<Database>,
 	now = new Date(),

--- a/packages/core/src/scheduler-health.ts
+++ b/packages/core/src/scheduler-health.ts
@@ -34,13 +34,13 @@ export async function getSchedulerHealth(
 	now = new Date(),
 ): Promise<SchedulerHealth> {
 	const lastCompletedAt = await new OptionsRepository(db).get<string>(SCHEDULER_HEARTBEAT_OPTION);
-	if (!lastCompletedAt || Number.isNaN(Date.parse(lastCompletedAt))) {
+	const lastCompletedAtMs = lastCompletedAt ? Date.parse(lastCompletedAt) : Number.NaN;
+	if (!lastCompletedAt || Number.isNaN(lastCompletedAtMs)) {
 		return { status: "unknown", lastCompletedAt: null };
 	}
 
 	return {
-		status:
-			now.getTime() - Date.parse(lastCompletedAt) > SCHEDULER_STALE_AFTER_MS ? "stale" : "healthy",
+		status: now.getTime() - lastCompletedAtMs > SCHEDULER_STALE_AFTER_MS ? "stale" : "healthy",
 		lastCompletedAt,
 	};
 }

--- a/packages/core/src/scheduler-health.ts
+++ b/packages/core/src/scheduler-health.ts
@@ -1,0 +1,35 @@
+import type { Kysely } from "kysely";
+
+import { OptionsRepository } from "./database/repositories/options.js";
+import type { Database } from "./database/types.js";
+
+export const SCHEDULER_HEARTBEAT_OPTION = "system:scheduler:last_completed_at";
+export const SCHEDULER_STALE_AFTER_MS = 5 * 60 * 1000;
+
+export interface SchedulerHealth {
+	status: "healthy" | "stale" | "unknown";
+	lastCompletedAt: string | null;
+}
+
+export async function recordSchedulerHeartbeat(
+	db: Kysely<Database>,
+	completedAt = new Date(),
+): Promise<void> {
+	await new OptionsRepository(db).set(SCHEDULER_HEARTBEAT_OPTION, completedAt.toISOString());
+}
+
+export async function getSchedulerHealth(
+	db: Kysely<Database>,
+	now = new Date(),
+): Promise<SchedulerHealth> {
+	const lastCompletedAt = await new OptionsRepository(db).get<string>(SCHEDULER_HEARTBEAT_OPTION);
+	if (!lastCompletedAt || Number.isNaN(Date.parse(lastCompletedAt))) {
+		return { status: "unknown", lastCompletedAt: null };
+	}
+
+	return {
+		status:
+			now.getTime() - Date.parse(lastCompletedAt) > SCHEDULER_STALE_AFTER_MS ? "stale" : "healthy",
+		lastCompletedAt,
+	};
+}

--- a/packages/core/tests/integration/runtime/media-usage-scheduled-driver.test.ts
+++ b/packages/core/tests/integration/runtime/media-usage-scheduled-driver.test.ts
@@ -76,10 +76,14 @@ describe("media usage scheduled drivers", () => {
 	it("does not fail Node maintenance when the heartbeat write fails", async () => {
 		const scheduler = new CapturingScheduler();
 		runtime = await EmDashRuntime.create(createDeps(() => scheduler));
+		await new OptionsRepository(runtime.db).set(
+			SCHEDULER_HEARTBEAT_OPTION,
+			"2026-08-16T00:00:00.000Z",
+		);
 		await sql`
 			CREATE TRIGGER fail_scheduler_heartbeat
-			BEFORE INSERT ON options
-			WHEN NEW.name = 'system:scheduler:last_completed_at'
+			BEFORE UPDATE ON options
+			WHEN NEW.name = ${sql.lit(SCHEDULER_HEARTBEAT_OPTION)}
 			BEGIN
 				SELECT RAISE(ABORT, 'heartbeat unavailable');
 			END

--- a/packages/core/tests/integration/runtime/media-usage-scheduled-driver.test.ts
+++ b/packages/core/tests/integration/runtime/media-usage-scheduled-driver.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import Database from "better-sqlite3";
 import { sql, SqliteDialect } from "kysely";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MediaUsageRepository } from "../../../src/database/repositories/media-usage.js";
 import { OptionsRepository } from "../../../src/database/repositories/options.js";
@@ -71,6 +71,26 @@ describe("media usage scheduled drivers", () => {
 		);
 		expect(heartbeat).not.toBeNull();
 		expect(Number.isNaN(Date.parse(heartbeat!))).toBe(false);
+	});
+
+	it("does not fail Node maintenance when the heartbeat write fails", async () => {
+		const scheduler = new CapturingScheduler();
+		runtime = await EmDashRuntime.create(createDeps(() => scheduler));
+		await sql`
+			CREATE TRIGGER fail_scheduler_heartbeat
+			BEFORE INSERT ON options
+			WHEN NEW.name = 'system:scheduler:last_completed_at'
+			BEGIN
+				SELECT RAISE(ABORT, 'heartbeat unavailable');
+			END
+		`.execute(runtime.db);
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await expect(scheduler.runMaintenance()).resolves.toBeUndefined();
+		expect(consoleError).toHaveBeenCalledWith(
+			"[scheduler] Failed to record heartbeat:",
+			expect.anything(),
+		);
 	});
 
 	it("drains bounded work through a legacy Node scheduler cleanup callback", async () => {

--- a/packages/core/tests/integration/runtime/media-usage-scheduled-driver.test.ts
+++ b/packages/core/tests/integration/runtime/media-usage-scheduled-driver.test.ts
@@ -5,6 +5,7 @@ import { sql, SqliteDialect } from "kysely";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { MediaUsageRepository } from "../../../src/database/repositories/media-usage.js";
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
 import {
 	EmDashRuntime,
 	MEDIA_USAGE_MAINTENANCE_QUERY_RESERVATIONS,
@@ -13,6 +14,7 @@ import {
 import { installMediaUsageCaptureTriggers } from "../../../src/media/usage/capture-triggers.js";
 import type { CronScheduler, SystemCleanupFn } from "../../../src/plugins/scheduler/types.js";
 import { createRequestMetrics, runWithContext } from "../../../src/request-context.js";
+import { SCHEDULER_HEARTBEAT_OPTION } from "../../../src/scheduler-health.js";
 
 describe("media usage scheduled drivers", () => {
 	let runtime: EmDashRuntime | null = null;
@@ -56,6 +58,19 @@ describe("media usage scheduled drivers", () => {
 				canonicalSourceKey(fixture.collectionId, "entry-1"),
 			),
 		).not.toBeNull();
+	});
+
+	it("records a heartbeat from the Node timer maintenance callback", async () => {
+		const scheduler = new CapturingScheduler();
+		runtime = await EmDashRuntime.create(createDeps(() => scheduler));
+
+		await scheduler.runMaintenance();
+
+		const heartbeat = await new OptionsRepository(runtime.db).get<string>(
+			SCHEDULER_HEARTBEAT_OPTION,
+		);
+		expect(heartbeat).not.toBeNull();
+		expect(Number.isNaN(Date.parse(heartbeat!))).toBe(false);
 	});
 
 	it("drains bounded work through a legacy Node scheduler cleanup callback", async () => {

--- a/packages/core/tests/unit/api/dashboard-handlers.test.ts
+++ b/packages/core/tests/unit/api/dashboard-handlers.test.ts
@@ -3,7 +3,9 @@ import { describe, it, expect, afterEach } from "vitest";
 
 import { handleDashboardStats } from "../../../src/api/handlers/dashboard.js";
 import { ContentRepository } from "../../../src/database/repositories/content.js";
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
 import type { Database } from "../../../src/database/types.js";
+import { SCHEDULER_HEARTBEAT_OPTION } from "../../../src/scheduler-health.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { createPostFixture, createPageFixture } from "../../utils/fixtures.js";
 import {
@@ -102,6 +104,46 @@ describe("Dashboard Handlers", () => {
 			expect(postStats).toBeDefined();
 			expect(postStats!.total).toBe(3);
 			expect(postStats!.scheduled).toBe(2);
+		});
+
+		it("reports an unknown scheduler with overdue content when no heartbeat exists", async () => {
+			db = await setupTestDatabaseWithCollections();
+			const contentRepo = new ContentRepository(db);
+			const now = new Date("2026-08-16T12:00:00.000Z");
+			const post = await contentRepo.create(createPostFixture());
+			await contentRepo.update("post", post.id, {
+				status: "scheduled",
+				scheduledAt: "2026-08-16T11:59:00.000Z",
+			});
+
+			const result = await handleDashboardStats(db, now);
+
+			expect(result.success).toBe(true);
+			expect(result.data!.schedulerHealth).toEqual({
+				status: "unknown",
+				lastCompletedAt: null,
+			});
+			expect(
+				result.data!.collections.find((collection) => collection.slug === "post"),
+			).toMatchObject({
+				overdueScheduled: 1,
+			});
+		});
+
+		it("reports stale and healthy scheduler heartbeats", async () => {
+			db = await setupTestDatabase();
+			const options = new OptionsRepository(db);
+			const now = new Date("2026-08-16T12:00:00.000Z");
+			await options.set(SCHEDULER_HEARTBEAT_OPTION, "2026-08-16T11:50:00.000Z");
+
+			const stale = await handleDashboardStats(db, now);
+			expect(stale.success).toBe(true);
+			expect(stale.data!.schedulerHealth.status).toBe("stale");
+
+			await options.set(SCHEDULER_HEARTBEAT_OPTION, "2026-08-16T11:58:00.000Z");
+			const healthy = await handleDashboardStats(db, now);
+			expect(healthy.success).toBe(true);
+			expect(healthy.data!.schedulerHealth.status).toBe("healthy");
 		});
 
 		it("returns recent items across collections", async () => {

--- a/packages/core/tests/unit/scheduled-publish.test.ts
+++ b/packages/core/tests/unit/scheduled-publish.test.ts
@@ -273,6 +273,24 @@ describe("EmDashRuntime.runScheduledTasks()", () => {
 		expect(Date.parse(heartbeat!)).toBeGreaterThanOrEqual(startedAt);
 	});
 
+	it("does not fail Cloudflare scheduled maintenance when the heartbeat write fails", async () => {
+		await sql`
+			CREATE TRIGGER fail_scheduler_heartbeat
+			BEFORE INSERT ON options
+			WHEN NEW.name = 'system:scheduler:last_completed_at'
+			BEGIN
+				SELECT RAISE(ABORT, 'heartbeat unavailable');
+			END
+		`.execute(db);
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await expect(buildRuntime(db).runScheduledTasks()).resolves.toEqual({ published: [] });
+		expect(consoleError).toHaveBeenCalledWith(
+			"[scheduler] Failed to record heartbeat:",
+			expect.anything(),
+		);
+	});
+
 	it("leaves due content untouched while media usage activation is incomplete", async () => {
 		const post = await repo.create(createPostFixture());
 		const past = new Date(Date.now() - 60_000).toISOString();

--- a/packages/core/tests/unit/scheduled-publish.test.ts
+++ b/packages/core/tests/unit/scheduled-publish.test.ts
@@ -277,7 +277,7 @@ describe("EmDashRuntime.runScheduledTasks()", () => {
 		await sql`
 			CREATE TRIGGER fail_scheduler_heartbeat
 			BEFORE INSERT ON options
-			WHEN NEW.name = 'system:scheduler:last_completed_at'
+			WHEN NEW.name = ${sql.lit(SCHEDULER_HEARTBEAT_OPTION)}
 			BEGIN
 				SELECT RAISE(ABORT, 'heartbeat unavailable');
 			END

--- a/packages/core/tests/unit/scheduled-publish.test.ts
+++ b/packages/core/tests/unit/scheduled-publish.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { handleContentPublish } from "../../src/api/handlers/content.js";
 import type { EmDashConfig } from "../../src/astro/integration/runtime.js";
 import { ContentRepository } from "../../src/database/repositories/content.js";
+import { OptionsRepository } from "../../src/database/repositories/options.js";
 import { RevisionRepository } from "../../src/database/repositories/revision.js";
 import {
 	ContentMutationConflictError,
@@ -17,6 +18,7 @@ import {
 	type PublishedRef,
 	type ScheduledPublishFn,
 } from "../../src/scheduled-publish.js";
+import { SCHEDULER_HEARTBEAT_OPTION } from "../../src/scheduler-health.js";
 import { createPostFixture, createPageFixture } from "../utils/fixtures.js";
 import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
 
@@ -257,6 +259,18 @@ describe("EmDashRuntime.runScheduledTasks()", () => {
 		expect(published).toEqual([{ collection: "post", id: post.id }]);
 		const updated = await repo.findById("post", post.id);
 		expect(updated?.status).toBe("published");
+	});
+
+	it("records a heartbeat after Cloudflare scheduled maintenance completes", async () => {
+		const runtime = buildRuntime(db);
+		const options = new OptionsRepository(db);
+		const startedAt = Date.now();
+
+		await runtime.runScheduledTasks();
+
+		const heartbeat = await options.get<string>(SCHEDULER_HEARTBEAT_OPTION);
+		expect(heartbeat).not.toBeNull();
+		expect(Date.parse(heartbeat!)).toBeGreaterThanOrEqual(startedAt);
 	});
 
 	it("leaves due content untouched while media usage activation is incomplete", async () => {


### PR DESCRIPTION
## What does this PR do?

Records the completion time of scheduled maintenance from both Cloudflare's scheduled entry point and the Node timer scheduler. The authenticated dashboard response reports healthy, stale, or unknown scheduler health and folds overdue detection into its existing per-collection count queries. Editors see an actionable Kumo alert only when content is overdue and the heartbeat is missing or stale; no query or bookkeeping is added to public rendering.

Closes #2051. This is stack 2/2 and depends on #2511.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — N/A: bug fix tracked in #2051.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

- `pnpm test --run tests/unit/scheduled-publish.test.ts tests/integration/runtime/media-usage-scheduled-driver.test.ts tests/unit/api/dashboard-handlers.test.ts` — 52 tests passed, including non-fatal heartbeat write failures on Cloudflare and Node
- `pnpm test --run tests/components/Dashboard.test.tsx` — 11 tests passed
- `pnpm typecheck` — all package typechecks passed
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm format` — completed
- Arabic/RTL browser verification — `dir="rtl"`, stale-heartbeat alert rendered without layout overflow
- `pnpm --filter @emdash-cms/admin build` and `pnpm --filter emdash build` — passed
