### PR TITLE
docs: add EmDash documentation writing skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@ This file provides guidance to agentic coding tools working in this repository.
 
 For human-facing contributor info (setup, repo layout, PR policy, changesets, i18n), see [CONTRIBUTING.md](CONTRIBUTING.md). This file focuses on the patterns and gotchas an agent needs to write correct code.
 
-`CLAUDE.md` is a symlink to this file. `.opencode/skills` and `.claude/skills` are symlinks to `skills/`. Don't try to sync between them.
+`CLAUDE.md` is a symlink to this file. `.agents/skills` and `.claude/skills` are symlinks to `skills/`. Don't try to sync between them.
+
+When writing, revising, or reviewing documentation, load the `writing-emdash-docs` skill. Use it for public docs, READMEs, contributor guidance, technical specifications, release notes and changesets, and skill instructions.
 
 # Rules
 

--- a/infra/flue-review/.flue/skills/review/SKILL.md
+++ b/infra/flue-review/.flue/skills/review/SKILL.md
@@ -11,6 +11,20 @@ Review **statically**. Do not run the test suite, linter, builds, or install any
 
 The repo's AGENTS.md is at the repo root in your context. Check the PR against its conventions (Lingui localization, RTL-safe Tailwind, SQL safety, API envelope shape, authorization, locale filtering on content tables, index discipline, changesets, query counts on logged-out routes, comment discipline). A violation is a real finding, not a nit.
 
+## Documentation changes
+
+When the diff changes documentation prose, load the `writing-emdash-docs` skill before reviewing those files. This includes public docs, READMEs, contributor guidance, technical specifications, release notes and changesets, and skill instructions. Apply the skill only to documentation; do not spend review context on it for code, tests, generated files, or prose fixtures.
+
+Verify documentation claims against the implementation, types, tests, command output, and adjacent docs. The writing skill does not replace technical investigation.
+
+Calibrate documentation findings by their effect:
+
+- Use `needs_fixing` for a false technical claim, an obsolete or unsafe command, an API example that cannot work, a procedure that cannot reach its stated outcome, a missing prerequisite that causes failure or data loss, or documentation that contradicts shipped behavior.
+- Use `suggestion` for voice, organization, accessibility, verbosity, or anti-slop edits that preserve meaning.
+- Do not flag a watched word or sentence shape by itself. Confirm that it makes the documentation less precise, less useful, or harder to understand.
+
+When code changes user-visible behavior, check whether existing documentation becomes false or incomplete. Do not require public documentation for internal changes that do not alter how readers use EmDash.
+
 ## Your only tool: `code`
 
 You have a single tool, **`code`**, that runs JavaScript in an isolated worker against the checked-out repo through a `state` API (the full `state` type declarations are in the tool description). There is **no shell, no `git`, no `rg`, no `cat`** — everything is `state.*`. Each call is `async () => { ... return result; }` and must `return` its result.

