### PR TITLE
i18n(fr): replace byline translation

### DIFF
--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -83,7 +83,7 @@ msgstr "{0, plural, one {(# élément)} other {(# éléments)}}"
 #: packages/admin/src/components/BylineFilter.tsx:103
 #: packages/admin/src/components/BylineFilter.tsx:104
 msgid "{0, plural, one {# byline} other {# bylines}}"
-msgstr "{0, plural, one {# auteur} other {# auteurs}}"
+msgstr "{0, plural, one {# collaborateur} other {# collaborateurs}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
@@ -716,7 +716,7 @@ msgstr "Ajouter des champs"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr "Ajoutez des champs comme « Intitulé du poste » ou « Pronoms » pour enrichir chaque auteur."
+msgstr "Ajoutez des champs comme « Intitulé du poste » ou « Pronoms » pour enrichir chaque collaborateur."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:628
 msgid "Add fields to define the structure of your content"
@@ -880,7 +880,7 @@ msgstr "Tous les auteurs"
 #: packages/admin/src/components/BylineFilter.tsx:101
 #: packages/admin/src/routes/bylines.tsx:412
 msgid "All bylines"
-msgstr "Tous les auteurs"
+msgstr "Tous les collaborateurs"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:110
 msgid "All capabilities"
@@ -952,7 +952,7 @@ msgstr "Supprimez également les données de stockage du module d'extension"
 
 #: packages/admin/src/components/BylineFilter.tsx:175
 msgid "Also match the byline linked to an entry's author when it has none assigned."
-msgstr "Fait également correspondre l'auteur associé au propriétaire de l'entrée, lorsqu'aucun n'est attribué."
+msgstr "Fait également correspondre le collaborateur associé à l'auteur de l'entrée, lorsqu'aucun collaborateur n'est attribué."
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:376
 #: packages/admin/src/components/editor/ImageNode.tsx:231
@@ -1394,11 +1394,11 @@ msgstr "Liste à puces"
 #: packages/admin/src/routes/byline-schema.tsx:218
 #: packages/admin/src/routes/bylines.tsx:383
 msgid "Byline schema"
-msgstr "Schéma des auteurs"
+msgstr "Schéma des collaborateurs"
 
 #: packages/admin/src/components/Sidebar.tsx:295
 msgid "Byline Schema"
-msgstr "Schéma des auteurs"
+msgstr "Schéma des collaborateurs"
 
 #: packages/admin/src/components/BylineFilter.tsx:135
 #: packages/admin/src/components/ContentSettingsPanel.tsx:661
@@ -1406,7 +1406,7 @@ msgstr "Schéma des auteurs"
 #: packages/admin/src/components/Sidebar.tsx:285
 #: packages/admin/src/routes/bylines.tsx:375
 msgid "Bylines"
-msgstr "Auteurs"
+msgstr "Collaborateurs"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
@@ -1992,7 +1992,7 @@ msgstr "Impossible de détecter WordPress"
 
 #: packages/admin/src/routes/byline-schema.tsx:268
 msgid "Couldn't load byline fields."
-msgstr "Impossible de charger les champs d'auteur."
+msgstr "Impossible de charger les champs de collaborateur."
 
 #: packages/admin/src/routes/bylines.tsx:547
 msgid "Couldn't load custom fields."
@@ -2004,7 +2004,7 @@ msgstr "Impossible d'associer \"{draft}\" à un type MIME. Saisissez directement
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1009
 msgid "Couldn't search bylines. Please try again."
-msgstr "Impossible de rechercher des auteurs. Veuillez réessayer."
+msgstr "Impossible de rechercher des collaborateurs. Veuillez réessayer."
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
@@ -2059,7 +2059,7 @@ msgstr "Créer un compte"
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1089
 #: packages/admin/src/routes/bylines.tsx:476
 msgid "Create byline"
-msgstr "Créer un auteur"
+msgstr "Créer un collaborateur"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:575
 msgid "Create Content Type"
