### PR TITLE
fix: skip admin Font component when fonts are disabled

### DIFF
--- a/.changeset/fix-admin-fonts-disabled-empty-response.md
+++ b/.changeset/fix-admin-fonts-disabled-empty-response.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the admin UI (dashboard, login, and the setup wizard) returning a completely empty response when `fonts: false` is set in the `emdash()` integration config. Previously, disabling fonts left the admin shell rendering a `<Font>` reference to a family that was never registered, which threw partway through the response and produced a 200 with no body.

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -13,6 +13,10 @@ import adminStylesUrl from "@emdash-cms/admin/styles.css?url";
 // (relative imports resolve to absolute paths which break client hydration)
 import AdminWrapper from "emdash/routes/PluginRegistry";
 import { Font } from "astro:assets";
+// EmDashConfig.fonts isn't part of serializableConfig (see integration/index.ts),
+// so Astro.locals.emdash.config.fonts is never available here - check Astro's own
+// font registry instead of guessing from EmDash's config.
+import { componentDataByCssVariable } from "virtual:astro:assets/fonts/internal";
 
 export const prerender = false;
 
@@ -84,7 +88,13 @@ const faviconType = adminConfig?.favicon ? undefined : siteFaviconType;
 			})();
 		</script>
 		<link rel="stylesheet" href={adminStylesUrl} />
-		<Font cssVariable="--font-emdash" />
+		{/* fonts: false disables font injection and never registers --font-emdash
+		with Astro's Font API, so <Font> throws FontFamilyNotFound mid-stream -
+		after the 200 response has already started, producing an empty body.
+		Skip it and let the admin CSS's system-font fallback stack apply instead. */}
+		{componentDataByCssVariable.has("--font-emdash") && (
+			<Font cssVariable="--font-emdash" />
+		)}
 		{favicon ? (
 			<link rel="icon" href={favicon} type={faviconType} />
 		) : (

--- a/packages/core/tests/repro/admin-fonts-disabled.render.test.ts
+++ b/packages/core/tests/repro/admin-fonts-disabled.render.test.ts
@@ -1,0 +1,34 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it } from "vitest";
+
+import AdminPage from "../../src/astro/routes/admin.astro";
+
+// admin.astro renders AdminWrapper with client:only="react" - Astro only
+// needs a renderer registered under a matching name to emit the hydration
+// island (client:only never calls check/renderToStaticMarkup server-side),
+// so a minimal stand-in is enough here without pulling in real React SSR.
+const fakeReactRenderer = {
+	name: "@astrojs/react",
+	check: () => false,
+	renderToStaticMarkup: () => ({ html: "" }),
+};
+
+describe("admin shell with no fonts registered", () => {
+	it("renders instead of throwing FontFamilyNotFound", async () => {
+		// No fonts are configured for this container (mirrors `fonts: false`
+		// in the emdash() integration option, which injects an empty fonts
+		// array into Astro's config). Before the fix, admin.astro rendered
+		// <Font cssVariable="--font-emdash" /> unconditionally, and Astro's
+		// Font component throws AstroError(FontFamilyNotFound) when no family
+		// is registered for that cssVariable -- which happens mid-stream,
+		// after the response has already started, producing a 200 with a
+		// completely empty body in production.
+		const container = await AstroContainer.create();
+		container.addServerRenderer({ name: "@astrojs/react", renderer: fakeReactRenderer });
+		container.addClientRenderer({ name: "@astrojs/react", entrypoint: "@astrojs/react/client.js" });
+
+		const html = await container.renderToString(AdminPage, { locals: {} });
+
+		expect(html).toContain('id="admin-root"');
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes `admin.astro` (the shell that serves `/_emdash/admin/*` - dashboard, login, and the setup wizard) unconditionally rendering `<Font cssVariable="--font-emdash" />` regardless of the `fonts` config option.

When `fonts: false` is passed to `emdash()` - documented as disabling font injection entirely and falling back to system fonts - no font family is ever registered for `--font-emdash`. Astro's `<Font>` component throws `AstroError(FontFamilyNotFound)` when that happens, and because the error surfaces mid-stream (after the response has already started), the entire admin app degrades to a 200 response with a completely empty body. No error is visible to the user or obviously logged anywhere.

Fix: check Astro's own font registry (`componentDataByCssVariable` from the fonts virtual module - the same source `Font.astro` itself checks) before rendering `<Font>`. Note that `Astro.locals.emdash.config.fonts` isn't a viable check here - `fonts` isn't included in the `serializableConfig` object that backs it, so that field is always `undefined`.

Closes #2527

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5 (Claude Code)

## Screenshots / test output

New regression test (`packages/core/tests/repro/admin-fonts-disabled.render.test.ts`) confirmed failing against the pre-fix code with:

```
FontFamilyNotFound: No data was found for the `"--font-emdash"` family passed to the `<Font>` component.
```

and passing after the fix. `pnpm typecheck`, `pnpm lint`, and `pnpm test:repro` all pass.