### PR TITLE
fix(bot): preserve publication bytes and retry modes

### DIFF
--- a/infra/emdash-bot/.flue/lib/exec-env.ts
+++ b/infra/emdash-bot/.flue/lib/exec-env.ts
@@ -566,15 +566,21 @@ function decodeBase64Utf8(encoded: string, label: string): string {
 	const value = encoded.trim();
 	if (value === "") return "";
 	try {
-		const binary = atob(value);
-		const bytes = new Uint8Array(binary.length);
-		for (let index = 0; index < binary.length; index += 1) {
-			bytes[index] = binary.charCodeAt(index);
-		}
-		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+		return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(
+			decodeBase64Bytes(value),
+		);
 	} catch (error) {
 		throw new Error(`${label} was not valid base64-encoded UTF-8`, { cause: error });
 	}
+}
+
+function decodeBase64Bytes(encoded: string): Uint8Array {
+	const binary = atob(encoded);
+	const bytes = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index += 1) {
+		bytes[index] = binary.charCodeAt(index);
+	}
+	return bytes;
 }
 
 async function assertGitBlobContent(
@@ -644,8 +650,8 @@ export function fromSandbox(sandbox: Sandbox): ContainerBackend {
 			await sandbox.writeFile(path, content);
 		},
 		async readFileBytes(path) {
-			const stream = await sandbox.readFileStream(path);
-			return new Uint8Array(await new Response(stream).arrayBuffer());
+			const { content } = await sandbox.readFile(path, { encoding: "base64" });
+			return decodeBase64Bytes(content);
 		},
 	};
 }

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -236,6 +236,7 @@ const STORAGE = {
 	kind: "o:kind",
 	currentRunId: "o:currentRunId",
 	currentRunMode: "o:currentRunMode",
+	failedRunMode: "o:failedRunMode",
 	currentRunStartedAt: "o:currentRunStartedAt",
 	currentAgentId: "o:currentAgentId",
 	currentDispatchId: "o:currentDispatchId",
@@ -424,10 +425,14 @@ export class OrchestratorDO extends DurableObject<Env> {
 		// back to the webhook's snapshot for first-time mentions.
 		const persistedLabels = await this.projectLabels();
 		const labels = persistedLabels.length > 0 ? persistedLabels : input.labels;
-		const resumableRun =
+		const [resumableRun, failedRunMode] = await Promise.all([
 			resolvedEvent === "resume"
-				? ((await this.ctx.storage.get<ResumableRunCheckpoint>(STORAGE.resumableRun)) ?? null)
-				: null;
+				? this.ctx.storage.get<ResumableRunCheckpoint>(STORAGE.resumableRun)
+				: null,
+			resolvedEvent === "retry"
+				? this.ctx.storage.get<InvestigationMode>(STORAGE.failedRunMode)
+				: null,
+		]);
 
 		const decision = resolve({
 			labels,
@@ -435,6 +440,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			arg: resolvedArg,
 			actor: input.actor,
 			...(resumableRun ? { resumeState: resumableRun.state } : {}),
+			...(failedRunMode ? { retryMode: failedRunMode } : {}),
 		});
 
 		if (decision.kind === "noop") {
@@ -1881,6 +1887,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 					);
 				}
 			}