@@ -2325,7 +2325,7 @@ msgstr "Définir une nouvelle taxonomie pour classer le contenu"
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr "Définissez des champs personnalisés enregistrés pour chaque auteur — intitulé du poste, pronoms, identifiants sur les réseaux sociaux, etc."
+msgstr "Définissez des champs personnalisés enregistrés pour chaque collaborateur — intitulé du poste, pronoms, identifiants sur les réseaux sociaux, etc."
 
 #: packages/admin/src/components/ContentTypeList.tsx:118
 msgid "Define the structure of your content"
@@ -2402,11 +2402,11 @@ msgstr "Supprimer la sauvegarde ?"
 
 #: packages/admin/src/routes/byline-schema.tsx:358
 msgid "Delete byline field?"
-msgstr "Supprimer le champ d'auteur ?"
+msgstr "Supprimer le champ de collaborateur ?"
 
 #: packages/admin/src/routes/bylines.tsx:622
 msgid "Delete Byline?"
-msgstr "Supprimer l'auteur ?"
+msgstr "Supprimer le collaborateur ?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3745
 msgid "Delete column"
@@ -2501,7 +2501,7 @@ msgstr "Supprimé"
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr "La suppression de « {0} » supprimera également {1, plural, one {# valeur enregistrée} other {# valeurs enregistrées}} dans tous les auteurs. Cette action est irréversible."
+msgstr "La suppression de « {0} » supprimera également {1, plural, one {# valeur enregistrée} other {# valeurs enregistrées}} dans tous les collaborateurs. Cette action est irréversible."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:409
 #: packages/admin/src/components/ContentTypeEditor.tsx:688
@@ -2924,11 +2924,11 @@ msgstr "Modifier {title}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1151
 msgid "Edit byline"
-msgstr "Modifier l'auteur"
+msgstr "Modifier le collaborateur"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "Edit byline field"
-msgstr "Modifier le champ d'auteur"
+msgstr "Modifier le champ de collaborateur"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:321
 msgid "Edit Domain"
@@ -3262,11 +3262,11 @@ msgstr "Échec lors de la création de la sauvegarde"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1135
 msgid "Failed to create byline"
-msgstr "Échec lors de la création de l'auteur"
+msgstr "Échec lors de la création du collaborateur"
 
 #: packages/admin/src/lib/api/byline-fields.ts:120
 msgid "Failed to create byline field"
-msgstr "Échec lors de la création du champ d'auteur"
+msgstr "Échec lors de la création du champ de collaborateur"
 
 #: packages/admin/src/routes/byline-schema.tsx:102
 msgid "Failed to create field"
@@ -3306,11 +3306,11 @@ msgstr "Échec lors de la suppression de la sauvegarde"
 
 #: packages/admin/src/lib/api/bylines.ts:143
 msgid "Failed to delete byline"
-msgstr "Échec lors de la suppression de l'auteur"
+msgstr "Échec lors de la suppression du collaborateur"
 
 #: packages/admin/src/lib/api/byline-fields.ts:143
 msgid "Failed to delete byline field"
-msgstr "Échec lors de la suppression du champ d'auteur"
+msgstr "Échec lors de la suppression du champ de collaborateur"
 
 #: packages/admin/src/lib/api/schema.ts:244
 msgid "Failed to delete collection"
@@ -3539,7 +3539,7 @@ msgstr "Échec lors de l'installation du module d'extension"
 
 #: packages/admin/src/lib/api/byline-fields.ts:98
 msgid "Failed to list byline fields"
-msgstr "Échec lors du chargement de la liste des champs d'auteur"
+msgstr "Échec lors du chargement de la liste des champs de collaborateur"
 
 #: packages/admin/src/router.tsx:286
 msgid "Failed to load admin"
@@ -3557,7 +3557,7 @@ msgstr "Échec lors du chargement des paramètres de sauvegarde"
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "Failed to load bylines: {0}"
-msgstr "Échec lors du chargement des auteurs : {0}"
+msgstr "Échec lors du chargement des collaborateurs : {0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:80
 #: packages/admin/src/components/settings/EmailSettings.tsx:81
@@ -3629,7 +3629,7 @@ msgstr "Échec lors de la publication"
 
 #: packages/admin/src/lib/api/byline-fields.ts:106
 msgid "Failed to read byline field usage"
