### PR TITLE
fix(client): retry requests with a body after a token refresh

### DIFF
--- a/.changeset/fix-refresh-retry-with-body.md
+++ b/.changeset/fix-refresh-retry-with-body.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash content create` and `content update` failing with "Cannot construct a Request with a Request object that has already been used" when the stored access token has expired. Requests carrying a body are now retried correctly after the token is refreshed.

--- a/packages/core/src/client/transport.ts
+++ b/packages/core/src/client/transport.ts
@@ -186,6 +186,13 @@ export function refreshInterceptor(options: {
 	}
 
 	return async (request, next) => {
+		// A request body can only be read once, and sending the request consumes
+		// it. Keep a clone taken before the first attempt so the retry has an
+		// unused request to rebuild from -- deriving it from the original throws
+		// "Cannot construct a Request with a Request object that has already been
+		// used" for every request that carries a body.
+		const retryTemplate = request.body ? request.clone() : request;
+
 		const response = await next(request);
 
 		if (response.status === 401) {
@@ -199,9 +206,9 @@ export function refreshInterceptor(options: {
 			const newToken = await refreshing;
 			if (newToken) {
 				// Retry with new token
-				const headers = new Headers(request.headers);
+				const headers = new Headers(retryTemplate.headers);
 				headers.set("Authorization", `Bearer ${newToken}`);
-				return next(new Request(request, { headers }));
+				return next(new Request(retryTemplate, { headers }));
 			}
 		}
 

--- a/packages/core/src/client/transport.ts
+++ b/packages/core/src/client/transport.ts
@@ -186,11 +186,8 @@ export function refreshInterceptor(options: {
 	}
 
 	return async (request, next) => {
-		// A request body can only be read once, and sending the request consumes
-		// it. Keep a clone taken before the first attempt so the retry has an
-		// unused request to rebuild from -- deriving it from the original throws
-		// "Cannot construct a Request with a Request object that has already been
-		// used" for every request that carries a body.
+		// A request body can only be read once; clone before sending so the
+		// 401 retry has an unconsumed request to rebuild from.
 		const retryTemplate = request.body ? request.clone() : request;
 
 		const response = await next(request);

--- a/packages/core/tests/unit/client/transport.test.ts
+++ b/packages/core/tests/unit/client/transport.test.ts
@@ -293,6 +293,63 @@ describe("refreshInterceptor", () => {
 			globalThis.fetch = originalFetch;
 		}
 	});
+
+	it("retries a request that has a body, resending the same payload", async () => {
+		const payload = JSON.stringify({ title: "hello" });
+		const seenBodies: string[] = [];
+		let retryAuth: string | null = null;
+
+		const interceptor = refreshInterceptor({
+			refreshToken: "rt_old",
+			tokenEndpoint: "https://example.com/_emdash/api/oauth/token/refresh",
+		});
+
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = async (input: string | URL | Request) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes("/oauth/token/refresh")) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						data: { access_token: "new_access", expires_in: 3600 },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return originalFetch(input);
+		};
+
+		try {
+			const backend: Interceptor = async (req) => {
+				// Read the body, as a real fetch does — this is what leaves the
+				// request used and makes it unusable as a template for the retry
+				seenBodies.push(await req.text());
+				if (seenBodies.length === 1) {
+					return new Response("unauthorized", { status: 401 });
+				}
+				retryAuth = req.headers.get("Authorization");
+				return new Response("ok", { status: 200 });
+			};
+
+			const transport = createTransport({
+				interceptors: [interceptor, backend],
+			});
+
+			const res = await transport.fetch(
+				new Request("https://example.com/_emdash/api/content/posts", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: payload,
+				}),
+			);
+
+			expect(res.status).toBe(200);
+			expect(retryAuth).toBe("Bearer new_access");
+			expect(seenBodies).toEqual([payload, payload]);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a 401 retry path that throws for every request carrying a body.

`refreshInterceptor` retries by deriving a new `Request` from the one it already sent:

```ts
const response = await next(request);   // sending consumes request's body
if (response.status === 401) {
  ...
  return next(new Request(request, { headers }));   // request is already used -> TypeError
}
```

A request body can only be read once, so after `next(request)` the original can no longer be used as a template. Every retried POST/PUT throws:

```
TypeError: Cannot construct a Request with a Request object that has already been used.
```

GET requests are unaffected, which is why this went unnoticed — the existing `refreshInterceptor` test retries a bodyless request, and its mock backend never reads the body, so nothing marks the request as used.

In practice this makes the CLI fail on the first `emdash content create` / `content update` run after the stored access token expires. `packages/core/src/cli/client-factory.ts` deliberately builds the client with the expired access token plus a refresh token, so that first request is guaranteed to 401 and enter this path. The refresh itself succeeds and the new token is persisted before the throw, which is why re-running the same command immediately afterwards works — an easy failure to mistake for a flake.

The fix keeps a clone taken before the first attempt and rebuilds the retry from that.

No existing issue — filed directly as a PR, per CONTRIBUTING ("Bug fixes: open a PR directly").

**Follow-up, not fixed here:** after a successful refresh, `tokenInterceptor` still holds the old token, so every subsequent request on the same client pays another 401 + refresh round trip (visible as two refreshes in the trace below). That is a separate defect and I left it out to keep this PR to one change. Happy to open a Discussion or a second PR if you'd like it addressed.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — ran the full `packages/core` unit suite: 3963 tests, all passing
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 via Claude Code

## Screenshots / test output

The new test fails on `main` and points straight at the line:

```
 FAIL  tests/unit/client/transport.test.ts > refreshInterceptor > retries a request that has a body, resending the same payload
