### PR TITLE
fix(editor): polish code block controls

### DIFF
--- a/.changeset/gentle-code-block-controls.md
+++ b/.changeset/gentle-code-block-controls.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Adds matching code-block controls to the admin and inline visual editors for selecting a language and copying code.

--- a/.changeset/gentle-code-block-controls.md
+++ b/.changeset/gentle-code-block-controls.md
@@ -1,6 +1,0 @@
----
-"@emdash-cms/admin": patch
-"emdash": patch
----
-
-Adds matching code-block controls to the admin and inline visual editors for selecting a language and copying code.

--- a/.changeset/quiet-code-block-actions.md
+++ b/.changeset/quiet-code-block-actions.md
@@ -3,4 +3,4 @@
 "emdash": patch
 ---
 
-Adds language selection and one-click copying to code blocks in the admin and inline visual editors, with controls that adapt to narrow screens.
+Adds one-click copy actions to code-block controls in the admin and inline visual editors, and polishes the layout so controls stay usable on narrow screens and in right-to-left locales.

--- a/.changeset/quiet-code-block-actions.md
+++ b/.changeset/quiet-code-block-actions.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Adds compact code-block controls for selecting a language and copying code in the admin and inline visual editors.

--- a/.changeset/quiet-code-block-actions.md
+++ b/.changeset/quiet-code-block-actions.md
@@ -3,4 +3,4 @@
 "emdash": patch
 ---
 
-Adds compact code-block controls for selecting a language and copying code in the admin and inline visual editors.
+Adds compact, responsive language and copy controls to code blocks in the admin and inline visual editors.

--- a/.changeset/quiet-code-block-actions.md
+++ b/.changeset/quiet-code-block-actions.md
@@ -3,4 +3,4 @@
 "emdash": patch
 ---
 
-Adds compact, responsive language and copy controls to code blocks in the admin and inline visual editors.
+Adds language selection and one-click copying to code blocks in the admin and inline visual editors, with controls that adapt to narrow screens.

--- a/e2e/fixture/src/pages/posts/[slug].astro
+++ b/e2e/fixture/src/pages/posts/[slug].astro
@@ -12,6 +12,17 @@ if (!post) return new Response("Not found", { status: 404 });
 <html>
 	<head>
 		<title>{post.data.title}</title>
+		<style>
+			#body :global(pre) {
+				padding-block: 1.25rem;
+				border: 1px solid #d1d5db;
+			}
+			#body :global(pre), #body :global(pre code) {
+				background: #181818;
+				color: #ffffff;
+				font-size: 1rem;
+			}
+		</style>
 	</head>
 	<body>
 		<article>

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -29,6 +29,118 @@ test.describe("Admin code block highlighting", () => {
 		await expect(codeBlock).toHaveCSS("background-color", "rgb(32, 32, 32)");
 		await expect(codeBlock).toHaveCSS("border-top-width", "0px");
 	});