-msgstr "Échec lors de la lecture de l'utilisation du champ d'auteur"
+msgstr "Échec lors de la lecture de l'utilisation du champ de collaborateur"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:115
 msgid "Failed to remove domain"
@@ -3646,7 +3646,7 @@ msgstr "Échec lors du renommage de la clé d'accès"
 
 #: packages/admin/src/lib/api/byline-fields.ts:156
 msgid "Failed to reorder byline fields"
-msgstr "Échec lors de la réorganisation des champs d'auteur"
+msgstr "Échec lors de la réorganisation des champs de collaborateur"
 
 #: packages/admin/src/lib/api/schema.ts:332
 msgid "Failed to reorder content types"
@@ -3757,11 +3757,11 @@ msgstr "Échec lors de la mise à jour des paramètres de sauvegarde"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1185
 msgid "Failed to update byline"
-msgstr "Échec lors de la mise à jour de l'auteur"
+msgstr "Échec lors de la mise à jour du collaborateur"
 
 #: packages/admin/src/lib/api/byline-fields.ts:135
 msgid "Failed to update byline field"
-msgstr "Échec lors de la mise à jour du champ d'auteur"
+msgstr "Échec lors de la mise à jour du champ de collaborateur"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:98
 msgid "Failed to update domain"
@@ -3911,7 +3911,7 @@ msgstr "Filtrer par auteur"
 
 #: packages/admin/src/components/BylineFilter.tsx:111
 msgid "Filter by byline"
-msgstr "Filtrer par auteur"
+msgstr "Filtrer par collaborateur"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:115
 msgid "Filter by capability"
@@ -3941,7 +3941,7 @@ msgstr "Filtrer par type"
 
 #: packages/admin/src/routes/bylines.tsx:408
 msgid "Filter byline type"
-msgstr "Filtrer le type d'auteur"
+msgstr "Filtrer le type de collaborateur"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
@@ -4042,7 +4042,7 @@ msgstr "Regrouper par"
 
 #: packages/admin/src/routes/bylines.tsx:555
 msgid "Guest byline"
-msgstr "Auteur invité"
+msgstr "Collaborateur invité"
 
 #: packages/admin/src/routes/bylines.tsx:413
 msgid "Guest only"
@@ -4322,7 +4322,7 @@ msgstr "En cours d'importation des menus et des paramètres du site..."
 
 #: packages/admin/src/components/BylineFilter.tsx:172
 msgid "Include inferred bylines"
-msgstr "Inclure les auteurs déduits"
+msgstr "Inclure les collaborateurs déduits"
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
@@ -4567,7 +4567,7 @@ msgstr "Gardez cet onglet ouvert. L'importation s'exécute par petites étapes e
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1014
 msgid "Keep typing to narrow down more bylines."
-msgstr "Continuez à saisir pour affiner davantage les auteurs."
+msgstr "Poursuivez la saisie pour affiner davantage les collaborateurs."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283
@@ -4743,7 +4743,7 @@ msgstr "Chargement"
 
 #: packages/admin/src/routes/byline-schema.tsx:257
 msgid "Loading byline fields…"
-msgstr "En cours de chargement des champs d'auteur…"
+msgstr "En cours de chargement des champs de collaborateur…"
 
 #: packages/admin/src/components/ContentTypeList.tsx:198
 msgid "Loading collections..."
@@ -4907,7 +4907,7 @@ msgstr "Gérer les {0} pour les {1}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:976
 msgid "Manage bylines in {entryLocale}"
-msgstr "Gérer les auteurs en {entryLocale}"
+msgstr "Gérer les collaborateurs en {entryLocale}"
 
 #: packages/admin/src/components/Widgets.tsx:390
 msgid "Manage content widgets in your widget areas"
@@ -5310,7 +5310,7 @@ msgstr "Nouveau {itemLabel}"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
-msgstr "Nouveau champ d'auteur"
+msgstr "Nouveau champ de collaborateur"
 
 #: packages/admin/src/components/WordPressImport.tsx:1982
 msgid "New collection"
@@ -5419,28 +5419,28 @@ msgstr "Aucun commentaire approuvé pour l'instant."
 
 #: packages/admin/src/components/BylineFilter.tsx:99
 msgid "No byline"