+			if (decision.event === "agent.failed" && input.settlesRunId) {
+				const failedRunMode = await transaction.get<InvestigationMode>(STORAGE.currentRunMode);
+				if (failedRunMode) puts.push(transaction.put(STORAGE.failedRunMode, failedRunMode));
+			}
 			if (decision.to === "preview_building") {
 				const startedAt = Date.now();
 				puts.push(
@@ -1914,6 +1924,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 					transaction.put(STORAGE.currentAgentId, preparedInvestigation.agentId),
 					transaction.delete(STORAGE.deadlineWarningSentRunId),
 					transaction.delete(STORAGE.deadlineWarningRetryAt),
+					transaction.delete(STORAGE.failedRunMode),
 					transaction.put(STORAGE.pendingDispatch, {
 						...preparedInvestigation,
 						...(input.deliveryId ? { deliveryId: input.deliveryId } : {}),
@@ -1929,6 +1940,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 					transaction.put(STORAGE.currentAgentId, preparedResume.checkpoint.agentId),
 					transaction.delete(STORAGE.deadlineWarningSentRunId),
 					transaction.delete(STORAGE.deadlineWarningRetryAt),
+					transaction.delete(STORAGE.failedRunMode),
 					transaction.put(STORAGE.pendingResume, {
 						...preparedResume,
 						dryRun: input.dryRun === true,
@@ -1941,7 +1953,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 					decision.event === "decline" ||
 					decision.event === "take_over")
 			) {
-				puts.push(transaction.delete(STORAGE.resumableRun));
+				puts.push(
+					transaction.delete(STORAGE.resumableRun),
+					transaction.delete(STORAGE.failedRunMode),
+				);
 			}
 			const anchorNumber =
 				input.anchorNumber ?? (await transaction.get<number>(STORAGE.anchorNumber));

--- a/infra/emdash-bot/.flue/lib/router.ts
+++ b/infra/emdash-bot/.flue/lib/router.ts
@@ -180,6 +180,22 @@ export interface ResolveInput {
 	arg?: string | null;
 	actor?: Actor | "other";
 	resumeState?: StateId;
+	retryMode?: InvestigationMode;
+}
+
+function failedWriteRetry(mode: InvestigationMode | undefined): {
+	to: StateId;
+	action: string;
+} | null {
+	switch (mode) {
+		case "implement":
+		case "fix":
+			return { to: "fixing", action: `investigate.${mode}` };
+		case "revise":
+			return { to: "working", action: "investigate.revise" };
+		default:
+			return null;
+	}
 }
 
 /**
@@ -189,7 +205,14 @@ export interface ResolveInput {
  * handler, Orchestrator DO) is responsible for actor classification but the
  * router enforces that the event's `actors` list includes the caller.
  */
-export function resolve({ labels, event, arg, actor, resumeState }: ResolveInput): Decision {
+export function resolve({
+	labels,
+	event,
+	arg,
+	actor,
+	resumeState,
+	retryMode,
+}: ResolveInput): Decision {
 	const from = currentState(labels);
 	const meta = EVENTS[event];
 	if (!meta) return { kind: "noop", reason: `unknown event "${event}"` };
@@ -220,8 +243,11 @@ export function resolve({ labels, event, arg, actor, resumeState }: ResolveInput
 	if (!from) return { kind: "noop", reason: "item has conflicting state labels" };
 	const t = findTransition(from, event);
 	if (!t) return { kind: "noop", reason: `no transition for ${from} + ${event}`, from };
+	const retry = from === "failed" && event === "retry" ? failedWriteRetry(retryMode) : null;
 	const to =
-		event === "resume" && resumeState ? resumeState : transitionTarget(t, currentKind(labels));
+		event === "resume" && resumeState
+			? resumeState
+			: (retry?.to ?? transitionTarget(t, currentKind(labels)));
 	const toLabel = STATES[to].label;
 	const removeLabels = STATE_LABELS.filter((l) => l !== toLabel);
 
@@ -248,7 +274,7 @@ export function resolve({ labels, event, arg, actor, resumeState }: ResolveInput
 		kind: "transition",
 		from,
 		to,
-		action: t.action ?? null,
+		action: retry?.action ?? t.action ?? null,
 		addLabel: toLabel,
 		addLabels,
 		removeLabels,

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -326,6 +326,30 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect((await stub.getPersistedState()).currentRunId).toBe("write-run");
 	});
 
+	test("retrying a failed implementation preserves its write mode", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.event(makeEvent({ anchorNumber: 42 }));
+		await stub.debugSetStaleRun(
+			"failed-implementation",
+			Date.now(),
+			"investigate-42-failed-implementation",
+			"implement",
+		);
+		await stub.applyAgentResult({
+			runId: "failed-implementation",
+			result: { implemented: false, summary: "Candidate publication failed." },
+			pushed: false,
+			ok: false,
+		});
+
+		const retry = await stub.event(makeEvent({ event: "retry", arg: null, anchorNumber: 42 }));
+
+		expect(retry.kind).toBe("transition");
+		if (retry.kind === "transition") {
+			expect(retry.decision.action).toBe("investigate.implement");
+		}
+	});
+
 	test("a rejected implementation returns to a state where implement can be retried", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		await stub.event(makeEvent());

--- a/infra/emdash-bot/tests/unit/exec-env.test.ts
+++ b/infra/emdash-bot/tests/unit/exec-env.test.ts
@@ -1,8 +1,10 @@
+import type { Sandbox } from "@cloudflare/sandbox";
 import { describe, expect, test, vi } from "vitest";
 
 import {
 	type ContainerBackend,
 	ExecEnv,
+	fromSandbox,
 	type IsolateState,
 	parseRawGitDiff,
 } from "../../.flue/lib/exec-env.js";
@@ -155,6 +157,36 @@ function base64Utf8(value: string): string {
 	for (const byte of bytes) binary += String.fromCharCode(byte);
 	return btoa(binary);
 }
+
+function sandboxFileStream(content: string): ReadableStream<Uint8Array> {
+	const size = new TextEncoder().encode(content).byteLength;
+	const events = [
+		{ type: "metadata", mimeType: "text/plain", size, isBinary: false, encoding: "utf-8" },
+		{ type: "chunk", data: content },
+		{ type: "complete" },
+	];
+	const payload = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(payload));
+			controller.close();
+		},
+	});
+}
+
+describe("Sandbox container adapter", () => {
+	test("returns exact file bytes rather than the file stream protocol", async () => {
+		const content = "# r\u00e9sum\u00e9 \ud83d\ude80\n";
+		const sandbox = {
+			readFile: async () => ({ content: base64Utf8(content) }),
+			readFileStream: async () => sandboxFileStream(content),
+		} as unknown as Sandbox;
+
+		const bytes = await fromSandbox(sandbox).readFileBytes("/tmp/candidate");
+
+		expect(bytes).toEqual(new TextEncoder().encode(content));
+	});
+});
 
 describe("ExecEnv container exec", () => {
 	test("runs the command in the container with the repo cwd", async () => {

--- a/infra/emdash-bot/tests/unit/router.test.ts
+++ b/infra/emdash-bot/tests/unit/router.test.ts
@@ -121,6 +121,36 @@ describe("router", () => {
 		expect(decision.action).toBe("investigate.resume");
 	});
 
+	test.each([
+		{ retryMode: "implement", to: "fixing", action: "investigate.implement" },
+		{ retryMode: "fix", to: "fixing", action: "investigate.fix" },
+		{ retryMode: "revise", to: "working", action: "investigate.revise" },
+	] as const)("failed retry preserves $retryMode mode", ({ retryMode, to, action }) => {
+		const decision = resolve({
+			labels: ["bot:bug", "bot:failed"],
+			event: "retry",
+			actor: "maintainer",
+			retryMode,
+		});
+
+		assertTransition(decision);
+		expect(decision.to).toBe(to);
+		expect(decision.action).toBe(action);
+	});
+
+	test("failed retry keeps the repro fallback for read modes", () => {
+		const decision = resolve({
+			labels: ["bot:bug", "bot:failed"],
+			event: "retry",
+			actor: "maintainer",
+			retryMode: "repro",
+		});
+
+		assertTransition(decision);
+		expect(decision.to).toBe("working");
+		expect(decision.action).toBe("investigate.repro");
+	});
+
 	test("isDestructive flags decline and take_over only", () => {
 		expect(isDestructive("decline")).toBe(true);
 		expect(isDestructive("take_over")).toBe(true);


### PR DESCRIPTION
## What does this PR do?

Fixes two EmDashBot lifecycle failures observed while processing #1623 and #2299:

- Reads candidate files through the Sandbox SDK's base64 file API so Git blob verification receives exact bytes instead of the SSE framing returned by `readFileStream()`.
- Persists the mode of a failed write run so `retry` restarts `implement`, `fix`, or `revise` work with the correct 60-minute budget instead of falling back to a 30-minute repro run.

Both bugs have behavioral regressions covering the real stream protocol boundary and the Orchestrator DO's persisted retry path.

Related to #1623 and #2299.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
  - The bot typecheck still fails on pre-existing generated Durable Object binding/export errors and the existing verification test fixture error. The touched `TextDecoder` options error was repaired; no new changed-line type errors remain.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
  - N/A: private bot infrastructure only; no admin UI strings.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
  - N/A: only private `infra/emdash-bot` code changes.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
  - N/A: bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No visual changes.

- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 261 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 61 passed
- `pnpm --filter @emdash-cms/emdash-bot build` — passed
- `pnpm lint` — passed
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm format:check` — passed
- `pnpm --filter @emdash-cms/emdash-bot typecheck` — fails on the pre-existing errors disclosed above
