### PR TITLE
fix(auth): preserve CMS user identity on comment submissions

### DIFF
--- a/.changeset/fix-comment-session-auth.md
+++ b/.changeset/fix-comment-session-auth.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes session-authenticated CMS comment submissions so they retain the user identity and honor automatic approval settings.

--- a/e2e/tests/comments.spec.ts
+++ b/e2e/tests/comments.spec.ts
@@ -6,6 +6,8 @@
  * page rendering, empty state, comment list, approve, and delete.
  */
 
+import type { APIRequestContext } from "@playwright/test";
+
 import { test, expect } from "../fixtures";
 
 // Regex patterns (e18e/prefer-static-regex)
@@ -23,23 +25,27 @@ function apiHeaders(token: string) {
 	};
 }
 
-/** Seed a comment via the public API and return the response body. */
+/** Seed an anonymous comment via the public API. */
 async function seedComment(
-	page: import("@playwright/test").Page,
+	request: APIRequestContext,
 	baseUrl: string,
-	token: string,
 	postId: string,
 	overrides: { body?: string; authorName?: string; authorEmail?: string } = {},
 ) {
-	const res = await page.request.post(`${baseUrl}/_emdash/api/comments/posts/${postId}`, {
-		headers: apiHeaders(token),
+	const res = await request.post(`${baseUrl}/_emdash/api/comments/posts/${postId}`, {
+		headers: {
+			"Content-Type": "application/json",
+			"X-EmDash-Request": "1",
+		},
 		data: {
 			body: overrides.body ?? "Test comment from E2E",
 			authorName: overrides.authorName ?? "E2E Tester",
 			authorEmail: overrides.authorEmail ?? "e2e@test.com",
 		},
 	});
-	return res;
+	expect(res.ok()).toBe(true);
+	const json = (await res.json()) as { data: { status: string } };
+	expect(json.data.status).toBe("pending");
 }
 
 /** Delete all comments currently in the admin inbox (best-effort cleanup). */
@@ -101,19 +107,24 @@ test.describe("Comments Moderation", () => {
 		});
 	});
 