-msgstr "Aucun auteur"
+msgstr "Aucun collaborateur"
 
 #: packages/admin/src/components/BylineFilter.tsx:131
 msgid "No byline assigned"
-msgstr "Aucun auteur attribué"
+msgstr "Aucun collaborateur attribué"
 
 #: packages/admin/src/routes/byline-schema.tsx:291
 msgid "No byline fields yet."
-msgstr "Aucun champ d'auteur pour le moment."
+msgstr "Aucun champ de collaborateur pour le moment."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:968
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr "Aucun auteur disponible en {entryLocale}. Créez une variante depuis la page Auteurs avant d'en mentionner un dans cette entrée."
+msgstr "Aucun collaborateur disponible en {entryLocale}. Créez une variante depuis la page Collaborateurs avant d'en mentionner un dans cette entrée."
 
 #: packages/admin/src/components/BylineFilter.tsx:139
 #: packages/admin/src/routes/bylines.tsx:452
 msgid "No bylines found"
-msgstr "Aucun auteur trouvé"
+msgstr "Aucun collaborateur trouvé"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1076
 msgid "No bylines selected."
-msgstr "Aucun auteur sélectionné."
+msgstr "Aucun collaborateur sélectionné."
 
 #: packages/admin/src/components/Dashboard.tsx:275
 msgid "No collections configured"
@@ -5542,7 +5542,7 @@ msgstr "Aucun résultat"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1011
 msgid "No matching bylines."
-msgstr "Aucun auteur correspondant."
+msgstr "Aucun collaborateur correspondant."
 
 #: packages/admin/src/components/MediaLibrary.tsx:489
 #: packages/admin/src/components/MediaLibrary.tsx:517
@@ -6273,7 +6273,7 @@ msgstr "Python"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1084
 msgid "Quick create byline"
-msgstr "Création rapide d'un auteur"
+msgstr "Création rapide d'un collaborateur"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:196
 #: packages/admin/src/components/editor/ImageNode.tsx:197
@@ -6950,15 +6950,15 @@ msgstr "Rechercher par nom ou par email..."
 #: packages/admin/src/components/ContentSettingsPanel.tsx:985
 #: packages/admin/src/routes/bylines.tsx:401
 msgid "Search bylines"
-msgstr "Rechercher des auteurs"
+msgstr "Rechercher des collaborateurs"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:984
 msgid "Search bylines to add..."
-msgstr "Rechercher des auteurs à ajouter..."
+msgstr "Rechercher des collaborateurs à ajouter..."
 
 #: packages/admin/src/components/BylineFilter.tsx:122
 msgid "Search bylines…"
-msgstr "Rechercher des auteurs…"
+msgstr "Rechercher des collaborateurs…"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:164
 msgid "Search comments"
@@ -7377,7 +7377,7 @@ msgstr "Partager ce lien avec l'utilisateur invité"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:294
 msgid "Shared across all translations of the same byline."
-msgstr "Partagé entre toutes les traductions du même auteur."
+msgstr "Partagé entre toutes les traductions du même collaborateur."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:52
 msgid "Short text"
@@ -7672,7 +7672,7 @@ msgstr "Sauvegardes conservées"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:293
 msgid "Stored per locale — each translation of a byline gets its own value."
-msgstr "Groupé par langue — chaque traduction d'un auteur possède sa propre valeur."
+msgstr "Groupé par langue — chaque traduction d'un collaborateur possède sa propre valeur."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3639
 #: packages/admin/src/components/PortableTextEditor.tsx:4044
@@ -7980,7 +7980,7 @@ msgstr "Cette version nécessite un environnement plus récent que celui actuell
 
 #: packages/admin/src/routes/bylines.tsx:623
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr "Cela supprime le profil de l'auteur. Les liens vers l'auteur des contenus sont supprimés et les liens vers les pages de destination sont effacés."
+msgstr "Cela supprime le profil du collaborateur. Les liens vers le collaborateur des contenus sont supprimés et les liens vers les pages de destination sont effacés."
 
 #. placeholder {0}: sectionInsertErrorMarks.join(", ")
 #: packages/admin/src/components/PortableTextEditor.tsx:3359
