### PR TITLE
fix(bot): preserve workspaces through sandbox restarts

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -69,9 +69,16 @@ import verifySkill from "../skills/verify/SKILL.md";
 
 const REPO_DIR = "/workspace/repo";
 const DEFAULT_RPC_TIMEOUT_MS = 2 * 60_000;
+const CONTAINER_ATTACH_TIMEOUT_MS = 11 * 60_000;
 const EXEC_GRACE_MS = 30_000;
 const CLONE_DEPTH = 50;
-const DEADLINES = { defaultTimeoutMs: DEFAULT_RPC_TIMEOUT_MS, execGraceMs: EXEC_GRACE_MS };
+const INVESTIGATION_TIMEOUT_MS = 30 * 60_000;
+const SANDBOX_SLEEP_AFTER_SECONDS = (INVESTIGATION_TIMEOUT_MS + 5 * 60_000) / 1_000;
+const DEADLINES = {
+	defaultTimeoutMs: DEFAULT_RPC_TIMEOUT_MS,
+	attachTimeoutMs: CONTAINER_ATTACH_TIMEOUT_MS,
+	execGraceMs: EXEC_GRACE_MS,
+};
 /**
  * Ceiling on any single tool result returned to the model. Unbounded tool
  * output accumulates across a long investigation until the conversation
@@ -327,14 +334,14 @@ export function Investigate({ id }: AgentProps) {
 		defineTool({
 			name: "exec",
 			description:
-				"Run a shell command in the Linux container (git, pnpm, astro, vitest, agent-browser). Attaching the container is slow; prefer the VFS tools and `code` for reads and searches, and use exec only to run the project or its toolchain.",
+				"Run a read-only shell command in the Linux container (git, pnpm, astro, vitest, agent-browser). Attaching the container is slow; prefer the VFS tools and `code` for reads and searches. Commands that change tracked source are reverted and rejected; change source with edit_file/write_file.",
 			input: v.object({
 				command: v.string(),
 				cwd: v.optional(v.string()),
 				timeoutMs: v.optional(v.number()),
 			}),
 			async run({ data }) {
-				const result = await env.exec(data.command, {
+				const result = await env.execReadOnly(data.command, {
 					...(data.cwd ? { cwd: data.cwd } : {}),
 					...(data.timeoutMs ? { timeoutMs: data.timeoutMs } : {}),
 				});
@@ -586,7 +593,7 @@ export function Investigate({ id }: AgentProps) {
 
 Investigate.agentName = "investigate";
 Investigate.initialData = initialDataSchema;
-Investigate.durability = { maxAttempts: 5, timeoutMs: 30 * 60_000 };
+Investigate.durability = { maxAttempts: 5, timeoutMs: INVESTIGATION_TIMEOUT_MS };
 
 /**
  * Per-run ExecEnv, cached on `globalThis` so it survives the agent's re-renders
@@ -637,6 +644,7 @@ async function hydrateWorkspace(id: string, dir: string, ref: string): Promise<v
 	const url = `https://api.github.com/repos/${repo.owner}/${repo.repo}/tarball/${encodeURIComponent(ref)}`;
 	const response = await fetch(url, {
 		headers: { "User-Agent": "emdash-bot", Accept: "application/vnd.github+json" },
+		signal: AbortSignal.timeout(DEFAULT_RPC_TIMEOUT_MS),
 	});
 	if (!response.ok || !response.body) {
 		throw new Error(`tarball fetch failed: ${response.status}`);
@@ -765,7 +773,26 @@ function buildCodeToolDescription(): string {
  * left to the repro/fix skills -- isolate-first, container work on demand.
  */
 async function attachContainer(id: string, input: InvestigateData): Promise<ContainerBackend> {
-	const container = fromSandbox(getSandbox(workerEnv.Sandbox, id));
+	const container = fromSandbox(
+		getSandbox(workerEnv.Sandbox, id, { sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS }),
+	);
+	await prepareContainer(container, input);
+	return {
+		...container,
+		async isReady() {
+			const result = await container.exec(
+				`git -C ${quote(REPO_DIR)} rev-parse --is-inside-work-tree`,
+				{ cwd: "/", timeoutMs: DEFAULT_RPC_TIMEOUT_MS },
+			);
+			return result.exitCode === 0 && result.stdout.trim() === "true";
+		},
+	};
+}
+
+async function prepareContainer(
+	container: ContainerBackend,
+	input: InvestigateData,
+): Promise<void> {
 	const repo = readRepoContext(workerEnv);
 	if (!repo) throw new Error("repository context is not configured");
 	const ref = cloneRef(input);
@@ -812,7 +839,6 @@ async function attachContainer(id: string, input: InvestigateData): Promise<Cont
 			throw new Error(`container setup failed (${result.exitCode}): ${result.stderr.slice(-500)}`);
 		}
 	}
