### PR TITLE
feat(bot): bootstrap agent workspaces in harness

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -59,7 +59,11 @@ import {
 	recordWorkPlan,
 } from "../lib/investigation-result.js";
 import { flushAgentTraceWrites } from "../lib/observer.js";
-import { FLUE_RUN_TIMEOUT_MS, SANDBOX_SLEEP_AFTER_SECONDS } from "../lib/run-policy.js";
+import {
+	CONTAINER_PREPARE_TIMEOUT_MS,
+	FLUE_RUN_TIMEOUT_MS,
+	SANDBOX_SLEEP_AFTER_SECONDS,
+} from "../lib/run-policy.js";
 import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/timeout-recovery.js";
 import { untarInto } from "../lib/untar.js";
 import {
@@ -85,7 +89,7 @@ import verifySkill from "../skills/verify/SKILL.md";
 
 const REPO_DIR = "/workspace/repo";
 const DEFAULT_RPC_TIMEOUT_MS = 2 * 60_000;
-const CONTAINER_ATTACH_TIMEOUT_MS = 11 * 60_000;
+const CONTAINER_ATTACH_TIMEOUT_MS = CONTAINER_PREPARE_TIMEOUT_MS;
 const EXEC_GRACE_MS = 30_000;
 const CLONE_DEPTH = 50;
 const DEADLINES = {

--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -54,6 +54,7 @@ import {
 } from "../lib/github.js";
 import {
 	applyInvestigationResult,
+	prepareWorkPlanComment,
 	recordInvestigationProgress,
 	recordWorkPlan,
 } from "../lib/investigation-result.js";
@@ -72,6 +73,7 @@ import {
 	upsertVerificationRecord,
 } from "../lib/verification.js";
 import { requireWorkPlanReadyForReport, updateWorkPlan, type WorkPlan } from "../lib/work-plan.js";
+import { bootstrapWorkspace, type WorkspaceBootstrapStage } from "../lib/workspace-bootstrap.js";
 import diagnoseSkill from "../skills/diagnose/SKILL.md";
 import fixSkill from "../skills/fix/SKILL.md";
 import implementSkill from "../skills/implement/SKILL.md";
@@ -281,7 +283,9 @@ export function Investigate({ id }: AgentProps) {
 	useAgentStart(async ({ log }) => {
 		if (setupComplete || reported) return;
 		try {
+			await prepareWorkPlanComment(input);
 			await env.ensureRepo({ dir: REPO_DIR, ref: cloneRef(input) });
+			await env.ensureContainerReady();
 			setSetupComplete(true);
 			await recordInvestigationProgress(input, {
 				kind: "workspace_ready",
@@ -911,14 +915,20 @@ function buildCodeToolDescription(): string {
 /**
  * Attach the container substrate and reproduce the base checkout the toolchain
  * runs against: git identity, a clone (or fetch) at the run's ref, and the
- * issue-scoped push capability the outbound proxy verifies. pnpm install is
- * left to the repro/fix skills -- isolate-first, container work on demand.
+ * issue-scoped push capability the outbound proxy verifies. The harness then
+ * installs dependencies when needed and creates the base workspace build.
  */
 async function attachContainer(id: string, input: InvestigateData): Promise<ContainerBackend> {
 	const container = fromSandbox(
 		getSandbox(workerEnv.Sandbox, id, { sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS }),
 	);
 	await prepareContainer(container, input);
+	await bootstrapWorkspace(container, {
+		repoDir: REPO_DIR,
+		onProgress: async (stage) => {
+			await recordBootstrapProgress(input, stage);
+		},
+	});
 	return {
 		...container,
 		async isReady() {
@@ -929,6 +939,20 @@ async function attachContainer(id: string, input: InvestigateData): Promise<Cont
 			return result.exitCode === 0 && result.stdout.trim() === "true";
 		},
 	};
+}
+
+async function recordBootstrapProgress(
+	input: InvestigateData,
+	stage: WorkspaceBootstrapStage,
+): Promise<void> {
+	await recordInvestigationProgress(input, {
+		kind: stage,
+		title: stage === "workspace_installing" ? "Installing dependencies" : "Building workspace",
+		detail:
+			stage === "workspace_installing"
+				? "Preparing the repository dependency graph"
+				: "Creating the base package build outputs",
+	});
 }
 
 async function prepareContainer(

--- a/infra/emdash-bot/.flue/lib/exec-env.ts
+++ b/infra/emdash-bot/.flue/lib/exec-env.ts
@@ -140,6 +140,11 @@ export class ExecEnv {
 		await this.#bounded(this.#state.writeFile(HYDRATED_MARKER, ref), "writeFile");
 	}
 
+	async ensureContainerReady(): Promise<void> {
+		const container = await this.container();
+		await this.#materializeChanges(container);
+	}
+
 	async #readMarker(): Promise<string | null> {
 		if (!(await this.#bounded(this.#state.exists(HYDRATED_MARKER), "exists"))) return null;
 		return this.#bounded(this.#state.readFile(HYDRATED_MARKER), "readFile");

--- a/infra/emdash-bot/.flue/lib/investigation-result.ts
+++ b/infra/emdash-bot/.flue/lib/investigation-result.ts
@@ -56,3 +56,17 @@ export async function recordWorkPlan(
 		...plan,
 	});
 }
+
+export async function prepareWorkPlanComment(input: {
+	issueNumber: number;
+	runId: string;
+	issueTitle: string;
+	arg?: string | null;
+}): Promise<boolean> {
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Wrangler cannot infer Flue-generated RPC class types.
+	const { Orchestrator } = workerEnv as unknown as InvestigationEnv;
+	return Orchestrator.getByName(`issue-${input.issueNumber}`).prepareWorkPlanComment({
+		runId: input.runId,
+		summary: input.arg?.trim() || input.issueTitle,
+	});
+}

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -57,6 +57,7 @@ import {
 } from "./router.js";
 import {
 	advanceRunLifecycle,
+	beginRunLifecycle,
 	publicRunLifecycle,
 	resumeRunLifecycle,
 	settleRunLifecycle,
@@ -84,6 +85,7 @@ import {
 	TIMEOUT_SUMMARY_TIMEOUT_MS,
 } from "./timeout-recovery.js";
 import {
+	renderPreparingWorkPlanComment,
 	renderWorkPlanComment,
 	updateWorkPlan as applyWorkPlanUpdate,
 	type WorkCommentStatus,
@@ -621,25 +623,37 @@ export class OrchestratorDO extends DurableObject<Env> {
 		title: string;
 		detail?: string | null;
 	}): Promise<boolean> {
-		return this.ctx.storage.transaction(async (transaction) => {
-			if ((await transaction.get<string>(STORAGE.currentRunId)) !== input.runId) return false;
+		const result = await this.ctx.storage.transaction(async (transaction) => {
+			if ((await transaction.get<string>(STORAGE.currentRunId)) !== input.runId) {
+				return { accepted: false, startedBudget: false };
+			}
 			const existing = (await transaction.get<PublicProgressEntry[]>(STORAGE.publicProgress)) ?? [];
 			const run = await transaction.get<RunLifecycle>(STORAGE.runLifecycle);
+			const now = Date.now();
 			const entry: PublicProgressEntry = {
-				t: Date.now(),
+				t: now,
 				kind: input.kind,
 				title: sanitizePublicProgressText(input.title, 80),
 				detail: input.detail ? sanitizePublicProgressText(input.detail, 240) : null,
 				runId: input.runId,
 			};
+			const startsBudget =
+				input.kind === "workspace_ready" && run?.runId === input.runId && run.phase === "prepare";
+			const nextRun =
+				run?.runId === input.runId
+					? advanceRunLifecycle(startsBudget ? beginRunLifecycle(run, now) : run, input.kind)
+					: null;
 			await Promise.all([
 				transaction.put(STORAGE.publicProgress, [...existing, entry].slice(-PUBLIC_PROGRESS_LIMIT)),
-				...(run?.runId === input.runId
-					? [transaction.put(STORAGE.runLifecycle, advanceRunLifecycle(run, input.kind))]
-					: []),
+				...(nextRun ? [transaction.put(STORAGE.runLifecycle, nextRun)] : []),
+				...(startsBudget ? [transaction.put(STORAGE.currentRunStartedAt, now)] : []),
 			]);
-			return true;
+			return { accepted: true, startedBudget: startsBudget };
 		});
+		if (result.startedBudget) {
+			await this.armAlarm(true);
+		}
+		return result.accepted;
 	}
 
 	async recordRunTraceEvent(input: { runId: string; event: RunTraceEventInput }): Promise<boolean> {
@@ -751,6 +765,76 @@ export class OrchestratorDO extends DurableObject<Env> {
 			events,
 			nextBefore: hasMore ? (events[0]?.id ?? null) : null,
 		};
+	}
+
+	async prepareWorkPlanComment(input: { runId: string; summary: string }): Promise<boolean> {
+		const result = await this.ctx.storage.transaction(async (transaction) => {
+			const [currentRunId, run, storedPlan, comments, anchorNumber, dryRun] = await Promise.all([
+				transaction.get<string>(STORAGE.currentRunId),
+				transaction.get<RunLifecycle>(STORAGE.runLifecycle),
+				transaction.get<StoredWorkPlan>(STORAGE.workPlan),
+				transaction.get<WorkCommentProjection[]>(STORAGE.workComments),
+				transaction.get<number>(STORAGE.anchorNumber),
+				transaction.get<boolean>(STORAGE.currentRunDryRun),
+			]);
+			if (currentRunId !== input.runId || run?.runId !== input.runId) {
+				return { accepted: false, dryRun: true };
+			}
+			const existingPlan = storedPlan?.runId === input.runId ? storedPlan.plan : null;
+			if (existingPlan && existingPlan.steps[0]?.id !== "prepare-workspace") {
+				return { accepted: true, dryRun: true };
+			}
+			if (dryRun) return { accepted: true, dryRun: true };
+			if (anchorNumber === undefined) throw new Error("workspace preparation has no issue anchor");
+			const plan =
+				existingPlan ??
+				applyWorkPlanUpdate(
+					null,
+					{
+						summary: input.summary,
+						steps: [
+							{
+								id: "prepare-workspace",
+								title: "Install dependencies and build the repository",
+								status: "in_progress",
+							},
+						],
+					},
+					Date.now(),
+				);
+			const marker = `<!-- emdashbot-run:${input.runId} -->`;
+			const body = `${renderPreparingWorkPlanComment({
+				mode: run.mode,
+				summary: input.summary,
+			})}\n\n[View live dashboard](${DASHBOARD_ORIGIN}/?issue=${anchorNumber}) · Run: \`${input.runId}\``;
+			const existing = comments?.find((comment) => comment.runId === input.runId);
+			const projection: WorkCommentProjection = existing
+				? { ...existing, body, pending: true }
+				: {
+						runId: input.runId,
+						anchorNumber,
+						marker,
+						body,
+						commentId: null,
+						commentMayExist: false,
+						pending: true,
+					};
+			await Promise.all([
+				transaction.put(STORAGE.workPlan, { runId: input.runId, plan } satisfies StoredWorkPlan),
+				transaction.put(
+					STORAGE.workComments,
+					[
+						...(comments ?? []).filter((comment) => comment.runId !== input.runId),
+						projection,
+					].slice(-WORK_COMMENT_LIMIT),
+				),
+			]);
+			return { accepted: true, dryRun: false };
+		});
+		if (!result.accepted || result.dryRun) return result.accepted;
+		await this.ctx.storage.setAlarm(Date.now());
+		await this.flushWorkComment(input.runId);
+		return true;
 	}
 
 	updateWorkPlan(input: { runId: string } & WorkPlanInput): Promise<boolean> {
@@ -1259,7 +1343,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 		await this.armAlarm();
 	}
 
-	private async armAlarm(): Promise<void> {
+	private async armAlarm(force = false): Promise<void> {
 		const [
 			current,
 			run,
@@ -1313,7 +1397,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 		if (previewPollNextAt !== undefined) {
 			desired = Math.min(desired, Math.max(now + 1_000, previewPollNextAt));
 		}
-		if (current === null || current <= now || current > desired) {
+		if (force || current === null || current <= now || current > desired) {
 			await this.ctx.storage.setAlarm(desired);
 		}
 	}

--- a/infra/emdash-bot/.flue/lib/run-lifecycle.ts
+++ b/infra/emdash-bot/.flue/lib/run-lifecycle.ts
@@ -12,6 +12,8 @@ export { RUN_PHASES, runMachineSnapshot, runPlan };
 export type { RunMode, RunPhaseId, RunStatus };
 
 export type RunProgressKind =
+	| "workspace_installing"
+	| "workspace_building"
 	| "workspace_ready"
 	| "workspace_failed"
 	| "verification_passed"
@@ -64,6 +66,15 @@ export function resumeRunLifecycle(run: RunLifecycle, startedAt: number): RunLif
 	};
 }
 
+export function beginRunLifecycle(run: RunLifecycle, startedAt: number): RunLifecycle {
+	if (run.status !== "running" || run.phase !== "prepare") return run;
+	return {
+		...run,
+		startedAt,
+		deadlineAt: startedAt + runBudgetMs(run.mode),
+	};
+}
+
 export function advanceRunLifecycle(run: RunLifecycle, progress: RunProgressKind): RunLifecycle {
 	if (run.status !== "running") return run;
 	const target = progressPhase(run, progress);
@@ -94,6 +105,9 @@ export function publicRunLifecycle(run: RunLifecycle): PublicRunLifecycle {
 
 function progressPhase(run: RunLifecycle, progress: RunProgressKind): RunPhaseId | null {
 	switch (progress) {
+		case "workspace_installing":
+		case "workspace_building":
+			return "prepare";
 		case "workspace_ready":
 			return run.plan[1] ?? "report";
 		case "verification_passed":

--- a/infra/emdash-bot/.flue/lib/run-policy.ts
+++ b/infra/emdash-bot/.flue/lib/run-policy.ts
@@ -2,10 +2,13 @@ import type { InvestigationMode } from "./router.js";
 
 const READ_RUN_BUDGET_MS = 30 * 60_000;
 const WRITE_RUN_BUDGET_MS = 60 * 60_000;
+const RUN_START_HEADROOM_MS = 5 * 60_000;
 
 export const BOOTSTRAP_TIMEOUT_MS = 15 * 60_000;
+export const CONTAINER_PREPARE_TIMEOUT_MS = BOOTSTRAP_TIMEOUT_MS + 10 * 60_000;
 export const DEADLINE_WARNING_LEAD_MS = 10 * 60_000;
-export const FLUE_RUN_TIMEOUT_MS = WRITE_RUN_BUDGET_MS + BOOTSTRAP_TIMEOUT_MS;
+export const FLUE_RUN_TIMEOUT_MS =
+	WRITE_RUN_BUDGET_MS + CONTAINER_PREPARE_TIMEOUT_MS + RUN_START_HEADROOM_MS;
 export const SANDBOX_SLEEP_AFTER_SECONDS = (FLUE_RUN_TIMEOUT_MS + 5 * 60_000) / 1_000;
 export const DEADLINE_WARNING_MESSAGE =
 	"About 10 minutes remain. Stop broad investigation, finish the smallest correct change, run the required verification, and publish and report if possible. If completion is not possible, report a useful partial or failure outcome now. This warning does not extend the deadline.";

--- a/infra/emdash-bot/.flue/lib/run-policy.ts
+++ b/infra/emdash-bot/.flue/lib/run-policy.ts
@@ -3,8 +3,9 @@ import type { InvestigationMode } from "./router.js";
 const READ_RUN_BUDGET_MS = 30 * 60_000;
 const WRITE_RUN_BUDGET_MS = 60 * 60_000;
 
+export const BOOTSTRAP_TIMEOUT_MS = 15 * 60_000;
 export const DEADLINE_WARNING_LEAD_MS = 10 * 60_000;
-export const FLUE_RUN_TIMEOUT_MS = WRITE_RUN_BUDGET_MS;
+export const FLUE_RUN_TIMEOUT_MS = WRITE_RUN_BUDGET_MS + BOOTSTRAP_TIMEOUT_MS;
 export const SANDBOX_SLEEP_AFTER_SECONDS = (FLUE_RUN_TIMEOUT_MS + 5 * 60_000) / 1_000;
 export const DEADLINE_WARNING_MESSAGE =
 	"About 10 minutes remain. Stop broad investigation, finish the smallest correct change, run the required verification, and publish and report if possible. If completion is not possible, report a useful partial or failure outcome now. This warning does not extend the deadline.";

--- a/infra/emdash-bot/.flue/lib/work-plan.ts
+++ b/infra/emdash-bot/.flue/lib/work-plan.ts
@@ -111,6 +111,18 @@ export function renderWorkPlanComment(input: {
 	return lines.join("\n");
 }
 
+export function renderPreparingWorkPlanComment(input: { mode: RunMode; summary: string }): string {
+	return [
+		"### Preparing workspace",
+		"",
+		escapeMarkdown(boundedText(input.summary, MAX_SUMMARY_LENGTH, "workspace summary")),
+		"",
+		"Installing dependencies and building the repository before the agent starts.",
+		"",
+		`_Mode: ${input.mode.replaceAll("_", " ")}_`,
+	].join("\n");
+}
+
 function preserveFinishedSteps(
 	previous: readonly WorkPlanStep[],
 	next: readonly WorkPlanStep[],

--- a/infra/emdash-bot/.flue/lib/workspace-bootstrap.ts
+++ b/infra/emdash-bot/.flue/lib/workspace-bootstrap.ts
@@ -1,0 +1,49 @@
+import { BOOTSTRAP_TIMEOUT_MS } from "./run-policy.js";
+
+export const WORKSPACE_BOOTSTRAP_TIMEOUT_MS = BOOTSTRAP_TIMEOUT_MS;
+
+export type WorkspaceBootstrapStage = "workspace_installing" | "workspace_building";
+
+interface BootstrapContainer {
+	exec(
+		command: string,
+		options?: { cwd?: string; timeoutMs?: number },
+	): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+}
+
+export async function bootstrapWorkspace(
+	container: BootstrapContainer,
+	options: {
+		repoDir: string;
+		onProgress: (stage: WorkspaceBootstrapStage) => Promise<void>;
+	},
+): Promise<void> {
+	const dependencies = await container.exec(
+		"test -d node_modules -a -f node_modules/.modules.yaml",
+		{ cwd: options.repoDir },
+	);
+	if (dependencies.exitCode !== 0) {
+		await options.onProgress("workspace_installing");
+		const install = await container.exec("pnpm install --frozen-lockfile --prefer-offline", {
+			cwd: options.repoDir,
+			timeoutMs: WORKSPACE_BOOTSTRAP_TIMEOUT_MS,
+		});
+		assertBootstrapSuccess(install, "dependency installation");
+	}
+
+	await options.onProgress("workspace_building");
+	const build = await container.exec("pnpm build", {
+		cwd: options.repoDir,
+		timeoutMs: WORKSPACE_BOOTSTRAP_TIMEOUT_MS,
+	});
+	assertBootstrapSuccess(build, "workspace build");
+}
+
+function assertBootstrapSuccess(
+	result: { exitCode: number; stdout: string; stderr: string },
+	stage: string,
+): void {
+	if (result.exitCode === 0) return;
+	const output = (result.stderr || result.stdout || "no output").trim().slice(-1_000);
+	throw new Error(`${stage} failed (${result.exitCode}): ${output}`);
+}

--- a/infra/emdash-bot/.flue/lib/workspace-bootstrap.ts
+++ b/infra/emdash-bot/.flue/lib/workspace-bootstrap.ts
@@ -16,8 +16,11 @@ export async function bootstrapWorkspace(
 	options: {
 		repoDir: string;
 		onProgress: (stage: WorkspaceBootstrapStage) => Promise<void>;
+		now?: () => number;
 	},
 ): Promise<void> {
+	const now = options.now ?? Date.now;
+	const deadlineAt = now() + WORKSPACE_BOOTSTRAP_TIMEOUT_MS;
 	const dependencies = await container.exec(
 		"test -d node_modules -a -f node_modules/.modules.yaml",
 		{ cwd: options.repoDir },
@@ -26,7 +29,7 @@ export async function bootstrapWorkspace(
 		await options.onProgress("workspace_installing");
 		const install = await container.exec("pnpm install --frozen-lockfile --prefer-offline", {
 			cwd: options.repoDir,
-			timeoutMs: WORKSPACE_BOOTSTRAP_TIMEOUT_MS,
+			timeoutMs: remainingBootstrapMs(now, deadlineAt),
 		});
 		assertBootstrapSuccess(install, "dependency installation");
 	}
@@ -34,9 +37,17 @@ export async function bootstrapWorkspace(
 	await options.onProgress("workspace_building");
 	const build = await container.exec("pnpm build", {
 		cwd: options.repoDir,
-		timeoutMs: WORKSPACE_BOOTSTRAP_TIMEOUT_MS,
+		timeoutMs: remainingBootstrapMs(now, deadlineAt),
 	});
 	assertBootstrapSuccess(build, "workspace build");
+}
+
+function remainingBootstrapMs(now: () => number, deadlineAt: number): number {
+	const remaining = deadlineAt - now();
+	if (remaining <= 0) {
+		throw new Error(`workspace bootstrap exceeded ${WORKSPACE_BOOTSTRAP_TIMEOUT_MS}ms`);
+	}
+	return remaining;
 }
 
 function assertBootstrapSuccess(

--- a/infra/emdash-bot/.flue/skills/fix/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/fix/SKILL.md
@@ -12,7 +12,7 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
 ## Environment
 
 - **Edit in the VFS** with the `edit_file` / `write_file` tools; read surrounding code with `read_file` and `grep`. Every VFS edit is replayed onto the container checkout before each container command.
-- **Run final tests, lint, typecheck, and format checks through `run_check`** -- none of the toolchain exists in the VFS. Use `exec` for the pre-edit baseline and exploratory commands whose result is not a release gate.
+- **Run final tests, lint, typecheck, and format checks through `run_check`** -- none of the toolchain exists in the VFS. Use `exec` only for exploratory commands whose result is not a release gate.
 
 ## Do not
 
@@ -27,11 +27,10 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
 ## Procedure
 
 1. **Re-read diagnose's root cause and proposed fix.** That is your target and your spec. The change should land in the file and approximate line diagnose named. If your work drifts to a different file, stop -- diagnose may be wrong, in which case abandon, do not wander.
-2. **Bootstrap the checkout once.** Use `exec`. If `node_modules` is missing, run `pnpm install --frozen-lockfile --prefer-offline`. If workspace build artifacts are missing, run `pnpm build`; a fresh EmDash checkout needs them before package typechecks can resolve internal declarations. Do not repeat install or build unless a manifest changed or your change affects required compiled output.
-3. **Run the clean baseline once.** Use `exec`, before editing, for the repository-required baseline. Record failures outside the diagnosed scope; do not repair them and do not register a predictably failing broad command as a final `run_check`.
-4. **Choose the final verification set.** Plan the focused repro test, affected package tests and typechecks, lint, and a check-only formatter. Use the smallest checks that cover the behavior. Do not plan a monorepo-wide suite when focused or package-level checks are authoritative.
-5. **Establish a regression test where feasible.** Reproduce usually confirmed the bug without a test on disk. If the bug is unit- or integration-testable (a handler, a query, a pure function, an API route), write a `vitest` test now that fails for the reported reason, and confirm it fails in the container (`pnpm --filter <package> test <path>`) _before_ you touch the fix. A testable bug with no regression test is not fixed. If the bug only manifests in the browser (admin interaction, rendered output), do not write a browser test -- you cannot run one reliably here; verify through `agent-browser` instead and describe that manual verification so the maintainer can add a durable test when landing.
-6. **Implement the proposed fix -- the smallest change that fully resolves the bug.** Follow EmDash conventions:
+2. **Use the prepared workspace.** The harness installs dependencies and builds the base workspace before this turn. Do not run `pnpm install`, the root `pnpm build`, or a pre-edit lint baseline.
+3. **Choose the final verification set.** Plan the focused repro test, affected package tests and typechecks, final lint, and a check-only formatter. Use the smallest checks that cover the behavior. Do not plan a monorepo-wide suite when focused or package-level checks are authoritative.
+4. **Establish a regression test where feasible.** Reproduce usually confirmed the bug without a test on disk. If the bug is unit- or integration-testable (a handler, a query, a pure function, an API route), write a `vitest` test now that fails for the reported reason, and confirm it fails in the container (`pnpm --filter <package> test <path>`) _before_ you touch the fix. A testable bug with no regression test is not fixed. If the bug only manifests in the browser (admin interaction, rendered output), do not write a browser test -- you cannot run one reliably here; verify through `agent-browser` instead and describe that manual verification so the maintainer can add a durable test when landing.
+5. **Implement the proposed fix -- the smallest change that fully resolves the bug.** Follow EmDash conventions:
    - Internal imports end `.js`; type-only imports use `import type`.
    - State-changing routes start with `export const prerender = false;`.
    - Never interpolate values into SQL: Kysely `sql` tagged template for values, `sql.ref()` for identifiers, `validateIdentifier()` before any `sql.raw()`.
@@ -43,10 +42,10 @@ You are here because a maintainer issued a **fix** directive, verify returned `b
    - `import.meta.env.DEV`, never `process.env.NODE_ENV`.
    - Migrations are forward-only and additive; register in `runner.ts` via `StaticMigrationProvider`.
    - Prefer additive changes. A breaking change needs an explicit changeset -- do not introduce one for an automated fix without compelling justification.
-7. **Finish the candidate tree.** Apply formatting and add the changeset now, when a published package changed. Follow `.changeset/README.md`: write public CHANGELOG documentation with detail proportional to the impact, not a diff summary. Adding it after verification would invalidate every recorded check.
-8. **Run one final verification pass with `run_check`.** Run the focused repro test first, then the remaining planned checks. A check name is permanently bound to its first command, including flags and arguments; if you need a different command, choose a new name before running it. Run each check once on the final tree; do not repeat a passing check on an unchanged tree.
-9. **Respond to relevant failures only.** Fix a regression in touched behavior or abandon the change. If you edit the candidate, rerun the planned set once on the new tree. Never edit unrelated files to make a broad lint, typecheck, or test command pass.
-10. **Publish with `publish_candidate` as soon as the planned checks pass.** Do not reproduce its work with shell commands. Report `fixed: true` only after it succeeds.
+6. **Finish the candidate tree.** Apply formatting and add the changeset now, when a published package changed. Follow `.changeset/README.md`: write public CHANGELOG documentation with detail proportional to the impact, not a diff summary. Adding it after verification would invalidate every recorded check.
+7. **Run one final verification pass with `run_check`.** Run the focused repro test first, then the remaining planned checks. A check name is permanently bound to its first command, including flags and arguments; if you need a different command, choose a new name before running it. Run each check once on the final tree; do not repeat a passing check on an unchanged tree.
+8. **Respond to relevant failures only.** Fix a regression in touched behavior or abandon the change. If you edit the candidate, rerun the planned set once on the new tree. Never edit unrelated files to make a broad lint, typecheck, or test command pass.
+9. **Publish with `publish_candidate` as soon as the planned checks pass.** Do not reproduce its work with shell commands. Report `fixed: true` only after it succeeds.
 
 ## Efficient verification
 

--- a/infra/emdash-bot/.flue/skills/implement/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/implement/SKILL.md
@@ -10,23 +10,22 @@ A maintainer explicitly asked you to build the issue's requested change. Treat t
 ## Procedure
 
 1. Read `AGENTS.md` and the relevant implementation, tests, and contributor guidance before editing.
-2. Bootstrap the checkout once with `exec`, before the baseline. If `node_modules` is missing, run `pnpm install --frozen-lockfile --prefer-offline`. If workspace build artifacts are missing, run `pnpm build`; a fresh EmDash checkout needs them before package typechecks can resolve internal declarations. Do not repeat install or build unless a manifest changed or your change affects required compiled output.
-3. Run the repository-required clean baseline once with `exec`, before editing. A baseline command is diagnostic, not a final `run_check`. Record failures that are outside the requested scope; do not edit unrelated files to make the baseline pass.
-4. Choose the smallest authoritative final verification set before editing: the focused behavior test, affected package tests and typechecks, lint, and a check-only formatter. Do not plan a monorepo-wide test suite when focused or package-level checks cover the changed behavior.
-5. Resolve ambiguity from existing APIs, sibling code, and backwards-compatible behavior. If a missing decision would materially change the public contract, stop and report it instead of guessing.
-6. Edit through `edit_file` and `write_file`. Keep the change scoped to the request. Do not modify `.github/workflows` or generated Lingui catalogs.
-7. Add behavior-level tests where the change has testable behavior. For a directed bug fix, follow the repository's failing-test-first rule.
-8. Finish every candidate edit before final verification. Apply formatting and add the changeset now, when a published package changed. Follow `.changeset/README.md`: write public CHANGELOG documentation with detail proportional to the impact, not a diff summary. The changeset is part of the candidate tree, so adding it after checks would invalidate every result.
-9. Run the planned final checks through `run_check`. Use stable names and run each check once on the final candidate tree. A check name is permanently bound to its first command, including flags and arguments; if you need a different command, choose a new name before running it. If a relevant check fails and you edit the candidate, rerun the planned set once on the new tree with the original names and commands. Do not repeat a passing check on an unchanged tree.
-10. Call `publish_candidate` as soon as the planned checks pass. The trusted Worker owns Git objects and the `bot/fix-<issue>` ref; never run `git commit`, `git push`, or create a PR yourself.
-11. Call `report_implementation` exactly once. Set `implemented: true` only after publication succeeds. Summarize the observable change and verification, not a bug verdict.
+2. The harness installs dependencies and builds the base workspace before this turn. Do not run `pnpm install`, the root `pnpm build`, or a pre-edit lint baseline.
+3. Choose the smallest authoritative final verification set before editing: the focused behavior test, affected package tests and typechecks, final lint, and a check-only formatter. Do not plan a monorepo-wide test suite when focused or package-level checks cover the changed behavior.
+4. Resolve ambiguity from existing APIs, sibling code, and backwards-compatible behavior. If a missing decision would materially change the public contract, stop and report it instead of guessing.
+5. Edit through `edit_file` and `write_file`. Keep the change scoped to the request. Do not modify `.github/workflows` or generated Lingui catalogs.
+6. Add behavior-level tests where the change has testable behavior. For a directed bug fix, follow the repository's failing-test-first rule.
+7. Finish every candidate edit before final verification. Apply formatting and add the changeset now, when a published package changed. Follow `.changeset/README.md`: write public CHANGELOG documentation with detail proportional to the impact, not a diff summary. The changeset is part of the candidate tree, so adding it after checks would invalidate every result.
+8. Run the planned final checks through `run_check`. Use stable names and run each check once on the final candidate tree. A check name is permanently bound to its first command, including flags and arguments; if you need a different command, choose a new name before running it. If a relevant check fails and you edit the candidate, rerun the planned set once on the new tree with the original names and commands. Do not repeat a passing check on an unchanged tree.
+9. Call `publish_candidate` as soon as the planned checks pass. The trusted Worker owns Git objects and the `bot/fix-<issue>` ref; never run `git commit`, `git push`, or create a PR yourself.
+10. Call `report_implementation` exactly once. Set `implemented: true` only after publication succeeds. Summarize the observable change and verification, not a bug verdict.
 
 ## Verification scope
 
 - Prefer the focused regression test and affected package checks. Run a broader root check once only when the change crosses its surface or `AGENTS.md` explicitly requires it.
 - Treat install and the initial workspace build as bootstrap, not verification. Reuse them for the whole run and across resume when the saved container is still available.
 - Treat all coordinated edits for one change as one edit round. Do not run lint, typecheck, and tests after each individual file edit.
-- If a broad check already failed before your changes only in untouched files, report the baseline failure and use the narrow authoritative check for your files. Never repair unrelated failures or register a predictably failing broad command as a final `run_check`.
+- If a broad final check fails only in untouched files, report it and use the narrow authoritative check for your files. Never repair unrelated failures or register a predictably failing broad command as a final `run_check`.
 - If a broad suite times out, do not immediately run it again. Run the smallest relevant subsets, report the omitted or timed-out suite, and preserve time for publication and reporting.
 - If `run_check` reports that a name is already bound, choose a new name for the different command. The rejected command did not modify verification state; do not retry it under the bound name.
 - Verification commands must not modify source files. Use `edit_file` or `write_file` before the final pass, then use check-only formatter commands.

--- a/infra/emdash-bot/.flue/skills/repro-api/SKILL.md
+++ b/infra/emdash-bot/.flue/skills/repro-api/SKILL.md
@@ -10,7 +10,7 @@ The bug does not need a browser. It lives in a handler, the CLI, the MCP server,
 ## Environment
 
 - **Read and search in the VFS.** Use `read_file`, `ls`, `grep`, and `code` to find the package, read the handler in full, and trace call sites. This is most of the work and none of it needs a container.
-- **Attach a container only to run the project.** `pnpm install`, `pnpm build`, and `vitest` do not exist in the isolate. When you are ready to actually execute a reproduction, attach a container and run those there.
+- **Attach a container only to run the project.** The harness has already installed dependencies and built the base workspace. Use the container for the focused reproduction command; do not repeat the install or root build.
 
 ## Do not
 
@@ -25,14 +25,13 @@ The bug does not need a browser. It lives in a handler, the CLI, the MCP server,
 1. **Anchor on the issue's exact words.** In the isolate, pull the commands, file paths, package names, and stack traces out of the issue body verbatim. Your reproduction matches what the reporter wrote, not a paraphrase. If the body links a repo or gist, fetch it read-only before choosing an approach.
 2. **Find the package (isolate).** Use `area` plus file paths in the body. CLI -> `packages/core/src/cli/`. REST handlers -> `packages/core/src/api/handlers/`. Migrations -> `packages/core/src/database/migrations/`. MCP -> `packages/core/src/mcp/`. Build -> `packages/*/tsdown.config.ts` or root `pnpm-workspace.yaml`. If several packages are plausible, `grep` before guessing. Read the candidate code fully in the isolate before you spend a container on it.
 3. **Attach a container.** Everything from here needs one.
-4. **Install only if needed.** The clone may already carry `node_modules` from the base image / R2 template artifact. If it does, skip the install. Run `pnpm install --frozen-lockfile --prefer-offline` only when `node_modules` is missing or you changed a manifest -- it is the slowest thing you can do.
-5. **Build only what you must.** Most reproductions target source directly through vitest. Run `pnpm --filter <package> build` only when the bug is in compiled output or cross-package type generation.
-6. **Choose an approach, in order of preference:**
+4. **Use the prepared toolchain.** Do not run `pnpm install` or the root `pnpm build`. Run a package build only when the reproduction specifically targets compiled output.
+5. **Choose an approach, in order of preference:**
    - **Failing vitest test** in the package's `tests/` tree. Use `setupTestDatabase()` / `setupForDialect()` from `tests/utils/test-db.ts` for anything touching the database; use the dialect wrapper (`describeEachDialect`) when the bug could be dialect-specific. Mirror source structure (`.../src/api/handlers/foo.ts` -> `.../tests/integration/api/handlers/foo.test.ts`). Name it for the issue: `it("reproduces #<number>: <short description>", ...)`. Run with `pnpm --filter <package> test <path>` and confirm it fails **for the reason reported**, not an unrelated setup error.
    - **Repro script** under `/tmp/repro-<issueNumber>/` when a test would need too much scaffolding (needs a built binary, needs to spawn children in a specific order). One file when possible; capture stdout, stderr, exit code.
    - **`pnpm exec emdash ...`** when the bug is a single CLI invocation whose failure is obvious from the output.
-7. **Capture evidence.** For every attempt record the exact command, the meaningful slice of stdout/stderr (trim -- do not dump thousands of lines), and the exit code. This transcript is the deliverable.
-8. **Confirm the failure mode matches.** A crash for a different reason is not a reproduction. If you can only trigger an adjacent failure, say so and lower confidence.
+6. **Capture evidence.** For every attempt record the exact command, the meaningful slice of stdout/stderr (trim -- do not dump thousands of lines), and the exit code. This transcript is the deliverable.
+7. **Confirm the failure mode matches.** A crash for a different reason is not a reproduction. If you can only trigger an adjacent failure, say so and lower confidence.
 
 ## When to skip
 

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -476,6 +476,45 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect(completed.run).toMatchObject({ status: "succeeded", phase: "report" });
 	});
 
+	test("starts the run budget when workspace bootstrap completes", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		const admittedAt = Date.now() - 5 * 60_000;
+		await stub.debugSetStaleRun(
+			"bootstrap-run",
+			admittedAt,
+			"investigate-42-bootstrap-run",
+			"implement",
+		);
+		const readyAt = Date.now();
+
+		await stub.recordPublicProgress({
+			runId: "bootstrap-run",
+			kind: "workspace_installing",
+			title: "Installing dependencies",
+		});
+		await stub.recordPublicProgress({
+			runId: "bootstrap-run",
+			kind: "workspace_building",
+			title: "Building workspace",
+		});
+		await stub.recordPublicProgress({
+			runId: "bootstrap-run",
+			kind: "workspace_ready",
+			title: "Workspace ready",
+		});
+
+		const snapshot = await stub.getPublicSnapshot();
+		expect(snapshot.run?.createdAt).toBe(admittedAt);
+		expect(snapshot.run?.startedAt).toBeGreaterThanOrEqual(readyAt);
+		expect(snapshot.currentRunStartedAt).toBe(snapshot.run?.startedAt);
+		expect(snapshot.run?.deadlineAt).toBe((snapshot.run?.startedAt ?? 0) + 60 * 60_000);
+		expect(snapshot.progress.slice(-3).map((entry: { kind: string }) => entry.kind)).toEqual([
+			"workspace_installing",
+			"workspace_building",
+			"workspace_ready",
+		]);
+	});
+
 	test("records a reset active run as cancelled", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		await stub.event(makeEvent());
@@ -492,6 +531,59 @@ describe("OrchestratorDO (workers-pool)", () => {
 			status: "cancelled",
 			phase: "prepare",
 		});
+	});
+
+	test("posts workspace preparation before reusing the comment for the agent plan", async () => {
+		const requests: Array<{ method: string; url: string; body: string }> = [];
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		vi.stubGlobal("fetch", (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			const method = (init?.method ?? "GET").toUpperCase();
+			const body = typeof init?.body === "string" ? init.body : "";
+			requests.push({ method, url, body });
+			if (method === "POST" && url.endsWith("/comments")) {
+				return Promise.resolve(
+					new Response(JSON.stringify({ id: 776 }), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+			}
+			return Promise.resolve(new Response("{}", { status: 200 }));
+		});
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+		await stub.debugPrimeFixing(42);
+		await stub.debugSetStaleRun(
+			"preparing-run",
+			Date.now(),
+			"investigate-42-preparing-run",
+			"implement",
+		);
+
+		await stub.prepareWorkPlanComment({
+			runId: "preparing-run",
+			summary: "Implement adapter support.",
+		});
+		expect((await stub.getPublicSnapshot()).workPlan).toMatchObject({
+			summary: "Implement adapter support.",
+			steps: [{ id: "prepare-workspace", status: "in_progress" }],
+		});
+		await stub.updateWorkPlan({
+			runId: "preparing-run",
+			summary: "Implement adapter support.",
+			steps: [{ id: "implement", title: "Implement the adapter", status: "in_progress" }],
+		});
+
+		const posts = requests.filter(
+			(request) => request.method === "POST" && request.url.endsWith("/comments"),
+		);
+		const patches = requests.filter(
+			(request) => request.method === "PATCH" && request.url.endsWith("/issues/comments/776"),
+		);
+		expect(posts).toHaveLength(1);
+		expect(posts[0]?.body).toContain("### Preparing workspace");
+		expect(patches.at(-1)?.body).toContain("### Working on it");
 	});
 
 	test("creates one evolving work-plan comment and finalizes it in place", async () => {

--- a/infra/emdash-bot/tests/unit/exec-env.test.ts
+++ b/infra/emdash-bot/tests/unit/exec-env.test.ts
@@ -534,6 +534,19 @@ describe("ExecEnv deadlines", () => {
 });
 
 describe("ExecEnv container lifecycle", () => {
+	test("prepares the container once and reuses it for later commands", async () => {
+		const con = fakeContainer();
+		const attach = vi.fn(async () => con.container);
+		const env = makeEnv({ attachContainer: attach });
+
+		await env.ensureContainerReady();
+		await env.ensureContainerReady();
+		await env.exec("pnpm test");
+
+		expect(attach).toHaveBeenCalledTimes(1);
+		expect(con.execs).toEqual(["bash -o pipefail -c 'pnpm test'"]);
+	});
+
 	test("the container is attached lazily and reused across execs", async () => {
 		const con = fakeContainer();
 		const attach = vi.fn(async () => con.container);

--- a/infra/emdash-bot/tests/unit/run-lifecycle.test.ts
+++ b/infra/emdash-bot/tests/unit/run-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
 	advanceRunLifecycle,
+	beginRunLifecycle,
 	resumeRunLifecycle,
 	runMachineSnapshot,
 	runPlan,
@@ -59,6 +60,18 @@ describe("run lifecycle", () => {
 			status: "succeeded",
 			phase: "report",
 			completedAt: 5_000,
+		});
+	});
+
+	test("starts the agent deadline after workspace bootstrap without changing creation time", () => {
+		const admitted = startRunLifecycle({ runId: "run-1", mode: "implement", startedAt: 1_000 });
+		const started = beginRunLifecycle(admitted, 10_000);
+
+		expect(started).toMatchObject({
+			createdAt: 1_000,
+			startedAt: 10_000,
+			deadlineAt: 10_000 + 60 * 60_000,
+			phase: "prepare",
 		});
 	});
 

--- a/infra/emdash-bot/tests/unit/run-policy.test.ts
+++ b/infra/emdash-bot/tests/unit/run-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+	BOOTSTRAP_TIMEOUT_MS,
 	DEADLINE_WARNING_LEAD_MS,
 	DEADLINE_WARNING_MESSAGE,
 	FLUE_RUN_TIMEOUT_MS,
@@ -24,6 +25,7 @@ describe("run lifecycle policy", () => {
 			expect(FLUE_RUN_TIMEOUT_MS).toBeGreaterThanOrEqual(runBudgetMs(mode));
 			expect(SANDBOX_SLEEP_AFTER_SECONDS * 1_000).toBeGreaterThan(runBudgetMs(mode));
 		}
+		expect(FLUE_RUN_TIMEOUT_MS).toBe(runBudgetMs("implement") + BOOTSTRAP_TIMEOUT_MS);
 		expect(SANDBOX_SLEEP_AFTER_SECONDS * 1_000).toBe(FLUE_RUN_TIMEOUT_MS + 5 * 60_000);
 	});
 

--- a/infra/emdash-bot/tests/unit/run-policy.test.ts
+++ b/infra/emdash-bot/tests/unit/run-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
 	BOOTSTRAP_TIMEOUT_MS,
+	CONTAINER_PREPARE_TIMEOUT_MS,
 	DEADLINE_WARNING_LEAD_MS,
 	DEADLINE_WARNING_MESSAGE,
 	FLUE_RUN_TIMEOUT_MS,
@@ -25,7 +26,10 @@ describe("run lifecycle policy", () => {
 			expect(FLUE_RUN_TIMEOUT_MS).toBeGreaterThanOrEqual(runBudgetMs(mode));
 			expect(SANDBOX_SLEEP_AFTER_SECONDS * 1_000).toBeGreaterThan(runBudgetMs(mode));
 		}
-		expect(FLUE_RUN_TIMEOUT_MS).toBe(runBudgetMs("implement") + BOOTSTRAP_TIMEOUT_MS);
+		expect(CONTAINER_PREPARE_TIMEOUT_MS).toBe(BOOTSTRAP_TIMEOUT_MS + 10 * 60_000);
+		expect(FLUE_RUN_TIMEOUT_MS).toBeGreaterThan(
+			runBudgetMs("implement") + CONTAINER_PREPARE_TIMEOUT_MS,
+		);
 		expect(SANDBOX_SLEEP_AFTER_SECONDS * 1_000).toBe(FLUE_RUN_TIMEOUT_MS + 5 * 60_000);
 	});
 

--- a/infra/emdash-bot/tests/unit/work-plan.test.ts
+++ b/infra/emdash-bot/tests/unit/work-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+	renderPreparingWorkPlanComment,
 	renderWorkPlanComment,
 	requireWorkPlanReadyForReport,
 	updateWorkPlan,
@@ -120,5 +121,18 @@ describe("agent work plans", () => {
 				outcome: "The bug reproduced, but no candidate was published.",
 			}),
 		).toContain("### Needs follow-up");
+	});
+
+	test("renders a safe deterministic workspace-preparation comment", () => {
+		const comment = renderPreparingWorkPlanComment({
+			mode: "implement",
+			summary: "Implement <unsafe> adapter [support]",
+		});
+
+		expect(comment).toContain("### Preparing workspace");
+		expect(comment).toContain("Implement &lt;unsafe&gt; adapter \\[support\\]");
+		expect(comment).toContain("Installing dependencies and building the repository");
+		expect(comment).toContain("_Mode: implement_");
+		expect(comment).not.toContain("<unsafe>");
 	});
 });

--- a/infra/emdash-bot/tests/unit/workspace-bootstrap.test.ts
+++ b/infra/emdash-bot/tests/unit/workspace-bootstrap.test.ts
@@ -20,6 +20,7 @@ describe("workspace bootstrap", () => {
 			{ exec },
 			{
 				repoDir: "/workspace/repo",
+				now: () => 0,
 				onProgress: async (stage) => {
 					progress.push(stage);
 				},
@@ -49,6 +50,7 @@ describe("workspace bootstrap", () => {
 			{ exec },
 			{
 				repoDir: "/workspace/repo",
+				now: () => 0,
 				onProgress: async (stage) => {
 					progress.push(stage);
 				},
@@ -70,7 +72,39 @@ describe("workspace bootstrap", () => {
 		);
 
 		await expect(
-			bootstrapWorkspace({ exec }, { repoDir: "/workspace/repo", onProgress: async () => {} }),
+			bootstrapWorkspace(
+				{ exec },
+				{ repoDir: "/workspace/repo", onProgress: async () => {}, now: () => 0 },
+			),
 		).rejects.toThrow("workspace build failed (1): package build failed");
+	});
+
+	test("shares one timeout budget across installation and build", async () => {
+		let now = 0;
+		const timeouts: Array<{ command: string; timeoutMs?: number }> = [];
+		const exec = vi.fn(async (command: string, options?: { timeoutMs?: number }) => {
+			timeouts.push({ command, timeoutMs: options?.timeoutMs });
+			if (command.startsWith("test -d node_modules")) {
+				return { exitCode: 1, stdout: "", stderr: "" };
+			}
+			if (command.startsWith("pnpm install")) now += 9 * 60_000;
+			return { exitCode: 0, stdout: "ok", stderr: "" };
+		});
+
+		await bootstrapWorkspace(
+			{ exec },
+			{
+				repoDir: "/workspace/repo",
+				onProgress: async () => {},
+				now: () => now,
+			},
+		);
+
+		expect(timeouts.find((entry) => entry.command.startsWith("pnpm install"))?.timeoutMs).toBe(
+			WORKSPACE_BOOTSTRAP_TIMEOUT_MS,
+		);
+		expect(timeouts.find((entry) => entry.command === "pnpm build")?.timeoutMs).toBe(
+			WORKSPACE_BOOTSTRAP_TIMEOUT_MS - 9 * 60_000,
+		);
 	});
 });

--- a/infra/emdash-bot/tests/unit/workspace-bootstrap.test.ts
+++ b/infra/emdash-bot/tests/unit/workspace-bootstrap.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+	bootstrapWorkspace,
+	WORKSPACE_BOOTSTRAP_TIMEOUT_MS,
+} from "../../.flue/lib/workspace-bootstrap.js";
+
+describe("workspace bootstrap", () => {
+	test("installs missing dependencies and builds once before the agent starts", async () => {
+		const commands: Array<{ command: string; timeoutMs?: number }> = [];
+		const progress: string[] = [];
+		const exec = vi.fn(async (command: string, options?: { timeoutMs?: number }) => {
+			commands.push({ command, timeoutMs: options?.timeoutMs });
+			return command.startsWith("test -d node_modules")
+				? { exitCode: 1, stdout: "", stderr: "" }
+				: { exitCode: 0, stdout: "ok", stderr: "" };
+		});
+
+		await bootstrapWorkspace(
+			{ exec },
+			{
+				repoDir: "/workspace/repo",
+				onProgress: async (stage) => {
+					progress.push(stage);
+				},
+			},
+		);
+
+		expect(progress).toEqual(["workspace_installing", "workspace_building"]);
+		expect(commands).toEqual([
+			{ command: "test -d node_modules -a -f node_modules/.modules.yaml", timeoutMs: undefined },
+			{
+				command: "pnpm install --frozen-lockfile --prefer-offline",
+				timeoutMs: WORKSPACE_BOOTSTRAP_TIMEOUT_MS,
+			},
+			{ command: "pnpm build", timeoutMs: WORKSPACE_BOOTSTRAP_TIMEOUT_MS },
+		]);
+	});
+
+	test("reuses installed dependencies but still creates fresh base build outputs", async () => {
+		const commands: string[] = [];
+		const progress: string[] = [];
+		const exec = vi.fn(async (command: string) => {
+			commands.push(command);
+			return { exitCode: 0, stdout: "ok", stderr: "" };
+		});
+
+		await bootstrapWorkspace(
+			{ exec },
+			{
+				repoDir: "/workspace/repo",
+				onProgress: async (stage) => {
+					progress.push(stage);
+				},
+			},
+		);
+
+		expect(commands).toEqual([
+			"test -d node_modules -a -f node_modules/.modules.yaml",
+			"pnpm build",
+		]);
+		expect(progress).toEqual(["workspace_building"]);
+	});
+
+	test("fails workspace setup when the deterministic build fails", async () => {
+		const exec = vi.fn(async (command: string) =>
+			command === "pnpm build"
+				? { exitCode: 1, stdout: "", stderr: "package build failed" }
+				: { exitCode: 0, stdout: "", stderr: "" },
+		);
+
+		await expect(
+			bootstrapWorkspace({ exec }, { repoDir: "/workspace/repo", onProgress: async () => {} }),
+		).rejects.toThrow("workspace build failed (1): package build failed");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Moves deterministic repository bootstrap out of the model loop and into the bot harness.

- Posts the run's evolving GitHub comment immediately as `Preparing workspace`, before checkout hydration, dependency installation, or build work starts.
- Reuses that comment and its temporary dashboard plan when the agent publishes its task-specific work plan; bootstrap failures finalize the same comment instead of leaving it stuck.
- Attaches the run container before the first model turn, installs dependencies only when `node_modules` is missing, and runs one root workspace build without a buffered output pipeline.
- Emits explicit `Installing dependencies`, `Building workspace`, and `Workspace ready` progress events.
- Starts the 30/60-minute Orchestrator deadline when bootstrap completes while preserving the earlier run creation timestamp.
- Extends the agent-static Flue ceiling by a bounded bootstrap allowance and keeps Sandbox sleep five minutes beyond that ceiling.
- Removes model instructions to run install, root build, or a pre-edit lint baseline. Focused final verification and final lint remain required.

Related to #1623 and #2560.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
  - `pnpm --filter @emdash-cms/emdash-bot typecheck` still reports the pre-existing generated Durable Object namespace/export errors, Sandbox binding mismatch, pending-resume narrowing error, and verification fixture error. No bootstrap source file reports a type error.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
  - N/A: this changes private bot tooling and its public workbench, not the localized EmDash admin UI.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
  - N/A: only private `infra/emdash-bot` code changes.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
  - N/A: maintainer-directed private bot tooling.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 285 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 70 passed
- `pnpm --filter @emdash-cms/emdash-bot build` — passed
- `pnpm lint` — passed
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm format:check` — passed
- `docker info` — Docker 28.4.0 available
- `pnpm --filter @emdash-cms/emdash-bot typecheck` — fails only on the pre-existing errors disclosed above
