### PR TITLE
fix(bot): recover from stale verification

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -64,6 +64,8 @@ import {
 	assertVerificationIdentity,
 	findReusableVerificationRecord,
 	passingVerificationRecords,
+	requireTerminalReportAllowed,
+	StaleVerificationError,
 	type VerificationRecord,
 	upsertVerificationRecord,
 } from "../lib/verification.js";
@@ -194,6 +196,7 @@ type ImplementationResult = v.InferOutput<typeof implementationResultSchema>;
 interface RunFailure {
 	stage: "workspace" | "verification" | "publication" | "reporting";
 	message: string;
+	recoverable?: boolean;
 }
 
 export function Investigate({ id }: AgentProps) {
@@ -219,6 +222,28 @@ export function Investigate({ id }: AgentProps) {
 	}
 
 	const env = execEnvFor(id, input);
+	const ensureTerminalReportAllowed = async () => {
+		requireTerminalReportAllowed(lastFailure);
+		if (verification.length === 0) return;
+		let candidateTreeSha: string;
+		try {
+			candidateTreeSha = await env.candidateTreeSha();
+		} catch {
+			return;
+		}
+		try {
+			requireTerminalReportAllowed(null, verification, candidateTreeSha);
+		} catch (error) {
+			if (error instanceof StaleVerificationError) {
+				setLastFailure({
+					stage: "verification",
+					message: safeFailureMessage(error),
+					recoverable: true,
+				});
+			}
+			throw error;
+		}
+	};
 
 	if (input.mode === "implement") {
 		useSkill(implementSkill);
@@ -470,7 +495,7 @@ export function Investigate({ id }: AgentProps) {
 			defineTool({
 				name: "publish_candidate",
 				description:
-					"Publish the verified working tree to this issue's candidate branch. The trusted Worker snapshots the changes, creates the Git objects, updates only bot/fix-<issue>, and verifies the remote SHA. Do not run git commit or git push yourself.",
+					"Publish the verified working tree to this issue's candidate branch. The trusted Worker snapshots the changes, creates the Git objects, updates only bot/fix-<issue>, and verifies the remote SHA. If it reports stale checks, rerun every listed check with the same name and command, then call publish_candidate again; stale verification is recoverable and must not be reported as a terminal blocker. Do not run git commit or git push yourself.",
 				input: v.object({
 					commitMessage: v.pipe(v.string(), v.minLength(5), v.maxLength(200)),
 				}),
@@ -493,7 +518,11 @@ export function Investigate({ id }: AgentProps) {
 					try {
 						passingVerificationRecords(verification, snapshot.treeSha);
 					} catch (error) {
-						setLastFailure({ stage: "verification", message: safeFailureMessage(error) });
+						setLastFailure({
+							stage: "verification",
+							message: safeFailureMessage(error),
+							...(error instanceof StaleVerificationError ? { recoverable: true } : {}),
+						});
 						throw error;
 					}
 					try {
@@ -527,6 +556,7 @@ export function Investigate({ id }: AgentProps) {
 				output: reportedResultSchema,
 				durable: true,
 				async run({ data, step, log }) {
+					await ensureTerminalReportAllowed();
 					requireCandidatePublication(data.implemented, publication);
 					const pushed = await step.do("verify-publication", () =>
 						detectPublication(input.issueNumber, publication),
@@ -570,6 +600,7 @@ export function Investigate({ id }: AgentProps) {
 				output: reportedResultSchema,
 				durable: true,
 				async run({ data, step, log }) {
+					await ensureTerminalReportAllowed();
 					requireCandidatePublication(data.fixed === true, publication);
 					const pushed = await step.do("verify-publication", () =>
 						detectPublication(input.issueNumber, publication),
@@ -609,6 +640,14 @@ export function Investigate({ id }: AgentProps) {
 		const reportTool = input.mode === "implement" ? "report_implementation" : "report_result";
 		const reportCall = response.toolCalls.some((call) => call.tool === reportTool && !call.isError);
 		if (reported || reportCall) return;
+		if (lastFailure?.recoverable) {
+			append({
+				kind: "signal",
+				type: "investigation.verification-rerun-required",
+				body: lastFailure.message,
+			});
+			return;
+		}
 		if (!reminded) {
 			setReminded(true);
 			append({

--- a/infra/emdash-bot/.flue/lib/verification.ts
+++ b/infra/emdash-bot/.flue/lib/verification.ts
@@ -12,6 +12,36 @@ export interface VerificationIdentity {
 	readonly cwd?: string;
 }
 
+export class StaleVerificationError extends Error {
+	readonly checks: readonly string[];
+
+	constructor(checks: readonly string[]) {
+		super(
+			`Cannot report a terminal result because the candidate changed after verification. Rerun every listed check with its existing name and command on the current candidate, then call publish_candidate again. Stale checks: ${checks.join(", ")}.`,
+		);
+		this.name = "StaleVerificationError";
+		this.checks = [...checks];
+	}
+}
+
+export function requireTerminalReportAllowed(
+	failure: { readonly message: string; readonly recoverable?: boolean } | null,
+	records: readonly VerificationRecord[] = [],
+	candidateTreeSha?: string,
+): void {
+	if (failure?.recoverable === true) {
+		throw new Error(
+			`Cannot report a terminal result while verification is recoverable. ${failure.message}`,
+		);
+	}
+	if (candidateTreeSha === undefined || records.length === 0) return;
+	try {
+		passingVerificationRecords(records, candidateTreeSha);
+	} catch (error) {
+		if (error instanceof StaleVerificationError) throw error;
+	}
+}
+
 const PIPE_OPERATOR = /\|/;
 const STATUS_MASKING_SHELL_CONTROL = /[;&\r\n]/;
 const LEADING_SHELL_NEGATION = /^\s*!/;
@@ -97,9 +127,7 @@ export function passingVerificationRecords(
 			(record) => record.candidateTreeSha !== candidateTreeSha,
 		);
 		if (stale.length > 0) {
-			throw new Error(
-				`candidate changed after verification checks: ${stale.map((record) => record.name).join(", ")}`,
-			);
+			throw new StaleVerificationError(stale.map((record) => record.name));
 		}
 	}
 	return [...latest.values()];

--- a/infra/emdash-bot/tests/unit/verification.test.ts
+++ b/infra/emdash-bot/tests/unit/verification.test.ts
@@ -5,6 +5,8 @@ import {
 	assertVerificationIdentity,
 	findReusableVerificationRecord,
 	passingVerificationRecords,
+	requireTerminalReportAllowed,
+	StaleVerificationError,
 	upsertVerificationRecord,
 } from "../../.flue/lib/verification.js";
 
@@ -143,19 +145,57 @@ describe("verification commands", () => {
 		]);
 	});
 
-	test("does not publish a candidate changed after verification", () => {
+	test("requires stale checks to be rerun instead of allowing a terminal report", () => {
+		const records = [
+			{
+				name: "tests",
+				command: "pnpm test",
+				exitCode: 0,
+				candidateTreeSha: "verified-tree",
+			},
+			{
+				name: "lint",
+				command: "pnpm lint",
+				exitCode: 0,
+				candidateTreeSha: "verified-tree",
+			},
+		];
+		let failure: unknown;
+		try {
+			passingVerificationRecords(records, "changed-tree");
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(StaleVerificationError);
+		if (!(failure instanceof StaleVerificationError)) return;
+		expect(failure.checks).toEqual(["tests", "lint"]);
+		expect(failure.message).toContain("Rerun every listed check");
 		expect(() =>
-			passingVerificationRecords(
+			requireTerminalReportAllowed({ message: failure.message, recoverable: true }),
+		).toThrow(/cannot report a terminal result/i);
+		expect(() => requireTerminalReportAllowed(null, records, "changed-tree")).toThrow(
+			/cannot report a terminal result/i,
+		);
+	});
+
+	test("allows reporting after a non-recoverable verification failure", () => {
+		expect(() =>
+			requireTerminalReportAllowed({ message: "tests failed", recoverable: false }),
+		).not.toThrow();
+		expect(() =>
+			requireTerminalReportAllowed(
+				null,
 				[
 					{
 						name: "tests",
 						command: "pnpm test",
-						exitCode: 0,
-						candidateTreeSha: "verified-tree",
+						exitCode: 1,
+						candidateTreeSha: "failed-tree",
 					},
 				],
-				"published-tree",
+				"changed-tree",
 			),
-		).toThrow(/candidate changed/);
+		).not.toThrow();
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Prevents EmDashBot from treating stale verification as a terminal publication blocker.

When the candidate changes after checks pass, the bot now records a recoverable verification failure with the exact stale check names, tells the agent to rerun them using their existing commands, and blocks both reporting tools until the checks are current or a real check failure occurs. The reporting path also compares the current candidate tree directly, so a same-turn state update cannot bypass the gate.

This follows the #2299 run observed after #2545, where a changeset was added after five checks and the agent reported the resulting stale-check rejection instead of rerunning them.

Related to #2299.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
  - The bot typecheck still fails on the pre-existing generated Durable Object binding/export errors and existing verification test fixture error. No new errors point to this change.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
  - N/A: private bot infrastructure only; no admin UI strings.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
  - N/A: only private `infra/emdash-bot` code changes.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
  - N/A: bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No visual changes.

- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 262 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 61 passed
- `pnpm --filter @emdash-cms/emdash-bot build` — passed
- `pnpm lint` — passed
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm format:check` — passed
- `pnpm --filter @emdash-cms/emdash-bot typecheck` — fails on the pre-existing errors disclosed above
