### PR TITLE
fix(bot): make verification efficient and recoverable

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -58,8 +58,11 @@ import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/time
 import { untarInto } from "../lib/untar.js";
 import {
 	assertVerificationCommand,
+	assertVerificationIdentity,
+	findReusableVerificationRecord,
 	passingVerificationRecords,
 	type VerificationRecord,
+	upsertVerificationRecord,
 } from "../lib/verification.js";
 import diagnoseSkill from "../skills/diagnose/SKILL.md";
 import fixSkill from "../skills/fix/SKILL.md";
@@ -167,6 +170,7 @@ const publicationSchema = v.object({
 const verificationRecordSchema = v.object({
 	name: v.string(),
 	command: v.string(),
+	cwd: v.optional(v.string()),
 	exitCode: v.number(),
 	candidateTreeSha: v.string(),
 });
@@ -386,7 +390,7 @@ export function Investigate({ id }: AgentProps) {
 			defineTool({
 				name: "run_check",
 				description:
-					"Run a required read-only verification command and bind its real exit status to the exact candidate tree. The command must not modify source files; use edit_file/write_file for changes and check-only formatter commands. Do not add output pipelines or success fallbacks; the tool rejects them. Reuse a stable name such as test, lint, typecheck, or format when rerunning a check after a fix. Rerun every required check after any source change.",
+					"Run a required read-only verification command and bind its real exit status to the exact candidate tree. A name is permanently bound to its first command and cwd; use a new name for a different check. A passing check on the unchanged tree is reused without execution. The command must not modify source files; use edit_file/write_file for changes and check-only formatter commands. Do not add output pipelines or success fallbacks; the tool rejects them.",
 				input: v.object({
 					name: v.pipe(v.string(), v.minLength(1), v.maxLength(40)),
 					command: v.pipe(v.string(), v.minLength(1), v.maxLength(1_000)),
@@ -396,8 +400,19 @@ export function Investigate({ id }: AgentProps) {
 				async run({ data }) {
 					let result: ExecResult;
 					let candidateTreeSha: string;
+					const identity = {
+						name: data.name,
+						command: data.command,
+						...(data.cwd ? { cwd: data.cwd } : {}),
+					};
 					try {
 						assertVerificationCommand(data.command);
+						assertVerificationIdentity(verification, identity);
+						const currentTreeSha = await env.candidateTreeSha();
+						const reusable = findReusableVerificationRecord(verification, identity, currentTreeSha);
+						if (reusable) {
+							return `cached pass for ${data.name} on candidate tree ${currentTreeSha}`;
+						}
 						({ result, candidateTreeSha } = await env.runCheck(data.command, {
 							...(data.cwd ? { cwd: data.cwd } : {}),
 							...(data.timeoutMs ? { timeoutMs: data.timeoutMs } : {}),
@@ -407,12 +422,11 @@ export function Investigate({ id }: AgentProps) {
 						throw error;
 					}
 					const record = {
-						name: data.name,
-						command: data.command,
+						...identity,
 						exitCode: result.exitCode,
 						candidateTreeSha,
 					} satisfies VerificationRecord;
-					setVerification((current) => [...current, record]);
+					setVerification((current) => upsertVerificationRecord(current, record));
 					if (result.exitCode !== 0) {
 						setLastFailure({
 							stage: "verification",

--- a/infra/emdash-bot/.flue/lib/verification.ts
+++ b/infra/emdash-bot/.flue/lib/verification.ts
@@ -1,8 +1,15 @@
 export interface VerificationRecord {
 	readonly name: string;
 	readonly command: string;
+	readonly cwd?: string;
 	readonly exitCode: number;
 	readonly candidateTreeSha: string;
+}
+
+export interface VerificationIdentity {
+	readonly name: string;
+	readonly command: string;
+	readonly cwd?: string;
 }
 
 const PIPE_OPERATOR = /\|/;
@@ -25,18 +32,57 @@ export function assertVerificationCommand(command: string): void {
 	}
 }
 
+export function assertVerificationIdentity(
+	records: readonly VerificationRecord[],
+	identity: VerificationIdentity,
+): void {
+	const canonical = records.find((record) => record.name === identity.name);
+	if (!canonical || sameVerificationIdentity(canonical, identity)) return;
+	throw new Error(
+		`verification check ${identity.name} is already bound to a different command or cwd; use a new check name`,
+	);
+}
+
+export function findReusableVerificationRecord(
+	records: readonly VerificationRecord[],
+	identity: VerificationIdentity,
+	candidateTreeSha: string,
+): VerificationRecord | null {
+	for (let index = records.length - 1; index >= 0; index -= 1) {
+		const record = records[index];
+		if (
+			record &&
+			sameVerificationIdentity(record, identity) &&
+			record.exitCode === 0 &&
+			record.candidateTreeSha === candidateTreeSha
+		) {
+			return record;
+		}
+	}
+	return null;
+}
+
+export function upsertVerificationRecord(
+	records: readonly VerificationRecord[],
+	record: VerificationRecord,
+): VerificationRecord[] {
+	return [...records.filter((existing) => existing.name !== record.name), record];
+}
+
 export function passingVerificationRecords(
 	records: readonly VerificationRecord[],
 	candidateTreeSha?: string,
 ): VerificationRecord[] {
 	const latest = new Map<string, VerificationRecord>();
-	const commands = new Map<string, string>();
+	const canonical = new Map<string, VerificationRecord>();
 	for (const record of records) {
-		const previousCommand = commands.get(record.name);
-		if (previousCommand !== undefined && previousCommand !== record.command) {
-			throw new Error(`verification check ${record.name} changed command between runs`);
+		const canonicalRecord = canonical.get(record.name);
+		if (canonicalRecord === undefined) {
+			canonical.set(record.name, record);
+			latest.set(record.name, record);
+			continue;
 		}
-		commands.set(record.name, record.command);
+		if (!sameVerificationIdentity(canonicalRecord, record)) continue;
 		latest.set(record.name, record);
 	}
 	if (latest.size === 0) throw new Error("run at least one verification check before publishing");
@@ -57,4 +103,11 @@ export function passingVerificationRecords(
 		}
 	}
 	return [...latest.values()];
+}
+
+function sameVerificationIdentity(
+	left: VerificationIdentity,
+	right: VerificationIdentity,
+): boolean {
+	return left.name === right.name && left.command === right.command && left.cwd === right.cwd;
 }

--- a/infra/emdash-bot/.flue/skills/fix/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/fix/SKILL.md
@@ -44,7 +44,7 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
    - Migrations are forward-only and additive; register in `runner.ts` via `StaticMigrationProvider`.
    - Prefer additive changes. A breaking change needs an explicit changeset -- do not introduce one for an automated fix without compelling justification.
 7. **Finish the candidate tree.** Apply formatting and add the changeset now, when a published package changed. Write the changeset as release notes for someone upgrading -- lead with a verb and describe the observable effect. Adding it after verification would invalidate every recorded check.
-8. **Run one final verification pass with `run_check`.** Run the focused repro test first, then the remaining planned checks. Give each check a stable name. Run each once on the final tree; do not repeat a passing check on an unchanged tree.
+8. **Run one final verification pass with `run_check`.** Run the focused repro test first, then the remaining planned checks. A check name is permanently bound to its first command, including flags and arguments; if you need a different command, choose a new name before running it. Run each check once on the final tree; do not repeat a passing check on an unchanged tree.
 9. **Respond to relevant failures only.** Fix a regression in touched behavior or abandon the change. If you edit the candidate, rerun the planned set once on the new tree. Never edit unrelated files to make a broad lint, typecheck, or test command pass.
 10. **Publish with `publish_candidate` as soon as the planned checks pass.** Do not reproduce its work with shell commands. Report `fixed: true` only after it succeeds.
 
@@ -54,6 +54,7 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
 - Treat install and the initial workspace build as bootstrap, not verification. Reuse them for the whole run and across resume when the saved container is still available.
 - Prefer affected package checks. Run a broader root check once only when the change crosses its surface or `AGENTS.md` explicitly requires it.
 - If an affected package suite is known to exceed the remaining budget or has already timed out, do not repeat it. Run the focused relevant subsets, report the omitted suite, and preserve time to publish and report.
+- If `publish_candidate` reports that a verification check changed command between runs, stop. Existing agent tools cannot repair that verification history. Do not rerun the check or publication; report the verification-state failure.
 - Verification commands must not modify source files. Apply formatting before the final pass, then use a check-only formatter command.
 
 ## Finalization and resume

--- a/infra/emdash-bot/.flue/skills/fix/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/fix/SKILL.md
@@ -54,7 +54,7 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
 - Treat install and the initial workspace build as bootstrap, not verification. Reuse them for the whole run and across resume when the saved container is still available.
 - Prefer affected package checks. Run a broader root check once only when the change crosses its surface or `AGENTS.md` explicitly requires it.
 - If an affected package suite is known to exceed the remaining budget or has already timed out, do not repeat it. Run the focused relevant subsets, report the omitted suite, and preserve time to publish and report.
-- If `publish_candidate` reports that a verification check changed command between runs, stop. Existing agent tools cannot repair that verification history. Do not rerun the check or publication; report the verification-state failure.
+- If `run_check` reports that a name is already bound, choose a new name for the different command. The rejected command did not modify verification state; do not retry it under the bound name.
 - Verification commands must not modify source files. Apply formatting before the final pass, then use a check-only formatter command.
 
 ## Finalization and resume

--- a/infra/emdash-bot/.flue/skills/fix/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/fix/SKILL.md
@@ -12,7 +12,7 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
 ## Environment
 
 - **Edit in the VFS** with the `edit_file` / `write_file` tools; read surrounding code with `read_file` and `grep`. Every VFS edit is replayed onto the container checkout before each container command.
-- **Run final tests, lint, typecheck, and format checks through `run_check`** -- none of the toolchain exists in the VFS. Verification commands must not modify source files. Apply formatting with `edit_file`/`write_file`, then use a check-only formatter command. Use `exec` only for exploratory commands whose result is not a release gate.
+- **Run final tests, lint, typecheck, and format checks through `run_check`** -- none of the toolchain exists in the VFS. Use `exec` for the pre-edit baseline and exploratory commands whose result is not a release gate.
 
 ## Do not
 
@@ -22,13 +22,16 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
 - No `pnpm publish` / `npm publish`.
 - No drive-by edits. Touch only the files the diagnosed bug and its test need. A problem in a nearby file is a human's -- scope discipline.
 - Do not modify Lingui catalogs (`packages/admin/src/locales/*/messages.po`); the extract workflow handles them on merge.
-- Do not edit after final verification. Publication requires every latest named `run_check` result to match the exact candidate tree; rerun all required checks after any source change.
+- Do not edit after final verification. Publication requires every latest named `run_check` result to match the exact candidate tree.
 
 ## Procedure
 
 1. **Re-read diagnose's root cause and proposed fix.** That is your target and your spec. The change should land in the file and approximate line diagnose named. If your work drifts to a different file, stop -- diagnose may be wrong, in which case abandon, do not wander.
-2. **Establish a regression test where feasible.** Reproduce usually confirmed the bug without a test on disk. If the bug is unit- or integration-testable (a handler, a query, a pure function, an API route), write a `vitest` test now that fails for the reported reason, and confirm it fails in the container (`pnpm --filter <package> test <path>`) _before_ you touch the fix. A testable bug with no regression test is not fixed. If the bug only manifests in the browser (admin interaction, rendered output), do not write a browser test -- you cannot run one reliably here; verify through `agent-browser` instead and describe that manual verification so the maintainer can add a durable test when landing.
-3. **Implement the proposed fix -- the smallest change that fully resolves the bug.** Follow EmDash conventions:
+2. **Bootstrap the checkout once.** Use `exec`. If `node_modules` is missing, run `pnpm install --frozen-lockfile --prefer-offline`. If workspace build artifacts are missing, run `pnpm build`; a fresh EmDash checkout needs them before package typechecks can resolve internal declarations. Do not repeat install or build unless a manifest changed or your change affects required compiled output.
+3. **Run the clean baseline once.** Use `exec`, before editing, for the repository-required baseline. Record failures outside the diagnosed scope; do not repair them and do not register a predictably failing broad command as a final `run_check`.
+4. **Choose the final verification set.** Plan the focused repro test, affected package tests and typechecks, lint, and a check-only formatter. Use the smallest checks that cover the behavior. Do not plan a monorepo-wide suite when focused or package-level checks are authoritative.
+5. **Establish a regression test where feasible.** Reproduce usually confirmed the bug without a test on disk. If the bug is unit- or integration-testable (a handler, a query, a pure function, an API route), write a `vitest` test now that fails for the reported reason, and confirm it fails in the container (`pnpm --filter <package> test <path>`) _before_ you touch the fix. A testable bug with no regression test is not fixed. If the bug only manifests in the browser (admin interaction, rendered output), do not write a browser test -- you cannot run one reliably here; verify through `agent-browser` instead and describe that manual verification so the maintainer can add a durable test when landing.
+6. **Implement the proposed fix -- the smallest change that fully resolves the bug.** Follow EmDash conventions:
    - Internal imports end `.js`; type-only imports use `import type`.
    - State-changing routes start with `export const prerender = false;`.
    - Never interpolate values into SQL: Kysely `sql` tagged template for values, `sql.ref()` for identifiers, `validateIdentifier()` before any `sql.raw()`.
@@ -40,13 +43,24 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
    - `import.meta.env.DEV`, never `process.env.NODE_ENV`.
    - Migrations are forward-only and additive; register in `runner.ts` via `StaticMigrationProvider`.
    - Prefer additive changes. A breaking change needs an explicit changeset -- do not introduce one for an automated fix without compelling justification.
-4. **Run the repro test with `run_check`.** It must now pass. If not, your fix is wrong or incomplete -- investigate, adjust, or abandon. Never weaken the test to make it pass.
-5. **Run the affected package's suite with `run_check`.** `pnpm --filter <package> test`. New failures in tests you did not write are regressions -- fix them or abandon the whole change.
-6. **Typecheck with `run_check`.** `pnpm typecheck` for packages, `pnpm typecheck:demos` if a demo was involved. No new errors.
-7. **Lint with `run_check`.** Run `pnpm lint:quick`; a clean baseline stays clean.
-8. **Check formatting with `run_check`.** Apply any needed formatting with `edit_file`/`write_file`, then run `pnpm format:check` or the narrow check-only formatter command appropriate to the files you touched. Do not bulk-format unrelated files.
-9. **Add a changeset when a published package changed.** Create the file under `.changeset/` (patch bump for a bug fix unless diagnosis says otherwise). Write it as release notes for someone upgrading -- lead with a verb, describe the observable effect, reference the issue -- not as a commit message. Include it in your fix commit.
-10. **Publish with `publish_candidate`.** Do not reproduce its work with shell commands. Report `fixed: true` only after it succeeds.
+7. **Finish the candidate tree.** Apply formatting and add the changeset now, when a published package changed. Write the changeset as release notes for someone upgrading -- lead with a verb and describe the observable effect. Adding it after verification would invalidate every recorded check.
+8. **Run one final verification pass with `run_check`.** Run the focused repro test first, then the remaining planned checks. Give each check a stable name. Run each once on the final tree; do not repeat a passing check on an unchanged tree.
+9. **Respond to relevant failures only.** Fix a regression in touched behavior or abandon the change. If you edit the candidate, rerun the planned set once on the new tree. Never edit unrelated files to make a broad lint, typecheck, or test command pass.
+10. **Publish with `publish_candidate` as soon as the planned checks pass.** Do not reproduce its work with shell commands. Report `fixed: true` only after it succeeds.
+
+## Efficient verification
+
+- Treat coordinated edits across several files as one edit round. Do not run lint, typecheck, and tests after each individual file.
+- Treat install and the initial workspace build as bootstrap, not verification. Reuse them for the whole run and across resume when the saved container is still available.
+- Prefer affected package checks. Run a broader root check once only when the change crosses its surface or `AGENTS.md` explicitly requires it.
+- If an affected package suite is known to exceed the remaining budget or has already timed out, do not repeat it. Run the focused relevant subsets, report the omitted suite, and preserve time to publish and report.
+- Verification commands must not modify source files. Apply formatting before the final pass, then use a check-only formatter command.
+
+## Finalization and resume
+
+When a deadline warning arrives, stop investigation and broad verification. Do not start another package or root suite. Run only short missing checks from the existing plan, then publish and report. If relevant verification cannot finish, report the useful partial outcome instead of consuming the window with another long command.
+
+After a resume, follow the saved checkpoint's remaining-work list. Complete metadata such as a missing changeset before checks, then run one final verification pass. Do not reopen the diagnosis, repeat a timed-out broad suite, or investigate unrelated failures.
 
 ## When to abandon
 

--- a/infra/emdash-bot/.flue/skills/implement/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/implement/SKILL.md
@@ -10,19 +10,37 @@ A maintainer explicitly asked you to build the issue's requested change. Treat t
 ## Procedure
 
 1. Read `AGENTS.md` and the relevant implementation, tests, and contributor guidance before editing.
-2. Resolve ambiguity from existing APIs, sibling code, and backwards-compatible behavior. If a missing decision would materially change the public contract, stop and report it instead of guessing.
-3. Edit through `edit_file` and `write_file`. Keep the change scoped to the request. Do not modify `.github/workflows` or generated Lingui catalogs.
-4. Add behavior-level tests where the change has testable behavior. For a directed bug fix, follow the repository's failing-test-first rule.
-5. Use `run_check` for every final verification. At minimum run the focused test and the repository-prescribed lint/typecheck commands that apply. Verification commands must not modify source files; apply formatting with `edit_file`/`write_file`, then run a check-only formatter command. Give checks stable names when rerunning them; publication requires every latest named result to pass.
-6. Add a changeset when a published package changes. Write it as user-facing release notes.
-7. Call `publish_candidate` with a conventional commit message. The trusted Worker owns Git objects and the `bot/fix-<issue>` ref; never run `git commit`, `git push`, or create a PR yourself.
-8. Call `report_implementation` exactly once. Set `implemented: true` only after publication succeeds. Summarize the observable change and verification, not a bug verdict.
+2. Bootstrap the checkout once with `exec`, before the baseline. If `node_modules` is missing, run `pnpm install --frozen-lockfile --prefer-offline`. If workspace build artifacts are missing, run `pnpm build`; a fresh EmDash checkout needs them before package typechecks can resolve internal declarations. Do not repeat install or build unless a manifest changed or your change affects required compiled output.
+3. Run the repository-required clean baseline once with `exec`, before editing. A baseline command is diagnostic, not a final `run_check`. Record failures that are outside the requested scope; do not edit unrelated files to make the baseline pass.
+4. Choose the smallest authoritative final verification set before editing: the focused behavior test, affected package tests and typechecks, lint, and a check-only formatter. Do not plan a monorepo-wide test suite when focused or package-level checks cover the changed behavior.
+5. Resolve ambiguity from existing APIs, sibling code, and backwards-compatible behavior. If a missing decision would materially change the public contract, stop and report it instead of guessing.
+6. Edit through `edit_file` and `write_file`. Keep the change scoped to the request. Do not modify `.github/workflows` or generated Lingui catalogs.
+7. Add behavior-level tests where the change has testable behavior. For a directed bug fix, follow the repository's failing-test-first rule.
+8. Finish every candidate edit before final verification. Apply formatting and add the changeset now, when a published package changed. The changeset is part of the candidate tree, so adding it after checks would invalidate every result.
+9. Run the planned final checks through `run_check`. Use stable names and run each check once on the final candidate tree. If a relevant check fails and you edit the candidate, rerun the planned set once on the new tree. Do not repeat a passing check on an unchanged tree.
+10. Call `publish_candidate` as soon as the planned checks pass. The trusted Worker owns Git objects and the `bot/fix-<issue>` ref; never run `git commit`, `git push`, or create a PR yourself.
+11. Call `report_implementation` exactly once. Set `implemented: true` only after publication succeeds. Summarize the observable change and verification, not a bug verdict.
+
+## Verification scope
+
+- Prefer the focused regression test and affected package checks. Run a broader root check once only when the change crosses its surface or `AGENTS.md` explicitly requires it.
+- Treat install and the initial workspace build as bootstrap, not verification. Reuse them for the whole run and across resume when the saved container is still available.
+- Treat all coordinated edits for one change as one edit round. Do not run lint, typecheck, and tests after each individual file edit.
+- If a broad check already failed before your changes only in untouched files, report the baseline failure and use the narrow authoritative check for your files. Never repair unrelated failures or register a predictably failing broad command as a final `run_check`.
+- If a broad suite times out, do not immediately run it again. Run the smallest relevant subsets, report the omitted or timed-out suite, and preserve time for publication and reporting.
+- Verification commands must not modify source files. Use `edit_file` or `write_file` before the final pass, then use check-only formatter commands.
+
+## Finalization and resume
+
+When a deadline warning arrives, stop investigation and broad verification. Do not start a check that could consume the remaining window. Run only short missing checks from the existing plan, then publish and report. If relevant verification cannot finish, report the useful partial outcome instead of starting another long command.
+
+After a resume, use the saved checkpoint, candidate, and verification evidence. Complete listed metadata such as a missing changeset before checks, then make one final verification pass. Do not reopen settled design work, repeat a timed-out broad suite, or investigate unrelated failures.
 
 ## Boundaries
 
 - No direct GitHub writes, tags, package publication, or workflow edits.
 - No source-modifying commands, output pipelines, or `|| true` on final checks. `run_check` rejects candidate mutations and status-masking commands.
-- No edits after final verification. Publication requires every latest named check to match the exact candidate tree; rerun all required checks after any source change.
+- No edits after final verification. Publication requires every latest named check to match the exact candidate tree.
 - No drive-by refactors or broad cleanup.
 - Do not weaken a test to make it pass.
 

--- a/infra/emdash-bot/.flue/skills/implement/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/implement/SKILL.md
@@ -17,7 +17,7 @@ A maintainer explicitly asked you to build the issue's requested change. Treat t
 6. Edit through `edit_file` and `write_file`. Keep the change scoped to the request. Do not modify `.github/workflows` or generated Lingui catalogs.
 7. Add behavior-level tests where the change has testable behavior. For a directed bug fix, follow the repository's failing-test-first rule.
 8. Finish every candidate edit before final verification. Apply formatting and add the changeset now, when a published package changed. The changeset is part of the candidate tree, so adding it after checks would invalidate every result.
-9. Run the planned final checks through `run_check`. Use stable names and run each check once on the final candidate tree. If a relevant check fails and you edit the candidate, rerun the planned set once on the new tree. Do not repeat a passing check on an unchanged tree.
+9. Run the planned final checks through `run_check`. Use stable names and run each check once on the final candidate tree. A check name is permanently bound to its first command, including flags and arguments; if you need a different command, choose a new name before running it. If a relevant check fails and you edit the candidate, rerun the planned set once on the new tree with the original names and commands. Do not repeat a passing check on an unchanged tree.
 10. Call `publish_candidate` as soon as the planned checks pass. The trusted Worker owns Git objects and the `bot/fix-<issue>` ref; never run `git commit`, `git push`, or create a PR yourself.
 11. Call `report_implementation` exactly once. Set `implemented: true` only after publication succeeds. Summarize the observable change and verification, not a bug verdict.
 
@@ -28,6 +28,7 @@ A maintainer explicitly asked you to build the issue's requested change. Treat t
 - Treat all coordinated edits for one change as one edit round. Do not run lint, typecheck, and tests after each individual file edit.
 - If a broad check already failed before your changes only in untouched files, report the baseline failure and use the narrow authoritative check for your files. Never repair unrelated failures or register a predictably failing broad command as a final `run_check`.
 - If a broad suite times out, do not immediately run it again. Run the smallest relevant subsets, report the omitted or timed-out suite, and preserve time for publication and reporting.
+- If `publish_candidate` reports that a verification check changed command between runs, stop. Existing agent tools cannot repair that verification history. Do not rerun the check or publication; report the verification-state failure.
 - Verification commands must not modify source files. Use `edit_file` or `write_file` before the final pass, then use check-only formatter commands.
 
 ## Finalization and resume

--- a/infra/emdash-bot/.flue/skills/implement/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/implement/SKILL.md
@@ -28,7 +28,7 @@ A maintainer explicitly asked you to build the issue's requested change. Treat t
 - Treat all coordinated edits for one change as one edit round. Do not run lint, typecheck, and tests after each individual file edit.
 - If a broad check already failed before your changes only in untouched files, report the baseline failure and use the narrow authoritative check for your files. Never repair unrelated failures or register a predictably failing broad command as a final `run_check`.
 - If a broad suite times out, do not immediately run it again. Run the smallest relevant subsets, report the omitted or timed-out suite, and preserve time for publication and reporting.
-- If `publish_candidate` reports that a verification check changed command between runs, stop. Existing agent tools cannot repair that verification history. Do not rerun the check or publication; report the verification-state failure.
+- If `run_check` reports that a name is already bound, choose a new name for the different command. The rejected command did not modify verification state; do not retry it under the bound name.
 - Verification commands must not modify source files. Use `edit_file` or `write_file` before the final pass, then use check-only formatter commands.
 
 ## Finalization and resume

--- a/infra/emdash-bot/tests/unit/verification.test.ts
+++ b/infra/emdash-bot/tests/unit/verification.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "vitest";
 
 import {
 	assertVerificationCommand,
+	assertVerificationIdentity,
+	findReusableVerificationRecord,
 	passingVerificationRecords,
+	upsertVerificationRecord,
 } from "../../.flue/lib/verification.js";
 
 describe("verification commands", () => {
@@ -48,13 +51,96 @@ describe("verification commands", () => {
 		).toThrow(/tests/);
 	});
 
-	test("does not let a failed named check be replaced by a different command", () => {
+	test("ignores a conflicting legacy command and still requires the canonical check to pass", () => {
 		expect(() =>
 			passingVerificationRecords([
 				{ name: "tests", command: "pnpm test", exitCode: 1, candidateTreeSha: "tree" },
 				{ name: "tests", command: "true", exitCode: 0, candidateTreeSha: "tree" },
 			]),
-		).toThrow(/changed command/);
+		).toThrow(/tests/);
+
+		expect(
+			passingVerificationRecords([
+				{ name: "tests", command: "pnpm test", exitCode: 1, candidateTreeSha: "tree" },
+				{ name: "tests", command: "true", exitCode: 0, candidateTreeSha: "tree" },
+				{ name: "tests", command: "pnpm test", exitCode: 0, candidateTreeSha: "tree" },
+			]),
+		).toEqual([{ name: "tests", command: "pnpm test", exitCode: 0, candidateTreeSha: "tree" }]);
+	});
+
+	test("rejects command or cwd changes before they can poison verification state", () => {
+		const records = [
+			{
+				name: "tests",
+				command: "pnpm test",
+				cwd: "/workspace/repo",
+				exitCode: 0,
+				candidateTreeSha: "tree",
+			},
+		];
+
+		expect(() =>
+			assertVerificationIdentity(records, {
+				name: "tests",
+				command: "pnpm test --runInBand",
+				cwd: "/workspace/repo",
+			}),
+		).toThrow(/already bound/);
+		expect(() =>
+			assertVerificationIdentity(records, {
+				name: "tests",
+				command: "pnpm test",
+				cwd: "/workspace/other",
+			}),
+		).toThrow(/already bound/);
+		expect(() =>
+			assertVerificationIdentity(records, {
+				name: "tests",
+				command: "pnpm test",
+				cwd: "/workspace/repo",
+			}),
+		).not.toThrow();
+	});
+
+	test("reuses a passing check only on the same candidate tree", () => {
+		const records = [
+			{
+				name: "tests",
+				command: "pnpm test",
+				exitCode: 0,
+				candidateTreeSha: "verified-tree",
+			},
+		];
+		const identity = { name: "tests", command: "pnpm test" };
+
+		expect(findReusableVerificationRecord(records, identity, "verified-tree")).toEqual(records[0]);
+		expect(findReusableVerificationRecord(records, identity, "changed-tree")).toBeNull();
+		expect(
+			findReusableVerificationRecord([{ ...records[0], exitCode: 1 }], identity, "verified-tree"),
+		).toBeNull();
+	});
+
+	test("upserts one record per name and removes conflicting legacy rows", () => {
+		const replacement = {
+			name: "tests",
+			command: "pnpm test",
+			exitCode: 0,
+			candidateTreeSha: "new-tree",
+		};
+
+		expect(
+			upsertVerificationRecord(
+				[
+					{ name: "tests", command: "pnpm test", exitCode: 1, candidateTreeSha: "old" },
+					{ name: "tests", command: "true", exitCode: 0, candidateTreeSha: "old" },
+					{ name: "lint", command: "pnpm lint", exitCode: 0, candidateTreeSha: "old" },
+				],
+				replacement,
+			),
+		).toEqual([
+			{ name: "lint", command: "pnpm lint", exitCode: 0, candidateTreeSha: "old" },
+			replacement,
+		]);
 	});
 
 	test("does not publish a candidate changed after verification", () => {


### PR DESCRIPTION
## What does this PR do?

Updates EmDashBot's verification runtime and write-mode instructions so checks run once against the complete publishable candidate without creating unrecoverable verification history.

- Bootstraps fresh checkouts once with a lockfile install and workspace build, then reuses them for the run and resume.
- Requires the agent to choose a minimal authoritative verification set before editing and run it once on the final tree.
- Enforces each verification name, command, and working directory as an immutable identity before execution, upserts one record per name, reuses passing checks on unchanged trees, and safely recovers legacy conflicting histories.
- Moves formatting and changesets before final checks.
- Prevents unrelated baseline failures and timed-out broad suites from causing drive-by cleanup or immediate reruns.
- Turns the deadline warning and resume checkpoint into explicit finalization instructions: run only short missing checks, publish, and report.

This follows the repeated verification and late-publication behavior observed while EmDashBot worked on #1623.

Related to #1623.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI strings changed.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package). N/A: only the private `infra/emdash-bot` app changed.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: this is a private-infrastructure bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Non-visual bot runtime and instruction change; screenshots are not applicable.

Passed:

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 21 files, 250 tests
- `pnpm --filter @emdash-cms/emdash-bot build`
- `git diff --check`

The bot build reports the expected missing local production secrets and sandbox-denied Wrangler log-file warning, then completes successfully. No deployment was performed.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://codex-bot-verification-focus-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `codex/bot-verification-focus`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
