### PR TITLE
fix: persist read-replica bookmark when a request becomes authenticated

### DIFF
--- a/.changeset/fresh-login-bookmark.md
+++ b/.changeset/fresh-login-bookmark.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes intermittent logged-out bounces immediately after login, signup, or invite acceptance on D1 and Durable Object databases with read replication enabled. The request that establishes the session now persists its read-replica bookmark, so the next request sees the newly created user instead of querying a replica that hasn't caught up yet.

--- a/packages/cloudflare/src/db/d1.ts
+++ b/packages/cloudflare/src/db/d1.ts
@@ -162,6 +162,13 @@ interface CookieJar {
 export interface RequestScopedDbOpts {
 	config: D1Config;
 	isAuthenticated: boolean;
+	/**
+	 * Evaluated at commit() time: whether the request ended authenticated.
+	 * Login/signup/invite requests start unauthenticated and establish a
+	 * session mid-request; `isAuthenticated` captures only the request-start
+	 * state.
+	 */
+	endedAuthenticated?: () => boolean;
 	isWrite: boolean;
 	cookies: CookieJar;
 	url: URL;
@@ -435,8 +442,12 @@ export function createRequestScopedDb(opts: RequestScopedDbOpts): RequestScopedD
 		db,
 		commit() {
 			// Anonymous sessions can't resume across requests, so there's no
-			// value in persisting a bookmark for them.
-			if (!opts.isAuthenticated) return;
+			// value in persisting a bookmark for them. A request that became
+			// authenticated mid-flight (login, signup, invite) must persist:
+			// its writes landed on the primary, and the follow-up request reads
+			// authenticated — without this bookmark it can hit a replica that
+			// doesn't have the new user/session rows yet.
+			if (!opts.isAuthenticated && !opts.endedAuthenticated?.()) return;
 			const newBookmark = session.getBookmark?.();
 			if (!newBookmark) return;
 			opts.cookies.set(cookieName, newBookmark, {

--- a/packages/cloudflare/src/db/do-sql.ts
+++ b/packages/cloudflare/src/db/do-sql.ts
@@ -174,6 +174,13 @@ export interface RequestScopedDbOpts {
 	config: DurableObjectsConfig;
 	isAuthenticated: boolean;
 	/**
+	 * Evaluated at commit() time: whether the request ended authenticated.
+	 * Login/signup/invite requests start unauthenticated and establish a
+	 * session mid-request; `isAuthenticated` captures only the request-start
+	 * state.
+	 */
+	endedAuthenticated?: () => boolean;
+	/**
 	 * Whether this request mutates. Mutation scopes route their reads through the
 	 * primary so destructive preconditions cannot be evaluated against a lagging
 	 * replica.
@@ -244,8 +251,11 @@ export function createRequestScopedDb(opts: RequestScopedDbOpts): RequestScopedD
 	return {
 		db,
 		commit() {
-			// Only authenticated users benefit from resuming a bookmark.
-			if (!sessionEnabled || !opts.isAuthenticated) return;
+			// Only authenticated users benefit from resuming a bookmark. A
+			// request that became authenticated mid-flight (login, signup,
+			// invite) counts: its follow-up request reads authenticated and
+			// needs this bookmark to see the rows just written to the primary.
+			if (!sessionEnabled || (!opts.isAuthenticated && !opts.endedAuthenticated?.())) return;
 			const newBookmark = bookmarkSink.latest;
 			if (!newBookmark) return;
 			// Don't emit a cookie the browser will silently drop (~4 KB limit),

--- a/packages/cloudflare/tests/db/d1-request-scope.test.ts
+++ b/packages/cloudflare/tests/db/d1-request-scope.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+	const session = {
+		prepare: vi.fn(),
+		batch: vi.fn(),
+		getBookmark: vi.fn(() => "d1-bookmark-1"),
+	};
+	const binding = {
+		prepare: vi.fn(),
+		batch: vi.fn(),
+		withSession: vi.fn(() => session),
+	};
+	return { session, binding };
+});
+
+vi.mock("cloudflare:workers", () => ({
+	env: { DB: mocks.binding },
+}));
+
+import { createRequestScopedDb } from "../../src/db/d1.js";
+
+const config = { binding: "DB", session: "auto" as const };
+
+describe("D1 request scoping bookmark persistence", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.session.getBookmark.mockReturnValue("d1-bookmark-1");
+		mocks.binding.withSession.mockReturnValue(mocks.session);
+	});
+
+	it("persists the bookmark for a request that started authenticated", () => {
+		const cookies = { get: vi.fn(), set: vi.fn() };
+		const scoped = createRequestScopedDb({
+			config,
+			isAuthenticated: true,
+			isWrite: false,
+			cookies,
+			url: new URL("https://example.com/_emdash/admin"),
+		});
+
+		expect(scoped).not.toBeNull();
+		scoped!.commit();
+		expect(cookies.set).toHaveBeenCalledWith(
+			"__em_d1_bookmark",
+			"d1-bookmark-1",
+			expect.objectContaining({ httpOnly: true, secure: true }),
+		);
+	});
+
+	it("persists the bookmark when the request becomes authenticated mid-request", () => {
+		const cookies = { get: vi.fn(), set: vi.fn() };
+		const scoped = createRequestScopedDb({
+			config,
+			isAuthenticated: false,
+			endedAuthenticated: () => true,
+			isWrite: true,
+			cookies,
+			url: new URL("https://example.com/_emdash/api/auth/passkey/verify"),
+		});
+
+		expect(scoped).not.toBeNull();
+		scoped!.commit();
+		expect(cookies.set).toHaveBeenCalledWith(
+			"__em_d1_bookmark",
+			"d1-bookmark-1",
+			expect.objectContaining({ httpOnly: true, secure: true }),
+		);
+	});
+
+	it("persists nothing for a request that stays anonymous", () => {
+		const cookies = { get: vi.fn(), set: vi.fn() };
+		const scoped = createRequestScopedDb({
+			config,
+			isAuthenticated: false,
+			endedAuthenticated: () => false,
+			isWrite: false,
+			cookies,
+			url: new URL("https://example.com/"),
+		});
+
+		expect(scoped).not.toBeNull();
+		scoped!.commit();
+		expect(cookies.set).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cloudflare/tests/db/do-sql-request-scope.test.ts
+++ b/packages/cloudflare/tests/db/do-sql-request-scope.test.ts
@@ -48,6 +48,46 @@ describe("DO SQL request scoping", () => {
 		expect(cookies.set).not.toHaveBeenCalled();
 	});
 
+	it("persists the bookmark when the request becomes authenticated mid-request", async () => {
+		mocks.query.mockResolvedValue({ rows: [], bookmark: "do-bookmark-1" });
+		const cookies = { get: vi.fn(), set: vi.fn() };
+		const scoped = createRequestScopedDb({
+			config: { binding: "DB_DO", session: "auto" },
+			isAuthenticated: false,
+			endedAuthenticated: () => true,
+			isWrite: true,
+			cookies,
+			url: new URL("https://example.com/_emdash/api/auth/passkey/verify"),
+		});
+
+		expect(scoped).not.toBeNull();
+		await sql`UPDATE users SET name = 'x'`.execute(scoped!.db);
+		scoped!.commit();
+		expect(cookies.set).toHaveBeenCalledWith(
+			"__em_do_bookmark",
+			"do-bookmark-1",
+			expect.objectContaining({ httpOnly: true, secure: true }),
+		);
+	});
+
+	it("persists nothing for a request that stays anonymous", async () => {
+		mocks.query.mockResolvedValue({ rows: [], bookmark: "do-bookmark-1" });
+		const cookies = { get: vi.fn(), set: vi.fn() };
+		const scoped = createRequestScopedDb({
+			config: { binding: "DB_DO", session: "auto" },
+			isAuthenticated: false,
+			endedAuthenticated: () => false,
+			isWrite: true,
+			cookies,
+			url: new URL("https://example.com/comment"),
+		});
+
+		expect(scoped).not.toBeNull();
+		await sql`UPDATE comments SET body = 'x'`.execute(scoped!.db);
+		scoped!.commit();
+		expect(cookies.set).not.toHaveBeenCalled();
+	});
+
 	it("keeps anonymous reads on the singleton when replica sessions are disabled", () => {
 		expect(
 			createRequestScopedDb({

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -75,6 +75,7 @@ import {
 	ASTRO_COOKIES_SYMBOL,
 	coordinateScopedDbLifecycle,
 	finishScoped,
+	requestEndedAuthenticated,
 } from "./middleware/scoped-db.js";
 import { wrapBodyForStreamMetrics } from "./middleware/stream-end-metrics.js";
 import { prefetchLayoutData } from "./prefetch.js";
@@ -681,6 +682,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			.startsWith("bearer ");
 		const isWrite = request.method !== "GET" && request.method !== "HEAD";
 		const isAuthenticated = !!sessionUser || hasBearerAuth;
+		const endedAuthenticated = () => requestEndedAuthenticated(isAuthenticated, cookies);
 		const canUseCachedBinding =
 			!isAuthenticated &&
 			!isWrite &&
@@ -790,6 +792,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				const anonScoped = createRequestScopedDb({
 					config: config?.database?.config,
 					isAuthenticated,
+					endedAuthenticated,
 					isWrite,
 					canUseCachedBinding,
 					cookies,
@@ -1009,6 +1012,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			const scoped = createRequestScopedDb({
 				config: config?.database?.config,
 				isAuthenticated,
+				endedAuthenticated,
 				isWrite,
 				canUseCachedBinding,
 				cookies: context.cookies,

--- a/packages/core/src/astro/middleware/scoped-db.ts
+++ b/packages/core/src/astro/middleware/scoped-db.ts
@@ -24,6 +24,27 @@ interface ScopedDbLifecycle {
 	close?: () => void;
 }
 
+/**
+ * Whether the request ended authenticated, for the db adapter's `commit()`.
+ * `isAuthenticated` is captured before the route runs, so it misses
+ * login/signup/invite requests that create the Astro session mid-request;
+ * `session.set()` writes the `astro-session` cookie into the jar synchronously,
+ * so scanning the outgoing cookies detects them. Only outgoing cookies count —
+ * a stale `astro-session` cookie arriving on an anonymous render must not
+ * qualify, or its replica-read bookmark would overwrite a fresher one from an
+ * earlier authenticated write.
+ */
+export function requestEndedAuthenticated(
+	isAuthenticated: boolean,
+	cookies: { headers(): Iterable<string> },
+): boolean {
+	if (isAuthenticated) return true;
+	for (const header of cookies.headers()) {
+		if (header.startsWith("astro-session=")) return true;
+	}
+	return false;
+}
+
 /** Hold the real adapter close behind both response and deferred-task completion. */
 export function coordinateScopedDbLifecycle(scoped: ScopedDbLifecycle): {
 	closed?: Promise<void>;

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -55,6 +55,13 @@ declare module "virtual:emdash/dialect" {
 	export interface RequestScopedDbOpts {
 		config: unknown;
 		isAuthenticated: boolean;
+		/**
+		 * Evaluated at commit() time: whether the request ended authenticated.
+		 * Login/signup/invite requests start unauthenticated and establish a
+		 * session mid-request; `isAuthenticated` captures only the request-start
+		 * state.
+		 */
+		endedAuthenticated?: () => boolean;
 		isWrite: boolean;
 		/** Whether core routing allows this request to use an anonymous public-read cache. */
 		canUseCachedBinding?: boolean;

--- a/packages/core/tests/unit/middleware/scoped-db.test.ts
+++ b/packages/core/tests/unit/middleware/scoped-db.test.ts
@@ -5,6 +5,7 @@ import {
 	ASTRO_COOKIES_SYMBOL,
 	coordinateScopedDbLifecycle,
 	finishScoped,
+	requestEndedAuthenticated,
 	wrapResponseForScopedClose,
 } from "../../../src/astro/middleware/scoped-db.js";
 import { runWithContext } from "../../../src/request-context.js";
@@ -25,6 +26,39 @@ function streamingResponse(chunks: string[], init?: ResponseInit): Response {
 async function drain(response: Response): Promise<string> {
 	return response.body ? await new Response(response.body).text() : "";
 }
+
+describe("requestEndedAuthenticated", () => {
+	/**
+	 * Minimal AstroCookies stand-in: headers() yields serialized Set-Cookie
+	 * strings for cookies set during the request, and nothing for cookies that
+	 * only arrived on the request.
+	 */
+	function jar(outgoing: string[]) {
+		return { headers: () => outgoing };
+	}
+
+	it("is true when the request started authenticated", () => {
+		expect(requestEndedAuthenticated(true, jar([]))).toBe(true);
+	});
+
+	it("is true when the route created a session mid-request", () => {
+		expect(requestEndedAuthenticated(false, jar(["astro-session=abc123; Path=/; HttpOnly"]))).toBe(
+			true,
+		);
+	});
+
+	it("is false for an anonymous request that merely arrived with a session cookie", () => {
+		// A stale astro-session cookie on the request is not an outgoing
+		// cookie, so it yields nothing from headers().
+		expect(requestEndedAuthenticated(false, jar([]))).toBe(false);
+	});
+
+	it("ignores other cookies set during the request", () => {
+		expect(
+			requestEndedAuthenticated(false, jar(["emdash-edit-mode=true; Path=/", "theme=dark"])),
+		).toBe(false);
+	});
+});
 
 describe("wrapResponseForScopedClose", () => {
 	it("closes immediately for a bodyless response", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a read-your-writes hole on D1 and Durable Object databases with read replication: requests that become authenticated mid-request (login, signup, invite acceptance) never persisted their Sessions-API bookmark cookie, because `commit()` checked `isAuthenticated` as captured *before* the route ran. The follow-up authenticated request then read a nearest replica with no bookmark constraint, and the auth middleware's `getUserById` could miss the just-created user row — bouncing a brand-new user straight back to login. Intermittent, region-dependent, and worst exactly at first-run/onboarding.

The middleware now passes an `endedAuthenticated()` thunk (optional, additive field on `RequestScopedDbOpts`), evaluated at `commit()` time. It scans the **outgoing** cookie jar for `astro-session`: Astro's `session.set()` writes the cookie into the jar synchronously, so a session created during the request is visible by commit time via a pure in-memory lookup — zero new queries, zero KV reads, and genuinely anonymous requests still get no cookie, so the logged-out hot path is unchanged. Only outgoing cookies count: falling back to the request's own `Cookie` header would let an anonymous render carrying a stale session cookie overwrite a fresher bookmark with a lagging replica's.

Both bookmark adapters (D1 and DO-SQL) honour the new signal; Hyperdrive has no bookmark state and is untouched. The cron/outside-request path passes no thunk and behaves as before.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a, no admin UI changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (adversarial review pass: Claude Opus)

## Screenshots / test output

Tests written first and confirmed failing before the fix:

- `packages/cloudflare/tests/db/d1-request-scope.test.ts` — bookmark persisted when the request becomes authenticated; nothing persisted for anonymous requests; started-authenticated behaviour unchanged.
- `packages/cloudflare/tests/db/do-sql-request-scope.test.ts` — same two cases for the DO adapter, driven through a real query so the bookmark sink is populated.
- `packages/core/tests/unit/middleware/scoped-db.test.ts` — `requestEndedAuthenticated` consults only outgoing cookies: true when the route sets `astro-session`, false when the cookie merely arrived on the request (the stale-cookie clobber case), false for unrelated outgoing cookies.

Full cloudflare db suite (249 tests) and core middleware suite pass; `pnpm lint:json` reports 0 diagnostics; `pnpm typecheck` clean across all packages.
