### PR TITLE
feat(media): add numbered library pagination

### DIFF
--- a/.changeset/bright-media-pages.md
+++ b/.changeset/bright-media-pages.md
@@ -1,0 +1,8 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+---
+
+Adds numbered page navigation and page-size controls to the local Media Library. Media list requests can opt into numbered pages with `page` and receive an exact `totalCount`; cursor pagination remains the default.
+
+`MediaLibrary` accepts controlled numbered pagination through `pagination`. Existing `hasMore` and `onLoadMore` props remain supported when `pagination` is omitted.

--- a/e2e/tests/admin-fixes.spec.ts
+++ b/e2e/tests/admin-fixes.spec.ts
@@ -96,7 +96,7 @@ test.describe("Media metadata updates", () => {
 		await admin.waitForLoading();
 
 		// Wait for the image to appear in the grid
-		const mediaGrid = page.locator(".grid.gap-4");
+		const mediaGrid = page.locator("[data-media-grid]");
 		await expect(mediaGrid.locator("img").first()).toBeVisible({ timeout: 5000 });
 
 		// Click the image to open the detail panel

--- a/e2e/tests/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/keyboard-shortcuts.spec.ts
@@ -22,7 +22,7 @@ test.describe("Keyboard Shortcuts", () => {
 			await admin.waitForLoading();
 
 			// Seed data includes uploaded media — click the first grid item (a button)
-			const mediaItem = page.locator(".grid.gap-4 button").first();
+			const mediaItem = page.locator("[data-media-grid] button").first();
 			await expect(mediaItem).toBeVisible({ timeout: 10000 });
 			await mediaItem.click();
 
@@ -42,7 +42,7 @@ test.describe("Keyboard Shortcuts", () => {
 			await admin.waitForLoading();
 
 			// Click the first media item
-			const mediaItem = page.locator(".grid.gap-4 button").first();
+			const mediaItem = page.locator("[data-media-grid] button").first();
 			await expect(mediaItem).toBeVisible({ timeout: 10000 });
 			await mediaItem.click();
 

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -115,7 +115,7 @@ test.describe("Media Library", () => {
 			await uploadTestImage(page);
 
 			// Wait for the uploaded image to appear in the media grid
-			const mediaGrid = page.locator(".grid.gap-4");
+			const mediaGrid = page.locator("[data-media-grid]");
 			await expect(mediaGrid.locator("img").first()).toBeVisible({ timeout: 5000 });
 
 			// Should have at least one image in the grid now

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -1,5 +1,4 @@
-import { Button, Input, Loader, Select, Tabs } from "@cloudflare/kumo";
-import { plural } from "@lingui/core/macro";
+import { Button, Input, Loader, Pagination, Select, Tabs } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Upload, Images, SquaresFour, List, MagnifyingGlass } from "@phosphor-icons/react";
 import type { Icon } from "@phosphor-icons/react";
@@ -55,11 +54,24 @@ export interface MediaLibraryProps {
 	hasMore?: boolean;
 	/** Triggered to fetch the next page of local-library items */
 	onLoadMore?: () => void;
+	pagination?: MediaLibraryPagination;
 	/** Called (debounced) with the filename search term for the local library. */
 	onLocalSearchChange?: (q: string) => void;
 	/** Called with the MIME filter for the local library (undefined = all types). */
 	onLocalMimeFilterChange?: (mimeType: string | string[] | undefined) => void;
 }
+
+export interface MediaLibraryPagination {
+	page: number;
+	perPage: number;
+	totalCount: number;
+	isPending: boolean;
+	onPageChange: (page: number) => void;
+	onPageSizeChange: (perPage: number) => void;
+}
+
+const MEDIA_PAGE_SIZE_OPTIONS = [35, 70, 90];
+const MAX_DROPDOWN_PAGE_COUNT = 100;
 
 /**
  * Media library component with upload, provider tabs, and grid view
@@ -71,6 +83,7 @@ export function MediaLibrary({
 	onItemUpdated,
 	hasMore,
 	onLoadMore,
+	pagination,
 	onLocalSearchChange,
 	onLocalMimeFilterChange,
 }: MediaLibraryProps) {
@@ -83,6 +96,11 @@ export function MediaLibrary({
 	const [localTypeFilter, setLocalTypeFilter] = React.useState("all");
 	const mediaHeadingRef = React.useRef<HTMLHeadingElement>(null);
 	const detailOpenFrameRef = React.useRef<number | null>(null);
+	const paginationRequestedRef = React.useRef(false);
+	const paginationWasPendingRef = React.useRef(false);
+	const paginationRootRef = React.useRef<HTMLDivElement>(null);
+	const paginationFocusTargetRef = React.useRef<HTMLElement | null>(null);
+	const paginationFocusFallbackRef = React.useRef<"page" | "page-size">("page");
 	// Debounced filename search reported up for the local library's server query.
 	const debouncedSearch = useDebouncedValue(searchQuery, 300);
 	React.useEffect(() => {
@@ -148,6 +166,56 @@ export function MediaLibrary({
 	}, []);
 
 	React.useEffect(() => cancelPendingDetailOpen, [cancelPendingDetailOpen]);
+
+	const requestPage = React.useCallback(
+		(nextPage: number) => {
+			if (!pagination || pagination.isPending) return;
+			const pageCount = Math.max(1, Math.ceil(pagination.totalCount / pagination.perPage));
+			if (!Number.isSafeInteger(nextPage) || nextPage < 1 || nextPage > pageCount) return;
+			paginationRequestedRef.current = true;
+			paginationFocusTargetRef.current =
+				document.activeElement instanceof HTMLElement ? document.activeElement : null;
+			paginationFocusFallbackRef.current = "page";
+			pagination.onPageChange(nextPage);
+		},
+		[pagination],
+	);
+	const requestPageSize = React.useCallback(
+		(nextPerPage: number) => {
+			if (!pagination || pagination.isPending || !MEDIA_PAGE_SIZE_OPTIONS.includes(nextPerPage)) {
+				return;
+			}
+			paginationRequestedRef.current = true;
+			paginationFocusTargetRef.current =
+				document.activeElement instanceof HTMLElement ? document.activeElement : null;
+			paginationFocusFallbackRef.current = "page-size";
+			pagination.onPageSizeChange(nextPerPage);
+		},
+		[pagination],
+	);
+	React.useEffect(() => {
+		const pending = pagination?.isPending ?? false;
+		if (activeProvider !== "local") {
+			paginationRequestedRef.current = false;
+			paginationFocusTargetRef.current = null;
+		} else if (paginationRequestedRef.current && paginationWasPendingRef.current && !pending) {
+			paginationRequestedRef.current = false;
+			let focusTarget = paginationFocusTargetRef.current;
+			if (!focusTarget?.isConnected || focusTarget.matches(":disabled")) {
+				const slot =
+					paginationFocusFallbackRef.current === "page-size"
+						? "pagination-page-size"
+						: "pagination-controls";
+				focusTarget =
+					paginationRootRef.current?.querySelector<HTMLElement>(
+						`[data-slot="${slot}"] [role="combobox"], [data-slot="${slot}"] input, [data-slot="${slot}"] button:not(:disabled)`,
+					) ?? null;
+			}
+			paginationFocusTargetRef.current = null;
+			focusTarget?.focus({ preventScroll: true });
+		}
+		paginationWasPendingRef.current = pending;
+	}, [activeProvider, pagination?.isPending]);
 
 	const openDetail = React.useCallback(
 		(item: MediaItem) => {
@@ -256,13 +324,9 @@ export function MediaLibrary({
 	const currentLoading = activeProvider === "local" ? isLoading : providerLoading;
 
 	const resultCount =
-		activeProvider === "local" ? currentItems.length : currentProviderItems.length;
-	const hasMoreCurrentItems =
-		activeProvider === "local" ? Boolean(hasMore) : Boolean(providerData?.nextCursor);
-	const resultCountText =
-		resultCount > 0 && !hasMoreCurrentItems
-			? plural(resultCount, { one: "# item", other: "# items" })
-			: "";
+		activeProvider === "local"
+			? (pagination?.totalCount ?? currentItems.length)
+			: currentProviderItems.length;
 	const hasActiveQuery =
 		searchQuery.trim() !== "" || (activeProvider === "local" && localTypeFilter !== "all");
 	const clearLocalQuery = () => {
@@ -305,7 +369,7 @@ export function MediaLibrary({
 	}, [refetchProviderMedia, uploadTarget?.id]);
 
 	return (
-		<div className="space-y-4" data-media-library>
+		<div className="space-y-4" data-media-library aria-busy={currentLoading || undefined}>
 			{isFileDragActive && (
 				<div
 					className="pointer-events-none fixed inset-0 z-50 bg-kumo-base/70 p-4 backdrop-blur-sm sm:p-8"
@@ -363,7 +427,7 @@ export function MediaLibrary({
 				/>
 			)}
 
-			{/* Toolbar: search + type filter (start) · result count + view toggle (end).
+			{/* Toolbar: search + type filter (start) · view toggle (end).
 			    Local library search/filter is handled server-side. */}
 			{showToolbar && (
 				<div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
@@ -404,10 +468,7 @@ export function MediaLibrary({
 							/>
 						)}
 					</div>
-					<div className="flex flex-shrink-0 items-center justify-between gap-3 sm:justify-end">
-						<span className="text-sm text-kumo-subtle tabular-nums" aria-live="polite">
-							{resultCountText}
-						</span>
+					<div className="flex flex-shrink-0 items-center justify-end">
 						<div role="group" aria-label={t`View mode`}>
 							<Tabs
 								variant="segmented"
@@ -505,7 +566,11 @@ export function MediaLibrary({
 					/>
 				)
 			) : viewMode === "grid" ? (
-				<div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(160px,1fr))]">
+				<div
+					data-media-grid
+					inert={currentLoading || undefined}
+					className="grid gap-3 grid-cols-[repeat(auto-fill,minmax(160px,1fr))]"
+				>
 					{activeProvider === "local"
 						? currentItems.map((item) => (
 								<MediaGridItem
@@ -542,7 +607,10 @@ export function MediaLibrary({
 							))}
 				</div>
 			) : (
-				<div className="rounded-md border bg-kumo-base overflow-x-auto">
+				<div
+					inert={currentLoading || undefined}
+					className="rounded-md border bg-kumo-base overflow-x-auto"
+				>
 					<table className="w-full">
 						<thead>
 							<tr className="border-b bg-kumo-tint/50">
@@ -592,8 +660,51 @@ export function MediaLibrary({
 				</div>
 			)}
 
-			{/* Load more (local library only — providers handle pagination internally) */}
-			{activeProvider === "local" && hasMore && onLoadMore && (
+			{activeProvider === "local" && pagination && pagination.totalCount > 0 && (
+				<div ref={paginationRootRef} className="min-w-0">
+					<Pagination
+						page={pagination.page}
+						setPage={requestPage}
+						perPage={pagination.perPage}
+						totalCount={pagination.totalCount}
+						className="flex-wrap gap-y-3"
+						labels={{
+							navigation: t`Media pagination`,
+							firstPage: t`First page`,
+							previousPage: t`Previous page`,
+							nextPage: t`Next page`,
+							lastPage: t`Last page`,
+							pageNumber: t`Page number`,
+							pageSize: t`Page size`,
+						}}
+					>
+						<Pagination.Info className="min-w-fit">
+							{({ pageShowingRange, totalCount }) => (
+								<span role="status">{t`Showing ${pageShowingRange} of ${totalCount ?? 0}`}</span>
+							)}
+						</Pagination.Info>
+						<Pagination.Separator className="hidden sm:block" />
+						<div inert={pagination.isPending || undefined} className="contents">
+							<Pagination.PageSize
+								value={pagination.perPage}
+								onChange={requestPageSize}
+								options={MEDIA_PAGE_SIZE_OPTIONS}
+								label={t`Per page`}
+							/>
+							<Pagination.Controls
+								pageSelector={
+									Math.ceil(pagination.totalCount / pagination.perPage) <= MAX_DROPDOWN_PAGE_COUNT
+										? "dropdown"
+										: "input"
+								}
+								className="basis-full sm:basis-auto rtl:[&_svg]:-scale-x-100"
+							/>
+						</div>
+					</Pagination>
+				</div>
+			)}
+
+			{activeProvider === "local" && !pagination && hasMore && onLoadMore && (
 				<div className="flex justify-center">
 					<Button variant="outline" onClick={onLoadMore} disabled={isLoading}>
 						{isLoading ? t`Loading...` : t`Load More`}

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -51,18 +51,24 @@ export interface MediaItem {
 	meta?: Record<string, unknown>;
 }
 
+export interface MediaListResult extends FindManyResult<MediaItem> {
+	totalCount?: number;
+}
+
 /**
  * Fetch media list
  */
 export async function fetchMediaList(options?: {
 	cursor?: string;
+	page?: number;
 	limit?: number;
 	mimeType?: string | string[];
 	/** Case-insensitive filename substring search (also matches extensions). */
 	search?: string;
-}): Promise<FindManyResult<MediaItem>> {
+}): Promise<MediaListResult> {
 	const params = new URLSearchParams();
 	if (options?.cursor) params.set("cursor", options.cursor);
+	if (options?.page !== undefined) params.set("page", String(options.page));
 	if (options?.limit) params.set("limit", String(options.limit));
 	if (options?.mimeType) {
 		const value = Array.isArray(options.mimeType) ? options.mimeType.join(",") : options.mimeType;
@@ -77,7 +83,7 @@ export async function fetchMediaList(options?: {
 
 	const url = `${API_BASE}/media${params.toString() ? `?${params}` : ""}`;
 	const response = await apiFetch(url);
-	return parseApiResponse<FindManyResult<MediaItem>>(response, i18n._(msg`Failed to fetch media`));
+	return parseApiResponse<MediaListResult>(response, i18n._(msg`Failed to fetch media`));
 }
 
 /**

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -8,7 +8,13 @@ import { Button, Loader, Toast, useKumoToastManager } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import type { QueryClient } from "@tanstack/react-query";
-import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+	keepPreviousData,
+	useQuery,
+	useInfiniteQuery,
+	useMutation,
+	useQueryClient,
+} from "@tanstack/react-query";
 import {
 	createRouter,
 	createRootRouteWithContext,
@@ -1370,36 +1376,80 @@ const mediaRoute = createRoute({
 function MediaPage() {
 	const queryClient = useQueryClient();
 
-	// Filename search + MIME type filter for the local library (server-side).
 	const [search, setSearch] = React.useState("");
 	const [mimeFilter, setMimeFilter] = React.useState<string | string[] | undefined>(undefined);
+	const [page, setPage] = React.useState(1);
+	const [perPage, setPerPage] = React.useState(35);
+	const [retainedTotalCount, setRetainedTotalCount] = React.useState(0);
 	const mimeKey = Array.isArray(mimeFilter) ? mimeFilter.join(",") : (mimeFilter ?? "");
 
-	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } =
-		useInfiniteQuery({
-			queryKey: ["media", { search, mime: mimeKey }],
-			queryFn: ({ pageParam }) =>
-				fetchMediaList({
-					cursor: pageParam,
-					limit: 100,
-					search: search || undefined,
-					mimeType: mimeFilter,
-				}),
-			initialPageParam: undefined as string | undefined,
-			getNextPageParam: (lastPage) => lastPage.nextCursor,
-		});
+	const { data, isLoading, isFetching, error } = useQuery({
+		queryKey: ["media", { search, mime: mimeKey, page, perPage }],
+		queryFn: () =>
+			fetchMediaList({
+				page,
+				limit: perPage,
+				search: search || undefined,
+				mimeType: mimeFilter,
+			}),
+		placeholderData: keepPreviousData,
+	});
+
+	React.useEffect(() => {
+		if (data?.totalCount !== undefined) setRetainedTotalCount(data.totalCount);
+	}, [data?.totalCount]);
+
+	const totalCount = data?.totalCount ?? retainedTotalCount;
+	const lastPage = Math.max(1, Math.ceil((data?.totalCount ?? 0) / perPage));
+	const isRecoveringPage = data?.totalCount !== undefined && page > lastPage;
+	React.useEffect(() => {
+		if (isRecoveringPage) setPage(lastPage);
+	}, [isRecoveringPage, lastPage]);
+
+	const pageCount = Math.max(1, Math.ceil(totalCount / perPage));
+	const handlePageChange = React.useCallback(
+		(nextPage: number) => {
+			if (isFetching || !Number.isSafeInteger(nextPage) || nextPage < 1 || nextPage > pageCount) {
+				return;
+			}
+			setPage(nextPage);
+		},
+		[isFetching, pageCount],
+	);
+	const handlePageSizeChange = React.useCallback(
+		(nextPerPage: number) => {
+			if (isFetching) return;
+			setPerPage(nextPerPage);
+			setPage(1);
+			setRetainedTotalCount(0);
+		},
+		[isFetching],
+	);
+	const handleSearchChange = React.useCallback((nextSearch: string) => {
+		setSearch(nextSearch);
+		setPage(1);
+		setRetainedTotalCount(0);
+	}, []);
+	const handleMimeFilterChange = React.useCallback(
+		(nextMimeFilter: string | string[] | undefined) => {
+			setMimeFilter(nextMimeFilter);
+			setPage(1);
+			setRetainedTotalCount(0);
+		},
+		[],
+	);
+
+	const paginationPending = isLoading || isFetching || isRecoveringPage;
 
 	const uploadMutation = useMutation({
 		mutationFn: ({ file, options }: { file: File; options?: MediaUploadOptions }) =>
 			uploadMedia(file, options),
 		onSuccess: () => {
+			setPage(1);
+			setRetainedTotalCount(0);
 			void queryClient.invalidateQueries({ queryKey: ["media"] });
 		},
 	});
-
-	const items = React.useMemo(() => {
-		return data?.pages.flatMap((page) => page.items) || [];
-	}, [data]);
 
 	if (error) {
 		return <ErrorScreen error={error.message} />;
@@ -1407,15 +1457,21 @@ function MediaPage() {
 
 	return (
 		<MediaLibrary
-			items={items}
-			isLoading={isLoading || isFetchingNextPage}
-			hasMore={!!hasNextPage}
-			onLoadMore={() => void fetchNextPage()}
+			items={isRecoveringPage ? [] : (data?.items ?? [])}
+			isLoading={paginationPending}
+			pagination={{
+				page: isRecoveringPage ? lastPage : page,
+				perPage,
+				totalCount,
+				isPending: paginationPending,
+				onPageChange: handlePageChange,
+				onPageSizeChange: handlePageSizeChange,
+			}}
 			onUpload={async (file, options) => {
 				await uploadMutation.mutateAsync({ file, options });
 			}}
-			onLocalSearchChange={setSearch}
-			onLocalMimeFilterChange={setMimeFilter}
+			onLocalSearchChange={handleSearchChange}
+			onLocalMimeFilterChange={handleMimeFilterChange}
 		/>
 	);
 }

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -78,6 +78,20 @@ function makeMediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
 	};
 }
 
+function makePagination(
+	overrides: Partial<NonNullable<React.ComponentProps<typeof MediaLibrary>["pagination"]>> = {},
+): NonNullable<React.ComponentProps<typeof MediaLibrary>["pagination"]> {
+	return {
+		page: 1,
+		perPage: 35,
+		totalCount: 37,
+		isPending: false,
+		onPageChange: vi.fn(),
+		onPageSizeChange: vi.fn(),
+		...overrides,
+	};
+}
+
 describe("MediaLibrary", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -392,37 +406,123 @@ describe("MediaLibrary", () => {
 		});
 	});
 
-	describe("load more pagination", () => {
-		it("renders Load More button when hasMore is true", async () => {
-			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
-			const screen = await renderLibrary({ items, hasMore: true, onLoadMore: vi.fn() });
-			await expect.element(screen.getByRole("button", { name: "Load More" })).toBeInTheDocument();
-			expect(screen.getByText("1 item").query()).toBeNull();
-		});
-
-		it("does not render Load More button when hasMore is false", async () => {
-			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
-			const screen = await renderLibrary({ items, hasMore: false, onLoadMore: vi.fn() });
-			expect(screen.getByRole("button", { name: "Load More" }).query()).toBeNull();
-		});
-
-		it("invokes onLoadMore when Load More button is clicked", async () => {
+	describe("legacy load more compatibility", () => {
+		it("keeps hasMore and onLoadMore working when numbered pagination is absent", async () => {
 			const onLoadMore = vi.fn();
 			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
 			const screen = await renderLibrary({ items, hasMore: true, onLoadMore });
+
 			await screen.getByRole("button", { name: "Load More" }).click();
-			expect(onLoadMore).toHaveBeenCalled();
+
+			expect(onLoadMore).toHaveBeenCalledTimes(1);
 		});
 
-		it("keeps already-loaded items visible while fetching the next page (isLoading=true with items)", async () => {
-			const items = [makeMediaItem({ id: "1", filename: "first-page.jpg" })];
+		it("uses numbered pagination instead when both prop shapes are provided", async () => {
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
 			const screen = await renderLibrary({
 				items,
-				isLoading: true,
 				hasMore: true,
 				onLoadMore: vi.fn(),
+				pagination: makePagination(),
 			});
-			await expect.element(screen.getByAltText("first-page.jpg")).toBeInTheDocument();
+
+			await expect
+				.element(screen.getByRole("navigation", { name: "Media pagination" }))
+				.toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Load More" }).query()).toBeNull();
+		});
+	});
+
+	describe("numbered pagination", () => {
+		it("renders localized Kumo controls with the exact range and total", async () => {
+			const onPageChange = vi.fn();
+			const onPageSizeChange = vi.fn();
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({
+				items,
+				pagination: makePagination({ onPageChange, onPageSizeChange }),
+			});
+
+			await expect
+				.element(screen.getByRole("navigation", { name: "Media pagination" }))
+				.toBeInTheDocument();
+			await expect.element(screen.getByRole("status")).toHaveTextContent("Showing 1-35 of 37");
+			expect(screen.getByText("37 items", { exact: true }).query()).toBeNull();
+			await expect
+				.element(screen.getByRole("combobox", { name: "Page number" }))
+				.toBeInTheDocument();
+
+			await screen.getByRole("button", { name: "Next page" }).click();
+			expect(onPageChange).toHaveBeenCalledWith(2);
+
+			await screen.getByRole("combobox", { name: "Page size" }).click();
+			await screen.getByRole("option", { name: "70" }).click();
+			expect(onPageSizeChange).toHaveBeenCalledWith(70);
+		});
+
+		it("uses the page input above the dropdown page-count bound", async () => {
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({
+				items,
+				pagination: makePagination({ totalCount: 3535 }),
+			});
+
+			await expect
+				.element(screen.getByRole("textbox", { name: "Page number" }))
+				.toBeInTheDocument();
+			expect(screen.getByRole("combobox", { name: "Page number" }).query()).toBeNull();
+		});
+
+		it("keeps control styling stable while another page loads", async () => {
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({
+				items,
+				pagination: makePagination({ isPending: true }),
+			});
+
+			const nextPage = screen.getByRole("button", { name: "Next page" });
+			await expect.element(nextPage).not.toBeDisabled();
+			expect(nextPage.element().closest("[inert]")).not.toBeNull();
+		});
+
+		it("restores focus to the pagination control after a page finishes loading", async () => {
+			function Harness() {
+				const [page, setPage] = React.useState(1);
+				const [isPending, setIsPending] = React.useState(false);
+				return (
+					<>
+						<MediaLibrary
+							items={[makeMediaItem({ id: String(page), filename: `page-${page}.jpg` })]}
+							pagination={makePagination({
+								page,
+								totalCount: 90,
+								isPending,
+								onPageChange(nextPage) {
+									setPage(nextPage);
+									setIsPending(true);
+								},
+							})}
+						/>
+						<button type="button" onClick={() => setIsPending(false)}>
+							Finish page request
+						</button>
+					</>
+				);
+			}
+
+			const screen = await render(
+				<QueryWrapper>
+					<Harness />
+				</QueryWrapper>,
+			);
+
+			const nextPage = screen.getByRole("button", { name: "Next page" });
+			await nextPage.click();
+			await screen.getByRole("button", { name: "Finish page request" }).click();
+
+			await vi.waitFor(() => {
+				expect(document.activeElement).toBe(nextPage.element());
+			});
 		});
 	});
 
@@ -487,6 +587,7 @@ describe("MediaLibrary", () => {
 
 			const screen = await renderLibrary({
 				items: [makeMediaItem({ id: "1", filename: "a.jpg" })],
+				pagination: makePagination(),
 			});
 
 			await screen.getByRole("combobox", { name: "Filter by type" }).click();
@@ -494,6 +595,7 @@ describe("MediaLibrary", () => {
 			await screen.getByRole("tab", { name: "Cloudflare Images" }).click();
 
 			await expect.element(screen.getByText("No media found")).toBeInTheDocument();
+			expect(screen.getByRole("navigation", { name: "Media pagination" }).query()).toBeNull();
 			expect(screen.getByRole("tab", { name: "Grid view" }).query()).toBeNull();
 			expect(screen.getByRole("tab", { name: "List view" }).query()).toBeNull();
 		});

--- a/packages/admin/tests/lib/media-pagination.test.ts
+++ b/packages/admin/tests/lib/media-pagination.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchMediaList } from "../../src/lib/api/media";
+
+describe("media page API client", () => {
+	const originalFetch = globalThis.fetch;
+	let fetchSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchSpy = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ data: { items: [], totalCount: 37 } }), { status: 200 }),
+			);
+		globalThis.fetch = fetchSpy as typeof globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("requests a numbered page and returns its exact total", async () => {
+		const result = await fetchMediaList({ page: 1, limit: 35 });
+		const [url] = fetchSpy.mock.calls[0]!;
+		const requestUrl = new URL(url, "http://localhost");
+
+		expect(Object.fromEntries(requestUrl.searchParams)).toEqual({ page: "1", limit: "35" });
+		expect(result).toEqual({ items: [], totalCount: 37 });
+	});
+});

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -110,7 +110,24 @@ vi.mock("../src/components/ContentEditor", () => ({
 }));
 
 vi.mock("../src/components/MediaLibrary", () => ({
-	MediaLibrary: ({ onUpload }: { onUpload?: (file: File) => Promise<unknown> | void }) => {
+	MediaLibrary: ({
+		items,
+		isLoading,
+		onUpload,
+		onLocalSearchChange,
+		pagination,
+	}: {
+		items?: Array<{ id?: string }>;
+		isLoading?: boolean;
+		onUpload?: (file: File) => Promise<unknown> | void;
+		onLocalSearchChange?: (search: string) => void;
+		pagination?: {
+			page: number;
+			perPage: number;
+			onPageChange: (page: number) => void;
+			onPageSizeChange: (perPage: number) => void;
+		};
+	}) => {
 		const [uploadStatus, setUploadStatus] = React.useState("idle");
 
 		const upload = async () => {
@@ -129,6 +146,24 @@ vi.mock("../src/components/MediaLibrary", () => ({
 					Upload test file
 				</button>
 				<span>{uploadStatus}</span>
+				<span data-testid="media-item-count">{items?.length ?? 0}</span>
+				<span data-testid="media-first-item">{items?.[0]?.id ?? ""}</span>
+				<span data-testid="media-loading">{isLoading ? "loading" : "ready"}</span>
+				{pagination && (
+					<>
+						<span data-testid="media-page">{pagination.page}</span>
+						<span data-testid="media-page-size">{pagination.perPage}</span>
+						<button type="button" onClick={() => pagination.onPageChange(2)}>
+							Open page 2
+						</button>
+						<button type="button" onClick={() => pagination.onPageSizeChange(70)}>
+							Show 70 per page
+						</button>
+						<button type="button" onClick={() => onLocalSearchChange?.("photo")}>
+							Search media
+						</button>
+					</>
+				)}
 			</div>
 		);
 	},
@@ -213,7 +248,7 @@ describe("MediaPage – upload completion", () => {
 				data: { id: "user_01", role: 60 },
 			})
 			.on("GET", "/_emdash/api/media", {
-				data: { items: [], nextCursor: undefined },
+				data: { items: [], totalCount: 60 },
 			});
 	});
 
@@ -257,6 +292,133 @@ describe("MediaPage – upload completion", () => {
 		} finally {
 			globalThis.fetch = interceptedFetch;
 		}
+	});
+
+	it("requests numbered pages and resets page state for page size and search", async () => {
+		const requests: string[] = [];
+		const mockedFetch = globalThis.fetch;
+		globalThis.fetch = (input, init) => {
+			requests.push(
+				typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+			);
+			return mockedFetch(input, init);
+		};
+
+		const { router, TestApp } = buildRouter();
+		await router.navigate({ to: "/media" });
+		const screen = await render(<TestApp />);
+
+		await expect.element(screen.getByTestId("media-page")).toHaveTextContent("1");
+		await vi.waitFor(() => {
+			expect(requests.some((url) => url.includes("/_emdash/api/media?page=1&limit=35"))).toBe(true);
+		});
+
+		await screen.getByRole("button", { name: "Open page 2" }).click();
+		await expect.element(screen.getByTestId("media-page")).toHaveTextContent("2");
+		await vi.waitFor(() => {
+			expect(requests.some((url) => url.includes("/_emdash/api/media?page=2&limit=35"))).toBe(true);
+		});
+
+		await screen.getByRole("button", { name: "Show 70 per page" }).click();
+		await expect.element(screen.getByTestId("media-page")).toHaveTextContent("1");
+		await expect.element(screen.getByTestId("media-page-size")).toHaveTextContent("70");
+
+		await screen.getByRole("button", { name: "Search media" }).click();
+		await vi.waitFor(() => {
+			expect(
+				requests.some(
+					(url) => url.includes("/_emdash/api/media?page=1&limit=70") && url.includes("q=photo"),
+				),
+			).toBe(true);
+		});
+	});
+
+	it("recovers an emptied later page without exposing an invalid page number", async () => {
+		const mockedFetch = globalThis.fetch;
+		let requestedSecondPage = false;
+		globalThis.fetch = (input, init) => {
+			const rawUrl =
+				typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			const url = new URL(rawUrl, "http://localhost");
+			if (url.pathname === "/_emdash/api/media") {
+				const requestedPage = url.searchParams.get("page");
+				if (requestedPage === "2") {
+					requestedSecondPage = true;
+					return Promise.resolve(
+						new Response(JSON.stringify({ data: { items: [], totalCount: 0 } }), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						}),
+					);
+				}
+				const totalCount = requestedSecondPage ? 0 : 60;
+				return Promise.resolve(
+					new Response(JSON.stringify({ data: { items: [], totalCount } }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					}),
+				);
+			}
+			return mockedFetch(input, init);
+		};
+
+		const { router, TestApp } = buildRouter();
+		await router.navigate({ to: "/media" });
+		const screen = await render(<TestApp />);
+		await expect.element(screen.getByTestId("media-page")).toHaveTextContent("1");
+
+		await screen.getByRole("button", { name: "Open page 2" }).click();
+
+		await vi.waitFor(() => {
+			expect(requestedSecondPage).toBe(true);
+			expect(screen.getByTestId("media-page").element()).toHaveTextContent("1");
+		});
+	});
+
+	it("keeps the current page rendered while the next page loads", async () => {
+		const mockedFetch = globalThis.fetch;
+		let resolveSecondPage: ((response: Response) => void) | undefined;
+		globalThis.fetch = (input, init) => {
+			const rawUrl =
+				typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			const url = new URL(rawUrl, "http://localhost");
+			if (url.pathname === "/_emdash/api/media") {
+				if (url.searchParams.get("page") === "2") {
+					return new Promise<Response>((resolve) => {
+						resolveSecondPage = resolve;
+					});
+				}
+				return Promise.resolve(
+					new Response(JSON.stringify({ data: { items: [{ id: "page-1" }], totalCount: 60 } }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					}),
+				);
+			}
+			return mockedFetch(input, init);
+		};
+
+		const { router, TestApp } = buildRouter();
+		await router.navigate({ to: "/media" });
+		const screen = await render(<TestApp />);
+		await expect.element(screen.getByTestId("media-item-count")).toHaveTextContent("1");
+		await expect.element(screen.getByTestId("media-first-item")).toHaveTextContent("page-1");
+
+		await screen.getByRole("button", { name: "Open page 2" }).click();
+		await vi.waitFor(() => expect(resolveSecondPage).toBeTypeOf("function"));
+
+		await expect.element(screen.getByTestId("media-item-count")).toHaveTextContent("1");
+		await expect.element(screen.getByTestId("media-first-item")).toHaveTextContent("page-1");
+		await expect.element(screen.getByTestId("media-loading")).toHaveTextContent("loading");
+
+		resolveSecondPage?.(
+			new Response(JSON.stringify({ data: { items: [{ id: "page-2" }], totalCount: 60 } }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+		await expect.element(screen.getByTestId("media-loading")).toHaveTextContent("ready");
+		await expect.element(screen.getByTestId("media-first-item")).toHaveTextContent("page-2");
 	});
 });
 

--- a/packages/core/src/api/handlers/media.ts
+++ b/packages/core/src/api/handlers/media.ts
@@ -12,6 +12,7 @@ import type { ApiResult } from "../types.js";
 export interface MediaListResponse {
 	items: MediaItem[];
 	nextCursor?: string;
+	totalCount?: number;
 }
 
 export interface MediaResponse {
@@ -25,12 +26,38 @@ export async function handleMediaList(
 	db: Kysely<Database>,
 	params: {
 		cursor?: string;
+		page?: number;
 		limit?: number;
 		mimeType?: string | readonly string[];
 		q?: string;
 	},
 ): Promise<ApiResult<MediaListResponse>> {
 	try {
+		if (params.page !== undefined) {
+			const limit = Math.min(params.limit || 50, 100);
+			const offset = (params.page - 1) * limit;
+			if (
+				params.cursor !== undefined ||
+				!Number.isSafeInteger(params.page) ||
+				params.page < 1 ||
+				!Number.isSafeInteger(offset)
+			) {
+				return {
+					success: false,
+					error: { code: "VALIDATION_ERROR", message: "Invalid media page" },
+				};
+			}
+
+			const repo = new MediaRepository(db);
+			const result = await repo.findPage({
+				page: params.page,
+				limit,
+				mimeType: params.mimeType,
+				q: params.q,
+			});
+			return { success: true, data: result };
+		}
+
 		const repo = new MediaRepository(db);
 		const result = await repo.findMany({
 			cursor: params.cursor,

--- a/packages/core/src/api/schemas/media.ts
+++ b/packages/core/src/api/schemas/media.ts
@@ -21,12 +21,17 @@ const mimeTypeFilter = z
 
 export const mediaListQuery = cursorPaginationQuery
 	.extend({
+		page: z.coerce.number().int().min(1).max(Number.MAX_SAFE_INTEGER).optional(),
 		mimeType: mimeTypeFilter,
 		/** Case-insensitive filename substring search (also matches extensions). */
 		q: z.string().trim().min(1).max(200).optional(),
 		includeUsage: z.literal("1").optional().meta({
 			description: "Include a coverage-aware usage summary on each media item",
 		}),
+	})
+	.refine(({ cursor, page }) => cursor === undefined || page === undefined, {
+		message: "cursor and page cannot be used together",
+		path: ["page"],
 	})
 	.meta({ id: "MediaListQuery" });
 
@@ -143,6 +148,7 @@ export const mediaListReadResponseSchema = z
 	.object({
 		items: z.array(mediaListReadItemSchema),
 		nextCursor: z.string().optional(),
+		totalCount: z.number().int().nonnegative().optional(),
 	})
 	.meta({ id: "MediaListReadResponse" });
 
@@ -150,6 +156,7 @@ export const mediaListResponseSchema = z
 	.object({
 		items: z.array(mediaItemSchema),
 		nextCursor: z.string().optional(),
+		totalCount: z.number().int().nonnegative().optional(),
 	})
 	.meta({ id: "MediaListResponse" });
 

--- a/packages/core/src/astro/routes/api/media.ts
+++ b/packages/core/src/astro/routes/api/media.ts
@@ -55,6 +55,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
 
 	const result = await emdash.handleMediaList({
 		cursor: query.cursor,
+		page: query.page,
 		limit: query.limit,
 		mimeType: query.mimeType,
 		q: query.q,
@@ -67,7 +68,11 @@ export const GET: APIRoute = async ({ request, locals }) => {
 	// Add URL to each media item (relative URLs for portability)
 	const itemsWithUrl = result.data.items.map((item) => addUrlToMedia(item));
 	if (query.includeUsage !== "1") {
-		return apiSuccess({ items: itemsWithUrl, nextCursor: result.data.nextCursor });
+		return apiSuccess({
+			items: itemsWithUrl,
+			nextCursor: result.data.nextCursor,
+			totalCount: result.data.totalCount,
+		});
 	}
 
 	const includeCount = canReadMediaUsageCount(user, locals.tokenScopes);
@@ -85,7 +90,11 @@ export const GET: APIRoute = async ({ request, locals }) => {
 		itemsWithUsage.push({ ...item, usage });
 	}
 
-	return apiSuccess({ items: itemsWithUsage, nextCursor: result.data.nextCursor });
+	return apiSuccess({
+		items: itemsWithUsage,
+		nextCursor: result.data.nextCursor,
+		totalCount: result.data.totalCount,
+	});
 };
 
 /**

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -374,6 +374,7 @@ export interface EmDashHandlers {
 	// Media handlers
 	handleMediaList: (params: {
 		cursor?: string;
+		page?: number;
 		limit?: number;
 		mimeType?: string | readonly string[];
 	}) => Promise<HandlerResponse>;

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -811,16 +811,21 @@ export class EmDashClient {
 		mimeType?: string;
 		limit?: number;
 		cursor?: string;
+		page?: number;
 		includeUsage?: boolean;
-	}): Promise<ListResult<MediaItem>> {
+	}): Promise<ListResult<MediaItem> & { totalCount?: number }> {
 		const params = new URLSearchParams();
 		if (options?.mimeType) params.set("mimeType", options.mimeType);
 		if (options?.limit) params.set("limit", String(options.limit));
 		if (options?.cursor) params.set("cursor", options.cursor);
+		if (options?.page !== undefined) params.set("page", String(options.page));
 		if (options?.includeUsage === true) params.set("includeUsage", "1");
 
 		const qs = params.toString();
-		return this.request<ListResult<MediaItem>>("GET", `/media${qs ? `?${qs}` : ""}`);
+		return this.request<ListResult<MediaItem> & { totalCount?: number }>(
+			"GET",
+			`/media${qs ? `?${qs}` : ""}`,
+		);
 	}
 
 	/** Get a single media item */

--- a/packages/core/src/database/repositories/media.ts
+++ b/packages/core/src/database/repositories/media.ts
@@ -1,4 +1,10 @@
-import { sql, type ExpressionBuilder, type Kysely, type SqlBool } from "kysely";
+import {
+	sql,
+	type ExpressionBuilder,
+	type Kysely,
+	type SelectQueryBuilder,
+	type SqlBool,
+} from "kysely";
 import { ulid } from "ulidx";
 
 import type { Database, MediaRow } from "../types.js";
@@ -83,6 +89,15 @@ export interface FindManyMediaOptions {
 	status?: MediaStatus | "all"; // Filter by status, defaults to "ready"
 	/** Case-insensitive substring matched against the filename (covers filename and extension). */
 	q?: string;
+}
+
+export interface FindMediaPageOptions extends Omit<FindManyMediaOptions, "cursor"> {
+	page: number;
+}
+
+export interface MediaPageResult {
+	items: MediaItem[];
+	totalCount: number;
 }
 
 const UPLOAD_ATTEMPT_CLEANUP_AGE_MS = 60 * 60 * 1000;
@@ -367,8 +382,7 @@ export class MediaRepository {
 	async findMany(options: FindManyMediaOptions = {}): Promise<FindManyResult<MediaItem>> {
 		const limit = Math.min(options.limit || 50, 100);
 
-		let query = this.db
-			.selectFrom("media")
+		let query = this.applyListFilters(this.db.selectFrom("media"), options)
 			.selectAll()
 			.orderBy("created_at", "desc")
 			.orderBy("id", "desc")
@@ -387,28 +401,6 @@ export class MediaRepository {
 			);
 		}
 
-		const mimeFilters = normalizeMimeFilter(options.mimeType);
-		if (mimeFilters.length > 0) {
-			query = query.where((eb) => mimeMatchExpr(eb, mimeFilters));
-		}
-
-		// Case-insensitive filename substring search (also matches extensions).
-		// LIKE wildcards in the term are escaped so they're treated literally.
-		const term = options.q?.trim();
-		if (term) {
-			const pattern = `%${escapeLike(term)}%`;
-			query = query.where(
-				sql<string>`lower(filename)`,
-				"like",
-				sql<string>`lower(${pattern}) escape '\\'`,
-			);
-		}
-
-		// Default to only showing ready items
-		if (options.status !== "all") {
-			query = query.where("status", "=", options.status ?? "ready");
-		}
-
 		const rows = await query.execute();
 
 		const hasMore = rows.length > limit;
@@ -421,6 +413,27 @@ export class MediaRepository {
 		}
 
 		return { items, nextCursor };
+	}
+
+	async findPage(options: FindMediaPageOptions): Promise<MediaPageResult> {
+		const limit = Math.min(options.limit || 50, 100);
+		const offset = (options.page - 1) * limit;
+		const filtered = this.applyListFilters(this.db.selectFrom("media"), options);
+		const rows = await filtered
+			.selectAll()
+			.orderBy("created_at", "desc")
+			.orderBy("id", "desc")
+			.limit(limit)
+			.offset(offset)
+			.execute();
+		const count = await filtered
+			.select((eb) => eb.fn.count<number>("id").as("count"))
+			.executeTakeFirst();
+
+		return {
+			items: rows.map((row) => this.rowToItem(row)),
+			totalCount: Number(count?.count ?? 0),
+		};
 	}
 
 	/**
@@ -478,6 +491,32 @@ export class MediaRepository {
 
 		const result = await query.executeTakeFirst();
 		return Number(result?.count || 0);
+	}
+
+	private applyListFilters<O>(
+		query: SelectQueryBuilder<Database, "media", O>,
+		options: Omit<FindManyMediaOptions, "cursor" | "limit">,
+	): SelectQueryBuilder<Database, "media", O> {
+		const mimeFilters = normalizeMimeFilter(options.mimeType);
+		if (mimeFilters.length > 0) {
+			query = query.where((eb) => mimeMatchExpr(eb, mimeFilters));
+		}
+
+		const term = options.q?.trim();
+		if (term) {
+			const pattern = `%${escapeLike(term)}%`;
+			query = query.where(
+				sql<string>`lower(filename)`,
+				"like",
+				sql<string>`lower(${pattern}) escape '\\'`,
+			);
+		}
+
+		if (options.status !== "all") {
+			query = query.where("status", "=", options.status ?? "ready");
+		}
+
+		return query;
 	}
 
 	/**

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -3456,6 +3456,7 @@ export class EmDashRuntime {
 
 	async handleMediaList(params: {
 		cursor?: string;
+		page?: number;
 		limit?: number;
 		mimeType?: string | readonly string[];
 		q?: string;

--- a/packages/core/tests/integration/database/media-page-pagination.test.ts
+++ b/packages/core/tests/integration/database/media-page-pagination.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { MediaRepository, type MediaStatus } from "../../../src/database/repositories/media.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("MediaRepository numbered pages", (dialect) => {
+	let ctx: DialectTestContext;
+	let repo: MediaRepository;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		repo = new MediaRepository(ctx.db);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	async function createMedia(
+		filename: string,
+		createdAt: string,
+		mimeType = "image/jpeg",
+		status: MediaStatus = "ready",
+	) {
+		const item = await repo.create({
+			filename,
+			mimeType,
+			storageKey: filename,
+			status,
+		});
+		await ctx.db
+			.updateTable("media")
+			.set({ created_at: createdAt })
+			.where("id", "=", item.id)
+			.execute();
+	}
+
+	async function seedMedia() {
+		await createMedia("oldest.jpg", "2026-01-01T00:00:00.000Z");
+		await createMedia("guide.pdf", "2026-01-02T00:00:00.000Z", "application/pdf");
+		await createMedia("middle.jpg", "2026-01-03T00:00:00.000Z");
+		await createMedia("newest.jpg", "2026-01-04T00:00:00.000Z");
+		await createMedia("pending.jpg", "2026-01-05T00:00:00.000Z", "image/jpeg", "pending");
+		await createMedia("failed.jpg", "2026-01-06T00:00:00.000Z", "image/jpeg", "failed");
+	}
+
+	it("returns disjoint stable pages with the exact ready-item total", async () => {
+		await seedMedia();
+
+		const first = await repo.findPage({ page: 1, limit: 2 });
+		const second = await repo.findPage({ page: 2, limit: 2 });
+		const beyond = await repo.findPage({ page: 3, limit: 2 });
+
+		expect(first).toMatchObject({ totalCount: 4 });
+		expect(first.items.map((item) => item.filename)).toEqual(["newest.jpg", "middle.jpg"]);
+		expect(second).toMatchObject({ totalCount: 4 });
+		expect(second.items.map((item) => item.filename)).toEqual(["guide.pdf", "oldest.jpg"]);
+		expect(beyond).toEqual({ items: [], totalCount: 4 });
+	});
+
+	it("applies filename and MIME filters to both rows and total", async () => {
+		await seedMedia();
+
+		const result = await repo.findPage({
+			page: 2,
+			limit: 2,
+			q: ".jpg",
+			mimeType: "image/",
+		});
+
+		expect(result.totalCount).toBe(3);
+		expect(typeof result.totalCount).toBe("number");
+		expect(result.items.map((item) => item.filename)).toEqual(["oldest.jpg"]);
+	});
+});

--- a/packages/core/tests/unit/api/media-list-route.test.ts
+++ b/packages/core/tests/unit/api/media-list-route.test.ts
@@ -1,6 +1,7 @@
 import { it, expect, describe, beforeEach, afterEach } from "vitest";
 
 import { handleMediaList } from "../../../src/api/handlers/media.js";
+import { mediaListQuery } from "../../../src/api/schemas/media.js";
 import { MediaRepository } from "../../../src/database/repositories/media.js";
 import {
 	setupForDialect,
@@ -32,5 +33,44 @@ describe("handleMediaList multi-MIME", () => {
 			"application/pdf",
 			"image/png",
 		]);
+	});
+
+	it("returns one numbered page and its exact total", async () => {
+		const result = await handleMediaList(ctx.db, { page: 2, limit: 2 });
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: true,
+				data: expect.objectContaining({
+					items: [expect.objectContaining({ filename: expect.stringMatching(/\.(png|pdf|zip)$/) })],
+					totalCount: 3,
+				}),
+			}),
+		);
+	});
+
+	it("rejects invalid or ambiguous page requests before querying", async () => {
+		await expect(handleMediaList(ctx.db, { page: 0 })).resolves.toMatchObject({
+			success: false,
+			error: { code: "VALIDATION_ERROR" },
+		});
+		await expect(handleMediaList(ctx.db, { page: 1, cursor: "cursor" })).resolves.toMatchObject({
+			success: false,
+			error: { code: "VALIDATION_ERROR" },
+		});
+		await expect(
+			handleMediaList(ctx.db, { page: Number.MAX_SAFE_INTEGER, limit: 100 }),
+		).resolves.toMatchObject({
+			success: false,
+			error: { code: "VALIDATION_ERROR" },
+		});
+	});
+
+	it("accepts page mode in the REST query and rejects cursor plus page", () => {
+		expect(mediaListQuery.parse({ page: "1" }).page).toBe(1);
+		expect(mediaListQuery.safeParse({ page: "0" }).success).toBe(false);
+		expect(mediaListQuery.safeParse({ page: "1.5" }).success).toBe(false);
+		expect(mediaListQuery.safeParse({ page: "not-a-page" }).success).toBe(false);
+		expect(mediaListQuery.safeParse({ page: "1", cursor: "cursor" }).success).toBe(false);
 	});
 });

--- a/packages/core/tests/unit/api/media-usage-summary.test.ts
+++ b/packages/core/tests/unit/api/media-usage-summary.test.ts
@@ -313,6 +313,41 @@ describe("media usage summary handler and routes", () => {
 		expect(queries).toHaveLength(1);
 	});
 
+	it("returns an exact total only for page-mode list requests", async () => {
+		const response = await invokeList("?page=1&limit=1", Role.CONTRIBUTOR);
+		const data = await readSuccess<{
+			items: MediaListBodyItem[];
+			totalCount?: number;
+		}>(response);
+
+		expect(response.status).toBe(200);
+		expect(data.items).toHaveLength(1);
+		expect(data.totalCount).toBe(2);
+		expect(queries).toHaveLength(2);
+	});
+
+	it("preserves the page total when usage summaries are requested", async () => {
+		const response = await invokeList("?page=1&limit=1&includeUsage=1", Role.CONTRIBUTOR);
+		const data = await readSuccess<{
+			items: MediaListBodyItem[];
+			totalCount?: number;
+		}>(response);
+
+		expect(data.totalCount).toBe(2);
+		expect(data.items[0]?.usage).toBeDefined();
+		expect(queries).toHaveLength(4);
+	});
+
+	it("rejects cursor plus page without running a media query", async () => {
+		const response = await invokeList("?page=1&cursor=cursor", Role.CONTRIBUTOR);
+
+		expect(response.status).toBe(400);
+		expect((await response.json()) as ErrorBody).toEqual(
+			expect.objectContaining({ error: expect.objectContaining({ code: "VALIDATION_ERROR" }) }),
+		);
+		expect(queries).toHaveLength(0);
+	});
+
 	it("attaches numeric usage counts to every list item for an authorized session", async () => {
 		const response = await invokeList("?includeUsage=1", Role.CONTRIBUTOR);
 		const data = await readSuccess<{ items: MediaListBodyItem[] }>(response);

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -724,6 +724,27 @@ describe("EmDashClient", () => {
 	});
 
 	describe("media usage reads", () => {
+		it("requests a numbered media page and returns its total", async () => {
+			let capturedUrl: URL | undefined;
+			const backend: Interceptor = async (req) => {
+				capturedUrl = new URL(req.url);
+				return jsonResponse({ items: [{ id: "media-1" }], totalCount: 37 });
+			};
+			const client = new EmDashClient({
+				baseUrl: "http://localhost:4321",
+				token: "test",
+				interceptors: [backend],
+			});
+
+			const result = await client.mediaList({ page: 2, limit: 25 });
+
+			expect(Object.fromEntries(capturedUrl?.searchParams ?? [])).toEqual({
+				limit: "25",
+				page: "2",
+			});
+			expect(result).toEqual({ items: [{ id: "media-1" }], totalCount: 37 });
+		});
+
 		it("opts media list into usage summaries with an exact includeUsage value", async () => {
 			let capturedUrl: URL | undefined;
 			const backend: Interceptor = async (req) => {


### PR DESCRIPTION
## What does this PR do?

Adds numbered pagination to the local Media Library using Kumo's compound Pagination component. The new opt-in `page` API mode returns an exact `totalCount`, while existing cursor requests remain unchanged and keep their one-query path for media pickers, providers, CLI, MCP, and plugins.

The admin now provides 35/70/90 page sizes, stable loading without replacing the current grid, preserved scroll and focus, responsive wrapping, and RTL-safe controls. It also recovers cleanly when deletion or filtering makes the current page invalid, including when the result count drops to zero.

This is a follow-up to the accepted media-pagination Discussion #897 and its original cursor-based fix in #996.

Related to https://github.com/emdash-cms/emdash/discussions/897

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] Typechecks pass for the changed `emdash` and `@emdash-cms/admin` packages
- [x] Type-aware lint passes for the changed package scopes; whole-tree quick lint reports 0 diagnostics
- [x] Targeted tests pass for the API, client, Media Library, uploads, router, and cursor-based media pickers
- [x] All changed files pass oxfmt/Prettier checks
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No `messages.po` changes are included in the PR diff.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/897

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

- Core/API/client: 90 tests passed.
- Admin/browser: 94 tests passed, including multi-file uploads and unchanged media-picker flows.
- Builds: `emdash`, `@emdash-cms/admin`, and `demos/simple` passed.
- Live API: page mode returned 35 items and `totalCount: 127`; cursor mode returned `nextCursor` without `totalCount`.
- Live UI at 1512×982: 7 columns × 5 rows, 12px gaps, no horizontal overflow.
- Live UI at 390×844: responsive 2-column grid and wrapped pagination with no overflow.
- A delayed page request kept 35 items, grid height, and scroll position stable; focus returned to a valid pagination control afterward.
- Arabic RTL: logical layout and mirrored directional controls verified.

PostgreSQL was not configured locally, so dialect tests ran on SQLite. Admin Vitest reports the repository's existing mixed `vitest@4.1.5` / `@vitest/browser@4.1.10` warning; all tests pass.
