### PR TITLE
fix(editor): indent code blocks with Tab

### DIFF
--- a/.changeset/code-block-tab-indentation.md
+++ b/.changeset/code-block-tab-indentation.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes code blocks in the admin and inline visual editors so Tab and Shift+Tab indent and outdent code instead of moving focus.

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -211,7 +211,21 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
  * the editor's extensions array.
  */
 export const CodeBlockExtension = CodeBlock.extend({
+	addKeyboardShortcuts() {
+		const shortcuts = this.parent?.() ?? {};
+		const selectionIsInCodeBlock = () => {
+			const { $from, $to } = this.editor.state.selection;
+			return $from.parent.type === this.type && $from.sameParent($to);
+		};
+
+		return {
+			...shortcuts,
+			Tab: (props) => (selectionIsInCodeBlock() ? (shortcuts.Tab?.(props) ?? false) : false),
+			"Shift-Tab": (props) =>
+				selectionIsInCodeBlock() ? (shortcuts["Shift-Tab"]?.(props) ?? false) : false,
+		};
+	},
 	addNodeView() {
 		return ReactNodeViewRenderer(CodeBlockNodeView);
 	},
-});
+}).configure({ enableTabIndentation: true, tabSize: 4 });

--- a/packages/admin/tests/editor/CodeBlockNode.test.ts
+++ b/packages/admin/tests/editor/CodeBlockNode.test.ts
@@ -7,15 +7,41 @@
  *   - The `language` attribute is settable and round-trips through getJSON.
  *   - StarterKit's backtick input rule still fires when our extension is
  *     swapped in (since we extend the base extension rather than replace
- *     it). We can't drive real keyboard input in jsdom, so we verify the
- *     rule's regex is registered via the extension's inputRules schema.
+ *     it).
  */
 
-import { Editor } from "@tiptap/core";
+import { Editor, type Content } from "@tiptap/core";
+import { closeHistory } from "@tiptap/pm/history";
 import StarterKit from "@tiptap/starter-kit";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { CodeBlockExtension } from "../../src/components/editor/CodeBlockNode";
+
+type Selection = number | { from: number; to: number };
+
+const tabEventInit = { key: "Tab", bubbles: true, cancelable: true };
+
+function pressTab(editor: Editor, shiftKey = false) {
+	const event = new KeyboardEvent("keydown", { ...tabEventInit, shiftKey });
+	editor.view.dom.dispatchEvent(event);
+	return event;
+}
+
+function setCode(editor: Editor, text: string) {
+	editor.commands.setContent({ type: "codeBlock", content: [{ type: "text", text }] });
+}
+
+function expectTabUnhandled(editor: Editor, content: Content, selection: Selection) {
+	for (const shiftKey of [false, true]) {
+		editor.commands.setContent(content);
+		editor.commands.setTextSelection(selection);
+		const before = editor.state.doc.toJSON();
+		const selected = editor.state.selection.toJSON();
+		expect(pressTab(editor, shiftKey).defaultPrevented).toBe(false);
+		expect(editor.state.doc.toJSON()).toEqual(before);
+		expect(editor.state.selection.toJSON()).toEqual(selected);
+	}
+}
 
 describe("CodeBlockExtension", () => {
 	let editor: Editor;
@@ -73,5 +99,45 @@ describe("CodeBlockExtension", () => {
 		editor.commands.updateAttributes("codeBlock", { language: "typescript" });
 		const node = editor.getJSON().content?.find((n) => n.type === "codeBlock");
 		expect((node as { attrs?: { language?: string } }).attrs?.language).toBe("typescript");
+	});
+
+	it.each([
+		["indentation", false, "code", 3, "co    de"],
+		["outdent", true, "      code", 11, "  code"],
+	])("handles caret %s as one undoable operation", (_name, shiftKey, before, position, after) => {
+		setCode(editor, before);
+		editor.view.dispatch(closeHistory(editor.state.tr));
+		editor.commands.setTextSelection(position);
+		expect(pressTab(editor, shiftKey).defaultPrevented).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe(after);
+		expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+		expect(editor.commands.undo()).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe(before);
+		expect(editor.commands.redo()).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe(after);
+	});
+
+	it("indents and outdents a multiline selection", () => {
+		setCode(editor, "one\ntwo");
+		editor.commands.setTextSelection({ from: 1, to: 8 });
+		expect(pressTab(editor).defaultPrevented).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe("    one\n    two");
+		expect(pressTab(editor, true).defaultPrevented).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe("one\ntwo");
+	});
+
+	it("leaves paragraph and cross-block selections unhandled", () => {
+		expectTabUnhandled(editor, { type: "paragraph", content: [{ type: "text", text: "text" }] }, 2);
+		expectTabUnhandled(
+			editor,
+			{
+				type: "doc",
+				content: [
+					{ type: "codeBlock", content: [{ type: "text", text: "code" }] },
+					{ type: "paragraph", content: [{ type: "text", text: "after" }] },
+				],
+			},
+			{ from: 1, to: 9 },
+		);
 	});
 });

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -337,7 +337,21 @@ function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewP
  * extension to the editor.
  */
 export const InlineCodeBlockExtension = CodeBlock.extend({
+	addKeyboardShortcuts() {
+		const shortcuts = this.parent?.() ?? {};
+		const selectionIsInCodeBlock = () => {
+			const { $from, $to } = this.editor.state.selection;
+			return $from.parent.type === this.type && $from.sameParent($to);
+		};
+
+		return {
+			...shortcuts,
+			Tab: (props) => (selectionIsInCodeBlock() ? (shortcuts.Tab?.(props) ?? false) : false),
+			"Shift-Tab": (props) =>
+				selectionIsInCodeBlock() ? (shortcuts["Shift-Tab"]?.(props) ?? false) : false,
+		};
+	},
 	addNodeView() {
 		return ReactNodeViewRenderer(InlineCodeBlockNodeView);
 	},
-});
+}).configure({ enableTabIndentation: true, tabSize: 4 });

