### PR TITLE
chore(bot): link playground previews

### DIFF
--- a/infra/emdash-bot/.flue/lib/comments.ts
+++ b/infra/emdash-bot/.flue/lib/comments.ts
@@ -1,5 +1,10 @@
 import type { Kind, StateId } from "./machine.js";
-import { artifactsBranch, fixBranch, previewInstallCommand } from "./preview.js";
+import {
+	artifactsBranch,
+	fixBranch,
+	playgroundPreviewUrl,
+	previewInstallCommand,
+} from "./preview.js";
 import type { Decision } from "./router.js";
 
 export function shouldPostReadonlyReply(dryRun?: boolean): boolean {
@@ -167,6 +172,10 @@ export function renderPreviewReadyAsk(input: {
 		"```bash",
 		previewInstallCommand(input.issueNumber, input.previewPackage),
 		"```",
+		"",
+		"Or try the candidate in a ready-to-use playground:",
+		"",
+		`[Open the playground preview](${playgroundPreviewUrl(input.issueNumber)})`,
 		"",
 		...(shots.length > 0 ? ["**Screenshots:**", "", shots.join("\n\n"), ""] : []),
 		reporterAsk,

--- a/infra/emdash-bot/.flue/lib/preview.ts
+++ b/infra/emdash-bot/.flue/lib/preview.ts
@@ -57,6 +57,10 @@ export function previewInstallCommand(issueNumber: number, previewPackage = "emd
 	return `npm i ${previewUrl(issueNumber, previewPackage)}`;
 }
 
+export function playgroundPreviewUrl(issueNumber: number): string {
+	return `https://${fixBranch(issueNumber).replaceAll("/", "-")}.try.emdashcms.com/`;
+}
+
 /**
  * Probe pkg.pr.new for a published preview. Returns true on a 2xx, false on
  * anything else (a 404 while publishing is still in flight, a network error, or

--- a/infra/emdash-bot/tests/unit/orchestrator-comments.test.ts
+++ b/infra/emdash-bot/tests/unit/orchestrator-comments.test.ts
@@ -83,6 +83,7 @@ describe("renderPreviewReadyAsk", () => {
 		const body = ask();
 		expect(body).toContain("<!-- bot-ask: 2026-08-08T00:00:00Z -->");
 		expect(body).toContain("npm i https://pkg.pr.new/emdash@bot/fix-77");
+		expect(body).toContain("[Open the playground preview](https://bot-fix-77.try.emdashcms.com/)");
 		expect(body).toContain("Root cause: the loader drops the locale.");
 		expect(body).toContain("@alice");
 		expect(body).toContain("`bot/fix-77`");

--- a/infra/emdash-bot/tests/unit/preview.test.ts
+++ b/infra/emdash-bot/tests/unit/preview.test.ts
@@ -4,6 +4,7 @@ import {
 	artifactsBranch,
 	branchesToReap,
 	fixBranch,
+	playgroundPreviewUrl,
 	previewInstallCommand,
 	previewUrl,
 	probePreviewReady,
@@ -15,6 +16,7 @@ describe("preview branch + URL helpers", () => {
 		expect(artifactsBranch(42)).toBe("bot/artifacts-42");
 		expect(previewUrl(42)).toBe("https://pkg.pr.new/emdash@bot/fix-42");
 		expect(previewInstallCommand(42)).toBe("npm i https://pkg.pr.new/emdash@bot/fix-42");
+		expect(playgroundPreviewUrl(42)).toBe("https://bot-fix-42.try.emdashcms.com/");
 	});
 
 	test("supports a staging package without probing the production preview", () => {


### PR DESCRIPTION
## What does this PR do?

Adds a ready-to-use playground link to emdashbot's package-preview comment. Candidate branch names are converted to the custom-domain preview hostname, so `bot/fix-2573` links to `https://bot-fix-2573.try.emdashcms.com/`.

This builds on the playground preview URL configuration merged in #2579.

Related issue: none.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no admin UI changes)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (not applicable: no published package changes)
- [x] New features link to an approved Discussion (not applicable: internal bot tooling)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

No visual UI changes.

- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 293 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 74 passed
- `pnpm lint`
- `pnpm format`

`pnpm --filter @emdash-cms/emdash-bot typecheck` is currently blocked on `main`: Wrangler 4.124 regenerates the Durable Object bindings without their RPC types, producing existing `DurableObjectStub<undefined>` errors across the bot. This change does not touch Wrangler configuration or generated bindings.