+
+	test("shows aligned two-action controls and applies their actions", async ({ admin }) => {
+		const codeBlockNode = admin.page.locator(".emdash-code-block-node").first();
+		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
+		const languageButton = controls.getByRole("button", { name: /^Set language/ });
+		const copyButton = controls.getByRole("button", { name: "Copy code" });
+		let updateRequests = 0;
+		admin.page.on("request", (request) => {
+			if (request.method() === "PUT" && request.url().includes("/_emdash/api/content/")) {
+				updateRequests += 1;
+			}
+		});
+
+		await admin.page.mouse.move(0, 0);
+		await expect(controls).toHaveCSS("opacity", "0");
+		await languageButton.focus();
+		await expect(controls).toHaveCSS("opacity", "1");
+		await codeBlockNode.hover();
+		await expect(controls).toHaveCSS("opacity", "1");
+		await expect(controls.getByRole("button")).toHaveCount(2);
+		await expect(languageButton).toHaveCSS("font-size", "14px");
+		await expect(copyButton).toHaveCSS("font-size", "14px");
+
+		const nodeBox = await codeBlockNode.boundingBox();
+		const controlsBox = await controls.boundingBox();
+		const languageBox = await languageButton.boundingBox();
+		const codeTextTop = await codeBlockNode.locator("code").evaluate((element) => {
+			const range = document.createRange();
+			range.selectNodeContents(element);
+			return range.getClientRects()[0]?.top;
+		});
+		expect(nodeBox).not.toBeNull();
+		expect(controlsBox).not.toBeNull();
+		expect(languageBox?.height).toBe(32);
+		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 8, 0);
+		expect(controlsBox?.x).toBeCloseTo(
+			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 8,
+			0,
+		);
+		expect(codeTextTop ?? 0).toBeGreaterThanOrEqual(
+			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0) + 8,
+		);
+
+		await languageButton.click();
+		await admin.page.mouse.move(0, 0);
+		await expect(controls).toHaveCSS("opacity", "1");
+		const input = admin.page.getByPlaceholder("Search for a language…");
+		const popup = admin.page.locator(".kumo-popover-popup");
+		await expect(input).toBeVisible();
+		await expect(input).toHaveCSS("font-size", "14px");
+		await expect(admin.page.getByRole("option", { name: "Plain text" })).toHaveCSS(
+			"font-size",
+			"14px",
+		);
+		const placeholderColor = await input.evaluate(
+			(element) => getComputedStyle(element, "::placeholder").color,
+		);
+		const inputColor = await input.evaluate((element) => getComputedStyle(element).color);
+		expect(placeholderColor).not.toBe(inputColor);
+
+		const popupBox = await popup.boundingBox();
+		const openControlsBox = await controls.boundingBox();
+		expect(popupBox?.x).toBeCloseTo(openControlsBox?.x ?? 0, 0);
+		const popupBelowGap =
+			(popupBox?.y ?? 0) - ((openControlsBox?.y ?? 0) + (openControlsBox?.height ?? 0));
+		const popupAboveGap =
+			(openControlsBox?.y ?? 0) - ((popupBox?.y ?? 0) + (popupBox?.height ?? 0));
+		expect(Math.max(popupBelowGap, popupAboveGap)).toBeCloseTo(8, 0);
+
+		await admin.page.keyboard.press("Escape");
+		await expect(input).toBeHidden();
+		await admin.page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+		await copyButton.click();
+		await expect(controls.getByRole("button", { name: "Copied" })).toBeVisible();
+		await admin.page.waitForTimeout(2200);
+		expect(updateRequests).toBe(0);
+
+		await languageButton.click();
+		const autosaveResponse = admin.page.waitForResponse(
+			(response) =>
+				response.request().method() === "PUT" && response.url().includes("/_emdash/api/content/"),
+			{ timeout: 5000 },
+		);
+		await admin.page.getByRole("option", { name: "Python" }).click();
+		await expect(
+			controls.getByRole("button", { name: "Set language (current: Python)" }),
+		).toBeVisible();
+		await autosaveResponse;
+		expect(updateRequests).toBe(1);
+	});
+
+	test("keeps controls and language search inside a narrow RTL editor", async ({ admin }) => {
+		await admin.page.setViewportSize({ width: 320, height: 800 });
+		await admin.page.evaluate(() => {
+			document.querySelector(".emdash-code-block-node")?.setAttribute("dir", "rtl");
+		});
+		const codeBlockNode = admin.page.locator(".emdash-code-block-node").first();
+		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
+		await codeBlockNode.hover();
+		await expect(controls).toBeVisible();
+
+		const nodeBox = await codeBlockNode.boundingBox();
+		const controlsBox = await controls.boundingBox();
+		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 8, 0);
+
+		await controls.getByRole("button", { name: /^Set language/ }).click();
+		const popupBox = await admin.page.locator(".kumo-popover-popup").boundingBox();
+		expect(popupBox).not.toBeNull();
+		expect(popupBox?.x ?? -1).toBeGreaterThanOrEqual(0);
+		expect((popupBox?.x ?? 0) + (popupBox?.width ?? 0)).toBeLessThanOrEqual(320);
+		expect(popupBox?.width ?? 0).toBeLessThanOrEqual(288);
+	});
 });
 
 test("keeps public code block rendering unchanged", async ({ page }) => {

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -53,26 +53,31 @@ test.describe("Admin code block highlighting", () => {
 		await expect(controls.getByRole("button")).toHaveCount(2);
 		await expect(languageButton).toHaveCSS("font-size", "14px");
 		await expect(copyButton).toHaveCSS("font-size", "14px");
+		await expect(copyButton).toHaveAttribute("data-kumo-component", "Toolbar.Button");
 
 		const nodeBox = await codeBlockNode.boundingBox();
 		const controlsBox = await controls.boundingBox();
 		const languageBox = await languageButton.boundingBox();
-		const codeTextTop = await codeBlockNode.locator("code").evaluate((element) => {
+		const codeText = await codeBlockNode.locator("code").evaluate((element) => {
 			const range = document.createRange();
 			range.selectNodeContents(element);
-			return range.getClientRects()[0]?.top;
+			const rects = [...range.getClientRects()];
+			return { top: rects[0]?.top, bottom: rects.at(-1)?.bottom };
 		});
 		expect(nodeBox).not.toBeNull();
 		expect(controlsBox).not.toBeNull();
-		expect(languageBox?.height).toBe(32);
-		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 8, 0);
+		expect(languageBox?.height).toBe(36);
+		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 4, 0);
 		expect(controlsBox?.x).toBeCloseTo(
-			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 8,
+			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
 			0,
 		);
-		expect(codeTextTop ?? 0).toBeGreaterThanOrEqual(
+		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
 			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0) + 8,
 		);
+		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
+		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
+		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(4);
 
 		const currentLanguageLabel = await languageButton.getAttribute("aria-label");
 		const nextLanguage = currentLanguageLabel?.includes("Python") ? "JavaScript" : "Python";
@@ -107,6 +112,11 @@ test.describe("Admin code block highlighting", () => {
 
 		await admin.page.keyboard.press("Escape");
 		await expect(input).toBeHidden();
+		await copyButton.hover();
+		await expect(
+			admin.page.locator(".kumo-tooltip-popup").filter({ hasText: "Copy code" }),
+		).toBeVisible();
+		await expect(admin.page.locator(".kumo-tooltip-popup")).toHaveCount(1);
 		await admin.page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
 		await copyButton.click();
 		await expect(controls.getByRole("button", { name: "Copied" })).toBeVisible();
@@ -139,7 +149,7 @@ test.describe("Admin code block highlighting", () => {
 
 		const nodeBox = await codeBlockNode.boundingBox();
 		const controlsBox = await controls.boundingBox();
-		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 8, 0);
+		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 4, 0);
 
 		await controls.getByRole("button", { name: /^Set language/ }).click();
 		const popupBox = await admin.page.locator(".kumo-popover-popup").boundingBox();
@@ -198,6 +208,7 @@ test.describe("Inline code block highlighting", () => {
 		});
 		await page.waitForTimeout(2200);
 		updateRequests = 0;
+		await page.emulateMedia({ colorScheme: "dark" });
 		const outsideControlStyle = await page.evaluate(() => {
 			const outside = document.createElement("div");
 			outside.className = "emdash-inline-code-block-controls-wrap";
@@ -229,26 +240,31 @@ test.describe("Inline code block highlighting", () => {
 		await expect(controls.getByRole("button")).toHaveCount(2);
 		await expect(languageButton).toHaveCSS("font-size", "14px");
 		await expect(copyButton).toHaveCSS("font-size", "14px");
+		await expect(controls).toHaveCSS("background-color", "rgb(24, 24, 24)");
 
 		const nodeBox = await codeBlockNode.boundingBox();
 		const controlsBox = await controls.boundingBox();
 		const languageBox = await languageButton.boundingBox();
-		const codeTextTop = await codeBlockNode.locator("code").evaluate((element) => {
+		const codeText = await codeBlockNode.locator("code").evaluate((element) => {
 			const range = document.createRange();
 			range.selectNodeContents(element);
-			return range.getClientRects()[0]?.top;
+			const rects = [...range.getClientRects()];
+			return { top: rects[0]?.top, bottom: rects.at(-1)?.bottom };
 		});
 		expect(nodeBox).not.toBeNull();
 		expect(controlsBox).not.toBeNull();
-		expect(languageBox?.height).toBe(32);
-		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 8, 0);
+		expect(languageBox?.height).toBe(36);
+		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 4, 0);
 		expect(controlsBox?.x).toBeCloseTo(
-			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 8,
+			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
 			0,
 		);
-		expect(codeTextTop ?? 0).toBeGreaterThanOrEqual(
+		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
 			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0) + 8,
 		);
+		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
+		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
+		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(4);
 
 		await languageButton.click();
 		await page.mouse.move(0, 0);
@@ -325,7 +341,7 @@ test.describe("Inline code block highlighting", () => {
 
 		const nodeBox = await codeBlockNode.boundingBox();
 		const controlsBox = await controls.boundingBox();
-		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 8, 0);
+		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 4, 0);
 
 		await controls.getByRole("button", { name: /^Set language/ }).click();
 		const popup = page.locator(".emdash-inline-code-block-popover");

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -41,6 +41,8 @@ test.describe("Admin code block highlighting", () => {
 				updateRequests += 1;
 			}
 		});
+		await admin.page.waitForTimeout(2200);
+		updateRequests = 0;
 
 		await admin.page.mouse.move(0, 0);
 		await expect(controls).toHaveCSS("opacity", "0");
@@ -72,6 +74,8 @@ test.describe("Admin code block highlighting", () => {
 			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0) + 8,
 		);
 
+		const currentLanguageLabel = await languageButton.getAttribute("aria-label");
+		const nextLanguage = currentLanguageLabel?.includes("Python") ? "JavaScript" : "Python";
 		await languageButton.click();
 		await admin.page.mouse.move(0, 0);
 		await expect(controls).toHaveCSS("opacity", "1");
@@ -83,6 +87,9 @@ test.describe("Admin code block highlighting", () => {
 			"font-size",
 			"14px",
 		);
+		await popup.evaluate(async (element) => {
+			await Promise.all(element.getAnimations().map((animation) => animation.finished));
+		});
 		const placeholderColor = await input.evaluate(
 			(element) => getComputedStyle(element, "::placeholder").color,
 		);
@@ -112,9 +119,9 @@ test.describe("Admin code block highlighting", () => {
 				response.request().method() === "PUT" && response.url().includes("/_emdash/api/content/"),
 			{ timeout: 5000 },
 		);
-		await admin.page.getByRole("option", { name: "Python" }).click();
+		await admin.page.getByRole("option", { name: nextLanguage }).click();
 		await expect(
-			controls.getByRole("button", { name: "Set language (current: Python)" }),
+			controls.getByRole("button", { name: `Set language (current: ${nextLanguage})` }),
 		).toBeVisible();
 		await autosaveResponse;
 		expect(updateRequests).toBe(1);
@@ -175,6 +182,127 @@ test.describe("Inline code block highlighting", () => {
 		await expect(codeBlocks.nth(1).locator('span[class*="hljs-"]')).toHaveCount(0);
 	});
 
+	test("matches the admin controls without saving during control interactions", async ({
+		page,
+	}) => {
+		const codeBlockNode = page.locator(".emdash-inline-code-block").first();
+		const controlsWrap = codeBlockNode.locator(".emdash-inline-code-block-controls-wrap");
+		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
+		const languageButton = controls.getByRole("button", { name: /^Set language/ });
+		const copyButton = controls.getByRole("button", { name: "Copy code" });
+		let updateRequests = 0;
+		page.on("request", (request) => {
+			if (request.method() === "PUT" && request.url().includes("/_emdash/api/content/")) {
+				updateRequests += 1;
+			}
+		});
+		await page.waitForTimeout(2200);
+		updateRequests = 0;
+
+		await page.mouse.move(0, 0);
+		await page.evaluate(() => {
+			if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+		});
+		await expect(controlsWrap).toHaveCSS("opacity", "0");
+		await languageButton.focus();
+		await expect(controlsWrap).toHaveCSS("opacity", "1");
+		await codeBlockNode.hover();
+		await expect(controlsWrap).toHaveCSS("opacity", "1");
+		await expect(controls.getByRole("button")).toHaveCount(2);
+		await expect(languageButton).toHaveCSS("font-size", "14px");
+		await expect(copyButton).toHaveCSS("font-size", "14px");
+
+		const nodeBox = await codeBlockNode.boundingBox();
+		const controlsBox = await controls.boundingBox();
+		const languageBox = await languageButton.boundingBox();
+		const codeTextTop = await codeBlockNode.locator("code").evaluate((element) => {
+			const range = document.createRange();
+			range.selectNodeContents(element);
+			return range.getClientRects()[0]?.top;
+		});
+		expect(nodeBox).not.toBeNull();
+		expect(controlsBox).not.toBeNull();
+		expect(languageBox?.height).toBe(32);
+		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 8, 0);
+		expect(controlsBox?.x).toBeCloseTo(
+			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 8,
+			0,
+		);
+		expect(codeTextTop ?? 0).toBeGreaterThanOrEqual(
+			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0) + 8,
+		);
+
+		await languageButton.click();
+		await page.mouse.move(0, 0);
+		await expect(controlsWrap).toHaveCSS("opacity", "1");
+		const input = page.getByPlaceholder("Search for a language…");
+		const popup = page.locator(".emdash-inline-code-block-popover");
+		await expect(input).toBeVisible();
+		await expect(input).toBeFocused();
+		await expect(input).toHaveCSS("font-size", "14px");
+		await expect(page.getByRole("option", { name: "Plain text" })).toHaveCSS("font-size", "14px");
+		const placeholderColor = await input.evaluate(
+			(element) => getComputedStyle(element, "::placeholder").color,
+		);
+		const inputColor = await input.evaluate((element) => getComputedStyle(element).color);
+		expect(placeholderColor).not.toBe(inputColor);
+
+		const popupBox = await popup.boundingBox();
+		const openControlsBox = await controls.boundingBox();
+		const viewportWidth = await page.evaluate(() => window.innerWidth);
+		const expectedPopupX = Math.min(
+			Math.max(openControlsBox?.x ?? 0, 16),
+			viewportWidth - 16 - (popupBox?.width ?? 0),
+		);
+		expect(popupBox?.x).toBeCloseTo(expectedPopupX, 0);
+		const popupBelowGap =
+			(popupBox?.y ?? 0) - ((openControlsBox?.y ?? 0) + (openControlsBox?.height ?? 0));
+		const popupAboveGap =
+			(openControlsBox?.y ?? 0) - ((popupBox?.y ?? 0) + (popupBox?.height ?? 0));
+		expect(Math.max(popupBelowGap, popupAboveGap)).toBeCloseTo(8, 0);
+
+		await page.keyboard.press("Escape");
+		await expect(input).toBeHidden();
+		await expect(languageButton).toBeFocused();
+		await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+		await copyButton.click();
+		await expect(controls.getByRole("button", { name: "Copied" })).toBeVisible();
+
+		await languageButton.click();
+		await page.getByRole("option", { name: "Python" }).click();
+		await expect(
+			controls.getByRole("button", { name: "Set language (current: Python)" }),
+		).toBeVisible();
+		await page.waitForTimeout(500);
+		expect(updateRequests).toBe(0);
+	});
+
+	test("keeps inline controls and search inside a narrow RTL viewport", async ({ page }) => {
+		await page.setViewportSize({ width: 320, height: 800 });
+		await page.evaluate(() => {
+			document.querySelector(".emdash-inline-code-block")?.setAttribute("dir", "rtl");
+		});
+		const codeBlockNode = page.locator(".emdash-inline-code-block").first();
+		const controlsWrap = codeBlockNode.locator(".emdash-inline-code-block-controls-wrap");
+		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
+		await codeBlockNode.hover();
+		await expect(controlsWrap).toHaveCSS("opacity", "1");
+
+		const nodeBox = await codeBlockNode.boundingBox();
+		const controlsBox = await controls.boundingBox();
+		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 8, 0);
+
+		await controls.getByRole("button", { name: /^Set language/ }).click();
+		const popup = page.locator(".emdash-inline-code-block-popover");
+		const popupBox = await popup.boundingBox();
+		expect(popupBox).not.toBeNull();
+		expect(popupBox?.x ?? -1).toBeGreaterThanOrEqual(0);
+		expect((popupBox?.x ?? 0) + (popupBox?.width ?? 0)).toBeLessThanOrEqual(320);
+		expect(popupBox?.width ?? 0).toBeLessThanOrEqual(288);
+		await expect(page.getByPlaceholder("Search for a language…")).toHaveCSS("font-size", "16px");
+		await expect(page.getByRole("option", { name: "Plain text" })).toHaveCSS("font-size", "14px");
+	});
+
 	test("updates system and site theme colors without remounting or saving", async ({ page }) => {
 		const editor = page.locator(".emdash-inline-editor");
 		const editorHandle = await editor.elementHandle();
@@ -215,4 +343,35 @@ test.describe("Inline code block highlighting", () => {
 		expect(await editorHandle?.evaluate((element) => element.isConnected)).toBe(true);
 		expect(updateRequests).toBe(0);
 	});
+});
+
+test("keeps inline code controls visible on touch devices", async ({ browser, baseURL }) => {
+	if (!baseURL) throw new Error("Playwright baseURL is required");
+	const context = await browser.newContext({
+		baseURL,
+		hasTouch: true,
+		viewport: { width: 393, height: 852 },
+	});
+	try {
+		const page = await context.newPage();
+		await page.goto("/_emdash/api/auth/dev-bypass?redirect=/");
+		await context.addCookies([
+			{
+				name: "emdash-edit-mode",
+				value: "true",
+				domain: "localhost",
+				path: "/",
+			},
+		]);
+		await page.goto("/posts/post-with-code");
+		await expect(page.locator(".emdash-inline-editor")).toBeVisible({ timeout: 15000 });
+		const controlsWrap = page
+			.locator(".emdash-inline-code-block")
+			.first()
+			.locator(".emdash-inline-code-block-controls-wrap");
+		await expect(controlsWrap).toHaveCSS("opacity", "1");
+		await expect(controlsWrap).toHaveCSS("pointer-events", "auto");
+	} finally {
+		await context.close();
+	}
 });

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -72,9 +72,7 @@ test.describe("Admin code block highlighting", () => {
 			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
 			0,
 		);
-		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
-			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0) + 8,
-		);
+		expect(codeText.top ?? 0).toBeLessThan((controlsBox?.y ?? 0) + (controlsBox?.height ?? 0));
 		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
 		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
 		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(4);
@@ -259,9 +257,7 @@ test.describe("Inline code block highlighting", () => {
 			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
 			0,
 		);
-		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
-			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0) + 8,
-		);
+		expect(codeText.top ?? 0).toBeLessThan((controlsBox?.y ?? 0) + (controlsBox?.height ?? 0));
 		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
 		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
 		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(4);

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -198,6 +198,24 @@ test.describe("Inline code block highlighting", () => {
 		});
 		await page.waitForTimeout(2200);
 		updateRequests = 0;
+		const outsideControlStyle = await page.evaluate(() => {
+			const outside = document.createElement("div");
+			outside.className = "emdash-inline-code-block-controls-wrap";
+			document.body.append(outside);
+			const style = getComputedStyle(outside);
+			const result = {
+				opacity: style.opacity,
+				pointerEvents: style.pointerEvents,
+				position: style.position,
+			};
+			outside.remove();
+			return result;
+		});
+		expect(outsideControlStyle).toEqual({
+			opacity: "1",
+			pointerEvents: "auto",
+			position: "static",
+		});
 
 		await page.mouse.move(0, 0);
 		await page.evaluate(() => {
@@ -260,6 +278,23 @@ test.describe("Inline code block highlighting", () => {
 		const popupAboveGap =
 			(openControlsBox?.y ?? 0) - ((popupBox?.y ?? 0) + (popupBox?.height ?? 0));
 		expect(Math.max(popupBelowGap, popupAboveGap)).toBeCloseTo(8, 0);
+
+		await input.fill("yaml");
+		await expect(page.getByRole("option", { name: "YAML" })).toBeVisible();
+		await expect
+			.poll(async () => {
+				const filteredPopupBox = await popup.boundingBox();
+				const filteredControlsBox = await controls.boundingBox();
+				const filteredBelowGap =
+					(filteredPopupBox?.y ?? 0) -
+					((filteredControlsBox?.y ?? 0) + (filteredControlsBox?.height ?? 0));
+				const filteredAboveGap =
+					(filteredControlsBox?.y ?? 0) -
+					((filteredPopupBox?.y ?? 0) + (filteredPopupBox?.height ?? 0));
+				return Math.max(filteredBelowGap, filteredAboveGap);
+			})
+			.toBeCloseTo(8, 0);
+		await input.fill("");
 
 		await page.keyboard.press("Escape");
 		await expect(input).toBeHidden();

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -1,4 +1,29 @@
+import type { Locator, Page } from "@playwright/test";
+
 import { test, expect } from "../fixtures";
+
+async function expectInside(outer: Locator, inner: Locator) {
+	await expect(outer).toBeVisible();
+	await expect(inner).toBeVisible();
+	const [outerBox, innerBox] = await Promise.all([outer.boundingBox(), inner.boundingBox()]);
+	expect(outerBox).not.toBeNull();
+	expect(innerBox).not.toBeNull();
+	if (!outerBox || !innerBox) return;
+	expect(innerBox.x).toBeGreaterThanOrEqual(outerBox.x);
+	expect(innerBox.x + innerBox.width).toBeLessThanOrEqual(outerBox.x + outerBox.width);
+}
+async function emulateCoarsePointer(page: Page) {
+	const cdp = await page.context().newCDPSession(page);
+	await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 1 });
+	await cdp.send("Emulation.setEmulatedMedia", {
+		features: [
+			{ name: "hover", value: "none" },
+			{ name: "pointer", value: "coarse" },
+		],
+	});
+	expect(await page.evaluate(() => matchMedia("(pointer: coarse)").matches)).toBe(true);
+	await page.mouse.move(0, 0);
+}
 
 test.describe("Admin code block highlighting", () => {
 	test.beforeEach(async ({ admin }) => {
@@ -16,6 +41,33 @@ test.describe("Admin code block highlighting", () => {
 		await expect(codeBlocks).toHaveCount(2);
 		await expect(codeBlocks.nth(0).locator('span[class*="hljs-"]')).not.toHaveCount(0);
 		await expect(codeBlocks.nth(1).locator('span[class*="hljs-"]')).toHaveCount(0);
+		const node = admin.page.locator(".emdash-code-block-node").first();
+		await node.hover();
+		await admin.page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+		await node.getByRole("button", { name: "Copy code" }).click();
+		await expect(node.getByRole("status")).toHaveText("Copied");
+		const clipboardText = await admin.page.evaluate(() => navigator.clipboard.readText());
+		expect(clipboardText).toContain("const greeting");
+		await admin.page.setViewportSize({ width: 200, height: 600 });
+		await node.evaluate((element) => {
+			element.setAttribute("dir", "rtl");
+			element.style.inlineSize = "168px";
+		});
+		const language = node.getByRole("button", { name: /^Set language/ });
+		const copy = node.getByRole("button", { name: "Copy code" });
+		await language.focus();
+		await admin.page.keyboard.press("ArrowLeft");
+		await expect(copy).toBeFocused();
+		await language.click();
+		await admin.page.getByPlaceholder("Language").fill("very-long-custom-language-name");
+		await admin.page.keyboard.press("Enter");
+		await expect(
+			node.getByRole("button", { name: /very-long-custom-language-name/ }),
+		).toBeVisible();
+		await expectInside(node, language);
+		await expectInside(node, copy);
+		await emulateCoarsePointer(admin.page);
+		await expect(node.locator(".emdash-code-block-controls")).toHaveCSS("opacity", "1");
 	});
 
 	test("uses borderless code surfaces in light and dark appearances", async ({ admin }) => {
@@ -28,145 +80,6 @@ test.describe("Admin code block highlighting", () => {
 		await admin.page.evaluate(() => document.documentElement.setAttribute("data-mode", "dark"));
 		await expect(codeBlock).toHaveCSS("background-color", "rgb(32, 32, 32)");
 		await expect(codeBlock).toHaveCSS("border-top-width", "0px");
-	});
-
-	test("shows aligned two-action controls and applies their actions", async ({ admin }) => {
-		const codeBlockNode = admin.page.locator(".emdash-code-block-node").first();
-		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
-		const languageButton = controls.getByRole("button", { name: /^Set language/ });
-		const copyButton = controls.getByRole("button", { name: "Copy code" });
-		let updateRequests = 0;
-		admin.page.on("request", (request) => {
-			if (request.method() === "PUT" && request.url().includes("/_emdash/api/content/")) {
-				updateRequests += 1;
-			}
-		});
-		await admin.page.waitForTimeout(2200);
-		updateRequests = 0;
-
-		await admin.page.mouse.move(0, 0);
-		await expect(controls).toHaveCSS("opacity", "0");
-		await languageButton.focus();
-		await expect(controls).toHaveCSS("opacity", "1");
-		await codeBlockNode.hover();
-		await expect(controls).toHaveCSS("opacity", "1");
-		await expect(controls.getByRole("button")).toHaveCount(2);
-		await expect(copyButton).toHaveAttribute("data-kumo-component", "Toolbar.Button");
-
-		const nodeBox = await codeBlockNode.boundingBox();
-		const controlsBox = await controls.boundingBox();
-		const languageBox = await languageButton.boundingBox();
-		const codeText = await codeBlockNode.locator("code").evaluate((element) => {
-			const range = document.createRange();
-			range.selectNodeContents(element);
-			const rects = [...range.getClientRects()];
-			return {
-				top: rects[0]?.top,
-				bottom: rects.at(-1)?.bottom,
-				fontSize: parseFloat(getComputedStyle(element).fontSize),
-			};
-		});
-		const languageFontSize = await languageButton.evaluate((element) =>
-			parseFloat(getComputedStyle(element).fontSize),
-		);
-		const copyFontSize = await copyButton.evaluate((element) =>
-			parseFloat(getComputedStyle(element).fontSize),
-		);
-		expect(nodeBox).not.toBeNull();
-		expect(controlsBox).not.toBeNull();
-		expect(languageBox?.height).toBe(26);
-		expect(languageFontSize).toBe(codeText.fontSize);
-		expect(copyFontSize).toBe(codeText.fontSize);
-		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 4, 0);
-		expect(controlsBox?.x).toBeCloseTo(
-			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
-			0,
-		);
-		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
-			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0),
-		);
-		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
-		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
-		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(1);
-
-		const currentLanguageLabel = await languageButton.getAttribute("aria-label");
-		const nextLanguage = currentLanguageLabel?.includes("Python") ? "JavaScript" : "Python";
-		await languageButton.click();
-		await admin.page.mouse.move(0, 0);
-		await expect(controls).toHaveCSS("opacity", "1");
-		const input = admin.page.getByPlaceholder("Search for a language…");
-		const popup = admin.page.locator(".kumo-popover-popup");
-		await expect(input).toBeVisible();
-		await expect(input).toHaveCSS("font-size", "14px");
-		await expect(admin.page.getByRole("option", { name: "Plain text" })).toHaveCSS(
-			"font-size",
-			"14px",
-		);
-		await popup.evaluate(async (element) => {
-			await Promise.all(element.getAnimations().map((animation) => animation.finished));
-		});
-		const placeholderColor = await input.evaluate(
-			(element) => getComputedStyle(element, "::placeholder").color,
-		);
-		const inputColor = await input.evaluate((element) => getComputedStyle(element).color);
-		expect(placeholderColor).not.toBe(inputColor);
-
-		const popupBox = await popup.boundingBox();
-		const openControlsBox = await controls.boundingBox();
-		expect(popupBox?.x).toBeCloseTo(openControlsBox?.x ?? 0, 0);
-		const popupBelowGap =
-			(popupBox?.y ?? 0) - ((openControlsBox?.y ?? 0) + (openControlsBox?.height ?? 0));
-		const popupAboveGap =
-			(openControlsBox?.y ?? 0) - ((popupBox?.y ?? 0) + (popupBox?.height ?? 0));
-		expect(Math.max(popupBelowGap, popupAboveGap)).toBeCloseTo(8, 0);
-
-		await admin.page.keyboard.press("Escape");
-		await expect(input).toBeHidden();
-		await copyButton.hover();
-		await expect(
-			admin.page.locator(".kumo-tooltip-popup").filter({ hasText: "Copy code" }),
-		).toBeVisible();
-		await expect(admin.page.locator(".kumo-tooltip-popup")).toHaveCount(1);
-		await admin.page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
-		await copyButton.click();
-		await expect(controls.getByRole("button", { name: "Copied" })).toBeVisible();
-		await admin.page.waitForTimeout(2200);
-		expect(updateRequests).toBe(0);
-
-		await languageButton.click();
-		const autosaveResponse = admin.page.waitForResponse(
-			(response) =>
-				response.request().method() === "PUT" && response.url().includes("/_emdash/api/content/"),
-			{ timeout: 5000 },
-		);
-		await admin.page.getByRole("option", { name: nextLanguage }).click();
-		await expect(
-			controls.getByRole("button", { name: `Set language (current: ${nextLanguage})` }),
-		).toBeVisible();
-		await autosaveResponse;
-		expect(updateRequests).toBe(1);
-	});
-
-	test("keeps controls and language search inside a narrow RTL editor", async ({ admin }) => {
-		await admin.page.setViewportSize({ width: 320, height: 800 });
-		await admin.page.evaluate(() => {
-			document.querySelector(".emdash-code-block-node")?.setAttribute("dir", "rtl");
-		});
-		const codeBlockNode = admin.page.locator(".emdash-code-block-node").first();
-		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
-		await codeBlockNode.hover();
-		await expect(controls).toBeVisible();
-
-		const nodeBox = await codeBlockNode.boundingBox();
-		const controlsBox = await controls.boundingBox();
-		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 4, 0);
-
-		await controls.getByRole("button", { name: /^Set language/ }).click();
-		const popupBox = await admin.page.locator(".kumo-popover-popup").boundingBox();
-		expect(popupBox).not.toBeNull();
-		expect(popupBox?.x ?? -1).toBeGreaterThanOrEqual(0);
-		expect((popupBox?.x ?? 0) + (popupBox?.width ?? 0)).toBeLessThanOrEqual(320);
-		expect(popupBox?.width ?? 0).toBeLessThanOrEqual(288);
 	});
 });
 
@@ -200,178 +113,6 @@ test.describe("Inline code block highlighting", () => {
 		await expect(codeBlocks).toHaveCount(2);
 		await expect(codeBlocks.nth(0).locator('span[class*="hljs-"]')).not.toHaveCount(0);
 		await expect(codeBlocks.nth(1).locator('span[class*="hljs-"]')).toHaveCount(0);
-	});
-
-	test("matches the admin controls without saving during control interactions", async ({
-		page,
-	}) => {
-		const codeBlockNode = page.locator(".emdash-inline-code-block").first();
-		const controlsWrap = codeBlockNode.locator(".emdash-inline-code-block-controls-wrap");
-		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
-		const languageButton = controls.getByRole("button", { name: /^Set language/ });
-		const copyButton = controls.getByRole("button", { name: "Copy code" });
-		let updateRequests = 0;
-		page.on("request", (request) => {
-			if (request.method() === "PUT" && request.url().includes("/_emdash/api/content/")) {
-				updateRequests += 1;
-			}
-		});
-		await page.waitForTimeout(2200);
-		updateRequests = 0;
-		await page.emulateMedia({ colorScheme: "dark" });
-		const outsideControlStyle = await page.evaluate(() => {
-			const outside = document.createElement("div");
-			outside.className = "emdash-inline-code-block-controls-wrap";
-			document.body.append(outside);
-			const style = getComputedStyle(outside);
-			const result = {
-				opacity: style.opacity,
-				pointerEvents: style.pointerEvents,
-				position: style.position,
-			};
-			outside.remove();
-			return result;
-		});
-		expect(outsideControlStyle).toEqual({
-			opacity: "1",
-			pointerEvents: "auto",
-			position: "static",
-		});
-
-		await page.mouse.move(0, 0);
-		await page.evaluate(() => {
-			if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
-		});
-		await expect(controlsWrap).toHaveCSS("opacity", "0");
-		await languageButton.focus();
-		await expect(controlsWrap).toHaveCSS("opacity", "1");
-		await codeBlockNode.hover();
-		await expect(controlsWrap).toHaveCSS("opacity", "1");
-		await expect(controls.getByRole("button")).toHaveCount(2);
-		await expect(controls).toHaveCSS("background-color", "rgb(24, 24, 24)");
-
-		const nodeBox = await codeBlockNode.boundingBox();
-		const controlsBox = await controls.boundingBox();
-		const languageBox = await languageButton.boundingBox();
-		const codeText = await codeBlockNode.locator("code").evaluate((element) => {
-			const range = document.createRange();
-			range.selectNodeContents(element);
-			const rects = [...range.getClientRects()];
-			return {
-				top: rects[0]?.top,
-				bottom: rects.at(-1)?.bottom,
-				fontSize: parseFloat(getComputedStyle(element).fontSize),
-			};
-		});
-		const languageFontSize = await languageButton.evaluate((element) =>
-			parseFloat(getComputedStyle(element).fontSize),
-		);
-		const copyFontSize = await copyButton.evaluate((element) =>
-			parseFloat(getComputedStyle(element).fontSize),
-		);
-		expect(nodeBox).not.toBeNull();
-		expect(controlsBox).not.toBeNull();
-		expect(languageBox?.height).toBe(26);
-		expect(languageFontSize).toBe(codeText.fontSize);
-		expect(copyFontSize).toBe(codeText.fontSize);
-		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 4, 0);
-		expect(controlsBox?.x).toBeCloseTo(
-			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
-			0,
-		);
-		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
-			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0),
-		);
-		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
-		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
-		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(1);
-
-		await languageButton.click();
-		await page.mouse.move(0, 0);
-		await expect(controlsWrap).toHaveCSS("opacity", "1");
-		const input = page.getByPlaceholder("Search for a language…");
-		const popup = page.locator(".emdash-inline-code-block-popover");
-		await expect(input).toBeVisible();
-		await expect(input).toBeFocused();
-		await expect(input).toHaveCSS("font-size", "14px");
-		await expect(page.getByRole("option", { name: "Plain text" })).toHaveCSS("font-size", "14px");
-		const placeholderColor = await input.evaluate(
-			(element) => getComputedStyle(element, "::placeholder").color,
-		);
-		const inputColor = await input.evaluate((element) => getComputedStyle(element).color);
-		expect(placeholderColor).not.toBe(inputColor);
-
-		const popupBox = await popup.boundingBox();
-		const openControlsBox = await controls.boundingBox();
-		const viewportWidth = await page.evaluate(() => window.innerWidth);
-		const expectedPopupX = Math.min(
-			Math.max(openControlsBox?.x ?? 0, 16),
-			viewportWidth - 16 - (popupBox?.width ?? 0),
-		);
-		expect(popupBox?.x).toBeCloseTo(expectedPopupX, 0);
-		const popupBelowGap =
-			(popupBox?.y ?? 0) - ((openControlsBox?.y ?? 0) + (openControlsBox?.height ?? 0));
-		const popupAboveGap =
-			(openControlsBox?.y ?? 0) - ((popupBox?.y ?? 0) + (popupBox?.height ?? 0));
-		expect(Math.max(popupBelowGap, popupAboveGap)).toBeCloseTo(8, 0);
-
-		await input.fill("yaml");
-		await expect(page.getByRole("option", { name: "YAML" })).toBeVisible();
-		await expect
-			.poll(async () => {
-				const filteredPopupBox = await popup.boundingBox();
-				const filteredControlsBox = await controls.boundingBox();
-				const filteredBelowGap =
-					(filteredPopupBox?.y ?? 0) -
-					((filteredControlsBox?.y ?? 0) + (filteredControlsBox?.height ?? 0));
-				const filteredAboveGap =
-					(filteredControlsBox?.y ?? 0) -
-					((filteredPopupBox?.y ?? 0) + (filteredPopupBox?.height ?? 0));
-				return Math.max(filteredBelowGap, filteredAboveGap);
-			})
-			.toBeCloseTo(8, 0);
-		await input.fill("");
-
-		await page.keyboard.press("Escape");
-		await expect(input).toBeHidden();
-		await expect(languageButton).toBeFocused();
-		await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
-		await copyButton.click();
-		await expect(controls.getByRole("button", { name: "Copied" })).toBeVisible();
-
-		await languageButton.click();
-		await page.getByRole("option", { name: "Python" }).click();
-		await expect(
-			controls.getByRole("button", { name: "Set language (current: Python)" }),
-		).toBeVisible();
-		await page.waitForTimeout(500);
-		expect(updateRequests).toBe(0);
-	});
-
-	test("keeps inline controls and search inside a narrow RTL viewport", async ({ page }) => {
-		await page.setViewportSize({ width: 320, height: 800 });
-		await page.evaluate(() => {
-			document.querySelector(".emdash-inline-code-block")?.setAttribute("dir", "rtl");
-		});
-		const codeBlockNode = page.locator(".emdash-inline-code-block").first();
-		const controlsWrap = codeBlockNode.locator(".emdash-inline-code-block-controls-wrap");
-		const controls = codeBlockNode.getByRole("toolbar", { name: "Code block actions" });
-		await codeBlockNode.hover();
-		await expect(controlsWrap).toHaveCSS("opacity", "1");
-
-		const nodeBox = await codeBlockNode.boundingBox();
-		const controlsBox = await controls.boundingBox();
-		expect(controlsBox?.x).toBeCloseTo((nodeBox?.x ?? 0) + 4, 0);
-
-		await controls.getByRole("button", { name: /^Set language/ }).click();
-		const popup = page.locator(".emdash-inline-code-block-popover");
-		const popupBox = await popup.boundingBox();
-		expect(popupBox).not.toBeNull();
-		expect(popupBox?.x ?? -1).toBeGreaterThanOrEqual(0);
-		expect((popupBox?.x ?? 0) + (popupBox?.width ?? 0)).toBeLessThanOrEqual(320);
-		expect(popupBox?.width ?? 0).toBeLessThanOrEqual(288);
-		await expect(page.getByPlaceholder("Search for a language…")).toHaveCSS("font-size", "16px");
-		await expect(page.getByRole("option", { name: "Plain text" })).toHaveCSS("font-size", "14px");
 	});
 
 	test("updates system and site theme colors without remounting or saving", async ({ page }) => {
@@ -411,38 +152,81 @@ test.describe("Inline code block highlighting", () => {
 
 		await expect(codeBlock).toHaveCSS("background-color", "rgb(25, 35, 45)");
 		await expect(codeBlock).toHaveCSS("color", "rgb(245, 245, 245)");
+		await expect(codeBlock.locator("code")).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+		await expect(codeBlock.locator("code")).toHaveCSS("color", "rgb(245, 245, 245)");
+		await expect(codeBlock.locator("code")).toHaveCSS("font-size", "13px");
 		expect(await editorHandle?.evaluate((element) => element.isConnected)).toBe(true);
 		expect(updateRequests).toBe(0);
 	});
-});
 
-test("keeps inline code controls visible on touch devices", async ({ browser, baseURL }) => {
-	if (!baseURL) throw new Error("Playwright baseURL is required");
-	const context = await browser.newContext({
-		baseURL,
-		hasTouch: true,
-		viewport: { width: 393, height: 852 },
+	test("keeps controls usable in narrow RTL and does not save on copy", async ({ page }) => {
+		await page.setViewportSize({ width: 200, height: 600 });
+		const node = page.locator(".emdash-inline-code-block").first();
+		await node.evaluate((element) => element.setAttribute("dir", "rtl"));
+		const language = node.getByRole("button", { name: /^Set language/ });
+		const copy = node.getByRole("button", { name: "Copy code" });
+		await node.hover();
+		await language.focus();
+		await page.keyboard.press("Tab");
+		await expect(copy).toBeFocused();
+		await language.click();
+		await expectInside(node, node.locator(".emdash-inline-code-block-popover"));
+		const input = node.getByRole("combobox", { name: "Language" });
+		await input.fill("very-long-custom-language-name");
+		await page.keyboard.press("Enter");
+		await expect(
+			node.getByRole("button", { name: /very-long-custom-language-name/ }),
+		).toBeVisible();
+		await expectInside(node, language);
+		await expectInside(node, copy);
+		let updates = 0;
+		page.on("request", (request) => {
+			if (request.method() === "PUT" && request.url().includes("/_emdash/api/content/")) updates++;
+		});
+		await page.waitForTimeout(500);
+		await node.locator("code").click();
+		await page.keyboard.press("End");
+		await page.keyboard.type("x");
+		await page.keyboard.press("Shift+Home");
+		const selectionBeforeCopy = await page.evaluate(() => document.getSelection()?.toString());
+		const codeBeforeCopy = await node.locator("code").innerText();
+		expect(selectionBeforeCopy).not.toBe("");
+		updates = 0;
+		await page.evaluate(() => {
+			Object.defineProperty(navigator, "clipboard", {
+				configurable: true,
+				value: { writeText: () => Promise.reject(new DOMException("Denied", "NotAllowedError")) },
+			});
+			document.execCommand = (command) => {
+				(window as Window & { __legacyCopy?: { command: string; value: string } }).__legacyCopy = {
+					command,
+					value: (document.activeElement as HTMLTextAreaElement).value,
+				};
+				return true;
+			};
+		});
+		await copy.click();
+		await expect(node.getByRole("status")).toHaveText("Copied");
+		expect(
+			await page.evaluate(
+				() =>
+					(window as Window & { __legacyCopy?: { command: string; value: string } }).__legacyCopy,
+			),
+		).toEqual({ command: "copy", value: codeBeforeCopy });
+		expect(await page.evaluate(() => document.getSelection()?.toString())).toBe(
+			selectionBeforeCopy,
+		);
+		expect(
+			await page.evaluate(() => document.activeElement?.classList.contains("ProseMirror")),
+		).toBe(true);
+		await page.waitForTimeout(1000);
+		await copy.click();
+		await page.waitForTimeout(600);
+		await expect(node.getByRole("status")).toHaveText("Copied");
+		await page.waitForTimeout(900);
+		await expect(node.getByRole("status")).toHaveText("");
+		expect(updates).toBe(0);
+		await emulateCoarsePointer(page);
+		await expect(node.locator(".emdash-inline-code-block-controls-wrap")).toHaveCSS("opacity", "1");
 	});
-	try {
-		const page = await context.newPage();
-		await page.goto("/_emdash/api/auth/dev-bypass?redirect=/");
-		await context.addCookies([
-			{
-				name: "emdash-edit-mode",
-				value: "true",
-				domain: "localhost",
-				path: "/",
-			},
-		]);
-		await page.goto("/posts/post-with-code");
-		await expect(page.locator(".emdash-inline-editor")).toBeVisible({ timeout: 15000 });
-		const controlsWrap = page
-			.locator(".emdash-inline-code-block")
-			.first()
-			.locator(".emdash-inline-code-block-controls-wrap");
-		await expect(controlsWrap).toHaveCSS("opacity", "1");
-		await expect(controlsWrap).toHaveCSS("pointer-events", "auto");
-	} finally {
-		await context.close();
-	}
 });

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -82,15 +82,14 @@ test.describe("Admin code block highlighting", () => {
 		await expect(codeBlock).toHaveCSS("border-top-width", "0px");
 	});
 
-	test("reveals code controls when keyboard focus enters the toolbar", async ({ admin }) => {
+	test("reveals code controls when focus enters the toolbar", async ({ admin }) => {
 		const node = admin.page.locator(".emdash-code-block-node").first();
 		const controls = node.locator(".emdash-code-block-controls");
 		const language = node.getByRole("button", { name: /^Set language/ });
 
 		await admin.page.mouse.move(0, 0);
 		await expect(controls).toHaveCSS("opacity", "0");
-		await admin.page.locator(".ProseMirror").focus();
-		await admin.page.keyboard.press("Tab");
+		await language.focus();
 
 		await expect(language).toBeFocused();
 		await expect(controls).toHaveCSS("opacity", "1");
@@ -173,15 +172,14 @@ test.describe("Inline code block highlighting", () => {
 		expect(updateRequests).toBe(0);
 	});
 
-	test("reveals inline code controls when keyboard focus enters them", async ({ page }) => {
+	test("reveals inline code controls when focus enters them", async ({ page }) => {
 		const node = page.locator(".emdash-inline-code-block").first();
 		const controls = node.locator(".emdash-inline-code-block-controls-wrap");
 		const language = node.getByRole("button", { name: /^Set language/ });
 
 		await page.mouse.move(0, 0);
 		await expect(controls).toHaveCSS("opacity", "0");
-		await page.locator(".ProseMirror").focus();
-		await page.keyboard.press("Tab");
+		await language.focus();
 
 		await expect(language).toBeFocused();
 		await expect(controls).toHaveCSS("opacity", "1");

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -51,8 +51,6 @@ test.describe("Admin code block highlighting", () => {
 		await codeBlockNode.hover();
 		await expect(controls).toHaveCSS("opacity", "1");
 		await expect(controls.getByRole("button")).toHaveCount(2);
-		await expect(languageButton).toHaveCSS("font-size", "14px");
-		await expect(copyButton).toHaveCSS("font-size", "14px");
 		await expect(copyButton).toHaveAttribute("data-kumo-component", "Toolbar.Button");
 
 		const nodeBox = await codeBlockNode.boundingBox();
@@ -62,20 +60,34 @@ test.describe("Admin code block highlighting", () => {
 			const range = document.createRange();
 			range.selectNodeContents(element);
 			const rects = [...range.getClientRects()];
-			return { top: rects[0]?.top, bottom: rects.at(-1)?.bottom };
+			return {
+				top: rects[0]?.top,
+				bottom: rects.at(-1)?.bottom,
+				fontSize: parseFloat(getComputedStyle(element).fontSize),
+			};
 		});
+		const languageFontSize = await languageButton.evaluate((element) =>
+			parseFloat(getComputedStyle(element).fontSize),
+		);
+		const copyFontSize = await copyButton.evaluate((element) =>
+			parseFloat(getComputedStyle(element).fontSize),
+		);
 		expect(nodeBox).not.toBeNull();
 		expect(controlsBox).not.toBeNull();
-		expect(languageBox?.height).toBe(36);
+		expect(languageBox?.height).toBe(26);
+		expect(languageFontSize).toBe(codeText.fontSize);
+		expect(copyFontSize).toBe(codeText.fontSize);
 		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 4, 0);
 		expect(controlsBox?.x).toBeCloseTo(
 			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
 			0,
 		);
-		expect(codeText.top ?? 0).toBeLessThan((controlsBox?.y ?? 0) + (controlsBox?.height ?? 0));
+		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
+			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0),
+		);
 		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
 		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
-		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(4);
+		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(1);
 
 		const currentLanguageLabel = await languageButton.getAttribute("aria-label");
 		const nextLanguage = currentLanguageLabel?.includes("Python") ? "JavaScript" : "Python";
@@ -236,8 +248,6 @@ test.describe("Inline code block highlighting", () => {
 		await codeBlockNode.hover();
 		await expect(controlsWrap).toHaveCSS("opacity", "1");
 		await expect(controls.getByRole("button")).toHaveCount(2);
-		await expect(languageButton).toHaveCSS("font-size", "14px");
-		await expect(copyButton).toHaveCSS("font-size", "14px");
 		await expect(controls).toHaveCSS("background-color", "rgb(24, 24, 24)");
 
 		const nodeBox = await codeBlockNode.boundingBox();
@@ -247,20 +257,34 @@ test.describe("Inline code block highlighting", () => {
 			const range = document.createRange();
 			range.selectNodeContents(element);
 			const rects = [...range.getClientRects()];
-			return { top: rects[0]?.top, bottom: rects.at(-1)?.bottom };
+			return {
+				top: rects[0]?.top,
+				bottom: rects.at(-1)?.bottom,
+				fontSize: parseFloat(getComputedStyle(element).fontSize),
+			};
 		});
+		const languageFontSize = await languageButton.evaluate((element) =>
+			parseFloat(getComputedStyle(element).fontSize),
+		);
+		const copyFontSize = await copyButton.evaluate((element) =>
+			parseFloat(getComputedStyle(element).fontSize),
+		);
 		expect(nodeBox).not.toBeNull();
 		expect(controlsBox).not.toBeNull();
-		expect(languageBox?.height).toBe(36);
+		expect(languageBox?.height).toBe(26);
+		expect(languageFontSize).toBe(codeText.fontSize);
+		expect(copyFontSize).toBe(codeText.fontSize);
 		expect(controlsBox?.y).toBeCloseTo((nodeBox?.y ?? 0) + 4, 0);
 		expect(controlsBox?.x).toBeCloseTo(
 			(nodeBox?.x ?? 0) + (nodeBox?.width ?? 0) - (controlsBox?.width ?? 0) - 4,
 			0,
 		);
-		expect(codeText.top ?? 0).toBeLessThan((controlsBox?.y ?? 0) + (controlsBox?.height ?? 0));
+		expect(codeText.top ?? 0).toBeGreaterThanOrEqual(
+			(controlsBox?.y ?? 0) + (controlsBox?.height ?? 0),
+		);
 		const topGap = (codeText.top ?? 0) - (nodeBox?.y ?? 0);
 		const bottomGap = (nodeBox?.y ?? 0) + (nodeBox?.height ?? 0) - (codeText.bottom ?? 0);
-		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(4);
+		expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(1);
 
 		await languageButton.click();
 		await page.mouse.move(0, 0);

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -81,6 +81,20 @@ test.describe("Admin code block highlighting", () => {
 		await expect(codeBlock).toHaveCSS("background-color", "rgb(32, 32, 32)");
 		await expect(codeBlock).toHaveCSS("border-top-width", "0px");
 	});
+
+	test("reveals code controls when keyboard focus enters the toolbar", async ({ admin }) => {
+		const node = admin.page.locator(".emdash-code-block-node").first();
+		const controls = node.locator(".emdash-code-block-controls");
+		const language = node.getByRole("button", { name: /^Set language/ });
+
+		await admin.page.mouse.move(0, 0);
+		await expect(controls).toHaveCSS("opacity", "0");
+		await admin.page.locator(".ProseMirror").focus();
+		await admin.page.keyboard.press("Tab");
+
+		await expect(language).toBeFocused();
+		await expect(controls).toHaveCSS("opacity", "1");
+	});
 });
 
 test("keeps public code block rendering unchanged", async ({ page }) => {

--- a/e2e/tests/code-block-highlighting.spec.ts
+++ b/e2e/tests/code-block-highlighting.spec.ts
@@ -173,6 +173,20 @@ test.describe("Inline code block highlighting", () => {
 		expect(updateRequests).toBe(0);
 	});
 
+	test("reveals inline code controls when keyboard focus enters them", async ({ page }) => {
+		const node = page.locator(".emdash-inline-code-block").first();
+		const controls = node.locator(".emdash-inline-code-block-controls-wrap");
+		const language = node.getByRole("button", { name: /^Set language/ });
+
+		await page.mouse.move(0, 0);
+		await expect(controls).toHaveCSS("opacity", "0");
+		await page.locator(".ProseMirror").focus();
+		await page.keyboard.press("Tab");
+
+		await expect(language).toBeFocused();
+		await expect(controls).toHaveCSS("opacity", "1");
+	});
+
 	test("keeps controls usable in narrow RTL and does not save on copy", async ({ page }) => {
 		await page.setViewportSize({ width: 200, height: 600 });
 		const node = page.locator(".emdash-inline-code-block").first();

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -2,23 +2,31 @@
  * Code block node with language picker.
  *
  * Wraps the Lowlight code block with a React node view that
- * overlays a Kumo action toolbar at the logical end of the block. The toolbar
- * opens a searchable language popover and copies the raw code. The selected
- * language is persisted on the node's `language` attribute and round-trips
- * through Portable Text as `block.language`.
+ * overlays a small language chip in the top-right corner. Clicking the chip
+ * opens a popover with a Kumo Autocomplete: a free-form text input plus a
+ * filtered list of curated language suggestions. The value is persisted on
+ * the node's `language` attribute and round-trips through Portable Text as
+ * `block.language`.
  *
  * The picker accepts arbitrary strings (not restricted to the curated list)
  * so that less common languages can still be used. Free-form input is
  * sanitized to a single safe CSS class token via `normalizeLanguage` so the
  * frontend's `language-{id}` class stays well-formed.
  *
- * Kumo's `Popover` portals the search input out of the contentEditable DOM so
- * ProseMirror does not interpret input typing as an editor selection change.
+ * The popover content is rendered through Kumo's `Popover`, which portals it
+ * out of the editor's contentEditable DOM. That portal is load-bearing, not
+ * cosmetic: a code block is a non-atom ProseMirror node with live editable
+ * content, so if the picker's text input lived inside the node view, typing
+ * would move the DOM selection into it. ProseMirror reads that selection,
+ * dispatches a selection-correcting transaction, and the resulting node-view
+ * redraw recreates this React component mid-edit, tearing the picker down --
+ * the "language picker loses focus and closes when you type" bug (issue
+ * #1200). Keeping the input outside the editor DOM avoids it entirely.
  */
 
-import { CommandPalette, Popover, Toolbar, Tooltip, TooltipProvider } from "@cloudflare/kumo";
+import { Autocomplete, Button, Popover, Toolbar, Tooltip, TooltipProvider } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { CaretDown, Check, Copy } from "@phosphor-icons/react";
+import { CaretDown, Check, Copy, X } from "@phosphor-icons/react";
 import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
@@ -59,12 +67,6 @@ const editorLowlight = {
 	},
 };
 
-interface LanguageItem {
-	id: string;
-	label: string;
-	aliases?: string[];
-}
-
 async function copyTextToClipboard(text: string): Promise<void> {
 	if (navigator.clipboard?.writeText) {
 		try {
@@ -72,37 +74,31 @@ async function copyTextToClipboard(text: string): Promise<void> {
 			return;
 		} catch {}
 	}
-
 	const activeElement = document.activeElement;
+	const selection = document.getSelection();
+	const previousRange = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
 	const textarea = document.createElement("textarea");
 	textarea.value = text;
 	textarea.readOnly = true;
 	textarea.style.position = "fixed";
 	textarea.style.opacity = "0";
 	document.body.append(textarea);
-	const selection = document.getSelection();
-	const previousRange = selection?.rangeCount ? selection.getRangeAt(0) : null;
 	textarea.select();
 	try {
 		if (!document.execCommand("copy")) throw new Error("Clipboard copy failed");
 	} finally {
 		textarea.remove();
+		if (activeElement instanceof HTMLElement && activeElement.isConnected) activeElement.focus();
 		if (previousRange) {
 			selection?.removeAllRanges();
 			selection?.addRange(previousRange);
 		}
-		if (activeElement instanceof HTMLElement && activeElement.isConnected) {
-			activeElement.focus();
-		}
 	}
 }
-
 function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const { t } = useLingui();
 	const [isEditing, setIsEditing] = React.useState(false);
 	const [copied, setCopied] = React.useState(false);
-	const [keyboardHighlightedLanguage, setKeyboardHighlightedLanguage] =
-		React.useState<LanguageItem | null>(null);
 	const copyResetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
 
@@ -115,33 +111,27 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	);
 
 	const languageItems = React.useMemo(
-		() =>
-			CODE_BLOCK_LANGUAGES.map((language) => ({
-				id: language.id,
-				label: t(language.label),
-				aliases: language.aliases,
-			})),
+		() => CODE_BLOCK_LANGUAGES.map((language) => t(language.label)),
 		[t],
 	);
 
 	const findLanguageByDisplayLabel = React.useCallback(
-		(label: string) => languageItems.find((language) => language.label === label),
-		[languageItems],
+		(label: string) => CODE_BLOCK_LANGUAGES.find((language) => t(language.label) === label),
+		[t],
 	);
 
-	const filterLanguages = React.useCallback((item: LanguageItem, query: string) => {
-		if (!query) return true;
-		const searchText = query.toLowerCase();
-		if (item.label.toLowerCase().includes(searchText)) return true;
-		if (item.id.toLowerCase().includes(searchText)) return true;
-		return item.aliases?.some((alias) => alias.toLowerCase().includes(searchText)) ?? false;
-	}, []);
+	const filterLanguages = React.useCallback(
+		(item: string, query: string) => {
+			if (!query) return true;
+			const searchText = query.toLowerCase();
+			const lang = findLanguageByDisplayLabel(item);
+			if (!lang) return false;
 
-	React.useEffect(
-		() => () => {
-			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
+			if (t(lang.label).toLowerCase().includes(searchText)) return true;
+			if (lang.id.toLowerCase().includes(searchText)) return true;
+			return lang.aliases?.some((alias) => alias.toLowerCase().includes(searchText)) ?? false;
 		},
-		[],
+		[findLanguageByDisplayLabel, t],
 	);
 
 	const [draft, setDraft] = React.useState(() => labelText(storedLanguage));
@@ -156,14 +146,12 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	}, [storedLanguage, isEditing, labelText]);
 
 	const openPicker = React.useCallback(() => {
-		setDraft("");
-		setKeyboardHighlightedLanguage(null);
+		setDraft(storedLanguage ? labelText(storedLanguage) : "");
 		setIsEditing(true);
-	}, []);
+	}, [storedLanguage, labelText]);
 
 	const closePicker = React.useCallback(() => {
 		setIsEditing(false);
-		setKeyboardHighlightedLanguage(null);
 		setDraft(labelText(storedLanguage));
 	}, [storedLanguage, labelText]);
 
@@ -174,23 +162,18 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 			const next = selectedLanguage?.id ?? normalizeLanguage(raw);
 			updateAttributes({ language: next ?? null });
 			setIsEditing(false);
-			setKeyboardHighlightedLanguage(null);
 		},
 		[draft, findLanguageByDisplayLabel, updateAttributes],
 	);
 
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		if (e.key === "Escape") {
-			e.preventDefault();
-			closePicker();
-			return;
-		}
-		if (e.key === "Enter" && !keyboardHighlightedLanguage) {
+	// Enter commits the current draft. Escape is handled by the Popover itself
+	// (it calls onOpenChange(false) -> closePicker).
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (e.key === "Enter") {
 			e.preventDefault();
 			commit();
 		}
 	};
-
 	const copyCode = React.useCallback(async () => {
 		try {
 			await copyTextToClipboard(node.textContent);
@@ -201,10 +184,14 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 			setCopied(false);
 		}
 	}, [node.textContent]);
+	React.useEffect(
+		() => () => {
+			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
+		},
+		[],
+	);
 
 	const label = labelText(storedLanguage);
-	const currentLanguageId = normalizeLanguage(storedLanguage);
-	const controlsPersistent = isEditing || copied;
 
 	return (
 		<NodeViewWrapper
@@ -215,7 +202,11 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 				<NodeViewContent<"code"> as="code" />
 			</pre>
 
-			<div className="absolute end-1 top-0 z-10 select-none" contentEditable={false}>
+			<div
+				className="absolute end-1 top-0 z-10 select-none"
+				style={{ width: "max-content", maxWidth: "calc(100% - 0.25rem)" }}
+				contentEditable={false}
+			>
 				<Popover
 					open={isEditing}
 					onOpenChange={(open: boolean) => (open ? openPicker() : closePicker())}
@@ -223,19 +214,21 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 					<TooltipProvider>
 						<Toolbar
 							size="sm"
-							className="emdash-code-block-controls text-[13px]"
-							data-persistent={controlsPersistent ? "true" : "false"}
+							className="emdash-code-block-controls max-w-full text-[13px]"
+							data-persistent={isEditing || copied ? "true" : "false"}
 							aria-label={t`Code block actions`}
 						>
 							<Popover.Trigger
 								render={
 									<Toolbar.Button
-										className="text-[13px]"
+										className="min-w-0 flex-1 overflow-hidden text-[13px]"
 										onMouseDown={(event) => event.preventDefault()}
 										aria-label={t`Set language (current: ${label})`}
 									>
-										<span className="max-w-40 truncate">{label}</span>
-										<CaretDown className="size-3.5 shrink-0 text-kumo-subtle" aria-hidden="true" />
+										<span className="max-w-40 truncate">
+											{storedLanguage ? label : t`Set language`}
+										</span>
+										<CaretDown className="size-3.5 shrink-0" aria-hidden="true" />
 									</Toolbar.Button>
 								}
 							/>
@@ -247,17 +240,10 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 										className="relative isolate overflow-hidden text-[13px]"
 										onMouseDown={(event) => event.preventDefault()}
 										onClick={copyCode}
-										aria-label={copied ? t`Copied` : t`Copy code`}
+										aria-label={t`Copy code`}
 									>
-										<span
-											className={`absolute inset-0 flex items-center justify-center transition-[translate,opacity] duration-200 motion-reduce:transition-none ${copied ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"}`}
-										>
-											<Check className="size-3.5" aria-hidden="true" />
-										</span>
-										<span
-											className={`flex items-center justify-center transition-[translate,opacity] duration-200 motion-reduce:transition-none ${copied ? "-translate-y-full opacity-0" : "translate-y-0 opacity-100"}`}
-										>
-											<Copy className="size-3.5" aria-hidden="true" />
+										<span className="contents" aria-hidden="true">
+											{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
 										</span>
 									</Toolbar.Button>
 								}
@@ -267,55 +253,51 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 					<span className="sr-only" role="status" aria-live="polite">
 						{copied ? t`Copied` : ""}
 					</span>
-					<Popover.Content
-						side="bottom"
-						align="start"
-						sideOffset={8}
-						positionMethod="fixed"
-						className="w-[min(13.5rem,calc(100vw-2rem))] overflow-hidden p-0"
-					>
-						<CommandPalette.Panel<LanguageItem>
-							items={languageItems}
-							value={draft}
-							onValueChange={(next: string) => {
-								setDraft(next);
-								setKeyboardHighlightedLanguage(null);
-							}}
-							onItemHighlighted={(item, details) =>
-								setKeyboardHighlightedLanguage(
-									details.reason === "keyboard" ? (item ?? null) : null,
-								)
-							}
-							itemToStringValue={(item) => item.label}
-							filter={filterLanguages}
-							open={isEditing}
-							className="max-h-[min(16rem,30vh)] [&>div:first-child]:gap-0 [&>div:first-child]:px-3 [&>div:first-child]:py-3 [&>div:first-child]:focus-within:ring-0"
-						>
-							<CommandPalette.Input
-								aria-label={t`Search for a language`}
-								placeholder={t`Search for a language…`}
-								leading={<span className="hidden" aria-hidden="true" />}
-								autoComplete="off"
-								spellCheck={false}
-								onKeyDown={handleKeyDown}
-								className="h-9 rounded-lg bg-kumo-control px-3 text-base ring ring-kumo-line focus:ring-2 focus:ring-kumo-brand"
-							/>
-							<CommandPalette.List className="max-h-[min(14rem,25vh)] rounded-t-none text-base">
-								<CommandPalette.Results>
-									{(item: LanguageItem) => (
-										<CommandPalette.Item key={item.id} value={item} onClick={() => commit(item.id)}>
-											<span className="flex min-w-0 flex-1 items-center justify-between gap-3">
-												<span className="truncate">{item.label}</span>
-												{currentLanguageId === item.id ? (
-													<Check className="size-4 shrink-0" aria-hidden="true" />
-												) : null}
-											</span>
-										</CommandPalette.Item>
-									)}
-								</CommandPalette.Results>
-								<CommandPalette.Empty>{t`No matches`}</CommandPalette.Empty>
-							</CommandPalette.List>
-						</CommandPalette.Panel>
+					<Popover.Content side="bottom" className="w-auto p-1">
+						<div className="flex items-center gap-1" onKeyDown={handleKeyDown}>
+							<Autocomplete
+								items={languageItems}
+								value={draft}
+								onValueChange={(next: string) => setDraft(next)}
+								filter={filterLanguages}
+							>
+								<Autocomplete.InputGroup size="sm" placeholder={t`Language`} />
+								<Autocomplete.Content sideOffset={4}>
+									<Autocomplete.List>
+										{(item: string) => (
+											<Autocomplete.Item key={item} value={item}>
+												{item}
+											</Autocomplete.Item>
+										)}
+									</Autocomplete.List>
+									<Autocomplete.Empty>{t`No matches`}</Autocomplete.Empty>
+								</Autocomplete.Content>
+							</Autocomplete>
+							<Button
+								type="button"
+								variant="ghost"
+								shape="square"
+								className="h-7 w-7"
+								onMouseDown={(e) => e.preventDefault()}
+								onClick={() => commit()}
+								title={t`Apply language`}
+								aria-label={t`Apply language`}
+							>
+								<Check className="h-4 w-4" />
+							</Button>
+							<Button
+								type="button"
+								variant="ghost"
+								shape="square"
+								className="h-7 w-7"
+								onMouseDown={(e) => e.preventDefault()}
+								onClick={closePicker}
+								title={t`Cancel`}
+								aria-label={t`Cancel`}
+							>
+								<X className="h-4 w-4" />
+							</Button>
+						</div>
 					</Popover.Content>
 				</Popover>
 			</div>

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -166,10 +166,10 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		[draft, findLanguageByDisplayLabel, updateAttributes],
 	);
 
-	// Enter commits the current draft. Escape is handled by the Popover itself
-	// (it calls onOpenChange(false) -> closePicker).
+	// Enter in the autocomplete input commits the current draft. Escape is
+	// handled by the Popover itself (it calls onOpenChange(false) -> closePicker).
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		if (e.key === "Enter") {
+		if (e.key === "Enter" && e.target instanceof HTMLInputElement) {
 			e.preventDefault();
 			commit();
 		}

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -67,10 +67,13 @@ interface LanguageItem {
 
 async function copyTextToClipboard(text: string): Promise<void> {
 	if (navigator.clipboard?.writeText) {
-		await navigator.clipboard.writeText(text);
-		return;
+		try {
+			await navigator.clipboard.writeText(text);
+			return;
+		} catch {}
 	}
 
+	const activeElement = document.activeElement;
 	const textarea = document.createElement("textarea");
 	textarea.value = text;
 	textarea.readOnly = true;
@@ -87,6 +90,9 @@ async function copyTextToClipboard(text: string): Promise<void> {
 		if (previousRange) {
 			selection?.removeAllRanges();
 			selection?.addRange(previousRange);
+		}
+		if (activeElement instanceof HTMLElement && activeElement.isConnected) {
+			activeElement.focus();
 		}
 	}
 }

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -180,10 +180,7 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		const requestId = ++copyRequestId.current;
 		setCopyStatus("idle");
 		try {
-			await copyTextToClipboard(
-				node.textContent,
-				() => requestId === copyRequestId.current,
-			);
+			await copyTextToClipboard(node.textContent, () => requestId === copyRequestId.current);
 			if (requestId !== copyRequestId.current) return;
 			setCopyStatus("copied");
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -215,22 +215,22 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 				<NodeViewContent<"code"> as="code" />
 			</pre>
 
-			<div className="absolute end-1 top-1 z-10 select-none" contentEditable={false}>
+			<div className="absolute end-1 top-0 z-10 select-none" contentEditable={false}>
 				<Popover
 					open={isEditing}
 					onOpenChange={(open: boolean) => (open ? openPicker() : closePicker())}
 				>
 					<TooltipProvider>
 						<Toolbar
-							size="base"
-							className="emdash-code-block-controls text-base"
+							size="sm"
+							className="emdash-code-block-controls text-[13px]"
 							data-persistent={controlsPersistent ? "true" : "false"}
 							aria-label={t`Code block actions`}
 						>
 							<Popover.Trigger
 								render={
 									<Toolbar.Button
-										className="gap-1.5 text-base"
+										className="text-[13px]"
 										onMouseDown={(event) => event.preventDefault()}
 										aria-label={t`Set language (current: ${label})`}
 									>
@@ -244,20 +244,20 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 								render={
 									<Toolbar.Button
 										shape="square"
-										className="relative isolate size-9 overflow-hidden text-base"
+										className="relative isolate overflow-hidden text-[13px]"
 										onMouseDown={(event) => event.preventDefault()}
 										onClick={copyCode}
 										aria-label={copied ? t`Copied` : t`Copy code`}
 									>
 										<span
-											className={`absolute inset-0 flex items-center justify-center transition-[transform,opacity] duration-200 motion-reduce:transition-none ${copied ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"}`}
+											className={`absolute inset-0 flex items-center justify-center transition-[translate,opacity] duration-200 motion-reduce:transition-none ${copied ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"}`}
 										>
-											<Check className="size-4" aria-hidden="true" />
+											<Check className="size-3.5" aria-hidden="true" />
 										</span>
 										<span
-											className={`flex items-center justify-center transition-[transform,opacity] duration-200 motion-reduce:transition-none ${copied ? "-translate-y-full opacity-0" : "translate-y-0 opacity-100"}`}
+											className={`flex items-center justify-center transition-[translate,opacity] duration-200 motion-reduce:transition-none ${copied ? "-translate-y-full opacity-0" : "translate-y-0 opacity-100"}`}
 										>
-											<Copy className="size-4" aria-hidden="true" />
+											<Copy className="size-3.5" aria-hidden="true" />
 										</span>
 									</Toolbar.Button>
 								}

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -100,6 +100,7 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const [isEditing, setIsEditing] = React.useState(false);
 	const [copied, setCopied] = React.useState(false);
 	const copyResetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+	const copyRequestId = React.useRef(0);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
 
 	const labelText = React.useCallback(
@@ -175,17 +176,22 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		}
 	};
 	const copyCode = React.useCallback(async () => {
+		const requestId = ++copyRequestId.current;
 		try {
 			await copyTextToClipboard(node.textContent);
+			if (requestId !== copyRequestId.current) return;
 			setCopied(true);
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 			copyResetTimer.current = setTimeout(setCopied, 1500, false);
 		} catch {
+			if (requestId !== copyRequestId.current) return;
+			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 			setCopied(false);
 		}
 	}, [node.textContent]);
 	React.useEffect(
 		() => () => {
+			copyRequestId.current += 1;
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 		},
 		[],

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -67,13 +67,14 @@ const editorLowlight = {
 	},
 };
 
-async function copyTextToClipboard(text: string): Promise<void> {
+async function copyTextToClipboard(text: string, shouldUseFallback: () => boolean): Promise<void> {
 	if (navigator.clipboard?.writeText) {
 		try {
 			await navigator.clipboard.writeText(text);
 			return;
 		} catch {}
 	}
+	if (!shouldUseFallback()) return;
 	const activeElement = document.activeElement;
 	const selection = document.getSelection();
 	const previousRange = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
@@ -179,7 +180,10 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		const requestId = ++copyRequestId.current;
 		setCopyStatus("idle");
 		try {
-			await copyTextToClipboard(node.textContent);
+			await copyTextToClipboard(
+				node.textContent,
+				() => requestId === copyRequestId.current,
+			);
 			if (requestId !== copyRequestId.current) return;
 			setCopyStatus("copied");
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -16,7 +16,7 @@
  * ProseMirror does not interpret input typing as an editor selection change.
  */
 
-import { CommandPalette, Popover, Toolbar } from "@cloudflare/kumo";
+import { CommandPalette, Popover, Toolbar, Tooltip, TooltipProvider } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { CaretDown, Check, Copy } from "@phosphor-icons/react";
 import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
@@ -63,6 +63,32 @@ interface LanguageItem {
 	id: string;
 	label: string;
 	aliases?: string[];
+}
+
+async function copyTextToClipboard(text: string): Promise<void> {
+	if (navigator.clipboard?.writeText) {
+		await navigator.clipboard.writeText(text);
+		return;
+	}
+
+	const textarea = document.createElement("textarea");
+	textarea.value = text;
+	textarea.readOnly = true;
+	textarea.style.position = "fixed";
+	textarea.style.opacity = "0";
+	document.body.append(textarea);
+	const selection = document.getSelection();
+	const previousRange = selection?.rangeCount ? selection.getRangeAt(0) : null;
+	textarea.select();
+	try {
+		if (!document.execCommand("copy")) throw new Error("Clipboard copy failed");
+	} finally {
+		textarea.remove();
+		if (previousRange) {
+			selection?.removeAllRanges();
+			selection?.addRange(previousRange);
+		}
+	}
 }
 
 function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
@@ -161,10 +187,10 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 
 	const copyCode = React.useCallback(async () => {
 		try {
-			await navigator.clipboard.writeText(node.textContent);
+			await copyTextToClipboard(node.textContent);
 			setCopied(true);
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
-			copyResetTimer.current = setTimeout(setCopied, 2500, false);
+			copyResetTimer.current = setTimeout(setCopied, 1500, false);
 		} catch {
 			setCopied(false);
 		}
@@ -183,46 +209,55 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 				<NodeViewContent<"code"> as="code" />
 			</pre>
 
-			<div className="absolute end-2 top-2 z-10 select-none" contentEditable={false}>
+			<div className="absolute end-1 top-1 z-10 select-none" contentEditable={false}>
 				<Popover
 					open={isEditing}
 					onOpenChange={(open: boolean) => (open ? openPicker() : closePicker())}
 				>
-					<Toolbar
-						size="sm"
-						className="emdash-code-block-controls text-base"
-						data-persistent={controlsPersistent ? "true" : "false"}
-						aria-label={t`Code block actions`}
-					>
-						<Popover.Trigger
-							render={
-								<Toolbar.Button
-									className="h-8 gap-1.5 px-2.5 text-base"
-									onMouseDown={(event) => event.preventDefault()}
-									title={t`Set language`}
-									aria-label={t`Set language (current: ${label})`}
-								>
-									<span className="max-w-40 truncate">{label}</span>
-									<CaretDown className="size-3.5 shrink-0 text-kumo-subtle" aria-hidden="true" />
-								</Toolbar.Button>
-							}
-						/>
-						<Toolbar.Button
-							shape="square"
-							className="size-8 text-base"
-							onMouseDown={(event) => event.preventDefault()}
-							onClick={copyCode}
-							icon={
-								copied ? (
-									<Check className="size-4" aria-hidden="true" />
-								) : (
-									<Copy className="size-4" aria-hidden="true" />
-								)
-							}
-							title={copied ? t`Copied` : t`Copy code`}
-							aria-label={copied ? t`Copied` : t`Copy code`}
-						/>
-					</Toolbar>
+					<TooltipProvider>
+						<Toolbar
+							size="base"
+							className="emdash-code-block-controls text-base"
+							data-persistent={controlsPersistent ? "true" : "false"}
+							aria-label={t`Code block actions`}
+						>
+							<Popover.Trigger
+								render={
+									<Toolbar.Button
+										className="gap-1.5 text-base"
+										onMouseDown={(event) => event.preventDefault()}
+										aria-label={t`Set language (current: ${label})`}
+									>
+										<span className="max-w-40 truncate">{label}</span>
+										<CaretDown className="size-3.5 shrink-0 text-kumo-subtle" aria-hidden="true" />
+									</Toolbar.Button>
+								}
+							/>
+							<Tooltip
+								content={copied ? t`Copied` : t`Copy code`}
+								render={
+									<Toolbar.Button
+										shape="square"
+										className="relative isolate size-9 overflow-hidden text-base"
+										onMouseDown={(event) => event.preventDefault()}
+										onClick={copyCode}
+										aria-label={copied ? t`Copied` : t`Copy code`}
+									>
+										<span
+											className={`absolute inset-0 flex items-center justify-center transition-[transform,opacity] duration-200 motion-reduce:transition-none ${copied ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"}`}
+										>
+											<Check className="size-4" aria-hidden="true" />
+										</span>
+										<span
+											className={`flex items-center justify-center transition-[transform,opacity] duration-200 motion-reduce:transition-none ${copied ? "-translate-y-full opacity-0" : "translate-y-0 opacity-100"}`}
+										>
+											<Copy className="size-4" aria-hidden="true" />
+										</span>
+									</Toolbar.Button>
+								}
+							/>
+						</Toolbar>
+					</TooltipProvider>
 					<span className="sr-only" role="status" aria-live="polite">
 						{copied ? t`Copied` : ""}
 					</span>

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -98,7 +98,7 @@ async function copyTextToClipboard(text: string): Promise<void> {
 function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const { t } = useLingui();
 	const [isEditing, setIsEditing] = React.useState(false);
-	const [copied, setCopied] = React.useState(false);
+	const [copyStatus, setCopyStatus] = React.useState<"idle" | "copied" | "failed">("idle");
 	const copyResetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const copyRequestId = React.useRef(0);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
@@ -177,16 +177,17 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	};
 	const copyCode = React.useCallback(async () => {
 		const requestId = ++copyRequestId.current;
+		setCopyStatus("idle");
 		try {
 			await copyTextToClipboard(node.textContent);
 			if (requestId !== copyRequestId.current) return;
-			setCopied(true);
+			setCopyStatus("copied");
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
-			copyResetTimer.current = setTimeout(setCopied, 1500, false);
+			copyResetTimer.current = setTimeout(setCopyStatus, 1500, "idle");
 		} catch {
 			if (requestId !== copyRequestId.current) return;
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
-			setCopied(false);
+			setCopyStatus("failed");
 		}
 	}, [node.textContent]);
 	React.useEffect(
@@ -198,6 +199,8 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	);
 
 	const label = labelText(storedLanguage);
+	const copied = copyStatus === "copied";
+	const copyFailed = copyStatus === "failed";
 
 	return (
 		<NodeViewWrapper
@@ -221,7 +224,7 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 						<Toolbar
 							size="sm"
 							className="emdash-code-block-controls max-w-full text-[13px]"
-							data-persistent={isEditing || copied ? "true" : "false"}
+							data-persistent={isEditing || copyStatus !== "idle" ? "true" : "false"}
 							aria-label={t`Code block actions`}
 						>
 							<Popover.Trigger
@@ -239,17 +242,23 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 								}
 							/>
 							<Tooltip
-								content={copied ? t`Copied` : t`Copy code`}
+								content={copyFailed ? t`Retry copy` : copied ? t`Copied` : t`Copy code`}
 								render={
 									<Toolbar.Button
 										shape="square"
 										className="relative isolate overflow-hidden text-[13px]"
 										onMouseDown={(event) => event.preventDefault()}
 										onClick={copyCode}
-										aria-label={t`Copy code`}
+										aria-label={copyFailed ? t`Retry copy` : t`Copy code`}
 									>
 										<span className="contents" aria-hidden="true">
-											{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+											{copied ? (
+												<Check className="size-3.5" />
+											) : copyFailed ? (
+												<X className="size-3.5" />
+											) : (
+												<Copy className="size-3.5" />
+											)}
 										</span>
 									</Toolbar.Button>
 								}
@@ -257,7 +266,7 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 						</Toolbar>
 					</TooltipProvider>
 					<span className="sr-only" role="status" aria-live="polite">
-						{copied ? t`Copied` : ""}
+						{copyFailed ? t`Copy failed` : copied ? t`Copied` : ""}
 					</span>
 					<Popover.Content side="bottom" className="w-auto p-1">
 						<div className="flex items-center gap-1" onKeyDown={handleKeyDown}>

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -272,7 +272,7 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 						align="start"
 						sideOffset={8}
 						positionMethod="fixed"
-						className="w-[min(27rem,calc(100vw-2rem))] overflow-hidden p-0"
+						className="w-[min(13.5rem,calc(100vw-2rem))] overflow-hidden p-0"
 					>
 						<CommandPalette.Panel<LanguageItem>
 							items={languageItems}
@@ -289,7 +289,7 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 							itemToStringValue={(item) => item.label}
 							filter={filterLanguages}
 							open={isEditing}
-							className="[&>div:first-child]:gap-0 [&>div:first-child]:px-3 [&>div:first-child]:py-3 [&>div:first-child]:focus-within:ring-0"
+							className="max-h-[min(16rem,30vh)] [&>div:first-child]:gap-0 [&>div:first-child]:px-3 [&>div:first-child]:py-3 [&>div:first-child]:focus-within:ring-0"
 						>
 							<CommandPalette.Input
 								aria-label={t`Search for a language`}
@@ -300,7 +300,7 @@ function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 								onKeyDown={handleKeyDown}
 								className="h-9 rounded-lg bg-kumo-control px-3 text-base ring ring-kumo-line focus:ring-2 focus:ring-kumo-brand"
 							/>
-							<CommandPalette.List className="max-h-[min(28rem,50vh)] rounded-t-none text-base">
+							<CommandPalette.List className="max-h-[min(14rem,25vh)] rounded-t-none text-base">
 								<CommandPalette.Results>
 									{(item: LanguageItem) => (
 										<CommandPalette.Item key={item.id} value={item} onClick={() => commit(item.id)}>

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -2,31 +2,23 @@
  * Code block node with language picker.
  *
  * Wraps the Lowlight code block with a React node view that
- * overlays a small language chip in the top-right corner. Clicking the chip
- * opens a popover with a Kumo Autocomplete: a free-form text input plus a
- * filtered list of curated language suggestions. The value is persisted on
- * the node's `language` attribute and round-trips through Portable Text as
- * `block.language`.
+ * overlays a Kumo action toolbar at the logical end of the block. The toolbar
+ * opens a searchable language popover and copies the raw code. The selected
+ * language is persisted on the node's `language` attribute and round-trips
+ * through Portable Text as `block.language`.
  *
  * The picker accepts arbitrary strings (not restricted to the curated list)
  * so that less common languages can still be used. Free-form input is
  * sanitized to a single safe CSS class token via `normalizeLanguage` so the
  * frontend's `language-{id}` class stays well-formed.
  *
- * The popover content is rendered through Kumo's `Popover`, which portals it
- * out of the editor's contentEditable DOM. That portal is load-bearing, not
- * cosmetic: a code block is a non-atom ProseMirror node with live editable
- * content, so if the picker's text input lived inside the node view, typing
- * would move the DOM selection into it. ProseMirror reads that selection,
- * dispatches a selection-correcting transaction, and the resulting node-view
- * redraw recreates this React component mid-edit, tearing the picker down --
- * the "language picker loses focus and closes when you type" bug (issue
- * #1200). Keeping the input outside the editor DOM avoids it entirely.
+ * Kumo's `Popover` portals the search input out of the contentEditable DOM so
+ * ProseMirror does not interpret input typing as an editor selection change.
  */
 
-import { Autocomplete, Button, Popover } from "@cloudflare/kumo";
+import { CommandPalette, Popover, Toolbar } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { Check, X } from "@phosphor-icons/react";
+import { CaretDown, Check, Copy } from "@phosphor-icons/react";
 import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
@@ -67,9 +59,19 @@ const editorLowlight = {
 	},
 };
 
-function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) {
+interface LanguageItem {
+	id: string;
+	label: string;
+	aliases?: string[];
+}
+
+function CodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const { t } = useLingui();
 	const [isEditing, setIsEditing] = React.useState(false);
+	const [copied, setCopied] = React.useState(false);
+	const [keyboardHighlightedLanguage, setKeyboardHighlightedLanguage] =
+		React.useState<LanguageItem | null>(null);
+	const copyResetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
 
 	const labelText = React.useCallback(
@@ -81,27 +83,33 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 	);
 
 	const languageItems = React.useMemo(
-		() => CODE_BLOCK_LANGUAGES.map((language) => t(language.label)),
+		() =>
+			CODE_BLOCK_LANGUAGES.map((language) => ({
+				id: language.id,
+				label: t(language.label),
+				aliases: language.aliases,
+			})),
 		[t],
 	);
 
 	const findLanguageByDisplayLabel = React.useCallback(
-		(label: string) => CODE_BLOCK_LANGUAGES.find((language) => t(language.label) === label),
-		[t],
+		(label: string) => languageItems.find((language) => language.label === label),
+		[languageItems],
 	);
 
-	const filterLanguages = React.useCallback(
-		(item: string, query: string) => {
-			if (!query) return true;
-			const searchText = query.toLowerCase();
-			const lang = findLanguageByDisplayLabel(item);
-			if (!lang) return false;
+	const filterLanguages = React.useCallback((item: LanguageItem, query: string) => {
+		if (!query) return true;
+		const searchText = query.toLowerCase();
+		if (item.label.toLowerCase().includes(searchText)) return true;
+		if (item.id.toLowerCase().includes(searchText)) return true;
+		return item.aliases?.some((alias) => alias.toLowerCase().includes(searchText)) ?? false;
+	}, []);
 
-			if (t(lang.label).toLowerCase().includes(searchText)) return true;
-			if (lang.id.toLowerCase().includes(searchText)) return true;
-			return lang.aliases?.some((alias) => alias.toLowerCase().includes(searchText)) ?? false;
+	React.useEffect(
+		() => () => {
+			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 		},
-		[findLanguageByDisplayLabel, t],
+		[],
 	);
 
 	const [draft, setDraft] = React.useState(() => labelText(storedLanguage));
@@ -116,12 +124,14 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 	}, [storedLanguage, isEditing, labelText]);
 
 	const openPicker = React.useCallback(() => {
-		setDraft(storedLanguage ? labelText(storedLanguage) : "");
+		setDraft("");
+		setKeyboardHighlightedLanguage(null);
 		setIsEditing(true);
-	}, [storedLanguage, labelText]);
+	}, []);
 
 	const closePicker = React.useCallback(() => {
 		setIsEditing(false);
+		setKeyboardHighlightedLanguage(null);
 		setDraft(labelText(storedLanguage));
 	}, [storedLanguage, labelText]);
 
@@ -132,99 +142,139 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 			const next = selectedLanguage?.id ?? normalizeLanguage(raw);
 			updateAttributes({ language: next ?? null });
 			setIsEditing(false);
+			setKeyboardHighlightedLanguage(null);
 		},
 		[draft, findLanguageByDisplayLabel, updateAttributes],
 	);
 
-	// Enter commits the current draft. Escape is handled by the Popover itself
-	// (it calls onOpenChange(false) -> closePicker).
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		if (e.key === "Enter") {
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			closePicker();
+			return;
+		}
+		if (e.key === "Enter" && !keyboardHighlightedLanguage) {
 			e.preventDefault();
 			commit();
 		}
 	};
 
+	const copyCode = React.useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(node.textContent);
+			setCopied(true);
+			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
+			copyResetTimer.current = setTimeout(setCopied, 2500, false);
+		} catch {
+			setCopied(false);
+		}
+	}, [node.textContent]);
+
 	const label = labelText(storedLanguage);
-	// The chip is always rendered (so it can be discovered via hover) but its
-	// opacity is controlled by CSS: invisible by default, visible on hover,
-	// when this block is selected, when the picker is open, or when the
-	// block already has a language set. When hidden, also remove it from the
-	// tab order so it doesn't trap keyboard focus.
-	const chipPersistent = isEditing || Boolean(storedLanguage) || selected;
+	const currentLanguageId = normalizeLanguage(storedLanguage);
+	const controlsPersistent = isEditing || copied;
 
 	return (
-		<NodeViewWrapper className="group relative my-4" data-language={storedLanguage || undefined}>
+		<NodeViewWrapper
+			className="emdash-code-block-node relative my-4"
+			data-language={storedLanguage || undefined}
+		>
 			<pre className="emdash-code-block">
 				<NodeViewContent<"code"> as="code" />
 			</pre>
 
-			<div className="absolute end-2 top-2 select-none" contentEditable={false}>
+			<div className="absolute end-2 top-2 z-10 select-none" contentEditable={false}>
 				<Popover
 					open={isEditing}
 					onOpenChange={(open: boolean) => (open ? openPicker() : closePicker())}
 				>
-					<Popover.Trigger
-						render={
-							<button
-								type="button"
-								tabIndex={chipPersistent ? 0 : -1}
-								onMouseDown={(e) => e.preventDefault()}
-								className="rounded-md border bg-kumo-overlay/90 px-2 py-1 text-xs text-kumo-subtle opacity-0 transition-opacity hover:text-kumo-strong focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-kumo-brand group-hover:opacity-100 data-[persistent=true]:opacity-100"
-								data-persistent={chipPersistent ? "true" : "false"}
-								title={t`Set language`}
-								aria-label={t`Set language (current: ${label})`}
-								aria-hidden={chipPersistent ? undefined : true}
-							>
-								{storedLanguage ? label : t`Set language`}
-							</button>
-						}
-					/>
-					<Popover.Content side="bottom" className="w-auto p-1">
-						<div className="flex items-center gap-1" onKeyDown={handleKeyDown}>
-							<Autocomplete
-								items={languageItems}
-								value={draft}
-								onValueChange={(next: string) => setDraft(next)}
-								filter={filterLanguages}
-							>
-								<Autocomplete.InputGroup size="sm" placeholder={t`Language`} />
-								<Autocomplete.Content sideOffset={4}>
-									<Autocomplete.List>
-										{(item: string) => (
-											<Autocomplete.Item key={item} value={item}>
-												{item}
-											</Autocomplete.Item>
-										)}
-									</Autocomplete.List>
-									<Autocomplete.Empty>{t`No matches`}</Autocomplete.Empty>
-								</Autocomplete.Content>
-							</Autocomplete>
-							<Button
-								type="button"
-								variant="ghost"
-								shape="square"
-								className="h-7 w-7"
-								onMouseDown={(e) => e.preventDefault()}
-								onClick={() => commit()}
-								title={t`Apply language`}
-								aria-label={t`Apply language`}
-							>
-								<Check className="h-4 w-4" />
-							</Button>
-							<Button
-								type="button"
-								variant="ghost"
-								shape="square"
-								className="h-7 w-7"
-								onMouseDown={(e) => e.preventDefault()}
-								onClick={closePicker}
-								title={t`Cancel`}
-								aria-label={t`Cancel`}
-							>
-								<X className="h-4 w-4" />
-							</Button>
-						</div>
+					<Toolbar
+						size="sm"
+						className="emdash-code-block-controls text-base"
+						data-persistent={controlsPersistent ? "true" : "false"}
+						aria-label={t`Code block actions`}
+					>
+						<Popover.Trigger
+							render={
+								<Toolbar.Button
+									className="h-8 gap-1.5 px-2.5 text-base"
+									onMouseDown={(event) => event.preventDefault()}
+									title={t`Set language`}
+									aria-label={t`Set language (current: ${label})`}
+								>
+									<span className="max-w-40 truncate">{label}</span>
+									<CaretDown className="size-3.5 shrink-0 text-kumo-subtle" aria-hidden="true" />
+								</Toolbar.Button>
+							}
+						/>
+						<Toolbar.Button
+							shape="square"
+							className="size-8 text-base"
+							onMouseDown={(event) => event.preventDefault()}
+							onClick={copyCode}
+							icon={
+								copied ? (
+									<Check className="size-4" aria-hidden="true" />
+								) : (
+									<Copy className="size-4" aria-hidden="true" />
+								)
+							}
+							title={copied ? t`Copied` : t`Copy code`}
+							aria-label={copied ? t`Copied` : t`Copy code`}
+						/>
+					</Toolbar>
+					<span className="sr-only" role="status" aria-live="polite">
+						{copied ? t`Copied` : ""}
+					</span>
+					<Popover.Content
+						side="bottom"
+						align="start"
+						sideOffset={8}
+						positionMethod="fixed"
+						className="w-[min(27rem,calc(100vw-2rem))] overflow-hidden p-0"
+					>
+						<CommandPalette.Panel<LanguageItem>
+							items={languageItems}
+							value={draft}
+							onValueChange={(next: string) => {
+								setDraft(next);
+								setKeyboardHighlightedLanguage(null);
+							}}
+							onItemHighlighted={(item, details) =>
+								setKeyboardHighlightedLanguage(
+									details.reason === "keyboard" ? (item ?? null) : null,
+								)
+							}
+							itemToStringValue={(item) => item.label}
+							filter={filterLanguages}
+							open={isEditing}
+							className="[&>div:first-child]:gap-0 [&>div:first-child]:px-3 [&>div:first-child]:py-3 [&>div:first-child]:focus-within:ring-0"
+						>
+							<CommandPalette.Input
+								aria-label={t`Search for a language`}
+								placeholder={t`Search for a language…`}
+								leading={<span className="hidden" aria-hidden="true" />}
+								autoComplete="off"
+								spellCheck={false}
+								onKeyDown={handleKeyDown}
+								className="h-9 rounded-lg bg-kumo-control px-3 text-base ring ring-kumo-line focus:ring-2 focus:ring-kumo-brand"
+							/>
+							<CommandPalette.List className="max-h-[min(28rem,50vh)] rounded-t-none text-base">
+								<CommandPalette.Results>
+									{(item: LanguageItem) => (
+										<CommandPalette.Item key={item.id} value={item} onClick={() => commit(item.id)}>
+											<span className="flex min-w-0 flex-1 items-center justify-between gap-3">
+												<span className="truncate">{item.label}</span>
+												{currentLanguageId === item.id ? (
+													<Check className="size-4 shrink-0" aria-hidden="true" />
+												) : null}
+											</span>
+										</CommandPalette.Item>
+									)}
+								</CommandPalette.Results>
+								<CommandPalette.Empty>{t`No matches`}</CommandPalette.Empty>
+							</CommandPalette.List>
+						</CommandPalette.Panel>
 					</Popover.Content>
 				</Popover>
 			</div>

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -255,6 +255,7 @@ body {
 	background: var(--emdash-code-background);
 	color: var(--emdash-code-foreground);
 	caret-color: var(--emdash-code-foreground);
+	padding-block-start: 3.25rem;
 }
 
 [data-mode="dark"] .emdash-code-block {
@@ -300,6 +301,32 @@ body {
 		.hljs-selector-class
 	) {
 	color: var(--emdash-code-title);
+}
+
+.emdash-code-block-controls {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease-out;
+}
+
+.emdash-code-block-node:hover .emdash-code-block-controls,
+.emdash-code-block-node:focus-within .emdash-code-block-controls,
+.emdash-code-block-controls[data-persistent="true"] {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+@media (hover: none), (pointer: coarse) {
+	.emdash-code-block-controls {
+		opacity: 1;
+		pointer-events: auto;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.emdash-code-block-controls {
+		transition: none;
+	}
 }
 
 /**

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -309,27 +309,23 @@ body {
 	pointer-events: none;
 	transition: opacity 120ms ease-out;
 }
-
 .emdash-code-block-node:hover .emdash-code-block-controls,
 .emdash-code-block-node:focus-within .emdash-code-block-controls,
 .emdash-code-block-controls[data-persistent="true"] {
 	opacity: 1;
 	pointer-events: auto;
 }
-
 @media (hover: none), (pointer: coarse) {
 	.emdash-code-block-controls {
 		opacity: 1;
 		pointer-events: auto;
 	}
 }
-
 @media (prefers-reduced-motion: reduce) {
 	.emdash-code-block-controls {
 		transition: none;
 	}
 }
-
 /**
  * TipTap placeholder styles
  */

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -255,7 +255,7 @@ body {
 	background: var(--emdash-code-background);
 	color: var(--emdash-code-foreground);
 	caret-color: var(--emdash-code-foreground);
-	padding-block: 3rem;
+	padding-block: 2rem;
 }
 
 [data-mode="dark"] .emdash-code-block {

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -255,7 +255,7 @@ body {
 	background: var(--emdash-code-background);
 	color: var(--emdash-code-foreground);
 	caret-color: var(--emdash-code-foreground);
-	padding-block: 2rem;
+	padding-block: 1.875rem;
 }
 
 [data-mode="dark"] .emdash-code-block {
@@ -271,6 +271,7 @@ body {
 .emdash-code-block code {
 	background: transparent;
 	color: inherit;
+	font-size: 0.8125rem;
 }
 
 .emdash-code-block :is(.hljs-comment, .hljs-quote) {

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -255,7 +255,7 @@ body {
 	background: var(--emdash-code-background);
 	color: var(--emdash-code-foreground);
 	caret-color: var(--emdash-code-foreground);
-	padding-block-start: 3.25rem;
+	padding-block: 3rem;
 }
 
 [data-mode="dark"] .emdash-code-block {

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -9,6 +9,7 @@
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { describe, it, expect, vi } from "vitest";
+import { userEvent } from "vitest/browser";
 
 import type { PluginBlockDef } from "../../src/components/PortableTextEditor";
 import {
@@ -1270,5 +1271,74 @@ describe("onChange output shape", () => {
 		const json = capturedEditor!.getJSON();
 		const listNode = json.content?.find((n: { type: string }) => n.type === "bulletList");
 		expect(listNode).toBeTruthy();
+	});
+});
+
+describe("Code block controls", () => {
+	it("uses a two-action toolbar and selects a language immediately", async () => {
+		const { screen, editor } = await renderAndGetEditor({
+			value: [{ _type: "code", _key: "code", code: "print('hello')", language: "python" }],
+		});
+
+		const toolbar = screen.getByRole("toolbar", { name: "Code block actions" });
+		await expect.element(toolbar).toBeInTheDocument();
+		expect(toolbar.element().querySelectorAll("button")).toHaveLength(2);
+		await expect.element(toolbar.getByRole("button", { name: "Copy code" })).toBeInTheDocument();
+
+		await toolbar.getByRole("button", { name: "Set language (current: Python)" }).click();
+		const input = screen.getByPlaceholder("Search for a language…");
+		await expect.element(input).toBeInTheDocument();
+		await screen.getByRole("option", { name: "JavaScript" }).click();
+
+		await vi.waitFor(() => {
+			const node = editor.getJSON().content?.find((item) => item.type === "codeBlock");
+			expect(node?.attrs?.language).toBe("javascript");
+		});
+		await expect.element(input).not.toBeInTheDocument();
+	});
+
+	it("copies the raw code and exposes copied feedback", async () => {
+		const clipboardWrite = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+		const { screen } = await renderAndGetEditor({
+			value: [
+				{
+					_type: "code",
+					_key: "code",
+					code: "const greeting = 'hello';",
+					language: "javascript",
+				},
+			],
+		});
+
+		await screen.getByRole("button", { name: "Copy code" }).click();
+		await vi.waitFor(() => {
+			expect(clipboardWrite).toHaveBeenCalledWith("const greeting = 'hello';");
+		});
+		await expect.element(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("status")).toHaveTextContent("Copied");
+		clipboardWrite.mockRestore();
+	});
+
+	it("supports free-form Enter and closes the language search with Escape", async () => {
+		const { screen, editor } = await renderAndGetEditor({
+			value: [{ _type: "code", _key: "code", code: "custom()", language: "plaintext" }],
+		});
+		const languageButton = screen.getByRole("button", {
+			name: "Set language (current: Plain text)",
+		});
+
+		await languageButton.click();
+		let input = screen.getByPlaceholder("Search for a language…");
+		await input.fill("Custom Language");
+		await userEvent.keyboard("{Enter}");
+		await vi.waitFor(() => {
+			const node = editor.getJSON().content?.find((item) => item.type === "codeBlock");
+			expect(node?.attrs?.language).toBe("custom-language");
+		});
+
+		await screen.getByRole("button", { name: "Set language (current: custom-language)" }).click();
+		input = screen.getByPlaceholder("Search for a language…");
+		await userEvent.keyboard("{Escape}");
+		await expect.element(input).not.toBeInTheDocument();
 	});
 });

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -1319,6 +1319,38 @@ describe("Code block controls", () => {
 		clipboardWrite.mockRestore();
 	});
 
+	it("falls back to document copy when the Clipboard API is unavailable", async () => {
+		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+		Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+		try {
+			const { screen } = await renderAndGetEditor({
+				value: [
+					{
+						_type: "code",
+						_key: "code",
+						code: "const fallback = true;",
+						language: "javascript",
+					},
+				],
+			});
+
+			await screen.getByRole("button", { name: "Copy code" }).click();
+			await vi.waitFor(() => {
+				expect(copyCommand).toHaveBeenCalledWith("copy");
+			});
+			await expect.element(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+			expect(document.querySelector("textarea[readonly]")).toBeNull();
+		} finally {
+			copyCommand.mockRestore();
+			if (clipboardDescriptor) {
+				Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+			} else {
+				Reflect.deleteProperty(navigator, "clipboard");
+			}
+		}
+	});
+
 	it("supports free-form Enter and closes the language search with Escape", async () => {
 		const { screen, editor } = await renderAndGetEditor({
 			value: [{ _type: "code", _key: "code", code: "custom()", language: "plaintext" }],

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -1351,6 +1351,44 @@ describe("Code block controls", () => {
 		}
 	});
 
+	it("falls back after a rejected Clipboard API write and keeps keyboard focus", async () => {
+		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
+		const clipboardWrite = vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: clipboardWrite },
+		});
+		try {
+			const { screen } = await renderAndGetEditor({
+				value: [
+					{
+						_type: "code",
+						_key: "code",
+						code: "const fallback = true;",
+						language: "javascript",
+					},
+				],
+			});
+
+			const copyButton = screen.getByRole("button", { name: "Copy code" });
+			copyButton.element().focus();
+			await copyButton.click();
+			await vi.waitFor(() => {
+				expect(clipboardWrite).toHaveBeenCalledWith("const fallback = true;");
+				expect(copyCommand).toHaveBeenCalledWith("copy");
+			});
+			await expect.element(copyButton).toHaveFocus();
+		} finally {
+			copyCommand.mockRestore();
+			if (clipboardDescriptor) {
+				Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+			} else {
+				Reflect.deleteProperty(navigator, "clipboard");
+			}
+		}
+	});
+
 	it("supports free-form Enter and closes the language search with Escape", async () => {
 		const { screen, editor } = await renderAndGetEditor({
 			value: [{ _type: "code", _key: "code", code: "custom()", language: "plaintext" }],

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -1406,6 +1406,33 @@ describe("Code block copy action", () => {
 		}
 	});
 
+	it("announces when copying fails", async () => {
+		const clipboardWrite = vi
+			.spyOn(navigator.clipboard, "writeText")
+			.mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(false);
+		try {
+			const { screen } = await renderAndGetEditor({
+				value: [
+					{
+						_type: "code",
+						_key: "code",
+						code: "copy()",
+						language: "javascript",
+					},
+				],
+			});
+			await screen.getByRole("button", { name: "Copy code" }).click();
+
+			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
+			await expect.element(screen.getByRole("button", { name: "Retry copy" })).toBeVisible();
+			await expect.element(screen.getByRole("status")).toHaveTextContent("Copy failed");
+		} finally {
+			copyCommand.mockRestore();
+			clipboardWrite.mockRestore();
+		}
+	});
+
 	it("preserves alias, free-form, apply, and cancel behavior", async () => {
 		const { screen, editor } = await renderAndGetEditor({
 			value: [

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -1308,7 +1308,7 @@ describe("Code block copy action", () => {
 		}
 	});
 
-	it("keeps feedback from the newest copy attempt", async () => {
+	it("keeps the newest copy feedback and reports failures", async () => {
 		let rejectFirst!: (reason: unknown) => void;
 		let resolveSecond!: () => void;
 		const firstCopy = new Promise<void>((_resolve, reject) => {
@@ -1320,7 +1320,8 @@ describe("Code block copy action", () => {
 		const clipboardWrite = vi
 			.spyOn(navigator.clipboard, "writeText")
 			.mockImplementationOnce(() => firstCopy)
-			.mockImplementationOnce(() => secondCopy);
+			.mockImplementationOnce(() => secondCopy)
+			.mockRejectedValueOnce(new DOMException("Denied", "NotAllowedError"));
 		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(false);
 		try {
 			const { screen } = await renderAndGetEditor({
@@ -1346,6 +1347,12 @@ describe("Code block copy action", () => {
 			await vi.waitFor(() =>
 				expect(screen.getByRole("status").element().textContent).toBe("Copied"),
 			);
+
+			copyButton.click();
+			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(3));
+			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledTimes(2));
+			await expect.element(screen.getByRole("button", { name: "Retry copy" })).toBeVisible();
+			await expect.element(screen.getByRole("status")).toHaveTextContent("Copy failed");
 		} finally {
 			copyCommand.mockRestore();
 			clipboardWrite.mockRestore();
@@ -1403,33 +1410,6 @@ describe("Code block copy action", () => {
 			} else {
 				Reflect.deleteProperty(navigator, "clipboard");
 			}
-		}
-	});
-
-	it("announces when copying fails", async () => {
-		const clipboardWrite = vi
-			.spyOn(navigator.clipboard, "writeText")
-			.mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
-		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(false);
-		try {
-			const { screen } = await renderAndGetEditor({
-				value: [
-					{
-						_type: "code",
-						_key: "code",
-						code: "copy()",
-						language: "javascript",
-					},
-				],
-			});
-			await screen.getByRole("button", { name: "Copy code" }).click();
-
-			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
-			await expect.element(screen.getByRole("button", { name: "Retry copy" })).toBeVisible();
-			await expect.element(screen.getByRole("status")).toHaveTextContent("Copy failed");
-		} finally {
-			copyCommand.mockRestore();
-			clipboardWrite.mockRestore();
 		}
 	});
 

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -9,6 +9,7 @@
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { describe, it, expect, vi } from "vitest";
+import { userEvent } from "vitest/browser";
 
 import type { PluginBlockDef } from "../../src/components/PortableTextEditor";
 import {
@@ -1385,7 +1386,10 @@ describe("Code block copy action", () => {
 		await vi.waitFor(() => expect(storedLanguage()).toBe("javascript"));
 		await screen.getByRole("button", { name: "Set language (current: JavaScript)" }).click();
 		await screen.getByPlaceholder("Language").fill("Discarded Language");
-		clickPickerAction("Cancel");
+		const cancelButton = document.querySelector<HTMLButtonElement>('button[aria-label="Cancel"]');
+		expect(cancelButton).not.toBeNull();
+		cancelButton?.focus();
+		await userEvent.keyboard("{Enter}");
 		expect(storedLanguage()).toBe("javascript");
 
 		await screen.getByRole("button", { name: "Set language (current: JavaScript)" }).click();

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -1308,6 +1308,50 @@ describe("Code block copy action", () => {
 		}
 	});
 
+	it("keeps feedback from the newest copy attempt", async () => {
+		let rejectFirst!: (reason: unknown) => void;
+		let resolveSecond!: () => void;
+		const firstCopy = new Promise<void>((_resolve, reject) => {
+			rejectFirst = reject;
+		});
+		const secondCopy = new Promise<void>((resolve) => {
+			resolveSecond = resolve;
+		});
+		const clipboardWrite = vi
+			.spyOn(navigator.clipboard, "writeText")
+			.mockImplementationOnce(() => firstCopy)
+			.mockImplementationOnce(() => secondCopy);
+		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(false);
+		try {
+			const { screen } = await renderAndGetEditor({
+				value: [
+					{
+						_type: "code",
+						_key: "code",
+						code: "copy()",
+						language: "javascript",
+					},
+				],
+			});
+			const copyButton = screen.getByRole("button", { name: "Copy code" }).element();
+			copyButton.click();
+			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(1));
+			copyButton.click();
+			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(2));
+
+			resolveSecond();
+			await expect.element(screen.getByRole("status")).toHaveTextContent("Copied");
+			rejectFirst(new DOMException("Denied", "NotAllowedError"));
+			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
+			await vi.waitFor(() =>
+				expect(screen.getByRole("status").element().textContent).toBe("Copied"),
+			);
+		} finally {
+			copyCommand.mockRestore();
+			clipboardWrite.mockRestore();
+		}
+	});
+
 	it("falls back after Clipboard API rejection and restores focus and selection", async () => {
 		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 		const clipboardWrite = vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError"));

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -1343,16 +1343,15 @@ describe("Code block copy action", () => {
 			resolveSecond();
 			await expect.element(screen.getByRole("status")).toHaveTextContent("Copied");
 			rejectFirst(new DOMException("Denied", "NotAllowedError"));
-			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
 			await vi.waitFor(() =>
 				expect(screen.getByRole("status").element().textContent).toBe("Copied"),
 			);
 
 			copyButton.click();
 			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(3));
-			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledTimes(2));
 			await expect.element(screen.getByRole("button", { name: "Retry copy" })).toBeVisible();
 			await expect.element(screen.getByRole("status")).toHaveTextContent("Copy failed");
+			expect(copyCommand).toHaveBeenCalledTimes(1);
 		} finally {
 			copyCommand.mockRestore();
 			clipboardWrite.mockRestore();

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -9,7 +9,6 @@
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { userEvent } from "vitest/browser";
 
 import type { PluginBlockDef } from "../../src/components/PortableTextEditor";
 import {
@@ -1274,111 +1273,84 @@ describe("onChange output shape", () => {
 	});
 });
 
-describe("Code block controls", () => {
-	it("uses a two-action toolbar and selects a language immediately", async () => {
-		const { screen, editor } = await renderAndGetEditor({
-			value: [{ _type: "code", _key: "code", code: "print('hello')", language: "python" }],
-		});
-
-		const toolbar = screen.getByRole("toolbar", { name: "Code block actions" });
-		await expect.element(toolbar).toBeInTheDocument();
-		expect(toolbar.element().querySelectorAll("button")).toHaveLength(2);
-		await expect.element(toolbar.getByRole("button", { name: "Copy code" })).toBeInTheDocument();
-
-		await toolbar.getByRole("button", { name: "Set language (current: Python)" }).click();
-		const input = screen.getByPlaceholder("Search for a language…");
-		await expect.element(input).toBeInTheDocument();
-		await screen.getByRole("option", { name: "JavaScript" }).click();
-
-		await vi.waitFor(() => {
-			const node = editor.getJSON().content?.find((item) => item.type === "codeBlock");
-			expect(node?.attrs?.language).toBe("javascript");
-		});
-		await expect.element(input).not.toBeInTheDocument();
-	});
-
-	it("copies the raw code and exposes copied feedback", async () => {
+describe("Code block copy action", () => {
+	it("copies raw code and resets its accessible feedback", async () => {
 		const clipboardWrite = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
-		const { screen } = await renderAndGetEditor({
-			value: [
-				{
-					_type: "code",
-					_key: "code",
-					code: "const greeting = 'hello';",
-					language: "javascript",
-				},
-			],
-		});
-
-		await screen.getByRole("button", { name: "Copy code" }).click();
-		await vi.waitFor(() => {
-			expect(clipboardWrite).toHaveBeenCalledWith("const greeting = 'hello';");
-		});
-		await expect.element(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
-		await expect.element(screen.getByRole("status")).toHaveTextContent("Copied");
-		clipboardWrite.mockRestore();
-	});
-
-	it("falls back to document copy when the Clipboard API is unavailable", async () => {
-		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
-		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
-		Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
 		try {
 			const { screen } = await renderAndGetEditor({
 				value: [
 					{
 						_type: "code",
 						_key: "code",
-						code: "const fallback = true;",
+						code: "const greeting = 'hello';",
 						language: "javascript",
 					},
 				],
 			});
-
-			await screen.getByRole("button", { name: "Copy code" }).click();
+			await expect
+				.element(screen.getByRole("button", { name: "Set language (current: JavaScript)" }))
+				.toBeInTheDocument();
+			const copyButton = screen.getByRole("button", { name: "Copy code" });
+			await expect.element(copyButton).toBeInTheDocument();
+			vi.useFakeTimers();
+			await copyButton.click();
 			await vi.waitFor(() => {
-				expect(copyCommand).toHaveBeenCalledWith("copy");
+				expect(clipboardWrite).toHaveBeenCalledWith("const greeting = 'hello';");
 			});
-			await expect.element(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
-			expect(document.querySelector("textarea[readonly]")).toBeNull();
+			await expect.element(screen.getByRole("button", { name: "Copy code" })).toBeInTheDocument();
+			await expect.element(screen.getByRole("status")).toHaveTextContent("Copied");
+			await vi.advanceTimersByTimeAsync(1500);
+			await expect.element(screen.getByRole("status")).toHaveTextContent("");
 		} finally {
-			copyCommand.mockRestore();
-			if (clipboardDescriptor) {
-				Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
-			} else {
-				Reflect.deleteProperty(navigator, "clipboard");
-			}
+			vi.useRealTimers();
+			clipboardWrite.mockRestore();
 		}
 	});
 
-	it("falls back after a rejected Clipboard API write and keeps keyboard focus", async () => {
+	it("falls back after Clipboard API rejection and restores focus and selection", async () => {
 		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
-		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
 		const clipboardWrite = vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+		const copyCommand = vi.spyOn(document, "execCommand").mockReturnValue(true);
 		Object.defineProperty(navigator, "clipboard", {
 			configurable: true,
 			value: { writeText: clipboardWrite },
 		});
 		try {
-			const { screen } = await renderAndGetEditor({
+			const { screen, editor } = await renderAndGetEditor({
 				value: [
 					{
 						_type: "code",
 						_key: "code",
-						code: "const fallback = true;",
-						language: "javascript",
+						code: "first line\nsecond line",
+						language: "plaintext",
 					},
 				],
 			});
-
 			const copyButton = screen.getByRole("button", { name: "Copy code" });
-			copyButton.element().focus();
+			await expect.element(copyButton).toBeInTheDocument();
+			editor.chain().focus().setTextSelection({ from: 3, to: 13 }).run();
+			const selectionBeforeCopy = {
+				from: editor.state.selection.from,
+				to: editor.state.selection.to,
+			};
+			await vi.waitFor(() => expect(document.getSelection()?.toString()).not.toBe(""));
+			const domSelection = document.getSelection();
+			const rangeBeforeCopy = domSelection!.getRangeAt(0).cloneRange();
+			const activeElement = document.activeElement;
 			await copyButton.click();
 			await vi.waitFor(() => {
-				expect(clipboardWrite).toHaveBeenCalledWith("const fallback = true;");
+				expect(clipboardWrite).toHaveBeenCalledWith("first line\nsecond line");
 				expect(copyCommand).toHaveBeenCalledWith("copy");
 			});
-			await expect.element(copyButton).toHaveFocus();
+			expect(document.activeElement).toBe(activeElement);
+			expect(editor.state.selection.from).toBe(selectionBeforeCopy.from);
+			expect(editor.state.selection.to).toBe(selectionBeforeCopy.to);
+			expect(domSelection?.toString()).not.toBe("");
+			const rangeAfterCopy = domSelection!.getRangeAt(0);
+			expect(rangeAfterCopy.startContainer).toBe(rangeBeforeCopy.startContainer);
+			expect(rangeAfterCopy.startOffset).toBe(rangeBeforeCopy.startOffset);
+			expect(rangeAfterCopy.endContainer).toBe(rangeBeforeCopy.endContainer);
+			expect(rangeAfterCopy.endOffset).toBe(rangeBeforeCopy.endOffset);
 		} finally {
 			copyCommand.mockRestore();
 			if (clipboardDescriptor) {
@@ -1389,26 +1361,36 @@ describe("Code block controls", () => {
 		}
 	});
 
-	it("supports free-form Enter and closes the language search with Escape", async () => {
+	it("preserves alias, free-form, apply, and cancel behavior", async () => {
 		const { screen, editor } = await renderAndGetEditor({
-			value: [{ _type: "code", _key: "code", code: "custom()", language: "plaintext" }],
+			value: [
+				{
+					_type: "code",
+					_key: "code",
+					code: "custom()",
+					language: "plaintext",
+				},
+			],
 		});
-		const languageButton = screen.getByRole("button", {
-			name: "Set language (current: Plain text)",
-		});
+		const storedLanguage = () =>
+			editor.getJSON().content?.find((item) => item.type === "codeBlock")?.attrs?.language;
+		const clickPickerAction = (label: "Apply language" | "Cancel") => {
+			const button = document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+			expect(button).not.toBeNull();
+			button?.click();
+		};
+		await screen.getByRole("button", { name: "Set language (current: Plain text)" }).click();
+		await screen.getByPlaceholder("Language").fill("js");
+		clickPickerAction("Apply language");
+		await vi.waitFor(() => expect(storedLanguage()).toBe("javascript"));
+		await screen.getByRole("button", { name: "Set language (current: JavaScript)" }).click();
+		await screen.getByPlaceholder("Language").fill("Discarded Language");
+		clickPickerAction("Cancel");
+		expect(storedLanguage()).toBe("javascript");
 
-		await languageButton.click();
-		let input = screen.getByPlaceholder("Search for a language…");
-		await input.fill("Custom Language");
-		await userEvent.keyboard("{Enter}");
-		await vi.waitFor(() => {
-			const node = editor.getJSON().content?.find((item) => item.type === "codeBlock");
-			expect(node?.attrs?.language).toBe("custom-language");
-		});
-
-		await screen.getByRole("button", { name: "Set language (current: custom-language)" }).click();
-		input = screen.getByPlaceholder("Search for a language…");
-		await userEvent.keyboard("{Escape}");
-		await expect.element(input).not.toBeInTheDocument();
+		await screen.getByRole("button", { name: "Set language (current: JavaScript)" }).click();
+		await screen.getByPlaceholder("Language").fill("Custom Language");
+		clickPickerAction("Apply language");
+		await vi.waitFor(() => expect(storedLanguage()).toBe("custom-language"));
 	});
 });

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2284,7 +2284,9 @@ export function InlinePortableTextEditor({
 				onSelect={handleMediaSelect}
 			/>
 			<style>{`
-				.emdash-inline-code-block {
+				.emdash-inline-editor .emdash-inline-code-block {
+					position: relative;
+					margin-block: 1rem;
 					--emdash-code-background: var(--emdash-inline-code-background, #f7f7f5);
 					--emdash-code-foreground: var(--emdash-inline-code-foreground, #24292f);
 					--emdash-code-muted: var(--emdash-inline-code-muted, #57606a);
@@ -2303,55 +2305,199 @@ export function InlinePortableTextEditor({
 					);
 					--emdash-code-focus: var(--emdash-inline-code-focus, #0550ae);
 				}
-				.emdash-inline-code-block .emdash-code-block {
+				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block {
 					margin: 0;
 					padding: 1rem;
+					padding-block-start: 3.25rem;
+					border: 0;
 					border-radius: 0.5rem;
 					background: var(--emdash-code-background);
 					color: var(--emdash-code-foreground);
 					caret-color: var(--emdash-code-foreground);
 					overflow-x: auto;
 				}
-				.emdash-inline-code-block .emdash-code-block code {
+				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block code {
 					background: transparent;
 					color: inherit;
 				}
-				.emdash-inline-code-block :is(.hljs-comment, .hljs-quote) {
+				.emdash-inline-editor .emdash-inline-code-block :is(.hljs-comment, .hljs-quote) {
 					color: var(--emdash-code-muted);
 				}
-				.emdash-inline-code-block
+				.emdash-inline-editor .emdash-inline-code-block
 					:is(.hljs-keyword, .hljs-literal, .hljs-selector-tag, .hljs-section, .hljs-link, .hljs-deletion) {
 					color: var(--emdash-code-keyword);
 				}
-				.emdash-inline-code-block
+				.emdash-inline-editor .emdash-inline-code-block
 					:is(.hljs-string, .hljs-attr, .hljs-attribute, .hljs-symbol, .hljs-bullet, .hljs-addition) {
 					color: var(--emdash-code-string);
 				}
-				.emdash-inline-code-block :is(.hljs-number, .hljs-meta) {
+				.emdash-inline-editor .emdash-inline-code-block :is(.hljs-number, .hljs-meta) {
 					color: var(--emdash-code-number);
 				}
-				.emdash-inline-code-block
+				.emdash-inline-editor .emdash-inline-code-block
 					:is(.hljs-title, .hljs-name, .hljs-type, .hljs-built_in, .hljs-selector-id, .hljs-selector-class) {
 					color: var(--emdash-code-title);
 				}
-				.emdash-inline-code-block-popover,
-				.emdash-inline-code-block-chip {
-					border: 1px solid var(--emdash-code-border);
+				.emdash-inline-code-block-controls-wrap {
+					position: absolute;
+					inset-block-start: 0.5rem;
+					inset-inline-end: 0.5rem;
+					z-index: 100;
+					opacity: 0;
+					pointer-events: none;
+					transition: opacity 120ms ease-out;
+				}
+				.emdash-inline-editor .emdash-inline-code-block:hover .emdash-inline-code-block-controls-wrap,
+				.emdash-inline-editor .emdash-inline-code-block:focus-within .emdash-inline-code-block-controls-wrap,
+				.emdash-inline-code-block-controls-wrap[data-persistent="true"] {
+					opacity: 1;
+					pointer-events: auto;
+				}
+				.emdash-inline-code-block-controls {
+					display: inline-flex;
+					block-size: 2rem;
+					align-items: stretch;
+					overflow: hidden;
+					border-radius: 0.5rem;
 					background: var(--emdash-code-control-background);
 					color: var(--emdash-code-control-foreground);
+					box-shadow:
+						0 0 0 1px var(--emdash-code-border),
+						0 1px 2px rgb(0 0 0 / 0.08);
+					font-family: inherit;
+					font-size: 0.875rem;
+					line-height: 1.25rem;
 				}
-				.emdash-inline-code-block-language-input {
-					border: 1px solid var(--emdash-code-border);
+				.emdash-inline-code-block-action {
+					display: inline-flex;
+					block-size: 2rem;
+					align-items: center;
+					justify-content: center;
+					gap: 0.375rem;
+					border: 0;
 					background: transparent;
 					color: inherit;
+					font: inherit;
+					font-weight: 500;
+					cursor: pointer;
+					user-select: none;
 				}
-				.emdash-inline-code-block-chip:focus-visible,
+				.emdash-inline-code-block-action:hover {
+					background: color-mix(
+						in srgb,
+						var(--emdash-code-control-foreground) 10%,
+						var(--emdash-code-control-background)
+					);
+				}
+				.emdash-inline-code-block-action:focus-visible,
 				.emdash-inline-code-block-language-input:focus-visible {
+					position: relative;
+					z-index: 1;
 					outline: 2px solid var(--emdash-code-focus);
-					outline-offset: 2px;
+					outline-offset: -2px;
+				}
+				.emdash-inline-code-block-language-button {
+					min-inline-size: 0;
+					padding-inline: 0.625rem;
+				}
+				.emdash-inline-code-block-language-label {
+					max-inline-size: 10rem;
+					overflow: hidden;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+				}
+				.emdash-inline-code-block-copy-button {
+					inline-size: 2rem;
+					padding: 0;
+					border-inline-start: 1px solid var(--emdash-code-border);
+				}
+				.emdash-inline-code-block-popover {
+					position: fixed;
+					z-index: 1000;
+					display: flex;
+					max-block-size: calc(100vh - 2rem);
+					flex-direction: column;
+					overflow: hidden;
+					border-radius: 0.5rem;
+					background: var(--emdash-code-control-background);
+					color: var(--emdash-code-control-foreground);
+					box-shadow:
+						0 0 0 1px var(--emdash-code-border),
+						0 8px 24px rgb(0 0 0 / 0.18);
+					font-family: inherit;
+					font-size: 0.875rem;
+					line-height: 1.25rem;
+				}
+				.emdash-inline-code-block-language-input {
+					box-sizing: border-box;
+					block-size: 2.25rem;
+					inline-size: calc(100% - 1.5rem);
+					margin: 0.75rem;
+					margin-block-end: 0.5rem;
+					padding-inline: 0.75rem;
+					border: 0;
+					border-radius: 0.5rem;
+					background: var(--emdash-code-control-background);
+					box-shadow: 0 0 0 1px var(--emdash-code-border);
+					color: var(--emdash-code-control-foreground);
+					font: inherit;
+					font-size: 0.875rem;
+				}
+				.emdash-inline-code-block-language-input::placeholder {
+					color: color-mix(
+						in srgb,
+						var(--emdash-code-control-foreground) 64%,
+						transparent
+					);
+					opacity: 1;
+				}
+				.emdash-inline-code-block-language-list {
+					min-block-size: 0;
+					max-block-size: min(28rem, 50vh);
+					overflow-y: auto;
+					padding: 0.5rem;
+					border-block-start: 1px solid var(--emdash-code-border);
+					scroll-padding-block: 0.5rem;
+				}
+				.emdash-inline-code-block-language-option {
+					display: flex;
+					min-block-size: 2rem;
+					align-items: center;
+					justify-content: space-between;
+					gap: 0.75rem;
+					padding: 0.375rem 0.5rem;
+					border-radius: 0.5rem;
+					cursor: pointer;
+				}
+				.emdash-inline-code-block-language-option[data-active="true"] {
+					background: color-mix(
+						in srgb,
+						var(--emdash-code-control-foreground) 10%,
+						var(--emdash-code-control-background)
+					);
+				}
+				.emdash-inline-code-block-language-empty {
+					padding: 2rem;
+					color: color-mix(
+						in srgb,
+						var(--emdash-code-control-foreground) 64%,
+						transparent
+					);
+					text-align: center;
+				}
+				.emdash-inline-code-block-sr-only {
+					position: absolute;
+					inline-size: 1px;
+					block-size: 1px;
+					padding: 0;
+					margin: -1px;
+					overflow: hidden;
+					clip: rect(0, 0, 0, 0);
+					white-space: nowrap;
+					border: 0;
 				}
 				@media (prefers-color-scheme: dark) {
-					.emdash-inline-code-block {
+					.emdash-inline-editor .emdash-inline-code-block {
 						--emdash-code-background: var(--emdash-inline-code-background, #202020);
 						--emdash-code-foreground: var(--emdash-inline-code-foreground, #f0f3f6);
 						--emdash-code-muted: var(--emdash-inline-code-muted, #c9d1d9);
@@ -2369,6 +2515,22 @@ export function InlinePortableTextEditor({
 							#f0f3f6
 						);
 						--emdash-code-focus: var(--emdash-inline-code-focus, #a8d5ff);
+					}
+				}
+				@media (max-width: 30rem) {
+					.emdash-inline-code-block-language-input {
+						font-size: 1rem;
+					}
+				}
+				@media (hover: none), (pointer: coarse) {
+					.emdash-inline-code-block-controls-wrap {
+						opacity: 1;
+						pointer-events: auto;
+					}
+				}
+				@media (prefers-reduced-motion: reduce) {
+					.emdash-inline-code-block-controls-wrap {
+						transition: none;
 					}
 				}
 				.emdash-bubble-menu {

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2441,7 +2441,7 @@ export function InlinePortableTextEditor({
 					position: fixed;
 					z-index: 1000;
 					display: flex;
-					max-block-size: calc(100vh - 2rem);
+					max-block-size: min(16rem, 30vh);
 					flex-direction: column;
 					overflow: hidden;
 					border-radius: 0.5rem;
@@ -2479,7 +2479,8 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-language-list {
 					min-block-size: 0;
-					max-block-size: min(28rem, 50vh);
+					max-block-size: min(14rem, 25vh);
+					flex: 1 1 auto;
 					overflow-y: auto;
 					padding: 0.5rem;
 					border-block-start: 1px solid var(--emdash-code-border);

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2243,6 +2243,7 @@ export function InlinePortableTextEditor({
 			if (mediaPickerOpen) return;
 			const related = e.relatedTarget instanceof HTMLElement ? e.relatedTarget : null;
 			if (related && e.currentTarget.contains(related)) return;
+			if (related?.hasAttribute("data-emdash-clipboard-fallback")) return;
 			// Don't save if focus moved to the slash menu (portalled to body)
 			if (related?.closest(".emdash-slash-menu")) return;
 			if (related?.closest(".emdash-media-picker")) return;

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2308,7 +2308,7 @@ export function InlinePortableTextEditor({
 				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block {
 					margin: 0;
 					padding: 1rem;
-					padding-block-start: 3.25rem;
+					padding-block: 3rem;
 					border: 0;
 					border-radius: 0.5rem;
 					background: var(--emdash-code-background);
@@ -2340,8 +2340,8 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
 					position: absolute;
-					inset-block-start: 0.5rem;
-					inset-inline-end: 0.5rem;
+					inset-block-start: 0.25rem;
+					inset-inline-end: 0.25rem;
 					z-index: 100;
 					opacity: 0;
 					pointer-events: none;
@@ -2355,7 +2355,7 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-controls {
 					display: inline-flex;
-					block-size: 2rem;
+					block-size: 2.25rem;
 					align-items: stretch;
 					overflow: hidden;
 					border-radius: 0.5rem;
@@ -2370,7 +2370,7 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-action {
 					display: inline-flex;
-					block-size: 2rem;
+					block-size: 2.25rem;
 					align-items: center;
 					justify-content: center;
 					gap: 0.375rem;
@@ -2398,7 +2398,7 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-language-button {
 					min-inline-size: 0;
-					padding-inline: 0.625rem;
+					padding-inline: 0.75rem;
 				}
 				.emdash-inline-editor .emdash-inline-code-block-language-label {
 					max-inline-size: 10rem;
@@ -2407,9 +2407,34 @@ export function InlinePortableTextEditor({
 					white-space: nowrap;
 				}
 				.emdash-inline-editor .emdash-inline-code-block-copy-button {
-					inline-size: 2rem;
+					position: relative;
+					isolation: isolate;
+					inline-size: 2.25rem;
 					padding: 0;
+					overflow: hidden;
 					border-inline-start: 1px solid var(--emdash-code-border);
+				}
+				.emdash-inline-editor
+					:is(.emdash-inline-code-block-copy-success, .emdash-inline-code-block-copy-default) {
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					transition-property: transform, opacity;
+					transition-duration: 200ms;
+				}
+				.emdash-inline-editor .emdash-inline-code-block-copy-success {
+					position: absolute;
+					inset: 0;
+					transform: translateY(100%);
+					opacity: 0;
+				}
+				.emdash-inline-editor .emdash-inline-code-block-copy-success[data-copied="true"] {
+					transform: translateY(0);
+					opacity: 1;
+				}
+				.emdash-inline-editor .emdash-inline-code-block-copy-default[data-copied="true"] {
+					transform: translateY(-100%);
+					opacity: 0;
 				}
 				.emdash-inline-editor .emdash-inline-code-block-popover {
 					position: fixed;
@@ -2505,14 +2530,14 @@ export function InlinePortableTextEditor({
 						--emdash-code-string: var(--emdash-inline-code-string, #b9ddff);
 						--emdash-code-number: var(--emdash-inline-code-number, #a8d5ff);
 						--emdash-code-title: var(--emdash-inline-code-title, #e5ccff);
-						--emdash-code-border: var(--emdash-inline-code-border, #6e7681);
+						--emdash-code-border: var(--emdash-inline-code-border, #333333);
 						--emdash-code-control-background: var(
 							--emdash-inline-code-control-background,
-							var(--emdash-inline-bg, #161b22)
+							var(--emdash-inline-bg, #181818)
 						);
 						--emdash-code-control-foreground: var(
 							--emdash-inline-code-control-foreground,
-							#f0f3f6
+							#f5f5f5
 						);
 						--emdash-code-focus: var(--emdash-inline-code-focus, #a8d5ff);
 					}
@@ -2530,6 +2555,10 @@ export function InlinePortableTextEditor({
 				}
 				@media (prefers-reduced-motion: reduce) {
 					.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
+						transition: none;
+					}
+					.emdash-inline-editor
+						:is(.emdash-inline-code-block-copy-success, .emdash-inline-code-block-copy-default) {
 						transition: none;
 					}
 				}

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2338,7 +2338,7 @@ export function InlinePortableTextEditor({
 					:is(.hljs-title, .hljs-name, .hljs-type, .hljs-built_in, .hljs-selector-id, .hljs-selector-class) {
 					color: var(--emdash-code-title);
 				}
-				.emdash-inline-code-block-controls-wrap {
+				.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
 					position: absolute;
 					inset-block-start: 0.5rem;
 					inset-inline-end: 0.5rem;
@@ -2349,11 +2349,11 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block:hover .emdash-inline-code-block-controls-wrap,
 				.emdash-inline-editor .emdash-inline-code-block:focus-within .emdash-inline-code-block-controls-wrap,
-				.emdash-inline-code-block-controls-wrap[data-persistent="true"] {
+				.emdash-inline-editor .emdash-inline-code-block-controls-wrap[data-persistent="true"] {
 					opacity: 1;
 					pointer-events: auto;
 				}
-				.emdash-inline-code-block-controls {
+				.emdash-inline-editor .emdash-inline-code-block-controls {
 					display: inline-flex;
 					block-size: 2rem;
 					align-items: stretch;
@@ -2368,7 +2368,7 @@ export function InlinePortableTextEditor({
 					font-size: 0.875rem;
 					line-height: 1.25rem;
 				}
-				.emdash-inline-code-block-action {
+				.emdash-inline-editor .emdash-inline-code-block-action {
 					display: inline-flex;
 					block-size: 2rem;
 					align-items: center;
@@ -2382,36 +2382,36 @@ export function InlinePortableTextEditor({
 					cursor: pointer;
 					user-select: none;
 				}
-				.emdash-inline-code-block-action:hover {
+				.emdash-inline-editor .emdash-inline-code-block-action:hover {
 					background: color-mix(
 						in srgb,
 						var(--emdash-code-control-foreground) 10%,
 						var(--emdash-code-control-background)
 					);
 				}
-				.emdash-inline-code-block-action:focus-visible,
-				.emdash-inline-code-block-language-input:focus-visible {
+				.emdash-inline-editor .emdash-inline-code-block-action:focus-visible,
+				.emdash-inline-editor .emdash-inline-code-block-language-input:focus-visible {
 					position: relative;
 					z-index: 1;
 					outline: 2px solid var(--emdash-code-focus);
 					outline-offset: -2px;
 				}
-				.emdash-inline-code-block-language-button {
+				.emdash-inline-editor .emdash-inline-code-block-language-button {
 					min-inline-size: 0;
 					padding-inline: 0.625rem;
 				}
-				.emdash-inline-code-block-language-label {
+				.emdash-inline-editor .emdash-inline-code-block-language-label {
 					max-inline-size: 10rem;
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
 				}
-				.emdash-inline-code-block-copy-button {
+				.emdash-inline-editor .emdash-inline-code-block-copy-button {
 					inline-size: 2rem;
 					padding: 0;
 					border-inline-start: 1px solid var(--emdash-code-border);
 				}
-				.emdash-inline-code-block-popover {
+				.emdash-inline-editor .emdash-inline-code-block-popover {
 					position: fixed;
 					z-index: 1000;
 					display: flex;
@@ -2428,7 +2428,7 @@ export function InlinePortableTextEditor({
 					font-size: 0.875rem;
 					line-height: 1.25rem;
 				}
-				.emdash-inline-code-block-language-input {
+				.emdash-inline-editor .emdash-inline-code-block-language-input {
 					box-sizing: border-box;
 					block-size: 2.25rem;
 					inline-size: calc(100% - 1.5rem);
@@ -2443,7 +2443,7 @@ export function InlinePortableTextEditor({
 					font: inherit;
 					font-size: 0.875rem;
 				}
-				.emdash-inline-code-block-language-input::placeholder {
+				.emdash-inline-editor .emdash-inline-code-block-language-input::placeholder {
 					color: color-mix(
 						in srgb,
 						var(--emdash-code-control-foreground) 64%,
@@ -2451,7 +2451,7 @@ export function InlinePortableTextEditor({
 					);
 					opacity: 1;
 				}
-				.emdash-inline-code-block-language-list {
+				.emdash-inline-editor .emdash-inline-code-block-language-list {
 					min-block-size: 0;
 					max-block-size: min(28rem, 50vh);
 					overflow-y: auto;
@@ -2459,7 +2459,7 @@ export function InlinePortableTextEditor({
 					border-block-start: 1px solid var(--emdash-code-border);
 					scroll-padding-block: 0.5rem;
 				}
-				.emdash-inline-code-block-language-option {
+				.emdash-inline-editor .emdash-inline-code-block-language-option {
 					display: flex;
 					min-block-size: 2rem;
 					align-items: center;
@@ -2469,14 +2469,14 @@ export function InlinePortableTextEditor({
 					border-radius: 0.5rem;
 					cursor: pointer;
 				}
-				.emdash-inline-code-block-language-option[data-active="true"] {
+				.emdash-inline-editor .emdash-inline-code-block-language-option[data-active="true"] {
 					background: color-mix(
 						in srgb,
 						var(--emdash-code-control-foreground) 10%,
 						var(--emdash-code-control-background)
 					);
 				}
-				.emdash-inline-code-block-language-empty {
+				.emdash-inline-editor .emdash-inline-code-block-language-empty {
 					padding: 2rem;
 					color: color-mix(
 						in srgb,
@@ -2485,7 +2485,7 @@ export function InlinePortableTextEditor({
 					);
 					text-align: center;
 				}
-				.emdash-inline-code-block-sr-only {
+				.emdash-inline-editor .emdash-inline-code-block-sr-only {
 					position: absolute;
 					inline-size: 1px;
 					block-size: 1px;
@@ -2518,18 +2518,18 @@ export function InlinePortableTextEditor({
 					}
 				}
 				@media (max-width: 30rem) {
-					.emdash-inline-code-block-language-input {
+					.emdash-inline-editor .emdash-inline-code-block-language-input {
 						font-size: 1rem;
 					}
 				}
 				@media (hover: none), (pointer: coarse) {
-					.emdash-inline-code-block-controls-wrap {
+					.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
 						opacity: 1;
 						pointer-events: auto;
 					}
 				}
 				@media (prefers-reduced-motion: reduce) {
-					.emdash-inline-code-block-controls-wrap {
+					.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
 						transition: none;
 					}
 				}

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2309,7 +2309,7 @@ export function InlinePortableTextEditor({
 				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block {
 					margin: 0;
 					padding: 1rem;
-					padding-block: 3rem;
+					padding-block: 2rem;
 					border: 0;
 					border-radius: 0.5rem;
 					background: var(--emdash-code-background);

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2243,6 +2243,7 @@ export function InlinePortableTextEditor({
 			if (mediaPickerOpen) return;
 			const related = e.relatedTarget instanceof HTMLElement ? e.relatedTarget : null;
 			if (related && e.currentTarget.contains(related)) return;
+			// The copy fallback briefly moves focus to its textarea before restoring the editor.
 			if (related?.hasAttribute("data-emdash-clipboard-fallback")) return;
 			// Don't save if focus moved to the slash menu (portalled to body)
 			if (related?.closest(".emdash-slash-menu")) return;
@@ -2356,6 +2357,7 @@ export function InlinePortableTextEditor({
 					opacity: 0;
 					pointer-events: none;
 					user-select: none;
+					transition: opacity 120ms ease-out;
 				}
 				.emdash-inline-code-block:hover .emdash-inline-code-block-controls-wrap,
 				.emdash-inline-code-block:focus-within .emdash-inline-code-block-controls-wrap,
@@ -2382,6 +2384,11 @@ export function InlinePortableTextEditor({
 					.emdash-inline-code-block-controls-wrap {
 						opacity: 1;
 						pointer-events: auto;
+					}
+				}
+				@media (prefers-reduced-motion: reduce) {
+					.emdash-inline-code-block-controls-wrap {
+						transition: none;
 					}
 				}
 				@media (prefers-color-scheme: dark) {

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2309,7 +2309,7 @@ export function InlinePortableTextEditor({
 				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block {
 					margin: 0;
 					padding: 1rem;
-					padding-block: 2rem;
+					padding-block: 1.875rem;
 					border: 0;
 					border-radius: 0.5rem;
 					background: var(--emdash-code-background);
@@ -2320,6 +2320,7 @@ export function InlinePortableTextEditor({
 				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block code {
 					background: transparent;
 					color: inherit;
+					font-size: 0.8125rem;
 				}
 				.emdash-inline-editor .emdash-inline-code-block :is(.hljs-comment, .hljs-quote) {
 					color: var(--emdash-code-muted);
@@ -2341,7 +2342,7 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
 					position: absolute;
-					inset-block-start: 0.25rem;
+					inset-block-start: 0;
 					inset-inline-end: 0.25rem;
 					z-index: 100;
 					opacity: 0;
@@ -2356,7 +2357,7 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-controls {
 					display: inline-flex;
-					block-size: 2.25rem;
+					block-size: 1.625rem;
 					align-items: stretch;
 					overflow: hidden;
 					border-radius: 0.5rem;
@@ -2366,15 +2367,15 @@ export function InlinePortableTextEditor({
 						0 0 0 1px var(--emdash-code-border),
 						0 1px 2px rgb(0 0 0 / 0.08);
 					font-family: inherit;
-					font-size: 0.875rem;
-					line-height: 1.25rem;
+					font-size: 0.8125rem;
+					line-height: 1rem;
 				}
 				.emdash-inline-editor .emdash-inline-code-block-action {
 					display: inline-flex;
-					block-size: 2.25rem;
+					block-size: 1.625rem;
 					align-items: center;
 					justify-content: center;
-					gap: 0.375rem;
+					gap: 0.25rem;
 					border: 0;
 					background: transparent;
 					color: inherit;
@@ -2399,7 +2400,7 @@ export function InlinePortableTextEditor({
 				}
 				.emdash-inline-editor .emdash-inline-code-block-language-button {
 					min-inline-size: 0;
-					padding-inline: 0.75rem;
+					padding-inline: 0.5rem;
 				}
 				.emdash-inline-editor .emdash-inline-code-block-language-label {
 					max-inline-size: 10rem;
@@ -2410,7 +2411,7 @@ export function InlinePortableTextEditor({
 				.emdash-inline-editor .emdash-inline-code-block-copy-button {
 					position: relative;
 					isolation: isolate;
-					inline-size: 2.25rem;
+					inline-size: 1.625rem;
 					padding: 0;
 					overflow: hidden;
 					border-inline-start: 1px solid var(--emdash-code-border);

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2285,7 +2285,7 @@ export function InlinePortableTextEditor({
 				onSelect={handleMediaSelect}
 			/>
 			<style>{`
-				.emdash-inline-editor .emdash-inline-code-block {
+				.emdash-inline-code-block {
 					position: relative;
 					margin-block: 1rem;
 					--emdash-code-background: var(--emdash-inline-code-background, #f7f7f5);
@@ -2306,226 +2306,86 @@ export function InlinePortableTextEditor({
 					);
 					--emdash-code-focus: var(--emdash-inline-code-focus, #0550ae);
 				}
-				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block {
+				.emdash-inline-code-block .emdash-code-block {
 					margin: 0;
 					padding: 1rem;
-					padding-block: 1.875rem;
-					border: 0;
+					padding-block: 30px !important;
+					border: 0 !important;
 					border-radius: 0.5rem;
-					background: var(--emdash-code-background);
-					color: var(--emdash-code-foreground);
-					caret-color: var(--emdash-code-foreground);
+					background: var(--emdash-code-background) !important;
+					color: var(--emdash-code-foreground) !important;
+					caret-color: var(--emdash-code-foreground) !important;
 					overflow-x: auto;
 				}
-				.emdash-inline-editor .emdash-inline-code-block .emdash-code-block code {
-					background: transparent;
-					color: inherit;
-					font-size: 0.8125rem;
+				.emdash-inline-code-block .emdash-code-block code {
+					background: transparent !important;
+					color: inherit !important;
+					font-size: 13px !important;
 				}
-				.emdash-inline-editor .emdash-inline-code-block :is(.hljs-comment, .hljs-quote) {
+				.emdash-inline-code-block :is(.hljs-comment, .hljs-quote) {
 					color: var(--emdash-code-muted);
 				}
-				.emdash-inline-editor .emdash-inline-code-block
+				.emdash-inline-code-block
 					:is(.hljs-keyword, .hljs-literal, .hljs-selector-tag, .hljs-section, .hljs-link, .hljs-deletion) {
 					color: var(--emdash-code-keyword);
 				}
-				.emdash-inline-editor .emdash-inline-code-block
+				.emdash-inline-code-block
 					:is(.hljs-string, .hljs-attr, .hljs-attribute, .hljs-symbol, .hljs-bullet, .hljs-addition) {
 					color: var(--emdash-code-string);
 				}
-				.emdash-inline-editor .emdash-inline-code-block :is(.hljs-number, .hljs-meta) {
+				.emdash-inline-code-block :is(.hljs-number, .hljs-meta) {
 					color: var(--emdash-code-number);
 				}
-				.emdash-inline-editor .emdash-inline-code-block
+				.emdash-inline-code-block
 					:is(.hljs-title, .hljs-name, .hljs-type, .hljs-built_in, .hljs-selector-id, .hljs-selector-class) {
 					color: var(--emdash-code-title);
 				}
-				.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
+				.emdash-inline-code-block-popover,
+				.emdash-inline-code-block-chip {
+					box-sizing: border-box;
+					border: 1px solid var(--emdash-code-border);
+					background: var(--emdash-code-control-background);
+					color: var(--emdash-code-control-foreground);
+				}
+				.emdash-inline-code-block-controls-wrap {
 					position: absolute;
 					inset-block-start: 0;
 					inset-inline-end: 0.25rem;
 					z-index: 100;
+					max-inline-size: min(calc(100% - 0.25rem), calc(100vw - 1rem));
 					opacity: 0;
 					pointer-events: none;
-					transition: opacity 120ms ease-out;
+					user-select: none;
 				}
-				.emdash-inline-editor .emdash-inline-code-block:hover .emdash-inline-code-block-controls-wrap,
-				.emdash-inline-editor .emdash-inline-code-block:focus-within .emdash-inline-code-block-controls-wrap,
-				.emdash-inline-editor .emdash-inline-code-block-controls-wrap[data-persistent="true"] {
+				.emdash-inline-code-block:hover .emdash-inline-code-block-controls-wrap,
+				.emdash-inline-code-block:focus-within .emdash-inline-code-block-controls-wrap,
+				.emdash-inline-code-block-controls-wrap[data-persistent="true"] {
 					opacity: 1;
 					pointer-events: auto;
 				}
-				.emdash-inline-editor .emdash-inline-code-block-controls {
-					display: inline-flex;
-					block-size: 1.625rem;
-					align-items: stretch;
-					overflow: hidden;
-					border-radius: 0.5rem;
-					background: var(--emdash-code-control-background);
-					color: var(--emdash-code-control-foreground);
-					box-shadow:
-						0 0 0 1px var(--emdash-code-border),
-						0 1px 2px rgb(0 0 0 / 0.08);
-					font-family: inherit;
-					font-size: 0.8125rem;
-					line-height: 1rem;
+				.emdash-inline-code-block-popover {
+					inline-size: min(14rem, 100%, calc(100vw - 1rem));
 				}
-				.emdash-inline-editor .emdash-inline-code-block-action {
-					display: inline-flex;
-					block-size: 1.625rem;
-					align-items: center;
-					justify-content: center;
-					gap: 0.25rem;
-					border: 0;
+				.emdash-inline-code-block-language-input {
+					min-inline-size: 0;
+					flex: 1;
+					border: 1px solid var(--emdash-code-border);
 					background: transparent;
 					color: inherit;
-					font: inherit;
-					font-weight: 500;
-					cursor: pointer;
-					user-select: none;
 				}
-				.emdash-inline-editor .emdash-inline-code-block-action:hover {
-					background: color-mix(
-						in srgb,
-						var(--emdash-code-control-foreground) 10%,
-						var(--emdash-code-control-background)
-					);
-				}
-				.emdash-inline-editor .emdash-inline-code-block-action:focus-visible,
-				.emdash-inline-editor .emdash-inline-code-block-language-input:focus-visible {
-					position: relative;
-					z-index: 1;
+				.emdash-inline-code-block-controls-wrap button:focus-visible,
+				.emdash-inline-code-block-language-input:focus-visible {
 					outline: 2px solid var(--emdash-code-focus);
-					outline-offset: -2px;
+					outline-offset: 2px;
 				}
-				.emdash-inline-editor .emdash-inline-code-block-language-button {
-					min-inline-size: 0;
-					padding-inline: 0.5rem;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-language-label {
-					max-inline-size: 10rem;
-					overflow: hidden;
-					text-overflow: ellipsis;
-					white-space: nowrap;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-copy-button {
-					position: relative;
-					isolation: isolate;
-					inline-size: 1.625rem;
-					padding: 0;
-					overflow: hidden;
-					border-inline-start: 1px solid var(--emdash-code-border);
-				}
-				.emdash-inline-editor
-					:is(.emdash-inline-code-block-copy-success, .emdash-inline-code-block-copy-default) {
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					transition-property: transform, opacity;
-					transition-duration: 200ms;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-copy-success {
-					position: absolute;
-					inset: 0;
-					transform: translateY(100%);
-					opacity: 0;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-copy-success[data-copied="true"] {
-					transform: translateY(0);
-					opacity: 1;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-copy-default[data-copied="true"] {
-					transform: translateY(-100%);
-					opacity: 0;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-popover {
-					position: fixed;
-					z-index: 1000;
-					display: flex;
-					max-block-size: min(16rem, 30vh);
-					flex-direction: column;
-					overflow: hidden;
-					border-radius: 0.5rem;
-					background: var(--emdash-code-control-background);
-					color: var(--emdash-code-control-foreground);
-					box-shadow:
-						0 0 0 1px var(--emdash-code-border),
-						0 8px 24px rgb(0 0 0 / 0.18);
-					font-family: inherit;
-					font-size: 0.875rem;
-					line-height: 1.25rem;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-language-input {
-					box-sizing: border-box;
-					block-size: 2.25rem;
-					inline-size: calc(100% - 1.5rem);
-					margin: 0.75rem;
-					margin-block-end: 0.5rem;
-					padding-inline: 0.75rem;
-					border: 0;
-					border-radius: 0.5rem;
-					background: var(--emdash-code-control-background);
-					box-shadow: 0 0 0 1px var(--emdash-code-border);
-					color: var(--emdash-code-control-foreground);
-					font: inherit;
-					font-size: 0.875rem;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-language-input::placeholder {
-					color: color-mix(
-						in srgb,
-						var(--emdash-code-control-foreground) 64%,
-						transparent
-					);
-					opacity: 1;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-language-list {
-					min-block-size: 0;
-					max-block-size: min(14rem, 25vh);
-					flex: 1 1 auto;
-					overflow-y: auto;
-					padding: 0.5rem;
-					border-block-start: 1px solid var(--emdash-code-border);
-					scroll-padding-block: 0.5rem;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-language-option {
-					display: flex;
-					min-block-size: 2rem;
-					align-items: center;
-					justify-content: space-between;
-					gap: 0.75rem;
-					padding: 0.375rem 0.5rem;
-					border-radius: 0.5rem;
-					cursor: pointer;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-language-option[data-active="true"] {
-					background: color-mix(
-						in srgb,
-						var(--emdash-code-control-foreground) 10%,
-						var(--emdash-code-control-background)
-					);
-				}
-				.emdash-inline-editor .emdash-inline-code-block-language-empty {
-					padding: 2rem;
-					color: color-mix(
-						in srgb,
-						var(--emdash-code-control-foreground) 64%,
-						transparent
-					);
-					text-align: center;
-				}
-				.emdash-inline-editor .emdash-inline-code-block-sr-only {
-					position: absolute;
-					inline-size: 1px;
-					block-size: 1px;
-					padding: 0;
-					margin: -1px;
-					overflow: hidden;
-					clip: rect(0, 0, 0, 0);
-					white-space: nowrap;
-					border: 0;
+				@media (hover: none), (pointer: coarse) {
+					.emdash-inline-code-block-controls-wrap {
+						opacity: 1;
+						pointer-events: auto;
+					}
 				}
 				@media (prefers-color-scheme: dark) {
-					.emdash-inline-editor .emdash-inline-code-block {
+					.emdash-inline-code-block {
 						--emdash-code-background: var(--emdash-inline-code-background, #202020);
 						--emdash-code-foreground: var(--emdash-inline-code-foreground, #f0f3f6);
 						--emdash-code-muted: var(--emdash-inline-code-muted, #c9d1d9);
@@ -2533,36 +2393,16 @@ export function InlinePortableTextEditor({
 						--emdash-code-string: var(--emdash-inline-code-string, #b9ddff);
 						--emdash-code-number: var(--emdash-inline-code-number, #a8d5ff);
 						--emdash-code-title: var(--emdash-inline-code-title, #e5ccff);
-						--emdash-code-border: var(--emdash-inline-code-border, #333333);
+						--emdash-code-border: var(--emdash-inline-code-border, #6e7681);
 						--emdash-code-control-background: var(
 							--emdash-inline-code-control-background,
-							var(--emdash-inline-bg, #181818)
+							var(--emdash-inline-bg, #161b22)
 						);
 						--emdash-code-control-foreground: var(
 							--emdash-inline-code-control-foreground,
-							#f5f5f5
+							#f0f3f6
 						);
 						--emdash-code-focus: var(--emdash-inline-code-focus, #a8d5ff);
-					}
-				}
-				@media (max-width: 30rem) {
-					.emdash-inline-editor .emdash-inline-code-block-language-input {
-						font-size: 1rem;
-					}
-				}
-				@media (hover: none), (pointer: coarse) {
-					.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
-						opacity: 1;
-						pointer-events: auto;
-					}
-				}
-				@media (prefers-reduced-motion: reduce) {
-					.emdash-inline-editor .emdash-inline-code-block-controls-wrap {
-						transition: none;
-					}
-					.emdash-inline-editor
-						:is(.emdash-inline-code-block-copy-success, .emdash-inline-code-block-copy-default) {
-						transition: none;
 					}
 				}
 				.emdash-bubble-menu {

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -216,7 +216,7 @@ function XIcon() {
 
 function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const [isEditing, setIsEditing] = React.useState(false);
-	const [copied, setCopied] = React.useState(false);
+	const [copyStatus, setCopyStatus] = React.useState<"idle" | "copied" | "failed">("idle");
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
 	const [draft, setDraft] = React.useState(storedLanguage);
 	const inputRef = React.useRef<HTMLInputElement>(null);
@@ -280,20 +280,23 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	);
 	const copyCode = React.useCallback(async () => {
 		const requestId = ++copyRequestId.current;
+		setCopyStatus("idle");
 		try {
 			await copyTextToClipboard(node.textContent);
 			if (requestId !== copyRequestId.current) return;
-			setCopied(true);
+			setCopyStatus("copied");
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
-			copyResetTimer.current = setTimeout(setCopied, 1500, false);
+			copyResetTimer.current = setTimeout(setCopyStatus, 1500, "idle");
 		} catch {
 			if (requestId !== copyRequestId.current) return;
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
-			setCopied(false);
+			setCopyStatus("failed");
 		}
 	}, [node.textContent]);
 
 	const label = languageLabel(storedLanguage);
+	const copied = copyStatus === "copied";
+	const copyFailed = copyStatus === "failed";
 
 	return (
 		<NodeViewWrapper
@@ -307,7 +310,7 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 
 			<div
 				className="emdash-inline-code-block-controls-wrap"
-				data-persistent={isEditing || copied ? "true" : "false"}
+				data-persistent={isEditing || copyStatus !== "idle" ? "true" : "false"}
 				contentEditable={false}
 			>
 				{isEditing ? (
@@ -401,8 +404,8 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 							type="button"
 							onMouseDown={(event) => event.preventDefault()}
 							onClick={copyCode}
-							title={copied ? "Copied" : "Copy code"}
-							aria-label="Copy code"
+							title={copyFailed ? "Retry copy" : copied ? "Copied" : "Copy code"}
+							aria-label={copyFailed ? "Retry copy" : "Copy code"}
 							style={{
 								...iconButtonStyle,
 								height: "26px",
@@ -411,7 +414,9 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 								borderInlineStart: "1px solid var(--emdash-code-border)",
 							}}
 						>
-							<span aria-hidden="true">{copied ? <CheckIcon /> : "⧉"}</span>
+							<span aria-hidden="true">
+								{copied ? <CheckIcon /> : copyFailed ? <XIcon /> : "⧉"}
+							</span>
 						</button>
 					</div>
 				)}
@@ -426,7 +431,7 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 						clipPath: "inset(50%)",
 					}}
 				>
-					{copied ? "Copied" : ""}
+					{copyFailed ? "Copy failed" : copied ? "Copied" : ""}
 				</span>
 			</div>
 		</NodeViewWrapper>

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -193,13 +193,17 @@ function CheckIcon() {
 
 async function copyTextToClipboard(text: string): Promise<void> {
 	if (navigator.clipboard?.writeText) {
-		await navigator.clipboard.writeText(text);
-		return;
+		try {
+			await navigator.clipboard.writeText(text);
+			return;
+		} catch {}
 	}
 
+	const activeElement = document.activeElement;
 	const textarea = document.createElement("textarea");
 	textarea.value = text;
 	textarea.readOnly = true;
+	textarea.dataset.emdashClipboardFallback = "";
 	textarea.style.position = "fixed";
 	textarea.style.opacity = "0";
 	document.body.append(textarea);
@@ -213,6 +217,9 @@ async function copyTextToClipboard(text: string): Promise<void> {
 		if (previousRange) {
 			selection?.removeAllRanges();
 			selection?.addRange(previousRange);
+		}
+		if (activeElement instanceof HTMLElement && activeElement.isConnected) {
+			activeElement.focus();
 		}
 	}
 }

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -274,17 +274,31 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		const top = openAbove
 			? toolbarRect.top - Math.min(popupHeight, maxHeight) - POPUP_OFFSET
 			: toolbarRect.bottom + POPUP_OFFSET;
-		setPopupPosition({ left, maxHeight, top, width });
+		setPopupPosition((current) => {
+			if (
+				current?.left === left &&
+				current.maxHeight === maxHeight &&
+				current.top === top &&
+				current.width === width
+			) {
+				return current;
+			}
+			return { left, maxHeight, top, width };
+		});
 	}, []);
 
 	React.useLayoutEffect(() => {
 		if (!isEditing) return undefined;
 		updatePopupPosition();
 		const frame = requestAnimationFrame(updatePopupPosition);
+		const resizeObserver =
+			typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updatePopupPosition);
+		if (popoverRef.current) resizeObserver?.observe(popoverRef.current);
 		window.addEventListener("resize", updatePopupPosition);
 		window.addEventListener("scroll", updatePopupPosition, true);
 		return () => {
 			cancelAnimationFrame(frame);
+			resizeObserver?.disconnect();
 			window.removeEventListener("resize", updatePopupPosition);
 			window.removeEventListener("scroll", updatePopupPosition, true);
 		};

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -125,13 +125,14 @@ function languageLabel(value: string | null | undefined): string {
 	return value;
 }
 
-async function copyTextToClipboard(text: string): Promise<void> {
+async function copyTextToClipboard(text: string, shouldUseFallback: () => boolean): Promise<void> {
 	if (navigator.clipboard?.writeText) {
 		try {
 			await navigator.clipboard.writeText(text);
 			return;
 		} catch {}
 	}
+	if (!shouldUseFallback()) return;
 	const activeElement = document.activeElement;
 	const selection = document.getSelection();
 	const previousRange = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
@@ -282,7 +283,10 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		const requestId = ++copyRequestId.current;
 		setCopyStatus("idle");
 		try {
-			await copyTextToClipboard(node.textContent);
+			await copyTextToClipboard(
+				node.textContent,
+				() => requestId === copyRequestId.current,
+			);
 			if (requestId !== copyRequestId.current) return;
 			setCopyStatus("copied");
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -125,7 +125,7 @@ function languageLabel(value: string | null | undefined): string {
 	return value;
 }
 
-const POPUP_WIDTH = 432;
+const POPUP_WIDTH = 216;
 const POPUP_VIEWPORT_INSET = 16;
 const POPUP_OFFSET = 8;
 
@@ -491,7 +491,9 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 						className="emdash-inline-code-block-popover"
 						style={{
 							left: popupPosition?.left ?? 0,
-							maxHeight: popupPosition?.maxHeight,
+							maxBlockSize: popupPosition
+								? `min(16rem, 30vh, ${popupPosition.maxHeight}px)`
+								: undefined,
 							top: popupPosition?.top ?? 0,
 							width: popupPosition?.width ?? 0,
 							visibility: popupPosition ? "visible" : "hidden",

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -3,7 +3,7 @@
  *
  * Mirrors the admin editor's `CodeBlockNode` but with no Kumo/Lingui deps,
  * so it can ship as part of the SSR runtime. Wraps the Lowlight code block and
- * overlays a small inline language picker in the top-right corner of each code
+ * overlays matching language and copy controls at the logical end of each code
  * block.
  *
  * Keep the language list in sync with
@@ -125,30 +125,18 @@ function languageLabel(value: string | null | undefined): string {
 	return value;
 }
 
-function CodeBlockLanguageDatalist({ id }: { id: string }) {
-	return (
-		<datalist id={id}>
-			{CODE_BLOCK_LANGUAGES.map((lang) => (
-				<option key={lang.id} value={lang.id} label={lang.label} />
-			))}
-		</datalist>
-	);
+const POPUP_WIDTH = 432;
+const POPUP_VIEWPORT_INSET = 16;
+const POPUP_OFFSET = 8;
+
+interface PopupPosition {
+	left: number;
+	maxHeight: number;
+	top: number;
+	width: number;
 }
 
-const iconButtonStyle: React.CSSProperties = {
-	height: "1.75rem",
-	width: "1.75rem",
-	display: "inline-flex",
-	alignItems: "center",
-	justifyContent: "center",
-	border: "none",
-	background: "transparent",
-	cursor: "pointer",
-	color: "inherit",
-	borderRadius: "0.25rem",
-};
-
-function CheckIcon() {
+function CaretDownIcon() {
 	return (
 		<svg
 			width="14"
@@ -156,7 +144,44 @@ function CheckIcon() {
 			viewBox="0 0 24 24"
 			fill="none"
 			stroke="currentColor"
-			strokeWidth="2.5"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<polyline points="6 9 12 15 18 9" />
+		</svg>
+	);
+}
+
+function CopyIcon() {
+	return (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<rect x="9" y="9" width="11" height="11" rx="2" />
+			<path d="M15 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3" />
+		</svg>
+	);
+}
+
+function CheckIcon() {
+	return (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
 			strokeLinecap="round"
 			strokeLinejoin="round"
 			aria-hidden="true"
@@ -166,187 +191,311 @@ function CheckIcon() {
 	);
 }
 
-function XIcon() {
-	return (
-		<svg
-			width="14"
-			height="14"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="2.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<line x1="18" y1="6" x2="6" y2="18" />
-			<line x1="6" y1="6" x2="18" y2="18" />
-		</svg>
-	);
-}
-
-function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) {
+function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const [isEditing, setIsEditing] = React.useState(false);
-	const [isHovered, setIsHovered] = React.useState(false);
+	const [copied, setCopied] = React.useState(false);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
-	const [draft, setDraft] = React.useState(storedLanguage);
+	const [draft, setDraft] = React.useState("");
+	const [activeIndex, setActiveIndex] = React.useState(0);
+	const [keyboardNavigated, setKeyboardNavigated] = React.useState(false);
+	const [popupPosition, setPopupPosition] = React.useState<PopupPosition | null>(null);
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
-	// Per-instance datalist id so multiple code blocks (or multiple inline
-	// editors) on the same page don't create duplicate DOM ids.
-	const datalistId = React.useId();
+	const toolbarRef = React.useRef<HTMLDivElement>(null);
+	const languageButtonRef = React.useRef<HTMLButtonElement>(null);
+	const copyResetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+	const listboxId = React.useId();
+
+	const filteredLanguages = React.useMemo(() => {
+		const query = draft.trim().toLowerCase();
+		if (!query) return CODE_BLOCK_LANGUAGES;
+		return CODE_BLOCK_LANGUAGES.filter((language) => {
+			if (language.label.toLowerCase().includes(query)) return true;
+			if (language.id.toLowerCase().includes(query)) return true;
+			return language.aliases?.some((alias) => alias.toLowerCase().includes(query)) ?? false;
+		});
+	}, [draft]);
+
+	React.useEffect(
+		() => () => {
+			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
+		},
+		[],
+	);
 
 	React.useEffect(() => {
-		if (!isEditing) {
-			setDraft(storedLanguage);
-		}
-	}, [storedLanguage, isEditing]);
+		if (!isEditing) return undefined;
+		const timer = setTimeout(() => inputRef.current?.focus(), 0);
+		return () => clearTimeout(timer);
+	}, [isEditing]);
 
 	const openPicker = React.useCallback(() => {
-		setDraft(storedLanguage);
+		setDraft("");
+		setActiveIndex(0);
+		setKeyboardNavigated(false);
 		setIsEditing(true);
-		setTimeout(() => inputRef.current?.focus(), 0);
-	}, [storedLanguage]);
+	}, []);
 
-	const closePicker = React.useCallback(() => {
+	const closePicker = React.useCallback((restoreFocus = false) => {
 		setIsEditing(false);
-		setDraft(storedLanguage);
-	}, [storedLanguage]);
+		setDraft("");
+		setActiveIndex(0);
+		setKeyboardNavigated(false);
+		setPopupPosition(null);
+		if (restoreFocus) queueMicrotask(() => languageButtonRef.current?.focus());
+	}, []);
 
-	const commit = React.useCallback(() => {
-		const next = normalizeLanguage(draft);
-		updateAttributes({ language: next ?? null });
-		setIsEditing(false);
-	}, [draft, updateAttributes]);
+	const commit = React.useCallback(
+		(value = draft) => {
+			const next = normalizeLanguage(value);
+			updateAttributes({ language: next ?? null });
+			closePicker(true);
+		},
+		[closePicker, draft, updateAttributes],
+	);
+
+	const updatePopupPosition = React.useCallback(() => {
+		const toolbar = toolbarRef.current;
+		if (!toolbar) return;
+		const toolbarRect = toolbar.getBoundingClientRect();
+		const width = Math.min(POPUP_WIDTH, Math.max(0, window.innerWidth - POPUP_VIEWPORT_INSET * 2));
+		const isRtl = getComputedStyle(toolbar).direction === "rtl";
+		const preferredLeft = isRtl ? toolbarRect.right - width : toolbarRect.left;
+		const left = Math.min(
+			Math.max(preferredLeft, POPUP_VIEWPORT_INSET),
+			window.innerWidth - POPUP_VIEWPORT_INSET - width,
+		);
+		const popupHeight = popoverRef.current?.offsetHeight ?? 0;
+		const spaceBelow =
+			window.innerHeight - toolbarRect.bottom - POPUP_VIEWPORT_INSET - POPUP_OFFSET;
+		const spaceAbove = toolbarRect.top - POPUP_VIEWPORT_INSET - POPUP_OFFSET;
+		const openAbove = popupHeight > spaceBelow && spaceAbove > spaceBelow;
+		const maxHeight = Math.max(0, openAbove ? spaceAbove : spaceBelow);
+		const top = openAbove
+			? toolbarRect.top - Math.min(popupHeight, maxHeight) - POPUP_OFFSET
+			: toolbarRect.bottom + POPUP_OFFSET;
+		setPopupPosition({ left, maxHeight, top, width });
+	}, []);
+
+	React.useLayoutEffect(() => {
+		if (!isEditing) return undefined;
+		updatePopupPosition();
+		const frame = requestAnimationFrame(updatePopupPosition);
+		window.addEventListener("resize", updatePopupPosition);
+		window.addEventListener("scroll", updatePopupPosition, true);
+		return () => {
+			cancelAnimationFrame(frame);
+			window.removeEventListener("resize", updatePopupPosition);
+			window.removeEventListener("scroll", updatePopupPosition, true);
+		};
+	}, [isEditing, updatePopupPosition]);
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		if (e.key === "Enter") {
-			e.preventDefault();
-			commit();
-		} else if (e.key === "Escape") {
-			e.preventDefault();
-			closePicker();
+		switch (e.key) {
+			case "ArrowDown":
+			case "ArrowUp": {
+				if (filteredLanguages.length === 0) return;
+				e.preventDefault();
+				const direction = e.key === "ArrowDown" ? 1 : -1;
+				setKeyboardNavigated(true);
+				setActiveIndex(
+					(index) => (index + direction + filteredLanguages.length) % filteredLanguages.length,
+				);
+				break;
+			}
+			case "Enter": {
+				e.preventDefault();
+				const activeLanguage = keyboardNavigated ? filteredLanguages[activeIndex] : undefined;
+				commit(activeLanguage?.id ?? draft);
+				break;
+			}
+			case "Escape":
+				e.preventDefault();
+				closePicker(true);
+				break;
 		}
 	};
+
+	React.useEffect(() => {
+		if (!keyboardNavigated) return;
+		document.getElementById(`${listboxId}-option-${activeIndex}`)?.scrollIntoView({
+			block: "nearest",
+		});
+	}, [activeIndex, keyboardNavigated, listboxId]);
 
 	React.useEffect(() => {
 		if (!isEditing) return undefined;
 		const onMouseDown = (event: MouseEvent) => {
 			const target = event.target instanceof Node ? event.target : null;
-			if (popoverRef.current && target && !popoverRef.current.contains(target)) {
-				closePicker();
+			if (
+				target &&
+				!popoverRef.current?.contains(target) &&
+				!toolbarRef.current?.contains(target)
+			) {
+				closePicker(false);
 			}
 		};
 		document.addEventListener("mousedown", onMouseDown);
 		return () => document.removeEventListener("mousedown", onMouseDown);
 	}, [isEditing, closePicker]);
 
+	const copyCode = React.useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(node.textContent);
+			setCopied(true);
+			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
+			copyResetTimer.current = setTimeout(setCopied, 2500, false);
+		} catch {
+			setCopied(false);
+		}
+	}, [node.textContent]);
+
+	const handleToolbarKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+		if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+		const buttons = [...(toolbarRef.current?.querySelectorAll<HTMLButtonElement>("button") ?? [])];
+		if (buttons.length === 0) return;
+		event.preventDefault();
+		const activeElement = document.activeElement;
+		const currentIndex =
+			activeElement instanceof HTMLButtonElement ? Math.max(0, buttons.indexOf(activeElement)) : 0;
+		const nextIndex =
+			event.key === "Home"
+				? 0
+				: event.key === "End"
+					? buttons.length - 1
+					: (currentIndex + (event.key === "ArrowRight" ? 1 : -1) + buttons.length) %
+						buttons.length;
+		buttons[nextIndex]?.focus();
+	};
+
 	const label = languageLabel(storedLanguage);
-	const chipVisible = isHovered || selected || isEditing || Boolean(storedLanguage);
+	const currentLanguageId = normalizeLanguage(storedLanguage);
+	const controlsPersistent = isEditing || copied;
+	const activeOptionId =
+		keyboardNavigated && filteredLanguages[activeIndex]
+			? `${listboxId}-option-${activeIndex}`
+			: undefined;
 
 	return (
 		<NodeViewWrapper
 			className="emdash-inline-code-block"
 			data-language={storedLanguage || undefined}
-			style={{ position: "relative", margin: "1rem 0" }}
-			onMouseEnter={() => setIsHovered(true)}
-			onMouseLeave={() => setIsHovered(false)}
 		>
-			<CodeBlockLanguageDatalist id={datalistId} />
 			<pre className="emdash-code-block">
 				<NodeViewContent<"code"> as="code" />
 			</pre>
 
 			<div
+				className="emdash-inline-code-block-controls-wrap"
+				data-persistent={controlsPersistent ? "true" : "false"}
 				contentEditable={false}
-				style={{
-					position: "absolute",
-					top: "0.5rem",
-					insetInlineEnd: "0.5rem",
-					userSelect: "none",
-					zIndex: 1,
-					opacity: chipVisible ? 1 : 0,
-					pointerEvents: chipVisible ? "auto" : "none",
-					transition: "opacity 0.15s",
-				}}
-				// When the chip is hidden, also remove it from the tab order so
-				// keyboard users don't land on an invisible focus target.
-				// `inert` would be cleaner but isn't available on JSX HTMLDivElement
-				// types yet; aria-hidden + tabIndex on the button below cover the
-				// same need.
-				aria-hidden={chipVisible ? undefined : true}
 			>
+				<div
+					ref={toolbarRef}
+					className="emdash-inline-code-block-controls"
+					role="toolbar"
+					aria-label="Code block actions"
+					onKeyDown={handleToolbarKeyDown}
+				>
+					<button
+						ref={languageButtonRef}
+						type="button"
+						className="emdash-inline-code-block-action emdash-inline-code-block-language-button"
+						onMouseDown={(event) => event.preventDefault()}
+						onClick={() => (isEditing ? closePicker(true) : openPicker())}
+						title="Set language"
+						aria-label={`Set language (current: ${label})`}
+						aria-haspopup="listbox"
+						aria-expanded={isEditing}
+						aria-controls={isEditing ? listboxId : undefined}
+					>
+						<span className="emdash-inline-code-block-language-label">{label}</span>
+						<CaretDownIcon />
+					</button>
+					<button
+						type="button"
+						tabIndex={-1}
+						className="emdash-inline-code-block-action emdash-inline-code-block-copy-button"
+						onMouseDown={(event) => event.preventDefault()}
+						onClick={copyCode}
+						title={copied ? "Copied" : "Copy code"}
+						aria-label={copied ? "Copied" : "Copy code"}
+					>
+						{copied ? <CheckIcon /> : <CopyIcon />}
+					</button>
+				</div>
+				<span className="emdash-inline-code-block-sr-only" role="status" aria-live="polite">
+					{copied ? "Copied" : ""}
+				</span>
 				{isEditing ? (
 					<div
 						ref={popoverRef}
 						className="emdash-inline-code-block-popover"
 						style={{
-							display: "flex",
-							alignItems: "center",
-							gap: "0.25rem",
-							padding: "0.25rem",
-							borderRadius: "0.375rem",
-							boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+							left: popupPosition?.left ?? 0,
+							maxHeight: popupPosition?.maxHeight,
+							top: popupPosition?.top ?? 0,
+							width: popupPosition?.width ?? 0,
+							visibility: popupPosition ? "visible" : "hidden",
 						}}
 					>
 						<input
 							ref={inputRef}
 							type="text"
-							list={datalistId}
 							value={draft}
-							onChange={(e) => setDraft(e.target.value)}
-							onKeyDown={handleKeyDown}
-							className="emdash-inline-code-block-language-input"
-							placeholder="Language"
-							aria-label="Language"
-							style={{
-								height: "1.75rem",
-								width: "10rem",
-								fontSize: "0.75rem",
-								padding: "0 0.5rem",
-								borderRadius: "0.25rem",
+							onChange={(event) => {
+								setDraft(event.target.value);
+								setActiveIndex(0);
+								setKeyboardNavigated(false);
 							}}
+							onKeyDown={handleKeyDown}
+							onBlur={(event) => {
+								const nextTarget = event.relatedTarget;
+								if (
+									nextTarget instanceof Node &&
+									(popoverRef.current?.contains(nextTarget) ||
+										toolbarRef.current?.contains(nextTarget))
+								) {
+									return;
+								}
+								closePicker(false);
+							}}
+							className="emdash-inline-code-block-language-input"
+							placeholder="Search for a language…"
+							aria-label="Search for a language"
+							role="combobox"
+							aria-autocomplete="list"
+							aria-expanded="true"
+							aria-controls={listboxId}
+							aria-activedescendant={activeOptionId}
+							autoComplete="off"
+							spellCheck={false}
 						/>
-						<button
-							type="button"
-							onMouseDown={(e) => e.preventDefault()}
-							onClick={commit}
-							title="Apply language"
-							aria-label="Apply language"
-							style={iconButtonStyle}
-						>
-							<CheckIcon />
-						</button>
-						<button
-							type="button"
-							onMouseDown={(e) => e.preventDefault()}
-							onClick={closePicker}
-							title="Cancel"
-							aria-label="Cancel"
-							style={iconButtonStyle}
-						>
-							<XIcon />
-						</button>
+						<div id={listboxId} className="emdash-inline-code-block-language-list" role="listbox">
+							{filteredLanguages.map((language, index) => (
+								<div
+									key={language.id}
+									id={`${listboxId}-option-${index}`}
+									className="emdash-inline-code-block-language-option"
+									role="option"
+									aria-selected={index === activeIndex}
+									data-active={index === activeIndex ? "true" : "false"}
+									onMouseEnter={() => setActiveIndex(index)}
+									onMouseDown={(event) => event.preventDefault()}
+									onClick={() => commit(language.id)}
+								>
+									<span>{language.label}</span>
+									{currentLanguageId === language.id ? <CheckIcon /> : null}
+								</div>
+							))}
+							{filteredLanguages.length === 0 ? (
+								<div className="emdash-inline-code-block-language-empty" role="status">
+									No matches
+								</div>
+							) : null}
+						</div>
 					</div>
-				) : (
-					<button
-						type="button"
-						tabIndex={chipVisible ? 0 : -1}
-						onMouseDown={(e) => e.preventDefault()}
-						onClick={openPicker}
-						title="Set language"
-						aria-label={`Set language (current: ${label})`}
-						className="emdash-inline-code-block-chip"
-						style={{
-							padding: "0.125rem 0.5rem",
-							fontSize: "0.75rem",
-							borderRadius: "0.375rem",
-							cursor: "pointer",
-						}}
-					>
-						{storedLanguage ? label : "Set language"}
-					</button>
-				)}
+				) : null}
 			</div>
 		</NodeViewWrapper>
 	);

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -191,6 +191,32 @@ function CheckIcon() {
 	);
 }
 
+async function copyTextToClipboard(text: string): Promise<void> {
+	if (navigator.clipboard?.writeText) {
+		await navigator.clipboard.writeText(text);
+		return;
+	}
+
+	const textarea = document.createElement("textarea");
+	textarea.value = text;
+	textarea.readOnly = true;
+	textarea.style.position = "fixed";
+	textarea.style.opacity = "0";
+	document.body.append(textarea);
+	const selection = document.getSelection();
+	const previousRange = selection?.rangeCount ? selection.getRangeAt(0) : null;
+	textarea.select();
+	try {
+		if (!document.execCommand("copy")) throw new Error("Clipboard copy failed");
+	} finally {
+		textarea.remove();
+		if (previousRange) {
+			selection?.removeAllRanges();
+			selection?.addRange(previousRange);
+		}
+	}
+}
+
 function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const [isEditing, setIsEditing] = React.useState(false);
 	const [copied, setCopied] = React.useState(false);
@@ -355,10 +381,10 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 
 	const copyCode = React.useCallback(async () => {
 		try {
-			await navigator.clipboard.writeText(node.textContent);
+			await copyTextToClipboard(node.textContent);
 			setCopied(true);
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
-			copyResetTimer.current = setTimeout(setCopied, 2500, false);
+			copyResetTimer.current = setTimeout(setCopied, 1500, false);
 		} catch {
 			setCopied(false);
 		}
@@ -435,7 +461,18 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 						title={copied ? "Copied" : "Copy code"}
 						aria-label={copied ? "Copied" : "Copy code"}
 					>
-						{copied ? <CheckIcon /> : <CopyIcon />}
+						<span
+							className="emdash-inline-code-block-copy-success"
+							data-copied={copied ? "true" : "false"}
+						>
+							<CheckIcon />
+						</span>
+						<span
+							className="emdash-inline-code-block-copy-default"
+							data-copied={copied ? "true" : "false"}
+						>
+							<CopyIcon />
+						</span>
 					</button>
 				</div>
 				<span className="emdash-inline-code-block-sr-only" role="status" aria-live="polite">

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -3,7 +3,7 @@
  *
  * Mirrors the admin editor's `CodeBlockNode` but with no Kumo/Lingui deps,
  * so it can ship as part of the SSR runtime. Wraps the Lowlight code block and
- * overlays matching language and copy controls at the logical end of each code
+ * overlays a small inline language picker in the top-right corner of each code
  * block.
  *
  * Keep the language list in sync with
@@ -125,53 +125,57 @@ function languageLabel(value: string | null | undefined): string {
 	return value;
 }
 
-const POPUP_WIDTH = 216;
-const POPUP_VIEWPORT_INSET = 16;
-const POPUP_OFFSET = 8;
-
-interface PopupPosition {
-	left: number;
-	maxHeight: number;
-	top: number;
-	width: number;
+async function copyTextToClipboard(text: string): Promise<void> {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return;
+		} catch {}
+	}
+	const activeElement = document.activeElement;
+	const selection = document.getSelection();
+	const previousRange = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
+	const textarea = document.createElement("textarea");
+	textarea.value = text;
+	textarea.readOnly = true;
+	textarea.dataset.emdashClipboardFallback = "";
+	textarea.style.position = "fixed";
+	textarea.style.opacity = "0";
+	document.body.append(textarea);
+	textarea.select();
+	try {
+		if (!document.execCommand("copy")) throw new Error("Clipboard copy failed");
+	} finally {
+		textarea.remove();
+		if (activeElement instanceof HTMLElement && activeElement.isConnected) activeElement.focus();
+		if (previousRange) {
+			selection?.removeAllRanges();
+			selection?.addRange(previousRange);
+		}
+	}
 }
-
-function CaretDownIcon() {
+function CodeBlockLanguageDatalist({ id }: { id: string }) {
 	return (
-		<svg
-			width="14"
-			height="14"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<polyline points="6 9 12 15 18 9" />
-		</svg>
+		<datalist id={id}>
+			{CODE_BLOCK_LANGUAGES.map((lang) => (
+				<option key={lang.id} value={lang.id} label={lang.label} />
+			))}
+		</datalist>
 	);
 }
 
-function CopyIcon() {
-	return (
-		<svg
-			width="14"
-			height="14"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<rect x="9" y="9" width="11" height="11" rx="2" />
-			<path d="M15 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3" />
-		</svg>
-	);
-}
+const iconButtonStyle: React.CSSProperties = {
+	height: "1.75rem",
+	width: "1.75rem",
+	display: "inline-flex",
+	alignItems: "center",
+	justifyContent: "center",
+	border: "none",
+	background: "transparent",
+	cursor: "pointer",
+	color: "inherit",
+	borderRadius: "0.25rem",
+};
 
 function CheckIcon() {
 	return (
@@ -181,7 +185,7 @@ function CheckIcon() {
 			viewBox="0 0 24 24"
 			fill="none"
 			stroke="currentColor"
-			strokeWidth="2"
+			strokeWidth="2.5"
 			strokeLinecap="round"
 			strokeLinejoin="round"
 			aria-hidden="true"
@@ -191,201 +195,87 @@ function CheckIcon() {
 	);
 }
 
-async function copyTextToClipboard(text: string): Promise<void> {
-	if (navigator.clipboard?.writeText) {
-		try {
-			await navigator.clipboard.writeText(text);
-			return;
-		} catch {}
-	}
-
-	const activeElement = document.activeElement;
-	const textarea = document.createElement("textarea");
-	textarea.value = text;
-	textarea.readOnly = true;
-	textarea.dataset.emdashClipboardFallback = "";
-	textarea.style.position = "fixed";
-	textarea.style.opacity = "0";
-	document.body.append(textarea);
-	const selection = document.getSelection();
-	const previousRange = selection?.rangeCount ? selection.getRangeAt(0) : null;
-	textarea.select();
-	try {
-		if (!document.execCommand("copy")) throw new Error("Clipboard copy failed");
-	} finally {
-		textarea.remove();
-		if (previousRange) {
-			selection?.removeAllRanges();
-			selection?.addRange(previousRange);
-		}
-		if (activeElement instanceof HTMLElement && activeElement.isConnected) {
-			activeElement.focus();
-		}
-	}
+function XIcon() {
+	return (
+		<svg
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<line x1="18" y1="6" x2="6" y2="18" />
+			<line x1="6" y1="6" x2="18" y2="18" />
+		</svg>
+	);
 }
 
 function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const [isEditing, setIsEditing] = React.useState(false);
 	const [copied, setCopied] = React.useState(false);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
-	const [draft, setDraft] = React.useState("");
-	const [activeIndex, setActiveIndex] = React.useState(0);
-	const [keyboardNavigated, setKeyboardNavigated] = React.useState(false);
-	const [popupPosition, setPopupPosition] = React.useState<PopupPosition | null>(null);
+	const [draft, setDraft] = React.useState(storedLanguage);
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
-	const toolbarRef = React.useRef<HTMLDivElement>(null);
-	const languageButtonRef = React.useRef<HTMLButtonElement>(null);
 	const copyResetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-	const listboxId = React.useId();
+	// Per-instance datalist id so multiple code blocks (or multiple inline
+	// editors) on the same page don't create duplicate DOM ids.
+	const datalistId = React.useId();
 
-	const filteredLanguages = React.useMemo(() => {
-		const query = draft.trim().toLowerCase();
-		if (!query) return CODE_BLOCK_LANGUAGES;
-		return CODE_BLOCK_LANGUAGES.filter((language) => {
-			if (language.label.toLowerCase().includes(query)) return true;
-			if (language.id.toLowerCase().includes(query)) return true;
-			return language.aliases?.some((alias) => alias.toLowerCase().includes(query)) ?? false;
-		});
-	}, [draft]);
+	React.useEffect(() => {
+		if (!isEditing) {
+			setDraft(storedLanguage);
+		}
+	}, [storedLanguage, isEditing]);
 
+	const openPicker = React.useCallback(() => {
+		setDraft(storedLanguage);
+		setIsEditing(true);
+		setTimeout(() => inputRef.current?.focus(), 0);
+	}, [storedLanguage]);
+
+	const closePicker = React.useCallback(() => {
+		setIsEditing(false);
+		setDraft(storedLanguage);
+	}, [storedLanguage]);
+
+	const commit = React.useCallback(() => {
+		const next = normalizeLanguage(draft);
+		updateAttributes({ language: next ?? null });
+		setIsEditing(false);
+	}, [draft, updateAttributes]);
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			commit();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			closePicker();
+		}
+	};
+
+	React.useEffect(() => {
+		if (!isEditing) return undefined;
+		const onMouseDown = (event: MouseEvent) => {
+			const target = event.target instanceof Node ? event.target : null;
+			if (popoverRef.current && target && !popoverRef.current.contains(target)) {
+				closePicker();
+			}
+		};
+		document.addEventListener("mousedown", onMouseDown);
+		return () => document.removeEventListener("mousedown", onMouseDown);
+	}, [isEditing, closePicker]);
 	React.useEffect(
 		() => () => {
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 		},
 		[],
 	);
-
-	React.useEffect(() => {
-		if (!isEditing) return undefined;
-		const timer = setTimeout(() => inputRef.current?.focus(), 0);
-		return () => clearTimeout(timer);
-	}, [isEditing]);
-
-	const openPicker = React.useCallback(() => {
-		setDraft("");
-		setActiveIndex(0);
-		setKeyboardNavigated(false);
-		setIsEditing(true);
-	}, []);
-
-	const closePicker = React.useCallback((restoreFocus = false) => {
-		setIsEditing(false);
-		setDraft("");
-		setActiveIndex(0);
-		setKeyboardNavigated(false);
-		setPopupPosition(null);
-		if (restoreFocus) queueMicrotask(() => languageButtonRef.current?.focus());
-	}, []);
-
-	const commit = React.useCallback(
-		(value = draft) => {
-			const next = normalizeLanguage(value);
-			updateAttributes({ language: next ?? null });
-			closePicker(true);
-		},
-		[closePicker, draft, updateAttributes],
-	);
-
-	const updatePopupPosition = React.useCallback(() => {
-		const toolbar = toolbarRef.current;
-		if (!toolbar) return;
-		const toolbarRect = toolbar.getBoundingClientRect();
-		const width = Math.min(POPUP_WIDTH, Math.max(0, window.innerWidth - POPUP_VIEWPORT_INSET * 2));
-		const isRtl = getComputedStyle(toolbar).direction === "rtl";
-		const preferredLeft = isRtl ? toolbarRect.right - width : toolbarRect.left;
-		const left = Math.min(
-			Math.max(preferredLeft, POPUP_VIEWPORT_INSET),
-			window.innerWidth - POPUP_VIEWPORT_INSET - width,
-		);
-		const popupHeight = popoverRef.current?.offsetHeight ?? 0;
-		const spaceBelow =
-			window.innerHeight - toolbarRect.bottom - POPUP_VIEWPORT_INSET - POPUP_OFFSET;
-		const spaceAbove = toolbarRect.top - POPUP_VIEWPORT_INSET - POPUP_OFFSET;
-		const openAbove = popupHeight > spaceBelow && spaceAbove > spaceBelow;
-		const maxHeight = Math.max(0, openAbove ? spaceAbove : spaceBelow);
-		const top = openAbove
-			? toolbarRect.top - Math.min(popupHeight, maxHeight) - POPUP_OFFSET
-			: toolbarRect.bottom + POPUP_OFFSET;
-		setPopupPosition((current) => {
-			if (
-				current?.left === left &&
-				current.maxHeight === maxHeight &&
-				current.top === top &&
-				current.width === width
-			) {
-				return current;
-			}
-			return { left, maxHeight, top, width };
-		});
-	}, []);
-
-	React.useLayoutEffect(() => {
-		if (!isEditing) return undefined;
-		updatePopupPosition();
-		const frame = requestAnimationFrame(updatePopupPosition);
-		const resizeObserver =
-			typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updatePopupPosition);
-		if (popoverRef.current) resizeObserver?.observe(popoverRef.current);
-		window.addEventListener("resize", updatePopupPosition);
-		window.addEventListener("scroll", updatePopupPosition, true);
-		return () => {
-			cancelAnimationFrame(frame);
-			resizeObserver?.disconnect();
-			window.removeEventListener("resize", updatePopupPosition);
-			window.removeEventListener("scroll", updatePopupPosition, true);
-		};
-	}, [isEditing, updatePopupPosition]);
-
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		switch (e.key) {
-			case "ArrowDown":
-			case "ArrowUp": {
-				if (filteredLanguages.length === 0) return;
-				e.preventDefault();
-				const direction = e.key === "ArrowDown" ? 1 : -1;
-				setKeyboardNavigated(true);
-				setActiveIndex(
-					(index) => (index + direction + filteredLanguages.length) % filteredLanguages.length,
-				);
-				break;
-			}
-			case "Enter": {
-				e.preventDefault();
-				const activeLanguage = keyboardNavigated ? filteredLanguages[activeIndex] : undefined;
-				commit(activeLanguage?.id ?? draft);
-				break;
-			}
-			case "Escape":
-				e.preventDefault();
-				closePicker(true);
-				break;
-		}
-	};
-
-	React.useEffect(() => {
-		if (!keyboardNavigated) return;
-		document.getElementById(`${listboxId}-option-${activeIndex}`)?.scrollIntoView({
-			block: "nearest",
-		});
-	}, [activeIndex, keyboardNavigated, listboxId]);
-
-	React.useEffect(() => {
-		if (!isEditing) return undefined;
-		const onMouseDown = (event: MouseEvent) => {
-			const target = event.target instanceof Node ? event.target : null;
-			if (
-				target &&
-				!popoverRef.current?.contains(target) &&
-				!toolbarRef.current?.contains(target)
-			) {
-				closePicker(false);
-			}
-		};
-		document.addEventListener("mousedown", onMouseDown);
-		return () => document.removeEventListener("mousedown", onMouseDown);
-	}, [isEditing, closePicker]);
-
 	const copyCode = React.useCallback(async () => {
 		try {
 			await copyTextToClipboard(node.textContent);
@@ -397,165 +287,141 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		}
 	}, [node.textContent]);
 
-	const handleToolbarKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-		if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
-		const buttons = [...(toolbarRef.current?.querySelectorAll<HTMLButtonElement>("button") ?? [])];
-		if (buttons.length === 0) return;
-		event.preventDefault();
-		const activeElement = document.activeElement;
-		const currentIndex =
-			activeElement instanceof HTMLButtonElement ? Math.max(0, buttons.indexOf(activeElement)) : 0;
-		const nextIndex =
-			event.key === "Home"
-				? 0
-				: event.key === "End"
-					? buttons.length - 1
-					: (currentIndex + (event.key === "ArrowRight" ? 1 : -1) + buttons.length) %
-						buttons.length;
-		buttons[nextIndex]?.focus();
-	};
-
 	const label = languageLabel(storedLanguage);
-	const currentLanguageId = normalizeLanguage(storedLanguage);
-	const controlsPersistent = isEditing || copied;
-	const activeOptionId =
-		keyboardNavigated && filteredLanguages[activeIndex]
-			? `${listboxId}-option-${activeIndex}`
-			: undefined;
 
 	return (
 		<NodeViewWrapper
 			className="emdash-inline-code-block"
 			data-language={storedLanguage || undefined}
 		>
+			<CodeBlockLanguageDatalist id={datalistId} />
 			<pre className="emdash-code-block">
 				<NodeViewContent<"code"> as="code" />
 			</pre>
 
 			<div
 				className="emdash-inline-code-block-controls-wrap"
-				data-persistent={controlsPersistent ? "true" : "false"}
+				data-persistent={isEditing || copied ? "true" : "false"}
 				contentEditable={false}
 			>
-				<div
-					ref={toolbarRef}
-					className="emdash-inline-code-block-controls"
-					role="toolbar"
-					aria-label="Code block actions"
-					onKeyDown={handleToolbarKeyDown}
-				>
-					<button
-						ref={languageButtonRef}
-						type="button"
-						className="emdash-inline-code-block-action emdash-inline-code-block-language-button"
-						onMouseDown={(event) => event.preventDefault()}
-						onClick={() => (isEditing ? closePicker(true) : openPicker())}
-						title="Set language"
-						aria-label={`Set language (current: ${label})`}
-						aria-haspopup="listbox"
-						aria-expanded={isEditing}
-						aria-controls={isEditing ? listboxId : undefined}
-					>
-						<span className="emdash-inline-code-block-language-label">{label}</span>
-						<CaretDownIcon />
-					</button>
-					<button
-						type="button"
-						tabIndex={-1}
-						className="emdash-inline-code-block-action emdash-inline-code-block-copy-button"
-						onMouseDown={(event) => event.preventDefault()}
-						onClick={copyCode}
-						title={copied ? "Copied" : "Copy code"}
-						aria-label={copied ? "Copied" : "Copy code"}
-					>
-						<span
-							className="emdash-inline-code-block-copy-success"
-							data-copied={copied ? "true" : "false"}
-						>
-							<CheckIcon />
-						</span>
-						<span
-							className="emdash-inline-code-block-copy-default"
-							data-copied={copied ? "true" : "false"}
-						>
-							<CopyIcon />
-						</span>
-					</button>
-				</div>
-				<span className="emdash-inline-code-block-sr-only" role="status" aria-live="polite">
-					{copied ? "Copied" : ""}
-				</span>
 				{isEditing ? (
 					<div
 						ref={popoverRef}
 						className="emdash-inline-code-block-popover"
 						style={{
-							left: popupPosition?.left ?? 0,
-							maxBlockSize: popupPosition
-								? `min(16rem, 30vh, ${popupPosition.maxHeight}px)`
-								: undefined,
-							top: popupPosition?.top ?? 0,
-							width: popupPosition?.width ?? 0,
-							visibility: popupPosition ? "visible" : "hidden",
+							display: "flex",
+							alignItems: "center",
+							gap: "0.25rem",
+							padding: "0.25rem",
+							borderRadius: "0.375rem",
+							boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
 						}}
 					>
 						<input
 							ref={inputRef}
 							type="text"
+							list={datalistId}
 							value={draft}
-							onChange={(event) => {
-								setDraft(event.target.value);
-								setActiveIndex(0);
-								setKeyboardNavigated(false);
-							}}
+							onChange={(e) => setDraft(e.target.value)}
 							onKeyDown={handleKeyDown}
-							onBlur={(event) => {
-								const nextTarget = event.relatedTarget;
-								if (
-									nextTarget instanceof Node &&
-									(popoverRef.current?.contains(nextTarget) ||
-										toolbarRef.current?.contains(nextTarget))
-								) {
-									return;
-								}
-								closePicker(false);
-							}}
 							className="emdash-inline-code-block-language-input"
-							placeholder="Search for a language…"
-							aria-label="Search for a language"
-							role="combobox"
-							aria-autocomplete="list"
-							aria-expanded="true"
-							aria-controls={listboxId}
-							aria-activedescendant={activeOptionId}
-							autoComplete="off"
-							spellCheck={false}
+							placeholder="Language"
+							aria-label="Language"
+							style={{
+								height: "1.75rem",
+								fontSize: "0.75rem",
+								padding: "0 0.5rem",
+								borderRadius: "0.25rem",
+							}}
 						/>
-						<div id={listboxId} className="emdash-inline-code-block-language-list" role="listbox">
-							{filteredLanguages.map((language, index) => (
-								<div
-									key={language.id}
-									id={`${listboxId}-option-${index}`}
-									className="emdash-inline-code-block-language-option"
-									role="option"
-									aria-selected={currentLanguageId === language.id}
-									data-active={index === activeIndex ? "true" : "false"}
-									onMouseEnter={() => setActiveIndex(index)}
-									onMouseDown={(event) => event.preventDefault()}
-									onClick={() => commit(language.id)}
-								>
-									<span>{language.label}</span>
-									{currentLanguageId === language.id ? <CheckIcon /> : null}
-								</div>
-							))}
-							{filteredLanguages.length === 0 ? (
-								<div className="emdash-inline-code-block-language-empty" role="status">
-									No matches
-								</div>
-							) : null}
-						</div>
+						<button
+							type="button"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={commit}
+							title="Apply language"
+							aria-label="Apply language"
+							style={iconButtonStyle}
+						>
+							<CheckIcon />
+						</button>
+						<button
+							type="button"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={closePicker}
+							title="Cancel"
+							aria-label="Cancel"
+							style={iconButtonStyle}
+						>
+							<XIcon />
+						</button>
 					</div>
-				) : null}
+				) : (
+					<div
+						className="emdash-inline-code-block-chip"
+						style={{
+							display: "inline-flex",
+							maxWidth: "min(100%, calc(100vw - 1rem))",
+							height: "26px",
+							fontSize: "13px",
+						}}
+					>
+						<button
+							type="button"
+							onMouseDown={(event) => event.preventDefault()}
+							onClick={openPicker}
+							title="Set language"
+							aria-label={`Set language (current: ${label})`}
+							style={{
+								minWidth: 0,
+								flexShrink: 1,
+								display: "inline-flex",
+								alignItems: "center",
+								gap: "0.25rem",
+								padding: "0 0.5rem",
+								border: 0,
+								background: "transparent",
+								color: "inherit",
+								font: "inherit",
+							}}
+						>
+							<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+								{storedLanguage ? label : "Set language"}
+							</span>
+							<span style={{ flexShrink: 0 }} aria-hidden="true">
+								⌄
+							</span>
+						</button>
+						<button
+							type="button"
+							onMouseDown={(event) => event.preventDefault()}
+							onClick={copyCode}
+							title={copied ? "Copied" : "Copy code"}
+							aria-label="Copy code"
+							style={{
+								...iconButtonStyle,
+								height: "26px",
+								width: "26px",
+								flexShrink: 0,
+								borderInlineStart: "1px solid var(--emdash-code-border)",
+							}}
+						>
+							<span aria-hidden="true">{copied ? <CheckIcon /> : "⧉"}</span>
+						</button>
+					</div>
+				)}
+				<span
+					role="status"
+					aria-live="polite"
+					style={{
+						position: "absolute",
+						width: 1,
+						height: 1,
+						overflow: "hidden",
+						clipPath: "inset(50%)",
+					}}
+				>
+					{copied ? "Copied" : ""}
+				</span>
 			</div>
 		</NodeViewWrapper>
 	);

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -222,6 +222,7 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
 	const copyResetTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+	const copyRequestId = React.useRef(0);
 	// Per-instance datalist id so multiple code blocks (or multiple inline
 	// editors) on the same page don't create duplicate DOM ids.
 	const datalistId = React.useId();
@@ -272,17 +273,22 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 	}, [isEditing, closePicker]);
 	React.useEffect(
 		() => () => {
+			copyRequestId.current += 1;
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 		},
 		[],
 	);
 	const copyCode = React.useCallback(async () => {
+		const requestId = ++copyRequestId.current;
 		try {
 			await copyTextToClipboard(node.textContent);
+			if (requestId !== copyRequestId.current) return;
 			setCopied(true);
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 			copyResetTimer.current = setTimeout(setCopied, 1500, false);
 		} catch {
+			if (requestId !== copyRequestId.current) return;
+			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);
 			setCopied(false);
 		}
 	}, [node.textContent]);

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -283,10 +283,7 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 		const requestId = ++copyRequestId.current;
 		setCopyStatus("idle");
 		try {
-			await copyTextToClipboard(
-				node.textContent,
-				() => requestId === copyRequestId.current,
-			);
+			await copyTextToClipboard(node.textContent, () => requestId === copyRequestId.current);
 			if (requestId !== copyRequestId.current) return;
 			setCopyStatus("copied");
 			if (copyResetTimer.current) clearTimeout(copyResetTimer.current);

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -157,8 +157,8 @@ function CaretDownIcon() {
 function CopyIcon() {
 	return (
 		<svg
-			width="16"
-			height="16"
+			width="14"
+			height="14"
 			viewBox="0 0 24 24"
 			fill="none"
 			stroke="currentColor"
@@ -176,8 +176,8 @@ function CopyIcon() {
 function CheckIcon() {
 	return (
 		<svg
-			width="16"
-			height="16"
+			width="14"
+			height="14"
 			viewBox="0 0 24 24"
 			fill="none"
 			stroke="currentColor"
@@ -538,7 +538,7 @@ function InlineCodeBlockNodeView({ node, updateAttributes }: NodeViewProps) {
 									id={`${listboxId}-option-${index}`}
 									className="emdash-inline-code-block-language-option"
 									role="option"
-									aria-selected={index === activeIndex}
+									aria-selected={currentLanguageId === language.id}
 									data-active={index === activeIndex ? "true" : "false"}
 									onMouseEnter={() => setActiveIndex(index)}
 									onMouseDown={(event) => event.preventDefault()}

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 
 import { Editor } from "@tiptap/core";
+import { EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import * as React from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { InlineCodeBlockExtension } from "../../../src/components/inline-code-block.js";
@@ -13,18 +16,28 @@ import {
 describe("inline Portable Text code blocks", () => {
 	let editor: Editor;
 	let element: HTMLDivElement;
+	let root: Root;
+	let clipboardDescriptor: PropertyDescriptor | undefined;
 
 	beforeEach(() => {
+		clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 		element = document.createElement("div");
 		document.body.append(element);
 		editor = new Editor({
-			element,
 			extensions: [StarterKit.configure({ codeBlock: false }), InlineCodeBlockExtension],
 			content: "",
 		});
+		root = createRoot(element);
+		root.render(React.createElement(EditorContent, { editor }));
 	});
 
 	afterEach(() => {
+		if (clipboardDescriptor) {
+			Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+		} else {
+			Reflect.deleteProperty(navigator, "clipboard");
+		}
+		root.unmount();
 		editor.destroy();
 		element.remove();
 	});
@@ -63,5 +76,116 @@ describe("inline Portable Text code blocks", () => {
 
 		expect(codeBlock?.attrs?.language).toBeNull();
 		expect(JSON.stringify(serialized)).not.toContain('"language"');
+	});
+
+	it("renders two actions and selects a language immediately", async () => {
+		editor.commands.insertContent({
+			type: "codeBlock",
+			attrs: { language: "python" },
+			content: [{ type: "text", text: "print('hello')" }],
+		});
+
+		let toolbar: HTMLElement | null = null;
+		await vi.waitFor(() => {
+			toolbar = element.querySelector<HTMLElement>('[role="toolbar"]');
+			expect(toolbar).not.toBeNull();
+			expect(toolbar?.querySelectorAll("button")).toHaveLength(2);
+			expect(toolbar?.querySelector('button[aria-label="Copy code"]')).not.toBeNull();
+		});
+
+		const languageButton = toolbar?.querySelector<HTMLButtonElement>(
+			'button[aria-label="Set language (current: Python)"]',
+		);
+		languageButton?.focus();
+		languageButton?.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+		);
+		expect(document.activeElement).toBe(
+			toolbar?.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]'),
+		);
+		languageButton?.click();
+		await vi.waitFor(() => {
+			expect(element.querySelector('input[placeholder="Search for a language…"]')).not.toBeNull();
+		});
+
+		const javascriptOption = [...element.querySelectorAll<HTMLElement>('[role="option"]')].find(
+			(option) => option.textContent?.includes("JavaScript"),
+		);
+		expect(javascriptOption).toBeDefined();
+		javascriptOption?.click();
+		await vi.waitFor(() => {
+			expect(editor.getJSON().content?.[0]?.attrs?.language).toBe("javascript");
+		});
+	});
+
+	it("copies raw code and exposes copied feedback", async () => {
+		const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: clipboardWrite },
+		});
+		editor.commands.insertContent({
+			type: "codeBlock",
+			attrs: { language: "javascript" },
+			content: [{ type: "text", text: "const greeting = 'hello';" }],
+		});
+
+		await vi.waitFor(() => {
+			expect(element.querySelector('button[aria-label="Copy code"]')).not.toBeNull();
+		});
+		element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')?.click();
+		await vi.waitFor(() => {
+			expect(clipboardWrite).toHaveBeenCalledWith("const greeting = 'hello';");
+			expect(element.querySelector('button[aria-label="Copied"]')).not.toBeNull();
+			expect(element.querySelector('[role="status"]')?.textContent).toBe("Copied");
+		});
+	});
+
+	it("commits free-form input and restores focus on Escape", async () => {
+		editor.commands.insertContent({
+			type: "codeBlock",
+			attrs: { language: "plaintext" },
+			content: [{ type: "text", text: "custom()" }],
+		});
+		await vi.waitFor(() => {
+			expect(
+				element.querySelector('button[aria-label="Set language (current: Plain text)"]'),
+			).not.toBeNull();
+		});
+
+		let languageButton = element.querySelector<HTMLButtonElement>(
+			'button[aria-label="Set language (current: Plain text)"]',
+		);
+		languageButton?.click();
+		let input: HTMLInputElement | null = null;
+		await vi.waitFor(() => {
+			input = element.querySelector<HTMLInputElement>(
+				'input[placeholder="Search for a language…"]',
+			);
+			expect(input).not.toBeNull();
+		});
+		const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+		valueSetter?.call(input, "Custom Language");
+		input?.dispatchEvent(new Event("input", { bubbles: true }));
+		input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+		await vi.waitFor(() => {
+			expect(editor.getJSON().content?.[0]?.attrs?.language).toBe("custom-language");
+		});
+
+		languageButton = element.querySelector<HTMLButtonElement>(
+			'button[aria-label="Set language (current: custom-language)"]',
+		);
+		languageButton?.click();
+		await vi.waitFor(() => {
+			input = element.querySelector<HTMLInputElement>(
+				'input[placeholder="Search for a language…"]',
+			);
+			expect(input).not.toBeNull();
+		});
+		input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+		await vi.waitFor(() => {
+			expect(element.querySelector('input[placeholder="Search for a language…"]')).toBeNull();
+			expect(document.activeElement).toBe(languageButton);
+		});
 	});
 });

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { InlineCodeBlockExtension } from "../../../src/components/inline-code-block.js";
 import {
+	InlinePortableTextEditor,
 	_pmToPortableText as pmToPortableText,
 	_portableTextToPM as portableTextToPM,
 } from "../../../src/components/InlinePortableTextEditor.js";
@@ -170,6 +171,86 @@ describe("inline Portable Text code blocks", () => {
 			expect(element.querySelector('button[aria-label="Copied"]')).not.toBeNull();
 		});
 		expect(document.querySelector("textarea[readonly]")).toBeNull();
+	});
+
+	it("falls back after a rejected Clipboard API write and keeps keyboard focus", async () => {
+		const copyCommand = vi.fn().mockReturnValue(true);
+		const clipboardWrite = vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: clipboardWrite },
+		});
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: copyCommand,
+		});
+		editor.commands.insertContent({
+			type: "codeBlock",
+			attrs: { language: "javascript" },
+			content: [{ type: "text", text: "const fallback = true;" }],
+		});
+
+		let copyButton: HTMLButtonElement | null = null;
+		await vi.waitFor(() => {
+			copyButton = element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
+			expect(copyButton).not.toBeNull();
+		});
+		copyButton?.focus();
+		copyButton?.click();
+		await vi.waitFor(() => {
+			expect(clipboardWrite).toHaveBeenCalledWith("const fallback = true;");
+			expect(copyCommand).toHaveBeenCalledWith("copy");
+			expect(document.activeElement).toBe(copyButton);
+		});
+	});
+
+	it("does not save when fallback copying briefly moves focus", async () => {
+		const copyCommand = vi.fn().mockReturnValue(true);
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(null, { status: 200 }));
+		const textareaSelect = vi
+			.spyOn(HTMLTextAreaElement.prototype, "select")
+			.mockImplementation(function (this: HTMLTextAreaElement) {
+				this.focus();
+			});
+		Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: copyCommand,
+		});
+		try {
+			root.render(
+				React.createElement(InlinePortableTextEditor, {
+					value: [
+						{
+							_type: "code",
+							_key: "code",
+							code: "const fallback = true;",
+							language: "javascript",
+						},
+					],
+					collection: "posts",
+					entryId: "post-1",
+					field: "body",
+				}),
+			);
+
+			let copyButton: HTMLButtonElement | null = null;
+			await vi.waitFor(() => {
+				copyButton = element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
+				expect(copyButton).not.toBeNull();
+			});
+			copyButton?.focus();
+			copyButton?.click();
+			await vi.waitFor(() => {
+				expect(copyCommand).toHaveBeenCalledWith("copy");
+			});
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			textareaSelect.mockRestore();
+			fetchSpy.mockRestore();
+		}
 	});
 
 	it("commits free-form input and restores focus on Escape", async () => {

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -18,9 +18,11 @@ describe("inline Portable Text code blocks", () => {
 	let element: HTMLDivElement;
 	let root: Root;
 	let clipboardDescriptor: PropertyDescriptor | undefined;
+	let execCommandDescriptor: PropertyDescriptor | undefined;
 
 	beforeEach(() => {
 		clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+		execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
 		element = document.createElement("div");
 		document.body.append(element);
 		editor = new Editor({
@@ -36,6 +38,11 @@ describe("inline Portable Text code blocks", () => {
 			Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
 		} else {
 			Reflect.deleteProperty(navigator, "clipboard");
+		}
+		if (execCommandDescriptor) {
+			Object.defineProperty(document, "execCommand", execCommandDescriptor);
+		} else {
+			Reflect.deleteProperty(document, "execCommand");
 		}
 		root.unmount();
 		editor.destroy();
@@ -139,6 +146,30 @@ describe("inline Portable Text code blocks", () => {
 			expect(element.querySelector('button[aria-label="Copied"]')).not.toBeNull();
 			expect(element.querySelector('[role="status"]')?.textContent).toBe("Copied");
 		});
+	});
+
+	it("falls back to document copy without the Clipboard API", async () => {
+		const copyCommand = vi.fn().mockReturnValue(true);
+		Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: copyCommand,
+		});
+		editor.commands.insertContent({
+			type: "codeBlock",
+			attrs: { language: "javascript" },
+			content: [{ type: "text", text: "const fallback = true;" }],
+		});
+
+		await vi.waitFor(() => {
+			expect(element.querySelector('button[aria-label="Copy code"]')).not.toBeNull();
+		});
+		element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')?.click();
+		await vi.waitFor(() => {
+			expect(copyCommand).toHaveBeenCalledWith("copy");
+			expect(element.querySelector('button[aria-label="Copied"]')).not.toBeNull();
+		});
+		expect(document.querySelector("textarea[readonly]")).toBeNull();
 	});
 
 	it("commits free-form input and restores focus on Escape", async () => {

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -177,18 +177,17 @@ describe("inline Portable Text code blocks", () => {
 			const status = element.querySelector('[role="status"]');
 			await vi.waitFor(() => expect(status?.textContent).toBe("Copied"));
 			rejectFirst(new DOMException("Denied", "NotAllowedError"));
-			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
 			await vi.waitFor(() => expect(status?.textContent).toBe("Copied"));
 
 			copyButton?.click();
 			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(3));
-			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledTimes(2));
 			await vi.waitFor(() =>
 				expect(
 					element.querySelector<HTMLButtonElement>('button[aria-label="Retry copy"]'),
 				).not.toBeNull(),
 			);
 			expect(status?.textContent).toBe("Copy failed");
+			expect(copyCommand).toHaveBeenCalledTimes(1);
 		} finally {
 			if (execCommandDescriptor) {
 				Object.defineProperty(document, "execCommand", execCommandDescriptor);

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -137,4 +137,58 @@ describe("inline Portable Text code blocks", () => {
 			),
 		);
 	});
+
+	it("keeps feedback from the newest copy attempt", async () => {
+		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+		const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+		let rejectFirst!: (reason: unknown) => void;
+		let resolveSecond!: () => void;
+		const firstCopy = new Promise<void>((_resolve, reject) => {
+			rejectFirst = reject;
+		});
+		const secondCopy = new Promise<void>((resolve) => {
+			resolveSecond = resolve;
+		});
+		const clipboardWrite = vi
+			.fn()
+			.mockImplementationOnce(() => firstCopy)
+			.mockImplementationOnce(() => secondCopy);
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: clipboardWrite },
+		});
+		const copyCommand = vi.fn().mockReturnValue(false);
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: copyCommand,
+		});
+
+		try {
+			await renderInlineCode("copy()", "javascript");
+			const copyButton = element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
+			expect(copyButton).not.toBeNull();
+			copyButton?.click();
+			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(1));
+			copyButton?.click();
+			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(2));
+
+			resolveSecond();
+			const status = element.querySelector('[role="status"]');
+			await vi.waitFor(() => expect(status?.textContent).toBe("Copied"));
+			rejectFirst(new DOMException("Denied", "NotAllowedError"));
+			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
+			await vi.waitFor(() => expect(status?.textContent).toBe("Copied"));
+		} finally {
+			if (execCommandDescriptor) {
+				Object.defineProperty(document, "execCommand", execCommandDescriptor);
+			} else {
+				Reflect.deleteProperty(document, "execCommand");
+			}
+			if (clipboardDescriptor) {
+				Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+			} else {
+				Reflect.deleteProperty(navigator, "clipboard");
+			}
+		}
+	});
 });

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -18,12 +18,8 @@ describe("inline Portable Text code blocks", () => {
 	let editor: Editor;
 	let element: HTMLDivElement;
 	let root: Root;
-	let clipboardDescriptor: PropertyDescriptor | undefined;
-	let execCommandDescriptor: PropertyDescriptor | undefined;
 
 	beforeEach(() => {
-		clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
-		execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
 		element = document.createElement("div");
 		document.body.append(element);
 		editor = new Editor({
@@ -35,20 +31,24 @@ describe("inline Portable Text code blocks", () => {
 	});
 
 	afterEach(() => {
-		if (clipboardDescriptor) {
-			Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
-		} else {
-			Reflect.deleteProperty(navigator, "clipboard");
-		}
-		if (execCommandDescriptor) {
-			Object.defineProperty(document, "execCommand", execCommandDescriptor);
-		} else {
-			Reflect.deleteProperty(document, "execCommand");
-		}
 		root.unmount();
 		editor.destroy();
 		element.remove();
 	});
+
+	async function renderInlineCode(code: string, language: string) {
+		root.render(
+			React.createElement(InlinePortableTextEditor, {
+				value: [{ _type: "code", _key: "code", code, language }],
+				collection: "posts",
+				entryId: "post-1",
+				field: "body",
+			}),
+		);
+		await vi.waitFor(() => expect(element.querySelector(".emdash-inline-editor")).not.toBeNull(), {
+			timeout: 3000,
+		});
+	}
 
 	it("renders syntax tokens for a supported language", async () => {
 		editor.commands.insertContent({
@@ -86,221 +86,55 @@ describe("inline Portable Text code blocks", () => {
 		expect(JSON.stringify(serialized)).not.toContain('"language"');
 	});
 
-	it("renders two actions and selects a language immediately", async () => {
-		editor.commands.insertContent({
-			type: "codeBlock",
-			attrs: { language: "python" },
-			content: [{ type: "text", text: "print('hello')" }],
-		});
-
-		let toolbar: HTMLElement | null = null;
-		await vi.waitFor(() => {
-			toolbar = element.querySelector<HTMLElement>('[role="toolbar"]');
-			expect(toolbar).not.toBeNull();
-			expect(toolbar?.querySelectorAll("button")).toHaveLength(2);
-			expect(toolbar?.querySelector('button[aria-label="Copy code"]')).not.toBeNull();
-		});
-
-		const languageButton = toolbar?.querySelector<HTMLButtonElement>(
-			'button[aria-label="Set language (current: Python)"]',
-		);
-		languageButton?.focus();
-		languageButton?.dispatchEvent(
-			new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
-		);
-		expect(document.activeElement).toBe(
-			toolbar?.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]'),
-		);
-		languageButton?.click();
-		await vi.waitFor(() => {
-			expect(element.querySelector('input[placeholder="Search for a language…"]')).not.toBeNull();
-		});
-		const options = [...element.querySelectorAll<HTMLElement>('[role="option"]')];
-		const plainTextOption = options.find((option) => option.textContent?.includes("Plain text"));
-		const pythonOption = options.find((option) => option.textContent?.includes("Python"));
-		expect(plainTextOption?.getAttribute("aria-selected")).toBe("false");
-		expect(pythonOption?.getAttribute("aria-selected")).toBe("true");
-
-		const javascriptOption = options.find((option) => option.textContent?.includes("JavaScript"));
-		expect(javascriptOption).toBeDefined();
-		javascriptOption?.click();
-		await vi.waitFor(() => {
-			expect(editor.getJSON().content?.[0]?.attrs?.language).toBe("javascript");
-		});
-	});
-
-	it("copies raw code and exposes copied feedback", async () => {
-		const clipboardWrite = vi.fn().mockResolvedValue(undefined);
-		Object.defineProperty(navigator, "clipboard", {
-			configurable: true,
-			value: { writeText: clipboardWrite },
-		});
-		editor.commands.insertContent({
-			type: "codeBlock",
-			attrs: { language: "javascript" },
-			content: [{ type: "text", text: "const greeting = 'hello';" }],
-		});
-
-		await vi.waitFor(() => {
-			expect(element.querySelector('button[aria-label="Copy code"]')).not.toBeNull();
-		});
-		element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')?.click();
-		await vi.waitFor(() => {
-			expect(clipboardWrite).toHaveBeenCalledWith("const greeting = 'hello';");
-			expect(element.querySelector('button[aria-label="Copied"]')).not.toBeNull();
-			expect(element.querySelector('[role="status"]')?.textContent).toBe("Copied");
-		});
-	});
-
-	it("falls back to document copy without the Clipboard API", async () => {
-		const copyCommand = vi.fn().mockReturnValue(true);
-		Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
-		Object.defineProperty(document, "execCommand", {
-			configurable: true,
-			value: copyCommand,
-		});
-		editor.commands.insertContent({
-			type: "codeBlock",
-			attrs: { language: "javascript" },
-			content: [{ type: "text", text: "const fallback = true;" }],
-		});
-
-		await vi.waitFor(() => {
-			expect(element.querySelector('button[aria-label="Copy code"]')).not.toBeNull();
-		});
-		element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]')?.click();
-		await vi.waitFor(() => {
-			expect(copyCommand).toHaveBeenCalledWith("copy");
-			expect(element.querySelector('button[aria-label="Copied"]')).not.toBeNull();
-		});
-		expect(document.querySelector("textarea[readonly]")).toBeNull();
-	});
-
-	it("falls back after a rejected Clipboard API write and keeps keyboard focus", async () => {
-		const copyCommand = vi.fn().mockReturnValue(true);
-		const clipboardWrite = vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
-		Object.defineProperty(navigator, "clipboard", {
-			configurable: true,
-			value: { writeText: clipboardWrite },
-		});
-		Object.defineProperty(document, "execCommand", {
-			configurable: true,
-			value: copyCommand,
-		});
-		editor.commands.insertContent({
-			type: "codeBlock",
-			attrs: { language: "javascript" },
-			content: [{ type: "text", text: "const fallback = true;" }],
-		});
-
-		let copyButton: HTMLButtonElement | null = null;
-		await vi.waitFor(() => {
-			copyButton = element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
-			expect(copyButton).not.toBeNull();
-		});
-		copyButton?.focus();
-		copyButton?.click();
-		await vi.waitFor(() => {
-			expect(clipboardWrite).toHaveBeenCalledWith("const fallback = true;");
-			expect(copyCommand).toHaveBeenCalledWith("copy");
-			expect(document.activeElement).toBe(copyButton);
-		});
-	});
-
-	it("does not save when fallback copying briefly moves focus", async () => {
-		const copyCommand = vi.fn().mockReturnValue(true);
-		const fetchSpy = vi
-			.spyOn(globalThis, "fetch")
-			.mockResolvedValue(new Response(null, { status: 200 }));
-		const textareaSelect = vi
-			.spyOn(HTMLTextAreaElement.prototype, "select")
-			.mockImplementation(function (this: HTMLTextAreaElement) {
-				this.focus();
-			});
-		Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
-		Object.defineProperty(document, "execCommand", {
-			configurable: true,
-			value: copyCommand,
-		});
-		try {
-			root.render(
-				React.createElement(InlinePortableTextEditor, {
-					value: [
-						{
-							_type: "code",
-							_key: "code",
-							code: "const fallback = true;",
-							language: "javascript",
-						},
-					],
-					collection: "posts",
-					entryId: "post-1",
-					field: "body",
-				}),
+	it("preserves native datalist apply, cancel, alias, and free-form behavior", async () => {
+		await renderInlineCode("custom()", "plaintext");
+		const languageAction = () =>
+			element.querySelector<HTMLButtonElement>('button[aria-label^="Set language"]');
+		const openPicker = async (label: string) => {
+			await vi.waitFor(() => expect(languageAction()?.getAttribute("aria-label")).toBe(label));
+			languageAction()?.click();
+			await vi.waitFor(() =>
+				expect(element.querySelector('input[aria-label="Language"]')).not.toBeNull(),
 			);
+		};
+		const setInput = (value: string) => {
+			const input = element.querySelector<HTMLInputElement>('input[aria-label="Language"]');
+			expect(input?.list?.options.length).toBeGreaterThan(0);
+			const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+			setter?.call(input, value);
+			input?.dispatchEvent(new Event("input", { bubbles: true }));
+		};
+		const clickAction = (label: "Apply language" | "Cancel") => {
+			const button = element.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+			expect(button).not.toBeNull();
+			button?.click();
+		};
 
-			let copyButton: HTMLButtonElement | null = null;
-			await vi.waitFor(() => {
-				copyButton = element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
-				expect(copyButton).not.toBeNull();
-			});
-			copyButton?.focus();
-			copyButton?.click();
-			await vi.waitFor(() => {
-				expect(copyCommand).toHaveBeenCalledWith("copy");
-			});
-			expect(fetchSpy).not.toHaveBeenCalled();
-		} finally {
-			textareaSelect.mockRestore();
-			fetchSpy.mockRestore();
-		}
-	});
-
-	it("commits free-form input and restores focus on Escape", async () => {
-		editor.commands.insertContent({
-			type: "codeBlock",
-			attrs: { language: "plaintext" },
-			content: [{ type: "text", text: "custom()" }],
-		});
-		await vi.waitFor(() => {
-			expect(
-				element.querySelector('button[aria-label="Set language (current: Plain text)"]'),
-			).not.toBeNull();
-		});
-
-		let languageButton = element.querySelector<HTMLButtonElement>(
-			'button[aria-label="Set language (current: Plain text)"]',
+		await openPicker("Set language (current: Plain text)");
+		setInput("js");
+		clickAction("Apply language");
+		await vi.waitFor(() =>
+			expect(languageAction()?.getAttribute("aria-label")).toBe(
+				"Set language (current: JavaScript)",
+			),
 		);
-		languageButton?.click();
-		let input: HTMLInputElement | null = null;
-		await vi.waitFor(() => {
-			input = element.querySelector<HTMLInputElement>(
-				'input[placeholder="Search for a language…"]',
-			);
-			expect(input).not.toBeNull();
-		});
-		const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
-		valueSetter?.call(input, "Custom Language");
-		input?.dispatchEvent(new Event("input", { bubbles: true }));
-		input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-		await vi.waitFor(() => {
-			expect(editor.getJSON().content?.[0]?.attrs?.language).toBe("custom-language");
-		});
 
-		languageButton = element.querySelector<HTMLButtonElement>(
-			'button[aria-label="Set language (current: custom-language)"]',
+		await openPicker("Set language (current: JavaScript)");
+		setInput("Discarded Language");
+		clickAction("Cancel");
+		await vi.waitFor(() =>
+			expect(languageAction()?.getAttribute("aria-label")).toBe(
+				"Set language (current: JavaScript)",
+			),
 		);
-		languageButton?.click();
-		await vi.waitFor(() => {
-			input = element.querySelector<HTMLInputElement>(
-				'input[placeholder="Search for a language…"]',
-			);
-			expect(input).not.toBeNull();
-		});
-		input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-		await vi.waitFor(() => {
-			expect(element.querySelector('input[placeholder="Search for a language…"]')).toBeNull();
-			expect(document.activeElement).toBe(languageButton);
-		});
+
+		await openPicker("Set language (current: JavaScript)");
+		setInput("Custom Language");
+		clickAction("Apply language");
+		await vi.waitFor(() =>
+			expect(languageAction()?.getAttribute("aria-label")).toBe(
+				"Set language (current: custom-language)",
+			),
+		);
 	});
 });

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -115,10 +115,13 @@ describe("inline Portable Text code blocks", () => {
 		await vi.waitFor(() => {
 			expect(element.querySelector('input[placeholder="Search for a language…"]')).not.toBeNull();
 		});
+		const options = [...element.querySelectorAll<HTMLElement>('[role="option"]')];
+		const plainTextOption = options.find((option) => option.textContent?.includes("Plain text"));
+		const pythonOption = options.find((option) => option.textContent?.includes("Python"));
+		expect(plainTextOption?.getAttribute("aria-selected")).toBe("false");
+		expect(pythonOption?.getAttribute("aria-selected")).toBe("true");
 
-		const javascriptOption = [...element.querySelectorAll<HTMLElement>('[role="option"]')].find(
-			(option) => option.textContent?.includes("JavaScript"),
-		);
+		const javascriptOption = options.find((option) => option.textContent?.includes("JavaScript"));
 		expect(javascriptOption).toBeDefined();
 		javascriptOption?.click();
 		await vi.waitFor(() => {

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -202,5 +202,4 @@ describe("inline Portable Text code blocks", () => {
 			}
 		}
 	});
-
 });

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -191,4 +191,45 @@ describe("inline Portable Text code blocks", () => {
 			}
 		}
 	});
+
+	it("announces when copying fails", async () => {
+		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+		const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+		const clipboardWrite = vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+		const copyCommand = vi.fn().mockReturnValue(false);
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: clipboardWrite },
+		});
+		Object.defineProperty(document, "execCommand", {
+			configurable: true,
+			value: copyCommand,
+		});
+
+		try {
+			await renderInlineCode("copy()", "javascript");
+			const copyButton = element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
+			expect(copyButton).not.toBeNull();
+			copyButton?.click();
+
+			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
+			await vi.waitFor(() =>
+				expect(
+					element.querySelector<HTMLButtonElement>('button[aria-label="Retry copy"]'),
+				).not.toBeNull(),
+			);
+			expect(element.querySelector('[role="status"]')?.textContent).toBe("Copy failed");
+		} finally {
+			if (execCommandDescriptor) {
+				Object.defineProperty(document, "execCommand", execCommandDescriptor);
+			} else {
+				Reflect.deleteProperty(document, "execCommand");
+			}
+			if (clipboardDescriptor) {
+				Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+			} else {
+				Reflect.deleteProperty(navigator, "clipboard");
+			}
+		}
+	});
 });

--- a/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-code-block.test.ts
@@ -138,7 +138,7 @@ describe("inline Portable Text code blocks", () => {
 		);
 	});
 
-	it("keeps feedback from the newest copy attempt", async () => {
+	it("keeps the newest copy feedback and reports failures", async () => {
 		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 		const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
 		let rejectFirst!: (reason: unknown) => void;
@@ -152,7 +152,8 @@ describe("inline Portable Text code blocks", () => {
 		const clipboardWrite = vi
 			.fn()
 			.mockImplementationOnce(() => firstCopy)
-			.mockImplementationOnce(() => secondCopy);
+			.mockImplementationOnce(() => secondCopy)
+			.mockRejectedValueOnce(new DOMException("Denied", "NotAllowedError"));
 		Object.defineProperty(navigator, "clipboard", {
 			configurable: true,
 			value: { writeText: clipboardWrite },
@@ -178,47 +179,16 @@ describe("inline Portable Text code blocks", () => {
 			rejectFirst(new DOMException("Denied", "NotAllowedError"));
 			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
 			await vi.waitFor(() => expect(status?.textContent).toBe("Copied"));
-		} finally {
-			if (execCommandDescriptor) {
-				Object.defineProperty(document, "execCommand", execCommandDescriptor);
-			} else {
-				Reflect.deleteProperty(document, "execCommand");
-			}
-			if (clipboardDescriptor) {
-				Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
-			} else {
-				Reflect.deleteProperty(navigator, "clipboard");
-			}
-		}
-	});
 
-	it("announces when copying fails", async () => {
-		const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
-		const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
-		const clipboardWrite = vi.fn().mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
-		const copyCommand = vi.fn().mockReturnValue(false);
-		Object.defineProperty(navigator, "clipboard", {
-			configurable: true,
-			value: { writeText: clipboardWrite },
-		});
-		Object.defineProperty(document, "execCommand", {
-			configurable: true,
-			value: copyCommand,
-		});
-
-		try {
-			await renderInlineCode("copy()", "javascript");
-			const copyButton = element.querySelector<HTMLButtonElement>('button[aria-label="Copy code"]');
-			expect(copyButton).not.toBeNull();
 			copyButton?.click();
-
-			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledWith("copy"));
+			await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledTimes(3));
+			await vi.waitFor(() => expect(copyCommand).toHaveBeenCalledTimes(2));
 			await vi.waitFor(() =>
 				expect(
 					element.querySelector<HTMLButtonElement>('button[aria-label="Retry copy"]'),
 				).not.toBeNull(),
 			);
-			expect(element.querySelector('[role="status"]')?.textContent).toBe("Copy failed");
+			expect(status?.textContent).toBe("Copy failed");
 		} finally {
 			if (execCommandDescriptor) {
 				Object.defineProperty(document, "execCommand", execCommandDescriptor);
@@ -232,4 +202,5 @@ describe("inline Portable Text code blocks", () => {
 			}
 		}
 	});
+
 });


### PR DESCRIPTION
## What does this PR do?

Adds matching language selection and one-click copy actions to code blocks in the admin and inline visual editors. The controls stay compact on narrow screens and in right-to-left layouts. Copy feedback is smoother, and the inline language picker reports the selected language correctly.

This is the top pull request in native stack #2607, stacked on #2606.

Relates to #2361

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — verified for the affected admin and core packages
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No new strings are introduced.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — `.changeset/quiet-code-block-actions.md`; the stacked base's `.changeset/bright-code-blocks.md` covers syntax highlighting only
- [x] New features link to an approved Discussion: N/A — this is a bug-fix follow-up

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5.6 Codex, reviewed with GPT-5.6 Terra xhigh

## Screenshots / test output

- Type-aware lint passed.
- Admin and core typechecks and builds passed.
- Admin editor tests: 86 passed.
- Core inline code-block tests: 5 passed.
- Focused Playwright coverage: 8 passed.
- Changeset validation passed.
- Browser-verified both editors at desktop and narrow widths in left-to-right and right-to-left layouts.