-	test("displays seeded comments with author and body", async ({ admin, page, serverInfo }) => {
+	test("displays seeded comments with author and body", async ({
+		admin,
+		page,
+		request: anonymousRequest,
+		serverInfo,
+	}) => {
 		const postId = serverInfo.contentIds.posts[0]!;
 
 		// Clean slate
 		await cleanupComments(page, serverInfo.baseUrl, serverInfo.token);
 
 		// Seed two comments
-		await seedComment(page, serverInfo.baseUrl, serverInfo.token, postId, {
+		await seedComment(anonymousRequest, serverInfo.baseUrl, postId, {
 			body: "First seeded comment",
 			authorName: "Alice Commenter",
 			authorEmail: "alice@test.com",
 		});
-		await seedComment(page, serverInfo.baseUrl, serverInfo.token, postId, {
+		await seedComment(anonymousRequest, serverInfo.baseUrl, postId, {
 			body: "Second seeded comment",
 			authorName: "Bob Commenter",
 			authorEmail: "bob@test.com",
@@ -151,14 +162,19 @@ test.describe("Comments Moderation", () => {
 		await expect(page.locator("text=Second seeded comment").first()).toBeVisible();
 	});
 
-	test("approve a pending comment", async ({ admin, page, serverInfo }) => {
+	test("approve a pending comment", async ({
+		admin,
+		page,
+		request: anonymousRequest,
+		serverInfo,
+	}) => {
 		const postId = serverInfo.contentIds.posts[0]!;
 
 		// Clean slate
 		await cleanupComments(page, serverInfo.baseUrl, serverInfo.token);
 
 		// Seed a comment
-		await seedComment(page, serverInfo.baseUrl, serverInfo.token, postId, {
+		await seedComment(anonymousRequest, serverInfo.baseUrl, postId, {
 			body: "Comment to approve",
 			authorName: "Approval Tester",
 			authorEmail: "approve@test.com",
@@ -214,14 +230,19 @@ test.describe("Comments Moderation", () => {
 		});
 	});
 
-	test("delete a comment permanently", async ({ admin, page, serverInfo }) => {
+	test("delete a comment permanently", async ({
+		admin,
+		page,
+		request: anonymousRequest,
+		serverInfo,
+	}) => {
 		const postId = serverInfo.contentIds.posts[0]!;
 
 		// Clean slate
 		await cleanupComments(page, serverInfo.baseUrl, serverInfo.token);
 
 		// Seed a comment
-		await seedComment(page, serverInfo.baseUrl, serverInfo.token, postId, {
+		await seedComment(anonymousRequest, serverInfo.baseUrl, postId, {
 			body: "Comment to delete",
 			authorName: "Delete Tester",
 			authorEmail: "delete@test.com",

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -54,6 +54,7 @@ declare global {
 // Role level constants (matching @emdash-cms/auth)
 const ROLE_ADMIN = 50;
 const MCP_ENDPOINT_PATH = "/_emdash/api/mcp";
+const COMMENT_SUBMISSION_PATH = /^\/_emdash\/api\/comments\/[^/]+\/[^/]+\/?$/;
 
 function isUnsafeMethod(method: string): boolean {
 	return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
@@ -190,6 +191,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			const publicOrigin = getPublicOrigin(url, context.locals.emdash?.config);
 			const csrfError = checkPublicCsrf(context.request, url, publicOrigin);
 			if (csrfError) return csrfError;
+		}
+		if (method === "POST" && COMMENT_SUBMISSION_PATH.test(url.pathname)) {
+			return handlePublicRouteAuth(context, next);
 		}
 		return next();
 	}

--- a/packages/core/tests/integration/client/comment-session-auth.test.ts
+++ b/packages/core/tests/integration/client/comment-session-auth.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { TestServerContext } from "../server.js";
+import { assertNodeVersion, createTestServer } from "../server.js";
+
+const PORT = 4404;
+
+function adminFetch(ctx: TestServerContext, path: string, init?: RequestInit): Promise<Response> {
+	return fetch(`${ctx.baseUrl}${path}`, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${ctx.token}`,
+			"X-EmDash-Request": "1",
+			"Content-Type": "application/json",
+			...(init?.headers as Record<string, string>),
+		},
+	});
+}
+
+describe("Comment session authentication", () => {
+	let ctx: TestServerContext;
+
+	beforeAll(async () => {
+		assertNodeVersion();
+		ctx = await createTestServer({ port: PORT });
+
+		const response = await adminFetch(ctx, "/_emdash/api/schema/collections/posts", {
+			method: "PUT",
+			body: JSON.stringify({
+				commentsEnabled: true,
+				commentsModeration: "first_time",
+				commentsAutoApproveUsers: true,
+			}),
+		});
+		if (!response.ok) {
+			const body = await response.text().catch(() => "");
+			throw new Error(`Failed to configure comments (${response.status}): ${body}`);
+		}
+	});
+
+	afterAll(async () => {
+		await ctx?.cleanup();
+	});
+
+	it("retains the CMS user identity and auto-approves their first comment", async () => {
+		const meResponse = await fetch(`${ctx.baseUrl}/_emdash/api/auth/me`, {
+			headers: { Cookie: ctx.sessionCookie },
+		});
+		expect(meResponse.status).toBe(200);
+		const me = (await meResponse.json()) as {
+			data: { id: string; email: string };
+		};
+
+		const postId = ctx.contentIds.posts![0]!;
+		const listResponse = await fetch(`${ctx.baseUrl}/_emdash/api/comments/posts/${postId}`);
+		expect(listResponse.status).toBe(200);
+		const list = (await listResponse.json()) as { data: { total: number } };
+		expect(list.data.total).toBe(0);
+
+		const submitResponse = await fetch(`${ctx.baseUrl}/_emdash/api/comments/posts/${postId}`, {
+			method: "POST",
+			headers: {
+				Cookie: ctx.sessionCookie,
+				"Content-Type": "application/json",
+				Origin: ctx.baseUrl,
+			},
+			body: JSON.stringify({
+				authorName: "Submitted Name",
+				authorEmail: "submitted@example.com",
+				body: "Session-authenticated comment",
+			}),
+		});
+
+		expect(submitResponse.status).toBe(201);
+		const submission = (await submitResponse.json()) as {
+			data: { id: string; status: string; message: string };
+		};
+		expect(submission.data.status).toBe("approved");
+		expect(submission.data.message).toBe("Comment published");
+
+		const detailResponse = await adminFetch(
+			ctx,
+			`/_emdash/api/admin/comments/${submission.data.id}`,
+		);
+		expect(detailResponse.status).toBe(200);
+		const detail = (await detailResponse.json()) as {
+			data: {
+				status: string;
+				authorName: string;
+				authorEmail: string;
+				authorUserId: string | null;
+			};
+		};
+		expect(detail.data).toMatchObject({
+			status: "approved",
+			authorName: "Dev Admin",
+			authorEmail: me.data.email,
+			authorUserId: me.data.id,
+		});
+	});
+});

--- a/packages/core/tests/integration/client/comment-session-auth.test.ts
+++ b/packages/core/tests/integration/client/comment-session-auth.test.ts
@@ -17,32 +17,83 @@ function adminFetch(ctx: TestServerContext, path: string, init?: RequestInit): P
 	});
 }
 
+async function configureComments(
+	ctx: TestServerContext,
+	commentsModeration: "all" | "first_time",
+	commentsAutoApproveUsers: boolean,
+): Promise<void> {
+	const response = await adminFetch(ctx, "/_emdash/api/schema/collections/posts", {
+		method: "PUT",
+		body: JSON.stringify({
+			commentsEnabled: true,
+			commentsModeration,
+			commentsAutoApproveUsers,
+		}),
+	});
+	if (!response.ok) {
+		const body = await response.text().catch(() => "");
+		throw new Error(`Failed to configure comments (${response.status}): ${body}`);
+	}
+}
+
 describe("Comment session authentication", () => {
 	let ctx: TestServerContext;
 
 	beforeAll(async () => {
 		assertNodeVersion();
 		ctx = await createTestServer({ port: PORT });
-
-		const response = await adminFetch(ctx, "/_emdash/api/schema/collections/posts", {
-			method: "PUT",
-			body: JSON.stringify({
-				commentsEnabled: true,
-				commentsModeration: "first_time",
-				commentsAutoApproveUsers: true,
-			}),
-		});
-		if (!response.ok) {
-			const body = await response.text().catch(() => "");
-			throw new Error(`Failed to configure comments (${response.status}): ${body}`);
-		}
 	});
 
 	afterAll(async () => {
 		await ctx?.cleanup();
 	});
 
+	it("keeps an anonymous first comment pending without a CMS user identity", async () => {
+		await configureComments(ctx, "first_time", true);
+		const postId = ctx.contentIds.posts![0]!;
+		const submitResponse = await fetch(`${ctx.baseUrl}/_emdash/api/comments/posts/${postId}`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Origin: ctx.baseUrl,
+			},
+			body: JSON.stringify({
+				authorName: "Anonymous Visitor",
+				authorEmail: "anonymous@example.com",
+				body: "Anonymous first comment",
+			}),
+		});
+
+		expect(submitResponse.status).toBe(201);
+		const submission = (await submitResponse.json()) as {
+			data: { id: string; status: string; message: string };
+		};
+		expect(submission.data.status).toBe("pending");
+		expect(submission.data.message).toBe("Comment submitted for review");
+
+		const detailResponse = await adminFetch(
+			ctx,
+			`/_emdash/api/admin/comments/${submission.data.id}`,
+		);
+		expect(detailResponse.status).toBe(200);
+		const detail = (await detailResponse.json()) as {
+			data: {
+				status: string;
+				authorName: string;
+				authorEmail: string;
+				authorUserId: string | null;
+			};
+		};
+		expect(detail.data).toMatchObject({
+			status: "pending",
+			authorName: "Anonymous Visitor",
+			authorEmail: "anonymous@example.com",
+			authorUserId: null,
+		});
+	});
+
 	it("retains the CMS user identity and auto-approves their first comment", async () => {
+		await configureComments(ctx, "first_time", true);
 		const meResponse = await fetch(`${ctx.baseUrl}/_emdash/api/auth/me`, {
 			headers: { Cookie: ctx.sessionCookie },
 		});
@@ -51,7 +102,7 @@ describe("Comment session authentication", () => {
 			data: { id: string; email: string };
 		};
 
-		const postId = ctx.contentIds.posts![0]!;
+		const postId = ctx.contentIds.posts![1]!;
 		const listResponse = await fetch(`${ctx.baseUrl}/_emdash/api/comments/posts/${postId}`);
 		expect(listResponse.status).toBe(200);
 		const list = (await listResponse.json()) as { data: { total: number } };
@@ -93,6 +144,60 @@ describe("Comment session authentication", () => {
 		};
 		expect(detail.data).toMatchObject({
 			status: "approved",
+			authorName: "Dev Admin",
+			authorEmail: me.data.email,
+			authorUserId: me.data.id,
+		});
+	});
+
+	it("retains the CMS user identity when authenticated comments require moderation", async () => {
+		await configureComments(ctx, "all", false);
+
+		const meResponse = await fetch(`${ctx.baseUrl}/_emdash/api/auth/me`, {
+			headers: { Cookie: ctx.sessionCookie },
+		});
+		expect(meResponse.status).toBe(200);
+		const me = (await meResponse.json()) as {
+			data: { id: string; email: string };
+		};
+
+		const postId = ctx.contentIds.posts![0]!;
+		const submitResponse = await fetch(`${ctx.baseUrl}/_emdash/api/comments/posts/${postId}`, {
+			method: "POST",
+			headers: {
+				Cookie: ctx.sessionCookie,
+				"Content-Type": "application/json",
+				Origin: ctx.baseUrl,
+			},
+			body: JSON.stringify({
+				authorName: "Submitted Name",
+				authorEmail: "submitted@example.com",
+				body: "Authenticated comment awaiting moderation",
+			}),
+		});
+
+		expect(submitResponse.status).toBe(201);
+		const submission = (await submitResponse.json()) as {
+			data: { id: string; status: string; message: string };
+		};
+		expect(submission.data.status).toBe("pending");
+		expect(submission.data.message).toBe("Comment submitted for review");
+
+		const detailResponse = await adminFetch(
+			ctx,
+			`/_emdash/api/admin/comments/${submission.data.id}`,
+		);
+		expect(detailResponse.status).toBe(200);
+		const detail = (await detailResponse.json()) as {
+			data: {
+				status: string;
+				authorName: string;
+				authorEmail: string;
+				authorUserId: string | null;
+			};
+		};
+		expect(detail.data).toMatchObject({
+			status: "pending",
 			authorName: "Dev Admin",
 			authorEmail: me.data.email,
 			authorUserId: me.data.id,

--- a/packages/core/tests/unit/astro/comments-public-auth.test.ts
+++ b/packages/core/tests/unit/astro/comments-public-auth.test.ts
@@ -1,0 +1,124 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+
+const { getUserById, resolveSessionUser } = vi.hoisted(() => ({
+	getUserById: vi.fn(),
+	resolveSessionUser: vi.fn(),
+}));
+
+vi.mock("virtual:emdash/auth", () => ({ authenticate: vi.fn() }), { virtual: true });
+vi.mock("virtual:emdash/config", () => ({ default: {} }), { virtual: true });
+vi.mock("@emdash-cms/auth/adapters/kysely", () => ({
+	createKyselyAdapter: () => ({ getUserById }),
+}));
+vi.mock("../../../src/astro/session-user.js", () => ({ resolveSessionUser }));
+
+type AuthMiddlewareModule = typeof import("../../../src/astro/middleware/auth.js");
+
+let onRequest: AuthMiddlewareModule["onRequest"];
+
+beforeAll(async () => {
+	({ onRequest } = await import("../../../src/astro/middleware/auth.js"));
+});
+
+beforeEach(() => {
+	getUserById.mockReset();
+	resolveSessionUser.mockReset();
+});
+
+function createContext(pathname = "/_emdash/api/comments/posts/post-1", method = "POST") {
+	const url = new URL(pathname, "https://site.example.com");
+	const locals: Record<string, unknown> & {
+		user?: { id: string; email: string; disabled: boolean };
+	} = {
+		emdash: { db: {}, config: {} },
+	};
+	const session = {
+		get: vi.fn(),
+		set: vi.fn(),
+		destroy: vi.fn(),
+	};
+	const next = vi.fn(async () => new Response("ok"));
+	const requestInit: RequestInit = {
+		method,
+		headers: {
+			"Content-Type": "application/json",
+			Origin: url.origin,
+		},
+	};
+	if (method !== "GET" && method !== "HEAD") requestInit.body = "{}";
+
+	return {
+		locals,
+		next,
+		context: {
+			url,
+			request: new Request(url, requestInit),
+			locals,
+			session,
+			redirect: vi.fn(),
+		},
+	};
+}
+
+describe("session auth on the public comments API", () => {
+	it("sets locals.user when a valid CMS session submits a comment", async () => {
+		resolveSessionUser.mockResolvedValue({ id: "user-1" });
+		getUserById.mockResolvedValue({
+			id: "user-1",
+			email: "admin@example.com",
+			disabled: false,
+		});
+		const { context, locals, next } = createContext();
+
+		const response = await onRequest(
+			context as Parameters<AuthMiddlewareModule["onRequest"]>[0],
+			next,
+		);
+
+		expect(response.status).toBe(200);
+		expect(next).toHaveBeenCalledOnce();
+		expect(locals.user).toMatchObject({ id: "user-1", email: "admin@example.com" });
+	});
+
+	it("continues anonymously when no CMS session exists", async () => {
+		resolveSessionUser.mockResolvedValue(null);
+		const { context, locals, next } = createContext();
+
+		const response = await onRequest(
+			context as Parameters<AuthMiddlewareModule["onRequest"]>[0],
+			next,
+		);
+
+		expect(response.status).toBe(200);
+		expect(next).toHaveBeenCalledOnce();
+		expect(locals.user).toBeUndefined();
+	});
+
+	it.each([
+		["comment list requests", "GET", "/_emdash/api/comments/posts/post-1"],
+		["comment reaction requests", "POST", "/_emdash/api/comments/posts/post-1/reactions"],
+	])("does not resolve a CMS session for %s", async (_label, method, pathname) => {
+		resolveSessionUser.mockResolvedValue({ id: "user-1" });
+		getUserById.mockResolvedValue({
+			id: "user-1",
+			email: "admin@example.com",
+			disabled: false,
+		});
+		const { context, locals, next } = createContext(pathname, method);
+
+		const response = await onRequest(
+			context as Parameters<AuthMiddlewareModule["onRequest"]>[0],
+			next,
+		);
+
+		expect(response.status).toBe(200);
+		expect(next).toHaveBeenCalledOnce();
+		expect(resolveSessionUser).not.toHaveBeenCalled();
+		expect(getUserById).not.toHaveBeenCalled();
+		expect(locals.user).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Public comment API routes return before the middleware's normal authentication path. As a result, a valid CMS session was not resolved for comment submissions, so signed-in CMS users were treated as anonymous: `authorUserId` was stored as `null`, submitted author fields were used instead of the CMS identity, and `commentsAutoApproveUsers` was not honored. With `first_time` moderation and no prior approved comment for the submitted email, even a signed-in administrator's first comment remained pending.

This PR applies existing soft session authentication only to `POST /_emdash/api/comments/{collection}/{contentId}` after the existing CSRF check. Public comment list requests and nested routes such as reactions do not perform session or user lookups, and submissions without a valid session continue through the anonymous comment flow.

It adds:

- middleware regression coverage for authenticated and anonymous submissions;
- explicit coverage that comment-list and reaction requests do not resolve sessions;
- a real-server integration test that starts with zero comments, submits through a real CMS session under `first_time` moderation, and verifies both automatic approval and the persisted CMS user identity.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable; this PR adds no admin UI strings)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: not applicable; this is a bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No visual changes.

The integration regression test passes against this patch:

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

As a red/green check, temporarily removing the new soft-auth branch makes the same test fail with `expected 'pending' to be 'approved'`.

Additional validation:

```text
Related tests: 5 files passed, 71 tests passed
pnpm typecheck: passed
pnpm lint: passed
pnpm format:check: passed
git diff --check: passed
```
