### PR TITLE
test(bot): compare Workers AI models

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -53,6 +53,7 @@ import {
 	updateBranch,
 } from "../lib/github.js";
 import { applyInvestigationResult } from "../lib/investigation-result.js";
+import { BOT_MODELS, DEFAULT_BOT_MODEL } from "../lib/models.js";
 import { FLUE_RUN_TIMEOUT_MS, SANDBOX_SLEEP_AFTER_SECONDS } from "../lib/run-policy.js";
 import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/timeout-recovery.js";
 import { untarInto } from "../lib/untar.js";
@@ -100,6 +101,7 @@ const initialDataSchema = v.object({
 	runId: v.pipe(v.string(), v.minLength(1)),
 	issueNumber: v.number(),
 	mode: v.picklist(["repro", "implement", "revise", "diagnose", "fix"]),
+	model: v.optional(v.picklist(BOT_MODELS)),
 	arg: v.optional(v.nullable(v.string())),
 	issueTitle: v.pipe(v.string(), v.minLength(1)),
 	issueBody: v.string(),
@@ -210,7 +212,7 @@ export function Investigate({ id }: AgentProps) {
 	const [lastFailure, setLastFailure] = usePersistentState<RunFailure | null>("last-failure", null);
 	const writeResult = useDataWriter("investigation", { schema: reportedResultSchema });
 
-	useModel("cloudflare/@cf/moonshotai/kimi-k2.7-code");
+	useModel(input.model ?? DEFAULT_BOT_MODEL);
 	if (isTimeoutSummaryDelivery(delivery)) {
 		return buildTimeoutSummaryPrompt({ mode: input.mode, verification, lastFailure });
 	}

--- a/infra/emdash-bot/.flue/lib/models.ts
+++ b/infra/emdash-bot/.flue/lib/models.ts
@@ -1,0 +1,17 @@
+export const BOT_MODELS = [
+	"cloudflare/@cf/moonshotai/kimi-k2.7-code",
+	"cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731",
+	"cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813",
+] as const;
+
+export type BotModel = (typeof BOT_MODELS)[number];
+
+export const DEFAULT_BOT_MODEL: BotModel = BOT_MODELS[0];
+
+export function parseBotModel(value: string): BotModel | null {
+	return BOT_MODELS.find((model) => model === value) ?? null;
+}
+
+export function botModelSlug(model: BotModel): string {
+	return model.slice(model.lastIndexOf("/") + 1);
+}

--- a/infra/emdash-bot/evals/CUTOVER.md
+++ b/infra/emdash-bot/evals/CUTOVER.md
@@ -123,7 +123,7 @@ updating at cutover** until the follow-up lands.
 
 ## Eval gate (fill after the live pre-flight run)
 
-Run `pnpm evals -- --all` against the staging worker (see `evals/README.md`),
+Run `pnpm evals --all` against the staging worker (see `evals/README.md`),
 then paste the summary here. **Do not merge until this reads GATE PASSED.**
 
 Latest full run: 2026-08-10, results

--- a/infra/emdash-bot/evals/README.md
+++ b/infra/emdash-bot/evals/README.md
@@ -63,8 +63,21 @@ The gate passes only with **zero confident-wrong and zero errors**.
 pnpm evals -- --case 917               # one case
 pnpm evals -- --case 917 --case 895    # several
 pnpm evals -- --category not_reproducible
+pnpm evals -- --comparison             # six-case model comparison subset
 pnpm evals -- --all
 ```
+
+### Compare Workers AI models
+
+`MODEL` selects an allow-listed model for authenticated eval dispatches. It does not change the production default. Use `--comparison` for three confirmed bugs spanning easy through hard, two not-reproducible cases, and one needs-info case:
+
+```sh
+MODEL=cloudflare/@cf/moonshotai/kimi-k2.7-code pnpm evals -- --comparison
+MODEL=cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731 pnpm evals -- --comparison
+MODEL=cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813 pnpm evals -- --comparison
+```
+
+Each report prints the model and writes it into the JSON artifact. The artifact filename also includes the model slug, so sequential comparison runs do not produce ambiguous results. Run the comparison against a staging Worker that includes the eval model selector; production webhook dispatches omit the field and continue to use Kimi K2.7 Code.
 
 ### Environment
 
@@ -72,10 +85,13 @@ pnpm evals -- --all
 | ------------- | ------------------------------------------------------------------- |
 | `WORKER_URL`  | Base URL of the deployed bot worker                                 |
 | `ADMIN_TOKEN` | Bearer token for `/agents/*` (the worker's `GITHUB_WEBHOOK_SECRET`) |
-| `GH_TOKEN`    | GitHub token to read issue titles/bodies (read-only)                |
+| `GH_TOKEN`    | Optional token for higher GitHub read-only API limits               |
 | `REPO`        | `owner/name` to investigate (default `emdash-cms/emdash`)           |
 | `TIMEOUT_MS`  | Per-case verdict timeout (default 1800000 = 30 min)                 |
 | `POLL_MS`     | Snapshot poll interval (default 15000)                              |
+| `MODEL`       | Allow-listed Workers AI model (default Kimi K2.7 Code)              |
+
+Issue bodies come from GitHub's public API. `GH_TOKEN` is optional for this public repository; set it when running enough cases to risk the unauthenticated API rate limit.
 
 Results print as a table plus a gate banner and are written to
 `evals/results/<timestamp>.json` (gitignored). The process exits non-zero if the

--- a/infra/emdash-bot/evals/README.md
+++ b/infra/emdash-bot/evals/README.md
@@ -60,11 +60,11 @@ The gate passes only with **zero confident-wrong and zero errors**.
 ## Usage
 
 ```sh
-pnpm evals -- --case 917               # one case
-pnpm evals -- --case 917 --case 895    # several
-pnpm evals -- --category not_reproducible
-pnpm evals -- --comparison             # six-case model comparison subset
-pnpm evals -- --all
+pnpm evals --case 917               # one case
+pnpm evals --case 917 --case 895    # several
+pnpm evals --category not_reproducible
+pnpm evals --comparison             # six-case model comparison subset
+pnpm evals --all
 ```
 
 ### Compare Workers AI models
@@ -72,9 +72,9 @@ pnpm evals -- --all
 `MODEL` selects an allow-listed model for authenticated eval dispatches. It does not change the production default. Use `--comparison` for three confirmed bugs spanning easy through hard, two not-reproducible cases, and one needs-info case:
 
 ```sh
-MODEL=cloudflare/@cf/moonshotai/kimi-k2.7-code pnpm evals -- --comparison
-MODEL=cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731 pnpm evals -- --comparison
-MODEL=cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813 pnpm evals -- --comparison
+MODEL=cloudflare/@cf/moonshotai/kimi-k2.7-code pnpm evals --comparison
+MODEL=cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731 pnpm evals --comparison
+MODEL=cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813 pnpm evals --comparison
 ```
 
 Each report prints the model and writes it into the JSON artifact. The artifact filename also includes the model slug, so sequential comparison runs do not produce ambiguous results. Run the comparison against a staging Worker that includes the eval model selector; production webhook dispatches omit the field and continue to use Kimi K2.7 Code.

--- a/infra/emdash-bot/evals/bin/run.ts
+++ b/infra/emdash-bot/evals/bin/run.ts
@@ -3,20 +3,28 @@
 //   pnpm evals -- --case 917
 //   pnpm evals -- --case 917 --case 895
 //   pnpm evals -- --category not_reproducible
+//   pnpm evals -- --comparison
 //   pnpm evals -- --all
 //
 // Requires a DEPLOYED worker and live bindings. Environment:
 //   WORKER_URL    base URL of the deployed bot worker
 //   ADMIN_TOKEN   bearer token for /agents/* (the worker's GITHUB_WEBHOOK_SECRET)
-//   GH_TOKEN      GitHub token to read issue titles/bodies (read-only)
+//   GH_TOKEN      optional GitHub token for higher read-only API limits
 //   REPO          owner/name to investigate against (default emdash-cms/emdash)
 //   TIMEOUT_MS    per-case verdict timeout (default 1800000)
 //   POLL_MS       snapshot poll interval (default 15000)
+//   MODEL         allow-listed Workers AI model (default Kimi K2.7 Code)
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+	BOT_MODELS,
+	DEFAULT_BOT_MODEL,
+	botModelSlug,
+	parseBotModel,
+} from "../../.flue/lib/models.ts";
 import { loadDataset } from "../src/dataset.ts";
 import { formatReport, toJson } from "../src/format.ts";
 import { runEvals, type RunConfig, type Selection } from "../src/runner.ts";
@@ -39,10 +47,13 @@ function parseSelection(argv: readonly string[]): Selection {
 	const numbers: number[] = [];
 	let category: Category | undefined;
 	let all = false;
+	let comparison = false;
 	for (let i = 0; i < argv.length; i += 1) {
 		const arg = argv[i];
 		if (arg === "--all") {
 			all = true;
+		} else if (arg === "--comparison") {
+			comparison = true;
 		} else if (arg === "--case") {
 			const value = argv[(i += 1)];
 			if (!value) fail("--case needs an issue number");
@@ -62,8 +73,9 @@ function parseSelection(argv: readonly string[]): Selection {
 	}
 	if (numbers.length > 0) return { kind: "cases", numbers };
 	if (category) return { kind: "category", category };
+	if (comparison) return { kind: "comparison" };
 	if (all) return { kind: "all" };
-	fail("select cases with --case <n>, --category <c>, or --all");
+	fail("select cases with --case <n>, --category <c>, --comparison, or --all");
 }
 
 function requireEnv(name: string): string {
@@ -82,13 +94,17 @@ async function main(): Promise<void> {
 	const dataset = loadDataset();
 	const [owner, repo] = (process.env.REPO ?? "emdash-cms/emdash").split("/");
 	if (!owner || !repo) fail("REPO must be owner/name");
+	const modelValue = process.env.MODEL ?? DEFAULT_BOT_MODEL;
+	const model = parseBotModel(modelValue);
+	if (!model) fail(`MODEL must be one of ${BOT_MODELS.join(", ")}`);
 
 	const config: RunConfig = {
 		baseUrl: requireEnv("WORKER_URL"),
 		token: requireEnv("ADMIN_TOKEN"),
-		githubToken: requireEnv("GH_TOKEN"),
+		...(process.env.GH_TOKEN ? { githubToken: process.env.GH_TOKEN } : {}),
 		owner,
 		repo,
+		model,
 		...(process.env.TIMEOUT_MS ? { timeoutMs: Number(process.env.TIMEOUT_MS) } : {}),
 		...(process.env.POLL_MS ? { pollMs: Number(process.env.POLL_MS) } : {}),
 	};
@@ -96,12 +112,15 @@ async function main(): Promise<void> {
 	const results = await runEvals(config, dataset, selection);
 	const summary = summarize(results);
 
-	console.log(`\n${formatReport(results, summary)}\n`);
+	console.log(`\n${formatReport(results, summary, model)}\n`);
 
 	const dir = join(dirname(fileURLToPath(import.meta.url)), "../results");
 	mkdirSync(dir, { recursive: true });
-	const file = join(dir, `${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
-	writeFileSync(file, `${JSON.stringify(toJson(results, summary), null, 2)}\n`);
+	const file = join(
+		dir,
+		`${new Date().toISOString().replace(/[:.]/g, "-")}-${botModelSlug(model)}.json`,
+	);
+	writeFileSync(file, `${JSON.stringify(toJson(results, summary, undefined, model), null, 2)}\n`);
 	console.log(`results written to ${file}`);
 
 	process.exit(summary.gatePassed ? 0 : 1);

--- a/infra/emdash-bot/evals/bin/run.ts
+++ b/infra/emdash-bot/evals/bin/run.ts
@@ -1,10 +1,10 @@
 // Operator CLI for the investigation-bot eval harness.
 //
-//   pnpm evals -- --case 917
-//   pnpm evals -- --case 917 --case 895
-//   pnpm evals -- --category not_reproducible
-//   pnpm evals -- --comparison
-//   pnpm evals -- --all
+//   pnpm evals --case 917
+//   pnpm evals --case 917 --case 895
+//   pnpm evals --category not_reproducible
+//   pnpm evals --comparison
+//   pnpm evals --all
 //
 // Requires a DEPLOYED worker and live bindings. Environment:
 //   WORKER_URL    base URL of the deployed bot worker

--- a/infra/emdash-bot/evals/src/client.ts
+++ b/infra/emdash-bot/evals/src/client.ts
@@ -6,6 +6,7 @@
 // `extractInvestigationResult` is pure and unit-tested; the network calls are
 // operator-only.
 
+import type { BotModel } from "../../.flue/lib/models.ts";
 import type { ReportedResult } from "./types.ts";
 
 const TRAILING_SLASH = /\/$/;
@@ -25,6 +26,7 @@ export interface InvestigateInitialData {
 	readonly runId: string;
 	readonly issueNumber: number;
 	readonly mode: "diagnose";
+	readonly model: BotModel;
 	readonly arg: string | null;
 	readonly issueTitle: string;
 	readonly issueBody: string;

--- a/infra/emdash-bot/evals/src/dataset.ts
+++ b/infra/emdash-bot/evals/src/dataset.ts
@@ -13,6 +13,7 @@ import * as v from "valibot";
 import type { Category, Dataset, EvalCase, PreFix } from "./types.ts";
 
 const CATEGORIES = ["CONFIRMED_BUG", "NOT_REPRODUCIBLE", "NEEDS_INFO"] as const;
+const MODEL_COMPARISON_CASE_NUMBERS = [2344, 917, 2245, 1413, 914, 1272] as const;
 const COMMIT_SHA = /^[0-9a-f]{40}$/i;
 
 const preFixSchema = v.object({
@@ -88,6 +89,14 @@ export function filterByCategory(dataset: Dataset, category: Category): EvalCase
 
 export function findCase(dataset: Dataset, number: number): EvalCase | undefined {
 	return dataset.cases.find((c) => c.number === number);
+}
+
+export function modelComparisonCases(dataset: Dataset): EvalCase[] {
+	return MODEL_COMPARISON_CASE_NUMBERS.map((number) => {
+		const evalCase = findCase(dataset, number);
+		if (!evalCase) throw new Error(`model comparison case #${number} is missing`);
+		return evalCase;
+	});
 }
 
 const DATASET_PATH = join(dirname(fileURLToPath(import.meta.url)), "../dataset.json");

--- a/infra/emdash-bot/evals/src/format.ts
+++ b/infra/emdash-bot/evals/src/format.ts
@@ -1,6 +1,7 @@
 // Results formatting: a plain-text table + a prominent gate banner, plus the
 // JSON artifact the operator keeps alongside the run. Pure and unit-tested.
 
+import { DEFAULT_BOT_MODEL, type BotModel } from "../../.flue/lib/models.ts";
 import type { Summary } from "./scorer.ts";
 import type { ScoredResult } from "./types.ts";
 
@@ -22,6 +23,10 @@ function pad(value: string, width: number): string {
 	return value.length >= width ? value : value + " ".repeat(width - value.length);
 }
 
+function formatDuration(durationMs: number | undefined): string {
+	return durationMs === undefined ? "-" : `${(durationMs / 1_000).toFixed(1)}s`;
+}
+
 export function formatTable(results: readonly ScoredResult[]): string {
 	const rows = results.map((r) => ({
 		num: `#${r.number}`,
@@ -30,6 +35,7 @@ export function formatTable(results: readonly ScoredResult[]): string {
 		ref: r.checkoutRef === "main" ? "main" : r.checkoutRef.slice(0, 8),
 		outcome: r.outcome,
 		grade: GRADE_MARK[r.grade],
+		duration: formatDuration(r.durationMs),
 		detail: r.reason,
 	}));
 	const headers = {
@@ -39,6 +45,7 @@ export function formatTable(results: readonly ScoredResult[]): string {
 		ref: "ref",
 		outcome: "outcome",
 		grade: "grade",
+		duration: "duration",
 		detail: "detail",
 	};
 	const all = [headers, ...rows];
@@ -49,6 +56,7 @@ export function formatTable(results: readonly ScoredResult[]): string {
 		ref: Math.max(...all.map((r) => r.ref.length)),
 		outcome: Math.max(...all.map((r) => r.outcome.length)),
 		grade: Math.max(...all.map((r) => r.grade.length)),
+		duration: Math.max(...all.map((r) => r.duration.length)),
 	};
 	const line = (r: (typeof all)[number]) =>
 		[
@@ -58,6 +66,7 @@ export function formatTable(results: readonly ScoredResult[]): string {
 			pad(r.ref, widths.ref),
 			pad(r.outcome, widths.outcome),
 			pad(r.grade, widths.grade),
+			pad(r.duration, widths.duration),
 			r.detail,
 		].join("  ");
 	return [line(headers), ...rows.map(line)].join("\n");
@@ -81,6 +90,7 @@ export function formatSummary(summary: Summary): string {
 
 export interface ResultsJson {
 	readonly generatedAt: string;
+	readonly model: BotModel;
 	readonly summary: Summary;
 	readonly results: readonly ScoredResult[];
 }
@@ -89,10 +99,15 @@ export function toJson(
 	results: readonly ScoredResult[],
 	summary: Summary,
 	generatedAt: string = new Date().toISOString(),
+	model: BotModel = DEFAULT_BOT_MODEL,
 ): ResultsJson {
-	return { generatedAt, summary, results };
+	return { generatedAt, model, summary, results };
 }
 
-export function formatReport(results: readonly ScoredResult[], summary: Summary): string {
-	return `${formatTable(results)}\n${formatSummary(summary)}`;
+export function formatReport(
+	results: readonly ScoredResult[],
+	summary: Summary,
+	model: BotModel = DEFAULT_BOT_MODEL,
+): string {
+	return `model: ${model}\n\n${formatTable(results)}\n${formatSummary(summary)}`;
 }

--- a/infra/emdash-bot/evals/src/runner.ts
+++ b/infra/emdash-bot/evals/src/runner.ts
@@ -3,16 +3,18 @@
 // scores them. Pure scoring/formatting live in their own modules and are the
 // only parts CI exercises.
 
+import { DEFAULT_BOT_MODEL, type BotModel } from "../../.flue/lib/models.ts";
 import { dispatchInvestigation, waitForResult, type AgentEndpoint } from "./client.ts";
-import { checkoutRefFor, filterByCategory, findCase } from "./dataset.ts";
+import { checkoutRefFor, filterByCategory, findCase, modelComparisonCases } from "./dataset.ts";
 import { scoreCase } from "./scorer.ts";
 import type { Category, Dataset, EvalCase, ScoredResult } from "./types.ts";
 
 export interface RunConfig extends AgentEndpoint {
 	/** GitHub token used to read issue titles/bodies (read-only). */
-	readonly githubToken: string;
+	readonly githubToken?: string;
 	readonly owner: string;
 	readonly repo: string;
+	readonly model?: BotModel;
 	/** Per-case verdict timeout. Defaults to 30 min (the agent's durability ceiling). */
 	readonly timeoutMs?: number;
 	readonly pollMs?: number;
@@ -22,6 +24,7 @@ export interface RunConfig extends AgentEndpoint {
 
 export type Selection =
 	| { readonly kind: "all" }
+	| { readonly kind: "comparison" }
 	| { readonly kind: "category"; readonly category: Category }
 	| { readonly kind: "cases"; readonly numbers: readonly number[] };
 
@@ -32,6 +35,8 @@ export function selectCases(dataset: Dataset, selection: Selection): EvalCase[] 
 	switch (selection.kind) {
 		case "all":
 			return [...dataset.cases];
+		case "comparison":
+			return modelComparisonCases(dataset);
 		case "category":
 			return filterByCategory(dataset, selection.category);
 		case "cases": {
@@ -51,14 +56,17 @@ interface Issue {
 	readonly body: string;
 }
 
-async function fetchIssue(config: RunConfig, number: number): Promise<Issue> {
+export async function fetchIssue(
+	config: Pick<RunConfig, "owner" | "repo" | "githubToken">,
+	number: number,
+): Promise<Issue> {
 	const response = await fetch(
 		`https://api.github.com/repos/${config.owner}/${config.repo}/issues/${number}`,
 		{
 			headers: {
-				authorization: `Bearer ${config.githubToken}`,
 				accept: "application/vnd.github+json",
 				"user-agent": "emdash-bot-evals",
+				...(config.githubToken ? { authorization: `Bearer ${config.githubToken}` } : {}),
 			},
 		},
 	);
@@ -71,8 +79,14 @@ async function fetchIssue(config: RunConfig, number: number): Promise<Issue> {
 
 async function runOne(config: RunConfig, evalCase: EvalCase): Promise<ScoredResult> {
 	const log = config.log ?? console.log;
+	const model = config.model ?? DEFAULT_BOT_MODEL;
+	const startedAt = Date.now();
+	const scored = (input: Parameters<typeof scoreCase>[1]): ScoredResult => ({
+		...scoreCase(evalCase, input),
+		durationMs: Date.now() - startedAt,
+	});
 	const baseRef = checkoutRefFor(evalCase);
-	log(`#${evalCase.number} [${evalCase.category}] dispatching @ ${baseRef.slice(0, 12)}`);
+	log(`#${evalCase.number} [${evalCase.category}] dispatching ${model} @ ${baseRef.slice(0, 12)}`);
 	try {
 		const issue = await fetchIssue(config, evalCase.number);
 		const runId = crypto.randomUUID();
@@ -81,6 +95,7 @@ async function runOne(config: RunConfig, evalCase: EvalCase): Promise<ScoredResu
 			runId,
 			issueNumber: evalCase.number,
 			mode: "diagnose",
+			model,
 			arg: null,
 			issueTitle: issue.title,
 			issueBody: issue.body,
@@ -96,15 +111,15 @@ async function runOne(config: RunConfig, evalCase: EvalCase): Promise<ScoredResu
 			},
 		);
 		if (!reported) {
-			return scoreCase(evalCase, { error: "run settled without a reported verdict" });
+			return scored({ error: "run settled without a reported verdict" });
 		}
-		const scored = scoreCase(evalCase, reported);
-		log(`#${evalCase.number} -> ${scored.outcome} (${scored.grade})`);
-		return scored;
+		const result = scored(reported);
+		log(`#${evalCase.number} -> ${result.outcome} (${result.grade})`);
+		return result;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		log(`#${evalCase.number} -> ERROR: ${message}`);
-		return scoreCase(evalCase, { error: message });
+		return scored({ error: message });
 	}
 }
 

--- a/infra/emdash-bot/evals/src/types.ts
+++ b/infra/emdash-bot/evals/src/types.ts
@@ -112,6 +112,8 @@ export interface ScoredResult {
 	readonly anchorsMatched: readonly string[];
 	readonly summary: string | null;
 	readonly reason: string;
+	/** End-to-end dispatch-to-verdict time, recorded by live eval runs. */
+	readonly durationMs?: number;
 	/** Set when grade is "error". */
 	readonly error?: string;
 }

--- a/infra/emdash-bot/tests/unit/evals-client.test.ts
+++ b/infra/emdash-bot/tests/unit/evals-client.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
+import { BOT_MODELS } from "../../.flue/lib/models.js";
 import {
+	dispatchInvestigation,
 	extractInvestigationResult,
 	waitForResult,
 	type Snapshot,
@@ -14,6 +16,36 @@ const REPORTED = {
 	publication: null,
 	verification: [],
 };
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("dispatch includes the selected eval model in initial data", async () => {
+	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+		new Response(JSON.stringify({ submissionId: "submission-1" }), {
+			status: 202,
+			headers: { "content-type": "application/json" },
+		}),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+
+	await dispatchInvestigation({ baseUrl: "https://worker.test", token: "secret" }, "eval-917-run", {
+		runId: "run-1",
+		issueNumber: 917,
+		mode: "diagnose",
+		model: BOT_MODELS[1],
+		arg: null,
+		issueTitle: "Scheduled posts fail",
+		issueBody: "body",
+		previousBranchSha: null,
+		baseRef: "main",
+	});
+
+	const request = fetchMock.mock.calls[0]?.[1];
+	if (typeof request?.body !== "string") throw new Error("expected string request body");
+	expect(JSON.parse(request.body)).toMatchObject({
+		initialData: { model: BOT_MODELS[1] },
+	});
+});
 
 describe("extractInvestigationResult", () => {
 	test("finds the reported payload nested in a snapshot data part", () => {

--- a/infra/emdash-bot/tests/unit/evals-dataset.test.ts
+++ b/infra/emdash-bot/tests/unit/evals-dataset.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
 	checkoutRefFor,
 	loadDataset,
+	modelComparisonCases,
 	parseDataset,
 	resolvePreFixRef,
 } from "../../evals/src/dataset.ts";
@@ -132,5 +133,21 @@ describe("committed dataset.json", () => {
 		for (const c of ds.cases.filter((x) => x.category !== "CONFIRMED_BUG")) {
 			expect(checkoutRefFor(c)).toBe("main");
 		}
+	});
+
+	test("the model comparison subset spans outcomes and difficulty", () => {
+		const comparison = modelComparisonCases(ds);
+		expect(comparison.map((item) => item.number)).toEqual([2344, 917, 2245, 1413, 914, 1272]);
+		expect(comparison.map((item) => item.category)).toEqual([
+			"CONFIRMED_BUG",
+			"CONFIRMED_BUG",
+			"CONFIRMED_BUG",
+			"NOT_REPRODUCIBLE",
+			"NOT_REPRODUCIBLE",
+			"NEEDS_INFO",
+		]);
+		expect(new Set(comparison.map((item) => item.difficulty))).toEqual(
+			new Set(["easy", "medium", "hard"]),
+		);
 	});
 });

--- a/infra/emdash-bot/tests/unit/evals-format.test.ts
+++ b/infra/emdash-bot/tests/unit/evals-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import { BOT_MODELS } from "../../.flue/lib/models.js";
 import { formatReport, formatSummary, formatTable, toJson } from "../../evals/src/format.ts";
 import { summarize } from "../../evals/src/scorer.ts";
 import type { ScoredResult } from "../../evals/src/types.ts";
@@ -23,7 +24,7 @@ function result(overrides: Partial<ScoredResult>): ScoredResult {
 describe("formatTable", () => {
 	test("renders a header and one row per result with a short ref", () => {
 		const table = formatTable([
-			result({}),
+			result({ durationMs: 12_345 }),
 			result({
 				number: 1413,
 				category: "NOT_REPRODUCIBLE",
@@ -38,6 +39,7 @@ describe("formatTable", () => {
 		expect(table).toContain("c0c6c72e");
 		expect(table).not.toContain("c0c6c72e0a75e9560f204e3780cafb5baf6a9b4b");
 		expect(table).toContain("main");
+		expect(table).toContain("12.3s");
 	});
 });
 
@@ -71,8 +73,9 @@ describe("formatSummary", () => {
 describe("toJson", () => {
 	test("carries the summary and results with a fixed timestamp", () => {
 		const results = [result({})];
-		const json = toJson(results, summarize(results), "2026-08-08T00:00:00.000Z");
+		const json = toJson(results, summarize(results), "2026-08-08T00:00:00.000Z", BOT_MODELS[1]);
 		expect(json.generatedAt).toBe("2026-08-08T00:00:00.000Z");
+		expect(json.model).toBe(BOT_MODELS[1]);
 		expect(json.summary.gatePassed).toBe(true);
 		expect(json.results).toHaveLength(1);
 	});
@@ -81,7 +84,8 @@ describe("toJson", () => {
 describe("formatReport", () => {
 	test("combines the table and the summary banner", () => {
 		const results = [result({})];
-		const report = formatReport(results, summarize(results));
+		const report = formatReport(results, summarize(results), BOT_MODELS[1]);
+		expect(report).toContain(BOT_MODELS[1]);
 		expect(report).toContain("#917");
 		expect(report).toContain("GATE PASSED");
 	});

--- a/infra/emdash-bot/tests/unit/evals-runner.test.ts
+++ b/infra/emdash-bot/tests/unit/evals-runner.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { fetchIssue } from "../../evals/src/runner.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchIssue", () => {
+	test("reads a public issue without GitHub credentials", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(JSON.stringify({ title: "Issue title", body: "Issue body" }), {
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(fetchIssue({ owner: "emdash-cms", repo: "emdash" }, 917)).resolves.toEqual({
+			title: "Issue title",
+			body: "Issue body",
+		});
+
+		const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+		expect(headers.has("authorization")).toBe(false);
+	});
+
+	test("uses a GitHub token when the operator supplies one", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(JSON.stringify({ title: "Issue title", body: null }), {
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await fetchIssue({ owner: "emdash-cms", repo: "emdash", githubToken: "token" }, 917);
+
+		const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+		expect(headers.get("authorization")).toBe("Bearer token");
+	});
+});

--- a/infra/emdash-bot/tests/unit/models.test.ts
+++ b/infra/emdash-bot/tests/unit/models.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	BOT_MODELS,
+	DEFAULT_BOT_MODEL,
+	botModelSlug,
+	parseBotModel,
+} from "../../.flue/lib/models.js";
+
+describe("bot models", () => {
+	test("keeps Kimi as the production default and allow-lists eval alternatives", () => {
+		expect(DEFAULT_BOT_MODEL).toBe("cloudflare/@cf/moonshotai/kimi-k2.7-code");
+		expect(BOT_MODELS).toEqual([
+			"cloudflare/@cf/moonshotai/kimi-k2.7-code",
+			"cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731",
+			"cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813",
+		]);
+	});
+
+	test("parses only allow-listed models and produces stable artifact slugs", () => {
+		expect(parseBotModel(BOT_MODELS[1])).toBe(BOT_MODELS[1]);
+		expect(parseBotModel("cloudflare/unknown")).toBeNull();
+		expect(botModelSlug(BOT_MODELS[0])).toBe("kimi-k2.7-code");
+		expect(botModelSlug(BOT_MODELS[1])).toBe("deepseek-v4-flash-0731");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds an isolated Workers AI model-comparison path to the EmDashBot repro/diagnose eval harness and records the first comparison run.

- Keeps Kimi K2.7 Code as the production default.
- Allows authenticated direct eval dispatches to select Kimi K2.7 Code, DeepSeek V4 Flash, or DeepSeek V4 Pro from a fixed allow-list.
- Adds a six-case `--comparison` subset spanning confirmed bugs, not-reproducible reports, needs-info, and easy through hard cases.
- Records the selected model and end-to-end verdict duration in console and JSON output, with model-specific artifact filenames.
- Makes `GH_TOKEN` optional for this public repository while retaining token support for higher API rate limits.
- Corrects the pnpm v11 CLI examples so eval flags are passed without an extra literal `--`.

The comparison is read-only: it uses diagnose mode, creates a unique agent instance per case, and does not grant publication capabilities. The results support retaining Kimi K2.7 Code as the repro/diagnose default.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI strings changed.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package). N/A: only the private `infra/emdash-bot` app changed.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: private test tooling only.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Non-visual eval tooling; screenshots are not applicable.

Passed:

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 23 files, 256 tests
- `pnpm --filter @emdash-cms/emdash-bot build`
- `git diff --check`

Live six-case staging comparison:

| Model | Pass | Diagnosed | Miss | Confident-wrong | Error | Avg/case | Gate |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Kimi K2.7 Code | 2 | 1 | 3 | 0 | 0 | 8.7 min | Passed |
| DeepSeek V4 Flash | 2 | 0 | 4 | 0 | 0 | 13.9 min | Passed |
| DeepSeek V4 Pro | 2 | 0 | 3 | 0 | 1 | 18.1 min | Failed |

Kimi was fastest overall and produced one additional grounded diagnosis. Flash failed the easy #2344 case and was about 60% slower overall. Pro timed out on #2344 and was about twice as slow as Kimi.

The branch was deployed only to `emdash-bot-staging` for this comparison, retaining the existing staging container image. Production was not changed. The staging eval token is stored in the gitignored `infra/emdash-bot/.dev.vars` with mode `0600`.
