### PR TITLE
feat(bot): expose public run traces

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -57,6 +57,7 @@ import {
 	recordInvestigationProgress,
 	recordWorkPlan,
 } from "../lib/investigation-result.js";
+import { flushAgentTraceWrites } from "../lib/observer.js";
 import { FLUE_RUN_TIMEOUT_MS, SANDBOX_SLEEP_AFTER_SECONDS } from "../lib/run-policy.js";
 import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/timeout-recovery.js";
 import { untarInto } from "../lib/untar.js";
@@ -719,6 +720,10 @@ export function Investigate({ id }: AgentProps) {
 		});
 		setReported(true);
 		log.warn("agent stopped without reporting", { runId: input.runId });
+	});
+
+	useAgentFinish(async () => {
+		await flushAgentTraceWrites(id);
 	});
 
 	if (reported && !setupComplete) {

--- a/infra/emdash-bot/.flue/dashboard.html
+++ b/infra/emdash-bot/.flue/dashboard.html
@@ -45,7 +45,9 @@
 			}
 
 			a:focus-visible,
-			button:focus-visible {
+			button:focus-visible,
+			select:focus-visible,
+			summary:focus-visible {
 				outline: 2px solid light-dark(#7642da, #b092ff);
 				outline-offset: 2px;
 			}
@@ -719,6 +721,173 @@
 				font-size: 9px;
 			}
 
+			.trace-section {
+				padding: 15px 17px 17px;
+				border-bottom: 1px solid light-dark(#e5e6eb, #292b33);
+				background: light-dark(#fbfbfd, #121318);
+			}
+
+			.trace-head,
+			.trace-controls {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 10px;
+			}
+
+			.trace-head {
+				margin-bottom: 10px;
+				font-size: 10px;
+				font-weight: 600;
+			}
+
+			.trace-controls {
+				justify-content: flex-start;
+				margin-bottom: 10px;
+			}
+
+			.trace-select,
+			.trace-load {
+				min-width: 0;
+				border: 1px solid light-dark(#d9dbe2, #32353d);
+				border-radius: 6px;
+				background: light-dark(#fff, #1a1b21);
+				color: inherit;
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+			}
+
+			.trace-select {
+				max-width: 100%;
+				padding: 6px 24px 6px 8px;
+			}
+
+			.trace-load {
+				padding: 6px 9px;
+				cursor: pointer;
+			}
+
+			.trace-load:hover {
+				background: light-dark(#f4f0fb, #211c2b);
+			}
+
+			.trace-list {
+				display: grid;
+				gap: 7px;
+			}
+
+			.trace-event {
+				border: 1px solid light-dark(#e1e3e8, #292c33);
+				border-inline-start: 3px solid light-dark(#a2a6af, #6f747e);
+				border-radius: 7px;
+				background: light-dark(#fff, #17181d);
+			}
+
+			.trace-event.active {
+				border-inline-start-color: light-dark(#7642da, #a983ff);
+			}
+
+			.trace-event.success {
+				border-inline-start-color: light-dark(#16845b, #50d49b);
+			}
+
+			.trace-event.failed {
+				border-inline-start-color: light-dark(#c24747, #ee7676);
+			}
+
+			.trace-summary {
+				display: grid;
+				grid-template-columns: 48px minmax(0, 1fr) auto 12px;
+				gap: 9px;
+				align-items: start;
+				padding: 9px 10px;
+				cursor: pointer;
+				list-style: none;
+			}
+
+			.trace-summary::-webkit-details-marker {
+				display: none;
+			}
+
+			.trace-summary::after {
+				content: "+";
+				color: light-dark(#858995, #858a95);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 11px;
+			}
+
+			.trace-event[open] .trace-summary::after {
+				content: "–";
+			}
+
+			.trace-time,
+			.trace-kind,
+			.trace-duration,
+			.trace-block-label {
+				color: light-dark(#858995, #858a95);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 8px;
+				letter-spacing: 0.04em;
+				text-transform: uppercase;
+			}
+
+			.trace-title {
+				display: flex;
+				align-items: baseline;
+				gap: 7px;
+				font-size: 10px;
+				font-weight: 600;
+			}
+
+			.trace-detail,
+			.trace-preview {
+				margin-top: 3px;
+				color: light-dark(#686c77, #9da1ac);
+				font-size: 9px;
+				font-weight: 400;
+				line-height: 1.4;
+			}
+
+			.trace-preview {
+				display: -webkit-box;
+				overflow: hidden;
+				-webkit-box-orient: vertical;
+				-webkit-line-clamp: 2;
+			}
+
+			.trace-body {
+				display: grid;
+				gap: 10px;
+				padding: 0 10px 10px 67px;
+			}
+
+			.trace-block-label {
+				display: block;
+				margin-bottom: 5px;
+			}
+
+			.trace-body pre {
+				max-height: 360px;
+				margin: 0;
+				overflow: auto;
+				padding: 9px 10px;
+				border-radius: 6px;
+				background: light-dark(#f3f4f7, #0c0d10);
+				color: light-dark(#30323a, #dfe1e6);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+				font-size: 9px;
+				line-height: 1.5;
+				white-space: pre-wrap;
+				word-break: break-word;
+			}
+
+			.trace-empty {
+				padding: 18px 10px;
+				text-align: center;
+				color: light-dark(#777b86, #9195a0);
+				font-size: 10px;
+			}
+
 			.log-head {
 				display: flex;
 				align-items: center;
@@ -931,6 +1100,25 @@
 				.fact:last-child {
 					border-bottom: 0;
 				}
+
+				.trace-summary {
+					grid-template-columns: 43px minmax(0, 1fr) auto 12px;
+					padding: 9px 8px;
+				}
+
+				.trace-body {
+					padding: 0 8px 9px;
+				}
+
+				.trace-controls {
+					align-items: stretch;
+					flex-direction: column;
+				}
+
+				.trace-select,
+				.trace-load {
+					width: 100%;
+				}
 			}
 
 			@media (prefers-reduced-motion: reduce) {
@@ -1096,6 +1284,15 @@
 				10,
 			);
 			let selectedNumber = Number.isSafeInteger(requestedIssue) ? requestedIssue : null;
+			let traceState = {
+				issueNumber: null,
+				loading: false,
+				error: null,
+				page: null,
+			};
+			let traceRequest = 0;
+			let tracePending = false;
+			const openTraceEvents = new Set();
 
 			function element(tag, className, text) {
 				const node = document.createElement(tag);
@@ -1126,6 +1323,14 @@
 				const hours = Math.floor(seconds / 3600);
 				const minutes = Math.floor((seconds % 3600) / 60);
 				return hours ? `${hours}h ${minutes}m` : `${minutes}m ${seconds % 60}s`;
+			}
+
+			function shortDuration(milliseconds) {
+				if (!Number.isFinite(milliseconds)) return "";
+				if (milliseconds < 1_000) return `${Math.round(milliseconds)}ms`;
+				const seconds = milliseconds / 1_000;
+				if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+				return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
 			}
 
 			function renderCounts() {
@@ -1282,6 +1487,7 @@
 						selectedNumber = issue.number;
 						window.history.replaceState(null, "", `?issue=${issue.number}`);
 						render();
+						loadTrace(issue.number, { merge: "replace" });
 					});
 					target.append(button);
 				}
@@ -1353,6 +1559,128 @@
 				panel.append(section);
 			}
 
+			function tracePreview(event) {
+				const text = event.output ?? event.input ?? "";
+				return text.replaceAll(/\s+/g, " ").trim().slice(0, 220);
+			}
+
+			function appendTraceBlock(body, label, value) {
+				if (!value) return;
+				const block = element("div");
+				block.append(element("span", "trace-block-label", label));
+				const pre = element("pre", "", value);
+				block.append(pre);
+				body.append(block);
+			}
+
+			function renderTraceEvent(event) {
+				const row = element("details", `trace-event ${event.tone}`);
+				row.open = openTraceEvents.has(event.id);
+				row.addEventListener("toggle", () => {
+					if (row.open) openTraceEvents.add(event.id);
+					else openTraceEvents.delete(event.id);
+				});
+				const summary = element("summary", "trace-summary");
+				summary.append(
+					element(
+						"span",
+						"trace-time",
+						new Date(event.at).toLocaleTimeString([], {
+							hour: "2-digit",
+							minute: "2-digit",
+							second: "2-digit",
+						}),
+					),
+				);
+				const copy = element("span");
+				const title = element("span", "trace-title");
+				title.append(
+					element("span", "", event.title),
+					element("span", "trace-kind", stateLabel(event.kind)),
+				);
+				copy.append(title);
+				if (event.detail) copy.append(element("span", "trace-detail", event.detail));
+				const preview = tracePreview(event);
+				if (preview) copy.append(element("span", "trace-preview", preview));
+				summary.append(copy, element("span", "trace-duration", shortDuration(event.durationMs)));
+				row.append(summary);
+				if (event.input || event.output) {
+					const body = element("div", "trace-body");
+					appendTraceBlock(body, "Input", event.input);
+					appendTraceBlock(body, "Output", event.output);
+					row.append(body);
+				}
+				return row;
+			}
+
+			function renderTrace(issue, panel) {
+				const section = element("section", "trace-section");
+				section.setAttribute("aria-labelledby", "run-trace-title");
+				const head = element("div", "trace-head");
+				const title = element("span", "", "Run trace");
+				title.id = "run-trace-title";
+				head.append(title, element("span", "panel-meta", "turns · tools · results"));
+				section.append(head);
+
+				if (traceState.issueNumber !== issue.number || traceState.loading) {
+					section.append(element("div", "trace-empty", "Loading the full run trace…"));
+					panel.append(section);
+					return;
+				}
+				if (traceState.error) {
+					section.append(element("div", "trace-empty", traceState.error));
+					panel.append(section);
+					return;
+				}
+				const page = traceState.page;
+				if (!page?.selectedRunId) {
+					section.append(
+						element("div", "trace-empty", "No turn-by-turn trace has been recorded yet."),
+					);
+					panel.append(section);
+					return;
+				}
+
+				const controls = element("div", "trace-controls");
+				const select = element("select", "trace-select");
+				select.setAttribute("aria-label", "Choose a run trace");
+				for (const run of page.runs) {
+					const option = element(
+						"option",
+						"",
+						`${run.mode} · ${relativeTime(run.startedAt)} · ${run.eventCount} events`,
+					);
+					option.value = run.runId;
+					option.selected = run.runId === page.selectedRunId;
+					select.append(option);
+				}
+				select.addEventListener("change", () => {
+					loadTrace(issue.number, { runId: select.value, merge: "replace" });
+				});
+				controls.append(select);
+				if (page.nextBefore) {
+					const older = element("button", "trace-load", "Load earlier");
+					older.type = "button";
+					older.addEventListener("click", () => {
+						loadTrace(issue.number, {
+							runId: page.selectedRunId,
+							before: page.nextBefore,
+							merge: "older",
+						});
+					});
+					controls.append(older);
+				}
+				section.append(controls);
+				const list = element("div", "trace-list");
+				if (!page.events.length) {
+					list.append(element("div", "trace-empty", "This run has no recorded trace events."));
+				} else {
+					for (const event of page.events) list.append(renderTraceEvent(event));
+				}
+				section.append(list);
+				panel.append(section);
+			}
+
 			function renderDetail(issue) {
 				const panel = document.getElementById("detail-panel");
 				panel.replaceChildren();
@@ -1406,6 +1734,7 @@
 				}
 				panel.append(facts);
 				renderWorkPlan(issue, panel);
+				renderTrace(issue, panel);
 
 				const logHead = element("div", "log-head");
 				logHead.append(
@@ -1445,6 +1774,84 @@
 				panel.append(log);
 			}
 
+			function mergeTraceEvents(...groups) {
+				const events = new Map();
+				for (const group of groups) {
+					for (const event of group ?? []) events.set(event.id, event);
+				}
+				return [...events.values()].toSorted((left, right) => left.id - right.id);
+			}
+
+			function sameTraceEvents(left, right) {
+				return (
+					left.length === right.length &&
+					left.every((event, index) => event.id === right[index]?.id)
+				);
+			}
+
+			async function loadTrace(issueNumber, options = {}) {
+				const request = ++traceRequest;
+				tracePending = true;
+				const merge = options.merge ?? "replace";
+				const previous = traceState.issueNumber === issueNumber ? traceState.page : null;
+				if (merge === "replace") {
+					if (
+						traceState.issueNumber !== issueNumber ||
+						(options.runId && options.runId !== previous?.selectedRunId)
+					) {
+						openTraceEvents.clear();
+					}
+					traceState = { issueNumber, loading: true, error: null, page: null };
+					render();
+				}
+				const params = new URLSearchParams({ limit: "100" });
+				const runId = options.runId ?? (merge === "refresh" ? previous?.selectedRunId : null);
+				if (runId) params.set("run", runId);
+				if (options.before) params.set("before", String(options.before));
+				try {
+					const response = await fetch(`/api/issues/${issueNumber}/trace?${params}`, {
+						headers: { accept: "application/json" },
+						cache: "no-store",
+					});
+					if (!response.ok) throw new Error(`trace request failed: ${response.status}`);
+					const result = await response.json();
+					if (request !== traceRequest || selectedNumber !== issueNumber) return;
+					let page = result;
+					if (previous && previous.selectedRunId === result.selectedRunId) {
+						page = {
+							...result,
+							events:
+								merge === "older"
+									? mergeTraceEvents(result.events, previous.events)
+									: merge === "refresh"
+										? mergeTraceEvents(previous.events, result.events)
+										: result.events,
+							nextBefore: merge === "refresh" ? previous.nextBefore : result.nextBefore,
+						};
+					}
+					if (merge === "refresh" && previous && sameTraceEvents(previous.events, page.events)) {
+						tracePending = false;
+						return;
+					}
+					traceState = { issueNumber, loading: false, error: null, page };
+				} catch {
+					if (request !== traceRequest || selectedNumber !== issueNumber) return;
+					traceState = {
+						issueNumber,
+						loading: false,
+						error: "The run trace is temporarily unavailable.",
+						page: previous,
+					};
+				}
+				tracePending = false;
+				render();
+			}
+
+			function refreshTrace() {
+				if (!selectedNumber || traceState.loading || tracePending) return;
+				loadTrace(selectedNumber, { merge: traceState.page ? "refresh" : "replace" });
+			}
+
 			function render() {
 				const selected =
 					payload?.issues.find((issue) => issue.number === selectedNumber) ??
@@ -1468,6 +1875,16 @@
 					document.getElementById("updated-at").textContent = relativeTime(payload.updatedAt);
 					document.getElementById("system-status").textContent = "Live state";
 					render();
+					const selected =
+						payload.issues.find((issue) => issue.number === selectedNumber) ?? payload.issues[0];
+					if (selected) {
+						loadTrace(selected.number, {
+							merge:
+								traceState.issueNumber === selected.number && traceState.page
+									? "refresh"
+									: "replace",
+						});
+					}
 				} catch {
 					document.getElementById("system-status").textContent = "Data unavailable";
 					document.getElementById("counts").replaceChildren();
@@ -1478,6 +1895,7 @@
 
 			load();
 			setInterval(load, 20_000);
+			setInterval(refreshTrace, 5_000);
 		</script>
 	</body>
 </html>

--- a/infra/emdash-bot/.flue/dashboard.html
+++ b/infra/emdash-bot/.flue/dashboard.html
@@ -1830,7 +1830,6 @@
 						};
 					}
 					if (merge === "refresh" && previous && sameTraceEvents(previous.events, page.events)) {
-						tracePending = false;
 						return;
 					}
 					traceState = { issueNumber, loading: false, error: null, page };
@@ -1842,8 +1841,9 @@
 						error: "The run trace is temporarily unavailable.",
 						page: previous,
 					};
+				} finally {
+					if (request === traceRequest) tracePending = false;
 				}
-				tracePending = false;
 				render();
 			}
 

--- a/infra/emdash-bot/.flue/lib/observer.ts
+++ b/infra/emdash-bot/.flue/lib/observer.ts
@@ -4,26 +4,43 @@
 
 import { observe } from "@flue/runtime";
 
+import type { OrchestratorDO } from "./orchestrator.js";
+import { projectRunTraceObservation } from "./run-trace.js";
+import { withDeadline } from "./sandbox-deadline.js";
+
 let installed = false;
+
+interface ObserverEnv extends Env {
+	Orchestrator: DurableObjectNamespace<OrchestratorDO>;
+}
+
+const TRACE_WRITES = Symbol.for("emdash-bot.traceWrites");
+const TRACE_AGENT_ID_RE = /^investigate-(\d+)-(.+)$/;
+const TRACE_FLUSH_TIMEOUT_MS = 2_000;
+
+function traceWrites(): Map<string, Promise<void>> {
+	const store = globalThis as typeof globalThis & { [TRACE_WRITES]?: Map<string, Promise<void>> };
+	return (store[TRACE_WRITES] ??= new Map());
+}
 
 export function installAgentObserver(): void {
 	if (installed) return;
 	installed = true;
 
-	observe((event) => {
+	observe((event, context) => {
 		const correlationId = event.submissionId ?? event.instanceId;
 		const tag = correlationId ? `[flue/${correlationId.slice(-8)}]` : "[flue]";
 
 		switch (event.type) {
 			case "agent_start":
 				console.log(`${tag} agent_start agent=${event.agentName ?? "unknown"}`);
-				return;
+				break;
 			case "agent_end":
 				console.log(`${tag} agent_end messages=${event.messages.length}`);
-				return;
+				break;
 			case "turn_start":
 				console.log(`${tag} turn_start turn=${event.turnId.slice(-8)} purpose=${event.purpose}`);
-				return;
+				break;
 			case "turn_messages": {
 				const msg = event.message;
 				if (msg.role === "assistant") {
@@ -34,23 +51,69 @@ export function installAgentObserver(): void {
 						`${tag} turn_msg turn=${event.turnId.slice(-8)} role=${msg.role} tools=${event.toolResults.length}`,
 					);
 				}
-				return;
+				break;
 			}
 			case "tool_start":
 				console.log(`${tag} tool_start ${event.toolName} id=${event.toolCallId.slice(-8)}`);
-				return;
+				break;
 			case "tool":
 				console.log(
 					`${tag} tool_end ${event.toolName} id=${event.toolCallId.slice(-8)} isError=${event.isError}`,
 				);
-				return;
+				break;
 			case "submission_settled":
 				console.log(`${tag} submission_settled outcome=${event.outcome}`);
-				return;
+				break;
 			default:
-				return;
+				break;
 		}
+
+		const target = traceTarget(context.id);
+		const projected = target ? projectRunTraceObservation(event) : null;
+		if (!target || !projected) return;
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Flue exposes platform bindings through a generic event context.
+		const { Orchestrator } = context.env as unknown as ObserverEnv;
+		const writes = traceWrites();
+		const previous = writes.get(context.id) ?? Promise.resolve();
+		const next = previous.then(async () => {
+			try {
+				await Orchestrator.getByName(`issue-${target.issueNumber}`).recordRunTraceEvent({
+					runId: target.runId,
+					event: projected,
+				});
+			} catch (error) {
+				console.warn("[flue] run trace write failed", {
+					runId: target.runId,
+					event: projected.kind,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+			return undefined;
+		});
+		writes.set(context.id, next);
+		return next;
 	});
+}
+
+export async function flushAgentTraceWrites(agentId: string): Promise<void> {
+	const pending = traceWrites().get(agentId);
+	if (!pending) return;
+	try {
+		await withDeadline(pending, TRACE_FLUSH_TIMEOUT_MS, "Run trace flush");
+	} catch (error) {
+		console.warn("[flue] run trace flush timed out", {
+			agentId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+function traceTarget(agentId: string): { issueNumber: number; runId: string } | null {
+	const match = TRACE_AGENT_ID_RE.exec(agentId);
+	if (!match?.[1] || !match[2]) return null;
+	const issueNumber = Number(match[1]);
+	if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) return null;
+	return { issueNumber, runId: match[2] };
 }
 
 function summarizeAssistant(message: unknown): string {

--- a/infra/emdash-bot/.flue/lib/observer.ts
+++ b/infra/emdash-bot/.flue/lib/observer.ts
@@ -8,13 +8,12 @@ import type { OrchestratorDO } from "./orchestrator.js";
 import { projectRunTraceObservation } from "./run-trace.js";
 import { withDeadline } from "./sandbox-deadline.js";
 
-let installed = false;
-
 interface ObserverEnv extends Env {
 	Orchestrator: DurableObjectNamespace<OrchestratorDO>;
 }
 
 const TRACE_WRITES = Symbol.for("emdash-bot.traceWrites");
+const OBSERVER_INSTALLED = Symbol.for("emdash-bot.observerInstalled");
 const TRACE_AGENT_ID_RE = /^investigate-(\d+)-(.+)$/;
 const TRACE_FLUSH_TIMEOUT_MS = 2_000;
 
@@ -23,9 +22,15 @@ function traceWrites(): Map<string, Promise<void>> {
 	return (store[TRACE_WRITES] ??= new Map());
 }
 
+function claimObserverInstall(): boolean {
+	const store = globalThis as typeof globalThis & { [OBSERVER_INSTALLED]?: boolean };
+	if (store[OBSERVER_INSTALLED]) return false;
+	store[OBSERVER_INSTALLED] = true;
+	return true;
+}
+
 export function installAgentObserver(): void {
-	if (installed) return;
-	installed = true;
+	if (!claimObserverInstall()) return;
 
 	observe((event, context) => {
 		const correlationId = event.submissionId ?? event.instanceId;
@@ -91,6 +96,10 @@ export function installAgentObserver(): void {
 			return undefined;
 		});
 		writes.set(context.id, next);
+		void next.then(() => {
+			if (writes.get(context.id) === next) writes.delete(context.id);
+			return undefined;
+		});
 		return next;
 	});
 }

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -68,6 +68,7 @@ import {
 import { DEADLINE_WARNING_MESSAGE, runBudgetMs, runSchedule } from "./run-policy.js";
 import {
 	parseStoredRunTraceEvent,
+	RUN_TRACE_EVENT_LIMIT,
 	RUN_TRACE_PAGE_LIMIT,
 	type PublicRunTraceEvent,
 	type PublicRunTracePage,
@@ -662,6 +663,14 @@ export class OrchestratorDO extends DurableObject<Env> {
 			event.at,
 			event.kind,
 			JSON.stringify(event),
+		);
+		this.ctx.storage.sql.exec(
+			`DELETE FROM run_trace_events
+			 WHERE id <= COALESCE(
+				(SELECT id FROM run_trace_events ORDER BY id DESC LIMIT 1 OFFSET ?),
+				0
+			)`,
+			RUN_TRACE_EVENT_LIMIT,
 		);
 		return true;
 	}

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -66,6 +66,14 @@ import {
 	type RunProgressKind,
 } from "./run-lifecycle.js";
 import { DEADLINE_WARNING_MESSAGE, runBudgetMs, runSchedule } from "./run-policy.js";
+import {
+	parseStoredRunTraceEvent,
+	RUN_TRACE_PAGE_LIMIT,
+	type PublicRunTraceEvent,
+	type PublicRunTracePage,
+	type PublicRunTraceSummary,
+	type RunTraceEventInput,
+} from "./run-trace.js";
 import { DeadlineExceededError, withDeadline } from "./sandbox-deadline.js";
 import {
 	normalizeTimeoutSummary,
@@ -377,11 +385,37 @@ interface WorkCommentProjection {
 	readonly pending: boolean;
 }
 
+interface TraceEventRow {
+	readonly [key: string]: string | number;
+	readonly id: number;
+	readonly run_id: string;
+	readonly payload: string;
+}
+
 /** Bounded delivery-id dedupe window. */
 const DELIVERY_DEDUPE_LIMIT = 64;
 
 export class OrchestratorDO extends DurableObject<Env> {
 	private operationTail: Promise<void> = Promise.resolve();
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+		void ctx.blockConcurrencyWhile(async () => {
+			this.ctx.storage.sql.exec(`
+				CREATE TABLE IF NOT EXISTS run_trace_events (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					event_key TEXT NOT NULL UNIQUE,
+					run_id TEXT NOT NULL,
+					mode TEXT NOT NULL,
+					recorded_at INTEGER NOT NULL,
+					event_type TEXT NOT NULL,
+					payload TEXT NOT NULL
+				);
+				CREATE INDEX IF NOT EXISTS idx_run_trace_events_run_id_id
+					ON run_trace_events (run_id, id);
+			`);
+		});
+	}
 
 	async enqueue(input: NormalizedEvent): Promise<EnqueueOutcome> {
 		const { outcome, rearm } = await this.ctx.storage.transaction(async (transaction) => {
@@ -605,6 +639,109 @@ export class OrchestratorDO extends DurableObject<Env> {
 			]);
 			return true;
 		});
+	}
+
+	async recordRunTraceEvent(input: { runId: string; event: RunTraceEventInput }): Promise<boolean> {
+		const event = parseStoredRunTraceEvent(input.event);
+		if (!event) return false;
+		const [currentRunId, run, legacyMode] = await Promise.all([
+			this.ctx.storage.get<string>(STORAGE.currentRunId),
+			this.ctx.storage.get<RunLifecycle>(STORAGE.runLifecycle),
+			this.ctx.storage.get<InvestigationMode>(STORAGE.currentRunMode),
+		]);
+		if (currentRunId !== input.runId && run?.runId !== input.runId) return false;
+		const mode = run?.runId === input.runId ? run.mode : legacyMode;
+		if (!mode) return false;
+		this.ctx.storage.sql.exec(
+			`INSERT OR IGNORE INTO run_trace_events
+				(event_key, run_id, mode, recorded_at, event_type, payload)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			event.key,
+			input.runId,
+			mode,
+			event.at,
+			event.kind,
+			JSON.stringify(event),
+		);
+		return true;
+	}
+
+	async getPublicRunTrace(
+		options: { runId?: string; before?: number; limit?: number } = {},
+	): Promise<PublicRunTracePage> {
+		const requestedLimit = Number.isFinite(options.limit) ? (options.limit ?? 100) : 100;
+		const limit = Math.min(RUN_TRACE_PAGE_LIMIT, Math.max(1, Math.trunc(requestedLimit)));
+		const runRows = this.ctx.storage.sql
+			.exec<{
+				run_id: string;
+				mode: string;
+				started_at: number;
+				updated_at: number;
+				event_count: number;
+			}>(
+				`SELECT run_id, mode, MIN(recorded_at) AS started_at,
+					MAX(recorded_at) AS updated_at, COUNT(*) AS event_count
+				 FROM run_trace_events
+				 GROUP BY run_id, mode
+				 ORDER BY updated_at DESC
+				 LIMIT 50`,
+			)
+			.toArray();
+		const runs = runRows.flatMap((row): PublicRunTraceSummary[] => {
+			const mode = parseInvestigateMode(row.mode);
+			if (!mode) return [];
+			return [
+				{
+					runId: row.run_id,
+					mode,
+					startedAt: row.started_at,
+					updatedAt: row.updated_at,
+					eventCount: row.event_count,
+				},
+			];
+		});
+		const selectedRunId = options.runId ?? runs[0]?.runId ?? null;
+		if (!selectedRunId) return { runs, selectedRunId: null, events: [], nextBefore: null };
+		const before =
+			typeof options.before === "number" &&
+			Number.isSafeInteger(options.before) &&
+			options.before > 0
+				? options.before
+				: null;
+		const rows = (
+			before === null
+				? this.ctx.storage.sql.exec<TraceEventRow>(
+						`SELECT id, run_id, payload FROM run_trace_events
+						 WHERE run_id = ? ORDER BY id DESC LIMIT ?`,
+						selectedRunId,
+						limit + 1,
+					)
+				: this.ctx.storage.sql.exec<TraceEventRow>(
+						`SELECT id, run_id, payload FROM run_trace_events
+						 WHERE run_id = ? AND id < ? ORDER BY id DESC LIMIT ?`,
+						selectedRunId,
+						before,
+						limit + 1,
+					)
+		).toArray();
+		const hasMore = rows.length > limit;
+		const selectedRows = hasMore ? rows.slice(0, limit) : rows;
+		const events = selectedRows
+			.flatMap((row): PublicRunTraceEvent[] => {
+				try {
+					const event = parseStoredRunTraceEvent(JSON.parse(row.payload));
+					return event ? [{ ...event, id: row.id, runId: row.run_id }] : [];
+				} catch {
+					return [];
+				}
+			})
+			.toReversed();
+		return {
+			runs,
+			selectedRunId,
+			events,
+			nextBefore: hasMore ? (events[0]?.id ?? null) : null,
+		};
 	}
 
 	updateWorkPlan(input: { runId: string } & WorkPlanInput): Promise<boolean> {

--- a/infra/emdash-bot/.flue/lib/run-trace.ts
+++ b/infra/emdash-bot/.flue/lib/run-trace.ts
@@ -2,6 +2,7 @@ import type { FlueObservation, LlmAssistantMessage, PromptUsage } from "@flue/ru
 
 export const RUN_TRACE_TEXT_LIMIT = 49_152;
 export const RUN_TRACE_PAGE_LIMIT = 200;
+export const RUN_TRACE_EVENT_LIMIT = 5_000;
 
 export type RunTraceTone = "active" | "success" | "failed" | "neutral";
 

--- a/infra/emdash-bot/.flue/lib/run-trace.ts
+++ b/infra/emdash-bot/.flue/lib/run-trace.ts
@@ -1,0 +1,368 @@
+import type { FlueObservation, LlmAssistantMessage, PromptUsage } from "@flue/runtime";
+
+export const RUN_TRACE_TEXT_LIMIT = 49_152;
+export const RUN_TRACE_PAGE_LIMIT = 200;
+
+export type RunTraceTone = "active" | "success" | "failed" | "neutral";
+
+export interface RunTraceEventInput {
+	readonly key: string;
+	readonly at: number;
+	readonly kind:
+		| "agent_start"
+		| "agent_end"
+		| "message"
+		| "turn"
+		| "tool_start"
+		| "tool"
+		| "task_start"
+		| "task"
+		| "compaction_start"
+		| "compaction"
+		| "operation"
+		| "log"
+		| "submission_queued"
+		| "submission_running"
+		| "submission_recovery"
+		| "submission_settled";
+	readonly title: string;
+	readonly detail?: string | null;
+	readonly tone: RunTraceTone;
+	readonly turnId?: string;
+	readonly toolCallId?: string;
+	readonly durationMs?: number;
+	readonly input?: string;
+	readonly output?: string;
+}
+
+export interface PublicRunTraceEvent extends RunTraceEventInput {
+	readonly id: number;
+	readonly runId: string;
+}
+
+export interface PublicRunTraceSummary {
+	readonly runId: string;
+	readonly mode: "repro" | "implement" | "revise" | "diagnose" | "fix";
+	readonly startedAt: number;
+	readonly updatedAt: number;
+	readonly eventCount: number;
+}
+
+export interface PublicRunTracePage {
+	readonly runs: readonly PublicRunTraceSummary[];
+	readonly selectedRunId: string | null;
+	readonly events: readonly PublicRunTraceEvent[];
+	readonly nextBefore: number | null;
+}
+
+export function projectRunTraceObservation(event: FlueObservation): RunTraceEventInput | null {
+	const base = {
+		key: traceEventKey(event),
+		at: Date.parse(event.timestamp),
+	};
+	switch (event.type) {
+		case "agent_start":
+			return { ...base, kind: "agent_start", title: "Agent started", tone: "active" };
+		case "agent_end":
+			return {
+				...base,
+				kind: "agent_end",
+				title: "Agent finished",
+				detail: `${event.messages.length} messages produced`,
+				tone: "success",
+			};
+		case "message_end":
+			return projectInputMessage(event.message, base, event.turnId);
+		case "turn": {
+			const output = event.response.output
+				? serializeAssistantOutput(event.response.output)
+				: serializeTraceValue(withoutStack(event.response.error));
+			return {
+				...base,
+				kind: "turn",
+				title: event.purpose === "agent" ? "Model turn" : "Compaction model turn",
+				detail: turnDetail(
+					event.request.requestedModel,
+					event.response.finishReason,
+					event.response.usage,
+				),
+				tone: event.isError ? "failed" : "active",
+				turnId: event.turnId,
+				durationMs: event.durationMs,
+				...(output ? { output } : {}),
+			};
+		}
+		case "tool_start":
+			return {
+				...base,
+				kind: "tool_start",
+				title: event.toolName,
+				detail: event.origin ? `${event.origin} tool started` : "Tool started",
+				tone: "active",
+				...(event.turnId ? { turnId: event.turnId } : {}),
+				toolCallId: event.toolCallId,
+				...(event.args === undefined ? {} : { input: serializeTraceValue(event.args) }),
+			};
+		case "tool": {
+			const result = event.isError
+				? serializeTraceValue(withoutStack(event.errorInfo) ?? event.result)
+				: serializeTraceValue(event.effectiveResult ?? event.result);
+			return {
+				...base,
+				kind: "tool",
+				title: event.toolName,
+				detail: event.origin ? `${event.origin} tool finished` : "Tool finished",
+				tone: event.isError ? "failed" : "success",
+				...(event.turnId ? { turnId: event.turnId } : {}),
+				toolCallId: event.toolCallId,
+				durationMs: event.durationMs,
+				...(result ? { output: result } : {}),
+			};
+		}
+		case "task_start":
+			return {
+				...base,
+				kind: "task_start",
+				title: event.agent ? `Task · ${event.agent}` : "Task started",
+				detail: event.cwd ?? null,
+				tone: "active",
+				input: truncateTraceText(event.prompt),
+			};
+		case "task":
+			return {
+				...base,
+				kind: "task",
+				title: event.agent ? `Task · ${event.agent}` : "Task finished",
+				tone: event.isError ? "failed" : "success",
+				durationMs: event.durationMs,
+				...(event.result === undefined ? {} : { output: serializeTraceValue(event.result) }),
+			};
+		case "compaction_start":
+			return {
+				...base,
+				kind: "compaction_start",
+				title: "Context compaction started",
+				detail: `${event.reason} · about ${event.estimatedTokens.toLocaleString()} tokens`,
+				tone: "active",
+			};
+		case "compaction":
+			return {
+				...base,
+				kind: "compaction",
+				title: "Context compaction finished",
+				detail: `${event.messagesBefore} → ${event.messagesAfter} messages`,
+				tone: event.isError ? "failed" : "success",
+				durationMs: event.durationMs,
+				...(event.error === undefined ? {} : { output: serializeTraceValue(event.error) }),
+			};
+		case "operation":
+			return {
+				...base,
+				kind: "operation",
+				title: `${event.operationKind} operation`,
+				tone: event.isError ? "failed" : "success",
+				durationMs: event.durationMs,
+				...(event.agentOutput === undefined
+					? event.error === undefined
+						? {}
+						: { output: serializeTraceValue(event.error) }
+					: { output: serializeTraceValue(event.agentOutput) }),
+			};
+		case "log":
+			return {
+				...base,
+				kind: "log",
+				title: event.message,
+				detail: event.level,
+				tone: event.level === "error" ? "failed" : event.level === "warn" ? "active" : "neutral",
+				...(event.attributes === undefined
+					? {}
+					: { output: serializeTraceValue(event.attributes) }),
+			};
+		case "submission_queued":
+			return {
+				...base,
+				kind: "submission_queued",
+				title: "Submission queued",
+				detail: event.kind,
+				tone: "active",
+			};
+		case "submission_running":
+			return {
+				...base,
+				kind: "submission_running",
+				title: `Attempt ${event.attemptCount} started`,
+				detail: `${event.kind} · ${event.maxAttempts} attempts available`,
+				tone: "active",
+			};
+		case "submission_recovery":
+			return {
+				...base,
+				kind: "submission_recovery",
+				title: "Submission recovery",
+				detail: `${event.operation.replaceAll("_", " ")} · ${event.outcome.replaceAll("_", " ")}`,
+				tone: event.outcome === "terminated" ? "failed" : "active",
+				...(event.error === undefined ? {} : { output: serializeTraceValue(event.error) }),
+			};
+		case "submission_settled":
+			return {
+				...base,
+				kind: "submission_settled",
+				title: `Submission ${event.outcome}`,
+				tone: event.outcome === "completed" ? "success" : "failed",
+				...(event.error === undefined ? {} : { output: serializeTraceValue(event.error) }),
+			};
+		default:
+			return null;
+	}
+}
+
+export function parseStoredRunTraceEvent(value: unknown): RunTraceEventInput | null {
+	if (typeof value !== "object" || value === null) return null;
+	if (!("key" in value) || typeof value.key !== "string") return null;
+	if (!("at" in value) || typeof value.at !== "number" || !Number.isFinite(value.at)) return null;
+	if (!("kind" in value) || typeof value.kind !== "string") return null;
+	if (!("title" in value) || typeof value.title !== "string") return null;
+	if (!("tone" in value) || !isRunTraceTone(value.tone)) return null;
+	if (!isRunTraceKind(value.kind)) return null;
+	const detail = "detail" in value ? value.detail : undefined;
+	const turnId = "turnId" in value ? value.turnId : undefined;
+	const toolCallId = "toolCallId" in value ? value.toolCallId : undefined;
+	const durationMs = "durationMs" in value ? value.durationMs : undefined;
+	const input = "input" in value ? value.input : undefined;
+	const output = "output" in value ? value.output : undefined;
+	if (detail !== undefined && detail !== null && typeof detail !== "string") return null;
+	if (turnId !== undefined && typeof turnId !== "string") return null;
+	if (toolCallId !== undefined && typeof toolCallId !== "string") return null;
+	if (durationMs !== undefined && (typeof durationMs !== "number" || !Number.isFinite(durationMs)))
+		return null;
+	if (input !== undefined && typeof input !== "string") return null;
+	if (output !== undefined && typeof output !== "string") return null;
+	return {
+		key: value.key,
+		at: value.at,
+		kind: value.kind,
+		title: value.title,
+		tone: value.tone,
+		...(typeof detail === "string" || detail === null ? { detail } : {}),
+		...(typeof turnId === "string" ? { turnId } : {}),
+		...(typeof toolCallId === "string" ? { toolCallId } : {}),
+		...(typeof durationMs === "number" ? { durationMs } : {}),
+		...(typeof input === "string" ? { input } : {}),
+		...(typeof output === "string" ? { output } : {}),
+	};
+}
+
+function projectInputMessage(
+	message: unknown,
+	base: Pick<RunTraceEventInput, "key" | "at">,
+	turnId: string,
+): RunTraceEventInput | null {
+	if (typeof message !== "object" || message === null || !("role" in message)) return null;
+	if (message.role === "assistant" || message.role === "toolResult") return null;
+	return {
+		...base,
+		kind: "message",
+		title: message.role === "signal" ? "Agent signal" : "Input message",
+		tone: "neutral",
+		turnId,
+		input: serializeTraceValue(message) ?? "",
+	};
+}
+
+function serializeAssistantOutput(message: LlmAssistantMessage): string | undefined {
+	const sections: string[] = [];
+	for (const part of message.content) {
+		if (part.type === "text") {
+			if (part.text) sections.push(part.text);
+			continue;
+		}
+		if (part.type !== "toolCall") continue;
+		const args = serializeTraceValue(part.arguments);
+		sections.push(`Tool call: ${part.name}${args ? `\n${args}` : ""}`);
+	}
+	return sections.length ? truncateTraceText(sections.join("\n\n")) : undefined;
+}
+
+function turnDetail(
+	model: string,
+	finishReason: string | undefined,
+	usage: PromptUsage | undefined,
+) {
+	return [
+		model,
+		finishReason?.replaceAll(/([a-z])([A-Z])/g, "$1 $2").toLowerCase(),
+		usage ? `${usage.totalTokens.toLocaleString()} tokens` : null,
+	]
+		.filter((part): part is string => Boolean(part))
+		.join(" · ");
+}
+
+function serializeTraceValue(value: unknown): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "string") return truncateTraceText(value);
+	const seen = new WeakSet<object>();
+	try {
+		const json = JSON.stringify(
+			value,
+			(key, current: unknown) => {
+				if (key === "stack") return undefined;
+				if (typeof current === "bigint") return current.toString();
+				if (typeof current !== "object" || current === null) return current;
+				if (seen.has(current)) return "[circular]";
+				seen.add(current);
+				return current;
+			},
+			2,
+		);
+		return json === undefined ? undefined : truncateTraceText(json);
+	} catch {
+		return "[unserializable value]";
+	}
+}
+
+function truncateTraceText(value: string): string {
+	if (value.length <= RUN_TRACE_TEXT_LIMIT) return value;
+	const suffix = `\n… [truncated ${value.length - RUN_TRACE_TEXT_LIMIT} additional characters]`;
+	return `${value.slice(0, RUN_TRACE_TEXT_LIMIT - suffix.length)}${suffix}`;
+}
+
+function withoutStack(value: unknown): unknown {
+	if (typeof value !== "object" || value === null) return value;
+	return Object.fromEntries(Object.entries(value).filter(([key]) => key !== "stack"));
+}
+
+function traceEventKey(event: FlueObservation): string {
+	return [
+		event.instanceId ?? "agent",
+		event.submissionId ?? "none",
+		event.eventIndex,
+		event.type,
+		event.timestamp,
+	].join(":");
+}
+
+function isRunTraceTone(value: unknown): value is RunTraceTone {
+	return value === "active" || value === "success" || value === "failed" || value === "neutral";
+}
+
+function isRunTraceKind(value: string): value is RunTraceEventInput["kind"] {
+	return (
+		value === "agent_start" ||
+		value === "agent_end" ||
+		value === "message" ||
+		value === "turn" ||
+		value === "tool_start" ||
+		value === "tool" ||
+		value === "task_start" ||
+		value === "task" ||
+		value === "compaction_start" ||
+		value === "compaction" ||
+		value === "operation" ||
+		value === "log" ||
+		value === "submission_queued" ||
+		value === "submission_running" ||
+		value === "submission_recovery" ||
+		value === "submission_settled"
+	);
+}

--- a/infra/emdash-bot/.flue/routes.ts
+++ b/infra/emdash-bot/.flue/routes.ts
@@ -7,7 +7,12 @@ import type { Hono } from "hono";
 
 import dashboardHtml from "./dashboard.html?raw";
 import { getDashboardPayload } from "./lib/dashboard.js";
+import type { OrchestratorDO } from "./lib/orchestrator.js";
 import { normalizeWebhook, verifyWebhookSignature } from "./lib/webhook.js";
+
+interface TraceRouteEnv extends Env {
+	Orchestrator: DurableObjectNamespace<OrchestratorDO>;
+}
 
 export function registerCoreRoutes(app: Hono<{ Bindings: Env }>): Hono<{ Bindings: Env }> {
 	app.get("/", (c) => c.html(dashboardHtml));
@@ -22,6 +27,40 @@ export function registerCoreRoutes(app: Hono<{ Bindings: Env }>): Hono<{ Binding
 				error: error instanceof Error ? error.message : String(error),
 			});
 			return c.json({ error: "Dashboard data is temporarily unavailable" }, 503);
+		}
+	});
+	app.get("/api/issues/:number/trace", async (c) => {
+		const issueNumber = Number(c.req.param("number"));
+		if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+			return c.json({ error: "Invalid issue number" }, 400);
+		}
+		const beforeValue = c.req.query("before");
+		const limitValue = c.req.query("limit");
+		const before = beforeValue === undefined ? undefined : Number(beforeValue);
+		const limit = limitValue === undefined ? undefined : Number(limitValue);
+		if (before !== undefined && (!Number.isSafeInteger(before) || before <= 0)) {
+			return c.json({ error: "Invalid trace cursor" }, 400);
+		}
+		if (limit !== undefined && (!Number.isSafeInteger(limit) || limit <= 0)) {
+			return c.json({ error: "Invalid trace limit" }, 400);
+		}
+		try {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Wrangler cannot infer local DO RPC methods.
+			const { Orchestrator } = c.env as TraceRouteEnv;
+			const runId = c.req.query("run");
+			const trace = await Orchestrator.getByName(`issue-${issueNumber}`).getPublicRunTrace({
+				...(runId ? { runId } : {}),
+				...(before === undefined ? {} : { before }),
+				...(limit === undefined ? {} : { limit }),
+			});
+			c.header("cache-control", "no-store");
+			return c.json(trace);
+		} catch (error) {
+			console.error("[dashboard] trace load failed", {
+				issueNumber,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return c.json({ error: "Run trace is temporarily unavailable" }, 503);
 		}
 	});
 

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -161,6 +161,65 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect(snapshot.progress[0]).not.toHaveProperty("runId");
 	});
 
+	test("persists an idempotent paginated public trace for the current run", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetStaleRun(
+			"trace-run",
+			Date.now() - 1_000,
+			"investigate-trace-run",
+			"implement",
+		);
+		const first = {
+			key: "submission-1:1:turn",
+			at: Date.now() - 500,
+			kind: "turn" as const,
+			title: "Model turn",
+			detail: "deepseek-v4 · 100 tokens",
+			tone: "active" as const,
+			turnId: "turn-1",
+			durationMs: 1_000,
+			output: "Inspect the bridge.",
+		};
+		const second = {
+			key: "submission-1:2:tool",
+			at: Date.now(),
+			kind: "tool" as const,
+			title: "read_file",
+			detail: null,
+			tone: "success" as const,
+			toolCallId: "call-1",
+			durationMs: 5,
+			output: "bridge source",
+		};
+
+		await expect(stub.recordRunTraceEvent({ runId: "stale-run", event: first })).resolves.toBe(
+			false,
+		);
+		await expect(stub.recordRunTraceEvent({ runId: "trace-run", event: first })).resolves.toBe(
+			true,
+		);
+		await expect(stub.recordRunTraceEvent({ runId: "trace-run", event: first })).resolves.toBe(
+			true,
+		);
+		await expect(stub.recordRunTraceEvent({ runId: "trace-run", event: second })).resolves.toBe(
+			true,
+		);
+
+		const latest = await stub.getPublicRunTrace({ limit: 1 });
+		expect(latest.runs).toMatchObject([{ runId: "trace-run", mode: "implement", eventCount: 2 }]);
+		expect(latest.selectedRunId).toBe("trace-run");
+		expect(latest.events).toMatchObject([{ kind: "tool", output: "bridge source" }]);
+		expect(latest.nextBefore).toEqual(expect.any(Number));
+
+		const earlier = await stub.getPublicRunTrace({
+			runId: "trace-run",
+			before: latest.nextBefore ?? undefined,
+			limit: 1,
+		});
+		expect(earlier.events).toMatchObject([{ kind: "turn", output: "Inspect the bridge." }]);
+		expect(earlier.nextBefore).toBeNull();
+	});
+
 	test("duplicate deliveryId is deduped on the second event() call", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		const first = await stub.event(makeEvent({ deliveryId: "dup-1" }));

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -17,11 +17,13 @@
 // Each test uses a fresh DO instance via `getByName(uniqueName)` so test
 // ordering doesn't matter.
 
+import { runInDurableObject } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { applyInvestigationResult } from "../../.flue/lib/investigation-result.js";
 import type { NormalizedEvent } from "../../.flue/lib/orchestrator.js";
+import { RUN_TRACE_EVENT_LIMIT } from "../../.flue/lib/run-trace.js";
 
 interface TestEnv {
 	Orchestrator: Env["Orchestrator"];
@@ -218,6 +220,52 @@ describe("OrchestratorDO (workers-pool)", () => {
 		});
 		expect(earlier.events).toMatchObject([{ kind: "turn", output: "Inspect the bridge." }]);
 		expect(earlier.nextBefore).toBeNull();
+	});
+
+	test("bounds persisted trace history to the newest events", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetStaleRun(
+			"bounded-trace-run",
+			Date.now() - 1_000,
+			"investigate-bounded-trace-run",
+			"implement",
+		);
+		await runInDurableObject(stub, (_instance, state) => {
+			state.storage.sql.exec(
+				`WITH RECURSIVE sequence(value) AS (
+					SELECT 1
+					UNION ALL
+					SELECT value + 1 FROM sequence WHERE value < ?
+				)
+				INSERT INTO run_trace_events
+					(event_key, run_id, mode, recorded_at, event_type, payload)
+				SELECT 'seed-' || value, 'bounded-trace-run', 'implement', value, 'turn', ?
+				FROM sequence`,
+				RUN_TRACE_EVENT_LIMIT + 1,
+				JSON.stringify({
+					key: "seed",
+					at: 1,
+					kind: "turn",
+					title: "Model turn",
+					tone: "active",
+				}),
+			);
+		});
+
+		await stub.recordRunTraceEvent({
+			runId: "bounded-trace-run",
+			event: {
+				key: "newest-event",
+				at: Date.now(),
+				kind: "tool",
+				title: "run_check",
+				tone: "success",
+			},
+		});
+
+		const trace = await stub.getPublicRunTrace({ limit: 1 });
+		expect(trace.runs[0]?.eventCount).toBe(RUN_TRACE_EVENT_LIMIT);
+		expect(trace.events[0]?.key).toBe("newest-event");
 	});
 
 	test("duplicate deliveryId is deduped on the second event() call", async () => {

--- a/infra/emdash-bot/tests/integration/webhook.test.ts
+++ b/infra/emdash-bot/tests/integration/webhook.test.ts
@@ -117,12 +117,45 @@ describe("POST /webhook/github (workers-pool)", () => {
 		expect(html).toContain("Issue lifecycle");
 		expect(html).toContain("Agent run");
 		expect(html).toContain("Work plan");
+		expect(html).toContain("Run trace");
 	});
 
 	test("dashboard API fails closed when GitHub credentials are unavailable", async () => {
 		const res = await SELF.fetch("https://test/api/dashboard");
 		expect(res.status).toBe(503);
 		expect(await res.json()).toEqual({ error: "Dashboard data is temporarily unavailable" });
+	});
+
+	test("serves the selected issue's public run trace without GitHub credentials", async () => {
+		const issueNumber = uniqueIssueNumber();
+		const stub = testEnv.Orchestrator.getByName(`issue-${issueNumber}`);
+		await stub.debugSetStaleRun(
+			"dashboard-trace-run",
+			Date.now() - 1_000,
+			`investigate-${issueNumber}-dashboard-trace-run`,
+			"repro",
+		);
+		await stub.recordRunTraceEvent({
+			runId: "dashboard-trace-run",
+			event: {
+				key: "dashboard-trace-event",
+				at: Date.now(),
+				kind: "turn",
+				title: "Model turn",
+				detail: "deepseek-v4",
+				tone: "active",
+				output: "Inspecting the issue.",
+			},
+		});
+
+		const res = await SELF.fetch(`https://test/api/issues/${issueNumber}/trace`);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get("cache-control")).toBe("no-store");
+		expect(await res.json()).toMatchObject({
+			selectedRunId: "dashboard-trace-run",
+			events: [{ kind: "turn", output: "Inspecting the issue." }],
+		});
 	});
 
 	test("rejects requests without a valid signature", async () => {

--- a/infra/emdash-bot/tests/unit/run-trace.test.ts
+++ b/infra/emdash-bot/tests/unit/run-trace.test.ts
@@ -1,0 +1,128 @@
+import type { FlueObservation } from "@flue/runtime";
+import { describe, expect, test } from "vitest";
+
+import { projectRunTraceObservation, RUN_TRACE_TEXT_LIMIT } from "../../.flue/lib/run-trace.js";
+
+const envelope = {
+	v: 3,
+	eventIndex: 12,
+	timestamp: "2026-08-19T10:00:00.000Z",
+	instanceId: "investigate-1623-run-abc",
+	submissionId: "submission-1",
+} as const;
+
+describe("public run traces", () => {
+	test("projects each completed model turn without exposing reasoning blocks", () => {
+		const event = {
+			...envelope,
+			type: "turn",
+			turnId: "turn-1",
+			purpose: "agent",
+			durationMs: 1_234,
+			request: {
+				providerId: "workers-ai",
+				providerName: "cloudflare",
+				requestedModel: "deepseek-v4",
+				api: "responses",
+			},
+			response: {
+				finishReason: "toolUse",
+				usage: {
+					input: 100,
+					output: 25,
+					cacheRead: 50,
+					cacheWrite: 0,
+					totalTokens: 175,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				output: {
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "private chain of thought" },
+						{ type: "text", text: "I will inspect the bridge implementation." },
+						{
+							type: "toolCall",
+							id: "call-1",
+							name: "read_file",
+							arguments: { path: "packages/cloudflare/src/sandbox/bridge.ts" },
+						},
+					],
+				},
+			},
+			isError: false,
+		} satisfies FlueObservation;
+
+		const projected = projectRunTraceObservation(event);
+
+		expect(projected).toMatchObject({
+			kind: "turn",
+			title: "Model turn",
+			turnId: "turn-1",
+			durationMs: 1_234,
+			tone: "active",
+		});
+		expect(projected?.detail).toContain("deepseek-v4");
+		expect(projected?.detail).toContain("175 tokens");
+		expect(projected?.output).toContain("I will inspect the bridge implementation.");
+		expect(projected?.output).toContain("read_file");
+		expect(projected?.output).toContain("packages/cloudflare/src/sandbox/bridge.ts");
+		expect(projected?.output).not.toContain("private chain of thought");
+	});
+
+	test("records complete tool arguments and the model-visible result", () => {
+		const started = projectRunTraceObservation({
+			...envelope,
+			eventIndex: 13,
+			type: "tool_start",
+			turnId: "turn-1",
+			toolName: "exec",
+			toolCallId: "call-1",
+			args: { command: "pnpm --filter @emdash-cms/cloudflare test" },
+			origin: "model",
+		});
+		const finished = projectRunTraceObservation({
+			...envelope,
+			eventIndex: 14,
+			type: "tool",
+			turnId: "turn-1",
+			toolName: "exec",
+			toolCallId: "call-1",
+			isError: false,
+			durationMs: 3_500,
+			result: { content: [{ type: "text", text: "internal shape" }] },
+			effectiveResult: "exit 0\n334 tests passed",
+			origin: "model",
+		});
+
+		expect(started).toMatchObject({
+			kind: "tool_start",
+			title: "exec",
+			toolCallId: "call-1",
+		});
+		expect(started?.input).toContain("pnpm --filter @emdash-cms/cloudflare test");
+		expect(finished).toMatchObject({
+			kind: "tool",
+			title: "exec",
+			toolCallId: "call-1",
+			durationMs: 3_500,
+			tone: "success",
+			output: "exit 0\n334 tests passed",
+		});
+		expect(finished?.output).not.toContain("internal shape");
+	});
+
+	test("bounds a single oversized payload without dropping the event", () => {
+		const projected = projectRunTraceObservation({
+			...envelope,
+			type: "tool",
+			toolName: "read_file",
+			toolCallId: "call-large",
+			isError: false,
+			durationMs: 10,
+			effectiveResult: "x".repeat(RUN_TRACE_TEXT_LIMIT + 100),
+		});
+
+		expect(projected?.output?.length).toBeLessThanOrEqual(RUN_TRACE_TEXT_LIMIT);
+		expect(projected?.output).toContain("truncated");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds a public, turn-by-turn run trace to the bot dashboard without adding trace output to GitHub comments.

- Projects Flue's observable agent events into stable trace entries: model turns and visible assistant text, tool arguments and model-visible results, input messages, compaction, tasks, structured logs, and submission lifecycle/recovery events.
- Omits model reasoning blocks and raw image bytes. Individual text fields use the agent's existing 49,152-character tool-result ceiling, and each issue retains its newest 5,000 trace events.
- Persists idempotent trace rows in each issue's Orchestrator Durable Object and accepts events only for that issue's current/latest run.
- Serializes trace writes in event order and gives the final flush a two-second ceiling so trace delivery cannot wedge or extend an agent run.
- Adds a no-cache, paginated endpoint for the selected issue instead of inflating the dashboard payload for every managed issue.
- Adds a responsive dashboard trace with live polling, run selection, expandable inputs/outputs, preserved expansion state, and backwards pagination.

Related to #1623 and #2555.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
  - `pnpm --filter @emdash-cms/emdash-bot typecheck` still reports the pre-existing generated Durable Object namespace/export errors, Sandbox binding mismatch, pending-resume narrowing error, and verification fixture error. No trace source file reports a type error.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
  - N/A: this changes the private bot workbench, not the localized EmDash admin UI.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
  - N/A: only private `infra/emdash-bot` code changes.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
  - N/A: maintainer-directed private bot tooling.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Populated dashboard behavior was verified locally at 1280px desktop and 390px mobile widths. Run selection, expansion, earlier-event pagination, accessibility structure, and live refresh behavior were exercised; browser console and runtime error logs were empty.

- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 278 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 68 passed
- `pnpm --filter @emdash-cms/emdash-bot build` — passed
- `pnpm lint` — passed
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm format:check` — passed
- `pnpm --filter @emdash-cms/emdash-bot typecheck` — fails only on the pre-existing errors disclosed above