-	return container;
 }
 
 function cloneUrl(): string {

--- a/infra/emdash-bot/.flue/lib/exec-env.ts
+++ b/infra/emdash-bot/.flue/lib/exec-env.ts
@@ -43,6 +43,8 @@ export interface RepoOptions {
 export interface ExecEnvDeadlines {
 	/** Ceiling for VFS calls and for an exec with no explicit timeout. */
 	readonly defaultTimeoutMs: number;
+	/** Overall ceiling for attaching or rebuilding the container checkout. */
+	readonly attachTimeoutMs: number;
 	/** Added to an exec's own timeout so the substrate kills before we do. */
 	readonly execGraceMs: number;
 }
@@ -71,6 +73,7 @@ export interface IsolateState {
  * `fromSandbox` adapts the real sandbox, tests pass a fake.
  */
 export interface ContainerBackend {
+	isReady(): Promise<boolean>;
 	exec(
 		command: string,
 		options?: { cwd?: string; timeoutMs?: number },
@@ -111,6 +114,7 @@ export class ExecEnv {
 	readonly #deadlines: ExecEnvDeadlines;
 	readonly #repoDir: string;
 	#containerPromise: Promise<ContainerBackend> | undefined;
+	#containerRecoveryPromise: Promise<ContainerBackend> | undefined;
 
 	constructor(options: ExecEnvOptions) {
 		this.#state = options.state;
@@ -129,18 +133,15 @@ export class ExecEnv {
 		const ref = options.ref ?? "main";
 		if ((await this.#readMarker()) === ref) return;
 		await this.#bounded(this.#state.rm(options.dir, { recursive: true, force: true }), "rm");
-		await this.#hydrateRepo(options.dir, ref);
+		await this.#bounded(this.#hydrateRepo(options.dir, ref), "hydrateRepo");
 		await this.#bounded(this.#state.mkdir(META_DIR, { recursive: true }), "mkdir");
 		await this.#bounded(this.#state.writeFile(CHANGE_LOG, "[]"), "writeFile");
 		await this.#bounded(this.#state.writeFile(HYDRATED_MARKER, ref), "writeFile");
 	}
 
 	async #readMarker(): Promise<string | null> {
-		try {
-			return await this.#bounded(this.#state.readFile(HYDRATED_MARKER), "readFile");
-		} catch {
-			return null;
-		}
+		if (!(await this.#bounded(this.#state.exists(HYDRATED_MARKER), "exists"))) return null;
+		return this.#bounded(this.#state.readFile(HYDRATED_MARKER), "readFile");
 	}
 
 	readFile(path: string): Promise<string> {
@@ -203,6 +204,10 @@ export class ExecEnv {
 		);
 	}
 
+	async execReadOnly(command: string, options: ExecOptions = {}): Promise<ExecResult> {
+		return (await this.runCheck(command, options)).result;
+	}
+
 	async runCheck(
 		command: string,
 		options: ExecOptions = {},
@@ -224,7 +229,7 @@ export class ExecEnv {
 		if (candidateTreeSha !== beforeTreeSha) {
 			await this.#restoreContainerCandidate(container);
 			throw new Error(
-				"verification command modified the candidate; apply source changes with edit_file/write_file and rerun a check-only command",
+				"container command modified the candidate; apply source changes with edit_file/write_file and rerun a check-only command",
 			);
 		}
 		return { result, candidateTreeSha };
@@ -403,16 +408,51 @@ export class ExecEnv {
 		return this.#bounded(container.readFileBytes(path), "readArtifact");
 	}
 
-	/** Attach the container once and reuse it. */
-	container(): Promise<ContainerBackend> {
+	/** Reuse a live checkout, rebuilding it when the sandbox replaced its container. */
+	async container(): Promise<ContainerBackend> {
+		const container = await this.#attachedContainer();
+		try {
+			if (await this.#containerReady(container)) return container;
+		} catch {
+			this.#containerPromise = undefined;
+		}
+		return this.#recoverContainer();
+	}
+
+	#attachedContainer(): Promise<ContainerBackend> {
 		return (this.#containerPromise ??= withDeadline(
 			this.#attachContainer(),
-			this.#deadlines.defaultTimeoutMs,
+			this.#deadlines.attachTimeoutMs,
 			"container attach",
 		).catch((error: unknown) => {
 			this.#containerPromise = undefined;
 			throw error;
 		}));
+	}
+
+	#containerReady(container: ContainerBackend): Promise<boolean> {
+		return withDeadline(
+			container.isReady(),
+			this.#deadlines.attachTimeoutMs,
+			"container readiness",
+		);
+	}
+
+	#recoverContainer(): Promise<ContainerBackend> {
+		if (this.#containerRecoveryPromise) return this.#containerRecoveryPromise;
+		this.#containerPromise = undefined;
+		const recovery = (async () => {
+			const replacement = await this.#attachedContainer();
+			if (!(await this.#containerReady(replacement))) {
+				this.#containerPromise = undefined;
+				throw new Error("container checkout is unavailable after reattachment");
+			}
+			return replacement;
+		})();
+		this.#containerRecoveryPromise = recovery.finally(() => {
+			this.#containerRecoveryPromise = undefined;
+		});
+		return this.#containerRecoveryPromise;
 	}
 
 	async #recordChange(path: string): Promise<void> {
@@ -425,13 +465,21 @@ export class ExecEnv {
 	}
 
 	async #readChangeLog(): Promise<string[]> {
+		if (!(await this.#bounded(this.#state.exists(CHANGE_LOG), "exists"))) return [];
+		const raw = await this.#bounded(this.#state.readFile(CHANGE_LOG), "readFile");
+		let parsed: unknown;
 		try {
-			const raw = await this.#bounded(this.#state.readFile(CHANGE_LOG), "readFile");
-			const parsed: unknown = JSON.parse(raw);
-			return Array.isArray(parsed) ? parsed.filter((p): p is string => typeof p === "string") : [];
-		} catch {
-			return [];
+			parsed = JSON.parse(raw);
+		} catch (error) {
+			throw new Error("invalid VFS change log: malformed JSON", { cause: error });
 		}
+		if (!Array.isArray(parsed) || parsed.some((path) => typeof path !== "string")) {
+			throw new Error("invalid VFS change log: expected an array of paths");
+		}
+		if (parsed.some((path) => !path.startsWith(`${this.#repoDir}/`))) {
+			throw new Error("invalid VFS change log: path outside repository");
+		}
+		return parsed;
 	}
 
 	/**
@@ -537,6 +585,7 @@ export function pipefailCommand(command: string): string {
 /** Adapt a @cloudflare/sandbox session to the ContainerBackend seam. */
 export function fromSandbox(sandbox: Sandbox): ContainerBackend {
 	return {
+		isReady: async () => true,
 		async exec(command, options) {
 			const result = await sandbox.exec(command, {
 				...(options?.cwd ? { cwd: options.cwd } : {}),

--- a/infra/emdash-bot/.flue/lib/investigation-base-ref.ts
+++ b/infra/emdash-bot/.flue/lib/investigation-base-ref.ts
@@ -1,0 +1,14 @@
+import type { InvestigationMode } from "./router.js";
+
+export function investigationBaseRef(
+	mode: InvestigationMode,
+	mainBranchSha: string | null,
+	previousBranchSha: string | null,
+): string {
+	if (mode === "revise") {
+		if (!previousBranchSha) throw new Error("candidate branch is missing for revision");
+		return previousBranchSha;
+	}
+	if (!mainBranchSha) throw new Error("main branch is missing");
+	return mainBranchSha;
+}

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -35,6 +35,7 @@ import {
 	removeLabels,
 	type RepoContext,
 } from "./github.js";
+import { investigationBaseRef } from "./investigation-base-ref.js";
 import { STATES, type EventId, type Kind, type StateId } from "./machine.js";
 import { branchesToReap, previewUrl, probePreviewReady } from "./preview.js";
 import {
@@ -238,6 +239,7 @@ interface PreparedInvestigation {
 	issueTitle: string;
 	issueBody: string;
 	previousBranchSha: string | null;
+	baseRef?: string;
 }
 
 interface PendingDispatch extends PreparedInvestigation {
@@ -990,10 +992,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 		if (!mode) return `unknown investigation mode "${decision.action}"`;
 		const token = await this.getInstallationToken(creds);
 		try {
-			const [issue, previousBranchSha] = await Promise.all([
+			const [issue, previousBranchSha, mainBranchSha] = await Promise.all([
 				getIssue(token, repo, anchorNumber),
 				getBranchSha(token, repo, `bot/fix-${anchorNumber}`),
+				getBranchSha(token, repo, "main"),
 			]);
+			const baseRef = investigationBaseRef(mode, mainBranchSha, previousBranchSha);
 			const runId = crypto.randomUUID();
 			const agentId = `investigate-${anchorNumber}-${runId}`;
 			return {
@@ -1005,6 +1009,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 				issueTitle: issue.title,
 				issueBody: issue.body,
 				previousBranchSha,
+				baseRef,
 			};
 		} catch (err) {
 			return `prepare investigation failed: ${errorMessage(err)}`;
@@ -1036,6 +1041,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 					issueTitle: prepared.issueTitle,
 					issueBody: prepared.issueBody,
 					previousBranchSha: prepared.previousBranchSha,
+					...(prepared.baseRef ? { baseRef: prepared.baseRef } : {}),
 				},
 			}),
 		);

--- a/infra/emdash-bot/Dockerfile
+++ b/infra/emdash-bot/Dockerfile
@@ -33,7 +33,7 @@ RUN npm install -g pnpm@11.1.3 bgproc@0.3.0 agent-browser@0.30.1 \
 # /root/.agent-browser/browsers.
 RUN agent-browser install
 
-FROM cloudflare/sandbox:0.12.1
+FROM cloudflare/sandbox:0.12.3
 
 # Base OS packages: git for the repo clone the agent does in revise mode,
 # ca-certificates for HTTPS, fonts/libs Chromium needs (the agent-browser CLI

--- a/infra/emdash-bot/package.json
+++ b/infra/emdash-bot/package.json
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@cloudflare/codemode": "^0.4.1",
-		"@cloudflare/sandbox": "^0.12.1",
+		"@cloudflare/sandbox": "0.12.3",
 		"@cloudflare/shell": "^0.4.0",
 		"@flue/runtime": "2.0.3",
 		"agents": "^0.20.1",

--- a/infra/emdash-bot/tests/unit/exec-env.test.ts
+++ b/infra/emdash-bot/tests/unit/exec-env.test.ts
@@ -81,6 +81,7 @@ function fakeContainer(): {
 		...results: Array<{ exitCode: number; stdout: string; stderr: string }>
 	) => void;
 	setReadFileBytes: (read: (path: string) => Uint8Array) => void;
+	queueReadyResults: (...results: Array<boolean | Error>) => void;
 	hangExec: () => void;
 } {
 	const execs: string[] = [];
@@ -88,8 +89,14 @@ function fakeContainer(): {
 	let execResult = { exitCode: 0, stdout: "container-ran", stderr: "" };
 	const queuedExecResults: Array<{ exitCode: number; stdout: string; stderr: string }> = [];
 	let readFileBytes: (path: string) => Uint8Array = (_path) => new Uint8Array([1, 2, 3]);
+	const readyResults: Array<boolean | Error> = [];
 	let hang = false;
 	const container: ContainerBackend = {
+		isReady: async () => {
+			const result = readyResults.shift() ?? true;
+			if (result instanceof Error) throw result;
+			return result;
+		},
 		exec: async (command) => {
 			execs.push(command);
 			if (hang) return new Promise<never>(() => {});
@@ -113,13 +120,16 @@ function fakeContainer(): {
 		setReadFileBytes: (read) => {
 			readFileBytes = read;
 		},
+		queueReadyResults: (...results) => {
+			readyResults.push(...results);
+		},
 		hangExec: () => {
 			hang = true;
 		},
 	};
 }
 
-const deadlines = { defaultTimeoutMs: 10_000, execGraceMs: 500 };
+const deadlines = { defaultTimeoutMs: 10_000, attachTimeoutMs: 20_000, execGraceMs: 500 };
 const noHydrate = async () => {};
 
 function makeEnv(overrides?: {
@@ -127,7 +137,7 @@ function makeEnv(overrides?: {
 	container?: ContainerBackend;
 	hydrateRepo?: (dir: string, ref: string) => Promise<void>;
 	attachContainer?: () => Promise<ContainerBackend>;
-	deadlines?: { defaultTimeoutMs: number; execGraceMs: number };
+	deadlines?: { defaultTimeoutMs: number; attachTimeoutMs: number; execGraceMs: number };
 }): ExecEnv {
 	return new ExecEnv({
 		state: overrides?.state ?? fakeState().state,
@@ -183,8 +193,24 @@ describe("ExecEnv container exec", () => {
 		);
 		const env = makeEnv({ container: con.container });
 
-		await expect(env.runCheck("pnpm format")).rejects.toThrow(
-			/verification command modified the candidate/,
+		await expect(env.runCheck("pnpm format")).rejects.toThrow(/command modified the candidate/);
+		expect(con.execs.at(-1)).toContain("git reset --hard HEAD");
+	});
+
+	test("rejects tracked source changes from exploratory commands", async () => {
+		const con = fakeContainer();
+		con.queueExecResults(
+			{ exitCode: 0, stdout: "", stderr: "" },
+			{ exitCode: 0, stdout: "before-tree\n", stderr: "" },
+			{ exitCode: 0, stdout: "formatted", stderr: "" },
+			{ exitCode: 0, stdout: "", stderr: "" },
+			{ exitCode: 0, stdout: "after-tree\n", stderr: "" },
+			{ exitCode: 0, stdout: "", stderr: "" },
+		);
+		const env = makeEnv({ container: con.container });
+
+		await expect(env.execReadOnly("pnpm format")).rejects.toThrow(
+			/container command modified the candidate/,
 		);
 		expect(con.execs.at(-1)).toContain("git reset --hard HEAD");
 	});
@@ -366,6 +392,22 @@ describe("ExecEnv candidate snapshots", () => {
 });
 
 describe("ExecEnv deadlines", () => {
+	test("uses the dedicated attachment deadline for slow container setup", async () => {
+		vi.useFakeTimers();
+		try {
+			const env = makeEnv({
+				attachContainer: () => new Promise<never>(() => {}),
+				deadlines: { defaultTimeoutMs: 50, attachTimeoutMs: 100, execGraceMs: 5 },
+			});
+			const pending = env.exec("pnpm test");
+			const assertion = expect(pending).rejects.toThrow("container attach timed out after 100ms");
+			await vi.advanceTimersByTimeAsync(110);
+			await assertion;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	test("container exec adds the grace margin to its own timeout", async () => {
 		vi.useFakeTimers();
 		try {
@@ -373,7 +415,7 @@ describe("ExecEnv deadlines", () => {
 			con.hangExec();
 			const env = makeEnv({
 				container: con.container,
-				deadlines: { defaultTimeoutMs: 1_000, execGraceMs: 5 },
+				deadlines: { defaultTimeoutMs: 1_000, attachTimeoutMs: 2_000, execGraceMs: 5 },
 			});
 			const pending = env.exec("vitest", { timeoutMs: 10 });
 			const assertion = expect(pending).rejects.toThrow("container exec timed out after 15ms");
@@ -391,7 +433,7 @@ describe("ExecEnv deadlines", () => {
 			fs.hangReads();
 			const env = makeEnv({
 				state: fs.state,
-				deadlines: { defaultTimeoutMs: 50, execGraceMs: 5 },
+				deadlines: { defaultTimeoutMs: 50, attachTimeoutMs: 100, execGraceMs: 5 },
 			});
 			const pending = env.readFile("/repo/a.ts");
 			const assertion = expect(pending).rejects.toThrow("VFS readFile timed out after 50ms");
@@ -418,6 +460,64 @@ describe("ExecEnv container lifecycle", () => {
 			"bash -o pipefail -c 'pnpm install'",
 			"bash -o pipefail -c 'pnpm test'",
 		]);
+	});
+
+	test("reattaches when the cached container checkout is no longer ready", async () => {
+		const fs = fakeState({ "/repo/src/x.ts": "old" });
+		const first = fakeContainer();
+		const replacement = fakeContainer();
+		first.queueReadyResults(true, false);
+		const attach = vi
+			.fn<() => Promise<ContainerBackend>>()
+			.mockResolvedValueOnce(first.container)
+			.mockResolvedValueOnce(replacement.container);
+		const env = makeEnv({ state: fs.state, attachContainer: attach });
+
+		await env.exec("pnpm install");
+		await env.writeFile("/repo/src/x.ts", "new");
+		await env.exec("pnpm test");
+
+		expect(attach).toHaveBeenCalledTimes(2);
+		expect(first.execs).toEqual(["bash -o pipefail -c 'pnpm install'"]);
+		expect(replacement.writes).toEqual([{ path: "/repo/src/x.ts", content: "new" }]);
+		expect(replacement.execs).toEqual(["bash -o pipefail -c 'pnpm test'"]);
+	});
+
+	test("shares one reattachment across concurrent commands", async () => {
+		const first = fakeContainer();
+		const replacement = fakeContainer();
+		first.queueReadyResults(false, false);
+		const attach = vi
+			.fn<() => Promise<ContainerBackend>>()
+			.mockResolvedValueOnce(first.container)
+			.mockResolvedValueOnce(replacement.container);
+		const env = makeEnv({ attachContainer: attach });
+
+		await Promise.all([env.exec("pnpm test"), env.exec("pnpm lint")]);
+
+		expect(attach).toHaveBeenCalledTimes(2);
+		expect(replacement.execs).toEqual(
+			expect.arrayContaining([
+				"bash -o pipefail -c 'pnpm test'",
+				"bash -o pipefail -c 'pnpm lint'",
+			]),
+		);
+	});
+
+	test("reattaches when the readiness probe rejects", async () => {
+		const first = fakeContainer();
+		const replacement = fakeContainer();
+		first.queueReadyResults(new Error("container replaced"));
+		const attach = vi
+			.fn<() => Promise<ContainerBackend>>()
+			.mockResolvedValueOnce(first.container)
+			.mockResolvedValueOnce(replacement.container);
+		const env = makeEnv({ attachContainer: attach });
+
+		await env.exec("pnpm test");
+
+		expect(attach).toHaveBeenCalledTimes(2);
+		expect(replacement.execs).toEqual(["bash -o pipefail -c 'pnpm test'"]);
 	});
 });
 
@@ -511,6 +611,68 @@ describe("ExecEnv ensureRepo", () => {
 		expect(calls).toEqual(["main", "c0c6c72e"]);
 		expect(fs.files.get("/.emdash-bot/hydrated")).toBe("c0c6c72e");
 		expect(con.writes).toEqual([]);
+	});
+
+	test("bounds a stalled workspace hydration", async () => {
+		vi.useFakeTimers();
+		try {
+			const env = makeEnv({
+				hydrateRepo: () => new Promise<never>(() => {}),
+				deadlines: { defaultTimeoutMs: 50, attachTimeoutMs: 100, execGraceMs: 5 },
+			});
+			const pending = env.ensureRepo({ dir: "/repo", ref: "main" });
+			const assertion = expect(pending).rejects.toThrow("VFS hydrateRepo timed out after 50ms");
+			await vi.advanceTimersByTimeAsync(60);
+			await assertion;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("does not discard the workspace when the hydration marker read fails", async () => {
+		vi.useFakeTimers();
+		try {
+			const fs = fakeState({ "/.emdash-bot/hydrated": "main", "/repo/src/a.ts": "edited" });
+			fs.hangReads();
+			const hydrate = vi.fn(noHydrate);
+			const env = makeEnv({
+				state: fs.state,
+				hydrateRepo: hydrate,
+				deadlines: { defaultTimeoutMs: 50, attachTimeoutMs: 100, execGraceMs: 5 },
+			});
+			const pending = env.ensureRepo({ dir: "/repo", ref: "main" });
+			const assertion = expect(pending).rejects.toThrow("VFS readFile timed out after 50ms");
+			await vi.advanceTimersByTimeAsync(60);
+			await assertion;
+			expect(hydrate).not.toHaveBeenCalled();
+			expect(fs.files.get("/repo/src/a.ts")).toBe("edited");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("rejects a corrupt change log instead of executing without VFS edits", async () => {
+		const fs = fakeState({
+			"/.emdash-bot/changes.json": "not-json",
+			"/repo/src/a.ts": "edited",
+		});
+		const con = fakeContainer();
+		const env = makeEnv({ state: fs.state, container: con.container });
+
+		await expect(env.exec("pnpm test")).rejects.toThrow("invalid VFS change log");
+		expect(con.execs).toEqual([]);
+	});
+
+	test("rejects change-log paths outside the repository", async () => {
+		const fs = fakeState({
+			"/.emdash-bot/changes.json": JSON.stringify(["/tmp/escape"]),
+			"/tmp/escape": "content",
+		});
+		const con = fakeContainer();
+		const env = makeEnv({ state: fs.state, container: con.container });
+
+		await expect(env.exec("pnpm test")).rejects.toThrow("path outside repository");
+		expect(con.execs).toEqual([]);
 	});
 });
 

--- a/infra/emdash-bot/tests/unit/investigation-base-ref.test.ts
+++ b/infra/emdash-bot/tests/unit/investigation-base-ref.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+
+import { investigationBaseRef } from "../../.flue/lib/investigation-base-ref.js";
+
+describe("investigationBaseRef", () => {
+	test("pins a new implementation to the resolved main commit", () => {
+		expect(investigationBaseRef("implement", "main-sha", "old-candidate-sha")).toBe("main-sha");
+	});
+
+	test("pins a revision to the existing candidate commit", () => {
+		expect(investigationBaseRef("revise", "main-sha", "candidate-sha")).toBe("candidate-sha");
+	});
+
+	test("rejects a revision when its candidate branch is missing", () => {
+		expect(() => investigationBaseRef("revise", "main-sha", null)).toThrow(
+			"candidate branch is missing",
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,7 +1032,7 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@cloudflare/sandbox':
-        specifier: ^0.12.1
+        specifier: 0.12.3
         version: 0.12.3
       '@cloudflare/shell':
         specifier: ^0.4.0


### PR DESCRIPTION
## What does this PR do?

Fixes implementation agents losing their native checkout while they are still editing through the durable VFS.

Production logs for #1623 showed the Sandbox container idling out after ten minutes without a shell command even though the agent was actively using `read_file` and `edit_file`. The next shell command started a fresh ephemeral container, and replaying only the edited paths produced a partial tree with no `.git`, root `package.json`, or lockfile.

The wider lifecycle audit found and fixes the related failure modes:

- keeps the Sandbox alive longer than the agent's 30-minute durability budget;
- probes checkout readiness before each container phase and single-flights reattachment after idle stop, replacement, or a failed readiness RPC;
- re-clones the checkout before replaying durable VFS edits;
- pins the VFS tarball and container checkout to the same resolved commit instead of resolving a moving branch twice;
- gives attachment its own deadline consistent with the two five-minute Git operations;
- bounds tarball hydration and fails closed on missing/corrupt VFS bookkeeping;
- rejects exploratory shell commands that mutate tracked source outside the durable edit log; and
- pins the Sandbox SDK and container image to the same `0.12.3` release.

Related to #1623, where this infrastructure failure was observed. This PR does not close that product issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Typecheck note: the bot package's existing `wrangler types` output lacks the generated Flue Durable Object and service-binding RPC types, so its full package typecheck fails across existing DO tests/routes. It reports no new errors in the changed lifecycle code.

i18n is not applicable because this does not change admin UI. A changeset is not applicable because `infra/emdash-bot` is private infrastructure. A Discussion is not required for this bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not visual.

- `pnpm build`
- `pnpm -s lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter @emdash-cms/emdash-bot test:unit` → 232 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` → 46 passed
- `pnpm --filter @emdash-cms/emdash-bot build`
- `docker build --platform linux/amd64 -t emdash-bot-sandbox:lifecycle .`
- `docker run --rm --platform linux/amd64 --entrypoint /bin/sh emdash-bot-sandbox:lifecycle -c 'node --version && pnpm --version && git --version && agent-browser --version'` → passed (`node` 22.21.0, `pnpm` 11.1.3, `git` 2.34.1, `agent-browser` 0.30.1)

The updated `linux/amd64` image built successfully on Colima from `cloudflare/sandbox:0.12.3` and passed the runtime tool smoke check.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-bot-sandbox-lifecycle-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/bot-sandbox-lifecycle`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
