### PR TITLE
docs: correct AGENTS.md secrets guidance to match #2140

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,7 +354,8 @@ Tool directives are exempt from all of the above: `eslint-disable`, `oxlint-disa
 
 - Use `import.meta.env.DEV` / `import.meta.env.PROD` (Vite/Astro standard). Never `process.env.NODE_ENV`.
 - Dev-only endpoints must check `import.meta.env.DEV` and return 403 otherwise -- it's a compile-time constant, unspoofable at runtime.
-- Secrets pattern: `import.meta.env.EMDASH_X || import.meta.env.X || ""`.
+- Public build-time config pattern: `import.meta.env.EMDASH_X || import.meta.env.X || ""`.
+- **Secrets read `process.env` only, never `import.meta.env`** -- Vite statically inlines `import.meta.env`, which bakes build-machine secrets into the bundle and shadows runtime values set on the deployment platform. See `packages/core/src/config/secrets.ts`.
 
 ## Cloudflare Env
 


### PR DESCRIPTION
## What does this PR do?

Fixes stale agent guidance in AGENTS.md: the Environment section still taught `import.meta.env.EMDASH_X || import.meta.env.X || ""` as the "Secrets pattern". Since #2140 secrets are read from `process.env` only — Vite statically inlines `import.meta.env` at build time, which bakes build-machine secrets into the shipped bundle and shadows runtime values set via `wrangler secret put` (see #2139 and the `readDefaultEnv` doc comment in `packages/core/src/config/secrets.ts`).

The fallback chain is still the documented convention for public build-time config, so the line is relabeled and a secrets rule added alongside it, rather than removed.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a, docs-only change (no source touched)
- [ ] `pnpm lint` passes — n/a, docs-only change
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a, docs-only change
- [ ] `pnpm format` has been run — n/a, markdown edit only
- [ ] I have added/updated tests for my changes (if applicable) — n/a
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — n/a, no published package changed
- [ ] New features link to an approved Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (autonomous docs fix)

## Screenshots / test output

n/a
