### PR TITLE
test(core): stabilize migration signal cleanup

### DIFF
--- a/packages/core/tests/integration/cli/migrate-sqlite.test.ts
+++ b/packages/core/tests/integration/cli/migrate-sqlite.test.ts
@@ -129,7 +129,7 @@ describe("built migrate CLI with SQLite", () => {
 			export function createMigrationExecutor(config) {
 				return {
 					target: Object.freeze({ kind: "test", label: "signal-target", fingerprint: "${"d".repeat(64)}" }),
-					execute() { return new Promise(() => { timer = setInterval(() => {}, 1_000); }); },
+					execute() { return new Promise(() => { timer = setInterval(() => {}, 1_000); process.stderr.write("executor ready\\n"); }); },
 				async dispose() { clearInterval(timer); await writeFile(config.markerPath, "disposed"); }
 				};
 			}`,
@@ -163,7 +163,7 @@ describe("built migrate CLI with SQLite", () => {
 		await new Promise<void>((resolveTarget, rejectTarget) => {
 			child.stderr.on("data", (chunk: string) => {
 				stderr += chunk;
-				if (stderr.includes("Target fingerprint:")) resolveTarget();
+				if (stderr.includes("executor ready")) resolveTarget();
 			});
 			child.once("error", rejectTarget);
 			child.once("exit", (code, signal) =>
@@ -176,5 +176,5 @@ describe("built migrate CLI with SQLite", () => {
 		expect(code).toBe(MIGRATE_EXIT_CODES.interrupted);
 		expect(signal).toBeNull();
 		expect(await readFile(markerPath, "utf8")).toBe("disposed");
-	});
+	}, 15_000);
 });


### PR DESCRIPTION
## What does this PR do?

Stabilizes the built migrate CLI signal-cleanup integration test. The fixture now emits a readiness marker from its executor after the CLI signal handlers are installed, and the parent waits for that marker before sending SIGTERM. This removes the race where the process could receive SIGTERM after printing its target but before registering cleanup handlers.

The test has an explicit 15-second timeout so slower CI runners have bounded headroom without changing production behavior.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (n/a: test-only; no user-visible strings)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (n/a: test-only; no published package behavior changed)
- [x] New features link to an approved Discussion (n/a: no feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not visual.

TDD evidence: changing the wait condition to executor readiness failed with a 30-second timeout before the fixture emitted the marker. After the fixture change:

- `pnpm test:integration tests/integration/cli/migrate-sqlite.test.ts` — 2 passed
- `pnpm typecheck` — passed across 31 package projects
- `pnpm lint:json` — 0 diagnostics
- `pnpm lint:quick` — passed
- `pnpm format:check` — passed

No pre-existing failures remained after the fresh worktree build restored generated package artifacts.