### PR TITLE
fix(bot): retry transient workspace bootstrap failures

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -64,6 +64,7 @@ import {
 	FLUE_RUN_TIMEOUT_MS,
 	SANDBOX_SLEEP_AFTER_SECONDS,
 } from "../lib/run-policy.js";
+import { withDeadline } from "../lib/sandbox-deadline.js";
 import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/timeout-recovery.js";
 import { untarInto } from "../lib/untar.js";
 import {
@@ -77,6 +78,11 @@ import {
 	upsertVerificationRecord,
 } from "../lib/verification.js";
 import { requireWorkPlanReadyForReport, updateWorkPlan, type WorkPlan } from "../lib/work-plan.js";
+import {
+	attachWorkspaceWithRetry,
+	prepareWorkspaceBeforeModel,
+	WORKSPACE_SANDBOX_ATTEMPT_LIMIT,
+} from "../lib/workspace-attachment.js";
 import { bootstrapWorkspace, type WorkspaceBootstrapStage } from "../lib/workspace-bootstrap.js";
 import diagnoseSkill from "../skills/diagnose/SKILL.md";
 import fixSkill from "../skills/fix/SKILL.md";
@@ -239,6 +245,10 @@ export function Investigate({ id }: AgentProps) {
 	);
 	const [lastFailure, setLastFailure] = usePersistentState<RunFailure | null>("last-failure", null);
 	const [workPlan, setWorkPlan] = usePersistentState<WorkPlan | null>("work-plan", null);
+	const [workspaceSandboxAttempt, setWorkspaceSandboxAttempt] = usePersistentState(
+		"workspace-sandbox-attempt",
+		0,
+	);
 	const writeResult = useDataWriter("investigation", { schema: reportedResultSchema });
 
 	useModel("cloudflare/@cf/moonshotai/kimi-k2.7-code");
@@ -246,7 +256,7 @@ export function Investigate({ id }: AgentProps) {
 		return buildTimeoutSummaryPrompt({ mode: input.mode, verification, lastFailure });
 	}
 
-	const env = execEnvFor(id, input);
+	const env = execEnvFor(id, input, workspaceSandboxAttempt, setWorkspaceSandboxAttempt);
 	const ensureTerminalReportAllowed = async () => {
 		requireTerminalReportAllowed(lastFailure);
 		if (verification.length === 0) return;
@@ -286,39 +296,32 @@ export function Investigate({ id }: AgentProps) {
 
 	useAgentStart(async ({ log }) => {
 		if (setupComplete || reported) return;
-		try {
-			await prepareWorkPlanComment(input);
-			await env.ensureRepo({ dir: REPO_DIR, ref: cloneRef(input) });
-			await env.ensureContainerReady();
-			setSetupComplete(true);
-			await recordInvestigationProgress(input, {
-				kind: "workspace_ready",
-				title: "Workspace ready",
-				detail: `Checked out ${cloneRef(input)} and restored the investigation workspace`,
-			});
-		} catch (error) {
-			setLastFailure({ stage: "workspace", message: safeFailureMessage(error) });
-			await recordInvestigationProgress(input, {
-				kind: "workspace_failed",
-				title: "Workspace setup failed",
-				detail: "The investigation workspace could not be prepared",
-			});
-			const result = failedResult(
-				`I couldn't prepare the investigation workspace: ${errorMessage(error)}`,
-				"workspace",
-			);
-			await applyInvestigationResult(input, result, false, false);
-			writeResult({
-				result,
-				ok: false,
-				pushed: false,
-				runId: input.runId,
-				publication: null,
-				verification: [],
-			});
-			setReported(true);
-			log.error("workspace setup failed", { error: errorMessage(error) });
-		}
+		await prepareWorkspaceBeforeModel({
+			prepare: async () => {
+				await prepareWorkPlanComment(input);
+				await env.ensureRepo({ dir: REPO_DIR, ref: cloneRef(input) });
+				await env.ensureContainerReady();
+				setSetupComplete(true);
+				await recordInvestigationProgress(input, {
+					kind: "workspace_ready",
+					title: "Workspace ready",
+					detail: `Checked out ${cloneRef(input)} and restored the investigation workspace`,
+				});
+			},
+			onFailure: async (error) => {
+				await recordInvestigationProgress(input, {
+					kind: "workspace_failed",
+					title: "Workspace setup failed",
+					detail: "The investigation workspace could not be prepared",
+				});
+				const result = failedResult(
+					`I couldn't prepare the investigation workspace: ${errorMessage(error)}`,
+					"workspace",
+				);
+				await applyInvestigationResult(input, result, false, false);
+				log.error("workspace setup failed", { error: errorMessage(error) });
+			},
+		});
 	});
 
 	useTool(
@@ -753,23 +756,43 @@ Investigate.durability = { maxAttempts: 5, timeoutMs: FLUE_RUN_TIMEOUT_MS };
  */
 const EXEC_ENV_REGISTRY = Symbol.for("emdash-bot.execEnvs");
 
-function execEnvRegistry(): Map<string, ExecEnv> {
-	const store = globalThis as typeof globalThis & { [EXEC_ENV_REGISTRY]?: Map<string, ExecEnv> };
+interface ExecEnvEntry {
+	readonly env: ExecEnv;
+	readonly sandboxAttempt: { current: number };
+}
+
+function execEnvRegistry(): Map<string, ExecEnvEntry> {
+	const store = globalThis as typeof globalThis & {
+		[EXEC_ENV_REGISTRY]?: Map<string, ExecEnvEntry>;
+	};
 	return (store[EXEC_ENV_REGISTRY] ??= new Map());
 }
 
-function execEnvFor(id: string, input: InvestigateData): ExecEnv {
+function execEnvFor(
+	id: string,
+	input: InvestigateData,
+	workspaceSandboxAttempt: number,
+	setWorkspaceSandboxAttempt: (attempt: number) => void,
+): ExecEnv {
 	const registry = execEnvRegistry();
 	const existing = registry.get(id);
-	if (existing) return existing;
+	if (existing) {
+		existing.sandboxAttempt.current = workspaceSandboxAttempt;
+		return existing.env;
+	}
+	const sandboxAttempt = { current: workspaceSandboxAttempt };
 	const env = new ExecEnv({
 		state: new FileSystemStateBackend(new WorkspaceFileSystem(agentWorkspace(id))),
-		attachContainer: () => attachContainer(id, input),
+		attachContainer: () =>
+			attachContainer(id, input, sandboxAttempt.current, (attempt) => {
+				sandboxAttempt.current = attempt;
+				setWorkspaceSandboxAttempt(attempt);
+			}),
 		hydrateRepo: (dir, ref) => hydrateWorkspace(id, dir, ref),
 		deadlines: DEADLINES,
 		repoDir: REPO_DIR,
 	});
-	registry.set(id, env);
+	registry.set(id, { env, sandboxAttempt });
 	return env;
 }
 
@@ -922,10 +945,52 @@ function buildCodeToolDescription(): string {
  * issue-scoped push capability the outbound proxy verifies. The harness then
  * installs dependencies when needed and creates the base workspace build.
  */
-async function attachContainer(id: string, input: InvestigateData): Promise<ContainerBackend> {
-	const container = fromSandbox(
-		getSandbox(workerEnv.Sandbox, id, { sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS }),
-	);
+async function attachContainer(
+	id: string,
+	input: InvestigateData,
+	startAttempt: number,
+	onAttached: (attempt: number) => void,
+): Promise<ContainerBackend> {
+	return attachWorkspaceWithRetry({
+		agentId: id,
+		startAttempt,
+		attach: ({ sandboxId }) => attachContainerAttempt(sandboxId, input),
+		discard: async ({ sandboxId }) => {
+			await withDeadline(
+				workspaceSandbox(sandboxId).destroy(),
+				DEFAULT_RPC_TIMEOUT_MS,
+				"failed sandbox cleanup",
+			);
+		},
+		onDiscardFailure: async ({ sandboxId, discardError }) => {
+			console.warn("[investigate] failed sandbox cleanup", {
+				sandboxId,
+				error: errorMessage(discardError),
+			});
+		},
+		onRetry: async ({ attempt, error }) => {
+			console.warn("[investigate] retrying workspace on a fresh sandbox", {
+				runId: input.runId,
+				attempt: attempt + 1,
+				error: errorMessage(error),
+			});
+			await recordInvestigationProgress(input, {
+				kind: "workspace_installing",
+				title: "Retrying workspace preparation",
+				detail: `Starting a fresh sandbox after a transient platform failure (${attempt + 1}/${WORKSPACE_SANDBOX_ATTEMPT_LIMIT})`,
+			});
+		},
+		onAttached: async ({ attempt }) => {
+			onAttached(attempt);
+		},
+	});
+}
+
+async function attachContainerAttempt(
+	id: string,
+	input: InvestigateData,
+): Promise<ContainerBackend> {
+	const container = fromSandbox(workspaceSandbox(id));
 	await prepareContainer(container, input);
 	await bootstrapWorkspace(container, {
 		repoDir: REPO_DIR,
@@ -943,6 +1008,10 @@ async function attachContainer(id: string, input: InvestigateData): Promise<Cont
 			return result.exitCode === 0 && result.stdout.trim() === "true";
 		},
 	};
+}
+
+function workspaceSandbox(id: string) {
+	return getSandbox(workerEnv.Sandbox, id, { sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS });
 }
 
 async function recordBootstrapProgress(

--- a/infra/emdash-bot/.flue/lib/workspace-attachment.ts
+++ b/infra/emdash-bot/.flue/lib/workspace-attachment.ts
@@ -1,0 +1,144 @@
+export const WORKSPACE_SANDBOX_ATTEMPT_LIMIT = 3;
+
+const TRANSIENT_FAILURE_PATTERNS = [
+	/^HTTP error! status: 5\d\d\b/i,
+	/^internal error; reference\s*=\s*[a-z0-9]+$/i,
+	/network connection lost/i,
+	/container suddenly disconnected/i,
+	/error proxying request to container/i,
+	/container (?:is )?(?:unavailable|starting|provisioning|unhealthy|replaced)/i,
+	/no container instance/i,
+	/durable object.*(?:reset|upgraded)/i,
+];
+
+interface WorkspaceAttempt {
+	readonly attempt: number;
+	readonly sandboxId: string;
+}
+
+interface WorkspaceAttemptFailure extends WorkspaceAttempt {
+	readonly error: unknown;
+}
+
+interface WorkspaceRetry extends WorkspaceAttempt {
+	readonly error: unknown;
+}
+
+export async function attachWorkspaceWithRetry<T>(options: {
+	readonly agentId: string;
+	readonly startAttempt: number;
+	readonly attach: (attempt: WorkspaceAttempt) => Promise<T>;
+	readonly discard: (failure: WorkspaceAttemptFailure) => Promise<void>;
+	readonly onRetry?: (retry: WorkspaceRetry) => Promise<void>;
+	readonly onAttached?: (attempt: WorkspaceAttempt) => Promise<void>;
+	readonly onDiscardFailure?: (
+		failure: WorkspaceAttemptFailure & { readonly discardError: unknown },
+	) => Promise<void>;
+}): Promise<T> {
+	if (
+		!Number.isSafeInteger(options.startAttempt) ||
+		options.startAttempt < 0 ||
+		options.startAttempt >= WORKSPACE_SANDBOX_ATTEMPT_LIMIT
+	) {
+		throw new Error(`invalid workspace sandbox attempt: ${options.startAttempt}`);
+	}
+
+	for (
+		let attempt = options.startAttempt;
+		attempt < WORKSPACE_SANDBOX_ATTEMPT_LIMIT;
+		attempt += 1
+	) {
+		const sandboxId = workspaceSandboxId(options.agentId, attempt);
+		try {
+			const result = await options.attach({ attempt, sandboxId });
+			await options.onAttached?.({ attempt, sandboxId });
+			return result;
+		} catch (error) {
+			if (!isTransientWorkspaceFailure(error) || attempt + 1 >= WORKSPACE_SANDBOX_ATTEMPT_LIMIT) {
+				throw error;
+			}
+
+			try {
+				await options.discard({ attempt, sandboxId, error });
+			} catch (discardError) {
+				await options.onDiscardFailure?.({ attempt, sandboxId, error, discardError });
+			}
+
+			const nextAttempt = attempt + 1;
+			await options.onRetry?.({
+				attempt: nextAttempt,
+				sandboxId: workspaceSandboxId(options.agentId, nextAttempt),
+				error,
+			});
+		}
+	}
+
+	throw new Error("workspace sandbox attempts exhausted");
+}
+
+export async function prepareWorkspaceBeforeModel(options: {
+	readonly prepare: () => Promise<void>;
+	readonly onFailure: (error: unknown) => Promise<void>;
+}): Promise<void> {
+	try {
+		await options.prepare();
+	} catch (error) {
+		await options.onFailure(error);
+		throw error;
+	}
+}
+
+export function isTransientWorkspaceFailure(error: unknown): boolean {
+	for (const candidate of errorChain(error)) {
+		if (isRetryableError(candidate)) return true;
+		const name = errorName(candidate);
+		if (
+			name === "ContainerUnavailableError" ||
+			name === "OperationInterruptedError" ||
+			name === "RPCTransportError"
+		) {
+			return true;
+		}
+		const message = errorMessage(candidate);
+		if (TRANSIENT_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function workspaceSandboxId(agentId: string, attempt: number): string {
+	return attempt === 0 ? agentId : `${agentId}-r${attempt}`;
+}
+
+function* errorChain(error: unknown): Generator {
+	let current = error;
+	for (let depth = 0; depth < 8 && current != null; depth += 1) {
+		yield current;
+		current =
+			typeof current === "object" && "cause" in current
+				? (current as { readonly cause?: unknown }).cause
+				: undefined;
+	}
+}
+
+function errorName(error: unknown): string {
+	if (typeof error !== "object" || error === null || !("name" in error)) return "";
+	return typeof error.name === "string" ? error.name : "";
+}
+
+function errorMessage(error: unknown): string {
+	if (typeof error === "object" && error !== null && "message" in error) {
+		return typeof error.message === "string" ? error.message : "Unknown workspace error";
+	}
+	return typeof error === "string" ? error : "Unknown workspace error";
+}
+
+function isRetryableError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) return false;
+	if ("retryable" in error && error.retryable === true) return true;
+	if (!("context" in error) || typeof error.context !== "object" || error.context === null) {
+		return false;
+	}
+	return "retryable" in error.context && error.context.retryable === true;
+}

--- a/infra/emdash-bot/tests/unit/workspace-attachment.test.ts
+++ b/infra/emdash-bot/tests/unit/workspace-attachment.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+	attachWorkspaceWithRetry,
+	prepareWorkspaceBeforeModel,
+} from "../../.flue/lib/workspace-attachment.js";
+
+describe("workspace attachment", () => {
+	test("retries a transient platform failure on a fresh sandbox", async () => {
+		const attached: string[] = [];
+		const discarded: string[] = [];
+		const retries: Array<{ attempt: number; sandboxId: string; error: unknown }> = [];
+		const selected: number[] = [];
+
+		const result = await attachWorkspaceWithRetry({
+			agentId: "investigate-2535-run",
+			startAttempt: 0,
+			attach: async ({ sandboxId }) => {
+				attached.push(sandboxId);
+				if (attached.length === 1) {
+					throw new Error("internal error; reference = gea98gkmk3dntv1v53lg72if");
+				}
+				return "ready";
+			},
+			discard: async ({ sandboxId }) => {
+				discarded.push(sandboxId);
+			},
+			onRetry: async (event) => {
+				retries.push(event);
+			},
+			onAttached: async ({ attempt }) => {
+				selected.push(attempt);
+			},
+		});
+
+		expect(result).toBe("ready");
+		expect(attached).toEqual(["investigate-2535-run", "investigate-2535-run-r1"]);
+		expect(discarded).toEqual(["investigate-2535-run"]);
+		expect(retries).toMatchObject([
+			{
+				attempt: 1,
+				sandboxId: "investigate-2535-run-r1",
+				error: { message: "internal error; reference = gea98gkmk3dntv1v53lg72if" },
+			},
+		]);
+		expect(selected).toEqual([1]);
+	});
+
+	test("does not retry a deterministic workspace command failure", async () => {
+		const attach = vi.fn(async () => {
+			throw new Error("dependency installation failed (1): frozen lockfile mismatch");
+		});
+		const discard = vi.fn(async () => {});
+
+		await expect(
+			attachWorkspaceWithRetry({
+				agentId: "investigate-2535-run",
+				startAttempt: 0,
+				attach,
+				discard,
+			}),
+		).rejects.toThrow("dependency installation failed (1): frozen lockfile mismatch");
+
+		expect(attach).toHaveBeenCalledTimes(1);
+		expect(discard).not.toHaveBeenCalled();
+	});
+
+	test("continues on a fresh sandbox when failed-sandbox cleanup also fails", async () => {
+		const attached: string[] = [];
+		const cleanupFailures: unknown[] = [];
+
+		await expect(
+			attachWorkspaceWithRetry({
+				agentId: "investigate-2535-run",
+				startAttempt: 0,
+				attach: async ({ sandboxId }) => {
+					attached.push(sandboxId);
+					if (attached.length === 1) throw new Error("HTTP error! status: 500");
+					return "ready";
+				},
+				discard: async () => {
+					throw new Error("cleanup timed out");
+				},
+				onDiscardFailure: async ({ discardError }) => {
+					cleanupFailures.push(discardError);
+				},
+			}),
+		).resolves.toBe("ready");
+
+		expect(attached).toEqual(["investigate-2535-run", "investigate-2535-run-r1"]);
+		expect(cleanupFailures).toMatchObject([{ message: "cleanup timed out" }]);
+	});
+
+	test("reattaches to the persisted successful sandbox attempt", async () => {
+		const attached: string[] = [];
+
+		await attachWorkspaceWithRetry({
+			agentId: "investigate-2535-run",
+			startAttempt: 1,
+			attach: async ({ sandboxId }) => {
+				attached.push(sandboxId);
+				return "ready";
+			},
+			discard: async () => {},
+		});
+
+		expect(attached).toEqual(["investigate-2535-run-r1"]);
+	});
+
+	test("bounds fresh sandbox retries and preserves the final platform reference", async () => {
+		const attach = vi.fn(async ({ attempt }: { attempt: number; sandboxId: string }) => {
+			throw new Error(`internal error; reference = failure${attempt}`);
+		});
+
+		await expect(
+			attachWorkspaceWithRetry({
+				agentId: "investigate-2535-run",
+				startAttempt: 0,
+				attach,
+				discard: async () => {},
+			}),
+		).rejects.toThrow("internal error; reference = failure2");
+
+		expect(attach.mock.calls.map(([attempt]) => attempt.sandboxId)).toEqual([
+			"investigate-2535-run",
+			"investigate-2535-run-r1",
+			"investigate-2535-run-r2",
+		]);
+	});
+});
+
+describe("workspace setup gate", () => {
+	test("reports an exhausted workspace failure and rejects before the model can start", async () => {
+		const events: string[] = [];
+		const error = new Error("internal error; reference = finalfailure");
+
+		await expect(
+			prepareWorkspaceBeforeModel({
+				prepare: async () => {
+					events.push("prepare");
+					throw error;
+				},
+				onFailure: async (caught) => {
+					expect(caught).toBe(error);
+					events.push("report");
+				},
+			}),
+		).rejects.toBe(error);
+
+		expect(events).toEqual(["prepare", "report"]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Makes EmDashBot workspace bootstrap recover from the transient Cloudflare container failures observed on #2482 and #2535 without waking the model into a failed workspace.

- Retries only recognized Sandbox, container-proxy, Durable Object reset, and retryable transport failures; deterministic clone, install, and build command failures remain terminal.
- Rotates through at most three deterministic sandbox IDs so each retry receives a fresh Durable Object/container placement.
- Bounds failed-sandbox cleanup, continues onto the fresh placement if cleanup itself fails, and preserves platform error references in logs and the final outcome.
- Persists the successful sandbox attempt so later container reattachment returns to the same workspace.
- Reports retry progress while the run remains in its pre-deadline preparation phase.
- Reports an exhausted workspace failure and then rejects the `useAgentStart` hook, preventing any model turn or tool call from running without a prepared workspace.

Related to #2482 and #2535.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
  - `pnpm --dir infra/emdash-bot typecheck` still reports the pre-existing generated Durable Object namespace/export errors, Sandbox binding mismatch, pending-resume narrowing error, and verification fixture error. The new helper and tests add no type errors; the touched agent file reports only the existing generated `workerEnv.Sandbox` binding mismatch also present on `origin/main`.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
  - N/A: this changes private bot infrastructure, not the localized EmDash admin UI.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
  - N/A: only private `infra/emdash-bot` code changes.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
  - N/A: this is a maintainer-directed bug fix to private bot infrastructure.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm --dir infra/emdash-bot test` — 291 unit tests and 70 Worker integration tests passed
- `pnpm --dir infra/emdash-bot build` — passed
- `pnpm lint` — passed
- `pnpm lint:json | jq '.diagnostics | length'` — 0
- `pnpm format:check` — passed
- `pnpm --dir infra/emdash-bot typecheck` — fails only on the pre-existing baseline disclosed above

Residual risk: Cloudflare's untyped `internal error; reference = …` failures require message-based classification. Retries are capped at three placements, and command failures are explicitly excluded to avoid masking real repository failures.