--- a/packages/core/tests/unit/components/inline-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-code-block.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { Editor, type Content } from "@tiptap/core";
+import { closeHistory } from "@tiptap/pm/history";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { InlineCodeBlockExtension } from "../../../src/components/inline-code-block.js";
+
+type Selection = number | { from: number; to: number };
+const tabEventInit = { key: "Tab", bubbles: true, cancelable: true };
+let editor: Editor;
+function pressTab(shiftKey = false) {
+	const event = new KeyboardEvent("keydown", { ...tabEventInit, shiftKey });
+	editor.view.dom.dispatchEvent(event);
+	return event;
+}
+function setCode(text: string) {
+	editor.commands.setContent({ type: "codeBlock", content: [{ type: "text", text }] });
+}
+function expectTabUnhandled(content: Content, selection: Selection) {
+	for (const shiftKey of [false, true]) {
+		editor.commands.setContent(content);
+		editor.commands.setTextSelection(selection);
+		const before = editor.state.doc.toJSON();
+		const selected = editor.state.selection.toJSON();
+		expect(pressTab(shiftKey).defaultPrevented).toBe(false);
+		expect(editor.state.doc.toJSON()).toEqual(before);
+		expect(editor.state.selection.toJSON()).toEqual(selected);
+	}
+}
+
+describe("InlineCodeBlockExtension", () => {
+	beforeEach(() => {
+		editor = new Editor({
+			extensions: [StarterKit.configure({ codeBlock: false }), InlineCodeBlockExtension],
+		});
+	});
+
+	afterEach(() => editor.destroy());
+
+	it.each([
+		["indentation", false, "code", 3, "co    de"],
+		["outdent", true, "      code", 11, "  code"],
+	])("handles caret %s as one undoable operation", (_name, shiftKey, before, position, after) => {
+		setCode(before);
+		editor.view.dispatch(closeHistory(editor.state.tr));
+		editor.commands.setTextSelection(position);
+		expect(pressTab(shiftKey).defaultPrevented).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe(after);
+		expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+		editor.commands.undo();
+		expect(editor.state.doc.firstChild?.textContent).toBe(before);
+		editor.commands.redo();
+		expect(editor.state.doc.firstChild?.textContent).toBe(after);
+	});
+
+	it("indents and outdents a multiline selection", () => {
+		setCode("one\ntwo");
+		editor.commands.setTextSelection({ from: 1, to: 8 });
+		expect(pressTab().defaultPrevented).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe("    one\n    two");
+		expect(pressTab(true).defaultPrevented).toBe(true);
+		expect(editor.state.doc.firstChild?.textContent).toBe("one\ntwo");
+	});
+
+	it("leaves paragraph and cross-block selections unhandled", () => {
+		expectTabUnhandled({ type: "paragraph", content: [{ type: "text", text: "text" }] }, 2);
+		expectTabUnhandled(
+			{
+				type: "doc",
+				content: [
+					{ type: "codeBlock", content: [{ type: "text", text: "code" }] },
+					{ type: "paragraph", content: [{ type: "text", text: "after" }] },
+				],
+			},
+			{ from: 1, to: 9 },
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Makes `Tab` and `Shift+Tab` indent and outdent code blocks by four spaces in the admin and inline visual editors. The shortcuts run only when the complete selection is inside one code block, so paragraph and cross-block selections keep their normal keyboard behavior and structure.

Closes #2594

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

No new user-visible strings are included. A Discussion is not required because this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format` and `pnpm format:check`
- Admin Chromium tests: `tests/editor/CodeBlockNode.test.ts`
- Core jsdom tests: `tests/unit/components/inline-code-block.test.ts`
- Manual keyboard, focus-exit, autosave, and reload checks in both editor surfaces
