### PR TITLE
fix(bot): harden candidate publication

### DIFF
--- a/infra/emdash-bot/.flue/lib/candidate-publisher.ts
+++ b/infra/emdash-bot/.flue/lib/candidate-publisher.ts
@@ -44,6 +44,8 @@ export interface PublishCandidateInput {
 	readonly snapshot: CandidateSnapshot;
 }
 
+const LINE_BREAK = /\r?\n/;
+
 export function requireCandidatePublication(
 	claimed: boolean,
 	publication: CandidatePublication | null,
@@ -64,7 +66,10 @@ export async function publishCandidate(
 	if (liveBefore !== input.expectedPreviousSha) {
 		if (liveBefore) {
 			const liveCommit = await github.getCommit(liveBefore);
-			if (liveCommit.message.includes(runMarker)) {
+			if (hasRunMarker(liveCommit.message, runMarker)) {
+				if (liveCommit.treeSha !== input.snapshot.treeSha) {
+					throw new Error("candidate run was already published with a different candidate tree");
+				}
 				return { branch: input.branch, commitSha: liveBefore, files };
 			}
 		}
@@ -107,4 +112,8 @@ export async function publishCandidate(
 		);
 	}
 	return { branch: input.branch, commitSha, files };
+}
+
+function hasRunMarker(message: string, marker: string): boolean {
+	return message.split(LINE_BREAK).some((line) => line.trim() === marker);
 }

--- a/infra/emdash-bot/.flue/lib/exec-env.ts
+++ b/infra/emdash-bot/.flue/lib/exec-env.ts
@@ -115,6 +115,7 @@ export class ExecEnv {
 	readonly #repoDir: string;
 	#containerPromise: Promise<ContainerBackend> | undefined;
 	#containerRecoveryPromise: Promise<ContainerBackend> | undefined;
+	#mutationTail: Promise<void> = Promise.resolve();
 
 	constructor(options: ExecEnvOptions) {
 		this.#state = options.state;
@@ -148,23 +149,25 @@ export class ExecEnv {
 		return this.#bounded(this.#state.readFile(path), "readFile");
 	}
 
-	async writeFile(path: string, content: string): Promise<void> {
-		await this.#bounded(this.#state.writeFile(path, content), "writeFile");
-		await this.#recordChange(path);
+	writeFile(path: string, content: string): Promise<void> {
+		return this.#enqueueMutation(() => this.#writeFile(path, content));
 	}
 
 	/** Replace an exact substring; the file must contain it exactly once. */
-	async edit(path: string, oldString: string, newString: string): Promise<void> {
-		const current = await this.readFile(path);
-		if (!current.includes(oldString)) throw new Error(`edit target not found in ${path}`);
-		const first = current.indexOf(oldString);
-		if (current.slice(first + oldString.length).includes(oldString)) {
-			throw new Error(`edit target is not unique in ${path}`);
-		}
-		await this.writeFile(
-			path,
-			current.slice(0, first) + newString + current.slice(first + oldString.length),
-		);
+	edit(path: string, oldString: string, newString: string): Promise<void> {
+		return this.#enqueueMutation(async () => {
+			this.#assertEditablePath(path);
+			const current = await this.readFile(path);
+			if (!current.includes(oldString)) throw new Error(`edit target not found in ${path}`);
+			const first = current.indexOf(oldString);
+			if (current.slice(first + oldString.length).includes(oldString)) {
+				throw new Error(`edit target is not unique in ${path}`);
+			}
+			await this.#writeFile(
+				path,
+				current.slice(0, first) + newString + current.slice(first + oldString.length),
+			);
+		});
 	}
 
 	ls(path: string): Promise<Array<{ name: string; type: string }>> {
@@ -240,6 +243,7 @@ export class ExecEnv {
 		const container = await this.container();
 		await this.#materializeChanges(container);
 		await this.#stageCandidate(container);
+		// Sandbox exec returns text, so binary NUL-delimited Git output crosses the boundary as base64.
 		const [base, tree, diff] = await Promise.all([
 			this.#bounded(
 				container.exec(pipefailCommand("git rev-parse HEAD"), { cwd: this.#repoDir }),
@@ -251,7 +255,9 @@ export class ExecEnv {
 			),
 			this.#bounded(
 				container.exec(
-					pipefailCommand("git diff --cached --raw --abbrev=64 --no-renames -z HEAD --"),
+					pipefailCommand(
+						"git diff --cached --raw --abbrev=64 --no-renames -z HEAD -- | base64 -w0",
+					),
 					{
 						cwd: this.#repoDir,
 					},
@@ -262,7 +268,7 @@ export class ExecEnv {
 		if (base.exitCode !== 0) throw new Error(`candidate base lookup failed: ${lastOutput(base)}`);
 		if (tree.exitCode !== 0) throw new Error(`candidate tree lookup failed: ${lastOutput(tree)}`);
 		if (diff.exitCode !== 0) throw new Error(`candidate diff failed: ${lastOutput(diff)}`);
-		const entries = parseRawGitDiff(diff.stdout);
+		const entries = parseRawGitDiff(decodeBase64Utf8(diff.stdout, "candidate diff"));
 		if (entries.length === 0) throw new Error("candidate has no staged changes");
 		if (entries.length > CANDIDATE_FILE_LIMIT) {
 			throw new Error(
@@ -464,6 +470,31 @@ export class ExecEnv {
 		await this.#bounded(this.#state.writeFile(CHANGE_LOG, JSON.stringify(changed)), "writeFile");
 	}
 
+	async #writeFile(path: string, content: string): Promise<void> {
+		this.#assertEditablePath(path);
+		await this.#bounded(this.#state.writeFile(path, content), "writeFile");
+		await this.#recordChange(path);
+	}
+
+	#assertEditablePath(path: string): void {
+		const prefix = `${this.#repoDir.replace(TRAILING_SLASH, "")}/`;
+		if (!path.startsWith(prefix)) return;
+		try {
+			assertCandidatePath(path.slice(prefix.length));
+		} catch {
+			throw new Error(`cannot edit path: ${path}`);
+		}
+	}
+
+	#enqueueMutation<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.#mutationTail.then(operation, operation);
+		this.#mutationTail = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+
 	async #readChangeLog(): Promise<string[]> {
 		if (!(await this.#bounded(this.#state.exists(CHANGE_LOG), "exists"))) return [];
 		const raw = await this.#bounded(this.#state.readFile(CHANGE_LOG), "readFile");
@@ -531,6 +562,21 @@ export function parseRawGitDiff(raw: string): RawDiffEntry[] {
 	return entries;
 }
 
+function decodeBase64Utf8(encoded: string, label: string): string {
+	const value = encoded.trim();
+	if (value === "") return "";
+	try {
+		const binary = atob(value);
+		const bytes = new Uint8Array(binary.length);
+		for (let index = 0; index < binary.length; index += 1) {
+			bytes[index] = binary.charCodeAt(index);
+		}
+		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+	} catch (error) {
+		throw new Error(`${label} was not valid base64-encoded UTF-8`, { cause: error });
+	}
+}
+
 async function assertGitBlobContent(
 	content: Uint8Array,
 	expectedSha: string,
@@ -557,10 +603,11 @@ function gitTreeMode(mode: string | undefined): GitTreeMode {
 }
 
 function assertCandidatePath(path: string): void {
+	const segments = path.split("/");
 	if (
 		path === "" ||
 		path.startsWith("/") ||
-		path.split("/").includes("..") ||
+		segments.some((segment) => segment === "" || segment === "." || segment === "..") ||
 		DISALLOWED_CANDIDATE_PATHS.some(
 			(prefix) => path === prefix.slice(0, -1) || path.startsWith(prefix),
 		)

--- a/infra/emdash-bot/tests/unit/candidate-publisher.test.ts
+++ b/infra/emdash-bot/tests/unit/candidate-publisher.test.ts
@@ -103,7 +103,7 @@ describe("publishCandidate", () => {
 		const github = fakeGitHub({
 			getBranchSha: vi.fn(async () => "already-published"),
 			getCommit: vi.fn(async () => ({
-				treeSha: "tree",
+				treeSha: "tree-sha",
 				message: "Change\n\nEmDash-Run: run-42",
 			})),
 		});
@@ -129,6 +129,61 @@ describe("publishCandidate", () => {
 			files: ["x.ts"],
 		});
 		expect(github.createBlob).not.toHaveBeenCalled();
+	});
+
+	test("rejects a repeated run marker when the published tree differs", async () => {
+		const github = fakeGitHub({
+			getBranchSha: vi.fn(async () => "already-published"),
+			getCommit: vi.fn(async () => ({
+				treeSha: "different-tree",
+				message: "Change\n\nEmDash-Run: run-42",
+			})),
+		});
+
+		await expect(
+			publishCandidate(
+				{
+					branch: "bot/fix-42",
+					runId: "run-42",
+					commitMessage: "Change",
+					expectedPreviousSha: null,
+					snapshot: {
+						baseCommitSha: "base",
+						treeSha: "verified-tree",
+						changes: [{ path: "x.ts", mode: "100644", content: new Uint8Array([1]) }],
+					},
+				},
+				github,
+			),
+		).rejects.toThrow(/different candidate tree/);
+		expect(github.createBlob).not.toHaveBeenCalled();
+	});
+
+	test("does not treat a longer run id as an idempotent marker match", async () => {
+		const github = fakeGitHub({
+			getBranchSha: vi.fn(async () => "already-published"),
+			getCommit: vi.fn(async () => ({
+				treeSha: "tree-sha",
+				message: "Change\n\nEmDash-Run: run-420",
+			})),
+		});
+
+		await expect(
+			publishCandidate(
+				{
+					branch: "bot/fix-42",
+					runId: "run-42",
+					commitMessage: "Change",
+					expectedPreviousSha: null,
+					snapshot: {
+						baseCommitSha: "base",
+						treeSha: "tree-sha",
+						changes: [{ path: "x.ts", mode: "100644", content: new Uint8Array([1]) }],
+					},
+				},
+				github,
+			),
+		).rejects.toThrow(/candidate branch changed/);
 	});
 
 	test("represents deletions as null tree entries", async () => {

--- a/infra/emdash-bot/tests/unit/exec-env.test.ts
+++ b/infra/emdash-bot/tests/unit/exec-env.test.ts
@@ -149,6 +149,13 @@ function makeEnv(overrides?: {
 	});
 }
 
+function base64Utf8(value: string): string {
+	const bytes = new TextEncoder().encode(value);
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary);
+}
+
 describe("ExecEnv container exec", () => {
 	test("runs the command in the container with the repo cwd", async () => {
 		const con = fakeContainer();
@@ -270,6 +277,38 @@ describe("ExecEnv container exec", () => {
 
 		expect(con.writes).toEqual([]);
 	});
+
+	test("serializes parallel edits so every changed path is materialized", async () => {
+		const fs = fakeState({ "/repo/a.ts": "a", "/repo/b.ts": "b" });
+		const con = fakeContainer();
+		const env = makeEnv({ state: fs.state, container: con.container });
+
+		await Promise.all([
+			env.writeFile("/repo/a.ts", "changed-a"),
+			env.writeFile("/repo/b.ts", "changed-b"),
+		]);
+		await env.exec("pnpm test");
+
+		expect(con.writes).toEqual([
+			{ path: "/repo/a.ts", content: "changed-a" },
+			{ path: "/repo/b.ts", content: "changed-b" },
+		]);
+	});
+
+	test("rejects traversal and Git metadata paths before writing to the VFS", async () => {
+		const fs = fakeState();
+		const env = makeEnv({ state: fs.state });
+
+		await expect(env.writeFile("/repo/../escape", "x")).rejects.toThrow(/cannot edit path/);
+		await expect(env.writeFile("/repo/.git/config", "x")).rejects.toThrow(/cannot edit path/);
+		await expect(env.writeFile("/repo/./.git/config", "x")).rejects.toThrow(/cannot edit path/);
+		await expect(env.writeFile("/repo/.github//workflows/pwn.yml", "x")).rejects.toThrow(
+			/cannot edit path/,
+		);
+		expect(fs.files.has("/repo/../escape")).toBe(false);
+		expect(fs.files.has("/repo/.git/config")).toBe(false);
+		expect(fs.files.has("/repo/./.git/config")).toBe(false);
+	});
 });
 
 describe("ExecEnv candidate snapshots", () => {
@@ -308,7 +347,7 @@ describe("ExecEnv candidate snapshots", () => {
 			{ exitCode: 0, stdout: "", stderr: "" },
 			{ exitCode: 0, stdout: "base-commit\n", stderr: "" },
 			{ exitCode: 0, stdout: "candidate-tree\n", stderr: "" },
-			{ exitCode: 0, stdout: raw, stderr: "" },
+			{ exitCode: 0, stdout: `${base64Utf8(raw)}\n`, stderr: "" },
 		);
 		con.setReadFileBytes(() => new TextEncoder().encode("new\n"));
 		const env = makeEnv({ container: con.container });
@@ -326,6 +365,21 @@ describe("ExecEnv candidate snapshots", () => {
 				(command) => command.includes("git cat-file blob") && command.includes(stagedBlobSha),
 			),
 		).toBe(true);
+		expect(con.execs.some((command) => command.includes("base64 -w0"))).toBe(true);
+	});
+
+	test("rejects staged diff output that is not valid base64", async () => {
+		const con = fakeContainer();
+		con.queueExecResults(
+			{ exitCode: 0, stdout: "", stderr: "" },
+			{ exitCode: 0, stdout: "base\n", stderr: "" },
+			{ exitCode: 0, stdout: "candidate-tree\n", stderr: "" },
+			{ exitCode: 0, stdout: "not-base64!", stderr: "" },
+		);
+
+		await expect(makeEnv({ container: con.container }).snapshotCandidate()).rejects.toThrow(
+			/not valid base64-encoded UTF-8/,
+		);
 	});
 
 	test("rejects content that does not match the staged blob", async () => {
@@ -336,7 +390,9 @@ describe("ExecEnv candidate snapshots", () => {
 			{ exitCode: 0, stdout: "candidate-tree\n", stderr: "" },
 			{
 				exitCode: 0,
-				stdout: `:000000 100644 ${zeroSha} 3e757656cf36eca53338e520d134963a44f793f8 A\0src/new.ts\0`,
+				stdout: base64Utf8(
+					`:000000 100644 ${zeroSha} 3e757656cf36eca53338e520d134963a44f793f8 A\0src/new.ts\0`,
+				),
 				stderr: "",
 			},
 		);
@@ -362,7 +418,7 @@ describe("ExecEnv candidate snapshots", () => {
 			{ exitCode: 0, stdout: "candidate-tree\n", stderr: "" },
 			{
 				exitCode: 0,
-				stdout: `:000000 100644 ${zeroSha} ${blobSha} A\0.github/workflows/pwn.yml\0`,
+				stdout: base64Utf8(`:000000 100644 ${zeroSha} ${blobSha} A\0.github/workflows/pwn.yml\0`),
 				stderr: "",
 			},
 		);
@@ -379,7 +435,7 @@ describe("ExecEnv candidate snapshots", () => {
 			{ exitCode: 0, stdout: "candidate-tree\n", stderr: "" },
 			{
 				exitCode: 0,
-				stdout: `:000000 100644 ${zeroSha} ${blobSha} A\0large.bin\0`,
+				stdout: base64Utf8(`:000000 100644 ${zeroSha} ${blobSha} A\0large.bin\0`),
 				stderr: "",
 			},
 		);


### PR DESCRIPTION
## What does this PR do?

Fixes the trusted candidate publisher failure that left #1623 verified but unable to create `bot/fix-1623`, and hardens adjacent publication boundaries found during an adversarial review.

- Base64-encodes Git's NUL-delimited raw diff inside the Sandbox and decodes it in the Worker before parsing, so text stdout transport cannot corrupt record framing.
- Serializes VFS writes/edits so parallel tool calls cannot lose a change-log entry and silently omit a file from verification/publication.
- Rejects traversal, Git metadata, workflow, and normalized-path bypasses before a VFS edit can be materialized into the container.
- Requires an idempotent same-run retry to match both the exact run marker and the verified candidate tree.

The #1623 failure occurred before any GitHub API mutation: Git staging and `git write-tree` succeeded, then `parseRawGitDiff` rejected the Sandbox text representation as `malformed staged diff`.

Related to #1623.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI strings changed.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package). N/A: only the private `infra/emdash-bot` app changed.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: private-infrastructure bug fixes only.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Non-visual infrastructure change; screenshots are not applicable.

Passed:

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 21 files, 255 tests
- `pnpm --filter @emdash-cms/emdash-bot build`
- `git diff --check`

The bot build reports the expected local secret warning and sandbox-denied Wrangler log-file warning, then completes successfully. No deployment was performed.
