### PR TITLE
fix(bot): summarize and resume timed-out runs

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -14,6 +14,7 @@ import {
 	useAgentFinish,
 	useAgentStart,
 	useDataWriter,
+	useDelivery,
 	useInitialData,
 	useModel,
 	usePersistentState,
@@ -53,6 +54,7 @@ import {
 } from "../lib/github.js";
 import { applyInvestigationResult } from "../lib/investigation-result.js";
 import { FLUE_RUN_TIMEOUT_MS, SANDBOX_SLEEP_AFTER_SECONDS } from "../lib/run-policy.js";
+import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/timeout-recovery.js";
 import { untarInto } from "../lib/untar.js";
 import {
 	assertVerificationCommand,
@@ -189,6 +191,7 @@ interface RunFailure {
 
 export function Investigate({ id }: AgentProps) {
 	const input = useInitialData<InvestigateData>();
+	const delivery = useDelivery();
 	const [setupComplete, setSetupComplete] = usePersistentState("setup-complete", false);
 	const [reported, setReported] = usePersistentState("reported", false);
 	const [reminded, setReminded] = usePersistentState("report-reminded", false);
@@ -202,9 +205,13 @@ export function Investigate({ id }: AgentProps) {
 	);
 	const [lastFailure, setLastFailure] = usePersistentState<RunFailure | null>("last-failure", null);
 	const writeResult = useDataWriter("investigation", { schema: reportedResultSchema });
-	const env = execEnvFor(id, input);
 
 	useModel("cloudflare/@cf/moonshotai/kimi-k2.7-code");
+	if (isTimeoutSummaryDelivery(delivery)) {
+		return buildTimeoutSummaryPrompt({ mode: input.mode, verification, lastFailure });
+	}
+
+	const env = execEnvFor(id, input);
 
 	if (input.mode === "implement") {
 		useSkill(implementSkill);

--- a/infra/emdash-bot/.flue/lib/comments.ts
+++ b/infra/emdash-bot/.flue/lib/comments.ts
@@ -27,7 +27,7 @@ export function renderReadonlyReply(state: StateId | null): string {
 		case "declined":
 			return "I declined this. Reopen with `@emdashbot reopen` if circumstances change.";
 		case "failed":
-			return "My last attempt failed. A maintainer can `@emdashbot retry` or take it over.";
+			return "My last attempt failed. A maintainer can `@emdashbot resume` if it saved a timeout checkpoint, start a fresh `@emdashbot retry`, or take it over.";
 		case "investigating":
 			return "Investigating now (reproduce + diagnose). I'll report a verdict with evidence.";
 		case "reproduced":

--- a/infra/emdash-bot/.flue/lib/machine.json
+++ b/infra/emdash-bot/.flue/lib/machine.json
@@ -111,6 +111,7 @@
 			"description": "An agent run errored or produced no usable result. Retryable -- not a dead end.",
 			"terminal": false,
 			"offeredCommands": [
+				"resume",
 				"retry",
 				"implement",
 				"repro",
@@ -243,6 +244,13 @@
 			"actors": [
 				"maintainer"
 			]
+		},
+		"resume": {
+			"description": "Continue the saved conversation and workspace from a timed-out run.",
+			"actors": [
+				"maintainer"
+			],
+			"arg": "directive"
 		},
 		"revise": {
 			"description": "Send review feedback back into the agent to update the open PR branch.",
@@ -672,6 +680,13 @@
 			"from": "declined",
 			"event": "reopen",
 			"to": "triage"
+		},
+		{
+			"from": "failed",
+			"event": "resume",
+			"to": "working",
+			"action": "investigate.resume",
+			"note": "the orchestrator replaces the fallback target with the active state saved in the timeout checkpoint"
 		},
 		{
 			"from": "failed",

--- a/infra/emdash-bot/.flue/lib/machine.ts
+++ b/infra/emdash-bot/.flue/lib/machine.ts
@@ -162,7 +162,7 @@ export const STATES: Record<StateId, StateMeta> = {
 		boardColumn: "Failed",
 		description: "An agent run errored or produced no usable result. Retryable -- not a dead end.",
 		terminal: false,
-		offeredCommands: ["retry", "implement", "repro", "investigate", "decline"],
+		offeredCommands: ["resume", "retry", "implement", "repro", "investigate", "decline"],
 	},
 
 	// -----------------------------------------------------------------------
@@ -261,6 +261,7 @@ export type CommandVerb =
 	| "repro"
 	| "implement"
 	| "retry"
+	| "resume"
 	| "revise"
 	| "confirm"
 	| "reject"
@@ -363,6 +364,11 @@ export const EVENTS: Record<EventId, EventMeta> = {
 	// description has to say what it actually does. After `implement`/`revise`,
 	// re-issue the original command verb instead.
 	retry: { description: "Re-run the bug reproduction pipeline.", actors: ["maintainer"] },
+	resume: {
+		description: "Continue the saved conversation and workspace from a timed-out run.",
+		actors: ["maintainer"],
+		arg: "directive",
+	},
 	revise: {
 		description: "Send review feedback back into the agent to update the open PR branch.",
 		actors: ["maintainer"],
@@ -492,6 +498,7 @@ export type ActionId =
 	| "investigate.repro" // bug repro -> diagnose -> verify -> fix
 	| "investigate.implement" // directed build/fix (sets maintainerDirective)
 	| "investigate.revise" // re-run against existing bot/fix-<n> with PR feedback
+	| "investigate.resume" // continue the saved timed-out agent conversation and workspace
 	| "openPr" // push branch (already done) + gh pr create
 	| "closePr" // close the bot PR
 	// --- next-generation actions ---
@@ -646,6 +653,13 @@ export const TRANSITIONS: Transition[] = [
 	{ from: "declined", event: "reopen", to: "triage" },
 
 	// --- failed: retryable ---
+	{
+		from: "failed",
+		event: "resume",
+		to: "working",
+		action: "investigate.resume",
+		note: "the orchestrator replaces the fallback target with the active state saved in the timeout checkpoint",
+	},
 	{ from: "failed", event: "retry", to: "working", action: "investigate.repro" },
 	{ from: "failed", event: "implement", to: "fixing", action: "investigate.implement" },
 	{ from: "failed", event: "repro", to: "working", action: "investigate.repro" },

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -4,7 +4,7 @@
 // the canonical state for that issue's bot lifecycle. Labels on GitHub are a
 // projection of this state, not the source of truth.
 
-import { dispatch } from "@flue/runtime";
+import { dispatch, init } from "@flue/runtime";
 import { DurableObject } from "cloudflare:workers";
 
 import { Investigate } from "../agents/investigate.js";
@@ -54,6 +54,13 @@ import {
 } from "./router.js";
 import { DEADLINE_WARNING_MESSAGE, runBudgetMs, runSchedule } from "./run-policy.js";
 import { DeadlineExceededError, withDeadline } from "./sandbox-deadline.js";
+import {
+	normalizeTimeoutSummary,
+	RESUME_SIGNAL_TYPE,
+	resumeStateForMode,
+	TIMEOUT_SUMMARY_SIGNAL_TYPE,
+	TIMEOUT_SUMMARY_TIMEOUT_MS,
+} from "./timeout-recovery.js";
 
 /**
  * Inert states cannot be advanced by a late-arriving agent result. If a run
@@ -220,6 +227,8 @@ const STORAGE = {
 	lastDiagnosis: "o:lastDiagnosis",
 	deadlineWarningSentRunId: "o:deadlineWarningSentRunId",
 	deadlineWarningRetryAt: "o:deadlineWarningRetryAt",
+	resumableRun: "o:resumableRun",
+	pendingResume: "o:pendingResume",
 } as const;
 
 const TICK_INTERVAL_MS = 60 * 60 * 1000;
@@ -259,6 +268,26 @@ interface PreparedInvestigation {
 
 interface PendingDispatch extends PreparedInvestigation {
 	readonly deliveryId?: string;
+}
+
+export interface ResumableRunCheckpoint {
+	readonly runId: string;
+	readonly agentId: string;
+	readonly mode: InvestigationMode;
+	readonly state: StateId;
+	readonly attemptStartedAt: number;
+	readonly timedOutAt: number;
+	readonly summary: string | null;
+}
+
+interface PreparedResume {
+	readonly checkpoint: ResumableRunCheckpoint;
+	readonly directive: string | null;
+	readonly deliveryId?: string;
+}
+
+interface PendingResume extends PreparedResume {
+	readonly dryRun: boolean;
 }
 
 interface PendingSideEffect {
@@ -329,8 +358,9 @@ export class OrchestratorDO extends DurableObject<Env> {
 		const resumedDispatch = input.deliveryId
 			? await this.resumePendingDispatch(input.deliveryId)
 			: false;
+		const resumedRun = input.deliveryId ? await this.resumePendingRun(input.deliveryId) : false;
 		await this.drainPendingSideEffects();
-		if (resumedDispatch && input.deliveryId) {
+		if ((resumedDispatch || resumedRun) && input.deliveryId) {
 			await this.recordDelivery(input.deliveryId);
 			return { kind: "recovered" };
 		}
@@ -361,12 +391,17 @@ export class OrchestratorDO extends DurableObject<Env> {
 		// back to the webhook's snapshot for first-time mentions.
 		const persistedLabels = await this.projectLabels();
 		const labels = persistedLabels.length > 0 ? persistedLabels : input.labels;
+		const resumableRun =
+			resolvedEvent === "resume"
+				? ((await this.ctx.storage.get<ResumableRunCheckpoint>(STORAGE.resumableRun)) ?? null)
+				: null;
 
 		const decision = resolve({
 			labels,
 			event: resolvedEvent,
 			arg: resolvedArg,
 			actor: input.actor,
+			...(resumableRun ? { resumeState: resumableRun.state } : {}),
 		});
 
 		if (decision.kind === "noop") {
@@ -378,10 +413,22 @@ export class OrchestratorDO extends DurableObject<Env> {
 			if (input.deliveryId) await this.recordDelivery(input.deliveryId);
 			return { kind: "readonly", state: decision.state, event: decision.event };
 		}
+		if (resolvedEvent === "resume" && !resumableRun) {
+			if (!input.dryRun) await this.postResumeUnavailable(input);
+			if (input.deliveryId) await this.recordDelivery(input.deliveryId);
+			return { kind: "noop", reason: "no saved timed-out run to resume" };
+		}
 
 		let runError: string | null = null;
 		let preparedInvestigation: PreparedInvestigation | null = null;
-		if (decision.action?.startsWith("investigate.")) {
+		let preparedResume: PreparedResume | null = null;
+		if (decision.action === "investigate.resume" && resumableRun) {
+			preparedResume = {
+				checkpoint: resumableRun,
+				directive: resolvedArg ?? input.arg,
+				...(input.deliveryId ? { deliveryId: input.deliveryId } : {}),
+			};
+		} else if (decision.action?.startsWith("investigate.")) {
 			const preparation = await this.prepareInvestigation(
 				decision,
 				resolvedArg ?? input.arg,
@@ -398,11 +445,18 @@ export class OrchestratorDO extends DurableObject<Env> {
 			throw new Error(runError);
 		}
 
-		const sideEffectId = await this.persistDecision(decision, input, preparedInvestigation);
+		const sideEffectId = await this.persistDecision(
+			decision,
+			input,
+			preparedInvestigation,
+			preparedResume,
+		);
 		await this.armAlarm();
 
 		if (preparedInvestigation) {
 			runError = await this.dispatchInvestigation(preparedInvestigation);
+		} else if (preparedResume) {
+			runError = await this.dispatchResumedRun(preparedResume, input.dryRun === true);
 		} else if (decision.action === "closePr") {
 			await this.ctx.storage.delete(STORAGE.prNumber);
 		}
@@ -446,6 +500,8 @@ export class OrchestratorDO extends DurableObject<Env> {
 		if (currentRunId !== input.runId) {
 			return { kind: "stale-run", runId: input.runId, currentRunId: currentRunId ?? null };
 		}
+		const savedRun = await this.ctx.storage.get<ResumableRunCheckpoint>(STORAGE.resumableRun);
+		if (savedRun?.runId === input.runId) await this.ctx.storage.delete(STORAGE.resumableRun);
 		await this.confirmDispatchAdmission(input.runId);
 		const settledRuns = await this.drainPendingSideEffects();
 		if (settledRuns.has(input.runId)) return { kind: "recovered" };
@@ -868,7 +924,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 		await withDeadline(
 			dispatch(Investigate, {
 				id: input.agentId,
-				idempotencyKey: `deadline-warning:${input.runId}`,
+				idempotencyKey: `deadline-warning:${input.runId}:${input.deadlineAt}`,
 				message: {
 					kind: "signal",
 					type: "investigation.deadline-warning",
@@ -899,10 +955,64 @@ export class OrchestratorDO extends DurableObject<Env> {
 		});
 	}
 
+	private async requestTimeoutSummary(input: {
+		runId: string;
+		agentId: string;
+		mode: InvestigationMode;
+		attemptStartedAt: number;
+	}): Promise<string> {
+		const handle = init(Investigate, { id: input.agentId });
+		let receipt: Awaited<ReturnType<typeof handle.dispatch>>;
+		try {
+			receipt = await withDeadline(
+				handle.dispatch({
+					idempotencyKey: `timeout-summary:${input.runId}:${input.attemptStartedAt}`,
+					message: {
+						kind: "signal",
+						type: TIMEOUT_SUMMARY_SIGNAL_TYPE,
+						tagName: "timeout-summary",
+						attributes: { runId: input.runId, mode: input.mode },
+						body: "Execution has stopped. Provide the tool-free timeout checkpoint summary now.",
+					},
+				}),
+				DISPATCH_TIMEOUT_MS,
+				"Timeout summary admission",
+			);
+		} catch (error) {
+			console.error("[orchestrator] timeout summary admission failed", {
+				runId: input.runId,
+				error: errorMessage(error),
+			});
+			return normalizeTimeoutSummary("");
+		}
+
+		try {
+			const reply = await handle.read(receipt, {
+				signal: AbortSignal.timeout(TIMEOUT_SUMMARY_TIMEOUT_MS),
+			});
+			return normalizeTimeoutSummary(reply.text);
+		} catch (error) {
+			console.error("[orchestrator] timeout summary failed", {
+				runId: input.runId,
+				error: errorMessage(error),
+			});
+			try {
+				await handle.abort();
+			} catch (abortError) {
+				console.error("[orchestrator] timeout summary abort failed", {
+					runId: input.runId,
+					error: errorMessage(abortError),
+				});
+			}
+			return normalizeTimeoutSummary("");
+		}
+	}
+
 	private async recoverStaleRun(now: number): Promise<boolean> {
-		const [startedAt, mode] = await Promise.all([
+		const [startedAt, mode, state] = await Promise.all([
 			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
 			this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
+			this.ctx.storage.get<StateId>(STORAGE.state),
 		]);
 		if (startedAt === undefined) return false;
 		if (now - startedAt < runBudgetMs(mode ?? "repro")) return false;
@@ -924,6 +1034,35 @@ export class OrchestratorDO extends DurableObject<Env> {
 			await this.ctx.storage.put(STORAGE.abortConfirmedRunId, runId);
 		}
 		await this.discardLaunchSideEffects(runId);
+		const effectiveMode = mode ?? "repro";
+		const resumeState =
+			state === "working" || state === "investigating" || state === "fixing"
+				? state
+				: resumeStateForMode(effectiveMode);
+		const existing = await this.ctx.storage.get<ResumableRunCheckpoint>(STORAGE.resumableRun);
+		let checkpoint: ResumableRunCheckpoint =
+			existing?.runId === runId && existing.attemptStartedAt === startedAt
+				? existing
+				: {
+						runId,
+						agentId,
+						mode: effectiveMode,
+						state: resumeState,
+						attemptStartedAt: startedAt,
+						timedOutAt: now,
+						summary: null,
+					};
+		await this.ctx.storage.put(STORAGE.resumableRun, checkpoint);
+		if (checkpoint.summary === null) {
+			const summary = await this.requestTimeoutSummary({
+				runId,
+				agentId,
+				mode: effectiveMode,
+				attemptStartedAt: startedAt,
+			});
+			checkpoint = { ...checkpoint, summary };
+			await this.ctx.storage.put(STORAGE.resumableRun, checkpoint);
+		}
 
 		// Commit the failed transition before deleting retry evidence. If this
 		// throws, the run markers remain and the next alarm retries recovery.
@@ -934,7 +1073,9 @@ export class OrchestratorDO extends DurableObject<Env> {
 			actor: "system",
 			labels,
 			needsClassify: false,
-			agentSummary: "I couldn't complete this run before its durability deadline.",
+			agentSummary: `${checkpoint.summary}\n\nThe conversation and workspace are saved. A maintainer can continue them with \`@emdashbot resume\`.`,
+			agentFailureStage: "timeout",
+			agentRunId: runId,
 			settlesRunId: runId,
 		});
 		await this.clearRun(runId);
@@ -1256,6 +1397,58 @@ export class OrchestratorDO extends DurableObject<Env> {
 		return null;
 	}
 
+	private async dispatchResumedRun(
+		prepared: PreparedResume,
+		dryRun: boolean,
+	): Promise<string | null> {
+		if (dryRun) {
+			await this.ctx.storage.transaction(async (transaction) => {
+				if ((await transaction.get<string>(STORAGE.currentRunId)) !== prepared.checkpoint.runId)
+					return;
+				await Promise.all([
+					transaction.delete(STORAGE.pendingResume),
+					transaction.delete(STORAGE.resumableRun),
+				]);
+			});
+			return null;
+		}
+
+		const idempotencyKey = `resume:${prepared.checkpoint.runId}:${prepared.deliveryId ?? prepared.checkpoint.timedOutAt}`;
+		let receipt: Awaited<ReturnType<typeof dispatch>>;
+		try {
+			receipt = await withDeadline(
+				dispatch(Investigate, {
+					id: prepared.checkpoint.agentId,
+					idempotencyKey,
+					message: {
+						kind: "signal",
+						type: RESUME_SIGNAL_TYPE,
+						tagName: "resume",
+						attributes: { runId: prepared.checkpoint.runId },
+						body: prepared.directive
+							? `Resume the saved run. Additional maintainer directive: ${prepared.directive}`
+							: "Resume the saved run from its timeout checkpoint and continue toward a verified report.",
+					},
+				}),
+				DISPATCH_TIMEOUT_MS,
+				"Investigation resume admission",
+			);
+		} catch (error) {
+			return `dispatch(resume) failed: ${errorMessage(error)}`;
+		}
+
+		await this.ctx.storage.transaction(async (transaction) => {
+			if ((await transaction.get<string>(STORAGE.currentRunId)) !== prepared.checkpoint.runId)
+				return;
+			await Promise.all([
+				transaction.put(STORAGE.currentDispatchId, receipt.submissionId),
+				transaction.delete(STORAGE.pendingResume),
+				transaction.delete(STORAGE.resumableRun),
+			]);
+		});
+		return null;
+	}
+
 	private async recordDispatchFailure(
 		runId: string,
 		attemptId: string,
@@ -1405,6 +1598,26 @@ export class OrchestratorDO extends DurableObject<Env> {
 		}
 	}
 
+	private async postResumeUnavailable(input: NormalizedEvent): Promise<void> {
+		const anchorNumber =
+			input.anchorNumber ?? (await this.ctx.storage.get<number>(STORAGE.anchorNumber));
+		if (anchorNumber === undefined) {
+			if (import.meta.env.DEV) return;
+			throw new Error("no anchor number for resume reply");
+		}
+		const id = await this.persistStandaloneSideEffect({
+			anchorNumber,
+			commentBody:
+				"There isn't a saved timed-out run to resume. Start a fresh run with `@emdashbot retry`, `@emdashbot investigate`, or `@emdashbot implement <directive>`.",
+			...(input.deliveryId ? { deliveryId: input.deliveryId } : {}),
+		});
+		await this.armAlarm();
+		await this.drainPendingSideEffects();
+		if (await this.hasPendingSideEffect(id)) {
+			throw new Error("resume reply is queued behind an earlier GitHub projection");
+		}
+	}
+
 	// ---------------- Side effects (GitHub) ----------------
 
 	private async flushPendingSideEffect(id: string): Promise<void> {
@@ -1499,6 +1712,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 		decision: Extract<Decision, { kind: "transition" }>,
 		input: NormalizedEvent,
 		preparedInvestigation: PreparedInvestigation | null = null,
+		preparedResume: PreparedResume | null = null,
 	): Promise<string | null> {
 		const sideEffectId = input.dryRun ? null : crypto.randomUUID();
 		return this.ctx.storage.transaction(async (transaction) => {
@@ -1556,11 +1770,35 @@ export class OrchestratorDO extends DurableObject<Env> {
 						...preparedInvestigation,
 						...(input.deliveryId ? { deliveryId: input.deliveryId } : {}),
 					} satisfies PendingDispatch),
+					transaction.delete(STORAGE.resumableRun),
 				);
+			}
+			if (preparedResume) {
+				puts.push(
+					transaction.put(STORAGE.currentRunId, preparedResume.checkpoint.runId),
+					transaction.put(STORAGE.currentRunMode, preparedResume.checkpoint.mode),
+					transaction.put(STORAGE.currentRunStartedAt, Date.now()),
+					transaction.put(STORAGE.currentAgentId, preparedResume.checkpoint.agentId),
+					transaction.delete(STORAGE.deadlineWarningSentRunId),
+					transaction.delete(STORAGE.deadlineWarningRetryAt),
+					transaction.put(STORAGE.pendingResume, {
+						...preparedResume,
+						dryRun: input.dryRun === true,
+					} satisfies PendingResume),
+				);
+			}
+			if (
+				!preparedResume &&
+				(decision.event === "reset" ||
+					decision.event === "decline" ||
+					decision.event === "take_over")
+			) {
+				puts.push(transaction.delete(STORAGE.resumableRun));
 			}
 			const anchorNumber =
 				input.anchorNumber ?? (await transaction.get<number>(STORAGE.anchorNumber));
-			const effectRunId = preparedInvestigation?.runId ?? input.settlesRunId;
+			const effectRunId =
+				preparedInvestigation?.runId ?? preparedResume?.checkpoint.runId ?? input.settlesRunId;
 			if (sideEffectId && anchorNumber !== undefined) {
 				const pending =
 					(await transaction.get<PendingSideEffect[]>(STORAGE.pendingSideEffects)) ?? [];
@@ -1654,6 +1892,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 			]);
 			const pending = await transaction.get<PendingDispatch>(STORAGE.pendingDispatch);
 			if (pending?.runId === expectedRunId) await transaction.delete(STORAGE.pendingDispatch);
+			const pendingResume = await transaction.get<PendingResume>(STORAGE.pendingResume);
+			if (pendingResume?.checkpoint.runId === expectedRunId) {
+				await transaction.delete(STORAGE.pendingResume);
+			}
 		});
 	}
 
@@ -1671,12 +1913,21 @@ export class OrchestratorDO extends DurableObject<Env> {
 		return true;
 	}
 
+	private async resumePendingRun(deliveryId: string): Promise<boolean> {
+		const pending = await this.ctx.storage.get<PendingResume>(STORAGE.pendingResume);
+		if (pending?.deliveryId !== deliveryId) return false;
+		const runError = await this.dispatchResumedRun(pending, pending.dryRun);
+		if (runError) throw new Error(runError);
+		return true;
+	}
+
 	private async drainPendingSideEffects(): Promise<Set<string>> {
 		const settledRuns = new Set<string>();
 		for (;;) {
-			const [effects, pendingDispatch] = await Promise.all([
+			const [effects, pendingDispatch, pendingResume] = await Promise.all([
 				this.ctx.storage.get<PendingSideEffect[]>(STORAGE.pendingSideEffects),
 				this.ctx.storage.get<PendingDispatch>(STORAGE.pendingDispatch),
+				this.ctx.storage.get<PendingResume>(STORAGE.pendingResume),
 			]);
 			const effect = effects?.[0];
 			if (!effect) return settledRuns;
@@ -1687,7 +1938,8 @@ export class OrchestratorDO extends DurableObject<Env> {
 			if (
 				!effect.settlesRun &&
 				effect.runId !== undefined &&
-				effect.runId === pendingDispatch?.runId
+				(effect.runId === pendingDispatch?.runId ||
+					effect.runId === pendingResume?.checkpoint.runId)
 			)
 				return settledRuns;
 
@@ -1811,6 +2063,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 					transaction.delete(STORAGE.currentDispatchError),
 					transaction.delete(STORAGE.currentDispatchAttempt),
 					transaction.delete(STORAGE.pendingDispatch),
+					transaction.delete(STORAGE.pendingResume),
 					transaction.delete(STORAGE.abortConfirmedRunId),
 					transaction.delete(STORAGE.deadlineWarningSentRunId),
 					transaction.delete(STORAGE.deadlineWarningRetryAt),
@@ -1886,6 +2139,16 @@ export class OrchestratorDO extends DurableObject<Env> {
 		return (await this.ctx.storage.get<StoredDiagnosis>(STORAGE.lastDiagnosis)) ?? null;
 	}
 
+	/** Test-only: inspect the resumable checkpoint retained after a timeout. */
+	async debugGetResumableRun(): Promise<ResumableRunCheckpoint | null> {
+		return (await this.ctx.storage.get<ResumableRunCheckpoint>(STORAGE.resumableRun)) ?? null;
+	}
+
+	/** Test-only: seed a resumable checkpoint without invoking the model. */
+	async debugSetResumableRun(checkpoint: ResumableRunCheckpoint): Promise<void> {
+		await this.ctx.storage.put(STORAGE.resumableRun, checkpoint);
+	}
+
 	/** Test-only: inspect the current run's fixed deadline and warning marker. */
 	async debugGetRunSchedule(): Promise<{
 		deadlineAt: number | null;
@@ -1944,6 +2207,15 @@ export class OrchestratorDO extends DurableObject<Env> {
 	async debugPrimeFixing(anchorNumber: number): Promise<void> {
 		await Promise.all([
 			this.ctx.storage.put(STORAGE.state, "fixing" satisfies StateId),
+			this.ctx.storage.put(STORAGE.kind, "enhancement" satisfies Kind),
+			this.ctx.storage.put(STORAGE.anchorNumber, anchorNumber),
+		]);
+	}
+
+	/** Test-only: land in `failed` without dispatching an investigate run. */
+	async debugPrimeFailed(anchorNumber: number): Promise<void> {
+		await Promise.all([
+			this.ctx.storage.put(STORAGE.state, "failed" satisfies StateId),
 			this.ctx.storage.put(STORAGE.kind, "enhancement" satisfies Kind),
 			this.ctx.storage.put(STORAGE.anchorNumber, anchorNumber),
 		]);

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -144,6 +144,8 @@ export interface NormalizedEvent {
 	readonly commentFirst?: boolean;
 	/** Internal callback metadata: this event's projection completes the run. */
 	readonly settlesRunId?: string;
+	/** Delivery consumed with an internally synthesized recovery transition. */
+	readonly settlesDeliveryId?: string;
 }
 
 /**
@@ -1020,7 +1022,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 		if (now - startedAt < runBudgetMs(mode ?? "repro")) return false;
 		const runId = await this.ctx.storage.get<string>(STORAGE.currentRunId);
 		const agentId = await this.ctx.storage.get<string>(STORAGE.currentAgentId);
-		const pendingDispatch = await this.ctx.storage.get<PendingDispatch>(STORAGE.pendingDispatch);
+		const [pendingDispatch, pendingResume] = await Promise.all([
+			this.ctx.storage.get<PendingDispatch>(STORAGE.pendingDispatch),
+			this.ctx.storage.get<PendingResume>(STORAGE.pendingResume),
+		]);
 		if (!runId || !agentId) {
 			throw new Error("stale run is missing its run or agent identifier");
 		}
@@ -1065,6 +1070,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 			checkpoint = { ...checkpoint, summary };
 			await this.ctx.storage.put(STORAGE.resumableRun, checkpoint);
 		}
+		const deliveryId =
+			pendingDispatch?.runId === runId
+				? pendingDispatch.deliveryId
+				: pendingResume?.checkpoint.runId === runId
+					? pendingResume.deliveryId
+					: undefined;
 
 		// Commit the failed transition before deleting retry evidence. If this
 		// throws, the run markers remain and the next alarm retries recovery.
@@ -1079,11 +1090,9 @@ export class OrchestratorDO extends DurableObject<Env> {
 			agentFailureStage: "timeout",
 			agentRunId: runId,
 			settlesRunId: runId,
+			...(deliveryId ? { settlesDeliveryId: deliveryId } : {}),
 		});
 		await this.clearRun(runId);
-		if (pendingDispatch?.runId === runId && pendingDispatch.deliveryId) {
-			await this.recordDelivery(pendingDispatch.deliveryId);
-		}
 		return true;
 	}
 
@@ -1444,18 +1453,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			}),
 		);
 		const persistReceipt = async (receipt: Awaited<typeof dispatchPromise>) => {
-			await this.ctx.storage.transaction(async (transaction) => {
-				if ((await transaction.get<string>(STORAGE.currentRunId)) !== prepared.checkpoint.runId)
-					return;
-				if ((await transaction.get<string>(STORAGE.currentDispatchAttempt)) !== attemptId) return;
-				await Promise.all([
-					transaction.put(STORAGE.currentDispatchId, receipt.submissionId),
-					transaction.delete(STORAGE.currentDispatchAttempt),
-					transaction.delete(STORAGE.currentDispatchError),
-					transaction.delete(STORAGE.pendingResume),
-					transaction.delete(STORAGE.resumableRun),
-				]);
-			});
+			await this.persistResumeReceipt(prepared, attemptId, receipt.submissionId);
 		};
 		this.ctx.waitUntil(
 			dispatchPromise.then(
@@ -1501,6 +1499,36 @@ export class OrchestratorDO extends DurableObject<Env> {
 			return `dispatch(resume) receipt persistence uncertain: ${errorMessage(error)}`;
 		}
 		return null;
+	}
+
+	private async persistResumeReceipt(
+		prepared: PreparedResume,
+		attemptId: string,
+		submissionId: string,
+	): Promise<void> {
+		await this.ctx.storage.transaction(async (transaction) => {
+			if ((await transaction.get<string>(STORAGE.currentRunId)) !== prepared.checkpoint.runId)
+				return;
+			if ((await transaction.get<string>(STORAGE.currentDispatchAttempt)) !== attemptId) return;
+			const seen = prepared.deliveryId
+				? ((await transaction.get<string[]>(STORAGE.seenDeliveries)) ?? [])
+				: null;
+			await Promise.all([
+				transaction.put(STORAGE.currentDispatchId, submissionId),
+				transaction.delete(STORAGE.currentDispatchAttempt),
+				transaction.delete(STORAGE.currentDispatchError),
+				transaction.delete(STORAGE.pendingResume),
+				transaction.delete(STORAGE.resumableRun),
+				...(prepared.deliveryId && seen && !seen.includes(prepared.deliveryId)
+					? [
+							transaction.put(
+								STORAGE.seenDeliveries,
+								[...seen, prepared.deliveryId].slice(-DELIVERY_DEDUPE_LIMIT),
+							),
+						]
+					: []),
+			]);
+		});
 	}
 
 	private async recordDispatchFailure(
@@ -1787,6 +1815,17 @@ export class OrchestratorDO extends DurableObject<Env> {
 					? transaction.put(STORAGE.awaitingReporterSince, Date.now())
 					: transaction.delete(STORAGE.awaitingReporterSince),
 			];
+			if (input.settlesDeliveryId) {
+				const seen = (await transaction.get<string[]>(STORAGE.seenDeliveries)) ?? [];
+				if (!seen.includes(input.settlesDeliveryId)) {
+					puts.push(
+						transaction.put(
+							STORAGE.seenDeliveries,
+							[...seen, input.settlesDeliveryId].slice(-DELIVERY_DEDUPE_LIMIT),
+						),
+					);
+				}
+			}
 			if (decision.to === "preview_building") {
 				const startedAt = Date.now();
 				puts.push(
@@ -1853,6 +1892,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 				input.anchorNumber ?? (await transaction.get<number>(STORAGE.anchorNumber));
 			const effectRunId =
 				preparedInvestigation?.runId ?? preparedResume?.checkpoint.runId ?? input.settlesRunId;
+			const effectDeliveryId = input.settlesDeliveryId ?? input.deliveryId;
 			if (sideEffectId && anchorNumber !== undefined) {
 				const pending =
 					(await transaction.get<PendingSideEffect[]>(STORAGE.pendingSideEffects)) ?? [];
@@ -1861,7 +1901,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 						...pending,
 						{
 							id: sideEffectId,
-							...(input.deliveryId ? { deliveryId: input.deliveryId } : {}),
+							...(effectDeliveryId ? { deliveryId: effectDeliveryId } : {}),
 							...(effectRunId ? { runId: effectRunId } : {}),
 							settlesRun: input.settlesRunId !== undefined,
 							anchorNumber,
@@ -2370,6 +2410,16 @@ export class OrchestratorDO extends DurableObject<Env> {
 				? [this.ctx.storage.put(STORAGE.currentDispatchAttempt, input.dispatchAttempt)]
 				: []),
 		]);
+	}
+
+	/** Test-only: confirm a synthetic resume admission receipt. */
+	async debugConfirmPendingResumeReceipt(submissionId: string): Promise<void> {
+		const [pending, attemptId] = await Promise.all([
+			this.ctx.storage.get<PendingResume>(STORAGE.pendingResume),
+			this.ctx.storage.get<string>(STORAGE.currentDispatchAttempt),
+		]);
+		if (!pending || !attemptId) throw new Error("no pending resume admission");
+		await this.persistResumeReceipt(pending, attemptId, submissionId);
 	}
 }
 

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -2050,19 +2050,26 @@ export class OrchestratorDO extends DurableObject<Env> {
 
 	private async confirmDispatchAdmission(runId: string): Promise<void> {
 		await this.ctx.storage.transaction(async (transaction) => {
-			const pending = await transaction.get<PendingDispatch>(STORAGE.pendingDispatch);
-			if (pending?.runId !== runId) return;
-			if (pending.deliveryId) {
+			const [pendingDispatch, pendingResume] = await Promise.all([
+				transaction.get<PendingDispatch>(STORAGE.pendingDispatch),
+				transaction.get<PendingResume>(STORAGE.pendingResume),
+			]);
+			const matchesDispatch = pendingDispatch?.runId === runId;
+			const matchesResume = pendingResume?.checkpoint.runId === runId;
+			if (!matchesDispatch && !matchesResume) return;
+			const deliveryId = matchesDispatch ? pendingDispatch.deliveryId : pendingResume.deliveryId;
+			if (deliveryId) {
 				const seen = (await transaction.get<string[]>(STORAGE.seenDeliveries)) ?? [];
-				if (!seen.includes(pending.deliveryId)) {
+				if (!seen.includes(deliveryId)) {
 					await transaction.put(
 						STORAGE.seenDeliveries,
-						[...seen, pending.deliveryId].slice(-DELIVERY_DEDUPE_LIMIT),
+						[...seen, deliveryId].slice(-DELIVERY_DEDUPE_LIMIT),
 					);
 				}
 			}
 			await Promise.all([
-				transaction.delete(STORAGE.pendingDispatch),
+				...(matchesDispatch ? [transaction.delete(STORAGE.pendingDispatch)] : []),
+				...(matchesResume ? [transaction.delete(STORAGE.pendingResume)] : []),
 				transaction.delete(STORAGE.currentDispatchAttempt),
 				transaction.delete(STORAGE.currentDispatchError),
 			]);

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -845,6 +845,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			currentRunId,
 			inbox,
 			pendingSideEffects,
+			pendingResume,
 			previewPollNextAt,
 		] = await Promise.all([
 			this.ctx.storage.getAlarm(),
@@ -855,6 +856,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			this.ctx.storage.get<string>(STORAGE.currentRunId),
 			this.ctx.storage.get<InboxEntry[]>(STORAGE.inbox),
 			this.ctx.storage.get<PendingSideEffect[]>(STORAGE.pendingSideEffects),
+			this.ctx.storage.get<PendingResume>(STORAGE.pendingResume),
 			this.ctx.storage.get<number>(STORAGE.previewPollNextAt),
 		]);
 		const now = Date.now();
@@ -866,7 +868,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 				? Math.max(scheduledRunAlarm, warningRetryAt)
 				: scheduledRunAlarm;
 		let desired = now + TICK_INTERVAL_MS;
-		if (inbox?.length || pendingSideEffects?.length) {
+		if (inbox?.length || pendingSideEffects?.length || pendingResume) {
 			desired = Math.min(desired, now + INBOX_RETRY_MS);
 		}
 		if (runAlarmAt !== null) {
@@ -1086,13 +1088,15 @@ export class OrchestratorDO extends DurableObject<Env> {
 	}
 
 	private async recoverRejectedDispatch(): Promise<string | null> {
-		const [pending, dispatchError] = await Promise.all([
+		const [pending, pendingResume, dispatchError] = await Promise.all([
 			this.ctx.storage.get<PendingDispatch>(STORAGE.pendingDispatch),
+			this.ctx.storage.get<PendingResume>(STORAGE.pendingResume),
 			this.ctx.storage.get<string>(STORAGE.currentDispatchError),
 		]);
-		if (!pending || !dispatchError) return null;
+		const runId = pending?.runId ?? pendingResume?.checkpoint.runId;
+		if (!runId || !dispatchError) return null;
 
-		await this.discardLaunchSideEffects(pending.runId);
+		await this.discardLaunchSideEffects(runId);
 		const labels = await this.projectLabels();
 		await this.processEvent(
 			{
@@ -1101,14 +1105,17 @@ export class OrchestratorDO extends DurableObject<Env> {
 				actor: "system",
 				labels,
 				needsClassify: false,
-				agentSummary: `I couldn't start this run: ${dispatchError}`,
-				settlesRunId: pending.runId,
+				agentSummary: pendingResume
+					? `I couldn't resume the saved run: ${dispatchError}`
+					: `I couldn't start this run: ${dispatchError}`,
+				settlesRunId: runId,
 			},
 			false,
 		);
-		await this.clearRun(pending.runId);
-		if (pending.deliveryId) await this.recordDelivery(pending.deliveryId);
-		return pending.deliveryId ?? null;
+		await this.clearRun(runId);
+		const deliveryId = pending?.deliveryId ?? pendingResume?.deliveryId;
+		if (deliveryId) await this.recordDelivery(deliveryId);
+		return deliveryId ?? null;
 	}
 
 	private async reconcileLabels(): Promise<{ added: number; removed: number } | null> {
@@ -1414,38 +1421,85 @@ export class OrchestratorDO extends DurableObject<Env> {
 		}
 
 		const idempotencyKey = `resume:${prepared.checkpoint.runId}:${prepared.deliveryId ?? prepared.checkpoint.timedOutAt}`;
-		let receipt: Awaited<ReturnType<typeof dispatch>>;
+		const attemptId = crypto.randomUUID();
+		await this.ctx.storage.transaction(async (transaction) => {
+			await Promise.all([
+				transaction.put(STORAGE.currentDispatchAttempt, attemptId),
+				transaction.delete(STORAGE.currentDispatchError),
+			]);
+		});
+		const dispatchPromise = Promise.resolve(
+			dispatch(Investigate, {
+				id: prepared.checkpoint.agentId,
+				idempotencyKey,
+				message: {
+					kind: "signal",
+					type: RESUME_SIGNAL_TYPE,
+					tagName: "resume",
+					attributes: { runId: prepared.checkpoint.runId },
+					body: prepared.directive
+						? `Resume the saved run. Additional maintainer directive: ${prepared.directive}`
+						: "Resume the saved run from its timeout checkpoint and continue toward a verified report.",
+				},
+			}),
+		);
+		const persistReceipt = async (receipt: Awaited<typeof dispatchPromise>) => {
+			await this.ctx.storage.transaction(async (transaction) => {
+				if ((await transaction.get<string>(STORAGE.currentRunId)) !== prepared.checkpoint.runId)
+					return;
+				if ((await transaction.get<string>(STORAGE.currentDispatchAttempt)) !== attemptId) return;
+				await Promise.all([
+					transaction.put(STORAGE.currentDispatchId, receipt.submissionId),
+					transaction.delete(STORAGE.currentDispatchAttempt),
+					transaction.delete(STORAGE.currentDispatchError),
+					transaction.delete(STORAGE.pendingResume),
+					transaction.delete(STORAGE.resumableRun),
+				]);
+			});
+		};
+		this.ctx.waitUntil(
+			dispatchPromise.then(
+				(receipt) =>
+					persistReceipt(receipt).catch((error) =>
+						console.error("[orchestrator] failed to persist resume receipt", error),
+					),
+				(error) => {
+					const message = errorMessage(error);
+					console.error("[orchestrator] resume dispatch rejected", {
+						runId: prepared.checkpoint.runId,
+						error: message,
+					});
+					return this.recordDispatchFailure(prepared.checkpoint.runId, attemptId, message)
+						.then(() => this.ctx.storage.setAlarm(Date.now()))
+						.catch((persistError) =>
+							console.error("[orchestrator] failed to persist resume rejection", persistError),
+						);
+				},
+			),
+		);
+
+		let receipt: Awaited<typeof dispatchPromise>;
 		try {
 			receipt = await withDeadline(
-				dispatch(Investigate, {
-					id: prepared.checkpoint.agentId,
-					idempotencyKey,
-					message: {
-						kind: "signal",
-						type: RESUME_SIGNAL_TYPE,
-						tagName: "resume",
-						attributes: { runId: prepared.checkpoint.runId },
-						body: prepared.directive
-							? `Resume the saved run. Additional maintainer directive: ${prepared.directive}`
-							: "Resume the saved run from its timeout checkpoint and continue toward a verified report.",
-					},
-				}),
+				dispatchPromise,
 				DISPATCH_TIMEOUT_MS,
 				"Investigation resume admission",
 			);
 		} catch (error) {
-			return `dispatch(resume) failed: ${errorMessage(error)}`;
+			if (error instanceof DeadlineExceededError) {
+				return `dispatch(resume) uncertain: ${error.message}`;
+			}
+			const message = errorMessage(error);
+			await this.recordDispatchFailure(prepared.checkpoint.runId, attemptId, message);
+			await this.ctx.storage.setAlarm(Date.now());
+			return `dispatch(resume) rejected: ${message}`;
 		}
 
-		await this.ctx.storage.transaction(async (transaction) => {
-			if ((await transaction.get<string>(STORAGE.currentRunId)) !== prepared.checkpoint.runId)
-				return;
-			await Promise.all([
-				transaction.put(STORAGE.currentDispatchId, receipt.submissionId),
-				transaction.delete(STORAGE.pendingResume),
-				transaction.delete(STORAGE.resumableRun),
-			]);
-		});
+		try {
+			await persistReceipt(receipt);
+		} catch (error) {
+			return `dispatch(resume) receipt persistence uncertain: ${errorMessage(error)}`;
+		}
 		return null;
 	}
 
@@ -1914,8 +1968,14 @@ export class OrchestratorDO extends DurableObject<Env> {
 	}
 
 	private async resumePendingRun(deliveryId: string): Promise<boolean> {
-		const pending = await this.ctx.storage.get<PendingResume>(STORAGE.pendingResume);
+		const [pending, dispatchAttempt, dispatchError] = await Promise.all([
+			this.ctx.storage.get<PendingResume>(STORAGE.pendingResume),
+			this.ctx.storage.get<string>(STORAGE.currentDispatchAttempt),
+			this.ctx.storage.get<string>(STORAGE.currentDispatchError),
+		]);
 		if (pending?.deliveryId !== deliveryId) return false;
+		if (dispatchError) throw new Error(`dispatch(resume) rejected: ${dispatchError}`);
+		if (dispatchAttempt) throw new Error("dispatch(resume) admission is still uncertain");
 		const runError = await this.dispatchResumedRun(pending, pending.dryRun);
 		if (runError) throw new Error(runError);
 		return true;
@@ -2247,6 +2307,62 @@ export class OrchestratorDO extends DurableObject<Env> {
 				previousBranchSha: null,
 				context: "## Triggering directive (authoritative)\n\nTest directive",
 			} satisfies PendingDispatch),
+			...(input.dispatchError
+				? [this.ctx.storage.put(STORAGE.currentDispatchError, input.dispatchError)]
+				: []),
+			...(input.dispatchAttempt
+				? [this.ctx.storage.put(STORAGE.currentDispatchAttempt, input.dispatchAttempt)]
+				: []),
+		]);
+	}
+
+	/** Test-only: inject a rejected resume launch and its blocked projection. */
+	async debugSetPendingResume(input: {
+		runId: string;
+		agentId: string;
+		deliveryId: string;
+		startedAt: number;
+		dispatchError?: string;
+		dispatchAttempt?: string;
+	}): Promise<void> {
+		const checkpoint: ResumableRunCheckpoint = {
+			runId: input.runId,
+			agentId: input.agentId,
+			mode: "implement",
+			state: "fixing",
+			attemptStartedAt: input.startedAt - 60 * 60_000,
+			timedOutAt: input.startedAt,
+			summary: "The saved run still needs verification.",
+		};
+		await Promise.all([
+			this.ctx.storage.put(STORAGE.state, "fixing" satisfies StateId),
+			this.ctx.storage.put(STORAGE.kind, "enhancement" satisfies Kind),
+			this.ctx.storage.put(STORAGE.anchorNumber, 999),
+			this.ctx.storage.put(STORAGE.currentRunId, input.runId),
+			this.ctx.storage.put(STORAGE.currentRunMode, "implement" satisfies InvestigationMode),
+			this.ctx.storage.put(STORAGE.currentRunStartedAt, input.startedAt),
+			this.ctx.storage.put(STORAGE.currentAgentId, input.agentId),
+			this.ctx.storage.put(STORAGE.resumableRun, checkpoint),
+			this.ctx.storage.put(STORAGE.pendingResume, {
+				checkpoint,
+				directive: null,
+				deliveryId: input.deliveryId,
+				dryRun: false,
+			} satisfies PendingResume),
+			this.ctx.storage.put(STORAGE.pendingSideEffects, [
+				{
+					id: "pending-resume-projection",
+					deliveryId: input.deliveryId,
+					runId: input.runId,
+					settlesRun: false,
+					anchorNumber: 999,
+					addLabels: ["bot:fixing"],
+					removeLabels: ["bot:failed"],
+					commentBody: "",
+					commentMarker: "<!-- emdashbot-event:pending-resume-projection -->",
+					commentMayExist: false,
+				} satisfies PendingSideEffect,
+			]),
 			...(input.dispatchError
 				? [this.ctx.storage.put(STORAGE.currentDispatchError, input.dispatchError)]
 				: []),

--- a/infra/emdash-bot/.flue/lib/router.ts
+++ b/infra/emdash-bot/.flue/lib/router.ts
@@ -179,6 +179,7 @@ export interface ResolveInput {
 	event: EventId;
 	arg?: string | null;
 	actor?: Actor | "other";
+	resumeState?: StateId;
 }
 
 /**
@@ -188,7 +189,7 @@ export interface ResolveInput {
  * handler, Orchestrator DO) is responsible for actor classification but the
  * router enforces that the event's `actors` list includes the caller.
  */
-export function resolve({ labels, event, arg, actor }: ResolveInput): Decision {
+export function resolve({ labels, event, arg, actor, resumeState }: ResolveInput): Decision {
 	const from = currentState(labels);
 	const meta = EVENTS[event];
 	if (!meta) return { kind: "noop", reason: `unknown event "${event}"` };
@@ -219,7 +220,8 @@ export function resolve({ labels, event, arg, actor }: ResolveInput): Decision {
 	if (!from) return { kind: "noop", reason: "item has conflicting state labels" };
 	const t = findTransition(from, event);
 	if (!t) return { kind: "noop", reason: `no transition for ${from} + ${event}`, from };
-	const to = transitionTarget(t, currentKind(labels));
+	const to =
+		event === "resume" && resumeState ? resumeState : transitionTarget(t, currentKind(labels));
 	const toLabel = STATES[to].label;
 	const removeLabels = STATE_LABELS.filter((l) => l !== toLabel);
 

--- a/infra/emdash-bot/.flue/lib/timeout-recovery.ts
+++ b/infra/emdash-bot/.flue/lib/timeout-recovery.ts
@@ -1,0 +1,78 @@
+import type { DeliveredMessage } from "@flue/runtime";
+
+import type { StateId } from "./machine.js";
+import type { InvestigationMode } from "./router.js";
+
+export const TIMEOUT_SUMMARY_SIGNAL_TYPE = "investigation.timeout-summary";
+export const RESUME_SIGNAL_TYPE = "investigation.resume";
+export const TIMEOUT_SUMMARY_TIMEOUT_MS = 2 * 60_000;
+export const TIMEOUT_SUMMARY_MAX_CHARACTERS = 4_000;
+
+interface SummaryVerification {
+	readonly name: string;
+	readonly command: string;
+	readonly exitCode: number;
+}
+
+interface SummaryFailure {
+	readonly stage: string;
+	readonly message: string;
+}
+
+export function isTimeoutSummaryDelivery(delivery: DeliveredMessage): boolean {
+	return delivery.kind === "signal" && delivery.type === TIMEOUT_SUMMARY_SIGNAL_TYPE;
+}
+
+export function buildTimeoutSummaryPrompt(input: {
+	mode: InvestigationMode;
+	verification: readonly SummaryVerification[];
+	lastFailure: SummaryFailure | null;
+}): string {
+	const checks =
+		input.verification.length === 0
+			? "- No verification result was recorded."
+			: input.verification
+					.map(
+						(record) =>
+							`- ${record.name}: ${record.exitCode === 0 ? "passed" : `failed (exit ${record.exitCode})`} — \`${record.command}\``,
+					)
+					.join("\n");
+	const failure = input.lastFailure
+		? `\n\nLast recorded failure (${input.lastFailure.stage}): ${input.lastFailure.message}`
+		: "";
+	return [
+		`The ${input.mode} execution window has ended and execution has been stopped.`,
+		"No tools are available in this final turn. Do not attempt more investigation, edits, verification, or publication.",
+		"Summarize the useful checkpoint for a later resume in concise plain text:",
+		"- approach taken and important decisions;",
+		"- files or areas changed;",
+		"- verification that passed or failed;",
+		"- the current blocker and exact remaining work.",
+		"Do not claim a check passed or a candidate published unless the conversation proves it.",
+		"",
+		"Recorded verification:",
+		checks + failure,
+	].join("\n");
+}
+
+export function normalizeTimeoutSummary(text: string): string {
+	const summary = text.trim();
+	if (summary === "") {
+		return "The run stopped at its execution deadline before it could provide a checkpoint summary.";
+	}
+	if (summary.length <= TIMEOUT_SUMMARY_MAX_CHARACTERS) return summary;
+	return `${summary.slice(0, TIMEOUT_SUMMARY_MAX_CHARACTERS - 1)}…`;
+}
+
+export function resumeStateForMode(mode: InvestigationMode): StateId {
+	switch (mode) {
+		case "diagnose":
+			return "investigating";
+		case "implement":
+		case "fix":
+			return "fixing";
+		case "repro":
+		case "revise":
+			return "working";
+	}
+}

--- a/infra/emdash-bot/BOT_STATE_MACHINE.md
+++ b/infra/emdash-bot/BOT_STATE_MACHINE.md
@@ -17,7 +17,7 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `human_owned` | `bot:human-owned` | Human owned | no | no | `hand_back` |
 | `done` | `bot:done` | Done | yes | no | `reopen` |
 | `declined` | `bot:declined` | Declined | yes | no | `reopen` |
-| `failed` | `bot:failed` | Failed | no | no | `retry`, `implement`, `repro`, `investigate`, `decline` |
+| `failed` | `bot:failed` | Failed | no | no | `resume`, `retry`, `implement`, `repro`, `investigate`, `decline` |
 | `investigating` | `bot:investigating` | Investigating | no | yes | `status` |
 | `reproduced` | `bot:reproduced` | Reproduced | no | no | `fix`, `investigate`, `decline`, `take_over` |
 | `diagnosed` | `bot:diagnosed` | Diagnosed | no | no | `fix`, `investigate`, `decline`, `take_over` |
@@ -36,6 +36,7 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `implement` | command | maintainer | `directive` | Build the described change (feature or directed fix), skipping the bug-repro gate. |
 | `fix` | command | maintainer | `directive` | Build a candidate fix on a bot branch and post a preview for the reporter to try. |
 | `retry` | command | maintainer | — | Re-run the bug reproduction pipeline. |
+| `resume` | command | maintainer | `directive` | Continue the saved conversation and workspace from a timed-out run. |
 | `revise` | command | maintainer | `feedback` | Send review feedback back into the agent to update the open PR branch. |
 | `confirm` | command | reporter, maintainer | — | Confirm the staged fix works; open a PR. |
 | `reject` | command | reporter, maintainer | `feedback` | The staged fix does not work; retry with feedback. |
@@ -113,6 +114,7 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `human_owned` | `hand_back` | `triage` | — |
 | `done` | `reopen` | `triage` | — |
 | `declined` | `reopen` | `triage` | — |
+| `failed` | `resume` | saved: `working`, `investigating`, or `fixing` | `investigate.resume` |
 | `failed` | `retry` | `working` | `investigate.repro` |
 | `failed` | `implement` | `fixing` | `investigate.implement` |
 | `failed` | `repro` | `working` | `investigate.repro` |
@@ -212,6 +214,9 @@ stateDiagram-v2
     human_owned --> triage: hand_back
     done --> triage: reopen
     declined --> triage: reopen
+    failed --> working: resume [saved] / investigate.resume
+    failed --> investigating: resume [saved] / investigate.resume
+    failed --> fixing: resume [saved] / investigate.resume
     failed --> working: retry / investigate.repro
     failed --> fixing: implement / investigate.implement
     failed --> working: repro / investigate.repro

--- a/infra/emdash-bot/scripts/machine-artifacts.ts
+++ b/infra/emdash-bot/scripts/machine-artifacts.ts
@@ -86,6 +86,9 @@ function transitionsTable(): string {
 }
 
 function transitionDestination(transition: (typeof TRANSITIONS)[number]): string {
+	if (transition.event === "resume") {
+		return `saved: ${code("working")}, ${code("investigating")}, or ${code("fixing")}`;
+	}
 	const overrides = Object.entries(transition.toByKind ?? {});
 	if (overrides.length === 0) return code(transition.to);
 	return [
@@ -96,7 +99,10 @@ function transitionDestination(transition: (typeof TRANSITIONS)[number]): string
 
 function diagram(): string {
 	const edges = TRANSITIONS.flatMap((transition) =>
-		transitionTargets(transition).map((target) => {
+		(transition.event === "resume"
+			? (["working", "investigating", "fixing"] as const)
+			: transitionTargets(transition)
+		).map((target) => {
 			const kinds = Object.entries(transition.toByKind ?? {})
 				.filter(([, kindTarget]) => kindTarget === target)
 				.map(([kind]) => kind);
@@ -106,7 +112,7 @@ function diagram(): string {
 						? " [default]"
 						: ""
 					: ` [${kinds.join(", ")}]`;
-			return `    ${transition.from} --> ${target}: ${transition.event}${qualifier}${transition.action ? ` / ${transition.action}` : ""}`;
+			return `    ${transition.from} --> ${target}: ${transition.event}${transition.event === "resume" ? " [saved]" : qualifier}${transition.action ? ` / ${transition.action}` : ""}`;
 		}),
 	);
 	return [

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -534,6 +534,38 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect(await stub.getInboxDepth()).toBe(0);
 	});
 
+	test("a rejected resume returns to failed without discarding its checkpoint", async () => {
+		const calls: string[] = [];
+		const comments: string[] = [];
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		vi.stubGlobal("fetch", githubCallRecorder(calls, 201, comments));
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+		await stub.debugSetPendingResume({
+			runId: "rejected-resume-run",
+			agentId: "investigate-999-rejected-resume-run",
+			deliveryId: "rejected-resume",
+			startedAt: Date.now(),
+			dispatchError: "resume admission rejected",
+		});
+
+		await stub.tick();
+
+		expect(await stub.getPersistedState()).toMatchObject({
+			state: "failed",
+			currentRunId: null,
+			currentAgentId: null,
+		});
+		expect(await stub.debugGetResumableRun()).toMatchObject({
+			runId: "rejected-resume-run",
+			agentId: "investigate-999-rejected-resume-run",
+			mode: "implement",
+			state: "fixing",
+		});
+		expect(await stub.getPendingSideEffectCount()).toBe(0);
+		expect(comments.at(-1)).toContain("I couldn't resume the saved run");
+	});
+
 	test("stale recovery fails a dispatch that never admitted an agent", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		await stub.enqueue(makeEvent({ deliveryId: "missing-dispatch", anchorNumber: 999 }));

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -329,6 +329,92 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect(comments.at(-1)).toContain("Run: `implement-run-123`");
 	});
 
+	test("resume without a saved timed-out run comments and leaves the issue failed", async () => {
+		const calls: string[] = [];
+		const comments: string[] = [];
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		vi.stubGlobal("fetch", githubCallRecorder(calls, 201, comments));
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+		await stub.debugPrimeFailed(42);
+
+		const outcome = await stub.event(
+			makeEvent({
+				event: "resume",
+				arg: null,
+				anchorNumber: 42,
+				deliveryId: "resume-without-state",
+				dryRun: false,
+				labels: ["bot:enhancement", "bot:failed"],
+			}),
+		);
+
+		expect(outcome.kind).toBe("noop");
+		expect((await stub.getPersistedState()).state).toBe("failed");
+		expect(comments.at(-1)).toContain("There isn't a saved timed-out run to resume");
+	});
+
+	test("resume restores the saved run identity, mode, and active state", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugPrimeFailed(42);
+		await stub.debugSetResumableRun({
+			runId: "timed-out-run",
+			agentId: "investigate-42-timed-out-run",
+			mode: "implement",
+			state: "fixing",
+			attemptStartedAt: Date.now() - 60 * 60_000,
+			timedOutAt: Date.now(),
+			summary: "The implementation is complete but one focused test still fails.",
+		});
+
+		const outcome = await stub.event(
+			makeEvent({
+				event: "resume",
+				arg: "continue with the failing test",
+				anchorNumber: 42,
+				deliveryId: "resume-saved-run",
+				labels: ["bot:enhancement", "bot:failed"],
+			}),
+		);
+
+		expect(outcome.kind).toBe("transition");
+		if (outcome.kind === "transition") {
+			expect(outcome.decision.action).toBe("investigate.resume");
+			expect(outcome.decision.to).toBe("fixing");
+		}
+		expect(await stub.getPersistedState()).toMatchObject({
+			state: "fixing",
+			currentRunId: "timed-out-run",
+			currentAgentId: "investigate-42-timed-out-run",
+		});
+		expect(await stub.debugGetResumableRun()).toBeNull();
+	});
+
+	test("a timed-out run posts its checkpoint and resume command", async () => {
+		const calls: string[] = [];
+		const comments: string[] = [];
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		vi.stubGlobal("fetch", githubCallRecorder(calls, 201, comments));
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+		await stub.debugPrimeFixing(42);
+		await stub.debugSetStaleRun(
+			"timed-out-comment-run",
+			Date.now() - 61 * 60_000,
+			"investigate-42-timed-out-comment-run",
+			"implement",
+		);
+
+		const outcome = await stub.tick();
+		expect(outcome.droppedStaleRun).toBe(true);
+		expect(comments.at(-1)).toContain(
+			"The run stopped at its execution deadline before it could provide a checkpoint summary.",
+		);
+		expect(comments.at(-1)).toContain("`@emdashbot resume`");
+		expect(comments.at(-1)).toContain("Failed stage: `timeout`");
+		expect(comments.at(-1)).toContain("Run: `timed-out-comment-run`");
+	});
+
 	test("tick recovers a stale run", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		// Run() the DO with a synthetic stale run set in storage. The stale-
@@ -349,6 +435,12 @@ describe("OrchestratorDO (workers-pool)", () => {
 		const persisted = await stub.getPersistedState();
 		expect(persisted.currentRunId).toBe(null);
 		expect(persisted.state).toBe("failed");
+		expect(await stub.debugGetResumableRun()).toMatchObject({
+			runId: "ghost-run",
+			agentId: "investigate-999-ghost-run",
+			mode: "repro",
+			state: "fixing",
+		});
 	});
 
 	test("a failing inbox head does not block stale-run recovery", async () => {

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -566,6 +566,61 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect(comments.at(-1)).toContain("I couldn't resume the saved run");
 	});
 
+	test("a confirmed resume receipt atomically deduplicates its delivery", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetPendingResume({
+			runId: "confirmed-resume-run",
+			agentId: "investigate-999-confirmed-resume-run",
+			deliveryId: "confirmed-resume-delivery",
+			startedAt: Date.now(),
+			dispatchAttempt: "confirmed-resume-attempt",
+		});
+
+		await stub.debugConfirmPendingResumeReceipt("confirmed-resume-submission");
+		const redelivery = await stub.event(
+			makeEvent({
+				event: "resume",
+				arg: null,
+				anchorNumber: 999,
+				deliveryId: "confirmed-resume-delivery",
+				labels: ["bot:enhancement", "bot:failed"],
+			}),
+		);
+
+		expect(redelivery).toEqual({
+			kind: "duplicate",
+			deliveryId: "confirmed-resume-delivery",
+		});
+	});
+
+	test("stale recovery consumes an uncertain resume delivery", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetPendingResume({
+			runId: "uncertain-resume-run",
+			agentId: "investigate-999-abort-false-missing",
+			deliveryId: "uncertain-resume-delivery",
+			startedAt: Date.now() - 61 * 60_000,
+			dispatchAttempt: "uncertain-resume-attempt",
+		});
+
+		const recovery = await stub.tick();
+		expect(recovery.droppedStaleRun).toBe(true);
+		const redelivery = await stub.event(
+			makeEvent({
+				event: "resume",
+				arg: null,
+				anchorNumber: 999,
+				deliveryId: "uncertain-resume-delivery",
+				labels: ["bot:enhancement", "bot:failed"],
+			}),
+		);
+
+		expect(redelivery).toEqual({
+			kind: "duplicate",
+			deliveryId: "uncertain-resume-delivery",
+		});
+	});
+
 	test("stale recovery fails a dispatch that never admitted an agent", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		await stub.enqueue(makeEvent({ deliveryId: "missing-dispatch", anchorNumber: 999 }));

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -593,6 +593,39 @@ describe("OrchestratorDO (workers-pool)", () => {
 		});
 	});
 
+	test("an agent result confirms and deduplicates an uncertain resume admission", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetPendingResume({
+			runId: "completed-resume-run",
+			agentId: "investigate-999-completed-resume-run",
+			deliveryId: "completed-resume-delivery",
+			startedAt: Date.now(),
+			dispatchAttempt: "uncertain-completed-resume-attempt",
+		});
+
+		const completion = await stub.applyAgentResult({
+			runId: "completed-resume-run",
+			result: { implemented: true, summary: "Finished the resumed implementation." },
+			pushed: true,
+			ok: true,
+		});
+		expect(completion.kind).toBe("transition");
+
+		const redelivery = await stub.event(
+			makeEvent({
+				event: "resume",
+				arg: null,
+				anchorNumber: 999,
+				deliveryId: "completed-resume-delivery",
+				labels: ["bot:enhancement", "bot:failed"],
+			}),
+		);
+		expect(redelivery).toEqual({
+			kind: "duplicate",
+			deliveryId: "completed-resume-delivery",
+		});
+	});
+
 	test("stale recovery consumes an uncertain resume delivery", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		await stub.debugSetPendingResume({

--- a/infra/emdash-bot/tests/unit/classifier-client.test.ts
+++ b/infra/emdash-bot/tests/unit/classifier-client.test.ts
@@ -104,6 +104,25 @@ describe("classifyComment", () => {
 });
 
 describe("resolveClassification", () => {
+	test("accepts resume when a failed run offers it", () => {
+		const failedCommands = classifierCommands("failed");
+		expect(
+			resolveClassification(
+				{
+					event: "resume",
+					arg: "continue from the saved work",
+					reasoning: "The maintainer asks the previous run to continue",
+				},
+				failedCommands,
+			),
+		).toEqual({
+			kind: "event",
+			event: "resume",
+			arg: "continue from the saved work",
+			reasoning: "The maintainer asks the previous run to continue",
+		});
+	});
+
 	test("rejects a missing structured result", () => {
 		expect(resolveClassification(undefined, commands)).toEqual({
 			kind: "error",

--- a/infra/emdash-bot/tests/unit/router.test.ts
+++ b/infra/emdash-bot/tests/unit/router.test.ts
@@ -89,6 +89,7 @@ describe("router", () => {
 
 	test("parseCommand is strict: only an exact bare verb is deterministic", () => {
 		expect(parseCommand("@emdashbot retry")).toEqual({ event: "retry", arg: null });
+		expect(parseCommand("@emdashbot resume")).toEqual({ event: "resume", arg: null });
 		expect(parseCommand("@emdashbot take over")).toEqual({ event: "take_over", arg: null });
 		expect(parseCommand("@emdashbot confirmed")).toEqual({ event: "confirm", arg: null }); // alias
 		expect(parseCommand("@emdashbot hand back please")).toBe(null); // extra word
@@ -103,6 +104,21 @@ describe("router", () => {
 		expect(cmds.has("implement")).toBe(true);
 		expect(cmds.has("decline")).toBe(false);
 		expect(cmds.has("take_over")).toBe(false);
+	});
+
+	test("failed runs offer classifier-routable resume and restore their saved active state", () => {
+		const commands = new Set(classifierCommands("failed").map((command) => command.event));
+		expect(commands.has("resume")).toBe(true);
+
+		const decision = resolve({
+			labels: ["bot:enhancement", "bot:failed"],
+			event: "resume",
+			actor: "maintainer",
+			resumeState: "fixing",
+		});
+		assertTransition(decision);
+		expect(decision.to).toBe("fixing");
+		expect(decision.action).toBe("investigate.resume");
 	});
 
 	test("isDestructive flags decline and take_over only", () => {

--- a/infra/emdash-bot/tests/unit/timeout-recovery.test.ts
+++ b/infra/emdash-bot/tests/unit/timeout-recovery.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	buildTimeoutSummaryPrompt,
+	isTimeoutSummaryDelivery,
+	resumeStateForMode,
+} from "../../.flue/lib/timeout-recovery.js";
+
+describe("timeout recovery", () => {
+	test("recognizes only the summary-only delivery", () => {
+		expect(
+			isTimeoutSummaryDelivery({
+				kind: "signal",
+				type: "investigation.timeout-summary",
+				body: "Summarize the stopped run.",
+			}),
+		).toBe(true);
+		expect(
+			isTimeoutSummaryDelivery({
+				kind: "signal",
+				type: "investigation.resume",
+				body: "Continue the stopped run.",
+			}),
+		).toBe(false);
+	});
+
+	test("summary prompt carries known verification evidence without offering more work", () => {
+		const prompt = buildTimeoutSummaryPrompt({
+			mode: "implement",
+			verification: [
+				{ name: "typecheck", command: "pnpm typecheck", exitCode: 0 },
+				{ name: "test", command: "pnpm test", exitCode: 1 },
+			],
+			lastFailure: { stage: "verification", message: "test failed with exit 1" },
+		});
+
+		expect(prompt).toContain("No tools are available");
+		expect(prompt).toContain("typecheck: passed");
+		expect(prompt).toContain("test: failed (exit 1)");
+		expect(prompt).toContain("test failed with exit 1");
+	});
+
+	test("resume returns to the state owned by the saved run mode", () => {
+		expect(resumeStateForMode("diagnose")).toBe("investigating");
+		expect(resumeStateForMode("repro")).toBe("working");
+		expect(resumeStateForMode("revise")).toBe("working");
+		expect(resumeStateForMode("implement")).toBe("fixing");
+		expect(resumeStateForMode("fix")).toBe("fixing");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Preserves useful work when an EmDashBot implementation reaches its execution deadline.

The orchestrator now stops the tool-enabled submission, asks the same agent conversation for one bounded summary-only turn with no tools, and stores that summary with the original agent id, run id, mode, workspace, and active state. A maintainer can then use `@emdashbot resume` to continue the same conversation and durable workspace with a fresh mode-specific budget. `resume` is available to the free-text classifier as well as the exact command grammar.

If a failed issue has no timeout checkpoint, `resume` leaves the state unchanged and comments with the fresh-run commands instead of silently doing nothing. Starting a fresh run, resetting, or declining clears an obsolete checkpoint. Resumed attempts receive their own deadline warning and timeout-summary delivery ids.

If resume admission is rejected or never completes, the DO removes the blocked launch projection, returns the issue to `failed`, consumes the delivery, and retains the checkpoint for another attempt.

Related to #1623, where a healthy implementation run reached both the 30-minute and 60-minute ceilings while still making useful but unverified changes. This infrastructure change does not close the product issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Typecheck note: `pnpm --filter @emdash-cms/emdash-bot typecheck` still fails because its existing raw `wrangler types` output omits the generated Flue Durable Object and service-binding RPC types. The production Worker build and changed code compile successfully; the typecheck reports no new error in the timeout-summary or resume implementation.

i18n is not applicable because this does not change the admin UI. A changeset is not applicable because `infra/emdash-bot` is private infrastructure. A Discussion is not required for this bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not visual.

- `pnpm build`
- `pnpm -s lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter @emdash-cms/emdash-bot test:unit` → 247 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` → 56 passed
- `pnpm --filter @emdash-cms/emdash-bot build`

The Worker integration coverage verifies timeout checkpoint persistence, the summary fallback comment, restoration of the original run identity/mode/state, rejected resume recovery, accepted, uncertain, and agent-callback resume-delivery deduplication, classifier routing, and the explicit no-checkpoint reply.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-bot-resumable-timeout-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/bot-resumable-timeout`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