--- a/skills/writing-emdash-docs/SKILL.md
+++ b/skills/writing-emdash-docs/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: writing-emdash-docs
+description: Write, revise, and review EmDash documentation for technical accuracy, useful structure, house style, and natural prose. Use when working on user documentation, guides, API reference pages, migration or upgrade guides, READMEs, contributor documentation, technical specifications, or release notes in the EmDash repository, and when asked to improve, audit, de-slop, or humanize existing documentation.
+---
+
+# Writing EmDash docs
+
+Produce documentation that helps a specific reader complete a task or understand a concrete part of EmDash. Treat factual accuracy, information design, and sentence-level style as separate checks.
+
+## Load the right context
+
+Before drafting or editing:
+
+1. Read `docs/src/content/docs/contributing/docs-style-guide.mdx` completely for public documentation. Apply its relevant voice and readability rules to other prose in the repository.
+2. Read [references/docs-practice.md](references/docs-practice.md) completely for every writing or revision task.
+3. Read [references/anti-slop.md](references/anti-slop.md) completely for every writing or revision task.
+4. Read nearby pages of the same type to preserve established structure, terminology, frontmatter, imports, and Starlight component usage.
+5. Inspect the implementation, types, tests, command help, or configuration that establishes every technical claim. Do not rely on memory when the repository can answer the question.
+6. Read `AGENTS.md` for repository-wide rules. Apply its release-note guidance to changesets.
+
+## Define the reader and outcome
+
+State the intended outcome privately in one sentence: "After reading this, the reader can ..." Use it to decide what belongs on the page.
+
+Classify the document before choosing its structure:
+
+| Document | Reader need | Default shape |
+| --- | --- | --- |
+| Tutorial | Learn through a reliable, guided experience | Visible goal, prerequisites, one path, expected results after each stage, recap |
+| Task guide | Complete one practical task | Outcome, prerequisites, ordered actions, result, optional next step |
+| Concept or explanation | Build an accurate mental model | Definition, relevant behavior, concrete example, implications |
+| Reference | Look up exact behavior | Signature or syntax, parameters, defaults, return value, errors, examples |
+| Troubleshooting | Diagnose and resolve a known failure | Exact symptom, context, cause or diagnostic checks, workaround or resolution, verification |
+| Upgrade or migration guide | Make an existing project work after a change | Previous behavior, current behavior, required action, minimal diff |
+| README or contributor guide | Start or contribute quickly | Short purpose, fastest working path, common operations, deeper links |
+| Technical specification | Evaluate and implement a decision | Goal, constraints, decision, interfaces and data flow, failure handling, rollout, verification, open decisions |
+
+Do not force every section into the same size. Give common or risky tasks more space than incidental details.
+
+## Draft for the task
+
+- Lead with the reader's outcome. Move project history or implementation chronology to a page where it helps the reader make a decision.
+- Use the words readers will search for in the title, introduction, headings, and exact error messages. Prefer specific labels to `Overview`, `Introduction`, or `Why it matters`.
+- Use direct subject-verb-object sentences and precise nouns. Repeat the established name for a concept; synonyms can imply a second concept.
+- Use imperative instructions for required actions. Reserve "can" for a genuine option and explain consequences when a choice matters.
+- Put a condition before the action it governs so the reader knows whether the instruction applies before acting.
+- Keep prerequisites explicit. Do not hide setup assumptions inside a later step.
+- Prefer one realistic, working path over a menu of hypothetical choices. State the selection criteria before an opinionated example.
+- Introduce code samples with what they accomplish. Add `title=` filenames to blocks that represent files.
+- Keep code and output consistent with the current API. Include defaults, errors, permissions, and caveats when they affect successful use.
+- Link to authoritative material for non-EmDash topics. Keep explanations focused on EmDash-specific behavior.
+- Keep one canonical explanation for recurring information and link to it. Do not duplicate commands, option lists, or procedures across pages when they can drift independently.
+- Preserve valid frontmatter, imports, links, anchors, code-fence metadata, and MDX component boundaries while editing prose.
+
+For public docs, describe how to use EmDash. Put internal design detail in contributor or architecture documentation unless it changes a reader's decision.
+
+## Run the anti-slop pass
+
+Finish the content pass before polishing sentences. Then inspect every changed paragraph using [references/anti-slop.md](references/anti-slop.md).
+
+Ask of each sentence:
+
+1. Is it stating information or staging a reveal?
+2. Does it name the actor, behavior, and consequence precisely?
+3. Does it add information the reader needs?
+4. Does it preserve the source's meaning, uncertainty, and scope?
+
+Remove chatbot residue, generic promotion, manufactured drama, self-grading, process narration, diff-centered language, and empty transitions. Replace vague emphasis with facts. Do not add anecdotes, measurements, opinions, dates, citations, or guarantees merely to make prose sound more human.
+
+Treat pattern lists as prompts for judgment, not lexical bans. Keep a contrast when the reader is likely to hold the wrong model. Keep a hedge when evidence is limited. Keep repeated terminology when it prevents ambiguity.
+
+## Review the whole document
+
+Read the finished page in order after reviewing the diff.
+
+- Check that headings work as table-of-contents labels and use sentence case.
+- Check that the introduction matches what the page actually delivers.
+- Check that each step starts from the state produced by the previous step.
+- Check that examples use the same names and assumptions throughout.
+- Check links, filenames, commands, code, and stated outcomes against the repository.
+- Search for the same feature, option, command, and old terminology across the documentation. Resolve contradictions by updating related claims or linking to the canonical page.
+- Check that warnings explain the concrete risk and the action that avoids it.
+- Check headings, links, images, tables, and instructions against the accessibility and global-audience rules in [references/docs-practice.md](references/docs-practice.md).
+- Cut duplicated conclusions and paragraphs that only announce importance.
+
+When asked for an audit only, report prioritized, concrete findings without editing. Otherwise, make the edits and summarize only material changes.
+
+## Verify
+
+Run the narrowest checks that cover the changed artifact:
+
+```bash
+pnpm lint:quick
+pnpm --dir docs build
+git diff --check
+```
+
+Use additional tests when code samples or generated reference material depend on executable behavior. If a repository-wide check is already broken, record the pre-existing failure and still run any independent checks that remain meaningful.