TypeError: Cannot construct a Request with a Request object that has already been used.
 ❯ src/client/transport.ts:204:17
    202|     const headers = new Headers(request.headers);
    203|     headers.set("Authorization", `Bearer ${newToken}`);
    204|     return next(new Request(request, { headers }));
       |                 ^

 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

With the fix:

```
 Test Files  309 passed (309)
      Tests  3963 passed (3963)
```

Also reproduced end to end against a real HTTP server (no mocked `fetch`), driving the published `EmDashClient` the way the CLI does — expired access token plus refresh token:

<details>
<summary>Repro script</summary>

```js
import { createServer } from "node:http";
import { EmDashClient } from "emdash/client";

const server = createServer((req, res) => {
  let body = "";
  req.on("data", (c) => (body += c));
  req.on("end", () => {
    const send = (obj, status = 200) => {
      res.writeHead(status, { "Content-Type": "application/json" });
      res.end(JSON.stringify(obj));
    };
    if (req.url.endsWith("/oauth/token/refresh")) {
      return send({ success: true, data: { access_token: "new-token", expires_in: 3600 } });
    }
    if (req.headers.authorization !== "Bearer new-token") {
      console.log(`[server] ${req.method} ${req.url} -> 401 (expired token)`);
      return send({ error: { code: "UNAUTHORIZED" } }, 401);
    }
    console.log(`[server] ${req.method} ${req.url} -> 200 (body ${body.length} bytes)`);
    send({ data: { item: { id: "01ABC", slug: "test" }, fields: [] } });
  });
});
await new Promise((r) => server.listen(0, "127.0.0.1", r));

const client = new EmDashClient({
  baseUrl: `http://127.0.0.1:${server.address().port}`,
  token: "expired-token",
  refreshToken: "refresh-token",
});

try {
  await client.create("posts", { data: { title: "hello" }, slug: "test", status: "draft" });
  console.log("-> ok");
} catch (e) {
  console.log(`-> failed: ${e.constructor.name}: ${e.message}`);
}
server.close();
```

</details>

Before:

```
[server] GET  /_emdash/api/schema/collections/posts?includeFields=true -> 401 (expired token)
[server] GET  /_emdash/api/schema/collections/posts?includeFields=true -> 200 (body 0 bytes)
[server] POST /_emdash/api/content/posts -> 401 (expired token)
-> failed: TypeError: Cannot construct a Request with a Request object that has already been used.
```

After:

```
[server] GET  /_emdash/api/schema/collections/posts?includeFields=true -> 401 (expired token)
[server] GET  /_emdash/api/schema/collections/posts?includeFields=true -> 200 (body 0 bytes)
[server] POST /_emdash/api/content/posts -> 401 (expired token)
[server] POST /_emdash/api/content/posts -> 200 (body 57 bytes)
-> ok
```

The retried POST now carries the same payload it was given.
