### PR TITLE
fix(bot): report oversized review payloads

### DIFF
--- a/infra/flue-review/.flue/app.ts
+++ b/infra/flue-review/.flue/app.ts
@@ -8,9 +8,11 @@
 // durable workflow run, and returns. The review and the GitHub post happen
 // inside the workflow's Durable Object, which is not bound by that budget.
 
-import { getRun, listRuns } from "@flue/runtime";
+import { getRun, listRuns, registerProvider } from "@flue/runtime";
+import { env } from "cloudflare:workers";
 import { Hono } from "hono";
 
+import { createAiPayloadGuard } from "./lib/ai-payload-budget.js";
 import {
 	completeReviewCheck,
 	createReviewCheck,
@@ -25,6 +27,11 @@ import {
 	getWebhookDeliveryId,
 } from "./lib/webhook.js";
 import { admitReviewWorkflow } from "./lib/workflow-admission.js";
+
+registerProvider("cloudflare", {
+	api: "cloudflare-ai-binding",
+	binding: createAiPayloadGuard(env.AI),
+});
 
 // Extract a short, displayable message from an unknown run error without
 // risking an "[object Object]" stringification.

--- a/infra/flue-review/.flue/lib/ai-payload-budget.ts
+++ b/infra/flue-review/.flue/lib/ai-payload-budget.ts
@@ -1,0 +1,27 @@
+import type { CloudflareAIBinding } from "@flue/runtime/cloudflare";
+
+import { utf8ByteLength } from "./byte-budget.js";
+
+export const MAX_AI_PAYLOAD_BYTES = 1024 * 1024;
+
+export class ModelPayloadTooLargeError extends Error {
+	constructor(bytes: number, maxBytes: number) {
+		super(
+			`Review context is ${bytes} bytes, exceeding the ${maxBytes}-byte model-request budget. Narrow the review context or split the pull request.`,
+		);
+		this.name = "ModelPayloadTooLargeError";
+	}
+}
+
+export function createAiPayloadGuard(
+	binding: CloudflareAIBinding,
+	maxBytes = MAX_AI_PAYLOAD_BYTES,
+): CloudflareAIBinding {
+	return {
+		async run(modelId, inputs, options) {
+			const bytes = utf8ByteLength(JSON.stringify(inputs));
+			if (bytes > maxBytes) throw new ModelPayloadTooLargeError(bytes, maxBytes);
+			return binding.run(modelId, inputs, options);
+		},
+	};
+}

--- a/infra/flue-review/.flue/lib/byte-budget.ts
+++ b/infra/flue-review/.flue/lib/byte-budget.ts
@@ -1,0 +1,28 @@
+export function utf8ByteLength(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
+function utf8Prefix(value: string, maxBytes: number): string {
+	const bytes = new TextEncoder().encode(value);
+	let end = Math.min(bytes.byteLength, maxBytes);
+	const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
+	while (end > 0) {
+		try {
+			return decoder.decode(bytes.subarray(0, end));
+		} catch {
+			end--;
+		}
+	}
+	return "";
+}
+
+export function limitUtf8Text(value: string, maxBytes: number, suffix: string): string {
+	if (!Number.isInteger(maxBytes) || maxBytes <= 0) {
+		throw new Error("maxBytes must be a positive integer");
+	}
+	if (utf8ByteLength(value) <= maxBytes) return value;
+
+	const boundedSuffix = utf8Prefix(suffix, maxBytes);
+	const prefixBytes = Math.max(0, maxBytes - utf8ByteLength(boundedSuffix));
+	return utf8Prefix(value, prefixBytes) + boundedSuffix;
+}

--- a/infra/flue-review/.flue/lib/review-failure.ts
+++ b/infra/flue-review/.flue/lib/review-failure.ts
@@ -1,0 +1,22 @@
+import { limitUtf8Text } from "./byte-budget.js";
+import type { ReviewStage } from "./review-watchdog.js";
+
+const MAX_PUBLIC_ERROR_BYTES = 400;
+const WHITESPACE = /\s+/g;
+const SKILL_ERROR_PREFIX = /^skill\("[^"]+"\) failed:\s*/;
+
+function errorDetail(error: unknown): string {
+	const raw =
+		error instanceof Error
+			? error.message || error.name
+			: typeof error === "string"
+				? error
+				: "Unknown review error";
+	const normalized = raw.replaceAll(WHITESPACE, " ").trim();
+	const unwrapped = normalized.replace(SKILL_ERROR_PREFIX, "");
+	return limitUtf8Text(unwrapped, MAX_PUBLIC_ERROR_BYTES, "…");
+}
+
+export function formatReviewFailureSummary(stage: ReviewStage, error: unknown): string {
+	return `The review failed during the \`${stage}\` stage: ${errorDetail(error)} Reapply the \`bot:review\` label to retry.`;
+}

--- a/infra/flue-review/.flue/workflows/review.ts
+++ b/infra/flue-review/.flue/workflows/review.ts
@@ -39,6 +39,7 @@ import {
 	removeReaction,
 	updateReviewCheck,
 } from "../lib/github.js";
+import { formatReviewFailureSummary } from "../lib/review-failure.js";
 import { reviewResultSchema, type ReviewResult } from "../lib/review-schema.js";
 import {
 	getReviewWatchdog,
@@ -459,10 +460,9 @@ async function run(context: ActionContext<typeof reviewPayloadSchema>): Promise<
 		logReviewEvent("error", payload, runId, "review run failed", {
 			error: error instanceof Error ? error.message : String(error),
 		});
-		const errorName = error instanceof Error ? error.name : "Error";
 		await finishReviewCheck(env, payload, runId, {
 			conclusion: "failure",
-			summary: `The review failed during the \`${stage}\` stage (\`${errorName}\`). Reapply the \`bot:review\` label to retry.`,
+			summary: formatReviewFailureSummary(stage, error),
 		});
 		throw error;
 	} finally {

--- a/infra/flue-review/test/ai-payload-budget.test.ts
+++ b/infra/flue-review/test/ai-payload-budget.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAiPayloadGuard } from "../.flue/lib/ai-payload-budget.js";
+
+describe("createAiPayloadGuard", () => {
+	it("rejects a megabyte-scale request before it reaches Workers AI", async () => {
+		const run = vi.fn().mockResolvedValue({ response: "ok" });
+		const guarded = createAiPayloadGuard({ run });
+
+		await expect(
+			guarded.run("model", { messages: [{ content: "x".repeat(1024 * 1024) }] }),
+		).rejects.toThrow(/model-request budget/);
+		expect(run).not.toHaveBeenCalled();
+	});
+
+	it("passes a large but bounded review context through unchanged", async () => {
+		const response = { response: "ok" };
+		const run = vi.fn().mockResolvedValue(response);
+		const guarded = createAiPayloadGuard({ run });
+		const input = { messages: [{ content: "x".repeat(512 * 1024) }] };
+		const options = { returnRawResponse: true };
+
+		await expect(guarded.run("model", input, options)).resolves.toBe(response);
+		expect(run).toHaveBeenCalledWith("model", input, options);
+	});
+});

--- a/infra/flue-review/test/review-failure.test.ts
+++ b/infra/flue-review/test/review-failure.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { formatReviewFailureSummary } from "../.flue/lib/review-failure.js";
+
+describe("formatReviewFailureSummary", () => {
+	it("exposes the actionable provider error in the failed check", () => {
+		const error = new Error(
+			'skill("review") failed: Cloudflare AI binding request failed with 413 Payload Too Large.',
+		);
+		error.name = "FlueError";
+
+		expect(formatReviewFailureSummary("model_review", error)).toContain(
+			"Cloudflare AI binding request failed with 413 Payload Too Large.",
+		);
+	});
+
+	it("bounds error detail before publishing it on GitHub", () => {
+		const summary = formatReviewFailureSummary("model_review", new Error("x".repeat(10_000)));
+
+		expect(summary.length).toBeLessThanOrEqual(700);
+		expect(summary).toContain("Reapply the `bot:review` label to retry.");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

EmDashBot currently reduces workflow failures to the wrapper error name in its GitHub check, hiding actionable causes such as Workers AI's `413 Payload Too Large` response.

This change publishes a normalized, bounded version of the underlying error in the failed check. It also wraps the Workers AI binding with a 1 MiB preflight guard so pathological payloads are rejected locally before transmission with a useful remediation message. Existing diff budgets, tool output, and Flue compaction behavior remain unchanged so normal review quality is unaffected.

No linked issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — N/A: no admin UI changes.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — N/A: the reviewer is private infrastructure.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — N/A: bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Non-visual change.

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:quick`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm test` in `infra/flue-review` → 59 tests passed
- `pnpm build` in `infra/flue-review`
