### PR TITLE
chore(playground): enable preview URLs

### DIFF
--- a/demos/playground/wrangler.jsonc
+++ b/demos/playground/wrangler.jsonc
@@ -3,6 +3,7 @@
 	"name": "emdash-playground",
 	"compatibility_date": "2026-02-24",
 	"compatibility_flags": ["nodejs_compat"],
+	"preview_urls": true,
 	// Custom entrypoint that exports EmDashPreviewDB
 	"main": "./src/worker.ts",
 	"durable_objects": {
@@ -25,8 +26,8 @@
 	"routes": [
 		{
 			"pattern": "try.emdashcms.com",
-			"zone_name": "emdashcms.com",
 			"custom_domain": true,
+			"previews_enabled": true,
 		},
 	],
 	"kv_namespaces": [


### PR DESCRIPTION
## What does this PR do?

Explicitly enables Worker Preview URLs for the playground's `workers.dev` hostname and enables previews for the `try.emdashcms.com` custom domain.

The custom-domain route now uses Wrangler's preview-capable shape (`pattern`, `custom_domain`, and `previews_enabled`); Wrangler infers the zone from the hostname, so the redundant `zone_name` field is removed.

Related issue: none.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (not applicable: configuration-only change; validated with Wrangler)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no admin UI changes)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (not applicable: no published package changes)
- [x] New features link to an approved Discussion (not applicable: tooling configuration only)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

No visual changes.

- `pnpm build`
- `pnpm typecheck`
- `pnpm typecheck:demos`
- `pnpm lint`
- `pnpm lint:quick`
- `pnpm format`
- `wrangler types /tmp/emdash-playground-worker-types.d.ts --include-runtime false`
