### PR TITLE
fix(bot): separate issue and run lifecycles

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -508,6 +508,11 @@ export function Investigate({ id }: AgentProps) {
 						setLastFailure({ stage: "verification", message: safeFailureMessage(error) });
 						throw error;
 					}
+					await recordInvestigationProgress(input, {
+						kind: "candidate_publishing",
+						title: "Publishing candidate",
+						detail: `Preparing bot/fix-${input.issueNumber} from the verified candidate`,
+					});
 					let snapshot: CandidateSnapshot;
 					try {
 						snapshot = await env.snapshotCandidate();

--- a/infra/emdash-bot/.flue/dashboard.html
+++ b/infra/emdash-bot/.flue/dashboard.html
@@ -220,6 +220,65 @@
 				margin-bottom: 22px;
 			}
 
+			.machine-stack {
+				display: grid;
+				gap: 23px;
+			}
+
+			.machine-block + .machine-block {
+				padding-top: 22px;
+				border-top: 1px solid light-dark(#e5e6eb, #292b33);
+			}
+
+			.machine-heading {
+				display: flex;
+				align-items: start;
+				justify-content: space-between;
+				gap: 18px;
+				margin-bottom: 15px;
+			}
+
+			.machine-heading h3 {
+				margin: 0;
+				font-size: 12px;
+				font-weight: 600;
+			}
+
+			.machine-heading p {
+				margin: 4px 0 0;
+				color: light-dark(#767a85, #9296a1);
+				font-size: 10px;
+			}
+
+			.machine-badge {
+				display: inline-flex;
+				align-items: center;
+				min-height: 24px;
+				padding: 4px 8px;
+				border: 1px solid light-dark(#ded9eb, #3b304d);
+				border-radius: 999px;
+				background: light-dark(#f4f0fb, #211c2b);
+				color: light-dark(#6840ae, #c1a6ee);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+				white-space: nowrap;
+			}
+
+			.machine-badge.attention,
+			.machine-badge.cancelled,
+			.machine-badge.failed,
+			.machine-badge.timed_out {
+				border-color: light-dark(#efd2a8, #60471f);
+				background: light-dark(#fff1dc, #392b18);
+				color: light-dark(#95580b, #f2bd72);
+			}
+
+			.machine-badge.succeeded {
+				border-color: light-dark(#b9dfd0, #275544);
+				background: light-dark(#eaf8f2, #173429);
+				color: light-dark(#14704e, #74d8ad);
+			}
+
 			.section-head {
 				display: flex;
 				align-items: start;
@@ -266,10 +325,18 @@
 				background: light-dark(#8b5aee, #a983ff);
 			}
 
+			.route-line.skipped {
+				background: repeating-linear-gradient(
+					90deg,
+					light-dark(#aeb2bc, #656a75) 0 4px,
+					transparent 4px 7px
+				);
+			}
+
 			.workflow {
 				position: relative;
 				display: grid;
-				grid-template-columns: repeat(8, minmax(0, 1fr));
+				grid-template-columns: repeat(var(--phase-count, 8), minmax(0, 1fr));
 				padding-top: 5px;
 			}
 
@@ -327,6 +394,33 @@
 				color: light-dark(#fff, #17121f);
 				box-shadow: 0 0 0 5px light-dark(rgba(118, 66, 218, 0.11), rgba(169, 131, 255, 0.13));
 				transform: translateY(-1px);
+			}
+
+			.phase.skipped .phase-marker {
+				border-style: dashed;
+				background: light-dark(#f7f7f9, #121318);
+				color: light-dark(#b0b3bb, #5f646e);
+			}
+
+			.phase.skipped .phase-label {
+				color: light-dark(#a2a6af, #676c76);
+				text-decoration: line-through;
+				text-decoration-thickness: 1px;
+			}
+
+			.phase.skipped .phase-state {
+				color: light-dark(#9a9ea8, #747985);
+				opacity: 1;
+			}
+
+			.phase.current.attention .phase-marker,
+			.phase.current.cancelled .phase-marker,
+			.phase.current.failed .phase-marker,
+			.phase.current.timed_out .phase-marker {
+				border-color: light-dark(#c77a18, #e3a44f);
+				background: light-dark(#fff1dc, #392b18);
+				color: light-dark(#95580b, #f2bd72);
+				box-shadow: 0 0 0 5px light-dark(rgba(191, 120, 29, 0.1), rgba(227, 164, 79, 0.1));
 			}
 
 			.phase-label {
@@ -530,7 +624,7 @@
 
 			.facts {
 				display: grid;
-				grid-template-columns: repeat(3, minmax(0, 1fr));
+				grid-template-columns: repeat(4, minmax(0, 1fr));
 				border-bottom: 1px solid light-dark(#e5e6eb, #292b33);
 				background: light-dark(#fafafd, #14151a);
 			}
@@ -718,6 +812,11 @@
 					font-weight: 600;
 				}
 
+				.mobile-step.skipped {
+					opacity: 0.48;
+					text-decoration: line-through;
+				}
+
 				.detours {
 					justify-content: flex-start;
 					flex-wrap: wrap;
@@ -861,19 +960,53 @@
 			<section class="surface workflow-shell" aria-labelledby="workflow-title">
 				<div class="section-head">
 					<div>
-						<h2 id="workflow-title">The path from issue to merge</h2>
-						<p>Select an issue below to see its position and route.</p>
+						<h2 id="workflow-title">Two state machines, one delivery path</h2>
+						<p>Select an issue to see durable coordination separately from agent execution.</p>
 					</div>
 					<div class="route-key" aria-label="Workflow legend">
 						<span><i class="route-line selected" aria-hidden="true"></i> selected route</span>
 						<span><i class="route-line" aria-hidden="true"></i> remaining route</span>
+						<span><i class="route-line skipped" aria-hidden="true"></i> skipped phase</span>
 					</div>
 				</div>
-				<div class="workflow" id="workflow">
-					<div class="workflow-progress" id="workflow-progress"></div>
+				<div class="machine-stack">
+					<section class="machine-block" aria-labelledby="issue-machine-title">
+						<div class="machine-heading">
+							<div>
+								<h3 id="issue-machine-title">Issue lifecycle</h3>
+								<p>Long-lived coordination projected to GitHub labels.</p>
+							</div>
+							<span class="machine-badge" id="issue-machine-badge">unmanaged</span>
+						</div>
+						<div class="workflow" id="issue-workflow">
+							<div class="workflow-progress" id="issue-workflow-progress"></div>
+						</div>
+						<div
+							class="mobile-flow"
+							id="issue-mobile-flow"
+							aria-label="Selected issue lifecycle"
+						></div>
+						<div class="detours" id="issue-detours" aria-label="Issue lifecycle side routes"></div>
+					</section>
+
+					<section class="machine-block" aria-labelledby="run-machine-title">
+						<div class="machine-heading">
+							<div>
+								<h3 id="run-machine-title">Agent run</h3>
+								<p id="run-machine-description">No run recorded for this issue.</p>
+							</div>
+							<span class="machine-badge" id="run-machine-badge">idle</span>
+						</div>
+						<div class="workflow" id="run-workflow">
+							<div class="workflow-progress" id="run-workflow-progress"></div>
+						</div>
+						<div
+							class="mobile-flow"
+							id="run-mobile-flow"
+							aria-label="Selected agent run lifecycle"
+						></div>
+					</section>
 				</div>
-				<div class="mobile-flow" id="mobile-flow" aria-label="Selected issue workflow"></div>
-				<div class="detours" id="detours" aria-label="Possible side routes"></div>
 			</section>
 
 			<div class="workspace">
@@ -892,52 +1025,6 @@
 		</main>
 
 		<script>
-			const phases = [
-				"Triage",
-				"Investigate",
-				"Establish",
-				"Build",
-				"Preview",
-				"Confirm",
-				"Review",
-				"Done",
-			];
-			const detourStates = [
-				"needs_info",
-				"not_reproduced",
-				"blocked",
-				"failed",
-				"human_owned",
-				"declined",
-			];
-			const phaseByState = {
-				unmanaged: 0,
-				triage: 0,
-				working: 1,
-				investigating: 1,
-				reproduced: 2,
-				diagnosed: 2,
-				not_reproduced: 2,
-				needs_info: 2,
-				fixing: 3,
-				blocked: 3,
-				failed: 3,
-				preview_building: 4,
-				awaiting_feedback: 5,
-				awaiting_reporter: 5,
-				in_review: 6,
-				human_owned: 6,
-				done: 7,
-				declined: 7,
-			};
-			const activeStates = new Set(["working", "investigating", "fixing", "preview_building"]);
-			const waitingStates = new Set([
-				"awaiting_feedback",
-				"awaiting_reporter",
-				"in_review",
-				"human_owned",
-			]);
-			const attentionStates = new Set(["blocked", "failed", "not_reproduced", "needs_info"]);
 			let payload = null;
 			let selectedNumber = null;
 
@@ -953,9 +1040,7 @@
 			}
 
 			function routeFor(state) {
-				if (attentionStates.has(state)) return "attention";
-				if (waitingStates.has(state)) return "waiting";
-				return "active";
+				return payload?.machines.issue.states[state]?.tone ?? "active";
 			}
 
 			function relativeTime(value) {
@@ -966,9 +1051,9 @@
 				return `${Math.floor(seconds / 86400)}d ago`;
 			}
 
-			function durationSince(timestamp) {
+			function durationSince(timestamp, end = Date.now()) {
 				if (!timestamp) return "not running";
-				const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+				const seconds = Math.max(0, Math.floor((end - timestamp) / 1000));
 				const hours = Math.floor(seconds / 3600);
 				const minutes = Math.floor((seconds % 3600) / 60);
 				return hours ? `${hours}h ${minutes}m` : `${minutes}m ${seconds % 60}s`;
@@ -990,43 +1075,111 @@
 				}
 			}
 
-			function renderWorkflow(issue) {
-				const phase = issue ? (phaseByState[issue.state] ?? 0) : 0;
-				const isDetour = issue ? detourStates.includes(issue.state) : false;
-				const workflow = document.getElementById("workflow");
+			function renderPhaseRow(input) {
+				const workflow = document.getElementById(input.workflowId);
+				workflow.style.setProperty("--phase-count", String(input.phases.length));
 				workflow.querySelectorAll(".phase").forEach((node) => node.remove());
-				phases.forEach((label, index) => {
+				const plan = input.plan ?? input.phases.map((phase) => phase.id);
+				const currentPlanIndex = input.currentPhase ? plan.indexOf(input.currentPhase) : -1;
+				const currentPhaseIndex = input.currentPhase
+					? input.phases.findIndex((phase) => phase.id === input.currentPhase)
+					: -1;
+				input.phases.forEach((phase, index) => {
+					const planIndex = plan.indexOf(phase.id);
+					const skipped = input.plan !== null && planIndex === -1;
+					const passed =
+						!skipped &&
+						(input.status === "succeeded" ||
+							(currentPlanIndex >= 0 && planIndex < currentPlanIndex));
+					const current =
+						!skipped && input.status !== "succeeded" && phase.id === input.currentPhase;
 					const phaseNode = element(
 						"div",
-						`phase${index < phase ? " passed" : ""}${index === phase && !isDetour ? " current" : ""}`,
+						`phase${passed ? " passed" : ""}${current ? ` current ${input.tone ?? ""}` : ""}${skipped ? " skipped" : ""}`,
 					);
-					phaseNode.append(element("span", "phase-marker", String(index + 1)));
-					phaseNode.append(element("span", "phase-label", label));
+					phaseNode.append(element("span", "phase-marker", skipped ? "–" : String(index + 1)));
+					phaseNode.append(element("span", "phase-label", phase.label));
 					phaseNode.append(
-						element("span", "phase-state", index === phase && issue ? issue.state : ""),
+						element(
+							"span",
+							"phase-state",
+							skipped ? "skipped" : current ? (input.currentLabel ?? phase.id) : "",
+						),
 					);
 					workflow.append(phaseNode);
 				});
-				document.getElementById("workflow-progress").style.width = `${(phase / 7) * 88.2}%`;
+				const progressIndex =
+					input.status === "succeeded" ? input.phases.length - 1 : currentPhaseIndex;
+				const progress = progressIndex < 0 ? 0 : (progressIndex / (input.phases.length - 1)) * 88.2;
+				document.getElementById(input.progressId).style.width = `${progress}%`;
 
-				const mobile = document.getElementById("mobile-flow");
+				const mobile = document.getElementById(input.mobileId);
 				mobile.replaceChildren();
-				phases.forEach((label, index) => {
-					const step = element(
-						"span",
-						`mobile-step${index < phase ? " passed" : ""}${index === phase && !isDetour ? " current" : ""}`,
-						`${label}${index < phases.length - 1 ? " →" : ""}`,
+				input.phases.forEach((phase, index) => {
+					const planIndex = plan.indexOf(phase.id);
+					const skipped = input.plan !== null && planIndex === -1;
+					const passed =
+						!skipped &&
+						(input.status === "succeeded" ||
+							(currentPlanIndex >= 0 && planIndex < currentPlanIndex));
+					const current =
+						!skipped && input.status !== "succeeded" && phase.id === input.currentPhase;
+					mobile.append(
+						element(
+							"span",
+							`mobile-step${passed ? " passed" : ""}${current ? " current" : ""}${skipped ? " skipped" : ""}`,
+							`${phase.label}${index < input.phases.length - 1 ? " →" : ""}`,
+						),
 					);
-					mobile.append(step);
 				});
+			}
 
-				const detours = document.getElementById("detours");
+			function renderMachines(issue) {
+				const issueMachine = payload.machines.issue;
+				const issueMeta = issue ? issueMachine.states[issue.state] : issueMachine.states.unmanaged;
+				renderPhaseRow({
+					workflowId: "issue-workflow",
+					progressId: "issue-workflow-progress",
+					mobileId: "issue-mobile-flow",
+					phases: issueMachine.phases,
+					plan: null,
+					currentPhase: issueMeta.phase,
+					currentLabel: issue?.state ?? "unmanaged",
+					status: "running",
+					tone: issueMeta.tone,
+				});
+				const issueBadge = document.getElementById("issue-machine-badge");
+				issueBadge.className = `machine-badge ${issueMeta.tone}`;
+				issueBadge.textContent = stateLabel(issue?.state ?? "unmanaged");
+
+				const detours = document.getElementById("issue-detours");
 				detours.replaceChildren(element("span", "detour-label", "Side routes"));
-				for (const state of detourStates) {
+				for (const [state, meta] of Object.entries(issueMachine.states)) {
+					if (!meta.detour) continue;
 					detours.append(
 						element("span", `detour${issue?.state === state ? " current" : ""}`, stateLabel(state)),
 					);
 				}
+
+				const run = issue?.run ?? null;
+				const runMachine = payload.machines.run;
+				renderPhaseRow({
+					workflowId: "run-workflow",
+					progressId: "run-workflow-progress",
+					mobileId: "run-mobile-flow",
+					phases: runMachine.phases,
+					plan: run?.plan ?? null,
+					currentPhase: run?.phase ?? null,
+					currentLabel: run?.phase ?? "",
+					status: run?.status ?? "idle",
+					tone: run?.status ?? "",
+				});
+				const runBadge = document.getElementById("run-machine-badge");
+				runBadge.className = `machine-badge ${run?.status ?? ""}`;
+				runBadge.textContent = run ? `${run.mode} · ${run.status}` : "idle";
+				document.getElementById("run-machine-description").textContent = run
+					? `Attempt ${run.attempt} · ${run.plan.length} of ${runMachine.phases.length} phases · ${durationSince(run.startedAt, run.completedAt ?? Date.now())}`
+					: "No run recorded for this issue.";
 			}
 
 			function renderIssues() {
@@ -1122,14 +1275,22 @@
 				panel.append(head);
 
 				const facts = element("div", "facts");
+				const issuePhase = payload.machines.issue.states[issue.state].phase;
+				const issuePhaseIndex = payload.machines.issue.phases.findIndex(
+					(phase) => phase.id === issuePhase,
+				);
+				const previewPhaseIndex = payload.machines.issue.phases.findIndex(
+					(phase) => phase.id === "preview",
+				);
 				const candidate = issue.prNumber
 					? `PR #${issue.prNumber}`
-					: phaseByState[issue.state] >= 4
+					: issuePhaseIndex >= previewPhaseIndex
 						? `bot/fix-${issue.number}`
 						: "not published";
 				for (const [label, value] of [
-					["Run", durationSince(issue.currentRunStartedAt)],
-					["Current step", stateLabel(issue.state)],
+					["Issue state", stateLabel(issue.state)],
+					["Run", issue.run ? `${issue.run.mode} · ${issue.run.status}` : "not recorded"],
+					["Run phase", issue.run ? stateLabel(issue.run.phase) : "—"],
 					["Candidate", candidate],
 				]) {
 					const fact = element("div", "fact");
@@ -1183,7 +1344,7 @@
 					null;
 				if (selected && selectedNumber === null) selectedNumber = selected.number;
 				renderCounts();
-				renderWorkflow(selected);
+				renderMachines(selected);
 				renderIssues();
 				renderDetail(selected);
 			}
@@ -1204,7 +1365,6 @@
 					document.getElementById("counts").replaceChildren();
 					document.getElementById("issues").innerHTML =
 						'<div class="error"><strong>Could not load current work</strong>The bot itself may still be operating normally. Try this page again shortly.</div>';
-					renderWorkflow(null);
 				}
 			}
 

--- a/infra/emdash-bot/.flue/lib/dashboard.ts
+++ b/infra/emdash-bot/.flue/lib/dashboard.ts
@@ -5,9 +5,10 @@ import {
 	readRepoContext,
 	type ManagedIssueSummary,
 } from "./github.js";
-import { KINDS, type Kind, type StateId } from "./machine.js";
+import { KINDS, machineSnapshot, type Kind, type StateId } from "./machine.js";
 import type { OrchestratorDO, PublicIssueSnapshot } from "./orchestrator.js";
 import { currentState } from "./router.js";
+import { runMachineSnapshot } from "./run-lifecycle.js";
 
 const DASHBOARD_CACHE_MS = 20_000;
 const DASHBOARD_ISSUE_LIMIT = 100;
@@ -33,6 +34,10 @@ export interface DashboardIssue extends ManagedIssueSummary, PublicIssueSnapshot
 export interface DashboardPayload {
 	updatedAt: string;
 	repositoryUrl: string;
+	machines: {
+		issue: ReturnType<typeof machineSnapshot>;
+		run: ReturnType<typeof runMachineSnapshot>;
+	};
 	issues: DashboardIssue[];
 }
 
@@ -73,6 +78,7 @@ export async function loadDashboardPayload(env: Env): Promise<DashboardPayload> 
 	return {
 		updatedAt: new Date().toISOString(),
 		repositoryUrl: `https://github.com/${repo.owner}/${repo.repo}`,
+		machines: { issue: machineSnapshot(), run: runMachineSnapshot() },
 		issues,
 	};
 }

--- a/infra/emdash-bot/.flue/lib/machine.json
+++ b/infra/emdash-bot/.flue/lib/machine.json
@@ -5,9 +5,45 @@
 		"task"
 	],
 	"entryState": "unmanaged",
+	"phases": [
+		{
+			"id": "intake",
+			"label": "Triage"
+		},
+		{
+			"id": "evidence",
+			"label": "Investigate"
+		},
+		{
+			"id": "verdict",
+			"label": "Establish"
+		},
+		{
+			"id": "candidate",
+			"label": "Build"
+		},
+		{
+			"id": "preview",
+			"label": "Preview"
+		},
+		{
+			"id": "confirmation",
+			"label": "Confirm"
+		},
+		{
+			"id": "review",
+			"label": "Review"
+		},
+		{
+			"id": "complete",
+			"label": "Done"
+		}
+	],
 	"states": {
 		"unmanaged": {
 			"label": "",
+			"phase": "intake",
+			"tone": "active",
 			"boardColumn": "(none)",
 			"description": "No bot labels yet. An issue nobody has handed to the bot. Entry commands work directly.",
 			"terminal": false,
@@ -20,6 +56,8 @@
 		},
 		"triage": {
 			"label": "bot:triage",
+			"phase": "intake",
+			"tone": "active",
 			"boardColumn": "Triage",
 			"description": "Filed and awaiting a decision on whether/how the bot should act.",
 			"terminal": false,
@@ -32,6 +70,8 @@
 		},
 		"working": {
 			"label": "bot:working",
+			"phase": "evidence",
+			"tone": "active",
 			"boardColumn": "Working",
 			"description": "An agent run is in flight (reproduce / diagnose / verify / fix / implement).",
 			"terminal": false,
@@ -42,6 +82,9 @@
 		},
 		"blocked": {
 			"label": "bot:blocked",
+			"phase": "candidate",
+			"tone": "attention",
+			"detour": true,
 			"boardColumn": "Blocked",
 			"description": "The bot stopped and needs a human decision. Covers the old skipped / not-reproduced / reproduced-no-fix / by-design outcomes; the reason is in the bot's comment.",
 			"terminal": false,
@@ -56,6 +99,8 @@
 		},
 		"awaiting_feedback": {
 			"label": "bot:awaiting-feedback",
+			"phase": "confirmation",
+			"tone": "waiting",
 			"boardColumn": "Awaiting feedback",
 			"description": "A fix is staged on bot/fix-<n>; waiting for the reporter or a maintainer to confirm or reject.",
 			"terminal": false,
@@ -68,6 +113,8 @@
 		},
 		"in_review": {
 			"label": "bot:in-review",
+			"phase": "review",
+			"tone": "waiting",
 			"boardColumn": "In review",
 			"description": "A PR is open. The review/* sub-states live on the PR and roll up here. On a bot PR, a plain `@emdashbot` comment is feedback; explicit verbs still win.",
 			"terminal": false,
@@ -80,6 +127,9 @@
 		},
 		"human_owned": {
 			"label": "bot:human-owned",
+			"phase": "review",
+			"tone": "waiting",
+			"detour": true,
 			"boardColumn": "Human owned",
 			"description": "A maintainer took it over; the bot stays disengaged but the item stays on the board.",
 			"terminal": false,
@@ -89,6 +139,8 @@
 		},
 		"done": {
 			"label": "bot:done",
+			"phase": "complete",
+			"tone": "active",
 			"boardColumn": "Done",
 			"description": "Shipped (PR merged) or confirmed resolved.",
 			"terminal": true,
@@ -98,6 +150,9 @@
 		},
 		"declined": {
 			"label": "bot:declined",
+			"phase": "complete",
+			"tone": "attention",
+			"detour": true,
 			"boardColumn": "Declined",
 			"description": "Won't be actioned (by design, out of scope, or a maintainer call).",
 			"terminal": true,
@@ -107,6 +162,9 @@
 		},
 		"failed": {
 			"label": "bot:failed",
+			"phase": "candidate",
+			"tone": "attention",
+			"detour": true,
 			"boardColumn": "Failed",
 			"description": "An agent run errored or produced no usable result. Retryable -- not a dead end.",
 			"terminal": false,
@@ -121,6 +179,8 @@
 		},
 		"investigating": {
 			"label": "bot:investigating",
+			"phase": "evidence",
+			"tone": "active",
 			"boardColumn": "Investigating",
 			"description": "A maintainer-triggered investigation is in flight: reproduce + diagnose, no fix. Emits an evidence-carrying verdict.",
 			"terminal": false,
@@ -131,6 +191,8 @@
 		},
 		"reproduced": {
 			"label": "bot:reproduced",
+			"phase": "verdict",
+			"tone": "active",
 			"boardColumn": "Reproduced",
 			"description": "Verdict: reproduced with a diagnosis attached. Resting until a maintainer triggers the fix loop or disposes of it.",
 			"terminal": false,
@@ -143,6 +205,8 @@
 		},
 		"diagnosed": {
 			"label": "bot:diagnosed",
+			"phase": "verdict",
+			"tone": "active",
 			"boardColumn": "Diagnosed",
 			"description": "Verdict: root cause identified, but not confirmed by a reproduction (environment limits). Actionable like reproduced; the fix loop verifies with a failing test before changing anything.",
 			"terminal": false,
@@ -155,6 +219,9 @@
 		},
 		"not_reproduced": {
 			"label": "bot:not-reproduced",
+			"phase": "verdict",
+			"tone": "attention",
+			"detour": true,
 			"boardColumn": "Not reproduced",
 			"description": "Verdict: could not reproduce, transcript attached. A first-class outcome, not a failure. Reporter can add steps; a maintainer can re-investigate.",
 			"terminal": false,
@@ -166,6 +233,9 @@
 		},
 		"needs_info": {
 			"label": "bot:needs-info",
+			"phase": "verdict",
+			"tone": "attention",
+			"detour": true,
 			"boardColumn": "Needs info",
 			"description": "Verdict: the investigation needs information only the reporter has. Evidence records what was tried and what is missing.",
 			"terminal": false,
@@ -177,6 +247,8 @@
 		},
 		"fixing": {
 			"label": "bot:fixing",
+			"phase": "candidate",
+			"tone": "active",
 			"boardColumn": "Fixing",
 			"description": "A maintainer-triggered delivery run is building a candidate on bot/fix-<n>.",
 			"terminal": false,
@@ -187,6 +259,8 @@
 		},
 		"preview_building": {
 			"label": "bot:preview-building",
+			"phase": "preview",
+			"tone": "active",
 			"boardColumn": "Building preview",
 			"description": "The candidate change is published; a preview is building so the reporter can try it before a PR exists.",
 			"terminal": false,
@@ -197,6 +271,8 @@
 		},
 		"awaiting_reporter": {
 			"label": "bot:awaiting-reporter",
+			"phase": "confirmation",
+			"tone": "waiting",
 			"boardColumn": "Awaiting reporter",
 			"description": "Preview link posted; waiting for the reporter to confirm the change. On confirm a draft PR opens; on denial or 14-day silence the branch is reaped.",
 			"terminal": false,
@@ -965,5 +1041,90 @@
 			"event": "reset",
 			"to": "triage"
 		}
-	]
+	],
+	"run": {
+		"phases": [
+			{
+				"id": "prepare",
+				"label": "Prepare"
+			},
+			{
+				"id": "reproduce",
+				"label": "Reproduce"
+			},
+			{
+				"id": "diagnose",
+				"label": "Diagnose"
+			},
+			{
+				"id": "edit",
+				"label": "Edit"
+			},
+			{
+				"id": "finalize",
+				"label": "Finalize"
+			},
+			{
+				"id": "verify",
+				"label": "Verify"
+			},
+			{
+				"id": "publish",
+				"label": "Publish"
+			},
+			{
+				"id": "report",
+				"label": "Report"
+			}
+		],
+		"statuses": [
+			"running",
+			"succeeded",
+			"failed",
+			"timed_out",
+			"cancelled"
+		],
+		"plans": {
+			"diagnose": [
+				"prepare",
+				"reproduce",
+				"diagnose",
+				"report"
+			],
+			"repro": [
+				"prepare",
+				"reproduce",
+				"diagnose",
+				"edit",
+				"finalize",
+				"verify",
+				"publish",
+				"report"
+			],
+			"implement": [
+				"prepare",
+				"edit",
+				"finalize",
+				"verify",
+				"publish",
+				"report"
+			],
+			"fix": [
+				"prepare",
+				"edit",
+				"finalize",
+				"verify",
+				"publish",
+				"report"
+			],
+			"revise": [
+				"prepare",
+				"edit",
+				"finalize",
+				"verify",
+				"publish",
+				"report"
+			]
+		}
+	}
 }

--- a/infra/emdash-bot/.flue/lib/machine.ts
+++ b/infra/emdash-bot/.flue/lib/machine.ts
@@ -1,14 +1,13 @@
-// emdashbot orchestration state machine -- single source of truth.
+// emdashbot lifecycle machine definitions -- single source of truth.
 //
-// This file defines the *orchestration* layer only: the states a work item
-// can be in, the events that move it between them, who may fire each event,
-// and which agent action a transition kicks off. It deliberately says nothing
-// about HOW the agent reproduces, diagnoses, or fixes -- that lives in
-// `.flue/` and is invoked as an opaque "action" here.
+// The issue machine coordinates the long-lived GitHub item. The run machine
+// selects the bounded phase plan for one agent execution. Runtime progress and
+// deadlines live in `run-lifecycle.ts`; agent implementation remains opaque to
+// both machines.
 //
 // Everything else is generated from this file (run `pnpm bot:generate`):
-//   - machine.json          runtime artifact loaded by the router workflows
-//   - BOT_STATE_MACHINE.md   human docs: diagram + transition table + grammar
+//   - machine.json           serialized issue and run machine metadata
+//   - BOT_STATE_MACHINE.md   human docs: diagrams, plans, and transition tables
 //
 // CI re-runs the generator and fails if the committed artifacts drift, the
 // same contract as the query-count snapshots. Edit this file, regenerate,
@@ -28,6 +27,51 @@
 
 export const KINDS = ["bug", "enhancement", "task"] as const;
 export type Kind = (typeof KINDS)[number];
+
+// ---------------------------------------------------------------------------
+// Agent run machine (execution dimension -- independent from issue state)
+// ---------------------------------------------------------------------------
+
+export const RUN_PHASES = [
+	{ id: "prepare", label: "Prepare" },
+	{ id: "reproduce", label: "Reproduce" },
+	{ id: "diagnose", label: "Diagnose" },
+	{ id: "edit", label: "Edit" },
+	{ id: "finalize", label: "Finalize" },
+	{ id: "verify", label: "Verify" },
+	{ id: "publish", label: "Publish" },
+	{ id: "report", label: "Report" },
+] as const;
+
+export type RunPhaseId = (typeof RUN_PHASES)[number]["id"];
+export type RunMode = "repro" | "implement" | "revise" | "diagnose" | "fix";
+export type RunStatus = "running" | "succeeded" | "failed" | "timed_out" | "cancelled";
+
+const RUN_PLANS = {
+	diagnose: ["prepare", "reproduce", "diagnose", "report"],
+	repro: ["prepare", "reproduce", "diagnose", "edit", "finalize", "verify", "publish", "report"],
+	implement: ["prepare", "edit", "finalize", "verify", "publish", "report"],
+	fix: ["prepare", "edit", "finalize", "verify", "publish", "report"],
+	revise: ["prepare", "edit", "finalize", "verify", "publish", "report"],
+} as const satisfies Record<RunMode, readonly RunPhaseId[]>;
+
+export function runPlan(mode: RunMode): RunPhaseId[] {
+	return [...RUN_PLANS[mode]];
+}
+
+export function runMachineSnapshot() {
+	return {
+		phases: RUN_PHASES,
+		statuses: ["running", "succeeded", "failed", "timed_out", "cancelled"] as const,
+		plans: {
+			diagnose: runPlan("diagnose"),
+			repro: runPlan("repro"),
+			implement: runPlan("implement"),
+			fix: runPlan("fix"),
+			revise: runPlan("revise"),
+		},
+	};
+}
 
 // ---------------------------------------------------------------------------
 // States (lifecycle dimension -- mutually exclusive)
@@ -55,9 +99,29 @@ export type StateId =
 	| "preview_building"
 	| "awaiting_reporter";
 
+export const ISSUE_PHASES = [
+	{ id: "intake", label: "Triage" },
+	{ id: "evidence", label: "Investigate" },
+	{ id: "verdict", label: "Establish" },
+	{ id: "candidate", label: "Build" },
+	{ id: "preview", label: "Preview" },
+	{ id: "confirmation", label: "Confirm" },
+	{ id: "review", label: "Review" },
+	{ id: "complete", label: "Done" },
+] as const;
+
+export type IssuePhaseId = (typeof ISSUE_PHASES)[number]["id"];
+export type IssueStateTone = "active" | "waiting" | "attention";
+
 export interface StateMeta {
 	/** GitHub label that encodes this state. One per item, always. */
 	label: string;
+	/** Stable issue-lifecycle phase used by the dashboard projection. */
+	phase: IssuePhaseId;
+	/** Dashboard treatment for active, waiting, and human-attention states. */
+	tone: IssueStateTone;
+	/** A side route rendered outside the issue lifecycle's primary path. */
+	detour?: boolean;
 	/** Projects v2 "Triage State" board column. */
 	boardColumn: string;
 	/** Short description shown in docs and `@emdashbot status`. */
@@ -65,8 +129,8 @@ export interface StateMeta {
 	/** Terminal states are reopenable but otherwise at rest. */
 	terminal: boolean;
 	/**
-	 * Transient states mean an agent run is in flight; the control listener
-	 * tells the maintainer "a run is in progress" rather than racing it.
+	 * Transient states are backwards-compatible GitHub projections while a run
+	 * is active. The independent run lifecycle owns execution phase and status.
 	 */
 	transient?: boolean;
 	/** Commands offered in the bot's self-documenting comment footer. */
@@ -89,6 +153,8 @@ export const STATES: Record<StateId, StateMeta> = {
 		// investigate / implement / decline) work here directly -- triage is not
 		// a prerequisite.
 		label: "",
+		phase: "intake",
+		tone: "active",
 		boardColumn: "(none)",
 		description:
 			"No bot labels yet. An issue nobody has handed to the bot. Entry commands work directly.",
@@ -97,6 +163,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	triage: {
 		label: "bot:triage",
+		phase: "intake",
+		tone: "active",
 		boardColumn: "Triage",
 		description: "Filed and awaiting a decision on whether/how the bot should act.",
 		terminal: false,
@@ -104,6 +172,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	working: {
 		label: "bot:working",
+		phase: "evidence",
+		tone: "active",
 		boardColumn: "Working",
 		description: "An agent run is in flight (reproduce / diagnose / verify / fix / implement).",
 		terminal: false,
@@ -112,6 +182,9 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	blocked: {
 		label: "bot:blocked",
+		phase: "candidate",
+		tone: "attention",
+		detour: true,
 		boardColumn: "Blocked",
 		description:
 			"The bot stopped and needs a human decision. Covers the old skipped / not-reproduced / reproduced-no-fix / by-design outcomes; the reason is in the bot's comment.",
@@ -120,6 +193,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	awaiting_feedback: {
 		label: "bot:awaiting-feedback",
+		phase: "confirmation",
+		tone: "waiting",
 		boardColumn: "Awaiting feedback",
 		description:
 			"A fix is staged on bot/fix-<n>; waiting for the reporter or a maintainer to confirm or reject.",
@@ -128,6 +203,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	in_review: {
 		label: "bot:in-review",
+		phase: "review",
+		tone: "waiting",
 		boardColumn: "In review",
 		description:
 			"A PR is open. The review/* sub-states live on the PR and roll up here. On a bot PR, a plain `@emdashbot` comment is feedback; explicit verbs still win.",
@@ -137,6 +214,9 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	human_owned: {
 		label: "bot:human-owned",
+		phase: "review",
+		tone: "waiting",
+		detour: true,
 		boardColumn: "Human owned",
 		description:
 			"A maintainer took it over; the bot stays disengaged but the item stays on the board.",
@@ -145,6 +225,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	done: {
 		label: "bot:done",
+		phase: "complete",
+		tone: "active",
 		boardColumn: "Done",
 		description: "Shipped (PR merged) or confirmed resolved.",
 		terminal: true,
@@ -152,6 +234,9 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	declined: {
 		label: "bot:declined",
+		phase: "complete",
+		tone: "attention",
+		detour: true,
 		boardColumn: "Declined",
 		description: "Won't be actioned (by design, out of scope, or a maintainer call).",
 		terminal: true,
@@ -159,6 +244,9 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	failed: {
 		label: "bot:failed",
+		phase: "candidate",
+		tone: "attention",
+		detour: true,
 		boardColumn: "Failed",
 		description: "An agent run errored or produced no usable result. Retryable -- not a dead end.",
 		terminal: false,
@@ -173,6 +261,8 @@ export const STATES: Record<StateId, StateMeta> = {
 
 	investigating: {
 		label: "bot:investigating",
+		phase: "evidence",
+		tone: "active",
 		boardColumn: "Investigating",
 		description:
 			"A maintainer-triggered investigation is in flight: reproduce + diagnose, no fix. Emits an evidence-carrying verdict.",
@@ -182,6 +272,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	reproduced: {
 		label: "bot:reproduced",
+		phase: "verdict",
+		tone: "active",
 		boardColumn: "Reproduced",
 		description:
 			"Verdict: reproduced with a diagnosis attached. Resting until a maintainer triggers the fix loop or disposes of it.",
@@ -190,6 +282,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	diagnosed: {
 		label: "bot:diagnosed",
+		phase: "verdict",
+		tone: "active",
 		boardColumn: "Diagnosed",
 		description:
 			"Verdict: root cause identified, but not confirmed by a reproduction (environment limits). Actionable like reproduced; the fix loop verifies with a failing test before changing anything.",
@@ -198,6 +292,9 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	not_reproduced: {
 		label: "bot:not-reproduced",
+		phase: "verdict",
+		tone: "attention",
+		detour: true,
 		boardColumn: "Not reproduced",
 		description:
 			"Verdict: could not reproduce, transcript attached. A first-class outcome, not a failure. Reporter can add steps; a maintainer can re-investigate.",
@@ -206,6 +303,9 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	needs_info: {
 		label: "bot:needs-info",
+		phase: "verdict",
+		tone: "attention",
+		detour: true,
 		boardColumn: "Needs info",
 		description:
 			"Verdict: the investigation needs information only the reporter has. Evidence records what was tried and what is missing.",
@@ -214,6 +314,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	fixing: {
 		label: "bot:fixing",
+		phase: "candidate",
+		tone: "active",
 		boardColumn: "Fixing",
 		description: "A maintainer-triggered delivery run is building a candidate on bot/fix-<n>.",
 		terminal: false,
@@ -222,6 +324,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	preview_building: {
 		label: "bot:preview-building",
+		phase: "preview",
+		tone: "active",
 		boardColumn: "Building preview",
 		description:
 			"The candidate change is published; a preview is building so the reporter can try it before a PR exists.",
@@ -231,6 +335,8 @@ export const STATES: Record<StateId, StateMeta> = {
 	},
 	awaiting_reporter: {
 		label: "bot:awaiting-reporter",
+		phase: "confirmation",
+		tone: "waiting",
 		boardColumn: "Awaiting reporter",
 		description:
 			"Preview link posted; waiting for the reporter to confirm the change. On confirm a draft PR opens; on denial or 14-day silence the branch is reaped.",
@@ -963,6 +1069,7 @@ export function machineSnapshot() {
 	return {
 		kinds: KINDS,
 		entryState: ENTRY_STATE,
+		phases: ISSUE_PHASES,
 		states: STATES,
 		events: EVENTS,
 		transitions: TRANSITIONS,

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -52,6 +52,16 @@ import {
 	outcomeFromResult,
 	resolve,
 } from "./router.js";
+import {
+	advanceRunLifecycle,
+	publicRunLifecycle,
+	resumeRunLifecycle,
+	settleRunLifecycle,
+	startRunLifecycle,
+	type PublicRunLifecycle,
+	type RunLifecycle,
+	type RunProgressKind,
+} from "./run-lifecycle.js";
 import { DEADLINE_WARNING_MESSAGE, runBudgetMs, runSchedule } from "./run-policy.js";
 import { DeadlineExceededError, withDeadline } from "./sandbox-deadline.js";
 import {
@@ -192,12 +202,7 @@ interface EventLogEntry {
 	readonly deliveryId?: string;
 }
 
-export type PublicProgressKind =
-	| "workspace_ready"
-	| "workspace_failed"
-	| "verification_passed"
-	| "verification_failed"
-	| "candidate_published";
+export type PublicProgressKind = RunProgressKind;
 
 export interface PublicProgressEntry {
 	readonly t: number;
@@ -210,6 +215,7 @@ export interface PublicProgressEntry {
 export interface PublicIssueSnapshot {
 	readonly state: StateId | null;
 	readonly kind: Kind | null;
+	readonly run: PublicRunLifecycle | null;
 	readonly currentRunStartedAt: number | null;
 	readonly prNumber: number | null;
 	readonly transitions: ReadonlyArray<{
@@ -236,6 +242,7 @@ const STORAGE = {
 	kind: "o:kind",
 	currentRunId: "o:currentRunId",
 	currentRunMode: "o:currentRunMode",
+	runLifecycle: "o:runLifecycle",
 	failedRunMode: "o:failedRunMode",
 	currentRunStartedAt: "o:currentRunStartedAt",
 	currentAgentId: "o:currentAgentId",
@@ -425,14 +432,19 @@ export class OrchestratorDO extends DurableObject<Env> {
 		// back to the webhook's snapshot for first-time mentions.
 		const persistedLabels = await this.projectLabels();
 		const labels = persistedLabels.length > 0 ? persistedLabels : input.labels;
-		const [resumableRun, failedRunMode] = await Promise.all([
+		const [resumableRun, failedRunMode, previousRun] = await Promise.all([
 			resolvedEvent === "resume"
 				? this.ctx.storage.get<ResumableRunCheckpoint>(STORAGE.resumableRun)
 				: null,
 			resolvedEvent === "retry"
 				? this.ctx.storage.get<InvestigationMode>(STORAGE.failedRunMode)
 				: null,
+			resolvedEvent === "retry" ? this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle) : null,
 		]);
+		const retryMode =
+			previousRun?.status === "failed" || previousRun?.status === "timed_out"
+				? previousRun.mode
+				: failedRunMode;
 
 		const decision = resolve({
 			labels,
@@ -440,7 +452,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			arg: resolvedArg,
 			actor: input.actor,
 			...(resumableRun ? { resumeState: resumableRun.state } : {}),
-			...(failedRunMode ? { retryMode: failedRunMode } : {}),
+			...(retryMode ? { retryMode } : {}),
 		});
 
 		if (decision.kind === "noop") {
@@ -535,6 +547,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 		return this.ctx.storage.transaction(async (transaction) => {
 			if ((await transaction.get<string>(STORAGE.currentRunId)) !== input.runId) return false;
 			const existing = (await transaction.get<PublicProgressEntry[]>(STORAGE.publicProgress)) ?? [];
+			const run = await transaction.get<RunLifecycle>(STORAGE.runLifecycle);
 			const entry: PublicProgressEntry = {
 				t: Date.now(),
 				kind: input.kind,
@@ -542,10 +555,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 				detail: input.detail ? sanitizePublicProgressText(input.detail, 240) : null,
 				runId: input.runId,
 			};
-			await transaction.put(
-				STORAGE.publicProgress,
-				[...existing, entry].slice(-PUBLIC_PROGRESS_LIMIT),
-			);
+			await Promise.all([
+				transaction.put(STORAGE.publicProgress, [...existing, entry].slice(-PUBLIC_PROGRESS_LIMIT)),
+				...(run?.runId === input.runId
+					? [transaction.put(STORAGE.runLifecycle, advanceRunLifecycle(run, input.kind))]
+					: []),
+			]);
 			return true;
 		});
 	}
@@ -556,10 +571,12 @@ export class OrchestratorDO extends DurableObject<Env> {
 		pushed: boolean;
 		ok: boolean;
 	}): Promise<EventOutcome> {
-		const [currentRunId, currentRunMode] = await Promise.all([
+		const [currentRunId, legacyRunMode, run] = await Promise.all([
 			this.ctx.storage.get<string>(STORAGE.currentRunId),
 			this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
+			this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle),
 		]);
+		const currentRunMode = run?.runId === input.runId ? run.mode : legacyRunMode;
 		if (currentRunId !== input.runId) {
 			return { kind: "stale-run", runId: input.runId, currentRunId: currentRunId ?? null };
 		}
@@ -901,8 +918,9 @@ export class OrchestratorDO extends DurableObject<Env> {
 	private async armAlarm(): Promise<void> {
 		const [
 			current,
-			runStartedAt,
-			runMode,
+			run,
+			legacyRunStartedAt,
+			legacyRunMode,
 			warningSentRunId,
 			warningRetryAt,
 			currentRunId,
@@ -912,6 +930,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			previewPollNextAt,
 		] = await Promise.all([
 			this.ctx.storage.getAlarm(),
+			this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle),
 			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
 			this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
 			this.ctx.storage.get<string>(STORAGE.deadlineWarningSentRunId),
@@ -923,6 +942,9 @@ export class OrchestratorDO extends DurableObject<Env> {
 			this.ctx.storage.get<number>(STORAGE.previewPollNextAt),
 		]);
 		const now = Date.now();
+		const activeRun = run?.status === "running" ? run : null;
+		const runStartedAt = activeRun?.startedAt ?? legacyRunStartedAt;
+		const runMode = activeRun?.mode ?? legacyRunMode;
 		const scheduledRunAlarm = runStartedAt
 			? runSchedule(runMode ?? "repro", runStartedAt, warningSentRunId === currentRunId).nextAlarmAt
 			: null;
@@ -946,14 +968,19 @@ export class OrchestratorDO extends DurableObject<Env> {
 	}
 
 	private async sendDeadlineWarningIfDue(now: number): Promise<boolean> {
-		const [runId, agentId, mode, startedAt, warningSentRunId, state] = await Promise.all([
-			this.ctx.storage.get<string>(STORAGE.currentRunId),
-			this.ctx.storage.get<string>(STORAGE.currentAgentId),
-			this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
-			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
-			this.ctx.storage.get<string>(STORAGE.deadlineWarningSentRunId),
-			this.ctx.storage.get<StateId>(STORAGE.state),
-		]);
+		const [runId, agentId, run, legacyMode, legacyStartedAt, warningSentRunId, state] =
+			await Promise.all([
+				this.ctx.storage.get<string>(STORAGE.currentRunId),
+				this.ctx.storage.get<string>(STORAGE.currentAgentId),
+				this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle),
+				this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
+				this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
+				this.ctx.storage.get<string>(STORAGE.deadlineWarningSentRunId),
+				this.ctx.storage.get<StateId>(STORAGE.state),
+			]);
+		const activeRun = run && run.runId === runId && run.status === "running" ? run : null;
+		const mode = activeRun?.mode ?? legacyMode;
+		const startedAt = activeRun?.startedAt ?? legacyStartedAt;
 		if (
 			!runId ||
 			!agentId ||
@@ -1074,11 +1101,15 @@ export class OrchestratorDO extends DurableObject<Env> {
 	}
 
 	private async recoverStaleRun(now: number): Promise<boolean> {
-		const [startedAt, mode, state] = await Promise.all([
+		const [run, legacyStartedAt, legacyMode, state] = await Promise.all([
+			this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle),
 			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
 			this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
 			this.ctx.storage.get<StateId>(STORAGE.state),
 		]);
+		const activeRun = run?.status === "running" ? run : null;
+		const startedAt = activeRun?.startedAt ?? legacyStartedAt;
+		const mode = activeRun?.mode ?? legacyMode;
 		if (startedAt === undefined) return false;
 		if (now - startedAt < runBudgetMs(mode ?? "repro")) return false;
 		const runId = await this.ctx.storage.get<string>(STORAGE.currentRunId);
@@ -1859,9 +1890,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 	): Promise<string | null> {
 		const sideEffectId = input.dryRun ? null : crypto.randomUUID();
 		return this.ctx.storage.transaction(async (transaction) => {
+			const now = Date.now();
 			const existing = (await transaction.get<EventLogEntry[]>(STORAGE.eventLog)) ?? [];
 			const entry: EventLogEntry = {
-				t: Date.now(),
+				t: now,
 				event: decision.event,
 				actor: input.actor,
 				from: decision.from === "conflicting" ? "conflicting" : decision.from,
@@ -1873,7 +1905,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 				transaction.put(STORAGE.state, decision.to),
 				transaction.put(STORAGE.eventLog, eventLog),
 				decision.to === "awaiting_reporter"
-					? transaction.put(STORAGE.awaitingReporterSince, Date.now())
+					? transaction.put(STORAGE.awaitingReporterSince, now)
 					: transaction.delete(STORAGE.awaitingReporterSince),
 			];
 			if (input.settlesDeliveryId) {
@@ -1887,12 +1919,28 @@ export class OrchestratorDO extends DurableObject<Env> {
 					);
 				}
 			}
+			if (decision.event.startsWith("agent.") && input.settlesRunId) {
+				const run = await transaction.get<RunLifecycle>(STORAGE.runLifecycle);
+				if (run?.runId === input.settlesRunId) {
+					const status =
+						decision.event === "agent.failed"
+							? input.agentFailureStage === "timeout"
+								? "timed_out"
+								: "failed"
+							: "succeeded";
+					puts.push(transaction.put(STORAGE.runLifecycle, settleRunLifecycle(run, status, now)));
+				}
+			}
 			if (decision.event === "agent.failed" && input.settlesRunId) {
-				const failedRunMode = await transaction.get<InvestigationMode>(STORAGE.currentRunMode);
+				const run = await transaction.get<RunLifecycle>(STORAGE.runLifecycle);
+				const failedRunMode =
+					run?.runId === input.settlesRunId
+						? run.mode
+						: await transaction.get<InvestigationMode>(STORAGE.currentRunMode);
 				if (failedRunMode) puts.push(transaction.put(STORAGE.failedRunMode, failedRunMode));
 			}
 			if (decision.to === "preview_building") {
-				const startedAt = Date.now();
+				const startedAt = now;
 				puts.push(
 					transaction.put(STORAGE.previewBuildDeadline, startedAt + PREVIEW_BUILD_TIMEOUT_MS),
 					transaction.put(STORAGE.previewPollNextAt, startedAt + PREVIEW_POLL_INITIAL_MS),
@@ -1917,10 +1965,16 @@ export class OrchestratorDO extends DurableObject<Env> {
 				if (kind) puts.push(transaction.put(STORAGE.kind, kind));
 			}
 			if (preparedInvestigation) {
+				const run = startRunLifecycle({
+					runId: preparedInvestigation.runId,
+					mode: preparedInvestigation.mode,
+					startedAt: now,
+				});
 				puts.push(
 					transaction.put(STORAGE.currentRunId, preparedInvestigation.runId),
 					transaction.put(STORAGE.currentRunMode, preparedInvestigation.mode),
-					transaction.put(STORAGE.currentRunStartedAt, Date.now()),
+					transaction.put(STORAGE.currentRunStartedAt, now),
+					transaction.put(STORAGE.runLifecycle, run),
 					transaction.put(STORAGE.currentAgentId, preparedInvestigation.agentId),
 					transaction.delete(STORAGE.deadlineWarningSentRunId),
 					transaction.delete(STORAGE.deadlineWarningRetryAt),
@@ -1933,10 +1987,20 @@ export class OrchestratorDO extends DurableObject<Env> {
 				);
 			}
 			if (preparedResume) {
+				const existingRun = await transaction.get<RunLifecycle>(STORAGE.runLifecycle);
+				const run =
+					existingRun?.runId === preparedResume.checkpoint.runId
+						? resumeRunLifecycle(existingRun, now)
+						: startRunLifecycle({
+								runId: preparedResume.checkpoint.runId,
+								mode: preparedResume.checkpoint.mode,
+								startedAt: now,
+							});
 				puts.push(
 					transaction.put(STORAGE.currentRunId, preparedResume.checkpoint.runId),
 					transaction.put(STORAGE.currentRunMode, preparedResume.checkpoint.mode),
-					transaction.put(STORAGE.currentRunStartedAt, Date.now()),
+					transaction.put(STORAGE.currentRunStartedAt, now),
+					transaction.put(STORAGE.runLifecycle, run),
 					transaction.put(STORAGE.currentAgentId, preparedResume.checkpoint.agentId),
 					transaction.delete(STORAGE.deadlineWarningSentRunId),
 					transaction.delete(STORAGE.deadlineWarningRetryAt),
@@ -1953,9 +2017,13 @@ export class OrchestratorDO extends DurableObject<Env> {
 					decision.event === "decline" ||
 					decision.event === "take_over")
 			) {
+				const run = await transaction.get<RunLifecycle>(STORAGE.runLifecycle);
 				puts.push(
 					transaction.delete(STORAGE.resumableRun),
 					transaction.delete(STORAGE.failedRunMode),
+					...(run?.status === "running"
+						? [transaction.put(STORAGE.runLifecycle, settleRunLifecycle(run, "cancelled", now))]
+						: []),
 				);
 			}
 			const anchorNumber =
@@ -2285,17 +2353,32 @@ export class OrchestratorDO extends DurableObject<Env> {
 	}
 
 	async getPublicSnapshot(): Promise<PublicIssueSnapshot> {
-		const [state, kind, currentRunStartedAt, prNumber, transitions, progress] = await Promise.all([
-			this.ctx.storage.get<StateId>(STORAGE.state),
-			this.ctx.storage.get<Kind>(STORAGE.kind),
-			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
-			this.ctx.storage.get<number>(STORAGE.prNumber),
-			this.ctx.storage.get<EventLogEntry[]>(STORAGE.eventLog),
-			this.ctx.storage.get<PublicProgressEntry[]>(STORAGE.publicProgress),
-		]);
+		const [state, kind, run, legacyMode, currentRunStartedAt, prNumber, transitions, progress] =
+			await Promise.all([
+				this.ctx.storage.get<StateId>(STORAGE.state),
+				this.ctx.storage.get<Kind>(STORAGE.kind),
+				this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle),
+				this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
+				this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
+				this.ctx.storage.get<number>(STORAGE.prNumber),
+				this.ctx.storage.get<EventLogEntry[]>(STORAGE.eventLog),
+				this.ctx.storage.get<PublicProgressEntry[]>(STORAGE.publicProgress),
+			]);
+		const publicRun = run
+			? publicRunLifecycle(run)
+			: legacyMode && currentRunStartedAt !== undefined
+				? publicRunLifecycle(
+						startRunLifecycle({
+							runId: "legacy",
+							mode: legacyMode,
+							startedAt: currentRunStartedAt,
+						}),
+					)
+				: null;
 		return {
 			state: state ?? null,
 			kind: kind ?? null,
+			run: publicRun,
 			currentRunStartedAt: currentRunStartedAt ?? null,
 			prNumber: prNumber ?? null,
 			transitions: (transitions ?? []).map(({ t, event, from, to }) => ({
@@ -2337,6 +2420,14 @@ export class OrchestratorDO extends DurableObject<Env> {
 			this.ctx.storage.delete(STORAGE.deadlineWarningRetryAt),
 			...(agentId ? [this.ctx.storage.put(STORAGE.currentAgentId, agentId)] : []),
 			...(mode ? [this.ctx.storage.put(STORAGE.currentRunMode, mode)] : []),
+			...(mode
+				? [
+						this.ctx.storage.put(
+							STORAGE.runLifecycle,
+							startRunLifecycle({ runId, mode, startedAt }),
+						),
+					]
+				: []),
 		]);
 	}
 
@@ -2361,12 +2452,16 @@ export class OrchestratorDO extends DurableObject<Env> {
 		warningAt: number | null;
 		warningSentRunId: string | null;
 	}> {
-		const [runId, mode, startedAt, warningSentRunId] = await Promise.all([
+		const [runId, run, legacyMode, legacyStartedAt, warningSentRunId] = await Promise.all([
 			this.ctx.storage.get<string>(STORAGE.currentRunId),
+			this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle),
 			this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
 			this.ctx.storage.get<number>(STORAGE.currentRunStartedAt),
 			this.ctx.storage.get<string>(STORAGE.deadlineWarningSentRunId),
 		]);
+		const activeRun = run && run.runId === runId && run.status === "running" ? run : null;
+		const mode = activeRun?.mode ?? legacyMode;
+		const startedAt = activeRun?.startedAt ?? legacyStartedAt;
 		if (!runId || !mode || startedAt === undefined) {
 			return { deadlineAt: null, warningAt: null, warningSentRunId: warningSentRunId ?? null };
 		}

--- a/infra/emdash-bot/.flue/lib/router.ts
+++ b/infra/emdash-bot/.flue/lib/router.ts
@@ -18,6 +18,7 @@ import {
 	type Actor,
 	type EventId,
 	type Kind,
+	type RunMode,
 	type StateId,
 } from "./machine.js";
 
@@ -360,7 +361,7 @@ export interface AgentResult {
 	[key: string]: unknown;
 }
 
-export type InvestigationMode = "repro" | "implement" | "revise" | "diagnose" | "fix";
+export type InvestigationMode = RunMode;
 
 /**
  * Map the investigate agent's flat result to a machine event. Deterministic

--- a/infra/emdash-bot/.flue/lib/run-lifecycle.ts
+++ b/infra/emdash-bot/.flue/lib/run-lifecycle.ts
@@ -1,0 +1,109 @@
+import {
+	RUN_PHASES,
+	runMachineSnapshot,
+	runPlan,
+	type RunMode,
+	type RunPhaseId,
+	type RunStatus,
+} from "./machine.js";
+import { runBudgetMs } from "./run-policy.js";
+
+export { RUN_PHASES, runMachineSnapshot, runPlan };
+export type { RunMode, RunPhaseId, RunStatus };
+
+export type RunProgressKind =
+	| "workspace_ready"
+	| "workspace_failed"
+	| "verification_passed"
+	| "verification_failed"
+	| "candidate_publishing"
+	| "candidate_published";
+
+export interface RunLifecycle {
+	readonly runId: string;
+	readonly mode: RunMode;
+	readonly status: RunStatus;
+	readonly phase: RunPhaseId;
+	readonly plan: readonly RunPhaseId[];
+	readonly attempt: number;
+	readonly createdAt: number;
+	readonly startedAt: number;
+	readonly deadlineAt: number;
+	readonly completedAt: number | null;
+}
+
+export type PublicRunLifecycle = Omit<RunLifecycle, "runId">;
+
+export function startRunLifecycle(input: {
+	runId: string;
+	mode: RunMode;
+	startedAt: number;
+}): RunLifecycle {
+	return {
+		runId: input.runId,
+		mode: input.mode,
+		status: "running",
+		phase: "prepare",
+		plan: runPlan(input.mode),
+		attempt: 1,
+		createdAt: input.startedAt,
+		startedAt: input.startedAt,
+		deadlineAt: input.startedAt + runBudgetMs(input.mode),
+		completedAt: null,
+	};
+}
+
+export function resumeRunLifecycle(run: RunLifecycle, startedAt: number): RunLifecycle {
+	return {
+		...run,
+		status: "running",
+		attempt: run.attempt + 1,
+		startedAt,
+		deadlineAt: startedAt + runBudgetMs(run.mode),
+		completedAt: null,
+	};
+}
+
+export function advanceRunLifecycle(run: RunLifecycle, progress: RunProgressKind): RunLifecycle {
+	if (run.status !== "running") return run;
+	const target = progressPhase(run, progress);
+	if (!target) return run;
+	const currentIndex = run.plan.indexOf(run.phase);
+	const targetIndex = run.plan.indexOf(target);
+	if (targetIndex < currentIndex) return run;
+	return { ...run, phase: target };
+}
+
+export function settleRunLifecycle(
+	run: RunLifecycle,
+	status: Exclude<RunStatus, "running">,
+	completedAt: number,
+): RunLifecycle {
+	return {
+		...run,
+		status,
+		phase: status === "succeeded" ? "report" : run.phase,
+		completedAt,
+	};
+}
+
+export function publicRunLifecycle(run: RunLifecycle): PublicRunLifecycle {
+	const { runId: _runId, ...publicRun } = run;
+	return publicRun;
+}
+
+function progressPhase(run: RunLifecycle, progress: RunProgressKind): RunPhaseId | null {
+	switch (progress) {
+		case "workspace_ready":
+			return run.plan[1] ?? "report";
+		case "verification_passed":
+		case "verification_failed":
+			return run.plan.includes("verify") ? "verify" : null;
+		case "candidate_publishing":
+			return run.plan.includes("publish") ? "publish" : null;
+		case "candidate_published":
+			return "report";
+		case "workspace_failed":
+			return null;
+	}
+}

--- a/infra/emdash-bot/BOT_STATE_MACHINE.md
+++ b/infra/emdash-bot/BOT_STATE_MACHINE.md
@@ -1,33 +1,50 @@
-# emdashbot state machine
+# emdashbot lifecycle machines
 
 <!-- Generated from .flue/lib/machine.ts by `pnpm bot:generate`. Do not edit by hand. -->
 
+The issue lifecycle coordinates the long-lived GitHub item. The agent run lifecycle records one bounded execution attempt. GitHub labels project the issue state; run mode and phase remain in Durable Object storage.
+
+## Issue lifecycle
+
 Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 
-## States
+### Phases
 
-| State | Label | Board column | Terminal | Transient | Offered commands |
-| --- | --- | --- | --- | --- | --- |
-| `unmanaged` | — | (none) | no | no | `investigate`, `repro`, `implement`, `decline` |
-| `triage` | `bot:triage` | Triage | no | no | `investigate`, `repro`, `implement`, `decline` |
-| `working` | `bot:working` | Working | no | yes | `status` |
-| `blocked` | `bot:blocked` | Blocked | no | no | `investigate`, `implement`, `repro`, `retry`, `decline`, `take_over` |
-| `awaiting_feedback` | `bot:awaiting-feedback` | Awaiting feedback | no | no | `confirm`, `reject`, `retry`, `take_over` |
-| `in_review` | `bot:in-review` | In review | no | no | `revise`, `decline`, `take_over` |
-| `human_owned` | `bot:human-owned` | Human owned | no | no | `hand_back` |
-| `done` | `bot:done` | Done | yes | no | `reopen` |
-| `declined` | `bot:declined` | Declined | yes | no | `reopen` |
-| `failed` | `bot:failed` | Failed | no | no | `resume`, `retry`, `implement`, `repro`, `investigate`, `decline` |
-| `investigating` | `bot:investigating` | Investigating | no | yes | `status` |
-| `reproduced` | `bot:reproduced` | Reproduced | no | no | `fix`, `investigate`, `decline`, `take_over` |
-| `diagnosed` | `bot:diagnosed` | Diagnosed | no | no | `fix`, `investigate`, `decline`, `take_over` |
-| `not_reproduced` | `bot:not-reproduced` | Not reproduced | no | no | `investigate`, `decline`, `take_over` |
-| `needs_info` | `bot:needs-info` | Needs info | no | no | `investigate`, `decline`, `take_over` |
-| `fixing` | `bot:fixing` | Fixing | no | yes | `status` |
-| `preview_building` | `bot:preview-building` | Building preview | no | yes | `status` |
-| `awaiting_reporter` | `bot:awaiting-reporter` | Awaiting reporter | no | no | `confirm`, `reject`, `decline`, `take_over` |
+| Phase | Label |
+| --- | --- |
+| `intake` | Triage |
+| `evidence` | Investigate |
+| `verdict` | Establish |
+| `candidate` | Build |
+| `preview` | Preview |
+| `confirmation` | Confirm |
+| `review` | Review |
+| `complete` | Done |
 
-## Events
+### States
+
+| State | Phase | Label | Board column | Terminal | Transient | Offered commands |
+| --- | --- | --- | --- | --- | --- | --- |
+| `unmanaged` | `intake` | — | (none) | no | no | `investigate`, `repro`, `implement`, `decline` |
+| `triage` | `intake` | `bot:triage` | Triage | no | no | `investigate`, `repro`, `implement`, `decline` |
+| `working` | `evidence` | `bot:working` | Working | no | yes | `status` |
+| `blocked` | `candidate` | `bot:blocked` | Blocked | no | no | `investigate`, `implement`, `repro`, `retry`, `decline`, `take_over` |
+| `awaiting_feedback` | `confirmation` | `bot:awaiting-feedback` | Awaiting feedback | no | no | `confirm`, `reject`, `retry`, `take_over` |
+| `in_review` | `review` | `bot:in-review` | In review | no | no | `revise`, `decline`, `take_over` |
+| `human_owned` | `review` | `bot:human-owned` | Human owned | no | no | `hand_back` |
+| `done` | `complete` | `bot:done` | Done | yes | no | `reopen` |
+| `declined` | `complete` | `bot:declined` | Declined | yes | no | `reopen` |
+| `failed` | `candidate` | `bot:failed` | Failed | no | no | `resume`, `retry`, `implement`, `repro`, `investigate`, `decline` |
+| `investigating` | `evidence` | `bot:investigating` | Investigating | no | yes | `status` |
+| `reproduced` | `verdict` | `bot:reproduced` | Reproduced | no | no | `fix`, `investigate`, `decline`, `take_over` |
+| `diagnosed` | `verdict` | `bot:diagnosed` | Diagnosed | no | no | `fix`, `investigate`, `decline`, `take_over` |
+| `not_reproduced` | `verdict` | `bot:not-reproduced` | Not reproduced | no | no | `investigate`, `decline`, `take_over` |
+| `needs_info` | `verdict` | `bot:needs-info` | Needs info | no | no | `investigate`, `decline`, `take_over` |
+| `fixing` | `candidate` | `bot:fixing` | Fixing | no | yes | `status` |
+| `preview_building` | `preview` | `bot:preview-building` | Building preview | no | yes | `status` |
+| `awaiting_reporter` | `confirmation` | `bot:awaiting-reporter` | Awaiting reporter | no | no | `confirm`, `reject`, `decline`, `take_over` |
+
+### Events
 
 | Event | Category | Actors | Arg | Description |
 | --- | --- | --- | --- | --- |
@@ -64,7 +81,7 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `preview.failed` | preview | system | — | The preview deploy failed to build. |
 | `expire` | timer | system | — | The reporter-confirmation window elapsed without a reply. |
 
-## Transitions
+### Transitions
 
 | From | Event | To | Action |
 | --- | --- | --- | --- |
@@ -163,7 +180,7 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `preview_building` | `reset` | `triage` | — |
 | `awaiting_reporter` | `reset` | `triage` | — |
 
-## Diagram
+### Diagram
 
 ```mermaid
 stateDiagram-v2
@@ -267,4 +284,52 @@ stateDiagram-v2
     fixing --> triage: reset
     preview_building --> triage: reset
     awaiting_reporter --> triage: reset
+```
+
+## Agent run lifecycle
+
+A run stores its mode, selected phase plan, current phase, status, attempt, and fixed deadline independently from the issue state. An explicit `implement` directive selects the direct implementation plan and omits reproduction and diagnosis.
+
+### Phases
+
+| Phase | Label |
+| --- | --- |
+| `prepare` | Prepare |
+| `reproduce` | Reproduce |
+| `diagnose` | Diagnose |
+| `edit` | Edit |
+| `finalize` | Finalize |
+| `verify` | Verify |
+| `publish` | Publish |
+| `report` | Report |
+
+### Plans
+
+| Mode | Ordered phases |
+| --- | --- |
+| `diagnose` | `prepare` → `reproduce` → `diagnose` → `report` |
+| `repro` | `prepare` → `reproduce` → `diagnose` → `edit` → `finalize` → `verify` → `publish` → `report` |
+| `implement` | `prepare` → `edit` → `finalize` → `verify` → `publish` → `report` |
+| `fix` | `prepare` → `edit` → `finalize` → `verify` → `publish` → `report` |
+| `revise` | `prepare` → `edit` → `finalize` → `verify` → `publish` → `report` |
+
+### Statuses
+
+`running`, `succeeded`, `failed`, `timed_out`, `cancelled`
+
+### Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> prepare
+    prepare --> reproduce: diagnose, repro
+    reproduce --> diagnose: diagnose, repro
+    diagnose --> report: diagnose
+    diagnose --> edit: repro
+    edit --> finalize: repro, implement, fix, revise
+    finalize --> verify: repro, implement, fix, revise
+    verify --> publish: repro, implement, fix, revise
+    publish --> report: repro, implement, fix, revise
+    prepare --> edit: implement, fix, revise
+    report --> [*]
 ```

--- a/infra/emdash-bot/scripts/machine-artifacts.ts
+++ b/infra/emdash-bot/scripts/machine-artifacts.ts
@@ -12,15 +12,17 @@
 import {
 	ENTRY_STATE,
 	EVENTS,
+	ISSUE_PHASES,
 	KINDS,
 	machineSnapshot,
+	runMachineSnapshot,
 	STATES,
 	TRANSITIONS,
 	transitionTargets,
 } from "../.flue/lib/machine.ts";
 
 export function renderMachineJson(): string {
-	return `${JSON.stringify(machineSnapshot(), null, "\t")}\n`;
+	return `${JSON.stringify({ ...machineSnapshot(), run: runMachineSnapshot() }, null, "\t")}\n`;
 }
 
 function code(value: string): string {
@@ -42,15 +44,15 @@ function eventCategory(id: string): string {
 function statesTable(): string {
 	const rows = Object.entries(STATES).map(
 		([id, meta]) =>
-			`| ${code(id)} | ${meta.label ? code(meta.label) : "—"} | ${meta.boardColumn} | ${
+			`| ${code(id)} | ${code(meta.phase)} | ${meta.label ? code(meta.label) : "—"} | ${meta.boardColumn} | ${
 				meta.terminal ? "yes" : "no"
 			} | ${meta.transient ? "yes" : "no"} | ${commandList(meta.offeredCommands)} |`,
 	);
 	return [
-		"## States",
+		"### States",
 		"",
-		"| State | Label | Board column | Terminal | Transient | Offered commands |",
-		"| --- | --- | --- | --- | --- | --- |",
+		"| State | Phase | Label | Board column | Terminal | Transient | Offered commands |",
+		"| --- | --- | --- | --- | --- | --- | --- |",
 		...rows,
 	].join("\n");
 }
@@ -63,7 +65,7 @@ function eventsTable(): string {
 			} | ${meta.description} |`,
 	);
 	return [
-		"## Events",
+		"### Events",
 		"",
 		"| Event | Category | Actors | Arg | Description |",
 		"| --- | --- | --- | --- | --- |",
@@ -77,7 +79,7 @@ function transitionsTable(): string {
 			`| ${code(t.from)} | ${code(t.event)} | ${transitionDestination(t)} | ${t.action ? code(t.action) : "—"} |`,
 	);
 	return [
-		"## Transitions",
+		"### Transitions",
 		"",
 		"| From | Event | To | Action |",
 		"| --- | --- | --- | --- |",
@@ -116,7 +118,7 @@ function diagram(): string {
 		}),
 	);
 	return [
-		"## Diagram",
+		"### Diagram",
 		"",
 		"```mermaid",
 		"stateDiagram-v2",
@@ -126,14 +128,77 @@ function diagram(): string {
 	].join("\n");
 }
 
+function issuePhasesTable(): string {
+	return [
+		"### Phases",
+		"",
+		"| Phase | Label |",
+		"| --- | --- |",
+		...ISSUE_PHASES.map((phase) => `| ${code(phase.id)} | ${phase.label} |`),
+	].join("\n");
+}
+
+function runLifecycle(): string {
+	const run = runMachineSnapshot();
+	const planRows = Object.entries(run.plans).map(
+		([mode, phases]) => `| ${code(mode)} | ${phases.map(code).join(" → ")} |`,
+	);
+	const edges = new Map<string, string[]>();
+	for (const [mode, phases] of Object.entries(run.plans)) {
+		for (let index = 0; index < phases.length - 1; index += 1) {
+			const from = phases[index];
+			const to = phases[index + 1];
+			if (!from || !to) continue;
+			const key = `${from} --> ${to}`;
+			edges.set(key, [...(edges.get(key) ?? []), mode]);
+		}
+	}
+	return [
+		"## Agent run lifecycle",
+		"",
+		"A run stores its mode, selected phase plan, current phase, status, attempt, and fixed deadline independently from the issue state. An explicit `implement` directive selects the direct implementation plan and omits reproduction and diagnosis.",
+		"",
+		"### Phases",
+		"",
+		"| Phase | Label |",
+		"| --- | --- |",
+		...run.phases.map((phase) => `| ${code(phase.id)} | ${phase.label} |`),
+		"",
+		"### Plans",
+		"",
+		"| Mode | Ordered phases |",
+		"| --- | --- |",
+		...planRows,
+		"",
+		"### Statuses",
+		"",
+		run.statuses.map(code).join(", "),
+		"",
+		"### Diagram",
+		"",
+		"```mermaid",
+		"stateDiagram-v2",
+		"    [*] --> prepare",
+		...Array.from(edges.entries(), ([edge, modes]) => `    ${edge}: ${modes.join(", ")}`),
+		"    report --> [*]",
+		"```",
+	].join("\n");
+}
+
 export function renderMachineDoc(): string {
 	const kinds = KINDS.map(code).join(", ");
 	return `${[
-		"# emdashbot state machine",
+		"# emdashbot lifecycle machines",
 		"",
 		"<!-- Generated from .flue/lib/machine.ts by `pnpm bot:generate`. Do not edit by hand. -->",
 		"",
+		"The issue lifecycle coordinates the long-lived GitHub item. The agent run lifecycle records one bounded execution attempt. GitHub labels project the issue state; run mode and phase remain in Durable Object storage.",
+		"",
+		"## Issue lifecycle",
+		"",
 		`Entry state: ${code(ENTRY_STATE)}. Kinds: ${kinds}.`,
+		"",
+		issuePhasesTable(),
 		"",
 		statesTable(),
 		"",
@@ -142,5 +207,7 @@ export function renderMachineDoc(): string {
 		transitionsTable(),
 		"",
 		diagram(),
+		"",
+		runLifecycle(),
 	].join("\n")}\n`;
 }

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -326,6 +326,67 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect((await stub.getPersistedState()).currentRunId).toBe("write-run");
 	});
 
+	test("keeps issue state and run lifecycle independently observable", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.event(makeEvent());
+		await stub.debugSetStaleRun(
+			"implement-run",
+			Date.now(),
+			"investigate-42-implement-run",
+			"implement",
+		);
+
+		const started = await stub.getPublicSnapshot();
+		expect(started.state).toBe("fixing");
+		expect(started.run).toMatchObject({
+			mode: "implement",
+			status: "running",
+			phase: "prepare",
+			plan: ["prepare", "edit", "finalize", "verify", "publish", "report"],
+		});
+
+		await stub.recordPublicProgress({
+			runId: "implement-run",
+			kind: "workspace_ready",
+			title: "Workspace ready",
+		});
+		await stub.recordPublicProgress({
+			runId: "implement-run",
+			kind: "verification_passed",
+			title: "Tests",
+		});
+		expect((await stub.getPublicSnapshot()).run?.phase).toBe("verify");
+
+		await stub.applyAgentResult({
+			runId: "implement-run",
+			result: { implemented: true, summary: "Implemented the requested change." },
+			pushed: true,
+			ok: true,
+		});
+		const completed = await stub.getPublicSnapshot();
+		expect(completed.state).toBe("preview_building");
+		expect(completed.currentRunStartedAt).toBeNull();
+		expect(completed.run).toMatchObject({ status: "succeeded", phase: "report" });
+	});
+
+	test("records a reset active run as cancelled", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.event(makeEvent());
+		await stub.debugSetStaleRun(
+			"cancelled-run",
+			Date.now(),
+			"investigate-42-cancelled-run",
+			"implement",
+		);
+
+		await stub.event(makeEvent({ event: "reset", arg: null }));
+
+		expect((await stub.getPublicSnapshot()).run).toMatchObject({
+			status: "cancelled",
+			phase: "prepare",
+		});
+	});
+
 	test("retrying a failed implementation preserves its write mode", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		await stub.event(makeEvent({ anchorNumber: 42 }));

--- a/infra/emdash-bot/tests/integration/webhook.test.ts
+++ b/infra/emdash-bot/tests/integration/webhook.test.ts
@@ -113,7 +113,9 @@ describe("POST /webhook/github (workers-pool)", () => {
 		const res = await SELF.fetch("https://test/");
 		expect(res.status).toBe(200);
 		expect(res.headers.get("content-type")).toContain("text/html");
-		expect(await res.text()).toContain("The path from issue to merge");
+		const html = await res.text();
+		expect(html).toContain("Issue lifecycle");
+		expect(html).toContain("Agent run");
 	});
 
 	test("dashboard API fails closed when GitHub credentials are unavailable", async () => {

--- a/infra/emdash-bot/tests/unit/run-lifecycle.test.ts
+++ b/infra/emdash-bot/tests/unit/run-lifecycle.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	advanceRunLifecycle,
+	resumeRunLifecycle,
+	runMachineSnapshot,
+	runPlan,
+	settleRunLifecycle,
+	startRunLifecycle,
+} from "../../.flue/lib/run-lifecycle.js";
+
+describe("run lifecycle", () => {
+	test("direct implementation skips reproduction and diagnosis", () => {
+		expect(runPlan("implement")).toEqual([
+			"prepare",
+			"edit",
+			"finalize",
+			"verify",
+			"publish",
+			"report",
+		]);
+		expect(runPlan("implement")).not.toContain("reproduce");
+		expect(runPlan("implement")).not.toContain("diagnose");
+	});
+
+	test("investigation and repro choose different branches", () => {
+		expect(runPlan("diagnose")).toEqual(["prepare", "reproduce", "diagnose", "report"]);
+		expect(runPlan("repro")).toEqual([
+			"prepare",
+			"reproduce",
+			"diagnose",
+			"edit",
+			"finalize",
+			"verify",
+			"publish",
+			"report",
+		]);
+	});
+
+	test("advances observable phases and retains the completed run", () => {
+		const started = startRunLifecycle({ runId: "run-1", mode: "implement", startedAt: 1_000 });
+		expect(started).toMatchObject({
+			status: "running",
+			phase: "prepare",
+			attempt: 1,
+			deadlineAt: 1_000 + 60 * 60_000,
+		});
+
+		const editing = advanceRunLifecycle(started, "workspace_ready");
+		expect(editing.phase).toBe("edit");
+		const verifying = advanceRunLifecycle(editing, "verification_passed");
+		expect(verifying.phase).toBe("verify");
+		const publishing = advanceRunLifecycle(verifying, "candidate_publishing");
+		expect(publishing.phase).toBe("publish");
+		const reporting = advanceRunLifecycle(publishing, "candidate_published");
+		expect(reporting.phase).toBe("report");
+
+		expect(settleRunLifecycle(reporting, "succeeded", 5_000)).toMatchObject({
+			status: "succeeded",
+			phase: "report",
+			completedAt: 5_000,
+		});
+	});
+
+	test("resume keeps the plan and phase while starting a new attempt budget", () => {
+		const started = startRunLifecycle({ runId: "run-1", mode: "fix", startedAt: 1_000 });
+		const timedOut = settleRunLifecycle(
+			advanceRunLifecycle(started, "verification_passed"),
+			"timed_out",
+			2_000,
+		);
+		const resumed = resumeRunLifecycle(timedOut, 3_000);
+
+		expect(resumed).toMatchObject({
+			status: "running",
+			phase: "verify",
+			attempt: 2,
+			startedAt: 3_000,
+			completedAt: null,
+		});
+		expect(resumed.plan).toEqual(timedOut.plan);
+	});
+
+	test("records a human-cancelled run without advancing its phase", () => {
+		const started = advanceRunLifecycle(
+			startRunLifecycle({ runId: "run-1", mode: "implement", startedAt: 1_000 }),
+			"workspace_ready",
+		);
+		expect(settleRunLifecycle(started, "cancelled", 2_000)).toMatchObject({
+			status: "cancelled",
+			phase: "edit",
+			completedAt: 2_000,
+		});
+	});
+
+	test("serializes the run machine for the dashboard", () => {
+		const snapshot = runMachineSnapshot();
+		expect(snapshot.phases.map((phase) => phase.id)).toEqual([
+			"prepare",
+			"reproduce",
+			"diagnose",
+			"edit",
+			"finalize",
+			"verify",
+			"publish",
+			"report",
+		]);
+		expect(snapshot.statuses).toContain("cancelled");
+		expect(snapshot.plans.implement).toEqual(runPlan("implement"));
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Separates EmDashBot's long-lived issue lifecycle from each bounded agent run, then renders both state machines in the public dashboard.

- Adds an independent persisted run record containing mode, selected phase plan, current phase, status, attempt, start/completion times, and fixed deadline.
- Defines branching plans for `diagnose`, `repro`, `implement`, `fix`, and `revise`. Direct implementation omits reproduction and diagnosis.
- Uses the run record as the preferred source for deadlines, warnings, stale recovery, retry mode, resume attempts, public progress, completion, timeout, failure, and cancellation while retaining legacy storage fallbacks.
- Keeps GitHub issue labels backward compatible as issue-lifecycle projections.
- Sends issue/run machine metadata through the dashboard API and replaces the hand-maintained linear diagram with separate, selectable Issue lifecycle and Agent run views. Skipped phases are explicit on desktop and mobile.
- Generates `machine.json` and `BOT_STATE_MACHINE.md` from the combined machine definitions.

This addresses the lifecycle ambiguity exposed by #1623 and #2299 and follows the publication/recovery fixes in #2545 and #2550.

Related to #1623 and #2299.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
  - The bot typecheck still fails on the pre-existing generated Durable Object binding/export errors, the existing pending-resume narrowing error, and the existing verification fixture error. No new error points to this change.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
  - N/A: the dashboard is private bot infrastructure, not the localized admin UI.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
  - N/A: only private `infra/emdash-bot` code and its generated specification change.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
  - N/A: maintainer-directed bot lifecycle bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Dashboard verified locally at 1280px desktop and 390px mobile widths against public-safe production issue data plus an active direct-implementation fixture. Accessibility snapshots contained both machines, skipped phases and issue details; browser console and runtime error logs were empty.

- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 268 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 63 passed
- `pnpm --filter @emdash-cms/emdash-bot build` — passed
- `pnpm lint` — passed
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm format:check` — passed
- `pnpm --filter @emdash-cms/emdash-bot typecheck` — fails on the pre-existing errors disclosed above