--- a/skills/writing-emdash-docs/SKILL.md
+++ b/skills/writing-emdash-docs/SKILL.md
@@ -24,16 +24,16 @@ State the intended outcome privately in one sentence: "After reading this, the r
 
 Classify the document before choosing its structure:
 
-| Document | Reader need | Default shape |
-| --- | --- | --- |
-| Tutorial | Learn through a reliable, guided experience | Visible goal, prerequisites, one path, expected results after each stage, recap |
-| Task guide | Complete one practical task | Outcome, prerequisites, ordered actions, result, optional next step |
-| Concept or explanation | Build an accurate mental model | Definition, relevant behavior, concrete example, implications |
-| Reference | Look up exact behavior | Signature or syntax, parameters, defaults, return value, errors, examples |
-| Troubleshooting | Diagnose and resolve a known failure | Exact symptom, context, cause or diagnostic checks, workaround or resolution, verification |
-| Upgrade or migration guide | Make an existing project work after a change | Previous behavior, current behavior, required action, minimal diff |
-| README or contributor guide | Start or contribute quickly | Short purpose, fastest working path, common operations, deeper links |
-| Technical specification | Evaluate and implement a decision | Goal, constraints, decision, interfaces and data flow, failure handling, rollout, verification, open decisions |
+| Document                    | Reader need                                  | Default shape                                                                                                  |
+| --------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Tutorial                    | Learn through a reliable, guided experience  | Visible goal, prerequisites, one path, expected results after each stage, recap                                |
+| Task guide                  | Complete one practical task                  | Outcome, prerequisites, ordered actions, result, optional next step                                            |
+| Concept or explanation      | Build an accurate mental model               | Definition, relevant behavior, concrete example, implications                                                  |
+| Reference                   | Look up exact behavior                       | Signature or syntax, parameters, defaults, return value, errors, examples                                      |
+| Troubleshooting             | Diagnose and resolve a known failure         | Exact symptom, context, cause or diagnostic checks, workaround or resolution, verification                     |
+| Upgrade or migration guide  | Make an existing project work after a change | Previous behavior, current behavior, required action, minimal diff                                             |
+| README or contributor guide | Start or contribute quickly                  | Short purpose, fastest working path, common operations, deeper links                                           |
+| Technical specification     | Evaluate and implement a decision            | Goal, constraints, decision, interfaces and data flow, failure handling, rollout, verification, open decisions |
 
 Do not force every section into the same size. Give common or risky tasks more space than incidental details.
 

--- a/skills/writing-emdash-docs/agents/openai.yaml
+++ b/skills/writing-emdash-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write EmDash Docs"
+  short_description: "Write clear, accurate, natural EmDash docs"
+  default_prompt: "Use $writing-emdash-docs to revise this documentation for accuracy, clarity, and natural prose."