@@ -8368,7 +8368,7 @@ msgstr "En haut"
 
 #: packages/admin/src/components/BylineFilter.tsx:164
 msgid "Up to {MAX_SELECTED} bylines can be selected"
-msgstr "Vous pouvez sélectionner jusqu'à {MAX_SELECTED} auteurs"
+msgstr "Vous pouvez sélectionner jusqu'à {MAX_SELECTED} collaborateurs"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:662
 msgid "Update"
@@ -8961,7 +8961,7 @@ msgstr "Vous avez un accès complet pour gérer ce site, y compris les utilisate
 
 #: packages/admin/src/routes/byline-schema.tsx:175
 msgid "You need admin permissions to manage byline schema."
-msgstr "Vous avez besoin des permissions d'administration pour gérer le schéma des auteurs."
+msgstr "Vous avez besoin des permissions d'administration pour gérer le schéma des collaborateurs."
 
 #: packages/admin/src/router.tsx:1556
 msgid "You need Editor permissions to moderate comments."

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -4567,7 +4567,7 @@ msgstr "Gardez cet onglet ouvert. L'importation s'exécute par petites étapes e
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1014
 msgid "Keep typing to narrow down more bylines."
-msgstr "Poursuivez la saisie pour affiner davantage les collaborateurs."
+msgstr "Continuez à saisir pour affiner davantage les collaborateurs."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -5857,7 +5857,7 @@ msgstr "Remplace le titre de la page dans les résultats des moteurs de recherch
 #: packages/admin/src/components/ContentSettingsPanel.tsx:646
 #: packages/admin/src/components/ContentSettingsPanel.tsx:649
 msgid "Ownership"
-msgstr "Propriété"
+msgstr "Responsabilité"
 
 #: packages/admin/src/components/PluginManager.tsx:592
 msgid "Package"


### PR DESCRIPTION
## What does this PR do?

Updates the French translation for "byline" and "ownership".

In French, the most natural way to translate "byline" was "auteur" (e.g. "guest byline" would be translated with "auteur invité", this is a concept already used elsewhere). But, in EmDash, we also have the concept of "author" and this ends up clashing. The literal translation of "byline" would be "signature" but, in French, "signature invitée" doesn't sound natural/is not something we would use.

I think a reasonable translation for byline would be "collaborateur", and it would make sense for https://github.com/emdash-cms/emdash/blob/6602ae05bc23e17642e4dd1179abb6465e20491d/packages/admin/src/components/BylineFilter.tsx#L175
The translation would be:
> Fait également correspondre le collaborateur associé à l'auteur de l'entrée, lorsqu'aucun collaborateur n'est attribué.

I also updated the translation for "ownership". By default, the select field shows "Non attribué". As the label (Authors) is not visible, this is a bit confusing what "Propriété" is (this word can have different meaning). I think "Responsabilité" would be a better translation here.

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Follow-up on #2464 

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) (`MarketplacePluginDetail > displays install count` is still failing locally for me, but unrelated to my changes)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

When updating a post:

||Before|After|
|---|---|---|
|Sidebar|<img width="367" height="517" alt="Shows the 'Propriété', 'Auteurs', and 'Taxonomies' section in the French sidebar before the changes" src="https://github.com/user-attachments/assets/4584fa6d-6873-48d5-8615-1dffa071affa" />|<img width="367" height="515" alt="Shows the 'Propriété', 'Collaborateurs', and 'Taxonomies' section in the French sidebar after the changes" src="https://github.com/user-attachments/assets/683e04eb-ddb2-4d41-8098-29093ee5aecf" />|
|Accessibility tree|<img width="995" height="108" alt="Shows the accessibility tree in French before the changes: Propriété > Auteurs > Non attribué" src="https://github.com/user-attachments/assets/38f79bf2-f3a5-48f4-a0d7-e4f42a1f1455" />|<img width="989" height="112" alt="Shows the accessibility tree in French after the changes: Responsabilité > Auteurs > Non attribué" src="https://github.com/user-attachments/assets/394963e3-a8f1-464c-aeb5-1a9127ceb588" />|

<!-- Optional. Include if the change is visual or if you want to show test results. -->
