### PR TITLE
fix(bot): make workspace setup and candidate publication reliable

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -30,7 +30,7 @@ import {
 	type CandidatePublication,
 } from "../lib/candidate-publisher.js";
 import { type ContainerBackend, ExecEnv, fromSandbox, quote } from "../lib/exec-env.js";
-import { createPushCapability, PUSH_CAPABILITY_HEADER } from "../lib/github-proxy.js";
+import { createPushCapability, githubPushUrl } from "../lib/github-proxy.js";
 import {
 	getBranchSha,
 	mintInstallationToken,
@@ -900,7 +900,7 @@ async function prepareContainer(
 		...(pushCapability
 			? [
 					{
-						command: `cd ${REPO_DIR} && git config http.https://github.com/.extraHeader ${quote(`${PUSH_CAPABILITY_HEADER}: ${pushCapability}`)}`,
+						command: `cd ${REPO_DIR} && git remote set-url --push origin ${quote(githubPushUrl(repo.owner, repo.repo, pushCapability))}`,
 					},
 				]
 			: []),

--- a/infra/emdash-bot/.flue/cloudflare.ts
+++ b/infra/emdash-bot/.flue/cloudflare.ts
@@ -4,10 +4,12 @@
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 
 import {
-	githubAuthHeader,
+	githubGateDenialResponse,
 	inspectGithubRequest,
 	PUSH_CAPABILITY_HEADER,
+	pushCapabilityFromAuthorization,
 	verifyPushCapability,
+	withGithubAuthorization,
 } from "./lib/github-proxy.js";
 import { mintInstallationToken, readAppCreds } from "./lib/github.js";
 
@@ -62,13 +64,18 @@ async function handleAuthenticatedGithub(request: Request, env: Env): Promise<Re
 	}
 
 	const forwarded = new Request(request);
-	const capability = forwarded.headers.get(PUSH_CAPABILITY_HEADER);
+	const authorizationCapability = pushCapabilityFromAuthorization(
+		forwarded.headers.get("authorization"),
+	);
+	const legacyCapability = forwarded.headers.get(PUSH_CAPABILITY_HEADER);
+	const capability = authorizationCapability ?? legacyCapability;
 	const issueNumber = await verifyPushCapability(
 		capability,
 		env.GITHUB_WEBHOOK_SECRET,
 		owner,
 		repo,
 	);
+	forwarded.headers.delete("authorization");
 	forwarded.headers.delete(PUSH_CAPABILITY_HEADER);
 	const gate = await inspectGithubRequest(forwarded, url, owner, repo, issueNumber ?? undefined);
 	if (!gate.allowed) {
@@ -80,10 +87,15 @@ async function handleAuthenticatedGithub(request: Request, env: Env): Promise<Re
 			reason: gate.reason,
 			capabilityPresent: capability !== null,
 			capabilityValid: issueNumber !== null,
+			capabilityTransport: authorizationCapability
+				? "authorization"
+				: legacyCapability
+					? "legacy-header"
+					: "missing",
 			...(gate.refs ? { refs: gate.refs } : {}),
 			...(gate.parseError ? { parseError: gate.parseError } : {}),
 		});
-		return new Response(`forbidden: ${gate.reason}`, { status: 403 });
+		return githubGateDenialResponse(gate);
 	}
 
 	console.log("[sandbox/outbound] allow", {
@@ -105,8 +117,7 @@ async function handleAuthenticatedGithub(request: Request, env: Env): Promise<Re
 			});
 		}
 	}
