### PR TITLE
feat(bot): add public workbench dashboard

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -52,7 +52,10 @@ import {
 	readRepoContext,
 	updateBranch,
 } from "../lib/github.js";
-import { applyInvestigationResult } from "../lib/investigation-result.js";
+import {
+	applyInvestigationResult,
+	recordInvestigationProgress,
+} from "../lib/investigation-result.js";
 import { FLUE_RUN_TIMEOUT_MS, SANDBOX_SLEEP_AFTER_SECONDS } from "../lib/run-policy.js";
 import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/timeout-recovery.js";
 import { untarInto } from "../lib/untar.js";
@@ -236,8 +239,18 @@ export function Investigate({ id }: AgentProps) {
 		try {
 			await env.ensureRepo({ dir: REPO_DIR, ref: cloneRef(input) });
 			setSetupComplete(true);
+			await recordInvestigationProgress(input, {
+				kind: "workspace_ready",
+				title: "Workspace ready",
+				detail: `Checked out ${cloneRef(input)} and restored the investigation workspace`,
+			});
 		} catch (error) {
 			setLastFailure({ stage: "workspace", message: safeFailureMessage(error) });
+			await recordInvestigationProgress(input, {
+				kind: "workspace_failed",
+				title: "Workspace setup failed",
+				detail: "The investigation workspace could not be prepared",
+			});
 			const result = failedResult(
 				`I couldn't prepare the investigation workspace: ${errorMessage(error)}`,
 				"workspace",
@@ -411,6 +424,11 @@ export function Investigate({ id }: AgentProps) {
 						const currentTreeSha = await env.candidateTreeSha();
 						const reusable = findReusableVerificationRecord(verification, identity, currentTreeSha);
 						if (reusable) {
+							await recordInvestigationProgress(input, {
+								kind: "verification_passed",
+								title: data.name,
+								detail: "Reused a passing check on the unchanged candidate",
+							});
 							return `cached pass for ${data.name} on candidate tree ${currentTreeSha}`;
 						}
 						({ result, candidateTreeSha } = await env.runCheck(data.command, {
@@ -433,6 +451,14 @@ export function Investigate({ id }: AgentProps) {
 							message: `${data.name} failed with exit ${result.exitCode}`,
 						});
 					}
+					await recordInvestigationProgress(input, {
+						kind: result.exitCode === 0 ? "verification_passed" : "verification_failed",
+						title: data.name,
+						detail:
+							result.exitCode === 0
+								? "Verification passed on the current candidate"
+								: `Verification exited with code ${result.exitCode}`,
+					});
 					return truncateToolResult(
 						[`exit ${result.exitCode}`, result.stdout, result.stderr].filter(Boolean).join("\n"),
 					);
@@ -476,6 +502,11 @@ export function Investigate({ id }: AgentProps) {
 						);
 						setPublication(published);
 						setLastFailure(null);
+						await recordInvestigationProgress(input, {
+							kind: "candidate_published",
+							title: "Candidate published",
+							detail: `Published bot/fix-${input.issueNumber} for preview`,
+						});
 						return { output: published };
 					} catch (error) {
 						setLastFailure({ stage: "publication", message: safeFailureMessage(error) });

--- a/infra/emdash-bot/.flue/app.ts
+++ b/infra/emdash-bot/.flue/app.ts
@@ -1,6 +1,8 @@
 // Worker entry.
 //
 // Public surface:
+//   GET  /                 public workbench
+//   GET  /api/dashboard    managed issue state and safe activity
 //   GET  /health           liveness probe
 //   POST /webhook/github   GitHub App webhook ingress (signature-verified)
 //   /agents/investigate/*  Authenticated Flue agent control surface

--- a/infra/emdash-bot/.flue/dashboard.html
+++ b/infra/emdash-bot/.flue/dashboard.html
@@ -1,0 +1,1215 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="color-scheme" content="light dark" />
+		<title>EmDash bot — public workbench</title>
+		<style>
+			:root {
+				font-family:
+					Inter,
+					ui-sans-serif,
+					system-ui,
+					-apple-system,
+					BlinkMacSystemFont,
+					"Segoe UI",
+					sans-serif;
+				color: light-dark(#17181c, #f4f5f8);
+				background: light-dark(#f3f4f7, #090a0d);
+				font-synthesis: none;
+			}
+
+			* {
+				box-sizing: border-box;
+			}
+
+			body {
+				margin: 0;
+				min-width: 320px;
+				min-height: 100vh;
+				background-image: radial-gradient(
+					light-dark(rgba(30, 32, 38, 0.055), rgba(235, 237, 244, 0.05)) 0.7px,
+					transparent 0.7px
+				);
+				background-size: 18px 18px;
+			}
+
+			button,
+			a {
+				font: inherit;
+			}
+
+			button {
+				color: inherit;
+			}
+
+			a:focus-visible,
+			button:focus-visible {
+				outline: 2px solid light-dark(#7642da, #b092ff);
+				outline-offset: 2px;
+			}
+
+			.topbar {
+				display: flex;
+				align-items: center;
+				gap: 18px;
+				min-height: 58px;
+				padding: 0 max(22px, calc((100vw - 1180px) / 2));
+				background: light-dark(rgba(255, 255, 255, 0.9), rgba(15, 16, 20, 0.94));
+				border-bottom: 1px solid light-dark(#e1e3e8, #25272d);
+				backdrop-filter: blur(14px);
+			}
+
+			.brand {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				min-width: max-content;
+				color: light-dark(#0b0152, #fff);
+				text-decoration: none;
+			}
+
+			.brand-logo {
+				display: block;
+				width: 28px;
+				height: 28px;
+			}
+
+			.brand-name {
+				font-weight: 650;
+				letter-spacing: -0.025em;
+			}
+
+			.brand-bot {
+				color: light-dark(#777b87, #8d919d);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-weight: 400;
+				font-size: 11px;
+				letter-spacing: 0.04em;
+			}
+
+			.nav {
+				display: flex;
+				align-self: stretch;
+				margin-left: 12px;
+			}
+
+			.nav span {
+				position: relative;
+				display: flex;
+				align-items: center;
+				padding: 0 10px;
+				font-size: 13px;
+			}
+
+			.nav span::after {
+				content: "";
+				position: absolute;
+				inset-inline: 10px;
+				bottom: 0;
+				height: 2px;
+				background: light-dark(#17181c, #f4f5f8);
+			}
+
+			.top-actions {
+				display: flex;
+				align-items: center;
+				gap: 18px;
+				margin-inline-start: auto;
+			}
+
+			.live,
+			.github-link {
+				display: inline-flex;
+				align-items: center;
+				gap: 7px;
+				font-size: 12px;
+				color: light-dark(#555965, #a8acb7);
+			}
+
+			.github-link {
+				color: light-dark(#363942, #d4d6dc);
+				text-decoration: none;
+			}
+
+			.live-dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 999px;
+				background: light-dark(#16845b, #50d49b);
+				box-shadow: 0 0 0 4px light-dark(rgba(22, 132, 91, 0.1), rgba(80, 212, 155, 0.1));
+			}
+
+			main {
+				max-width: 1180px;
+				margin: 0 auto;
+				padding: 34px 28px 72px;
+			}
+
+			.intro {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 28px;
+				margin-bottom: 22px;
+			}
+
+			.eyebrow {
+				margin: 0 0 8px;
+				color: light-dark(#777b87, #8d919d);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 11px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+			}
+
+			.subtitle {
+				max-width: 560px;
+				margin: 0;
+				color: light-dark(#656974, #9ea2ad);
+				font-size: 13px;
+				line-height: 1.55;
+			}
+
+			.sr-only {
+				position: absolute;
+				width: 1px;
+				height: 1px;
+				padding: 0;
+				margin: -1px;
+				overflow: hidden;
+				clip: rect(0, 0, 0, 0);
+				white-space: nowrap;
+				border: 0;
+			}
+
+			.counts {
+				display: flex;
+				align-items: center;
+				gap: 6px;
+				padding-bottom: 3px;
+				white-space: nowrap;
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 11px;
+				color: light-dark(#686c77, #999da8);
+			}
+
+			.counts strong {
+				font-size: 17px;
+				font-weight: 500;
+				color: light-dark(#202228, #eeeff2);
+			}
+
+			.count-divider {
+				width: 1px;
+				height: 26px;
+				margin: 0 10px;
+				background: light-dark(#d5d8df, #30333a);
+			}
+
+			.surface {
+				background: light-dark(rgba(255, 255, 255, 0.93), rgba(17, 18, 23, 0.95));
+				border: 1px solid light-dark(#dfe1e7, #292b33);
+				border-radius: 15px;
+				box-shadow: 0 18px 50px light-dark(rgba(26, 30, 41, 0.06), rgba(0, 0, 0, 0.22));
+			}
+
+			.workflow-shell {
+				padding: 23px 25px 18px;
+				margin-bottom: 22px;
+			}
+
+			.section-head {
+				display: flex;
+				align-items: start;
+				justify-content: space-between;
+				gap: 20px;
+				margin-bottom: 23px;
+			}
+
+			.section-head h2,
+			.panel-head h2 {
+				margin: 0;
+				font-size: 14px;
+				font-weight: 600;
+				letter-spacing: -0.015em;
+			}
+
+			.section-head p {
+				margin: 5px 0 0;
+				color: light-dark(#767a85, #9296a1);
+				font-size: 11px;
+			}
+
+			.route-key {
+				display: flex;
+				align-items: center;
+				gap: 14px;
+				color: light-dark(#717580, #999da8);
+				font-size: 10px;
+			}
+
+			.route-key span {
+				display: inline-flex;
+				align-items: center;
+				gap: 6px;
+			}
+
+			.route-line {
+				width: 18px;
+				height: 2px;
+				background: light-dark(#d0d3db, #3b3e47);
+			}
+
+			.route-line.selected {
+				background: light-dark(#8b5aee, #a983ff);
+			}
+
+			.workflow {
+				position: relative;
+				display: grid;
+				grid-template-columns: repeat(8, minmax(0, 1fr));
+				padding-top: 5px;
+			}
+
+			.workflow::before {
+				content: "";
+				position: absolute;
+				inset-inline: 5.9%;
+				top: 20px;
+				height: 2px;
+				background: light-dark(#e1e3e8, #30323a);
+			}
+
+			.workflow-progress {
+				position: absolute;
+				inset-inline-start: 5.9%;
+				top: 20px;
+				height: 2px;
+				width: 0;
+				background: light-dark(#8b5aee, #a983ff);
+				transition: width 280ms ease;
+			}
+
+			.phase {
+				position: relative;
+				z-index: 1;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				min-width: 0;
+				text-align: center;
+			}
+
+			.phase-marker {
+				display: grid;
+				place-items: center;
+				width: 31px;
+				height: 31px;
+				border: 2px solid light-dark(#dde0e6, #363944);
+				border-radius: 999px;
+				background: light-dark(#fff, #17191f);
+				color: light-dark(#9a9ea8, #747985);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 10px;
+			}
+
+			.phase.passed .phase-marker {
+				border-color: light-dark(#8b5aee, #a983ff);
+				background: light-dark(#f4efff, #2b2140);
+				color: light-dark(#6d38d7, #c6adff);
+			}
+
+			.phase.current .phase-marker {
+				border-color: light-dark(#6f3bd4, #b092ff);
+				background: light-dark(#7642da, #a983ff);
+				color: light-dark(#fff, #17121f);
+				box-shadow: 0 0 0 5px light-dark(rgba(118, 66, 218, 0.11), rgba(169, 131, 255, 0.13));
+				transform: translateY(-1px);
+			}
+
+			.phase-label {
+				margin-top: 10px;
+				color: light-dark(#767a85, #8f939e);
+				font-size: 10px;
+				line-height: 1.25;
+			}
+
+			.phase.passed .phase-label,
+			.phase.current .phase-label {
+				color: light-dark(#2e3037, #e6e7eb);
+			}
+
+			.phase-state {
+				min-height: 15px;
+				margin-top: 4px;
+				color: light-dark(#7a47dc, #b597ff);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+				opacity: 0;
+			}
+
+			.phase.current .phase-state {
+				opacity: 1;
+			}
+
+			.detours {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				gap: 7px;
+				margin-top: 13px;
+				padding-top: 13px;
+				border-top: 1px dashed light-dark(#dfe1e7, #30323a);
+			}
+
+			.detour-label,
+			.panel-meta,
+			.detail-kicker,
+			.fact-label {
+				color: light-dark(#858995, #858a95);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+				letter-spacing: 0.07em;
+				text-transform: uppercase;
+			}
+
+			.detour-label {
+				margin-inline-end: 4px;
+			}
+
+			.detour {
+				padding: 4px 8px;
+				border-radius: 999px;
+				background: light-dark(#f0f1f4, #202228);
+				color: light-dark(#696d78, #a8acb6);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+			}
+
+			.detour.current {
+				background: light-dark(#fff1dc, #392b18);
+				color: light-dark(#95580b, #f2bd72);
+				box-shadow: inset 0 0 0 1px light-dark(#efd2a8, #60471f);
+			}
+
+			.workspace {
+				display: grid;
+				grid-template-columns: minmax(300px, 0.88fr) minmax(0, 1.45fr);
+				gap: 22px;
+			}
+
+			.list-panel,
+			.detail-panel {
+				min-width: 0;
+				overflow: hidden;
+			}
+
+			.panel-head {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 12px;
+				min-height: 59px;
+				padding: 16px 18px;
+				border-bottom: 1px solid light-dark(#e5e6eb, #292b33);
+			}
+
+			.issues {
+				display: flex;
+				flex-direction: column;
+			}
+
+			.issue {
+				position: relative;
+				display: grid;
+				grid-template-columns: 9px minmax(0, 1fr);
+				gap: 12px;
+				width: 100%;
+				padding: 15px 18px;
+				border: 0;
+				border-bottom: 1px solid light-dark(#eceef2, #24262d);
+				background: transparent;
+				text-align: start;
+				cursor: pointer;
+			}
+
+			.issue:last-child {
+				border-bottom: 0;
+			}
+
+			.issue:hover {
+				background: light-dark(#f7f5fb, #1b1921);
+			}
+
+			.issue[aria-pressed="true"] {
+				background: light-dark(#f4f0fb, #211c2b);
+			}
+
+			.issue[aria-pressed="true"]::after {
+				content: "";
+				position: absolute;
+				inset-block: 12px;
+				inset-inline-start: 0;
+				width: 3px;
+				border-radius: 0 999px 999px 0;
+				background: light-dark(#7642da, #a983ff);
+			}
+
+			.status-dot {
+				width: 8px;
+				height: 8px;
+				margin-top: 5px;
+				border-radius: 999px;
+				background: light-dark(#8b5aee, #a983ff);
+				box-shadow: 0 0 0 3px light-dark(rgba(139, 90, 238, 0.09), rgba(169, 131, 255, 0.1));
+			}
+
+			.issue.waiting .status-dot {
+				background: light-dark(#bf781d, #e3a44f);
+				box-shadow: 0 0 0 3px light-dark(rgba(191, 120, 29, 0.1), rgba(227, 164, 79, 0.1));
+			}
+
+			.issue.attention .status-dot {
+				background: light-dark(#c24747, #ee7676);
+				box-shadow: 0 0 0 3px light-dark(rgba(194, 71, 71, 0.1), rgba(238, 118, 118, 0.1));
+			}
+
+			.issue-title {
+				display: block;
+				font-size: 12px;
+				line-height: 1.45;
+			}
+
+			.issue-number {
+				color: light-dark(#858995, #858a95);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 10px;
+			}
+
+			.issue-foot {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 8px;
+				margin-top: 8px;
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+				color: light-dark(#777b86, #9195a0);
+			}
+
+			.state-label {
+				padding: 3px 6px;
+				border-radius: 5px;
+				background: light-dark(#ece7f8, #2c233c);
+				color: light-dark(#6840ae, #c1a6ee);
+			}
+
+			.detail-head-left {
+				min-width: 0;
+			}
+
+			.detail-kicker {
+				margin-bottom: 4px;
+			}
+
+			.detail-title {
+				margin: 0;
+				font-size: 14px;
+				font-weight: 600;
+				line-height: 1.35;
+			}
+
+			.detail-link {
+				color: light-dark(#646874, #a4a8b2);
+				text-decoration: none;
+				font-size: 10px;
+				white-space: nowrap;
+			}
+
+			.facts {
+				display: grid;
+				grid-template-columns: repeat(3, minmax(0, 1fr));
+				border-bottom: 1px solid light-dark(#e5e6eb, #292b33);
+				background: light-dark(#fafafd, #14151a);
+			}
+
+			.fact {
+				min-width: 0;
+				padding: 12px 15px;
+				border-inline-end: 1px solid light-dark(#e5e6eb, #292b33);
+			}
+
+			.fact:last-child {
+				border-inline-end: 0;
+			}
+
+			.fact-label {
+				display: block;
+				margin-bottom: 4px;
+			}
+
+			.fact-value {
+				display: block;
+				overflow: hidden;
+				color: light-dark(#292b32, #dfe1e6);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 10px;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			.log-head {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 14px 17px 9px;
+				font-size: 10px;
+				font-weight: 600;
+			}
+
+			.log-safe {
+				color: light-dark(#7b7f89, #8f949e);
+				font-size: 9px;
+				font-weight: 400;
+			}
+
+			.log {
+				padding: 3px 17px 18px;
+			}
+
+			.log-row {
+				position: relative;
+				display: grid;
+				grid-template-columns: 50px 14px minmax(0, 1fr);
+				gap: 8px;
+				min-height: 39px;
+				font-size: 10px;
+			}
+
+			.log-row:not(:last-child)::after {
+				content: "";
+				position: absolute;
+				inset-inline-start: 65px;
+				top: 17px;
+				bottom: -3px;
+				width: 1px;
+				background: light-dark(#dfe1e7, #30323a);
+			}
+
+			.log-time {
+				padding-top: 2px;
+				color: light-dark(#8c909a, #7f848e);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+			}
+
+			.log-mark {
+				position: relative;
+				z-index: 1;
+				width: 8px;
+				height: 8px;
+				margin-top: 3px;
+				border-radius: 999px;
+				background: light-dark(#a2a6af, #6f747e);
+				box-shadow: 0 0 0 4px light-dark(#fff, #111217);
+			}
+
+			.log-row.active .log-mark {
+				background: light-dark(#7642da, #a983ff);
+			}
+
+			.log-row.success .log-mark {
+				background: light-dark(#16845b, #50d49b);
+			}
+
+			.log-row.failed .log-mark {
+				background: light-dark(#c24747, #ee7676);
+			}
+
+			.log-message {
+				padding-bottom: 12px;
+				line-height: 1.42;
+				color: light-dark(#535762, #adb1bb);
+			}
+
+			.log-message strong {
+				display: block;
+				margin-bottom: 1px;
+				font-weight: 600;
+				color: light-dark(#24262c, #f0f1f4);
+			}
+
+			.empty,
+			.error {
+				padding: 34px 20px;
+				text-align: center;
+				color: light-dark(#777b86, #9195a0);
+				font-size: 12px;
+				line-height: 1.55;
+			}
+
+			.error strong {
+				display: block;
+				margin-bottom: 5px;
+				color: light-dark(#a23636, #f08a8a);
+			}
+
+			.mobile-flow {
+				display: none;
+			}
+
+			@media (max-width: 760px) {
+				.nav {
+					display: none;
+				}
+
+				main {
+					padding: 34px 20px 52px;
+				}
+
+				.intro {
+					align-items: start;
+					flex-direction: column;
+				}
+
+				.workspace {
+					grid-template-columns: 1fr;
+				}
+
+				.workflow {
+					display: none;
+				}
+
+				.mobile-flow {
+					display: flex;
+					align-items: center;
+					gap: 7px;
+					flex-wrap: wrap;
+					row-gap: 10px;
+					padding-bottom: 4px;
+				}
+
+				.mobile-step {
+					display: inline-flex;
+					align-items: center;
+					gap: 7px;
+					min-width: max-content;
+					color: light-dark(#858995, #838893);
+					font-size: 10px;
+				}
+
+				.mobile-step::before {
+					content: "";
+					width: 8px;
+					height: 8px;
+					border-radius: 999px;
+					background: light-dark(#dadde4, #3b3e46);
+				}
+
+				.mobile-step.passed::before,
+				.mobile-step.current::before {
+					background: light-dark(#8b5aee, #a983ff);
+				}
+
+				.mobile-step.current {
+					color: light-dark(#3a3d45, #eceef1);
+					font-weight: 600;
+				}
+
+				.detours {
+					justify-content: flex-start;
+					flex-wrap: wrap;
+				}
+			}
+
+			@media (max-width: 480px) {
+				.topbar {
+					padding: 0 16px;
+				}
+
+				.live span:last-child,
+				.github-label {
+					display: none;
+				}
+
+				main {
+					padding: 28px 14px 42px;
+				}
+
+				.counts {
+					white-space: normal;
+					flex-wrap: wrap;
+				}
+
+				.workflow-shell {
+					padding: 18px;
+				}
+
+				.section-head {
+					flex-direction: column;
+				}
+
+				.route-key {
+					display: none;
+				}
+
+				.facts {
+					grid-template-columns: 1fr;
+				}
+
+				.fact {
+					border-inline-end: 0;
+					border-bottom: 1px solid light-dark(#e5e6eb, #292b33);
+				}
+
+				.fact:last-child {
+					border-bottom: 0;
+				}
+			}
+
+			@media (prefers-reduced-motion: reduce) {
+				.workflow-progress {
+					transition: none;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<header class="topbar">
+			<a class="brand" href="/" aria-label="EmDash home">
+				<svg class="brand-logo" viewBox="0 0 118 118" fill="none" aria-hidden="true">
+					<path
+						d="M0.410156 96.5125V21.2097C0.410156 9.48841 9.91245 -0.013916 21.6338 -0.013916V9.40601L21.3291 9.40991C14.9509 9.57133 9.83008 14.7927 9.83008 21.2097V96.5125C9.83008 102.93 14.9509 108.151 21.3291 108.312L21.6338 108.316H96.9365L97.2412 108.312C103.518 108.153 108.577 103.094 108.736 96.8171L108.74 96.5125V21.2097C108.74 14.6909 103.455 9.40601 96.9365 9.40601V-0.013916C108.658 -0.013916 118.16 9.48838 118.16 21.2097V96.5125C118.16 108.234 108.658 117.736 96.9365 117.736H21.6338C9.91248 117.736 0.410156 108.234 0.410156 96.5125ZM96.9365 -0.013916V9.40601H21.6338V-0.013916H96.9365Z"
+						fill="url(#brand-icon)"
+					/>
+					<path d="M28.6699 53.366H90.4746V63.6668H28.6699V53.366Z" fill="url(#brand-dash)" />
+					<defs>
+						<linearGradient
+							id="brand-icon"
+							x1="-67.1002"
+							y1="194.666"
+							x2="145.514"
+							y2="-65.5554"
+							gradientUnits="userSpaceOnUse"
+						>
+							<stop stop-color="#0F006B" />
+							<stop offset=".0833" stop-color="#281A81" />
+							<stop offset=".1667" stop-color="#5D0C83" />
+							<stop offset=".25" stop-color="#911475" />
+							<stop offset=".3333" stop-color="#CE2F55" />
+							<stop offset=".4167" stop-color="#FF6633" />
+							<stop offset=".5" stop-color="#F6821F" />
+							<stop offset=".5833" stop-color="#FBAD41" />
+							<stop offset=".6667" stop-color="#FFCD89" />
+							<stop offset=".75" stop-color="#FFE9CB" />
+							<stop offset=".8333" stop-color="#FFF7EC" />
+							<stop offset=".9167" stop-color="#FFF8EE" />
+							<stop offset="1" stop-color="white" />
+						</linearGradient>
+						<linearGradient
+							id="brand-dash"
+							x1="144.064"
+							y1="43.1581"
+							x2="44.5609"
+							y2="85.0447"
+							gradientUnits="userSpaceOnUse"
+						>
+							<stop stop-color="white" />
+							<stop offset=".1293" stop-color="#FFF8EE" />
+							<stop offset=".6171" stop-color="#FBAD41" />
+							<stop offset=".848" stop-color="#F6821F" />
+							<stop offset="1" stop-color="#FF6633" />
+						</linearGradient>
+					</defs>
+				</svg>
+				<span class="brand-name">EmDash</span>
+				<span class="brand-bot">bot</span>
+			</a>
+			<nav class="nav" aria-label="Dashboard sections"><span>Overview</span></nav>
+			<div class="top-actions">
+				<span class="live"
+					><span class="live-dot" aria-hidden="true"></span
+					><span id="system-status">Live state</span></span
+				>
+				<a
+					class="github-link"
+					id="repository-link"
+					href="https://github.com/emdash-cms/emdash"
+					target="_blank"
+					rel="noreferrer"
+					aria-label="Open the EmDash repository on GitHub"
+					><span aria-hidden="true">↗</span><span class="github-label">GitHub</span></a
+				>
+			</div>
+		</header>
+
+		<main>
+			<section class="intro">
+				<div>
+					<p class="eyebrow">Public workbench</p>
+					<h1 class="sr-only">EmDash bot public workbench</h1>
+					<p class="subtitle">
+						A live, inspectable view of automated investigation—from first look to verified pull
+						request.
+					</p>
+				</div>
+				<div class="counts" id="counts" aria-label="Issue counts"></div>
+			</section>
+
+			<section class="surface workflow-shell" aria-labelledby="workflow-title">
+				<div class="section-head">
+					<div>
+						<h2 id="workflow-title">The path from issue to merge</h2>
+						<p>Select an issue below to see its position and route.</p>
+					</div>
+					<div class="route-key" aria-label="Workflow legend">
+						<span><i class="route-line selected" aria-hidden="true"></i> selected route</span>
+						<span><i class="route-line" aria-hidden="true"></i> remaining route</span>
+					</div>
+				</div>
+				<div class="workflow" id="workflow">
+					<div class="workflow-progress" id="workflow-progress"></div>
+				</div>
+				<div class="mobile-flow" id="mobile-flow" aria-label="Selected issue workflow"></div>
+				<div class="detours" id="detours" aria-label="Possible side routes"></div>
+			</section>
+
+			<div class="workspace">
+				<section class="surface list-panel" aria-labelledby="current-work-title">
+					<div class="panel-head">
+						<h2 id="current-work-title">Current work</h2>
+						<span class="panel-meta" id="updated-at">loading</span>
+					</div>
+					<div class="issues" id="issues"><div class="empty">Loading managed issues…</div></div>
+				</section>
+
+				<section class="surface detail-panel" id="detail-panel" aria-live="polite">
+					<div class="empty">Select an issue to inspect its route and public activity.</div>
+				</section>
+			</div>
+		</main>
+
+		<script>
+			const phases = [
+				"Triage",
+				"Investigate",
+				"Establish",
+				"Build",
+				"Preview",
+				"Confirm",
+				"Review",
+				"Done",
+			];
+			const detourStates = [
+				"needs_info",
+				"not_reproduced",
+				"blocked",
+				"failed",
+				"human_owned",
+				"declined",
+			];
+			const phaseByState = {
+				unmanaged: 0,
+				triage: 0,
+				working: 1,
+				investigating: 1,
+				reproduced: 2,
+				diagnosed: 2,
+				not_reproduced: 2,
+				needs_info: 2,
+				fixing: 3,
+				blocked: 3,
+				failed: 3,
+				preview_building: 4,
+				awaiting_feedback: 5,
+				awaiting_reporter: 5,
+				in_review: 6,
+				human_owned: 6,
+				done: 7,
+				declined: 7,
+			};
+			const activeStates = new Set(["working", "investigating", "fixing", "preview_building"]);
+			const waitingStates = new Set([
+				"awaiting_feedback",
+				"awaiting_reporter",
+				"in_review",
+				"human_owned",
+			]);
+			const attentionStates = new Set(["blocked", "failed", "not_reproduced", "needs_info"]);
+			let payload = null;
+			let selectedNumber = null;
+
+			function element(tag, className, text) {
+				const node = document.createElement(tag);
+				if (className) node.className = className;
+				if (text !== undefined) node.textContent = text;
+				return node;
+			}
+
+			function stateLabel(state) {
+				return state.replaceAll("_", " ");
+			}
+
+			function routeFor(state) {
+				if (attentionStates.has(state)) return "attention";
+				if (waitingStates.has(state)) return "waiting";
+				return "active";
+			}
+
+			function relativeTime(value) {
+				const seconds = Math.max(0, Math.floor((Date.now() - new Date(value).getTime()) / 1000));
+				if (seconds < 60) return "just now";
+				if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+				if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+				return `${Math.floor(seconds / 86400)}d ago`;
+			}
+
+			function durationSince(timestamp) {
+				if (!timestamp) return "not running";
+				const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+				const hours = Math.floor(seconds / 3600);
+				const minutes = Math.floor((seconds % 3600) / 60);
+				return hours ? `${hours}h ${minutes}m` : `${minutes}m ${seconds % 60}s`;
+			}
+
+			function renderCounts() {
+				const counts = { active: 0, waiting: 0, attention: 0 };
+				for (const issue of payload.issues) counts[routeFor(issue.state)] += 1;
+				const target = document.getElementById("counts");
+				target.replaceChildren();
+				for (const [index, item] of [
+					[counts.active, "active"],
+					[counts.waiting, "waiting"],
+					[counts.attention, "needs attention"],
+				].entries()) {
+					if (index) target.append(element("span", "count-divider"));
+					const strong = element("strong", "", String(item[0]));
+					target.append(strong, document.createTextNode(` ${item[1]}`));
+				}
+			}
+
+			function renderWorkflow(issue) {
+				const phase = issue ? (phaseByState[issue.state] ?? 0) : 0;
+				const isDetour = issue ? detourStates.includes(issue.state) : false;
+				const workflow = document.getElementById("workflow");
+				workflow.querySelectorAll(".phase").forEach((node) => node.remove());
+				phases.forEach((label, index) => {
+					const phaseNode = element(
+						"div",
+						`phase${index < phase ? " passed" : ""}${index === phase && !isDetour ? " current" : ""}`,
+					);
+					phaseNode.append(element("span", "phase-marker", String(index + 1)));
+					phaseNode.append(element("span", "phase-label", label));
+					phaseNode.append(
+						element("span", "phase-state", index === phase && issue ? issue.state : ""),
+					);
+					workflow.append(phaseNode);
+				});
+				document.getElementById("workflow-progress").style.width = `${(phase / 7) * 88.2}%`;
+
+				const mobile = document.getElementById("mobile-flow");
+				mobile.replaceChildren();
+				phases.forEach((label, index) => {
+					const step = element(
+						"span",
+						`mobile-step${index < phase ? " passed" : ""}${index === phase && !isDetour ? " current" : ""}`,
+						`${label}${index < phases.length - 1 ? " →" : ""}`,
+					);
+					mobile.append(step);
+				});
+
+				const detours = document.getElementById("detours");
+				detours.replaceChildren(element("span", "detour-label", "Side routes"));
+				for (const state of detourStates) {
+					detours.append(
+						element("span", `detour${issue?.state === state ? " current" : ""}`, stateLabel(state)),
+					);
+				}
+			}
+
+			function renderIssues() {
+				const target = document.getElementById("issues");
+				target.replaceChildren();
+				if (!payload.issues.length) {
+					target.append(
+						element("div", "empty", "No open bot-managed issues. The workbench is clear."),
+					);
+					return;
+				}
+				for (const issue of payload.issues) {
+					const button = element("button", `issue ${routeFor(issue.state)}`);
+					button.type = "button";
+					button.setAttribute("aria-pressed", String(issue.number === selectedNumber));
+					button.append(element("span", "status-dot"));
+					const body = element("span");
+					const title = element("span", "issue-title");
+					title.append(
+						element("span", "issue-number", `#${issue.number} `),
+						document.createTextNode(issue.title),
+					);
+					const foot = element("span", "issue-foot");
+					foot.append(
+						element("span", "state-label", stateLabel(issue.state)),
+						element("span", "", relativeTime(issue.updatedAt)),
+					);
+					body.append(title, foot);
+					button.append(body);
+					button.addEventListener("click", () => {
+						selectedNumber = issue.number;
+						render();
+					});
+					target.append(button);
+				}
+			}
+
+			function transitionActivity(entry) {
+				return {
+					t: entry.t,
+					tone:
+						entry.to === "failed" || entry.to === "blocked"
+							? "failed"
+							: entry.to === "done"
+								? "success"
+								: "active",
+					title: entry.to ? `Moved to ${stateLabel(entry.to)}` : entry.event.replaceAll("_", " "),
+					detail: `${stateLabel(entry.from ?? "unmanaged")} → ${stateLabel(entry.to ?? "unmanaged")} · ${entry.event.replaceAll("_", " ")}`,
+				};
+			}
+
+			function progressActivity(entry) {
+				return {
+					t: entry.t,
+					tone: entry.kind.endsWith("failed")
+						? "failed"
+						: entry.kind.endsWith("passed") ||
+							  entry.kind === "candidate_published" ||
+							  entry.kind === "workspace_ready"
+							? "success"
+							: "active",
+					title: entry.title,
+					detail: entry.detail,
+				};
+			}
+
+			function renderDetail(issue) {
+				const panel = document.getElementById("detail-panel");
+				panel.replaceChildren();
+				if (!issue) {
+					panel.append(
+						element("div", "empty", "Select an issue to inspect its route and public activity."),
+					);
+					return;
+				}
+				const head = element("div", "panel-head");
+				const headLeft = element("div", "detail-head-left");
+				headLeft.append(
+					element(
+						"div",
+						"detail-kicker",
+						`#${issue.number} · ${issue.kind} · ${stateLabel(issue.state)}`,
+					),
+				);
+				const heading = element("h2", "detail-title", issue.title);
+				heading.id = "selected-issue-title";
+				headLeft.append(heading);
+				const link = element("a", "detail-link", "Open issue ↗");
+				link.href = issue.url;
+				link.target = "_blank";
+				link.rel = "noreferrer";
+				head.append(headLeft, link);
+				panel.append(head);
+
+				const facts = element("div", "facts");
+				const candidate = issue.prNumber
+					? `PR #${issue.prNumber}`
+					: phaseByState[issue.state] >= 4
+						? `bot/fix-${issue.number}`
+						: "not published";
+				for (const [label, value] of [
+					["Run", durationSince(issue.currentRunStartedAt)],
+					["Current step", stateLabel(issue.state)],
+					["Candidate", candidate],
+				]) {
+					const fact = element("div", "fact");
+					fact.append(element("span", "fact-label", label), element("span", "fact-value", value));
+					facts.append(fact);
+				}
+				panel.append(facts);
+
+				const logHead = element("div", "log-head");
+				logHead.append(
+					element("span", "", "Live activity"),
+					element("span", "log-safe", "◇ public-safe events"),
+				);
+				panel.append(logHead);
+				const log = element("div", "log");
+				const activity = [
+					...issue.transitions.map(transitionActivity),
+					...issue.progress.map(progressActivity),
+				]
+					.toSorted((left, right) => left.t - right.t)
+					.slice(-10);
+				if (!activity.length) {
+					log.append(
+						element("div", "empty", "No public activity has been recorded for this issue yet."),
+					);
+				} else {
+					for (const entry of activity) {
+						const row = element("div", `log-row ${entry.tone}`);
+						row.append(
+							element(
+								"span",
+								"log-time",
+								new Date(entry.t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+							),
+							element("span", "log-mark"),
+						);
+						const message = element("span", "log-message");
+						message.append(element("strong", "", entry.title));
+						if (entry.detail) message.append(document.createTextNode(entry.detail));
+						row.append(message);
+						log.append(row);
+					}
+				}
+				panel.append(log);
+			}
+
+			function render() {
+				const selected =
+					payload?.issues.find((issue) => issue.number === selectedNumber) ??
+					payload?.issues[0] ??
+					null;
+				if (selected && selectedNumber === null) selectedNumber = selected.number;
+				renderCounts();
+				renderWorkflow(selected);
+				renderIssues();
+				renderDetail(selected);
+			}
+
+			async function load() {
+				try {
+					const response = await fetch("/api/dashboard", {
+						headers: { accept: "application/json" },
+					});
+					if (!response.ok) throw new Error(`dashboard request failed: ${response.status}`);
+					payload = await response.json();
+					document.getElementById("repository-link").href = payload.repositoryUrl;
+					document.getElementById("updated-at").textContent = relativeTime(payload.updatedAt);
+					document.getElementById("system-status").textContent = "Live state";
+					render();
+				} catch {
+					document.getElementById("system-status").textContent = "Data unavailable";
+					document.getElementById("counts").replaceChildren();
+					document.getElementById("issues").innerHTML =
+						'<div class="error"><strong>Could not load current work</strong>The bot itself may still be operating normally. Try this page again shortly.</div>';
+					renderWorkflow(null);
+				}
+			}
+
+			load();
+			setInterval(load, 20_000);
+		</script>
+	</body>
+</html>

--- a/infra/emdash-bot/.flue/lib/dashboard.ts
+++ b/infra/emdash-bot/.flue/lib/dashboard.ts
@@ -1,0 +1,87 @@
+import {
+	listOpenManagedIssues,
+	mintInstallationToken,
+	readAppCreds,
+	readRepoContext,
+	type ManagedIssueSummary,
+} from "./github.js";
+import { KINDS, type Kind, type StateId } from "./machine.js";
+import type { OrchestratorDO, PublicIssueSnapshot } from "./orchestrator.js";
+import { currentState } from "./router.js";
+
+const DASHBOARD_CACHE_MS = 20_000;
+const DASHBOARD_ISSUE_LIMIT = 100;
+
+interface DashboardCache {
+	expiresAt: number;
+	value: Promise<DashboardPayload>;
+}
+
+declare global {
+	var emdashBotDashboardCache: DashboardCache | undefined;
+}
+
+interface DashboardEnv extends Env {
+	Orchestrator: DurableObjectNamespace<OrchestratorDO>;
+}
+
+export interface DashboardIssue extends ManagedIssueSummary, PublicIssueSnapshot {
+	state: StateId;
+	kind: Kind;
+}
+
+export interface DashboardPayload {
+	updatedAt: string;
+	repositoryUrl: string;
+	issues: DashboardIssue[];
+}
+
+export function getDashboardPayload(env: Env): Promise<DashboardPayload> {
+	const cached = globalThis.emdashBotDashboardCache;
+	if (cached && cached.expiresAt > Date.now()) return cached.value;
+	const value = loadDashboardPayload(env).catch((error) => {
+		if (globalThis.emdashBotDashboardCache?.value === value) {
+			globalThis.emdashBotDashboardCache = undefined;
+		}
+		throw error;
+	});
+	globalThis.emdashBotDashboardCache = { expiresAt: Date.now() + DASHBOARD_CACHE_MS, value };
+	return value;
+}
+
+export async function loadDashboardPayload(env: Env): Promise<DashboardPayload> {
+	const creds = readAppCreds(env);
+	const repo = readRepoContext(env);
+	if (!creds || !repo) throw new Error("GitHub credentials or repository context missing");
+	const token = await mintInstallationToken(creds);
+	const githubIssues = (await listOpenManagedIssues(token, repo)).slice(0, DASHBOARD_ISSUE_LIMIT);
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Wrangler cannot infer local DO RPC methods.
+	const dashboardEnv = env as DashboardEnv;
+	const snapshots = await Promise.all(
+		githubIssues.map((issue) =>
+			dashboardEnv.Orchestrator.getByName(`issue-${issue.number}`).getPublicSnapshot(),
+		),
+	);
+	const issues = githubIssues.flatMap((issue, index) => {
+		const snapshot = snapshots[index];
+		if (!snapshot) return [];
+		const state = snapshot.state ?? stateFromLabels(issue.labels);
+		const kind = snapshot.kind ?? kindFromLabels(issue.labels);
+		if (!state || !kind) return [];
+		return [{ ...issue, ...snapshot, state, kind } satisfies DashboardIssue];
+	});
+	return {
+		updatedAt: new Date().toISOString(),
+		repositoryUrl: `https://github.com/${repo.owner}/${repo.repo}`,
+		issues,
+	};
+}
+
+function stateFromLabels(labels: readonly string[]): StateId | null {
+	return currentState(labels);
+}
+
+function kindFromLabels(labels: readonly string[]): Kind | null {
+	for (const kind of KINDS) if (labels.includes(`bot:${kind}`)) return kind;
+	return null;
+}

--- a/infra/emdash-bot/.flue/lib/github.ts
+++ b/infra/emdash-bot/.flue/lib/github.ts
@@ -128,6 +128,75 @@ export interface IssueSummary {
 	commentCount: number;
 }
 
+export interface ManagedIssueSummary {
+	number: number;
+	title: string;
+	url: string;
+	updatedAt: string;
+	labels: string[];
+}
+
+export async function listOpenManagedIssues(
+	token: string,
+	ctx: RepoContext,
+): Promise<ManagedIssueSummary[]> {
+	const kindLabels = ["bot:bug", "bot:enhancement", "bot:task"];
+	const pages = await Promise.all(
+		kindLabels.map(async (label) => {
+			const params = new URLSearchParams({
+				state: "open",
+				labels: label,
+				sort: "updated",
+				direction: "desc",
+				per_page: "100",
+			});
+			const res = await githubFetch(
+				`${GITHUB_API}/repos/${ctx.owner}/${ctx.repo}/issues?${params.toString()}`,
+				{ headers: authHeaders(token) },
+			);
+			if (!res.ok)
+				throw new Error(`listOpenManagedIssues failed: ${res.status} ${await res.text()}`);
+			return res.json<
+				Array<{
+					number?: number;
+					title?: string;
+					html_url?: string;
+					updated_at?: string;
+					labels?: Array<{ name?: string }>;
+					pull_request?: unknown;
+				}>
+			>();
+		}),
+	);
+
+	const issues = new Map<number, ManagedIssueSummary>();
+	for (const page of pages) {
+		for (const issue of page) {
+			if (
+				(issue.number !== undefined && issues.has(issue.number)) ||
+				issue.pull_request !== undefined ||
+				issue.number === undefined ||
+				!issue.title ||
+				!issue.html_url ||
+				!issue.updated_at
+			) {
+				continue;
+			}
+			const labels = issue.labels?.flatMap((label) => (label.name ? [label.name] : [])) ?? [];
+			issues.set(issue.number, {
+				number: issue.number,
+				title: issue.title,
+				url: issue.html_url,
+				updatedAt: issue.updated_at,
+				labels,
+			});
+		}
+	}
+	return [...issues.values()].toSorted((left, right) =>
+		right.updatedAt.localeCompare(left.updatedAt),
+	);
+}
+
 export async function getIssue(
 	token: string,
 	ctx: RepoContext,

--- a/infra/emdash-bot/.flue/lib/investigation-result.ts
+++ b/infra/emdash-bot/.flue/lib/investigation-result.ts
@@ -1,6 +1,6 @@
 import { env as workerEnv } from "cloudflare:workers";
 
-import type { AgentResult, OrchestratorDO } from "./orchestrator.js";
+import type { AgentResult, OrchestratorDO, PublicProgressKind } from "./orchestrator.js";
 
 interface InvestigationEnv {
 	Orchestrator: DurableObjectNamespace<OrchestratorDO>;
@@ -17,4 +17,29 @@ export async function applyInvestigationResult(
 	const stub = Orchestrator.getByName(`issue-${input.issueNumber}`);
 	await stub.applyAgentResult({ runId: input.runId, result, ok, pushed });
 	return true;
+}
+
+export async function recordInvestigationProgress(
+	input: { issueNumber: number; runId: string },
+	progress: {
+		kind: PublicProgressKind;
+		title: string;
+		detail?: string | null;
+	},
+): Promise<boolean> {
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Wrangler cannot infer Flue-generated RPC class types.
+	const { Orchestrator } = workerEnv as unknown as InvestigationEnv;
+	try {
+		return await Orchestrator.getByName(`issue-${input.issueNumber}`).recordPublicProgress({
+			runId: input.runId,
+			...progress,
+		});
+	} catch (error) {
+		console.warn("[investigate] public progress write failed", {
+			issueNumber: input.issueNumber,
+			kind: progress.kind,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return false;
+	}
 }

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -81,6 +81,7 @@ const INERT_STATES: ReadonlySet<StateId> = new Set<StateId>([
  * full history -- two weeks of activity on the busiest issue is plenty.
  */
 const EVENT_LOG_LIMIT = 200;
+const PUBLIC_PROGRESS_LIMIT = 100;
 
 /**
  * The actor classification the webhook handler resolves before calling
@@ -191,6 +192,35 @@ interface EventLogEntry {
 	readonly deliveryId?: string;
 }
 
+export type PublicProgressKind =
+	| "workspace_ready"
+	| "workspace_failed"
+	| "verification_passed"
+	| "verification_failed"
+	| "candidate_published";
+
+export interface PublicProgressEntry {
+	readonly t: number;
+	readonly kind: PublicProgressKind;
+	readonly title: string;
+	readonly detail: string | null;
+	readonly runId: string;
+}
+
+export interface PublicIssueSnapshot {
+	readonly state: StateId | null;
+	readonly kind: Kind | null;
+	readonly currentRunStartedAt: number | null;
+	readonly prNumber: number | null;
+	readonly transitions: ReadonlyArray<{
+		readonly t: number;
+		readonly event: EventId;
+		readonly from: StateId | "conflicting" | null;
+		readonly to: StateId | null;
+	}>;
+	readonly progress: ReadonlyArray<Omit<PublicProgressEntry, "runId">>;
+}
+
 interface InboxEntry {
 	readonly id: string;
 	readonly input: NormalizedEvent;
@@ -231,6 +261,7 @@ const STORAGE = {
 	deadlineWarningRetryAt: "o:deadlineWarningRetryAt",
 	resumableRun: "o:resumableRun",
 	pendingResume: "o:pendingResume",
+	publicProgress: "o:publicProgress",
 } as const;
 
 const TICK_INTERVAL_MS = 60 * 60 * 1000;
@@ -487,6 +518,30 @@ export class OrchestratorDO extends DurableObject<Env> {
 		ok: boolean;
 	}): Promise<EventOutcome> {
 		return this.runExclusive(() => this.processAgentResult(input));
+	}
+
+	async recordPublicProgress(input: {
+		runId: string;
+		kind: PublicProgressKind;
+		title: string;
+		detail?: string | null;
+	}): Promise<boolean> {
+		return this.ctx.storage.transaction(async (transaction) => {
+			if ((await transaction.get<string>(STORAGE.currentRunId)) !== input.runId) return false;
+			const existing = (await transaction.get<PublicProgressEntry[]>(STORAGE.publicProgress)) ?? [];
+			const entry: PublicProgressEntry = {
+				t: Date.now(),
+				kind: input.kind,
+				title: sanitizePublicProgressText(input.title, 80),
+				detail: input.detail ? sanitizePublicProgressText(input.detail, 240) : null,
+				runId: input.runId,
+			};
+			await transaction.put(
+				STORAGE.publicProgress,
+				[...existing, entry].slice(-PUBLIC_PROGRESS_LIMIT),
+			);
+			return true;
+		});
 	}
 
 	private async processAgentResult(input: {
@@ -2214,6 +2269,35 @@ export class OrchestratorDO extends DurableObject<Env> {
 		return (await this.ctx.storage.get<EventLogEntry[]>(STORAGE.eventLog)) ?? [];
 	}
 
+	async getPublicSnapshot(): Promise<PublicIssueSnapshot> {
+		const [state, kind, currentRunStartedAt, prNumber, transitions, progress] = await Promise.all([
+			this.ctx.storage.get<StateId>(STORAGE.state),
+			this.ctx.storage.get<Kind>(STORAGE.kind),
+			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
+			this.ctx.storage.get<number>(STORAGE.prNumber),
+			this.ctx.storage.get<EventLogEntry[]>(STORAGE.eventLog),
+			this.ctx.storage.get<PublicProgressEntry[]>(STORAGE.publicProgress),
+		]);
+		return {
+			state: state ?? null,
+			kind: kind ?? null,
+			currentRunStartedAt: currentRunStartedAt ?? null,
+			prNumber: prNumber ?? null,
+			transitions: (transitions ?? []).map(({ t, event, from, to }) => ({
+				t,
+				event,
+				from,
+				to,
+			})),
+			progress: (progress ?? []).map(({ t, kind: progressKind, title, detail }) => ({
+				t,
+				kind: progressKind,
+				title,
+				detail,
+			})),
+		};
+	}
+
 	async getInboxDepth(): Promise<number> {
 		return ((await this.ctx.storage.get<InboxEntry[]>(STORAGE.inbox)) ?? []).length;
 	}
@@ -2474,6 +2558,14 @@ class ClassifierProcessingError extends Error {
 		super(`classifier failed: ${reason}`);
 		this.name = "ClassifierProcessingError";
 	}
+}
+
+function sanitizePublicProgressText(value: string, limit: number): string {
+	const normalized = value
+		.replaceAll(/[\r\n\t]+/g, " ")
+		.replaceAll(/\s{2,}/g, " ")
+		.trim();
+	return normalized.length <= limit ? normalized : `${normalized.slice(0, limit - 1)}…`;
 }
 
 function errorMessage(error: unknown): string {

--- a/infra/emdash-bot/.flue/routes.ts
+++ b/infra/emdash-bot/.flue/routes.ts
@@ -1,14 +1,29 @@
-// Core bot routes (health, /webhook/github). Separated from app.ts so the
+// Core bot routes (dashboard, health, /webhook/github). Separated from app.ts so the
 // workers-pool test entry can mount them without pulling in Flue's
 // workflow-invoke routes (which require workflow DOs that aren't declared in
 // wrangler.test.jsonc).
 
 import type { Hono } from "hono";
 
+import dashboardHtml from "./dashboard.html?raw";
+import { getDashboardPayload } from "./lib/dashboard.js";
 import { normalizeWebhook, verifyWebhookSignature } from "./lib/webhook.js";
 
 export function registerCoreRoutes(app: Hono<{ Bindings: Env }>): Hono<{ Bindings: Env }> {
+	app.get("/", (c) => c.html(dashboardHtml));
 	app.get("/health", (c) => c.text("ok"));
+	app.get("/api/dashboard", async (c) => {
+		try {
+			const payload = await getDashboardPayload(c.env);
+			c.header("cache-control", "public, max-age=10, stale-while-revalidate=30");
+			return c.json(payload);
+		} catch (error) {
+			console.error("[dashboard] load failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return c.json({ error: "Dashboard data is temporarily unavailable" }, 503);
+		}
+	});
 
 	app.post("/webhook/github", async (c) => {
 		// Verify signature against the RAW body, before any parsing. Round-tripping

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -106,6 +106,61 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect(typeof entry.t).toBe("number");
 	});
 
+	test("public snapshots omit delivery and actor metadata", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.event(makeEvent({ deliveryId: "private-delivery-id" }));
+
+		const snapshot = await stub.getPublicSnapshot();
+		expect(snapshot).toMatchObject({
+			state: "fixing",
+			kind: "enhancement",
+			currentRunStartedAt: null,
+			prNumber: null,
+			progress: [],
+		});
+		expect(snapshot.transitions).toHaveLength(1);
+		expect(snapshot.transitions[0]).toMatchObject({
+			event: "implement",
+			from: "unmanaged",
+			to: "fixing",
+		});
+		expect(snapshot.transitions[0]).not.toHaveProperty("deliveryId");
+		expect(snapshot.transitions[0]).not.toHaveProperty("actor");
+	});
+
+	test("public progress accepts only the current run and sanitizes text", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		const startedAt = Date.now() - 1_000;
+		await stub.debugSetStaleRun("current-run", startedAt);
+
+		await expect(
+			stub.recordPublicProgress({
+				runId: "stale-run",
+				kind: "workspace_ready",
+				title: "Should not appear",
+			}),
+		).resolves.toBe(false);
+		await expect(
+			stub.recordPublicProgress({
+				runId: "current-run",
+				kind: "workspace_ready",
+				title: "Workspace\nready",
+				detail: "Checked out\tmain   and restored dependencies",
+			}),
+		).resolves.toBe(true);
+
+		const snapshot = await stub.getPublicSnapshot();
+		expect(snapshot.currentRunStartedAt).toBe(startedAt);
+		expect(snapshot.progress).toMatchObject([
+			{
+				kind: "workspace_ready",
+				title: "Workspace ready",
+				detail: "Checked out main and restored dependencies",
+			},
+		]);
+		expect(snapshot.progress[0]).not.toHaveProperty("runId");
+	});
+
 	test("duplicate deliveryId is deduped on the second event() call", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		const first = await stub.event(makeEvent({ deliveryId: "dup-1" }));

--- a/infra/emdash-bot/tests/integration/webhook.test.ts
+++ b/infra/emdash-bot/tests/integration/webhook.test.ts
@@ -109,6 +109,19 @@ describe("verifyWebhookSignature (workers-pool)", () => {
 });
 
 describe("POST /webhook/github (workers-pool)", () => {
+	test("serves the public dashboard", async () => {
+		const res = await SELF.fetch("https://test/");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/html");
+		expect(await res.text()).toContain("The path from issue to merge");
+	});
+
+	test("dashboard API fails closed when GitHub credentials are unavailable", async () => {
+		const res = await SELF.fetch("https://test/api/dashboard");
+		expect(res.status).toBe(503);
+		expect(await res.json()).toEqual({ error: "Dashboard data is temporarily unavailable" });
+	});
+
 	test("rejects requests without a valid signature", async () => {
 		const res = await postWebhook({
 			eventType: "ping",

--- a/infra/emdash-bot/tests/unit/github.test.ts
+++ b/infra/emdash-bot/tests/unit/github.test.ts
@@ -7,6 +7,7 @@ import {
 	createGitTree,
 	getGitCommit,
 	getIssueComments,
+	listOpenManagedIssues,
 	updateBranch,
 } from "../../.flue/lib/github.js";
 
@@ -22,6 +23,10 @@ function jsonResponse(body: unknown, status = 200): Response {
 function parseJsonBody(body: unknown): unknown {
 	if (typeof body !== "string") throw new Error("expected a string request body");
 	return JSON.parse(body);
+}
+
+function requestUrl(input: Parameters<typeof fetch>[0]): string {
+	return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
 }
 
 describe("GitHub Git Data requests", () => {
@@ -149,5 +154,70 @@ describe("GitHub issue context requests", () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		expect(fetchMock.mock.calls[0]?.[0]).toContain("page=3");
+	});
+});
+
+describe("GitHub dashboard requests", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	test("lists open bot-managed issues without pull requests or duplicates", async () => {
+		const issue = {
+			number: 42,
+			title: "A managed issue",
+			html_url: "https://github.com/emdash-cms/emdash/issues/42",
+			updated_at: "2026-08-18T10:00:00Z",
+			labels: [{ name: "bot:bug" }, { name: "bot:working" }],
+		};
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(jsonResponse([issue]))
+			.mockResolvedValueOnce(
+				jsonResponse([
+					{ ...issue, labels: [{ name: "bot:enhancement" }, { name: "bot:working" }] },
+					{
+						number: 43,
+						title: "A bot pull request",
+						html_url: "https://github.com/emdash-cms/emdash/pull/43",
+						updated_at: "2026-08-18T11:00:00Z",
+						labels: [{ name: "bot:enhancement" }, { name: "bot:in-review" }],
+						pull_request: {},
+					},
+				]),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse([
+					{
+						number: 44,
+						title: "A managed task",
+						html_url: "https://github.com/emdash-cms/emdash/issues/44",
+						updated_at: "2026-08-18T12:00:00Z",
+						labels: [{ name: "bot:task" }, { name: "bot:blocked" }],
+					},
+				]),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(listOpenManagedIssues("token", repo)).resolves.toEqual([
+			{
+				number: 44,
+				title: "A managed task",
+				url: "https://github.com/emdash-cms/emdash/issues/44",
+				updatedAt: "2026-08-18T12:00:00Z",
+				labels: ["bot:task", "bot:blocked"],
+			},
+			{
+				number: 42,
+				title: "A managed issue",
+				url: "https://github.com/emdash-cms/emdash/issues/42",
+				updatedAt: "2026-08-18T10:00:00Z",
+				labels: ["bot:bug", "bot:working"],
+			},
+		]);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(fetchMock.mock.calls.map(([url]) => requestUrl(url))).toEqual([
+			expect.stringContaining("labels=bot%3Abug"),
+			expect.stringContaining("labels=bot%3Aenhancement"),
+			expect.stringContaining("labels=bot%3Atask"),
+		]);
 	});
 });

--- a/infra/emdash-bot/wrangler.jsonc
+++ b/infra/emdash-bot/wrangler.jsonc
@@ -4,6 +4,13 @@
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-07-17",
 	"compatibility_flags": ["nodejs_compat"],
+	"routes": [
+		{
+			"pattern": "bot.emdashcms.com",
+			"zone_name": "emdashcms.com",
+			"custom_domain": true,
+		},
+	],
 
 	// Workers AI: structural binding, no API key. Every model the bot uses
 	// (classify, investigate, fix) resolves through `cloudflare/@cf/...`


### PR DESCRIPTION
## What does this PR do?

Adds a public workbench for `emdash-bot` at the Worker root and configures `bot.emdashcms.com` as its custom domain. The dashboard shows open bot-managed GitHub issues, their canonical Durable Object state, an interactive workflow, and a bounded public-safe activity timeline.

Agent progress is recorded as explicitly allowlisted, sanitized events. Internal delivery IDs, actor metadata, run IDs, prompts, model reasoning, command output, and raw platform logs are not exposed.

Related issue: n/a — maintainer-directed infrastructure work.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: n/a — this is maintainer-directed private infrastructure and does not change a published package.

The i18n checkbox is n/a because this is a standalone infrastructure dashboard, not the localized admin UI. The changeset checkbox is n/a because `infra/emdash-bot` is private and no published package changed.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:quick`
- Type-aware oxlint: 0 diagnostics
- `pnpm --dir infra/emdash-bot test:unit`: 251 tests passed
- `pnpm --dir infra/emdash-bot test:workers`: 60 tests passed
- `pnpm --dir infra/emdash-bot build`
- Browser-verified at desktop and mobile widths in light and dark modes
