### PR TITLE
fix(bot): classify comments with one AI call

### DIFF
--- a/infra/emdash-bot/.flue/lib/classifier-client.ts
+++ b/infra/emdash-bot/.flue/lib/classifier-client.ts
@@ -1,18 +1,22 @@
-// Synchronous classifier dispatch from the OrchestratorDO through a fresh
-// Flue 2 agent instance. The awaited handle returns the durable response's
-// structured data part.
-
-import { init } from "@flue/runtime";
 import * as v from "valibot";
 
-import { ClassifyCommand, classifyResultSchema } from "../agents/classify-command.js";
+import { classifyResultSchema } from "../agents/classify-command.js";
 import type { EventId, StateId } from "./machine.js";
 import { classifierCommands } from "./router.js";
-import { DeadlineExceededError, withDeadline } from "./sandbox-deadline.js";
+import { withDeadline } from "./sandbox-deadline.js";
 
 const CLASSIFY_TIMEOUT_MS = 10_000;
+const CLASSIFIER_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8" as const;
 
-export interface ClassifyInput {
+export interface ClassifierAi {
+	run(
+		model: typeof CLASSIFIER_MODEL,
+		inputs: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages,
+		options?: AiOptions,
+	): Promise<Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output>;
+}
+
+export interface ClassifierInput {
 	issueNumber: number;
 	state: StateId | null;
 	comment: string;
@@ -32,50 +36,107 @@ interface ClassifyResponse {
 	reasoning?: string;
 }
 
-export async function classifyComment(input: ClassifyInput): Promise<ClassifyResult> {
+export async function classifyComment(
+	ai: ClassifierAi,
+	input: ClassifierInput,
+): Promise<ClassifyResult> {
 	const commands = classifierCommands(input.state);
 	if (commands.length === 0) return { kind: "no-commands" };
 
-	let reply;
+	let response: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output;
 	try {
-		const handle = init(ClassifyCommand, {
-			id: `classify-${crypto.randomUUID()}`,
-			uid: null,
-		});
-		const startedAt = performance.now();
-		const receipt = await withDeadline(
-			handle.dispatch({
-				message: {
-					kind: "signal",
-					type: "github.comment",
-					body: `Classify this comment: ${input.comment}`,
-				},
-				initialData: {
-					issueNumber: input.issueNumber,
-					state: input.state ?? "unmanaged",
-					comment: input.comment,
-					...(input.botContext ? { botContext: input.botContext } : {}),
-					commands: commands.map((command) => ({
-						event: command.event,
-						description: command.description,
-						...(command.arg ? { arg: command.arg } : {}),
-					})),
-				},
+		response = await withDeadline(
+			ai.run(CLASSIFIER_MODEL, classifierRequest(input, commands), {
+				signal: AbortSignal.timeout(CLASSIFY_TIMEOUT_MS),
 			}),
 			CLASSIFY_TIMEOUT_MS,
-			"Classifier dispatch",
+			"Classifier request",
 		);
-		const remainingMs = CLASSIFY_TIMEOUT_MS - (performance.now() - startedAt);
-		if (remainingMs <= 0) {
-			throw new DeadlineExceededError("Classifier read", CLASSIFY_TIMEOUT_MS);
-		}
-		reply = await handle.read(receipt, { signal: AbortSignal.timeout(Math.ceil(remainingMs)) });
 	} catch (err) {
 		return { kind: "error", error: errorMessage(err) };
 	}
 
-	const writes = reply.data.classification;
-	return resolveClassification(writes?.at(-1), commands);
+	const argumentsJson = selectCommandArguments(response);
+	if (argumentsJson === null) {
+		return { kind: "error", error: "classifier returned no select_command tool call" };
+	}
+	let result: unknown;
+	try {
+		result = JSON.parse(argumentsJson);
+	} catch {
+		return { kind: "error", error: "classifier returned invalid tool arguments" };
+	}
+	return resolveClassification(result, commands);
+}
+
+function classifierRequest(
+	input: ClassifierInput,
+	commands: ReturnType<typeof classifierCommands>,
+): Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages {
+	const actionList = commands
+		.map(
+			(command) =>
+				`- ${command.event}: ${command.description}${command.arg ? ` Set arg to the ${command.arg}.` : ""}`,
+		)
+		.join("\n");
+	return {
+		messages: [
+			{
+				role: "system",
+				content: [
+					"Route the comment to exactly one available action.",
+					"The state only limits the available list; every listed action is valid.",
+					"Call select_command exactly once. Prefer none over guessing. Do not answer with prose.",
+				].join(" "),
+			},
+			{
+				role: "user",
+				content: [
+					`Issue: ${input.issueNumber}`,
+					`State: ${input.state ?? "unmanaged"}`,
+					"Available actions:",
+					actionList,
+					"Bot's last message:",
+					input.botContext?.trim() || "(none)",
+					"Comment:",
+					input.comment,
+				].join("\n"),
+			},
+		],
+		tools: [
+			{
+				type: "function",
+				function: {
+					name: "select_command",
+					description: "Return the single command intended by the comment, or none.",
+					parameters: {
+						type: "object",
+						properties: {
+							event: { type: "string", description: "The selected action or none" },
+							arg: { type: "string", description: "The directive for the action, if any" },
+							reasoning: {
+								type: "string",
+								description: "A short reason quoting the decisive phrase",
+							},
+						},
+						required: ["event", "reasoning"],
+					},
+				},
+			},
+		],
+		max_tokens: 1_024,
+		temperature: 0,
+	};
+}
+
+function selectCommandArguments(response: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output): string | null {
+	if (typeof response !== "object" || response === null || !("choices" in response)) return null;
+	const choice = response.choices?.[0];
+	if (!choice || !("message" in choice)) return null;
+	const toolCalls = choice.message?.tool_calls;
+	return (
+		toolCalls?.find((call) => call.function.name === "select_command")?.function.arguments ?? null
+	);
 }
 
 export function resolveClassification(

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -8,7 +8,7 @@ import { dispatch } from "@flue/runtime";
 import { DurableObject } from "cloudflare:workers";
 
 import { Investigate } from "../agents/investigate.js";
-import { classifyComment, type ClassifyResult } from "./classifier-client.js";
+import { classifyComment, type ClassifierInput, type ClassifyResult } from "./classifier-client.js";
 import {
 	type PreviewScreenshot,
 	renderAgentComment,
@@ -906,7 +906,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 		}
 		const persistedState = await this.ctx.storage.get<StateId>(STORAGE.state);
 		const state = persistedState ?? currentState(input.labels);
-		const result: ClassifyResult = await classifyComment({
+		const result = await this.requestClassification({
 			issueNumber: input.anchorNumber,
 			state,
 			comment: text,
@@ -922,6 +922,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 			case "event":
 				return { kind: "resolved", event: result.event, arg: result.arg };
 		}
+	}
+
+	protected requestClassification(input: ClassifierInput): Promise<ClassifyResult> {
+		return classifyComment(this.env.AI, input);
 	}
 
 	// ---------------- Workflow dispatch ----------------

--- a/infra/emdash-bot/tests/integration/_entry.ts
+++ b/infra/emdash-bot/tests/integration/_entry.ts
@@ -12,10 +12,17 @@
 
 import { Hono } from "hono";
 
+import type { ClassifierInput, ClassifyResult } from "../../.flue/lib/classifier-client.js";
+import { OrchestratorDO as ProductionOrchestratorDO } from "../../.flue/lib/orchestrator.js";
 import { registerCoreRoutes } from "../../.flue/routes.js";
 
 export { Sandbox, ContainerProxy } from "../../.flue/cloudflare.js";
-export { OrchestratorDO } from "../../.flue/lib/orchestrator.js";
+
+export class OrchestratorDO extends ProductionOrchestratorDO {
+	protected override requestClassification(_input: ClassifierInput): Promise<ClassifyResult> {
+		return Promise.resolve({ kind: "error", error: "classifier unavailable in workers-pool test" });
+	}
+}
 
 const app = registerCoreRoutes(new Hono<{ Bindings: Env }>());
 app.post("/agents/investigate/:id/abort", (context) =>

--- a/infra/emdash-bot/tests/integration/webhook.test.ts
+++ b/infra/emdash-bot/tests/integration/webhook.test.ts
@@ -166,8 +166,8 @@ describe("POST /webhook/github (workers-pool)", () => {
 
 	test("classifier failure remains retryable and does not persist state", async () => {
 		// The webhook acknowledges durable admission before classifier work. The
-		// test entry has no Flue runtime, so processing fails and leaves the item
-		// queued for retry without persisting state.
+		// test entry returns a classifier error, so processing leaves the item
+		// queued for retry without persisting state or using remote inference.
 		const issueNumber = uniqueIssueNumber();
 		const res = await postWebhook({
 			eventType: "issue_comment",

--- a/infra/emdash-bot/tests/unit/classifier-client.test.ts
+++ b/infra/emdash-bot/tests/unit/classifier-client.test.ts
@@ -1,113 +1,104 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-vi.mock("@flue/runtime", () => ({ init: vi.fn() }));
-
-import { init } from "@flue/runtime";
-
-import { classifyComment, resolveClassification } from "../../.flue/lib/classifier-client.js";
+import {
+	classifyComment,
+	type ClassifierAi,
+	resolveClassification,
+} from "../../.flue/lib/classifier-client.js";
 import { classifierCommands } from "../../.flue/lib/router.js";
 
-const commands = classifierCommands("working");
-const mockedInit = vi.mocked(init);
+const commands = classifierCommands("blocked");
+const input = {
+	issueNumber: 42,
+	state: "blocked" as const,
+	comment: "implement using your best judgement for the design",
+};
 
-function mockHandle(handle: {
-	dispatch: (input: unknown) => Promise<unknown>;
-	read: (receipt: unknown, options?: unknown) => Promise<unknown>;
-}) {
-	mockedInit.mockReturnValue(handle as unknown as ReturnType<typeof init>);
+function mockAi(output: Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output) {
+	const run = vi.fn<ClassifierAi["run"]>().mockResolvedValue(output);
+	return { ai: { run } satisfies ClassifierAi, run };
 }
 
-const input = { issueNumber: 42, state: "working" as const, comment: "@emdashbot retry" };
+function toolCallResponse(argumentsJson: string): Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Output {
+	return {
+		choices: [
+			{
+				message: {
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call-1",
+							type: "function",
+							function: { name: "select_command", arguments: argumentsJson },
+						},
+					],
+				},
+			},
+		],
+	};
+}
 
 describe("classifyComment", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
-		vi.resetAllMocks();
 		vi.useRealTimers();
 	});
 
-	test("returns no-commands without dispatching when the state offers none", async () => {
-		expect(await classifyComment({ ...input, state: null })).toEqual({ kind: "no-commands" });
-		expect(mockedInit).not.toHaveBeenCalled();
+	test("returns no-commands without running the model when the state offers none", async () => {
+		const { ai, run } = mockAi(toolCallResponse("{}"));
+
+		expect(await classifyComment(ai, { ...input, state: null })).toEqual({ kind: "no-commands" });
+		expect(run).not.toHaveBeenCalled();
 	});
 
-	test("dispatches and resolves the last classification write", async () => {
-		const event = commands[0];
+	test("resolves the command from one model tool call", async () => {
+		const event = commands.find((command) => command.event === "implement");
 		expect(event).toBeDefined();
 		if (!event) return;
-		const dispatched: unknown[] = [];
-		mockHandle({
-			dispatch: async (dispatchInput) => {
-				dispatched.push(dispatchInput);
-				return { id: "receipt" };
-			},
-			read: async () => ({
-				data: {
-					classification: [
-						{ event: "none", arg: null, reasoning: "first pass was undecided" },
-						{ event: event.event, arg: "try SQLite", reasoning: "the comment asks for a retry" },
-					],
-				},
-			}),
-		});
+		const { ai, run } = mockAi(
+			toolCallResponse(
+				JSON.stringify({
+					event: event.event,
+					arg: "using your best judgement for the design",
+					reasoning: "the comment explicitly asks to implement",
+				}),
+			),
+		);
 
-		expect(await classifyComment(input)).toEqual({
+		expect(await classifyComment(ai, input)).toEqual({
 			kind: "event",
 			event: event.event,
-			arg: "try SQLite",
-			reasoning: "the comment asks for a retry",
+			arg: "using your best judgement for the design",
+			reasoning: "the comment explicitly asks to implement",
 		});
-		expect(dispatched).toHaveLength(1);
+		expect(run).toHaveBeenCalledOnce();
 	});
 
-	test("returns an error when dispatch admission stalls past the budget", async () => {
-		vi.useFakeTimers();
-		mockHandle({
-			dispatch: () => new Promise(() => {}),
-			read: async () => ({ data: { classification: [] } }),
-		});
+	test("returns an error when the model does not call the classifier tool", async () => {
+		const { ai } = mockAi({ choices: [{ message: { role: "assistant", content: "retry" } }] });
 
-		const pending = classifyComment(input);
-		await vi.advanceTimersByTimeAsync(10_001);
-		expect(await pending).toEqual({
+		expect(await classifyComment(ai, input)).toEqual({
 			kind: "error",
-			error: "Classifier dispatch timed out after 10000ms",
+			error: "classifier returned no select_command tool call",
 		});
 	});
 
-	test("fails deterministically when dispatch consumes the whole budget", async () => {
-		let now = 0;
-		vi.spyOn(performance, "now").mockImplementation(() => now);
-		let read = 0;
-		mockHandle({
-			dispatch: async () => {
-				now = 10_000;
-				return { id: "receipt" };
-			},
-			read: async () => {
-				read += 1;
-				return { data: { classification: [] } };
-			},
-		});
+	test("returns an error when the tool arguments are not JSON", async () => {
+		const { ai } = mockAi(toolCallResponse("not-json"));
 
-		expect(await classifyComment(input)).toEqual({
+		expect(await classifyComment(ai, input)).toEqual({
 			kind: "error",
-			error: "Classifier read timed out after 10000ms",
+			error: "classifier returned invalid tool arguments",
 		});
-		expect(read).toBe(0);
 	});
 
-	test("maps a rejected read to an error result", async () => {
-		mockHandle({
-			dispatch: async () => ({ id: "receipt" }),
-			read: async () => {
-				throw new Error("durable response lost");
-			},
-		});
+	test("maps a rejected model request to an error result", async () => {
+		const run = vi.fn<ClassifierAi["run"]>().mockRejectedValue(new Error("Workers AI unavailable"));
 
-		expect(await classifyComment(input)).toEqual({
+		expect(await classifyComment({ run }, input)).toEqual({
 			kind: "error",
-			error: "durable response lost",
+			error: "Workers AI unavailable",
 		});
 	});
 });

--- a/infra/emdash-bot/wrangler.test.jsonc
+++ b/infra/emdash-bot/wrangler.test.jsonc
@@ -1,7 +1,7 @@
 {
 	// Test-only wrangler config consumed by @cloudflare/vitest-pool-workers via
 	// vitest.workers.config.ts. Mirrors production bindings for the
-	// user-owned DOs (Sandbox, OrchestratorDO) and the AI / R2 surfaces but
+	// user-owned DOs (Sandbox, OrchestratorDO) and the R2 surface but
 	// skips the Flue-generated workflow DOs (FlueRegistry, FlueClassify-
 	// CommandWorkflow, ...) because the test entry below doesn't go through
 	// Flue routing. Workflow integration tests need a separate harness once
@@ -19,10 +19,6 @@
 	// The test pool dispatches to this entry. It re-exports the DOs and
 	// provides a minimal fetch handler so SELF.fetch() works in tests.
 	"main": "./tests/integration/_entry.ts",
-
-	"ai": {
-		"binding": "AI",
-	},
 
 	// Sandbox is structurally identical to production, including the
 	// container image. The pool builds the image on first use; subsequent


### PR DESCRIPTION
## What does this PR do?

Fixes free-text `@emdashbot` commands being silently dropped after the classifier selected the correct action. The classifier now makes one typed Workers AI function-call request and reads the selected command directly, avoiding the failing Flue tool-result continuation.

The workers-pool harness now overrides classification deterministically and no longer connects to the remote AI binding during integration tests. The existing classifier Durable Object remains in the production build for migration compatibility.

Related to #1623, where the failed bot command was observed. This PR does not close that issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Typecheck note: the bot package's existing `wrangler types` output lacks the generated Flue Durable Object and service-binding RPC types, so the full package typecheck fails across the existing DO tests and routes. It reports no errors in the changed classifier files.

i18n is not applicable because this does not change admin UI. A changeset is not applicable because `infra/emdash-bot` is private infrastructure. A Discussion is not required for this bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not visual.

- `pnpm build`
- `pnpm -s lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter @emdash-cms/emdash-bot test:unit` → 220 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` → 46 passed
- `pnpm --filter @emdash-cms/emdash-bot build`
- Wrangler type generation against `wrangler.test.jsonc`

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-bot-direct-classifier-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/bot-direct-classifier`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