-	const authed = new Request(forwarded);
-	if (token) authed.headers.set("authorization", githubAuthHeader(url.host, token));
+	const authed = withGithubAuthorization(forwarded, url.host, token);
 	authed.headers.set("user-agent", "emdash-bot");
 	try {
 		const res = await fetch(authed, { signal: AbortSignal.timeout(2 * 60_000) });

--- a/infra/emdash-bot/.flue/lib/github-proxy.ts
+++ b/infra/emdash-bot/.flue/lib/github-proxy.ts
@@ -1,6 +1,8 @@
 const PKT_LINE_HEADER = /^[0-9a-fA-F]{4}$/;
+const BASIC_AUTHORIZATION = /^Basic ([A-Za-z0-9+/]+={0,2})$/i;
 const WHITESPACE = /\s/;
 const MAX_RECEIVE_PACK_COMMAND_BYTES = 64 * 1024;
+const PUSH_CAPABILITY_USERNAME = "emdashbot";
 export const PUSH_CAPABILITY_HEADER = "X-EmDash-Push-Capability";
 
 export async function createPushCapability(
@@ -37,6 +39,30 @@ export async function verifyPushCapability(
 			new TextEncoder().encode(`${owner}/${repo}/${payload}`),
 		);
 		return valid ? issueNumber : null;
+	} catch {
+		return null;
+	}
+}
+
+export function githubPushUrl(owner: string, repo: string, capability: string): string {
+	if (!capability) throw new Error("push capability is not configured");
+	const url = new URL(`https://github.com/${owner}/${repo}.git`);
+	url.username = PUSH_CAPABILITY_USERNAME;
+	url.password = capability;
+	return url.toString();
+}
+
+export function pushCapabilityFromAuthorization(authorization: string | null): string | null {
+	const match = BASIC_AUTHORIZATION.exec(authorization ?? "");
+	if (!match?.[1]) return null;
+
+	try {
+		const credentials = atob(match[1]);
+		const separator = credentials.indexOf(":");
+		if (separator === -1 || credentials.slice(0, separator) !== PUSH_CAPABILITY_USERNAME) {
+			return null;
+		}
+		return credentials.slice(separator + 1) || null;
 	} catch {
 		return null;
 	}
@@ -84,6 +110,17 @@ export function githubAuthHeader(host: string, token: string): string {
 	return `Basic ${btoa(`x-access-token:${token}`)}`;
 }
 
+export function withGithubAuthorization(
+	request: Request,
+	host: string,
+	token: string | null,
+): Request {
+	const forwarded = new Request(request);
+	forwarded.headers.delete("authorization");
+	if (token) forwarded.headers.set("authorization", githubAuthHeader(host, token));
+	return forwarded;
+}
+
 export async function gateGithubRequest(
 	request: Request,
 	url: URL,
@@ -105,6 +142,19 @@ export type GithubGateResult =
 			parseError?: string;
 	  };
 
+export function githubGateDenialResponse(
+	result: Extract<GithubGateResult, { allowed: false }>,
+): Response {
+	const headers = new Headers({ "x-emdash-proxy-stage": result.stage });
+	if (result.stage === "capability") {
+		headers.set("www-authenticate", 'Basic realm="EmDash candidate push", charset="UTF-8"');
+	}
+	return new Response(`forbidden: ${result.reason}`, {
+		status: result.stage === "capability" ? 401 : 403,
+		headers,
+	});
+}
+
 export async function inspectGithubRequest(
 	request: Request,
 	url: URL,
@@ -123,6 +173,19 @@ export async function inspectGithubRequest(
 			(url.pathname === repoPath || url.pathname === `${repoPath}/`)
 		) {
 			return { allowed: true, stage: "allowed" };
+		}
+		if (
+			url.pathname === `${gitPath}/info/refs` &&
+			(method === "GET" || method === "HEAD") &&
+			url.searchParams.get("service") === "git-receive-pack"
+		) {
+			return issueNumber === undefined
+				? {
+						allowed: false,
+						stage: "capability",
+						reason: "git push requires a valid issue-scoped capability",
+					}
+				: { allowed: true, stage: "allowed" };
 		}
 		if (url.pathname === `${gitPath}/git-receive-pack` && method === "POST") {
 			if (issueNumber === undefined) {

--- a/infra/emdash-bot/Dockerfile
+++ b/infra/emdash-bot/Dockerfile
@@ -108,6 +108,9 @@ RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && node --version && npm --version && pnpm --version
 
 ENV NODE_OPTIONS="--max-old-space-size=6144"
+# Native dependency fallbacks use the Node headers copied into this image.
+# Without this, node-gyp downloads the same headers again at runtime.
+ENV npm_config_nodedir=/usr/local
 
 # The agent operates under /workspace; the workflow clones into /workspace/repo.
 WORKDIR /workspace

--- a/infra/emdash-bot/tests/unit/git-publication.test.ts
+++ b/infra/emdash-bot/tests/unit/git-publication.test.ts
@@ -55,7 +55,7 @@ describe("candidate git publication", () => {
 		} finally {
 			await rm(root, { recursive: true, force: true });
 		}
-	});
+	}, 15_000);
 });
 
 function memoryState(): IsolateState {

--- a/infra/emdash-bot/tests/unit/github-proxy.test.ts
+++ b/infra/emdash-bot/tests/unit/github-proxy.test.ts
@@ -4,7 +4,11 @@ import {
 	createPushCapability,
 	gateGithubRequest,
 	githubAuthHeader,
+	githubGateDenialResponse,
+	githubPushUrl,
 	inspectGithubRequest,
+	pushCapabilityFromAuthorization,
+	withGithubAuthorization,
 	verifyPushCapability,
 } from "../../.flue/lib/github-proxy.js";
 
@@ -35,6 +39,47 @@ describe("githubAuthHeader", () => {
 });
 
 describe("push capabilities", () => {
+	test("travels as standard Basic credentials on the push URL", async () => {
+		const capability = await createPushCapability("webhook-secret", OWNER, REPO, 123);
+		const url = new URL(githubPushUrl(OWNER, REPO, capability));
+		const authorization = `Basic ${btoa(`${url.username}:${url.password}`)}`;
+
+		expect(url.origin).toBe("https://github.com");
+		expect(url.pathname).toBe(`/${OWNER}/${REPO}.git`);
+		expect(pushCapabilityFromAuthorization(authorization)).toBe(capability);
+	});
+
+	test("rejects malformed or unrelated Basic credentials", () => {
+		expect(pushCapabilityFromAuthorization(null)).toBeNull();
+		expect(pushCapabilityFromAuthorization("Bearer sandbox-capability")).toBeNull();
+		expect(pushCapabilityFromAuthorization("Basic not-base64!")).toBeNull();
+		expect(
+			pushCapabilityFromAuthorization(`Basic ${btoa("someone-else:123.signature")}`),
+		).toBeNull();
+		expect(pushCapabilityFromAuthorization(`Basic ${btoa("emdashbot:")}`)).toBeNull();
+	});
+
+	test("strips sandbox credentials and replaces them only with the installation token", async () => {
+		const request = new Request("https://github.com/emdash-cms/emdash.git/git-receive-pack", {
+			method: "POST",
+			headers: { authorization: `Basic ${btoa("emdashbot:123.signature")}` },
+			body: "PACK payload",
+		});
+		const anonymous = withGithubAuthorization(request.clone(), "github.com", null);
+		const authenticated = withGithubAuthorization(
+			request.clone(),
+			"github.com",
+			"installation-token",
+		);
+
+		expect(anonymous.headers.has("authorization")).toBe(false);
+		expect(authenticated.headers.get("authorization")).toBe(
+			`Basic ${btoa("x-access-token:installation-token")}`,
+		);
+		await expect(anonymous.text()).resolves.toBe("PACK payload");
+		await expect(authenticated.text()).resolves.toBe("PACK payload");
+	});
+
 	test("round-trips only with the signing secret", async () => {
 		const capability = await createPushCapability("webhook-secret", OWNER, REPO, 123);
 
@@ -130,6 +175,25 @@ describe("gateGithubRequest", () => {
 			allowed: false,
 			stage: "receive-pack",
 			refs: ["refs/heads/bot/fix-123"],
+		});
+	});
+
+	test("challenges before advertising receive-pack so Git sends push credentials", async () => {
+		const url = new URL(
+			"https://github.com/emdash-cms/emdash.git/info/refs?service=git-receive-pack",
+		);
+		const request = new Request(url);
+
+		const result = await inspectGithubRequest(request, url, OWNER, REPO);
+		expect(result).toMatchObject({ allowed: false, stage: "capability" });
+		if (result.allowed) throw new Error("expected the push advertisement to be denied");
+
+		const response = githubGateDenialResponse(result);
+		expect(response.status).toBe(401);
+		expect(response.headers.get("www-authenticate")).toMatch(/^Basic /);
+		expect(response.headers.get("x-emdash-proxy-stage")).toBe("capability");
+		await expect(inspectGithubRequest(request, url, OWNER, REPO, 123)).resolves.toMatchObject({
+			allowed: true,
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

Fixes two independent failures that prevented EmDashBot runs from completing reliably.

First, native dependency fallback builds now use the Node headers already baked into the sandbox image. `better-sqlite3` tries a source build when its prebuilt binary is unavailable; without `npm_config_nodedir`, node-gyp downloaded the same headers again from `nodejs.org`. That intermittent runtime request caused the clean-install failures seen on #1623 and #2535 while #2482 succeeded on another placement.

Second, candidate pushes no longer depend on a custom HTTP header surviving Sandbox TLS interception. Write-mode sandboxes receive an issue-scoped HMAC capability as standard Basic credentials on the push-only Git remote. The proxy:

- challenges the receive-pack advertisement so Git sends those credentials;
- validates the capability before accepting a push;
- preserves the existing candidate/artifact branch allowlist and receive-pack inspection;
- strips the sandbox credential and replaces it with the short-lived GitHub App installation token; and
- reports proxy denial stages separately from upstream GitHub responses.

The legacy capability header remains accepted during rollout for compatibility with existing sandboxes. The installation token is never exposed to the sandbox.

The PR also raises the one filesystem-heavy candidate publication test timeout from 5 to 15 seconds. It took 8.2 seconds under local load while all assertions passed, so the previous global default produced a false failure.

Related to #1623, #2482, and #2535.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
  - The private bot's pre-existing generated Durable Object binding baseline still fails. Examples include `DurableObjectNamespace<undefined>` for `Sandbox`, missing generated methods on `Orchestrator` stubs, `Cloudflare.Exports.default`, and the existing `pendingResume is possibly undefined` error. No typecheck error points to the changed proxy/authentication code.
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
  - N/A: private bot infrastructure only; no admin UI strings change.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
  - N/A: only private `infra/emdash-bot` code and its container image change.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
  - N/A: this is a bug fix, not a new feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm lint:json | jq '.diagnostics | length'` — `0`
- `pnpm lint:quick` — passed
- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 26 files, 273 tests passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 2 files, 70 tests passed
- Focused GitHub proxy tests — 15 tests passed
- `pnpm --filter @emdash-cms/emdash-bot build` — passed
- `pnpm format` — completed
- `docker build --platform linux/amd64 ... infra/emdash-bot` — passed for the image change
- Offline native-build probe before the image change — attempted `nodejs.org` and failed with `EAI_AGAIN`
- Identical offline probe after the image change — used `/usr/local/include/node/common.gypi` and compiled `better_sqlite3.node`
- Local Git HTTP probe — Git first sent no credentials, then sent the expected Basic credentials after a 401 challenge; the proxy tests lock in that negotiation

Residual risk: the exact Sandbox TLS interception path still needs production confirmation after release. The capability is not a GitHub credential and remains limited by the proxy to the current issue's candidate/artifact branches. Native source compilation is slower than a prebuilt binary when the prebuild is unavailable, but it no longer adds a second runtime download dependency.