--- a/skills/writing-emdash-docs/references/anti-slop.md
+++ b/skills/writing-emdash-docs/references/anti-slop.md
@@ -1,0 +1,120 @@
+# Anti-slop editing reference
+
+Use this pass after the document is factually complete. Judge what each sentence does. Treat word lists as prompts: a flagged phrase may be legitimate, and an unfamiliar phrase can still perform the same bad pattern.
+
+## Contents
+
+- [The central test](#the-central-test)
+- [Staged reveals](#staged-reveals)
+- [Missing precision](#missing-precision)
+- [Generic AI vocabulary](#generic-ai-vocabulary)
+- [Structure and rhythm](#structure-and-rhythm)
+- [Chatbot and diff residue](#chatbot-and-diff-residue)
+- [Avoid overcorrection](#avoid-overcorrection)
+- [Final questions](#final-questions)
+
+## The central test
+
+Ask whether a sentence is **stating** information or **staging** it.
+
+Stated prose puts the subject, behavior, and consequence on the page. Staged prose withholds a noun, invents a contrast, labels its own significance, or manufactures a beat before delivering the fact.
+
+> Staged: It is not just a schema change. It is the key to a more flexible content model.
+>
+> Stated: Adding the field changes the collection schema and makes the field available to every entry in that collection.
+
+Also ask whether a paragraph could describe any CMS, API, or open-source project. If it could, replace generic praise or advice with verified EmDash behavior, or delete it.
+
+Read the whole document before editing individual tics. Importance claims, vague transitions, and generic summaries often cover a contradiction, unsupported claim, missing prerequisite, or gap in the procedure. Report factual conflicts separately and leave their resolution to the author.
+
+## Staged reveals
+
+Look for these mechanisms:
+
+- **Negation-first reveal:** "not just X, but Y", "the problem is not X; it is Y", or a straw-man interpretation the reader never proposed. State the supported behavior directly. Keep a contrast only when correcting a likely misconception or distinguishing two easily confused APIs.
+- **Significance designation:** "the real issue", "what matters", "the key takeaway", "crucial", or "pivotal". Delete the ranking and state the fact that makes it important.
+- **Deferred nouns and suspense:** "there is one catch", a paragraph-ending colon before the answer, or "here is where it gets interesting". Name the constraint when it first becomes relevant.
+- **Rhetorical questions:** asking a question only to answer it in the next sentence. Replace both with one declarative sentence unless the question is a real heading readers use to navigate.
+- **Drama beats:** isolated fragments, punch-line em dashes, or a short sentence placed alone for gravitas. Join the thought to its paragraph or state the result normally.
+- **Aphoristic closers:** a quotable contrast or moral that restates the paragraph. End on the last useful fact or action.
+- **Self-grading:** "this is rigorous", "worth noting", "the useful distinction", or "as the data clearly shows". Present the evidence and let the reader assess it.
+
+## Missing precision
+
+Replace style that hides the actual mechanism:
+
+- Give agency to a real actor. Prefer "The runtime caches the result for the request" to "The cache takes care of repeated work."
+- Name an available noun instead of pointing at it with "this", "that", "the former", "the latter", or "one thing".
+- Replace structural and dressed metaphors such as "the hinge", "the seam", "load-bearing", "under the hood", "magic", or "wearing the costume of" with the concrete behavior.
+- Replace promotional adjectives and verdicts with observable effects, requirements, names, or measurements.
+- Use `is`, `has`, and `uses` when "serves as", "boasts", "features", or "offers" adds ceremony rather than meaning.
+- Cut participle tails that claim significance: "highlighting", "showcasing", "underscoring", "ensuring", "fostering", or "reflecting". Keep the claim only if the evidence supports it, then give it a full sentence.
+- Name who reported or measured a claim. Do not use "experts say", "developers agree", or other vague attribution.
+- Preserve unusual, concrete details that the repository supports. Generic rewriting often smooths exact behavior into a broad claim that could describe any product.
+
+## Generic AI vocabulary
+
+Treat these as strong prompts to inspect the sentence, especially in clusters:
+
+- delve, dive deep, embark, navigate the complexities
+- tapestry, landscape, realm, ecosystem when used figuratively
+- robust, seamless, scalable, cutting-edge, game-changing
+- unlock, harness, elevate, leverage or utilize when `use` is accurate
+- crucial, pivotal, myriad, plethora, transformative
+- "in today's ...", "at the end of the day", "it is important to note", "that said"
+- seam, fold, load-bearing, belt-and-suspenders
+- footgun, rabbit hole, yak shaving, sane defaults, just works
+
+Replace the phrase with specific behavior. If the sentence has no specific behavior, delete it.
+
+## Structure and rhythm
+
+Check the document above the sentence level:
+
+- **Forced triads:** List the real number of items. Do not add or remove one to produce a set of three.
+- **Staccato fragments:** Combine three or more short parallel fragments when they are a list disguised as prose.
+- **Sentence uniformity:** Vary length according to the idea. Do not mechanically alternate short and long sentences.
+- **Over-balanced sections:** Allocate space by reader need and risk, not symmetry.
+- **False ranges:** Use "from X to Y" only for actual endpoints. Otherwise, list the topics.
+- **Coy headings:** Replace "Why it matters", "What this really means", or verdict-shaped headings with a short label that names the section's content.
+- **Broken hierarchy:** Remove duplicate page-title headings, skipped heading levels, headings followed immediately by subheadings, and decorative thematic breaks that substitute for structure.
+- **Inline-header lists:** Avoid bold labels that merely repeat the first words of each bullet. Keep labels when they are real terms, option names, or an index.
+- **List addiction:** Use prose for a connected argument and lists for genuinely parallel items or steps.
+- **Table addiction:** Use a table for data with meaningful row and column relationships, not to decorate a short list or force unlike ideas into equal boxes.
+- **Em-dash overuse:** Use an em dash for a useful inline aside, not to delay the point. Repeated punch-line dashes make technical prose sound manufactured.
+- **Elegant variation:** Repeat the same technical term when it refers to the same thing. A synonym can imply a second concept.
+
+## Chatbot and diff residue
+
+Delete text that belongs to the generation process rather than the document:
+
+- "Great question", "Certainly", "I hope this helps", or invitations to ask for more.
+- "In this guide, we will explore", "let's dive in", "first, some background", or other throat-clearing.
+- Praise, agreement, performed humility, or comments about how difficult the writing task was.
+- "Now", "new", "previously", "was added", "was updated", or "replaces the old approach" in evergreen docs. Put version differences in release notes or an upgrade guide.
+- Generic conclusions that summarize the outline without adding a result, action, or constraint.
+- Placeholder instructions, prompt fragments, model citation markers, search-result links, tracking parameters, and other generation artifacts.
+
+Verify every citation and external link. Confirm that it exists, resolves to the claimed source, and supports the adjacent statement. A polished rewrite does not repair an invented DOI, unrelated source, or unsupported attribution.
+
+## Avoid overcorrection
+
+Editing out AI tics must not flatten or falsify the document.
+
+- Preserve necessary caveats, uncertainty, scope, and warnings.
+- Preserve a negation that defines a real boundary or prevents a common error.
+- Preserve lists, tables, headings, and bold terms when they improve lookup or navigation.
+- Preserve deliberate voice in an authored post. Public EmDash docs use the neutral voice defined by the style guide.
+- Preserve a surrounding page's established register unless that register conflicts with the EmDash style guide. A sudden polished or promotional passage is a quality problem even when each sentence passes alone.
+- Never invent a fact, source, quote, measurement, date, opinion, or anecdote to add specificity.
+- Never trade a precise technical term for a casual synonym merely to sound human.
+- Do not optimize for evading AI detectors. Optimize for a reader completing a task accurately.
+
+## Final questions
+
+1. Could a sentence be deleted without costing the reader information or a needed transition?
+2. Does any sentence tell the reader which sentence is important?
+3. Does a heading name its contents when read alone in a table of contents?
+4. Does the last paragraph add a result or action, or only restate the page's theme?
+5. Did an edit change a claim, remove a caveat, or add unsupported specificity?
+6. Does every example use real EmDash names and behavior?

--- a/skills/writing-emdash-docs/references/docs-practice.md
+++ b/skills/writing-emdash-docs/references/docs-practice.md
@@ -1,0 +1,173 @@
+# Documentation practice
+
+Use this reference with the EmDash documentation style guide. The style guide defines the house voice and local conventions. This reference covers information architecture, document types, accessibility, examples, and maintenance.
+
+## Contents
+
+- [Start with the reader](#start-with-the-reader)
+- [Keep document types distinct](#keep-document-types-distinct)
+- [Write clearly and directly](#write-clearly-and-directly)
+- [Design for finding and scanning](#design-for-finding-and-scanning)
+- [Write usable code examples](#write-usable-code-examples)
+- [Make the page accessible and global](#make-the-page-accessible-and-global)
+- [Maintain one source of truth](#maintain-one-source-of-truth)
+- [Test the reader's path](#test-the-readers-path)
+
+## Start with the reader
+
+Define these before outlining:
+
+- **Role:** site builder, plugin author, administrator, contributor, evaluator, or another specific reader.
+- **Goal:** the task they need to complete or decision they need to make.
+- **Starting state:** installed software, permissions, configuration, prior reading, and knowledge they already have.
+- **Outcome:** the observable state or understanding they need at the end.
+
+Document the difference between what the reader needs and what the reader already knows. Give experienced readers direct access to tasks. Explain setup that a beginner cannot infer.
+
+Define the page scope. State non-scope only for adjacent topics a reader would reasonably expect the page to cover, then link to the correct page when it exists.
+
+## Keep document types distinct
+
+Choose the reader need before the format. A page can contain multiple topic types, but each section should do one job.
+
+### Tutorial
+
+Use a tutorial to help a learner acquire familiarity through a guided experience.
+
+- Choose one achievable, meaningful result and one reliable path.
+- Assume little beyond the stated prerequisites.
+- Produce visible output early and after each meaningful stage.
+- State expected output so the learner can confirm that each step worked.
+- Mention likely failure signals at the step where they can occur.
+- Remove options, exhaustive reference detail, and long explanations that interrupt the learning flow. Link to them instead.
+- Test the complete tutorial from its stated starting state. A tutorial that only works in the author's existing environment is broken.
+
+### Task guide
+
+Use a task guide to help a competent reader solve a real problem.
+
+- Define the task by the reader's goal. Include buttons, functions, and settings only when the reader needs them to complete it.
+- Start and end at meaningful states in the reader's work.
+- List permissions, setup, destructive effects, and other prerequisites before the steps.
+- Document the primary path. Add alternatives only when different reader contexts require them, ordered by likely use.
+- Keep each step focused on one action or decision and preserve the sequence of the reader's work.
+- State the result and any necessary verification after the steps.
+- Move background teaching and exhaustive option lists to concept or reference pages.
+
+### Concept or explanation
+
+Use a concept topic to answer what something is, why it exists, how its parts relate, or what trade-offs it creates.
+
+- Cover one concept per section.
+- Use a noun or specific noun phrase for the title.
+- Connect new ideas to knowledge the stated audience already has.
+- Include a concrete example or diagram only when it makes a relationship easier to understand.
+- Do not let step-by-step instructions take over the explanation. Link to task guides.
+
+### Reference
+
+Use reference material for exact facts a reader consults while working.
+
+- Mirror the product's conceptual structure so names and relationships are predictable.
+- Use a stable, repeated schema for comparable APIs, commands, fields, hooks, or settings.
+- Include syntax, type, required status, default, constraints, return value, errors, permissions, and version or environment conditions when applicable.
+- Prefer scan-friendly lists, description lists, or tables when the data is genuinely parallel.
+- Place each caveat beside the item it qualifies. Avoid catch-all `Important notes` or `Limitations` sections.
+- Include concise examples to show context, then link to task guides for complete procedures.
+- Verify completeness and exact spelling against source, generated types, schemas, or command output.
+
+### Troubleshooting
+
+Use troubleshooting content for a known symptom or failure mode.
+
+- Put the exact error text or observable symptom in the heading and body so readers can find it by search.
+- State the environment or action in which the problem appears.
+- Separate confirmed causes from diagnostic possibilities.
+- Give diagnostic checks before a resolution when multiple causes produce the same symptom.
+- Distinguish a temporary **workaround** from a permanent **resolution**.
+- Put data-changing or destructive commands behind a concrete warning. Include backup, test-environment, or recovery steps when required.
+- State how to confirm that the problem is resolved.
+- Keep rare but useful failures near the relevant feature. Split out a troubleshooting page when they overwhelm the main task.
+
+### Upgrade and migration guide
+
+Use an upgrade guide when a version change requires reader action.
+
+- Identify who is affected and how to check.
+- State the previous and current behavior only as needed to choose an action.
+- Give the migration action and a minimal before-and-after example.
+- Include ordering, downtime, rollback, backup, and compatibility constraints when applicable.
+- End each breaking change with a verifiable working state.
+
+## Write clearly and directly
+
+- Use a neutral, factual tone that is calm, friendly, and respectful. Avoid whimsy, mascots, cultural references, and jokes that add work for the reader or translator.
+- Use active voice and present tense. Name the actor when responsibility matters.
+- Address the reader as `you` when necessary. Do not use `I`, `we`, `us`, `our`, or `let's` in documentation.
+- Give required actions as direct imperative instructions. Use `can` only for an available option or permission. Replace ambiguous `should` statements with the expected result or a clear recommendation and its reason.
+- Start instructions with the goal or action and the reason the reader needs it. Remove narration such as "next, we will" or "now that this is configured."
+- Prefer short sentences, short paragraphs, and familiar words. Define an abbreviation on first use and explain only the background the stated audience lacks.
+- When several valid choices exist, state the requirement or selection criteria first. Choose one option for the example and identify that choice so the reader can substitute another.
+- Keep headings short, specific, and in sentence case. Do not end a heading with punctuation. Format code terms in headings as code.
+- Use bullets for related items and numbers for an ordered sequence. Convert long, multi-paragraph list items into subsections.
+- Write `for example` when introducing one example. Use `e.g.` inside parentheses for a non-exhaustive list. Do not label a complete list as examples.
+- Keep exclamation points rare. Use a period unless the sentence is genuinely encouraging or surprising.
+
+## Design for finding and scanning
+
+- Use the terms readers see in the UI, API, command output, and error message. Include common prior terminology only when it helps migration or search.
+- Write titles that identify the task or subject without depending on navigation context.
+- Front-load the distinguishing information in a paragraph, list item, heading, and link.
+- Keep heading levels hierarchical and never skip levels. Add prose between a heading and its first subheading.
+- Avoid one-sentence sections and pages that exist only to collect links. Merge thin material or add a brief explanation of what the reader will find.
+- Use related links sparingly and group them after the content they support. Prefer an inline link at the point of need.
+- Introduce lists and tables. Use a table for information with meaningful row and column relationships.
+- Keep parallel items grammatically parallel, but do not force equal length or a set of three.
+
+## Write usable code examples
+
+- Use repository conventions and current public APIs.
+- Show the smallest complete example that demonstrates the behavior without teaching an unsafe or obsolete shortcut.
+- Use realistic names and reserved example values. Make placeholders visually unambiguous and explain each replacement.
+- Include imports, setup, permissions, and surrounding structure needed to run the example, or link to a clearly defined starting project.
+- Mark omitted code with a language-appropriate comment. Do not use an ellipsis that a reader might copy as code.
+- Introduce every sample with a complete sentence that states its purpose. A direct imperative can introduce a sample inside an ordered step.
+- Add a `title=` filename to a block that represents a file.
+- Follow the sample with the expected result or the detail the reader should notice.
+- Keep comments for non-obvious choices. Explain the code in prose when several lines need narration.
+- Run or type-check examples when practical. Otherwise, verify every symbol and behavior against executable source or tests.
+- Never put secrets, live tokens, unsafe permissions, destructive production commands, or non-reserved domains in copyable examples.
+
+## Make the page accessible and global
+
+- Use descriptive link text that makes sense outside its sentence. Do not use `click here` or expose a raw URL as the label unless the URL is the subject.
+- Preserve heading hierarchy and semantic Markdown or HTML. Do not choose markup only for its visual appearance.
+- Write alt text for the image's purpose in context. Use empty alt text for decoration. Put any new information from an image, diagram, video, or animation in text as well.
+- Do not depend on color, position, shape, sound, punctuation, or mouse input alone to communicate a step.
+- Introduce tables and interactive elements before they appear. Avoid complex or merged table cells.
+- Define unfamiliar abbreviations on first use and avoid idioms, cultural references, jokes, and figurative language that do not translate literally.
+- Prefer simple sentence structures. State a condition before its instruction.
+- Describe unexpected link behavior such as a download or an external tool.
+
+## Maintain one source of truth
+
+- Search the documentation before adding a definition, option list, setup sequence, or recurring command.
+- Put stable information in one canonical location and link to it from other pages. Repeated prose drifts.
+- Check every page that names a changed API, option, default, workflow, or old term.
+- Preserve redirects or update inbound links when moving or renaming content.
+- Keep promises about unreleased behavior out of evergreen docs. Document shipped behavior; put planned work in issues, discussions, or a clearly marked experimental section.
+- Treat documentation like code: review diffs, build the site, test procedures, and keep changes scoped to the behavior being documented.
+
+## Test the reader's path
+
+Before finishing, verify more than grammar:
+
+1. Start from the stated prerequisites, ideally in a clean environment.
+2. Follow every step in order and copy commands exactly as rendered.
+3. Compare actual and documented output, defaults, errors, and side effects.
+4. Test at least one likely failure or boundary when the page gives troubleshooting or safety guidance.
+5. Scan headings and links without body text. Confirm that they still identify the destination or task.
+6. Search for duplicate and contradictory claims elsewhere in the docs.
+7. Build the rendered site and inspect components, code fences, tables, images, and anchors.
+
+Apply these principles with the EmDash style guide and repository rules, which take precedence when conventions differ.


### PR DESCRIPTION
## What does this PR do?

Adds a repository skill for writing, revising, and reviewing EmDash documentation.

The skill provides:

- A workflow for verifying claims, choosing the document type, drafting, reviewing, and validating documentation.
- Documentation practices for tutorials, task guides, concepts, reference pages, troubleshooting, migrations, accessibility, code examples, and maintenance.
- An anti-slop editing pass that catches staged reveals, generic AI vocabulary, manufactured rhythm, chatbot residue, and meaning-changing rewrites.
- Codex interface metadata for skill discovery and invocation.
- Repository guidance that tells agents to load the skill for documentation work.
- Conditional integration with the Flue auto-reviewer for documentation changes.

Related issue: None.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

The unchecked items are not applicable to a repository-only documentation skill. The pnpm commands are also blocked in this checkout by the existing `patchedDependencies` verification error. Direct oxlint and Prettier checks pass, no published package changes, no admin strings change, and no feature Discussion is required.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- Skill validation: passed
- Prettier check: passed
- Direct oxlint: 0 diagnostics across 2,449 files
- `git diff --check`: passed
- Docs build: passed
- Flue reviewer typecheck: passed
- Flue Cloudflare build: passed

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://docs-writing-emdash-docs-skill-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `docs/writing-emdash-docs-skill`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
