### PR TITLE
i18n(ja): complete Japanese translations

### DIFF
--- a/.changeset/bright-kites-translate.md
+++ b/.changeset/bright-kites-translate.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Completes the Japanese admin translation so Japanese-speaking users see localized text for every catalog message.

--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -334,7 +334,7 @@ msgstr "{base}（接続先: {0}）"
 
 #: packages/admin/src/components/RevisionHistory.tsx:355
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
-msgstr "{changedCount, plural, one {次のリビジョンから#件の変更} other {次のリビジョンから#件の変更}}"
+msgstr "{changedCount, plural, one {次の版との差分#件} other {次の版との差分#件}}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2512
 msgid "{characters, plural, one {# character} other {# characters}}"
@@ -1168,7 +1168,7 @@ msgstr "認証に失敗しました"
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/SecuritySettings.tsx:111
 msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
-msgstr "認証は外部プロバイダー（{0}）で管理されています。外部認証を使用している場合、パスキー設定は利用できません。"
+msgstr "認証は外部認証サービス（{0}）で管理されています。外部認証を使用している場合、パスキー設定は利用できません。"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:261
 msgid "Authentication was cancelled or timed out. Please try again."
@@ -1251,7 +1251,7 @@ msgstr "利用可能なメディア"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:202
 msgid "Available Providers"
-msgstr "利用可能なプロバイダー"
+msgstr "利用可能なメール送信サービス"
 
 #: packages/admin/src/components/Widgets.tsx:466
 msgid "Available Widgets"
@@ -1892,7 +1892,7 @@ msgstr "コンテンツの公開を予約しました"
 
 #: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Content has been updated to the selected revision."
-msgstr "コンテンツが選択したリビジョンに更新されました。"
+msgstr "選択した版の内容に更新しました。"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
@@ -3068,7 +3068,7 @@ msgstr "メールパイプライン"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:165
 msgid "Email provider active"
-msgstr "メールプロバイダー有効"
+msgstr "メール送信サービスは有効です"
 
 #: packages/admin/src/components/Settings.tsx:91
 #: packages/admin/src/components/settings/EmailSettings.tsx:58
@@ -3215,7 +3215,7 @@ msgstr "ウィジェットの更新エラー"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:596
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
-msgstr "このプラグインで公開されたすべてのリリースは撤回されたか、検証できませんでした。後でもう一度確認するか、公開者にお問い合わせください。"
+msgstr "このプラグインのリリースはすべて撤回されたか、確認できませんでした。時間をおいて再度確認するか、提供元にお問い合わせください。"
 
 #. placeholder {0}: formData.dateFormat ?? "MMMM d, yyyy"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:327
@@ -3376,7 +3376,7 @@ msgstr "フィールドの削除に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:468
 msgid "Failed to delete from provider"
-msgstr "プロバイダーからの削除に失敗しました"
+msgstr "連携先からの削除に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:335
 msgid "Failed to delete media"
@@ -3495,7 +3495,7 @@ msgstr "メディア項目の取得に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:401
 msgid "Failed to fetch media providers"
-msgstr "メディアプロバイダーの取得に失敗しました"
+msgstr "メディア連携サービスの取得に失敗しました"
 
 #: packages/admin/src/lib/api/plugins.ts:70
 #: packages/admin/src/lib/api/plugins.ts:74
@@ -3512,12 +3512,12 @@ msgstr "プラグイン一覧の取得に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:431
 msgid "Failed to fetch provider media"
-msgstr "プロバイダーのメディア取得に失敗しました"
+msgstr "連携先のメディア取得に失敗しました"
 
 #: packages/admin/src/lib/api/content.ts:579
 #: packages/admin/src/lib/api/content.ts:584
 msgid "Failed to fetch revision"
-msgstr "リビジョンの取得に失敗しました"
+msgstr "版の取得に失敗しました"
 
 #: packages/admin/src/lib/api/sections.ts:76
 msgid "Failed to fetch section"
@@ -3635,7 +3635,7 @@ msgstr "プラグインを読み込めませんでした。レジストリアグ
 
 #: packages/admin/src/components/RevisionHistory.tsx:198
 msgid "Failed to load revisions"
-msgstr "リビジョンの読み込みに失敗しました"
+msgstr "変更履歴の読み込みに失敗しました"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
@@ -3716,7 +3716,7 @@ msgstr "コンテンツの復元に失敗しました"
 #: packages/admin/src/lib/api/content.ts:601
 #: packages/admin/src/lib/api/content.ts:606
 msgid "Failed to restore revision"
-msgstr "リビジョンの復元に失敗しました"
+msgstr "版の復元に失敗しました"
 
 #: packages/admin/src/lib/api/api-tokens.ts:99
 msgid "Failed to revoke API token"
@@ -3850,7 +3850,7 @@ msgstr "メディアのアップロードに失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:456
 msgid "Failed to upload to provider"
-msgstr "プロバイダーへのアップロードに失敗しました"
+msgstr "連携先へのアップロードに失敗しました"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:248
 msgid "Failed to verify authentication"
@@ -4476,7 +4476,7 @@ msgstr "インストール"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:147
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr "招待、マジックリンク、パスワード回復などのメール機能を有効にするには、メールプロバイダープラグインをインストールして有効にしてください。"
+msgstr "招待、メールでのログイン、パスワード再設定などのメール機能を有効にするには、メール送信プラグインをインストールして有効にしてください。"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:197
 msgid "Install blocked"
@@ -4985,7 +4985,7 @@ msgstr "{providerName}が管理"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:318
 msgid "Managed by an external media provider"
-msgstr "外部メディアプロバイダーが管理"
+msgstr "外部メディアサービスで管理"
 
 #: packages/admin/src/components/Redirects.tsx:432
 msgid "Manual"
@@ -5537,11 +5537,11 @@ msgstr "ドメインが設定されていません。ユーザーは個別に招
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:144
 msgid "No email provider configured"
-msgstr "メールプロバイダーが設定されていません"
+msgstr "メール送信サービスが設定されていません"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:83
 msgid "No email provider configured. Share this link manually."
-msgstr "メールプロバイダーが設定されていません。このリンクを手動で共有してください。"
+msgstr "メール送信サービスが設定されていません。このリンクを手動で共有してください。"
 
 #: packages/admin/src/components/WordPressImport.tsx:2516
 msgid "No EmDash users found"
@@ -5613,11 +5613,11 @@ msgstr "上限なし"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:694
 msgid "No media available from this provider"
-msgstr "このプロバイダーから利用可能なメディアはありません"
+msgstr "この連携先で利用できるメディアがありません"
 
 #: packages/admin/src/components/MediaLibrary.tsx:503
 msgid "No media available from this provider."
-msgstr "このプロバイダーで利用できるメディアがありません。"
+msgstr "この連携先で利用できるメディアがありません。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:502
 #: packages/admin/src/components/MediaPickerModal.tsx:688
@@ -5707,7 +5707,7 @@ msgstr "結果が見つかりませんでした"
 
 #: packages/admin/src/components/RevisionHistory.tsx:201
 msgid "No revisions yet"
-msgstr "リビジョンはまだありません"
+msgstr "変更履歴はまだありません"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:108
 msgid "No sections available"
@@ -6145,7 +6145,7 @@ msgstr "プラグインが見つかりません"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:411
 msgid "Plugin not found. The publisher handle or slug may be incorrect."
-msgstr "プラグインが見つかりません。公開者のハンドルまたはスラッグが正しくない可能性があります。"
+msgstr "プラグインが見つかりません。提供元のアカウント名またはプラグインIDが正しくない可能性があります。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1209
 msgid "plugin on your WordPress site."
@@ -6282,7 +6282,7 @@ msgstr "非公開"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:167
 msgid "Provider:"
-msgstr "プロバイダー:"
+msgstr "メール送信サービス:"
 
 #: packages/admin/src/components/ContentList.tsx:485
 #: packages/admin/src/components/ContentSettingsPanel.tsx:198
@@ -6319,7 +6319,7 @@ msgstr "公開日時"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:472
 msgid "Published by"
-msgstr "公開者"
+msgstr "提供元"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
@@ -6627,7 +6627,7 @@ msgstr "リクエストに失敗しました"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:430
 msgid "Require a slug before content can be published"
-msgstr "コンテンツを公開する前にスラッグを必須にする"
+msgstr "公開するコンテンツに個別URLを設定する"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:280
 #: packages/admin/src/components/ContentTypeEditor.tsx:745
@@ -6682,7 +6682,7 @@ msgstr "復元に失敗しました"
 
 #: packages/admin/src/components/RevisionHistory.tsx:232
 msgid "Restore Revision?"
-msgstr "リビジョンを復元しますか？"
+msgstr "この版を復元しますか？"
 
 #: packages/admin/src/components/RevisionHistory.tsx:299
 #: packages/admin/src/components/RevisionHistory.tsx:300
@@ -6692,7 +6692,7 @@ msgstr "このバージョンを復元"
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
 #: packages/admin/src/components/RevisionHistory.tsx:235
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
-msgstr "{0}からこのバージョンを復元しますか？現在のコンテンツがこのリビジョンのデータに更新されます。"
+msgstr "この版（{0}）を復元しますか？現在のコンテンツを、この版の内容に置き換えます。"
 
 #: packages/admin/src/components/RevisionHistory.tsx:239
 msgid "Restoring..."
@@ -6734,13 +6734,13 @@ msgstr "新しい権限を確認"
 
 #: packages/admin/src/components/RevisionHistory.tsx:129
 msgid "Revision restored"
-msgstr "リビジョンを復元しました"
+msgstr "版を復元しました"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:776
 #: packages/admin/src/components/ContentTypeEditor.tsx:76
 #: packages/admin/src/components/RevisionHistory.tsx:168
 msgid "Revisions"
-msgstr "リビジョン"
+msgstr "変更履歴"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:190
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
@@ -6804,7 +6804,7 @@ msgstr "ロールラベル"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:428
 msgid "Routable"
-msgstr "ルーティング可能"
+msgstr "個別ページを作成"
 
 #. placeholder {0}: tool.route
 #. placeholder {1}: tool.permission
@@ -8037,7 +8037,7 @@ msgstr "このプラグインに特別な権限は不要です。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:579
 msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
-msgstr "この公開者は、所有を証明できなかった名前を名乗っており、他者になりすましている可能性があります。インストールは無効です。公開者を知っていて信頼できる場合は、再試行する前に本人確認の設定を修正するよう依頼してください。"
+msgstr "この提供元は、所有を証明できない名前を使用しており、他者になりすましている可能性があります。安全のためインストールできません。提供元を知っていて信頼できる場合は、本人確認の設定を修正するよう依頼してから、もう一度お試しください。"
 
 #: packages/admin/src/components/Redirects.tsx:602
 msgid "This redirect rule will be permanently removed."
@@ -8429,7 +8429,7 @@ msgstr "無題のウィジェット"
 
 #: packages/admin/src/components/PublisherHandle.tsx:145
 msgid "Unverified publisher"
-msgstr "未確認の公開者"
+msgstr "提供元を確認できません"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1032
 msgid "Up"
@@ -8550,7 +8550,7 @@ msgstr "画像をアップロード"
 
 #: packages/admin/src/components/MediaLibrary.tsx:468
 msgid "Upload images, videos, and documents to keep reusable assets in one place."
-msgstr "画像、動画、ドキュメントをアップロードし、再利用できるアセットを1か所で管理します。"
+msgstr "画像、動画、ドキュメントをアップロードし、再利用できる素材を1か所で管理します。"
 
 #: packages/admin/src/components/Dashboard.tsx:163
 msgid "Upload Media"
@@ -8558,7 +8558,7 @@ msgstr "メディアをアップロード"
 
 #: packages/admin/src/components/MediaLibrary.tsx:492
 msgid "Upload media to keep reusable assets in one place."
-msgstr "メディアをアップロードし、再利用できるアセットを1か所で管理します。"
+msgstr "メディアをアップロードし、再利用できる素材を1か所で管理します。"
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:329
@@ -8661,7 +8661,7 @@ msgstr "ユーザー"
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
-msgstr "ユーザーアクセスは外部プロバイダー（{0}）で管理されています。外部認証を使用している場合、セルフサインアップドメイン設定は利用できません。"
+msgstr "ユーザーアクセスは外部認証サービス（{0}）で管理されています。外部認証を使用している場合、ユーザー登録用ドメインの設定は利用できません。"
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
@@ -8698,19 +8698,19 @@ msgstr "バリデーション"
 #: packages/admin/src/components/RegistryBrowse.tsx:189
 #: packages/admin/src/components/RegistryPluginDetail.tsx:462
 msgid "Verified publisher"
-msgstr "確認済みの公開者"
+msgstr "確認済みの提供元"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:461
 msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
-msgstr "確認済みの公開者（ラベラー{verifiedLabeller}が確認）"
+msgstr "確認済みの提供元（確認サービス「{verifiedLabeller}」が確認）"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:452
 msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
-msgstr "確認済みの公開者です。ラベラー（{verifiedLabeller}）がこの公開者の本人確認を行いました。"
+msgstr "確認済みの提供元です。第三者の確認サービス（{verifiedLabeller}）が本人確認を行いました。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:453
 msgid "Verified publisher. A labeller has confirmed this publisher's identity."
-msgstr "確認済みの公開者です。ラベラーがこの公開者の本人確認を行いました。"
+msgstr "確認済みの提供元です。第三者の確認サービスが本人確認を行いました。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:228
 msgid "Verifying your invite..."
@@ -8743,7 +8743,7 @@ msgstr "動画"
 #: packages/admin/src/components/Settings.tsx:96
 #: packages/admin/src/components/settings/EmailSettings.tsx:59
 msgid "View email provider status and send test emails"
-msgstr "メールプロバイダーの状態を確認し、テストメールを送信"
+msgstr "メール送信サービスの状態を確認し、テストメールを送信"
 
 #: packages/admin/src/components/PluginManager.tsx:464
 msgid "View in Marketplace"
@@ -8793,7 +8793,7 @@ msgstr "{0}のWordPressサイトに接続できませんでした。サイトが
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:577
 msgid "We couldn't verify this publisher's identity"
-msgstr "この公開者の本人確認ができませんでした"
+msgstr "この提供元の本人確認ができませんでした"
 
 #: packages/admin/src/components/WordPressImport.tsx:1084
 msgid "We'll check what import options are available for your site."
@@ -8949,7 +8949,7 @@ msgstr "は招待なしで登録できなくなります。既存のユーザー
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:148
 msgid "Without an email provider, invite links must be shared manually."
-msgstr "メールプロバイダーがない場合、招待リンクは手動で共有する必要があります。"
+msgstr "メール送信サービスがない場合、招待リンクは手動で共有する必要があります。"
 
 #: packages/admin/src/components/WordPressImport.tsx:210
 msgid "WordPress authorization was rejected"
@@ -9032,7 +9032,7 @@ msgstr "執筆者情報の項目を管理するには、管理者権限が必要
 
 #: packages/admin/src/router.tsx:1558
 msgid "You need Editor permissions to moderate comments."
-msgstr "コメントをモデレートするには、編集者権限が必要です。"
+msgstr "コメントを管理するには、編集者権限が必要です。"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:199

--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -42,7 +42,7 @@ msgstr "-- 選択 --"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
 msgid ", or open the admin at"
-msgstr "、または管理画面を開く:"
+msgstr "、または管理画面を開く："
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
@@ -88,7 +88,7 @@ msgstr "{0, plural, one {#件の執筆者} other {#件の執筆者}}"
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
 msgid "{0, plural, one {# collection} other {# collections}}"
-msgstr "{0, plural, one {#個のコレクション} other {#個のコレクション}}"
+msgstr "{0, plural, one {#件のコンテンツタイプ} other {#件のコンテンツタイプ}}"
 
 #. placeholder {0}: result.comments.imported
 #: packages/admin/src/components/WordPressImport.tsx:2263
@@ -118,7 +118,7 @@ msgstr "{0, plural, one {#件のコンテンツをインポート} other {#件�
 #. placeholder {0}: selectedItems.length
 #: packages/admin/src/components/MediaPickerModal.tsx:787
 msgid "{0, plural, one {# item selected} other {# items selected}}"
-msgstr "{0, plural, one {#件のアイテムを選択} other {#件のアイテムを選択}}"
+msgstr "{0, plural, one {#件を選択中} other {#件を選択中}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
@@ -208,7 +208,7 @@ msgstr "{0, plural, one {ユーザー} other {ユーザー}}"
 #. placeholder {2}: m.host
 #: packages/admin/src/components/RegistryPluginDetail.tsx:636
 msgid "{0} {1} required — you have {2}."
-msgstr "{0} {1}が必要です — 現在は{2}です。"
+msgstr "{0} {1}が必要です。現在は{2}です。"
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-2xl font-semibold leading-tight">{t`Menus`}</h1> <p className="mt-1 text-sm leading-5 text-pretty text-kumo-subtle"> {t`Manage navigation menus for your site`} </p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
@@ -224,7 +224,7 @@ msgstr "{0}バナー"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:228
 msgid "{0} can't be moved here — its parent has no translation in this locale, so this list isn't the group it belongs to."
-msgstr "{0}はここに移動できません — 親項目にこの言語の翻訳がないため、この一覧は所属先のグループではありません。"
+msgstr "{0}はここに移動できません。親項目にこの言語の翻訳がないため、この一覧は所属先のグループではありません。"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1303
@@ -330,7 +330,7 @@ msgstr "{0}/160文字"
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:313
 msgid "{base} to: {0}"
-msgstr "{base}（接続先: {0}）"
+msgstr "{base}（接続先：{0}）"
 
 #: packages/admin/src/components/RevisionHistory.tsx:355
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
@@ -370,19 +370,19 @@ msgstr "{failedCount, plural, one {#件のアップロードに失敗} other {#�
 #. placeholder {1}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:1088
 msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
-msgstr "{filteredCount, plural, one {#{0}件のアイテム} other {#{1}件のアイテム}}"
+msgstr "{filteredCount, plural, one {#{0}件} other {#{1}件}}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
-msgstr "{label} — 翻訳なし"
+msgstr "{label}（翻訳なし）"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
-msgstr "{label} — 翻訳を表示"
+msgstr "{label}（翻訳を表示）"
 
 #: packages/admin/src/components/ContentList.tsx:1077
 msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr "{matchCount, plural, one {「{searchQuery}」に一致する#件のアイテム} other {「{searchQuery}」に一致する#件のアイテム}}"
+msgstr "{matchCount, plural, one {「{searchQuery}」に一致：#件} other {「{searchQuery}」に一致：#件}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2473
 msgid "{matchedCount} of {totalCount} assigned"
@@ -394,19 +394,19 @@ msgstr "{totalCount}人中{matchedCount}人の著者をメールで一致"
 
 #: packages/admin/src/components/WordPressImport.tsx:1879
 msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
-msgstr "{needsNewCollections, plural, one {#個の新しいコレクションが作成されます} other {#個の新しいコレクションが作成されます}}"
+msgstr "{needsNewCollections, plural, one {#件のコンテンツタイプが作成されます} other {#件のコンテンツタイプが作成されます}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1888
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr "{needsNewFields, plural, one {#個の既存コレクションにフィールドを追加} other {#個の既存コレクションにフィールドを追加}}"
+msgstr "{needsNewFields, plural, one {#件の既存コンテンツタイプにフィールドを追加} other {#件の既存コンテンツタイプにフィールドを追加}}"
 
 #: packages/admin/src/components/Dashboard.tsx:102
 msgid "{overdueCount, plural, one {One scheduled item is overdue and the scheduler heartbeat is stale. Run `npx emdash doctor` and verify the deployed Cron Trigger.} other {# scheduled items are overdue and the scheduler heartbeat is stale. Run `npx emdash doctor` and verify the deployed Cron Trigger.}}"
-msgstr "{overdueCount, plural, one {公開予定のアイテムが1件期限を過ぎており、スケジューラーのハートビートも古くなっています。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。} other {公開予定のアイテムが#件期限を過ぎており、スケジューラーのハートビートも古くなっています。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。}}"
+msgstr "{overdueCount, plural, one {1件のコンテンツが公開予定時刻を過ぎており、公開スケジュール処理の最終実行から時間がたっています。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。} other {#件のコンテンツが公開予定時刻を過ぎており、公開スケジュール処理の最終実行から時間がたっています。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。}}"
 
 #: packages/admin/src/components/Dashboard.tsx:97
 msgid "{overdueCount, plural, one {One scheduled item is overdue, but no scheduler run has completed. Run `npx emdash doctor` and verify the deployed Cron Trigger.} other {# scheduled items are overdue, but no scheduler run has completed. Run `npx emdash doctor` and verify the deployed Cron Trigger.}}"
-msgstr "{overdueCount, plural, one {公開予定のアイテムが1件期限を過ぎていますが、スケジューラーはまだ一度も完了していません。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。} other {公開予定のアイテムが#件期限を過ぎていますが、スケジューラーはまだ一度も完了していません。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。}}"
+msgstr "{overdueCount, plural, one {1件のコンテンツが公開予定時刻を過ぎていますが、公開スケジュール処理はまだ一度も完了していません。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。} other {#件のコンテンツが公開予定時刻を過ぎていますが、公開スケジュール処理はまだ一度も完了していません。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。}}"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:458
 msgid "{overflowCount, plural, one {# file was not added because the upload list is full.} other {# files were not added because the upload list is full.}}"
@@ -414,11 +414,11 @@ msgstr "{overflowCount, plural, one {アップロード一覧が上限に達し�
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:83
 msgid "{pluginName} is requesting additional permissions:"
-msgstr "{pluginName}が追加の権限を要求しています:"
+msgstr "{pluginName}が追加の権限を要求しています："
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:84
 msgid "{pluginName} requires the following permissions:"
-msgstr "{pluginName}に以下の権限が必要です:"
+msgstr "{pluginName}に以下の権限が必要です："
 
 #: packages/admin/src/components/PluginSettings.tsx:128
 #: packages/admin/src/components/PluginSettings.tsx:142
@@ -428,11 +428,11 @@ msgstr "{pluginName}の設定"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2513
 msgid "{readingTime, plural, one {# min read} other {# min read}}"
-msgstr "{readingTime, plural, one {読了時間#分} other {読了時間#分}}"
+msgstr "{readingTime, plural, one {約#分で読めます} other {約#分で読めます}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:263
 msgid "{resultCount, plural, one {# item} other {# items}}"
-msgstr "{resultCount, plural, one {#件のアイテム} other {#件のアイテム}}"
+msgstr "{resultCount, plural, one {#件} other {#件}}"
 
 #: packages/admin/src/components/ContentList.tsx:474
 msgid "{selectedCount, plural, one {# selected} other {# selected}}"
@@ -440,11 +440,11 @@ msgstr "{selectedCount, plural, one {#件を選択中} other {#件を選択中}}
 
 #: packages/admin/src/components/ContentList.tsx:516
 msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
-msgstr "{selectedCount, plural, one {#件のアイテムをゴミ箱に移動しますか？後で復元できます。} other {#件のアイテムをゴミ箱に移動しますか？後で復元できます。}}"
+msgstr "{selectedCount, plural, one {#件のコンテンツをゴミ箱に移動しますか？後で復元できます。} other {#件のコンテンツをゴミ箱に移動しますか？後で復元できます。}}"
 
 #: packages/admin/src/components/ContentList.tsx:1083
 msgid "{total, plural, one {# item} other {# items}}"
-msgstr "{total, plural, one {#件のアイテム} other {#件のアイテム}}"
+msgstr "{total, plural, one {#件} other {#件}}"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:150
 msgid "{total, plural, one {# total} other {# total}}"
@@ -511,7 +511,7 @@ msgstr "1. WordPress管理画面にログイン"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "2. Go to"
-msgstr "2. 移動:"
+msgstr "2. 次の画面を開く："
 
 #: packages/admin/src/components/WordPressImport.tsx:1523
 msgid "2. Go to Users → Profile"
@@ -559,7 +559,7 @@ msgstr "404エラー"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "410 Content Deleted (Gone)"
-msgstr "410 コンテンツ削除済み（Gone）"
+msgstr "410 完全削除済み"
 
 #: packages/admin/src/components/Redirects.tsx:161
 msgid "451 Unavailable for legal reasons"
@@ -731,7 +731,7 @@ msgstr "最初のフィールドを追加"
 
 #: packages/admin/src/components/RepeaterField.tsx:174
 msgid "Add First Item"
-msgstr "最初のアイテムを追加"
+msgstr "最初の項目を追加"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:200
 msgid "Add Images"
@@ -743,11 +743,11 @@ msgstr "ギャラリーに画像を追加"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2124
 msgid "Add item"
-msgstr "アイテムを追加"
+msgstr "項目を追加"
 
 #: packages/admin/src/components/RepeaterField.tsx:158
 msgid "Add Item"
-msgstr "アイテムを追加"
+msgstr "項目を追加"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3668
 msgid "Add link"
@@ -839,7 +839,7 @@ msgstr "管理者"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:191
 msgid "After send:"
-msgstr "送信後:"
+msgstr "送信後："
 
 #: packages/admin/src/components/PluginManager.tsx:543
 msgid "Agent access"
@@ -891,7 +891,7 @@ msgstr "すべての権限"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:134
 msgid "All collections"
-msgstr "すべてのコレクション"
+msgstr "すべてのコンテンツタイプ"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:63
 msgid "All comments require approval"
@@ -908,7 +908,7 @@ msgstr "すべての言語"
 #: packages/admin/src/components/users/UserList.tsx:42
 #: packages/admin/src/components/users/UserList.tsx:46
 msgid "All roles"
-msgstr "すべてのロール"
+msgstr "すべての権限"
 
 #: packages/admin/src/components/Sections.tsx:240
 msgid "All Sources"
@@ -939,7 +939,7 @@ msgstr "特定のドメインからのユーザー登録を許可"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:510
 msgid "Allow visitors to leave comments on this collection's content"
-msgstr "訪問者がこのコレクションのコンテンツにコメントできるようにします"
+msgstr "訪問者がこのコンテンツタイプのコンテンツにコメントできるようにします"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:195
 msgid "Allowed Domains"
@@ -1056,7 +1056,7 @@ msgstr "WordPressサイトを解析中..."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:105
 msgid "Any media type allowed (subject to global limits)."
-msgstr "すべてのメディアタイプを許可します（全体の制限は適用されます）。"
+msgstr "この項目ではファイル形式を制限しません。ただし、ファイル形式やサイズに関するサイト全体の設定は適用されます。"
 
 #: packages/admin/src/components/Settings.tsx:82
 #: packages/admin/src/components/Settings.tsx:86
@@ -1123,7 +1123,7 @@ msgstr "「{0}」を削除しますか？このフィールドを参照する保
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:233
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
-msgstr "\"{0}\"を削除しますか？このコレクション内のすべてのコンテンツも削除されます。"
+msgstr "「{0}」を削除しますか？このコンテンツタイプ内のすべてのコンテンツも削除されます。"
 
 #. placeholder {0}: deleteFieldTarget.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:684
@@ -1320,7 +1320,7 @@ msgstr "バックアップ中..."
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:115
 msgid "Backup created: {0}"
-msgstr "バックアップを作成しました: {0}"
+msgstr "バックアップを作成しました：{0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:98
 msgid "Backup settings saved"
@@ -1341,7 +1341,7 @@ msgstr "Bash"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:186
 msgid "Before send:"
-msgstr "送信前:"
+msgstr "送信前："
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:233
 #: packages/admin/src/components/settings/SeoSettings.tsx:247
@@ -1394,7 +1394,7 @@ msgstr "アップロードするファイルを選択"
 
 #: packages/admin/src/components/PluginManager.tsx:204
 msgid "Browse the"
-msgstr "参照:"
+msgstr "参照："
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
 msgid "Browse themes and preview them with your own content."
@@ -1515,7 +1515,7 @@ msgstr "テーマセクションは削除できません"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:456
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr "URLからMIMEタイプを判別できません。認識可能な画像拡張子（例: .jpg、.png、.webp）で終わるURLを使用してください。"
+msgstr "URLからMIMEタイプを判別できません。認識可能な画像拡張子（例：.jpg、.png、.webp）で終わるURLを使用してください。"
 
 #: packages/admin/src/components/SeoPanel.tsx:224
 #: packages/admin/src/components/SeoPanel.tsx:228
@@ -1549,7 +1549,7 @@ msgstr "カテゴリ"
 #. placeholder {0}: analysis.categories
 #: packages/admin/src/components/WordPressImport.tsx:1785
 msgid "Categories ({0})"
-msgstr "カテゴリ ({0})"
+msgstr "カテゴリ（{0}）"
 
 #: packages/admin/src/components/WordPressImport.tsx:1146
 msgid "Categories & Tags"
@@ -1598,7 +1598,7 @@ msgstr "変更を破棄しました"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:167
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr "ページタイトルとサイト名の間の文字（例: \"記事タイトル | サイト名\"）"
+msgstr "ページタイトルとサイト名の間の文字（例：「記事タイトル | サイト名」）"
 
 #: packages/admin/src/components/PluginManager.tsx:171
 msgid "Check for updates"
@@ -1774,19 +1774,19 @@ msgstr "colleague@example.com"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
-msgstr "コレクション"
+msgstr "コンテンツタイプ"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:106
 msgid "Collection:"
-msgstr "コレクション:"
+msgstr "コンテンツタイプ："
 
 #: packages/admin/src/components/TaxonomyManager.tsx:840
 msgid "Collections"
-msgstr "コレクション"
+msgstr "コンテンツタイプ"
 
 #: packages/admin/src/components/WordPressImport.tsx:2327
 msgid "Collections created:"
-msgstr "作成されたコレクション:"
+msgstr "作成したコンテンツタイプ："
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:185
 msgid "Columns"
@@ -1884,7 +1884,7 @@ msgstr "コンテンツエラー ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1317
 msgid "Content found:"
-msgstr "検出されたコンテンツ:"
+msgstr "検出されたコンテンツ："
 
 #: packages/admin/src/router.tsx:1129
 msgid "Content has been scheduled for publishing"
@@ -1928,7 +1928,7 @@ msgstr "コンテンツを下書きに戻しました"
 
 #: packages/admin/src/components/RevisionHistory.tsx:314
 msgid "Content snapshot:"
-msgstr "コンテンツスナップショット:"
+msgstr "コンテンツスナップショット："
 
 #: packages/admin/src/components/WordPressImport.tsx:1731
 msgid "Content to Import"
@@ -2117,7 +2117,7 @@ msgstr "新しいトークンを作成"
 
 #: packages/admin/src/components/WordPressImport.tsx:1501
 msgid "Create one in WordPress: Users → Profile → Application Passwords"
-msgstr "WordPressで作成: ユーザー → プロフィール → アプリケーションパスワード"
+msgstr "WordPressで作成：ユーザー → プロフィール → アプリケーションパスワード"
 
 #: packages/admin/src/components/SetupWizard.tsx:298
 msgid "Create Passkey"
@@ -2224,7 +2224,7 @@ msgstr "「{0}」を作成しました。"
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:260
 msgid "Created {0}"
-msgstr "作成日: {0}"
+msgstr "作成日：{0}"
 
 #. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
 #: packages/admin/src/router.tsx:1181
@@ -2237,7 +2237,7 @@ msgstr "作成日時"
 
 #: packages/admin/src/components/WordPressImport.tsx:887
 msgid "Creating collections and fields..."
-msgstr "コレクションとフィールドを作成中..."
+msgstr "コンテンツタイプとフィールドを作成中..."
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1141
 #: packages/admin/src/components/MenuList.tsx:178
@@ -2263,7 +2263,7 @@ msgstr "現在"
 
 #: packages/admin/src/components/PluginSettings.tsx:340
 msgid "Currently set — enter a new value to replace"
-msgstr "現在設定済み — 置き換える新しい値を入力してください"
+msgstr "設定済みです。変更するには新しい値を入力してください"
 
 #: packages/admin/src/components/Sections.tsx:46
 msgid "Custom"
@@ -2338,11 +2338,11 @@ msgstr "宣言された権限"
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:345
 msgid "Default Role"
-msgstr "デフォルトロール"
+msgstr "初期権限"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:241
 msgid "Default role:"
-msgstr "デフォルトロール:"
+msgstr "初期権限："
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:181
 msgid "Default social image"
@@ -2358,7 +2358,7 @@ msgstr "コンテンツを整理するための分類を作成"
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr "執筆者ごとに保存する追加項目を設定します — 役職、代名詞、SNSアカウントなど。"
+msgstr "執筆者ごとに保存する追加項目を設定します。役職、代名詞、SNSアカウントなどを追加できます。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:118
 msgid "Define the structure of your content"
@@ -2394,7 +2394,7 @@ msgstr "削除"
 #. placeholder {0}: item.filename
 #: packages/admin/src/components/MediaDetailPanel.tsx:452
 msgid "Delete \"{0}\"? This cannot be undone."
-msgstr "\"{0}\"を削除しますか？この操作は取り消せません。"
+msgstr "「{0}」を削除しますか？この操作は取り消せません。"
 
 #. placeholder {0}: archive.name
 #. placeholder {0}: collection.label
@@ -2646,7 +2646,7 @@ msgstr "Diff"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:280
 msgid "Dimensions:"
-msgstr "サイズ:"
+msgstr "サイズ："
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Disable"
@@ -2681,7 +2681,7 @@ msgstr "無効"
 
 #: packages/admin/src/components/PluginManager.tsx:614
 msgid "Disabled:"
-msgstr "無効:"
+msgstr "無効："
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #: packages/admin/src/routes/users.tsx:274
@@ -2764,7 +2764,7 @@ msgstr "画像の下にキャプションとして表示されます。"
 
 #: packages/admin/src/components/ContentEditor.tsx:726
 msgid "Distraction-free mode (⌘⇧\\)"
-msgstr "集中モード (⌘⇧\\)"
+msgstr "集中モード（⌘⇧\\）"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1488
 msgid "Divider"
@@ -2816,7 +2816,7 @@ msgstr "{0}をダウンロード"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:191
 msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
-msgstr "サイト全体のバックアップをダウンロードします。すべてのコンテンツ（下書きとゴミ箱を含む）、コレクション、分類、メニュー、ウィジェット、メディアメタデータ、サイト設定が含まれます。ユーザーアカウントとシークレットは含まれません。"
+msgstr "サイト全体のバックアップをダウンロードします。すべてのコンテンツ（下書きとゴミ箱を含む）、コンテンツタイプ、分類、メニュー、ウィジェット、メディアメタデータ、サイト設定が含まれます。ユーザーアカウントとシークレットは含まれません。"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:195
 msgid "Download backup"
@@ -2919,19 +2919,19 @@ msgstr "{title}を複製"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr "例: application/zip または .pdf"
+msgstr "例：application/zip または .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:168
 msgid "e.g. import, blog"
-msgstr "例: import、blog"
+msgstr "例：import、blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:484
 msgid "e.g., CI/CD Pipeline"
-msgstr "例: CI/CDパイプライン"
+msgstr "例：CI/CDパイプライン"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr "例: MacBook Pro、iPhone"
+msgstr "例：MacBook Pro、iPhone"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1044
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
@@ -3102,7 +3102,7 @@ msgstr "EmDash Exporterプラグインを検出しました！直接インポー
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:160
 msgid "Empty gallery — open settings to add images"
-msgstr "空のギャラリー — 設定を開いて画像を追加してください"
+msgstr "ギャラリーは空です。設定を開いて画像を追加してください"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
@@ -3114,7 +3114,7 @@ msgstr "コメントを有効化"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:87
 msgid "Enable full-text search on this collection"
-msgstr "このコレクションで全文検索を有効にする"
+msgstr "このコンテンツタイプで全文検索を有効にする"
 
 #: packages/admin/src/components/PluginManager.tsx:494
 msgid "Enable plugin"
@@ -3140,7 +3140,7 @@ msgstr "URL（https://…）または相対パス（/…）を入力"
 
 #: packages/admin/src/components/ContentEditor.tsx:1493
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr "有効なURL（例: https://example.com）を入力"
+msgstr "有効なURL（例：https://example.com）を入力"
 
 #: packages/admin/src/components/WordPressImport.tsx:1380
 msgid "Enter credentials manually"
@@ -3220,7 +3220,7 @@ msgstr "このプラグインのリリースはすべて撤回されたか、確
 #. placeholder {0}: formData.dateFormat ?? "MMMM d, yyyy"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:327
 msgid "Example: {0} → January 23, 2026"
-msgstr "例: {0} → 2026年1月23日"
+msgstr "例：{0} → 2026年1月23日"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:285
 msgid "example.com"
@@ -3322,7 +3322,7 @@ msgstr "セクションの作成に失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:1714
 msgid "Failed to create some collections"
-msgstr "一部のコレクションの作成に失敗しました"
+msgstr "一部のコンテンツタイプの作成に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:638
 msgid "Failed to create term"
@@ -3358,7 +3358,7 @@ msgstr "執筆者情報の項目の削除に失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:244
 msgid "Failed to delete collection"
-msgstr "コレクションの削除に失敗しました"
+msgstr "コンテンツタイプの削除に失敗しました"
 
 #: packages/admin/src/lib/api/comments.ts:111
 #: packages/admin/src/router.tsx:1517
@@ -3467,7 +3467,7 @@ msgstr "バックアップ設定の取得に失敗しました"
 #: packages/admin/src/lib/api/schema.ts:192
 #: packages/admin/src/lib/api/schema.ts:196
 msgid "Failed to fetch collection"
-msgstr "コレクションの取得に失敗しました"
+msgstr "コンテンツタイプの取得に失敗しました"
 
 #: packages/admin/src/lib/api/dashboard.ts:47
 msgid "Failed to fetch dashboard stats"
@@ -3601,7 +3601,7 @@ msgstr "バックアップ設定の読み込みに失敗しました"
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "Failed to load bylines: {0}"
-msgstr "執筆者の読み込みに失敗しました: {0}"
+msgstr "執筆者の読み込みに失敗しました：{0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:80
 #: packages/admin/src/components/settings/EmailSettings.tsx:81
@@ -3627,7 +3627,7 @@ msgstr "プラグイン設定の読み込みに失敗しました"
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:149
 msgid "Failed to load plugins: {0}"
-msgstr "プラグインの読み込みに失敗しました: {0}"
+msgstr "プラグインの読み込みに失敗しました：{0}"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:98
 msgid "Failed to load plugins. The registry aggregator may be unreachable."
@@ -3648,7 +3648,7 @@ msgstr "テーマの読み込みに失敗しました"
 #. placeholder {0}: usersQuery.error.message
 #: packages/admin/src/routes/users.tsx:205
 msgid "Failed to load users: {0}"
-msgstr "ユーザーの読み込みに失敗しました: {0}"
+msgstr "ユーザーの読み込みに失敗しました：{0}"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:46
 msgid "Failed to load widget"
@@ -3920,7 +3920,7 @@ msgstr "フィールド"
 
 #: packages/admin/src/components/WordPressImport.tsx:2333
 msgid "Fields created:"
-msgstr "作成されたフィールド:"
+msgstr "作成されたフィールド："
 
 #: packages/admin/src/components/FieldEditor.tsx:239
 msgid "File"
@@ -3967,11 +3967,11 @@ msgstr "権限でフィルタ"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:178
 msgid "Filter by collection"
-msgstr "コレクションでフィルタ"
+msgstr "コンテンツタイプで絞り込む"
 
 #: packages/admin/src/components/users/UserList.tsx:82
 msgid "Filter by role"
-msgstr "ロールで絞り込む"
+msgstr "権限で絞り込む"
 
 #: packages/admin/src/components/Sections.tsx:245
 msgid "Filter by source"
@@ -4005,7 +4005,7 @@ msgstr "下書きやすべてのコンテンツを含む完全なインポート
 
 #: packages/admin/src/components/WordPressImport.tsx:1207
 msgid "For the best import experience, install the"
-msgstr "最適なインポートのために、以下をインストールしてください:"
+msgstr "最適なインポートのために、以下をインストールしてください："
 
 #: packages/admin/src/components/ContentList.tsx:928
 msgid "From date"
@@ -4266,7 +4266,7 @@ msgstr "画像URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:2370
 msgid "image URLs updated in"
-msgstr "画像URLを更新:"
+msgstr "画像URLを更新："
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:192
@@ -4339,7 +4339,7 @@ msgstr "インポート済み"
 
 #: packages/admin/src/components/WordPressImport.tsx:2344
 msgid "Imported by Collection"
-msgstr "コレクション別インポート"
+msgstr "コンテンツタイプ別のインポート件数"
 
 #. placeholder {0}: wpImportProgress.comments
 #: packages/admin/src/components/WordPressImport.tsx:903
@@ -4500,11 +4500,11 @@ msgstr "インストール済み"
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:583
 msgid "Installed from marketplace (v{0})"
-msgstr "マーケットプレイスからインストール (v{0})"
+msgstr "マーケットプレイスからインストール（v{0}）"
 
 #: packages/admin/src/components/PluginManager.tsx:602
 msgid "Installed:"
-msgstr "インストール済み:"
+msgstr "インストール済み："
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:198
 msgid "Installing..."
@@ -4565,19 +4565,19 @@ msgstr "斜体"
 #: packages/admin/src/components/PortableTextEditor.tsx:2286
 #: packages/admin/src/components/RepeaterField.tsx:239
 msgid "Item {0}"
-msgstr "アイテム {0}"
+msgstr "項目{0}"
 
 #: packages/admin/src/components/MenuEditor.tsx:175
 msgid "Item added"
-msgstr "アイテムを追加しました"
+msgstr "メニュー項目を追加しました"
 
 #: packages/admin/src/components/MenuEditor.tsx:187
 msgid "Item deleted"
-msgstr "アイテムを削除しました"
+msgstr "メニュー項目を削除しました"
 
 #: packages/admin/src/components/MenuEditor.tsx:212
 msgid "Item updated"
-msgstr "アイテムを更新しました"
+msgstr "メニュー項目を更新しました"
 
 #: packages/admin/src/components/SetupWizard.tsx:213
 #: packages/admin/src/components/SignupPage.tsx:206
@@ -4661,7 +4661,7 @@ msgstr "大見出し"
 
 #: packages/admin/src/components/PluginManager.tsx:608
 msgid "Last enabled:"
-msgstr "最終有効化:"
+msgstr "最終有効化："
 
 #: packages/admin/src/components/users/UserDetail.tsx:227
 msgid "Last login"
@@ -4687,7 +4687,7 @@ msgstr "最終使用"
 #. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:262
 msgid "Last used {0}"
-msgstr "最終使用日: {0}"
+msgstr "最終使用日：{0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:337
 msgid "Learn more"
@@ -4736,12 +4736,12 @@ msgstr "リンクの有効期限が切れました"
 
 #: packages/admin/src/components/FieldEditor.tsx:246
 msgid "Link to another content item"
-msgstr "他のコンテンツアイテムへのリンク"
+msgstr "別のコンテンツへのリンク"
 
 #. placeholder {0}: user.oauthAccounts.length
 #: packages/admin/src/components/users/UserDetail.tsx:276
 msgid "Linked Accounts ({0})"
-msgstr "リンクされたアカウント ({0})"
+msgstr "連携済みアカウント（{0}）"
 
 #: packages/admin/src/routes/bylines.tsx:414
 msgid "Linked only"
@@ -4796,7 +4796,7 @@ msgstr "執筆者情報の項目を読み込み中…"
 
 #: packages/admin/src/components/ContentTypeList.tsx:198
 msgid "Loading collections..."
-msgstr "コレクションを読み込み中..."
+msgstr "コンテンツタイプを読み込み中..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:308
 msgid "Loading comments..."
@@ -5003,11 +5003,11 @@ msgstr "WordPressユーザー{0}をEmDashユーザーに割り当て"
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:256
 msgid "Mark {0} as Gone (410)"
-msgstr "{0}をGone（410）に設定"
+msgstr "{0}を完全削除として扱う（410）"
 
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr "Gone（410）に設定 — 完全に削除されたことを検索エンジンに通知します"
+msgstr "完全削除として扱う（410）：削除済みであることを検索エンジンに通知します"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:502
 msgid "Mark as spam"
@@ -5030,7 +5030,7 @@ msgstr "マーケットプレイス"
 
 #: packages/admin/src/components/FieldEditor.tsx:656
 msgid "Max Items"
-msgstr "最大アイテム数"
+msgstr "最大項目数"
 
 #: packages/admin/src/components/FieldEditor.tsx:499
 msgid "Max Length"
@@ -5109,7 +5109,7 @@ msgstr "メニュー「{0}」（{1}）を作成しました。"
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:56
 msgid "Menu \"{0}\" has been created."
-msgstr "メニュー\"{0}\"を作成しました。"
+msgstr "メニュー「{0}」を作成しました。"
 
 #: packages/admin/src/components/MenuList.tsx:55
 msgid "Menu created"
@@ -5178,7 +5178,7 @@ msgstr "移行キー"
 
 #: packages/admin/src/components/FieldEditor.tsx:649
 msgid "Min Items"
-msgstr "最小アイテム数"
+msgstr "最小項目数"
 
 #: packages/admin/src/components/FieldEditor.tsx:492
 msgid "Min Length"
@@ -5194,15 +5194,15 @@ msgstr "小見出し"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:519
 msgid "Moderation"
-msgstr "モデレーション"
+msgstr "コメントの承認"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
-msgstr "モデレーションシグナル"
+msgstr "承認判定情報"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:73
 msgid "Modify collection schemas"
-msgstr "コレクションスキーマを変更"
+msgstr "コンテンツタイプの構造を変更"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Monthly"
@@ -5232,7 +5232,7 @@ msgstr "「{0}」を上へ移動"
 
 #: packages/admin/src/components/ContentList.tsx:1245
 msgid "Move \"{title}\" to trash? You can restore it later."
-msgstr "\"{title}\"をゴミ箱に移動しますか？後で復元できます。"
+msgstr "「{title}」をゴミ箱に移動しますか？後で復元できます。"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:251
@@ -5242,7 +5242,7 @@ msgstr "{0}を下へ移動"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Move {0} down — unavailable, its parent has no translation in this locale"
-msgstr "{0}を下へ移動 — 親項目にこの言語の翻訳がないため利用できません"
+msgstr "{0}は下へ移動できません。親項目にこの言語の翻訳がありません"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:238
@@ -5252,7 +5252,7 @@ msgstr "{0}を上へ移動"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:237
 msgid "Move {0} up — unavailable, its parent has no translation in this locale"
-msgstr "{0}を上へ移動 — 親項目にこの言語の翻訳がないため利用できません"
+msgstr "{0}は上へ移動できません。親項目にこの言語の翻訳がありません"
 
 #: packages/admin/src/components/ContentList.tsx:1236
 msgid "Move {title} to trash"
@@ -5285,11 +5285,11 @@ msgstr "上に移動"
 
 #: packages/admin/src/router.tsx:535
 msgid "Moved {total} items to draft"
-msgstr "{total}件のアイテムを下書きに移動しました"
+msgstr "{total}件を下書きに移動しました"
 
 #: packages/admin/src/router.tsx:556
 msgid "Moved {total} items to trash"
-msgstr "{total}件のアイテムをゴミ箱に移動しました"
+msgstr "{total}件をゴミ箱に移動しました"
 
 #: packages/admin/src/components/FieldEditor.tsx:221
 msgid "Multi Select"
@@ -5363,7 +5363,7 @@ msgstr "新しい執筆者情報の項目"
 
 #: packages/admin/src/components/WordPressImport.tsx:1982
 msgid "New collection"
-msgstr "新しいコレクション"
+msgstr "新しいコンテンツタイプ"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:356
 #: packages/admin/src/components/ContentTypeList.tsx:122
@@ -5493,11 +5493,11 @@ msgstr "執筆者が選択されていません。"
 
 #: packages/admin/src/components/Dashboard.tsx:275
 msgid "No collections configured"
-msgstr "コレクションが設定されていません"
+msgstr "コンテンツタイプが設定されていません"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:547
 msgid "No comments awaiting moderation."
-msgstr "モデレーション待ちのコメントはありません。"
+msgstr "承認待ちのコメントはありません。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:543
 msgid "No comments match your search."
@@ -5513,7 +5513,7 @@ msgstr "コンテンツが見つかりません"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:177
 msgid "No content in this collection"
-msgstr "このコレクションにはコンテンツがありません"
+msgstr "このコンテンツタイプにはコンテンツがありません"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:511
 msgid "No content locale is configured, so EmDash stores new content as English (en). Changing the admin language does not change this value."
@@ -5579,7 +5579,7 @@ msgstr "招待トークンが指定されていません"
 #: packages/admin/src/components/RepeaterField.tsx:165
 #: packages/admin/src/components/settings/BackupSettings.tsx:283
 msgid "No items yet"
-msgstr "アイテムはまだありません"
+msgstr "項目はまだありません"
 
 #: packages/admin/src/components/FieldEditor.tsx:660
 msgid "No limit"
@@ -5639,7 +5639,7 @@ msgstr "下限なし"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:65
 msgid "No moderation (auto-approve all)"
-msgstr "モデレーションなし（すべて自動承認）"
+msgstr "承認不要（すべて自動承認）"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "No parent (top level)"
@@ -5679,7 +5679,7 @@ msgstr "利用可能な公開URLがありません"
 
 #: packages/admin/src/components/Dashboard.tsx:354
 msgid "No recent activity"
-msgstr "最近のアクティビティはありません"
+msgstr "最近の更新はありません"
 
 #: packages/admin/src/components/Redirects.tsx:468
 msgid "No redirects yet"
@@ -5698,7 +5698,7 @@ msgstr "「{activeSearch}」の結果はありません"
 #: packages/admin/src/components/MarketplaceBrowse.tsx:178
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
-msgstr "\"{debouncedQuery}\"の結果はありません。別の検索キーワードをお試しください。"
+msgstr "「{debouncedQuery}」の結果はありません。別の検索キーワードをお試しください。"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:465
 #: packages/admin/src/components/Settings.tsx:141
@@ -5897,7 +5897,7 @@ msgstr "順序を保存しました"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:257
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:446
 msgid "Original:"
-msgstr "元の値:"
+msgstr "元の値："
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:768
 #: packages/admin/src/components/editor/DocumentOutline.tsx:191
@@ -6021,7 +6021,7 @@ msgstr "パターン（正規表現）"
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:450
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr "URL生成パターン（例: /blog/{0}）"
+msgstr "URL生成パターン（例：/blog/{0}）"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:446
@@ -6046,7 +6046,7 @@ msgstr "未保存の変更"
 
 #: packages/admin/src/components/ContentList.tsx:1413
 msgid "Permanently delete \"{title}\"? This cannot be undone."
-msgstr "\"{title}\"を完全に削除しますか？この操作は取り消せません。"
+msgstr "「{title}」を完全に削除しますか？この操作は取り消せません。"
 
 #: packages/admin/src/components/ContentList.tsx:1402
 msgid "Permanently delete {title}"
@@ -6170,13 +6170,13 @@ msgstr "プラグインレジストリ"
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginPage.tsx:40
 msgid "Plugin responded with {0}: {text}"
-msgstr "プラグインから{0}が返されました: {text}"
+msgstr "プラグインから{0}が返されました：{text}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:512
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:515
 msgid "Plugin tools: {0}"
-msgstr "プラグインツール: {0}"
+msgstr "プラグインツール：{0}"
 
 #: packages/admin/src/components/PluginManager.tsx:323
 msgid "Plugin uninstalled"
@@ -6282,7 +6282,7 @@ msgstr "非公開"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:167
 msgid "Provider:"
-msgstr "メール送信サービス:"
+msgstr "メール送信サービス："
 
 #: packages/admin/src/components/ContentList.tsx:485
 #: packages/admin/src/components/ContentSettingsPanel.tsx:198
@@ -6307,11 +6307,11 @@ msgstr "公開済み"
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:337
 msgid "Published {0}"
-msgstr "公開日: {0}"
+msgstr "公開日：{0}"
 
 #: packages/admin/src/router.tsx:512
 msgid "Published {total} items"
-msgstr "{total}件のアイテムを公開しました"
+msgstr "{total}件を公開しました"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
@@ -6350,11 +6350,11 @@ msgstr "生のメタデータ"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:68
 msgid "Read collection schemas"
-msgstr "コレクションスキーマを読み取り"
+msgstr "コンテンツタイプの構造を読み取り"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:48
 msgid "Read content entries"
-msgstr "コンテンツエントリを読み取り"
+msgstr "コンテンツを読み取り"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:58
 msgid "Read media files"
@@ -6388,7 +6388,7 @@ msgstr "準備完了"
 
 #: packages/admin/src/components/Dashboard.tsx:348
 msgid "Recent Activity"
-msgstr "最近のアクティビティ"
+msgstr "最近の更新"
 
 #: packages/admin/src/components/Widgets.tsx:126
 msgid "Recent Posts"
@@ -6535,7 +6535,7 @@ msgstr "画像を削除しますか？"
 #: packages/admin/src/components/PortableTextEditor.tsx:2325
 #: packages/admin/src/components/RepeaterField.tsx:275
 msgid "Remove item {0}"
-msgstr "アイテム{0}を削除"
+msgstr "項目{0}を削除"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3606
 #: packages/admin/src/components/PortableTextEditor.tsx:3607
@@ -6611,7 +6611,7 @@ msgstr "画像を置換"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:117
 msgid "Reply to:"
-msgstr "返信先:"
+msgstr "返信先："
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
 msgid "Repository"
@@ -6639,7 +6639,7 @@ msgstr "必須"
 
 #: packages/admin/src/components/WordPressImport.tsx:1999
 msgid "Required fields:"
-msgstr "必須フィールド:"
+msgstr "必須フィールド："
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:348
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:537
@@ -6780,7 +6780,7 @@ msgstr "右"
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:322
 msgid "Risk score: {0}/100"
-msgstr "リスクスコア: {0}/100"
+msgstr "リスクスコア：{0}/100"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:255
 #: packages/admin/src/components/settings/SeoSettings.tsx:258
@@ -6792,15 +6792,15 @@ msgstr "robots.txt"
 #: packages/admin/src/components/users/UserDetail.tsx:181
 #: packages/admin/src/components/users/UserList.tsx:101
 msgid "Role"
-msgstr "ロール"
+msgstr "権限"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
-msgstr "ロール: {role}"
+msgstr "権限：{role}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1058
 msgid "Role label"
-msgstr "ロールラベル"
+msgstr "役割名"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:428
 msgid "Routable"
@@ -6811,7 +6811,7 @@ msgstr "個別ページを作成"
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:149
 #: packages/admin/src/components/PluginManager.tsx:568
 msgid "Route: {0} · Permission: {1}"
-msgstr "ルート: {0} · 権限: {1}"
+msgstr "ルート：{0} · 権限：{1}"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
@@ -6929,7 +6929,7 @@ msgstr "予約済み"
 #. placeholder {0}: formatScheduledDate(item.scheduledAt)
 #: packages/admin/src/components/ContentSettingsPanel.tsx:545
 msgid "Scheduled for: {0}"
-msgstr "公開予約: {0}"
+msgstr "公開予約：{0}"
 
 #: packages/admin/src/components/Dashboard.tsx:111
 msgid "Scheduled publishing needs attention"
@@ -7118,7 +7118,7 @@ msgstr "セクション"
 
 #: packages/admin/src/components/SectionEditor.tsx:83
 msgid "Section \"{slug}\" could not be found."
-msgstr "セクション\"{slug}\"が見つかりませんでした。"
+msgstr "セクション「{slug}」が見つかりませんでした。"
 
 #: packages/admin/src/components/Sections.tsx:93
 msgid "Section created"
@@ -7312,13 +7312,13 @@ msgstr "選択した画像"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:795
 msgid "Selected:"
-msgstr "選択中:"
+msgstr "選択中："
 
 #: packages/admin/src/components/Settings.tsx:76
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:149
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:171
 msgid "Self-Signup Domains"
-msgstr "セルフサインアップドメイン"
+msgstr "登録を許可するドメイン"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:98
 msgid "Send a test email through the full pipeline to verify your email configuration."
@@ -7393,7 +7393,7 @@ msgstr "言語を設定"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:147
 msgid "Set language (current: {label})"
-msgstr "言語を設定（現在: {label}）"
+msgstr "言語を設定（現在：{label}）"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:544
 msgid "Set to 0 to never close comments automatically."
@@ -7587,7 +7587,7 @@ msgstr "サイズ"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:274
 msgid "Size:"
-msgstr "サイズ:"
+msgstr "サイズ："
 
 #: packages/admin/src/components/WordPressImport.tsx:2104
 msgid "Skip Media Import"
@@ -7729,7 +7729,7 @@ msgstr "ステータスコード"
 
 #: packages/admin/src/components/Dashboard.tsx:401
 msgid "Status: {status}"
-msgstr "ステータス: {status}"
+msgstr "ステータス：{status}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:205
 msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
@@ -7795,7 +7795,7 @@ msgstr "システム"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
-msgstr "システム ({resolvedLabel})"
+msgstr "システム（{resolvedLabel}）"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:614
 msgid "System Fields"
@@ -7822,7 +7822,7 @@ msgstr "タグ"
 #. placeholder {0}: analysis.tags
 #: packages/admin/src/components/WordPressImport.tsx:1797
 msgid "Tags ({0})"
-msgstr "タグ ({0})"
+msgstr "タグ（{0}）"
 
 #: packages/admin/src/components/MenuEditor.tsx:427
 #: packages/admin/src/components/MenuEditor.tsx:606
@@ -7848,15 +7848,15 @@ msgstr "分類を作成しました"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1014
 msgid "Taxonomy not found:"
-msgstr "分類が見つかりません:"
+msgstr "分類が見つかりません："
 
 #: packages/admin/src/components/TaxonomyManager.tsx:341
 msgid "Taxonomy: {taxonomyName}"
-msgstr "分類: {taxonomyName}"
+msgstr "分類：{taxonomyName}"
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
-msgstr "テンプレート:"
+msgstr "テンプレート："
 
 #: packages/admin/src/components/TaxonomyManager.tsx:539
 #: packages/admin/src/components/TaxonomyManager.tsx:540
@@ -7888,15 +7888,15 @@ msgstr "デバイスにはアクセスが許可されません。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1862
 msgid "The existing collection has fields with incompatible types."
-msgstr "既存のコレクションに互換性のないタイプのフィールドがあります。"
+msgstr "既存のコンテンツタイプに互換性のない型のフィールドがあります。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:136
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
-msgstr "以下のテーブルにはコンテンツがありますが、コレクションとして登録されていません。管理画面でこのコンテンツを管理するには登録してください。"
+msgstr "以下のテーブルにはコンテンツがありますが、コンテンツタイプとして登録されていません。管理画面でこのコンテンツを管理するには登録してください。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:179
 msgid "The invited user will have this role once they complete registration."
-msgstr "招待されたユーザーは登録完了後にこのロールが割り当てられます。"
+msgstr "招待されたユーザーには登録完了後にこの権限が設定されます。"
 
 #: packages/admin/src/components/LoginPage.tsx:114
 #: packages/admin/src/components/SignupPage.tsx:140
@@ -7962,7 +7962,7 @@ msgstr "テーマ提供のセクションは削除できません。セクショ
 
 #: packages/admin/src/components/ThemeToggle.tsx:33
 msgid "Theme: {label}"
-msgstr "テーマ: {label}"
+msgstr "テーマ：{label}"
 
 #: packages/admin/src/components/Sidebar.tsx:324
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
@@ -7975,7 +7975,7 @@ msgstr "これらのツールは、インストール後もエージェントア
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:371
 msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
-msgstr "このコレクションはコードで定義されています。一部の設定はここでは変更できません。スキーマを変更するには、live.config.tsファイルを編集してください。"
+msgstr "このコンテンツタイプはコードで定義されています。一部の設定はここでは変更できません。構造を変更するには、live.config.tsファイルを編集してください。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3330
 msgid "This content cannot be edited safely"
@@ -8008,7 +8008,7 @@ msgstr "これはWordPressサイトです。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:503
 msgid "This is stored with the entry and is separate from your admin language."
-msgstr "これはエントリとともに保存され、管理画面の言語とは別に扱われます。"
+msgstr "これはコンテンツとともに保存され、管理画面の言語とは別に扱われます。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:112
 msgid "This link expires in 7 days and can only be used once."
@@ -8066,7 +8066,7 @@ msgstr "このセクションは別のシステムからインポートされま
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:125
 msgid "This update exposes the following routes without authentication:"
-msgstr "この更新により、次のルートが認証なしで公開されます:"
+msgstr "この更新により、次のルートが認証なしで公開されます："
 
 #: packages/admin/src/components/Widgets.tsx:715
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
@@ -8078,17 +8078,17 @@ msgstr "これにより、あなたの権限でCLIアクセスが許可されま
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:808
 msgid "This will move the item to trash. You can restore it later from the trash."
-msgstr "アイテムをゴミ箱に移動します。後でゴミ箱から復元できます。"
+msgstr "このコンテンツをゴミ箱に移動します。後でゴミ箱から復元できます。"
 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:1110
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr "\"{0}\"を完全に削除し、すべてのコンテンツから削除されます。"
+msgstr "「{0}」を完全に削除し、すべてのコンテンツとの関連付けも解除します。"
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:304
 msgid "This will permanently delete \"{0}\". This action cannot be undone."
-msgstr "\"{0}\"を完全に削除します。この操作は取り消せません。"
+msgstr "「{0}」を完全に削除します。この操作は取り消せません。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:407
 msgid "This will permanently delete this comment. This action cannot be undone."
@@ -8112,7 +8112,7 @@ msgstr "タイムゾーン"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:335
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr "日付表示のタイムゾーン（例: Asia/Tokyo）"
+msgstr "日付表示のタイムゾーン（例：Asia/Tokyo）"
 
 #: packages/admin/src/components/ContentList.tsx:577
 #: packages/admin/src/components/ContentList.tsx:737
@@ -8158,12 +8158,12 @@ msgstr "ヘッダー行を切り替え"
 #: packages/admin/src/components/ThemeToggle.tsx:31
 #: packages/admin/src/components/ThemeToggle.tsx:42
 msgid "Toggle theme (current: {label})"
-msgstr "テーマを切り替え（現在: {label}）"
+msgstr "テーマを切り替え（現在：{label}）"
 
 #. placeholder {0}: newToken.info.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:255
 msgid "Token created: {0}"
-msgstr "トークンを作成しました: {0}"
+msgstr "トークンを作成しました：{0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:481
 msgid "Token Name"
@@ -8312,7 +8312,7 @@ msgstr "タイプ"
 #. placeholder {0}: status.existingType
 #: packages/admin/src/components/WordPressImport.tsx:2018
 msgid "Type mismatch ({0})"
-msgstr "タイプの不一致 ({0})"
+msgstr "型の不一致（{0}）"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:56
 msgid "TypeScript"
@@ -8362,7 +8362,7 @@ msgstr "一意"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:107
 msgid "Unique identifier (ULID)"
-msgstr "一意識別子 (ULID)"
+msgstr "一意の識別子（ULID）"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:169
 #: packages/admin/src/components/users/useRolesConfig.ts:7
@@ -8371,7 +8371,7 @@ msgstr "不明"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:62
 msgid "Unknown role"
-msgstr "不明なロール"
+msgstr "不明な権限"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
@@ -8412,7 +8412,7 @@ msgstr "予約なし"
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128
 msgid "Unsupported widget element type: {0}"
-msgstr "サポートされていないウィジェット要素タイプ: {0}"
+msgstr "サポートされていないウィジェット要素タイプ：{0}"
 
 #: packages/admin/src/components/Dashboard.tsx:368
 msgid "Untitled"
@@ -8529,7 +8529,7 @@ msgstr "アップロードに失敗しました"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:669
 msgid "Upload failed: {uploadError}"
-msgstr "アップロード失敗: {uploadError}"
+msgstr "アップロード失敗：{uploadError}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:661
 msgid "Upload file"
@@ -8575,7 +8575,7 @@ msgstr "WordPressのエクスポートファイルをアップロード"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:289
 msgid "Uploaded:"
-msgstr "アップロード済み:"
+msgstr "アップロード済み："
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:80
 #: packages/admin/src/components/WordPressImport.tsx:2127
@@ -8608,7 +8608,7 @@ msgstr "URLに適した識別子"
 
 #: packages/admin/src/components/MenuList.tsx:165
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr "URLに適した識別子（例: \"primary\"、\"footer\"）"
+msgstr "URLに適した識別子（例：「primary」、「footer」）"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:295
 msgid "URL:"
@@ -8628,7 +8628,7 @@ msgstr "登録済みのパスキーで安全にサインインできます。"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:173
 msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
-msgstr "ページに画像がない場合のOpen Graph画像として使用されます。推奨サイズ: 1200×630。"
+msgstr "ページに画像がない場合のOpen Graph画像として使用されます。推奨サイズ：1200×630。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:828
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
@@ -8683,7 +8683,7 @@ msgstr "ドメインのユーザー:"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:196
 msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
-msgstr "これらのドメインのメールアドレスを持つユーザーは招待なしで登録できます。指定されたロールが自動的に割り当てられます。"
+msgstr "これらのドメインのメールアドレスを持つユーザーは招待なしで登録できます。指定した権限が自動的に設定されます。"
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:387
@@ -8805,7 +8805,7 @@ msgstr "パスワード不要のサインインリンクをお送りします。
 
 #: packages/admin/src/components/SignupPage.tsx:133
 msgid "We've sent a verification link to"
-msgstr "確認リンクを送信しました:"
+msgstr "確認リンクを送信しました："
 
 #: packages/admin/src/components/FieldEditor.tsx:264
 msgid "Web address"
@@ -8835,7 +8835,7 @@ msgstr "EmDashへようこそ！"
 
 #: packages/admin/src/components/WordPressImport.tsx:2091
 msgid "What happens when you import:"
-msgstr "インポート時の動作:"
+msgstr "インポート時の動作："
 
 #: packages/admin/src/components/WordPressImport.tsx:1874
 msgid "What will happen when you import"
@@ -8843,15 +8843,15 @@ msgstr "インポート時の動作"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:125
 msgid "When the entry was created"
-msgstr "エントリの作成日時"
+msgstr "コンテンツの作成日時"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:131
 msgid "When the entry was last modified"
-msgstr "エントリの最終更新日時"
+msgstr "コンテンツの最終更新日時"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:137
 msgid "When the entry was published"
-msgstr "エントリの公開日時"
+msgstr "コンテンツの公開日時"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:842
 msgid "Which content types can use this taxonomy"
@@ -9020,7 +9020,7 @@ msgstr "サイトの閲覧と投稿ができます。"
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
-msgstr "自分のロールは変更できません"
+msgstr "自分の権限は変更できません"
 
 #: packages/admin/src/components/WelcomeModal.tsx:47
 msgid "You have full access to manage this site, including users, settings, and all content."
@@ -9037,7 +9037,7 @@ msgstr "コメントを管理するには、編集者権限が必要です。"
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:199
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
-msgstr "\"{0}\"でサインインできなくなります。この操作は取り消せません。"
+msgstr "「{0}」ではサインインできなくなります。この操作は取り消せません。"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:200
 msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
@@ -9058,7 +9058,7 @@ msgstr "接続を認可するためにWordPressにリダイレクトされます
 
 #: packages/admin/src/components/SignupPage.tsx:192
 msgid "You'll be signing up as"
-msgstr "登録されるアカウント:"
+msgstr "登録されるアカウント："
 
 #: packages/admin/src/components/SetupWizard.tsx:564
 msgid "You're signed in via Cloudflare Access"
@@ -9127,7 +9127,7 @@ msgstr "名前（任意）"
 
 #: packages/admin/src/components/WelcomeModal.tsx:46
 msgid "Your Role"
-msgstr "あなたのロール"
+msgstr "あなたの権限"
 
 #. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
 #: packages/admin/src/components/RegistryPluginDetail.tsx:612
@@ -9136,7 +9136,7 @@ msgstr "サイトの設定により、リリースは公開から少なくとも
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:142
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr "Twitter/Xのハンドル名（例: @username）"
+msgstr "Twitter/Xのハンドル名（例：@username）"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:437
 msgid "Your unsaved media changes will be lost."

--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -15,11 +15,11 @@ msgstr ""
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Guest"
-msgstr ""
+msgstr " - ゲスト"
 
 #: packages/admin/src/routes/bylines.tsx:446
 msgid " - Linked"
-msgstr ""
+msgstr " - リンク済み"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:72
 #: packages/admin/src/components/TranslationsPanel.tsx:81
@@ -37,7 +37,7 @@ msgstr "（選択済み）"
 
 #: packages/admin/src/routes/bylines.tsx:706
 msgid "-- Select --"
-msgstr ""
+msgstr "-- 選択 --"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
@@ -56,7 +56,7 @@ msgstr "（{0}より）"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:533
 msgid "(pre-release)"
-msgstr ""
+msgstr "（プレリリース）"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:151
 msgid "(synced)"
@@ -64,7 +64,7 @@ msgstr "（同期済み）"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:536
 msgid "(too new)"
-msgstr ""
+msgstr "（対応バージョンより新しい）"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:310
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
@@ -83,7 +83,7 @@ msgstr "{0, plural, one {（#件）} other {（#件）}}"
 #: packages/admin/src/components/BylineFilter.tsx:103
 #: packages/admin/src/components/BylineFilter.tsx:104
 msgid "{0, plural, one {# byline} other {# bylines}}"
-msgstr ""
+msgstr "{0, plural, one {#件の署名} other {#件の署名}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
@@ -93,12 +93,12 @@ msgstr "{0, plural, one {#個のコレクション} other {#個のコレクシ�
 #. placeholder {0}: result.comments.imported
 #: packages/admin/src/components/WordPressImport.tsx:2263
 msgid "{0, plural, one {# comment imported} other {# comments imported}}"
-msgstr ""
+msgstr "{0, plural, one {#件のコメントをインポート} other {#件のコメントをインポート}}"
 
 #. placeholder {0}: result.affected
 #: packages/admin/src/router.tsx:1537
 msgid "{0, plural, one {# comment updated} other {# comments updated}}"
-msgstr ""
+msgstr "{0, plural, one {#件のコメントを更新} other {#件のコメントを更新}}"
 
 #. placeholder {0}: comments.length
 #: packages/admin/src/components/comments/CommentInbox.tsx:345
@@ -118,7 +118,7 @@ msgstr "{0, plural, one {#件のコンテンツをインポート} other {#件�
 #. placeholder {0}: selectedItems.length
 #: packages/admin/src/components/MediaPickerModal.tsx:787
 msgid "{0, plural, one {# item selected} other {# items selected}}"
-msgstr ""
+msgstr "{0, plural, one {#件のアイテムを選択} other {#件のアイテムを選択}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
@@ -130,7 +130,7 @@ msgstr "{0, plural, one {#件} other {#件}}"
 #. placeholder {0}: mcpTools.length
 #: packages/admin/src/components/PluginManager.tsx:420
 msgid "{0, plural, one {# MCP tool} other {# MCP tools}}"
-msgstr ""
+msgstr "{0, plural, one {#個のMCPツール} other {#個のMCPツール}}"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2279
@@ -145,7 +145,7 @@ msgstr "{0, plural, one {#件のメディアファイルをインポート} othe
 #. placeholder {0}: result.menus.created
 #: packages/admin/src/components/WordPressImport.tsx:2255
 msgid "{0, plural, one {# menu imported} other {# menus imported}}"
-msgstr ""
+msgstr "{0, plural, one {#件のメニューをインポート} other {#件のメニューをインポート}}"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1903
@@ -181,50 +181,50 @@ msgstr "{0, plural, one {#件スキップ（既に存在）} other {#件スキ�
 #. placeholder {0}: result.taxonomyAssignments
 #: packages/admin/src/components/WordPressImport.tsx:2247
 msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
-msgstr ""
+msgstr "{0, plural, one {#件のタクソノミー割り当て} other {#件のタクソノミー割り当て}}"
 
 #. placeholder {0}: result.taxonomiesCreated.length
 #: packages/admin/src/components/WordPressImport.tsx:2239
 msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
-msgstr ""
+msgstr "{0, plural, one {#件のタクソノミーを作成} other {#件のタクソノミーを作成}}"
 
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:600
 msgid "{0, plural, one {field} other {fields}}"
-msgstr ""
+msgstr "{0, plural, one {フィールド} other {フィールド}}"
 
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:213
 msgid "{0, plural, one {Media file} other {Media files}}"
-msgstr ""
+msgstr "{0, plural, one {メディアファイル} other {メディアファイル}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:217
 msgid "{0, plural, one {User} other {Users}}"
-msgstr ""
+msgstr "{0, plural, one {ユーザー} other {ユーザー}}"
 
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
 #. placeholder {2}: m.host
 #: packages/admin/src/components/RegistryPluginDetail.tsx:636
 msgid "{0} {1} required — you have {2}."
-msgstr ""
+msgstr "{0} {1}が必要です — 現在は{2}です。"
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-2xl font-semibold leading-tight">{t`Menus`}</h1> <p className="mt-1 text-sm leading-5 text-pretty text-kumo-subtle"> {t`Manage navigation menus for your site`} </p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ADMIN_NAV_ICONS.menus className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
 #: packages/admin/src/components/MenuList.tsx:218
 msgid "{0} • {1}"
-msgstr ""
+msgstr "{0} • {1}"
 
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:425
 msgid "{0} banner"
-msgstr ""
+msgstr "{0}バナー"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:228
 msgid "{0} can't be moved here — its parent has no translation in this locale, so this list isn't the group it belongs to."
-msgstr ""
+msgstr "{0}はここに移動できません — 親にこのロケールの翻訳がないため、このリストは所属先のグループではありません。"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1303
@@ -234,7 +234,7 @@ msgstr "{0}を検出"
 #. placeholder {0}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:356
 msgid "{0} fallback"
-msgstr ""
+msgstr "{0}のフォールバック"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:115
@@ -249,7 +249,7 @@ msgstr "{0}を削除しました"
 #. placeholder {0}: displayName ?? slug
 #: packages/admin/src/components/RegistryPluginDetail.tsx:437
 msgid "{0} icon"
-msgstr ""
+msgstr "{0}のアイコン"
 
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:213
@@ -275,17 +275,17 @@ msgstr "{0}件がインポートされます"
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:560
 msgid "{0} of {total} could not be deleted"
-msgstr ""
+msgstr "全{total}件中{0}件を削除できませんでした"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:516
 msgid "{0} of {total} could not be published"
-msgstr ""
+msgstr "全{total}件中{0}件を公開できませんでした"
 
 #. placeholder {0}: failedIds.length
 #: packages/admin/src/router.tsx:539
 msgid "{0} of {total} could not be updated"
-msgstr ""
+msgstr "全{total}件中{0}件を更新できませんでした"
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:179
@@ -302,7 +302,7 @@ msgstr "{0}プレビュー"
 #. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); const [routable, setRoutable] = React.useState(collection?.routable ?? true); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || routable !== (collection.routable ?? true) || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, routable, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, routable, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, routable, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="truncate text-2xl font-semibold"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && <span className="ms-2 text-kumo-info">{t`Defined in code`}</span>} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-kumo-info/50 bg-kumo-info-tint p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-kumo-info" /> <p className="text-sm text-kumo-subtle"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder={t`Post`} disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder={t`Posts`} disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <Switch checked={routable} onCheckedChange={setRoutable} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Routable`}</span> <p className="text-xs text-kumo-subtle"> {t`Require a slug before content can be published`} </p> </div> } /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>{t`Features`}</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && (isNew ? ( <Button type="submit" disabled={!hasChanges || !urlPatternValid} loading={isSaving} className="w-full justify-center" > {t`Create Content Type`} </Button> ) : ( <SaveButton type="submit" isDirty={!!hasChanges} isSaving={!!isSaving} announce={false} disabled={!urlPatternValid} className="w-full justify-center" /> ))} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
 #: packages/admin/src/components/ContentTypeEditor.tsx:598
 msgid "{0} system + {1} custom {2}"
-msgstr ""
+msgstr "{0}件のシステムフィールド + {1}件のカスタム{2}"
 
 #. placeholder {0}: taxonomy.label
 #: packages/admin/src/components/TaxonomySidebar.tsx:411
@@ -330,7 +330,7 @@ msgstr "{0}/160文字"
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:313
 msgid "{base} to: {0}"
-msgstr ""
+msgstr "{base}（接続先: {0}）"
 
 #: packages/admin/src/components/RevisionHistory.tsx:355
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
@@ -338,17 +338,17 @@ msgstr "{changedCount, plural, one {次のリビジョンから#件の変更} ot
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2512
 msgid "{characters, plural, one {# character} other {# characters}}"
-msgstr ""
+msgstr "{characters, plural, one {#文字} other {#文字}}"
 
 #. placeholder {0}: rows.length
 #: packages/admin/src/components/MediaUploadDialog.tsx:482
 msgid "{completedCount} of {0} complete"
-msgstr ""
+msgstr "{0}件中{completedCount}件が完了"
 
 #. placeholder {0}: rows.length
 #: packages/admin/src/components/MediaUploadDialog.tsx:367
 msgid "{completedCount} of {0} uploads complete"
-msgstr ""
+msgstr "{0}件のアップロード中{completedCount}件が完了"
 
 #: packages/admin/src/components/WordPressImport.tsx:2072
 msgid "{count, plural, one {# file} other {# files}}"
@@ -364,13 +364,13 @@ msgstr "{current}/{total}"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:369
 msgid "{failedCount, plural, one {# upload failed} other {# uploads failed}}"
-msgstr ""
+msgstr "{failedCount, plural, one {#件のアップロードに失敗} other {#件のアップロードに失敗}}"
 
 #. placeholder {0}: hasMore ? "+" : ""
 #. placeholder {1}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:1088
 msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
-msgstr ""
+msgstr "{filteredCount, plural, one {#{0}件のアイテム} other {#{1}件のアイテム}}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
@@ -382,7 +382,7 @@ msgstr "{label} — 翻訳を表示"
 
 #: packages/admin/src/components/ContentList.tsx:1077
 msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{matchCount, plural, one {「{searchQuery}」に一致する#件のアイテム} other {「{searchQuery}」に一致する#件のアイテム}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2473
 msgid "{matchedCount} of {totalCount} assigned"
@@ -402,15 +402,15 @@ msgstr "{needsNewFields, plural, one {#個の既存コレクションにフィ�
 
 #: packages/admin/src/components/Dashboard.tsx:102
 msgid "{overdueCount, plural, one {One scheduled item is overdue and the scheduler heartbeat is stale. Run `npx emdash doctor` and verify the deployed Cron Trigger.} other {# scheduled items are overdue and the scheduler heartbeat is stale. Run `npx emdash doctor` and verify the deployed Cron Trigger.}}"
-msgstr ""
+msgstr "{overdueCount, plural, one {公開予定のアイテムが1件期限を過ぎており、スケジューラーのハートビートも古くなっています。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。} other {公開予定のアイテムが#件期限を過ぎており、スケジューラーのハートビートも古くなっています。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。}}"
 
 #: packages/admin/src/components/Dashboard.tsx:97
 msgid "{overdueCount, plural, one {One scheduled item is overdue, but no scheduler run has completed. Run `npx emdash doctor` and verify the deployed Cron Trigger.} other {# scheduled items are overdue, but no scheduler run has completed. Run `npx emdash doctor` and verify the deployed Cron Trigger.}}"
-msgstr ""
+msgstr "{overdueCount, plural, one {公開予定のアイテムが1件期限を過ぎていますが、スケジューラーはまだ一度も完了していません。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。} other {公開予定のアイテムが#件期限を過ぎていますが、スケジューラーはまだ一度も完了していません。`npx emdash doctor`を実行し、デプロイ済みのCron Triggerを確認してください。}}"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:458
 msgid "{overflowCount, plural, one {# file was not added because the upload list is full.} other {# files were not added because the upload list is full.}}"
-msgstr ""
+msgstr "{overflowCount, plural, one {アップロード一覧が上限に達しているため、#件のファイルを追加できませんでした。} other {アップロード一覧が上限に達しているため、#件のファイルを追加できませんでした。}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:83
 msgid "{pluginName} is requesting additional permissions:"
@@ -424,27 +424,27 @@ msgstr "{pluginName}に以下の権限が必要です:"
 #: packages/admin/src/components/PluginSettings.tsx:142
 #: packages/admin/src/components/PluginSettings.tsx:170
 msgid "{pluginName} Settings"
-msgstr ""
+msgstr "{pluginName}の設定"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2513
 msgid "{readingTime, plural, one {# min read} other {# min read}}"
-msgstr ""
+msgstr "{readingTime, plural, one {読了時間#分} other {読了時間#分}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:263
 msgid "{resultCount, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{resultCount, plural, one {#件のアイテム} other {#件のアイテム}}"
 
 #: packages/admin/src/components/ContentList.tsx:474
 msgid "{selectedCount, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {#件を選択中} other {#件を選択中}}"
 
 #: packages/admin/src/components/ContentList.tsx:516
 msgid "{selectedCount, plural, one {Move # item to trash? You can restore it later.} other {Move # items to trash? You can restore them later.}}"
-msgstr ""
+msgstr "{selectedCount, plural, one {#件のアイテムをゴミ箱に移動しますか？後で復元できます。} other {#件のアイテムをゴミ箱に移動しますか？後で復元できます。}}"
 
 #: packages/admin/src/components/ContentList.tsx:1083
 msgid "{total, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{total, plural, one {#件のアイテム} other {#件のアイテム}}"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:150
 msgid "{total, plural, one {# total} other {# total}}"
@@ -452,11 +452,11 @@ msgstr "{total, plural, one {合計#件} other {合計#件}}"
 
 #: packages/admin/src/components/Dashboard.tsx:201
 msgid "{totalDrafts, plural, one {Draft} other {Drafts}}"
-msgstr ""
+msgstr "{totalDrafts, plural, one {下書き} other {下書き}}"
 
 #: packages/admin/src/components/Dashboard.tsx:207
 msgid "{totalScheduled, plural, one {Scheduled} other {Scheduled}}"
-msgstr ""
+msgstr "{totalScheduled, plural, one {公開予定} other {公開予定}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:367
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
@@ -468,15 +468,15 @@ msgstr "{unchangedCount, plural, one {変更なし#件を表示} other {変更�
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2511
 msgid "{words, plural, one {# word} other {# words}}"
-msgstr ""
+msgstr "{words, plural, one {#語} other {#語}}"
 
 #: packages/admin/src/components/Redirects.tsx:142
 msgid "/new-page or /articles/[slug]"
-msgstr ""
+msgstr "/new-page または /articles/[slug]"
 
 #: packages/admin/src/components/Redirects.tsx:133
 msgid "/old-page or /blog/[slug]"
-msgstr ""
+msgstr "/old-page または /blog/[slug]"
 
 #: packages/admin/src/components/WordPressImport.tsx:2093
 msgid "• Files are downloaded from your WordPress site"
@@ -559,11 +559,11 @@ msgstr "404エラー"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "410 Content Deleted (Gone)"
-msgstr ""
+msgstr "410 コンテンツ削除済み（Gone）"
 
 #: packages/admin/src/components/Redirects.tsx:161
 msgid "451 Unavailable for legal reasons"
-msgstr ""
+msgstr "451 法的理由により利用不可"
 
 #: packages/admin/src/components/WordPressImport.tsx:1526
 msgid "5. Copy the generated password"
@@ -583,11 +583,11 @@ msgstr "90日"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:417
 msgid "A brief description of this content type"
-msgstr ""
+msgstr "このコンテンツタイプの簡単な説明"
 
 #: packages/admin/src/components/Sections.tsx:203
 msgid "A full-width hero banner with heading, text, and CTA button"
-msgstr ""
+msgstr "見出し、テキスト、CTAボタンを備えた全幅のヒーローバナー"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:176
 msgid "A short description of your site"
@@ -595,7 +595,7 @@ msgstr "サイトの短い説明"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:455
 msgid "A source and target locale are required"
-msgstr ""
+msgstr "移行元と移行先のロケールが必要です"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:201
 msgid "Accept & Install"
@@ -607,20 +607,20 @@ msgstr "承認して更新"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:240
 msgid "Accept Invite"
-msgstr ""
+msgstr "招待を承諾"
 
 #: packages/admin/src/routes/byline-schema.tsx:174
 msgid "Access denied"
-msgstr ""
+msgstr "アクセスが拒否されました"
 
 #: packages/admin/src/router.tsx:1557
 msgid "Access Denied"
-msgstr ""
+msgstr "アクセスが拒否されました"
 
 #: packages/admin/src/lib/api/marketplace.ts:282
 #: packages/admin/src/lib/api/marketplace.ts:290
 msgid "Access your media library"
-msgstr ""
+msgstr "メディアライブラリへのアクセス"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
@@ -628,7 +628,7 @@ msgstr "アカウント"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:154
 msgid "Account already exists"
-msgstr ""
+msgstr "アカウントはすでに存在します"
 
 #: packages/admin/src/components/SignupPage.tsx:262
 msgid "Account exists"
@@ -640,7 +640,7 @@ msgstr "アカウント情報"
 
 #: packages/admin/src/components/WordPressImport.tsx:1158
 msgid "ACF Fields"
-msgstr ""
+msgstr "ACFフィールド"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/ContentList.tsx:617
@@ -669,7 +669,7 @@ msgstr "追加"
 #: packages/admin/src/components/TaxonomyManager.tsx:540
 #: packages/admin/src/components/TaxonomyManager.tsx:1041
 msgid "Add {0}"
-msgstr ""
+msgstr "{0}を追加"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:316
 msgid "Add {label}"
@@ -719,15 +719,15 @@ msgstr "フィールドを追加"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr ""
+msgstr "「役職」や「代名詞」などのフィールドを追加して、各署名の情報を充実させます。"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:628
 msgid "Add fields to define the structure of your content"
-msgstr ""
+msgstr "フィールドを追加してコンテンツの構造を定義します"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:631
 msgid "Add First Field"
-msgstr ""
+msgstr "最初のフィールドを追加"
 
 #: packages/admin/src/components/RepeaterField.tsx:174
 msgid "Add First Item"
@@ -735,15 +735,15 @@ msgstr "最初のアイテムを追加"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:200
 msgid "Add Images"
-msgstr ""
+msgstr "画像を追加"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:247
 msgid "Add images to gallery"
-msgstr ""
+msgstr "ギャラリーに画像を追加"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2124
 msgid "Add item"
-msgstr ""
+msgstr "アイテムを追加"
 
 #: packages/admin/src/components/RepeaterField.tsx:158
 msgid "Add Item"
@@ -751,7 +751,7 @@ msgstr "アイテムを追加"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3668
 msgid "Add link"
-msgstr ""
+msgstr "リンクを追加"
 
 #: packages/admin/src/components/MenuEditor.tsx:486
 msgid "Add links to build your navigation menu"
@@ -759,7 +759,7 @@ msgstr "ナビゲーションメニューを構築するためにリンクを追
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:162
 msgid "Add MIME type or extension"
-msgstr ""
+msgstr "MIMEタイプまたは拡張子を追加"
 
 #: packages/admin/src/components/ContentList.tsx:408
 msgid "Add New"
@@ -792,7 +792,7 @@ msgstr "前に行を追加"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:489
 msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
-msgstr ""
+msgstr "SEOメタデータフィールド（タイトル、説明、画像）を追加し、サイトマップに含めます"
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Add Sub-Field"
@@ -804,7 +804,7 @@ msgstr "タグを追加..."
 
 #: packages/admin/src/components/Widgets.tsx:403
 msgid "Add Widget Area"
-msgstr ""
+msgstr "ウィジェットエリアを追加"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:135
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
@@ -821,7 +821,7 @@ msgstr "インポートする追加データ。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1483
 msgid "admin"
-msgstr ""
+msgstr "管理者"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:102
 #: packages/admin/src/components/Sidebar.tsx:426
@@ -843,33 +843,33 @@ msgstr "送信後:"
 
 #: packages/admin/src/components/PluginManager.tsx:543
 msgid "Agent access"
-msgstr ""
+msgstr "エージェントアクセス"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:335
 msgid "Agent access for {0} has been updated"
-msgstr ""
+msgstr "{0}のエージェントアクセスを更新しました"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:139
 msgid "Agent-callable MCP tools"
-msgstr ""
+msgstr "エージェントから呼び出し可能なMCPツール"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4136
 msgid "Align Center"
-msgstr ""
+msgstr "中央揃え"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4129
 msgid "Align Left"
-msgstr ""
+msgstr "左揃え"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4143
 msgid "Align Right"
-msgstr ""
+msgstr "右揃え"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:324
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:513
 msgid "Alignment"
-msgstr ""
+msgstr "配置"
 
 #: packages/admin/src/components/ContentList.tsx:435
 msgid "All"
@@ -878,12 +878,12 @@ msgstr "すべて"
 #: packages/admin/src/components/ContentList.tsx:891
 #: packages/admin/src/components/ContentList.tsx:895
 msgid "All authors"
-msgstr ""
+msgstr "すべての著者"
 
 #: packages/admin/src/components/BylineFilter.tsx:101
 #: packages/admin/src/routes/bylines.tsx:412
 msgid "All bylines"
-msgstr ""
+msgstr "すべての署名"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:110
 msgid "All capabilities"
@@ -895,7 +895,7 @@ msgstr "すべてのコレクション"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:63
 msgid "All comments require approval"
-msgstr ""
+msgstr "すべてのコメントを承認待ちにする"
 
 #: packages/admin/src/components/WordPressImport.tsx:2518
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
@@ -926,11 +926,11 @@ msgstr "すべてのタイプ"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:371
 msgid "All uploads finished"
-msgstr ""
+msgstr "すべてのアップロードが完了しました"
 
 #: packages/admin/src/components/PluginManager.tsx:545
 msgid "Allow MCP tokens with plugin-tool scope to invoke these routes."
-msgstr ""
+msgstr "plugin-toolスコープを持つMCPトークンに、これらのルートの呼び出しを許可します。"
 
 #: packages/admin/src/components/Settings.tsx:77
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:150
@@ -939,7 +939,7 @@ msgstr "特定のドメインからのユーザー登録を許可"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:510
 msgid "Allow visitors to leave comments on this collection's content"
-msgstr ""
+msgstr "訪問者がこのコレクションのコンテンツにコメントできるようにします"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:195
 msgid "Allowed Domains"
@@ -947,7 +947,7 @@ msgstr "許可ドメイン"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:102
 msgid "Allowed types"
-msgstr ""
+msgstr "許可する種類"
 
 #: packages/admin/src/components/SignupPage.tsx:439
 msgid "Already have an account?"
@@ -959,13 +959,13 @@ msgstr "プラグインのストレージデータも削除"
 
 #: packages/admin/src/components/BylineFilter.tsx:175
 msgid "Also match the byline linked to an entry's author when it has none assigned."
-msgstr ""
+msgstr "署名が割り当てられていない場合、エントリの著者にリンクされた署名も一致対象にします。"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:376
 #: packages/admin/src/components/editor/ImageNode.tsx:231
 #: packages/admin/src/components/MediaLibrary.tsx:552
 msgid "Alt text"
-msgstr ""
+msgstr "代替テキスト"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:344
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:533
@@ -1040,11 +1040,11 @@ msgstr "エラーが発生しました"
 
 #: packages/admin/src/routes/byline-schema.tsx:272
 msgid "An unexpected error occurred."
-msgstr ""
+msgstr "予期しないエラーが発生しました。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:251
 msgid "An unknown error occurred"
-msgstr ""
+msgstr "不明なエラーが発生しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:1575
 msgid "Analyzing export file..."
@@ -1056,7 +1056,7 @@ msgstr "WordPressサイトを解析中..."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:105
 msgid "Any media type allowed (subject to global limits)."
-msgstr ""
+msgstr "すべてのメディアタイプを許可します（全体の制限は適用されます）。"
 
 #: packages/admin/src/components/Settings.tsx:82
 #: packages/admin/src/components/Settings.tsx:86
@@ -1067,7 +1067,7 @@ msgstr "APIトークン"
 
 #: packages/admin/src/components/Widgets.tsx:440
 msgid "Appears on posts and pages"
-msgstr ""
+msgstr "投稿とページに表示されます"
 
 #: packages/admin/src/components/WordPressImport.tsx:1490
 msgid "Application Password"
@@ -1075,17 +1075,17 @@ msgstr "アプリケーションパスワード"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4225
 msgid "Apply"
-msgstr ""
+msgstr "適用"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:181
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:182
 msgid "Apply language"
-msgstr ""
+msgstr "言語を適用"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3594
 #: packages/admin/src/components/PortableTextEditor.tsx:3595
 msgid "Apply link"
-msgstr ""
+msgstr "リンクを適用"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:148
 #: packages/admin/src/components/comments/CommentInbox.tsx:238
@@ -1108,17 +1108,17 @@ msgstr "任意のJSONデータ"
 #: packages/admin/src/components/ContentList.tsx:835
 #: packages/admin/src/components/ContentStatusBadge.tsx:65
 msgid "Archived"
-msgstr ""
+msgstr "アーカイブ済み"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 #: packages/admin/src/components/Widgets.tsx:158
 msgid "Archives"
-msgstr ""
+msgstr "アーカイブ"
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:375
 msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
-msgstr ""
+msgstr "「{0}」を削除しますか？このフィールドを参照する保存済みの値はありません。"
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:233
@@ -1128,7 +1128,7 @@ msgstr "\"{0}\"を削除しますか？このコレクション内のすべて�
 #. placeholder {0}: deleteFieldTarget.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:684
 msgid "Are you sure you want to delete the \"{0}\" field?"
-msgstr ""
+msgstr "「{0}」フィールドを削除しますか？"
 
 #: packages/admin/src/components/MenuList.tsx:257
 msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
@@ -1144,12 +1144,12 @@ msgstr "WordPressの著者をEmDashユーザーに割り当てます。投稿は
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:28
 msgid "Astro"
-msgstr ""
+msgstr "Astro"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 #: packages/admin/src/components/MediaLibrary.tsx:399
 msgid "Audio"
-msgstr ""
+msgstr "音声"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:277
@@ -1163,7 +1163,7 @@ msgstr "認証エラー: {error}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:254
 msgid "Authentication failed"
-msgstr ""
+msgstr "認証に失敗しました"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/SecuritySettings.tsx:111
@@ -1192,7 +1192,7 @@ msgstr "認可が拒否されました"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:105
 msgid "Authorization failed"
-msgstr ""
+msgstr "認可に失敗しました"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorize"
@@ -1208,7 +1208,7 @@ msgstr "認可中..."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:685
 msgid "Authors"
-msgstr ""
+msgstr "著者"
 
 #: packages/admin/src/components/Redirects.tsx:530
 msgid "auto"
@@ -1220,7 +1220,7 @@ msgstr "自動（スラッグ変更）"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:554
 msgid "Auto-approve authenticated users"
-msgstr ""
+msgstr "認証済みユーザーを自動承認"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:586
 msgid "Auto-generated from name (you can edit)"
@@ -1229,21 +1229,21 @@ msgstr "名前から自動生成（編集可能）"
 #: packages/admin/src/components/settings/BackupSettings.tsx:204
 #: packages/admin/src/components/settings/BackupSettings.tsx:260
 msgid "Automatic Backups"
-msgstr ""
+msgstr "自動バックアップ"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:261
 #: packages/admin/src/components/settings/BackupSettings.tsx:279
 msgid "Automatic backups need a storage backend (R2, S3, or local storage). Configure storage in your EmDash config to enable them."
-msgstr ""
+msgstr "自動バックアップにはストレージバックエンド（R2、S3、またはローカルストレージ）が必要です。有効にするにはEmDashの設定でストレージを構成してください。"
 
 #: packages/admin/src/router.tsx:1056
 msgid "Autosave failed"
-msgstr ""
+msgstr "自動保存に失敗しました"
 
 #. placeholder {0}: assignment.availableLocales.map((locale) => locale.toUpperCase()).join(", ")
 #: packages/admin/src/components/TaxonomySidebar.tsx:545
 msgid "Available in {0}"
-msgstr ""
+msgstr "{0}で利用可能"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:710
 msgid "Available media"
@@ -1255,12 +1255,12 @@ msgstr "利用可能なプロバイダー"
 
 #: packages/admin/src/components/Widgets.tsx:466
 msgid "Available Widgets"
-msgstr ""
+msgstr "利用可能なウィジェット"
 
 #: packages/admin/src/components/BylineAvatarField.tsx:46
 #: packages/admin/src/components/BylineAvatarField.tsx:71
 msgid "Avatar"
-msgstr ""
+msgstr "アバター"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:266
 #: packages/admin/src/components/MenuEditor.tsx:362
@@ -1275,7 +1275,7 @@ msgstr "{collectionLabel}一覧に戻る"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:337
 msgid "Back to Content Types"
-msgstr ""
+msgstr "コンテンツタイプに戻る"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:172
 #: packages/admin/src/components/LoginPage.tsx:118
@@ -1293,7 +1293,7 @@ msgstr "マーケットプレイスに戻る"
 #: packages/admin/src/components/PluginSettings.tsx:118
 #: packages/admin/src/components/RegistryPluginDetail.tsx:820
 msgid "Back to plugins"
-msgstr ""
+msgstr "プラグインに戻る"
 
 #: packages/admin/src/components/SectionEditor.tsx:74
 #: packages/admin/src/components/SectionEditor.tsx:175
@@ -1311,33 +1311,33 @@ msgstr "テーマに戻る"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:214
 msgid "Back up now"
-msgstr ""
+msgstr "今すぐバックアップ"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:214
 msgid "Backing up..."
-msgstr ""
+msgstr "バックアップ中..."
 
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:115
 msgid "Backup created: {0}"
-msgstr ""
+msgstr "バックアップを作成しました: {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:98
 msgid "Backup settings saved"
-msgstr ""
+msgstr "バックアップ設定を保存しました"
 
 #: packages/admin/src/components/Settings.tsx:101
 #: packages/admin/src/components/settings/BackupSettings.tsx:143
 msgid "Backups"
-msgstr ""
+msgstr "バックアップ"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:238
 msgid "Backups to keep"
-msgstr ""
+msgstr "保持するバックアップ数"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:29
 msgid "Bash"
-msgstr ""
+msgstr "Bash"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:186
 msgid "Before send:"
@@ -1350,16 +1350,16 @@ msgstr "Bing認証"
 
 #: packages/admin/src/routes/bylines.tsx:496
 msgid "Bio"
-msgstr ""
+msgstr "プロフィール"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:188
 msgid "Block actions - drag to reorder, click for menu"
-msgstr ""
+msgstr "ブロック操作 - ドラッグして並べ替え、クリックしてメニューを表示"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3618
 #: packages/admin/src/components/PortableTextEditor.tsx:4023
 msgid "Bold"
-msgstr ""
+msgstr "太字"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:55
 #: packages/admin/src/components/FieldEditor.tsx:203
@@ -1373,7 +1373,7 @@ msgstr "検索結果でタイトルの下に表示される概要"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:73
 msgid "Browse and install plugins published to the decentralized registry."
-msgstr ""
+msgstr "分散型レジストリで公開されているプラグインを参照してインストールします。"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:89
 msgid "Browse and install plugins to extend your site."
@@ -1381,7 +1381,7 @@ msgstr "プラグインを参照してインストールし、サイトを拡張
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:439
 msgid "Browse files"
-msgstr ""
+msgstr "ファイルを選択"
 
 #: packages/admin/src/components/WordPressImport.tsx:1124
 #: packages/admin/src/components/WordPressImport.tsx:1594
@@ -1390,7 +1390,7 @@ msgstr "ファイルを参照"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:448
 msgid "Browse files to upload"
-msgstr ""
+msgstr "アップロードするファイルを選択"
 
 #: packages/admin/src/components/PluginManager.tsx:204
 msgid "Browse the"
@@ -1409,11 +1409,11 @@ msgstr "箇条書きリスト"
 #: packages/admin/src/routes/byline-schema.tsx:218
 #: packages/admin/src/routes/bylines.tsx:383
 msgid "Byline schema"
-msgstr ""
+msgstr "署名スキーマ"
 
 #: packages/admin/src/components/Sidebar.tsx:295
 msgid "Byline Schema"
-msgstr ""
+msgstr "署名スキーマ"
 
 #: packages/admin/src/components/BylineFilter.tsx:135
 #: packages/admin/src/components/ContentSettingsPanel.tsx:661
@@ -1425,15 +1425,15 @@ msgstr "署名"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
-msgstr ""
+msgstr "C"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:32
 msgid "C#"
-msgstr ""
+msgstr "C#"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:31
 msgid "C++"
-msgstr ""
+msgstr "C++"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -1494,16 +1494,16 @@ msgstr "キャンセル"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:405
 msgid "Cancel (Esc)"
-msgstr ""
+msgstr "キャンセル（Esc）"
 
 #. placeholder {0}: row.file.name
 #: packages/admin/src/components/MediaUploadDialog.tsx:156
 msgid "Cancel {0}"
-msgstr ""
+msgstr "{0}をキャンセル"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:502
 msgid "Cancel remaining"
-msgstr ""
+msgstr "残りをキャンセル"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:141
 msgid "Cancel rename"
@@ -1515,7 +1515,7 @@ msgstr "テーマセクションは削除できません"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:456
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr ""
+msgstr "URLからMIMEタイプを判別できません。認識可能な画像拡張子（例: .jpg、.png、.webp）で終わるURLを使用してください。"
 
 #: packages/admin/src/components/SeoPanel.tsx:224
 #: packages/admin/src/components/SeoPanel.tsx:228
@@ -1539,7 +1539,7 @@ msgstr "キャプション"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:68
 msgid "Captions / Subtitles"
-msgstr ""
+msgstr "キャプション / 字幕"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:192
 #: packages/admin/src/components/Widgets.tsx:135
@@ -1553,11 +1553,11 @@ msgstr "カテゴリ ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1146
 msgid "Categories & Tags"
-msgstr ""
+msgstr "カテゴリーとタグ"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:161
 msgid "Center"
-msgstr ""
+msgstr "中央"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
@@ -1574,7 +1574,7 @@ msgstr "変更"
 #. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
 #: packages/admin/src/routes/users.tsx:296
 msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
-msgstr ""
+msgstr "<0>{0}</0>を<1>{1}</1>から<2>{2}</2>に変更しますか？上位レベルの機能にアクセスできなくなります。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:280
 msgid "Change Favicon"
@@ -1582,7 +1582,7 @@ msgstr "ファビコンを変更"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:203
 msgid "Change Image"
-msgstr ""
+msgstr "画像を変更"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:220
 msgid "Change Logo"
@@ -1590,11 +1590,11 @@ msgstr "ロゴを変更"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:808
 msgid "Changelog"
-msgstr ""
+msgstr "変更履歴"
 
 #: packages/admin/src/router.tsx:1107
 msgid "Changes discarded"
-msgstr ""
+msgstr "変更を破棄しました"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:167
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
@@ -1625,11 +1625,11 @@ msgstr "認証を確認中..."
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:362
 msgid "Checking how many stored values reference \"{0}\"…"
-msgstr ""
+msgstr "「{0}」を参照する保存済みの値の数を確認中…"
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
-msgstr ""
+msgstr "ログイン方法を選択"
 
 #: packages/admin/src/components/Settings.tsx:119
 msgid "Choose your preferred admin language"
@@ -1637,30 +1637,30 @@ msgstr "管理画面の言語を選択"
 
 #: packages/admin/src/components/ContentList.tsx:551
 msgid "Clear"
-msgstr ""
+msgstr "クリア"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:487
 msgid "Clear completed"
-msgstr ""
+msgstr "完了済みをクリア"
 
 #: packages/admin/src/components/ContentList.tsx:947
 #: packages/admin/src/components/MediaLibrary.tsx:460
 #: packages/admin/src/components/users/UserList.tsx:129
 msgid "Clear filters"
-msgstr ""
+msgstr "フィルターをクリア"
 
 #: packages/admin/src/components/MediaLibrary.tsx:460
 #: packages/admin/src/components/MediaLibrary.tsx:484
 msgid "Clear search"
-msgstr ""
+msgstr "検索をクリア"
 
 #: packages/admin/src/components/PluginSettings.tsx:354
 msgid "Clear stored value"
-msgstr ""
+msgstr "保存済みの値をクリア"
 
 #: packages/admin/src/components/PluginSettings.tsx:352
 msgid "Clear stored value for {fieldKey}"
-msgstr ""
+msgstr "{fieldKey}の保存済みの値をクリア"
 
 #: packages/admin/src/components/SignupPage.tsx:139
 msgid "Click the link in the email to continue setting up your account."
@@ -1734,11 +1734,11 @@ msgstr "閉じる"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:533
 msgid "Close comments after (days)"
-msgstr ""
+msgstr "コメントを自動的に閉じるまでの日数"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:178
 msgid "Close gallery settings"
-msgstr ""
+msgstr "ギャラリー設定を閉じる"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
@@ -1746,7 +1746,7 @@ msgstr "パネルを閉じる"
 
 #: packages/admin/src/components/ContentEditor.tsx:1085
 msgid "Close settings"
-msgstr ""
+msgstr "設定を閉じる"
 
 #: packages/admin/src/components/ContentTypeList.tsx:356
 #: packages/admin/src/components/PortableTextEditor.tsx:3660
@@ -1774,7 +1774,7 @@ msgstr "colleague@example.com"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
-msgstr ""
+msgstr "コレクション"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:106
 msgid "Collection:"
@@ -1790,7 +1790,7 @@ msgstr "作成されたコレクション:"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:185
 msgid "Columns"
-msgstr ""
+msgstr "列"
 
 #: packages/admin/src/components/SectionEditor.tsx:288
 msgid "Comma-separated keywords for search."
@@ -1813,11 +1813,11 @@ msgstr "コメント"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:557
 msgid "Comments from logged-in CMS users are approved automatically"
-msgstr ""
+msgstr "ログイン済みCMSユーザーのコメントを自動承認します"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:88
 msgid "Complete"
-msgstr ""
+msgstr "完了"
 
 #: packages/admin/src/components/SignupPage.tsx:403
 msgid "Complete signup"
@@ -1825,7 +1825,7 @@ msgstr "登録を完了"
 
 #: packages/admin/src/components/Widgets.tsx:931
 msgid "Component"
-msgstr ""
+msgstr "コンポーネント"
 
 #: packages/admin/src/components/FieldEditor.tsx:368
 msgid "Configure Field"
@@ -1838,7 +1838,7 @@ msgstr "確認"
 #: packages/admin/src/components/WordPressImport.tsx:701
 #: packages/admin/src/components/WordPressImport.tsx:1054
 msgid "Connect"
-msgstr ""
+msgstr "接続"
 
 #: packages/admin/src/components/WordPressImport.tsx:1507
 msgid "Connect & Analyze"
@@ -1860,7 +1860,7 @@ msgstr "{0}に接続済み"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:192
 msgid "content"
-msgstr ""
+msgstr "コンテンツ"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:378
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
@@ -1888,7 +1888,7 @@ msgstr "検出されたコンテンツ:"
 
 #: packages/admin/src/router.tsx:1129
 msgid "Content has been scheduled for publishing"
-msgstr ""
+msgstr "コンテンツの公開を予約しました"
 
 #: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Content has been updated to the selected revision."
@@ -1900,7 +1900,7 @@ msgstr "コンテンツID:"
 
 #: packages/admin/src/router.tsx:1070
 msgid "Content is now live"
-msgstr ""
+msgstr "コンテンツを公開しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:2371
 msgid "content items"
@@ -1908,11 +1908,11 @@ msgstr "コンテンツ"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:499
 msgid "Content locale"
-msgstr ""
+msgstr "コンテンツのロケール"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:510
 msgid "Content locale defaults to English"
-msgstr ""
+msgstr "コンテンツのロケールはデフォルトで英語です"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:47
 msgid "Content Read"
@@ -1920,11 +1920,11 @@ msgstr "コンテンツ読み取り"
 
 #: packages/admin/src/router.tsx:1088
 msgid "Content removed from public view"
-msgstr ""
+msgstr "コンテンツを公開表示から外しました"
 
 #: packages/admin/src/router.tsx:1150
 msgid "Content reverted to draft"
-msgstr ""
+msgstr "コンテンツを下書きに戻しました"
 
 #: packages/admin/src/components/RevisionHistory.tsx:314
 msgid "Content snapshot:"
@@ -1963,7 +1963,7 @@ msgstr "インポートを続行"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4087
 msgid "Continue numbering"
-msgstr ""
+msgstr "番号を継続"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -2001,7 +2001,7 @@ msgstr "トークンをコピー"
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:323
 #: packages/admin/src/components/MediaDetailPanel.tsx:301
 msgid "Copy URL"
-msgstr ""
+msgstr "URLをコピー"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:136
 msgid "Could not copy automatically. Please select the URL above and copy manually."
@@ -2009,11 +2009,11 @@ msgstr "自動コピーできませんでした。上のURLを選択して手動
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3357
 msgid "Could not insert section"
-msgstr ""
+msgstr "セクションを挿入できませんでした"
 
 #: packages/admin/src/components/Dashboard.tsx:124
 msgid "Could not load dashboard data"
-msgstr ""
+msgstr "ダッシュボードデータを読み込めませんでした"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:486
 msgid "Could not load image from URL"
@@ -2025,24 +2025,24 @@ msgstr "WordPressを検出できませんでした"
 
 #: packages/admin/src/routes/byline-schema.tsx:268
 msgid "Couldn't load byline fields."
-msgstr ""
+msgstr "署名フィールドを読み込めませんでした。"
 
 #: packages/admin/src/routes/bylines.tsx:547
 msgid "Couldn't load custom fields."
-msgstr ""
+msgstr "カスタムフィールドを読み込めませんでした。"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:88
 msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
-msgstr ""
+msgstr "「{draft}」をMIMEタイプに変換できませんでした。MIMEタイプを直接入力してください。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1009
 msgid "Couldn't search bylines. Please try again."
-msgstr ""
+msgstr "署名を検索できませんでした。もう一度お試しください。"
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
 msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
-msgstr ""
+msgstr "「{0}」を参照する値の数を確認できませんでした。削除すると、このフィールドに保存されているすべての値は引き続き削除されますが、上記の件数は確認できていません。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1049
 msgid "Count"
@@ -2060,12 +2060,12 @@ msgstr "作成"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:339
 msgid "Create \"{trimmedInput}\""
-msgstr ""
+msgstr "「{trimmedInput}」を作成"
 
 #. placeholder {0}: resolvedEntryLocale.toUpperCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:556
 msgid "Create {0} translation"
-msgstr ""
+msgstr "{0}の翻訳を作成"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1441
 msgid "Create a bullet list"
@@ -2096,11 +2096,11 @@ msgstr "署名を作成"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:575
 msgid "Create Content Type"
-msgstr ""
+msgstr "コンテンツタイプを作成"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Create field"
-msgstr ""
+msgstr "フィールドを作成"
 
 #: packages/admin/src/components/MenuList.tsx:129
 #: packages/admin/src/components/MenuList.tsx:192
@@ -2168,7 +2168,7 @@ msgstr "トークンを作成"
 
 #: packages/admin/src/components/Widgets.tsx:410
 msgid "Create Widget Area"
-msgstr ""
+msgstr "ウィジェットエリアを作成"
 
 #: packages/admin/src/components/SetupWizard.tsx:560
 msgid "Create your account"
@@ -2195,15 +2195,15 @@ msgstr "パスキーを作成"
 #: packages/admin/src/lib/api/marketplace.ts:280
 #: packages/admin/src/lib/api/marketplace.ts:289
 msgid "Create, update, and delete content"
-msgstr ""
+msgstr "コンテンツの作成、更新、削除"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:83
 msgid "Create, update, and delete navigation menus"
-msgstr ""
+msgstr "ナビゲーションメニューの作成、更新、削除"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:78
 msgid "Create, update, and delete taxonomy terms"
-msgstr ""
+msgstr "タクソノミー用語の作成、更新、削除"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:53
 msgid "Create, update, delete content"
@@ -2219,7 +2219,7 @@ msgstr "作成済み"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:96
 msgid "Created \"{0}\"."
-msgstr ""
+msgstr "「{0}」を作成しました。"
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:260
@@ -2229,7 +2229,7 @@ msgstr "作成日: {0}"
 #. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
 #: packages/admin/src/router.tsx:1181
 msgid "Created {0} translation"
-msgstr ""
+msgstr "{0}の翻訳を作成しました"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "Created At"
@@ -2251,7 +2251,7 @@ msgstr "作成中..."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:33
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:83
 msgid "current"
@@ -2263,7 +2263,7 @@ msgstr "現在"
 
 #: packages/admin/src/components/PluginSettings.tsx:340
 msgid "Currently set — enter a new value to replace"
-msgstr ""
+msgstr "現在設定済み — 置き換える新しい値を入力してください"
 
 #: packages/admin/src/components/Sections.tsx:46
 msgid "Custom"
@@ -2271,7 +2271,7 @@ msgstr "カスタム"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:638
 msgid "Custom Fields"
-msgstr ""
+msgstr "カスタムフィールド"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:262
 msgid "Custom robots.txt content. Leave empty to use the default."
@@ -2283,11 +2283,11 @@ msgstr "カスタムセクション"
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "Custom Taxonomies"
-msgstr ""
+msgstr "カスタムタクソノミー"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:223
 msgid "Daily automatic backups"
-msgstr ""
+msgstr "毎日の自動バックアップ"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
@@ -2321,7 +2321,7 @@ msgstr "日時ピッカー"
 
 #: packages/admin/src/components/ContentList.tsx:912
 msgid "Date field to filter on"
-msgstr ""
+msgstr "絞り込みに使用する日付フィールド"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:324
 msgid "Date Format"
@@ -2333,7 +2333,7 @@ msgstr "小数"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:750
 msgid "Declared permissions"
-msgstr ""
+msgstr "宣言された権限"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:345
@@ -2346,11 +2346,11 @@ msgstr "デフォルトロール:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:181
 msgid "Default social image"
-msgstr ""
+msgstr "デフォルトのソーシャル画像"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:172
 msgid "Default Social Image"
-msgstr ""
+msgstr "デフォルトのソーシャル画像"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:785
 msgid "Define a new taxonomy for classifying content"
@@ -2358,7 +2358,7 @@ msgstr "コンテンツを分類するための新しいタクソノミーを定
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr ""
+msgstr "すべての署名に保存されるカスタムフィールドを定義します — 役職、代名詞、ソーシャルハンドルなど。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:118
 msgid "Define the structure of your content"
@@ -2366,7 +2366,7 @@ msgstr "コンテンツの構造を定義"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:361
 msgid "Defined in code"
-msgstr ""
+msgstr "コードで定義"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:268
 #: packages/admin/src/components/comments/CommentInbox.tsx:408
@@ -2412,7 +2412,7 @@ msgstr "{0}を削除"
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:764
 msgid "Delete {0} field"
-msgstr ""
+msgstr "{0}フィールドを削除"
 
 #. placeholder {0}: menu.name
 #: packages/admin/src/components/MenuList.tsx:240
@@ -2422,7 +2422,7 @@ msgstr "{0}メニューを削除"
 #. placeholder {0}: area.label
 #: packages/admin/src/components/Widgets.tsx:664
 msgid "Delete {0} widget area"
-msgstr ""
+msgstr "{0}ウィジェットエリアを削除"
 
 #. placeholder {0}: taxonomyDef.labelSingular || "Term"
 #: packages/admin/src/components/TaxonomyManager.tsx:1108
@@ -2431,15 +2431,15 @@ msgstr "{0}を削除しますか？"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:350
 msgid "Delete backup?"
-msgstr ""
+msgstr "バックアップを削除しますか？"
 
 #: packages/admin/src/routes/byline-schema.tsx:358
 msgid "Delete byline field?"
-msgstr ""
+msgstr "署名フィールドを削除しますか？"
 
 #: packages/admin/src/routes/bylines.tsx:622
 msgid "Delete Byline?"
-msgstr ""
+msgstr "署名を削除しますか？"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3745
 msgid "Delete column"
@@ -2455,26 +2455,26 @@ msgstr "コンテンツタイプを削除しますか？"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:379
 msgid "Delete embed"
-msgstr ""
+msgstr "埋め込みを削除"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:681
 msgid "Delete Field?"
-msgstr ""
+msgstr "フィールドを削除しますか？"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:237
 #: packages/admin/src/components/editor/GalleryNode.tsx:219
 #: packages/admin/src/components/editor/GalleryNode.tsx:220
 msgid "Delete gallery"
-msgstr ""
+msgstr "ギャラリーを削除"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
 msgid "Delete HTML block"
-msgstr ""
+msgstr "HTMLブロックを削除"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:220
 #: packages/admin/src/components/editor/ImageNode.tsx:221
 msgid "Delete image"
-msgstr ""
+msgstr "画像を削除"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:451
 msgid "Delete Media?"
@@ -2524,7 +2524,7 @@ msgstr "テーブルを削除"
 
 #: packages/admin/src/components/Widgets.tsx:714
 msgid "Delete Widget Area?"
-msgstr ""
+msgstr "ウィジェットエリアを削除しますか？"
 
 #: packages/admin/src/components/ContentList.tsx:740
 msgid "Deleted"
@@ -2534,7 +2534,7 @@ msgstr "削除済み"
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr ""
+msgstr "「{0}」を削除すると、すべての署名から{1, plural, one {保存済みの値#件} other {保存済みの値#件}}も削除されます。この操作は取り消せません。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:409
 #: packages/admin/src/components/ContentTypeEditor.tsx:688
@@ -2553,7 +2553,7 @@ msgstr "削除中..."
 
 #: packages/admin/src/routes/byline-schema.tsx:379
 msgid "Deleting…"
-msgstr ""
+msgstr "削除中…"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:254
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
@@ -2562,15 +2562,15 @@ msgstr "デモ"
 
 #: packages/admin/src/routes/users.tsx:303
 msgid "Demote User"
-msgstr ""
+msgstr "ユーザーを降格"
 
 #: packages/admin/src/routes/users.tsx:294
 msgid "Demote User?"
-msgstr ""
+msgstr "ユーザーを降格しますか？"
 
 #: packages/admin/src/routes/users.tsx:304
 msgid "Demoting..."
-msgstr ""
+msgstr "降格中..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:270
 msgid "Deny"
@@ -2579,7 +2579,7 @@ msgstr "拒否"
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:379
 #: packages/admin/src/components/editor/ImageNode.tsx:238
 msgid "Describe the image..."
-msgstr ""
+msgstr "画像の説明を入力..."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:347
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:536
@@ -2614,7 +2614,7 @@ msgstr "転送先パス"
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:153
 #: packages/admin/src/components/PluginManager.tsx:564
 msgid "Destructive"
-msgstr ""
+msgstr "破壊的"
 
 #: packages/admin/src/components/PluginManager.tsx:506
 msgid "details"
@@ -2642,7 +2642,7 @@ msgstr "メールが届きませんでしたか？"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:34
 msgid "Diff"
-msgstr ""
+msgstr "Diff"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:280
 msgid "Dimensions:"
@@ -2658,7 +2658,7 @@ msgstr "プラグインを無効にする"
 
 #: packages/admin/src/components/PluginManager.tsx:554
 msgid "Disable plugin MCP tools"
-msgstr ""
+msgstr "プラグインのMCPツールを無効化"
 
 #: packages/admin/src/components/Redirects.tsx:513
 msgid "Disable redirect"
@@ -2666,11 +2666,11 @@ msgstr "リダイレクトを無効にする"
 
 #: packages/admin/src/routes/users.tsx:279
 msgid "Disable User"
-msgstr ""
+msgstr "ユーザーを無効化"
 
 #: packages/admin/src/routes/users.tsx:272
 msgid "Disable User?"
-msgstr ""
+msgstr "ユーザーを無効化しますか？"
 
 #: packages/admin/src/components/PluginManager.tsx:383
 #: packages/admin/src/components/Redirects.tsx:426
@@ -2686,15 +2686,15 @@ msgstr "無効:"
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #: packages/admin/src/routes/users.tsx:274
 msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
-msgstr ""
+msgstr "<0>{0}</0>を無効化すると、再度有効にするまでログインできなくなります。コンテンツは保持されます。"
 
 #: packages/admin/src/routes/users.tsx:280
 msgid "Disabling..."
-msgstr ""
+msgstr "無効化中..."
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:438
 msgid "Discard"
-msgstr ""
+msgstr "破棄"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:86
 #: packages/admin/src/components/ContentSettingsPanel.tsx:106
@@ -2703,7 +2703,7 @@ msgstr "変更を破棄"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:436
 msgid "Discard changes?"
-msgstr ""
+msgstr "変更を破棄しますか？"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:91
 msgid "Discard draft changes?"
@@ -2711,7 +2711,7 @@ msgstr "下書きの変更を破棄しますか？"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:439
 msgid "Discarding..."
-msgstr ""
+msgstr "破棄中..."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:267
 msgid "Dismiss"
@@ -2720,15 +2720,15 @@ msgstr "閉じる"
 #. placeholder {0}: row.file.name
 #: packages/admin/src/components/MediaUploadDialog.tsx:158
 msgid "Dismiss completed {0}"
-msgstr ""
+msgstr "完了した{0}を閉じる"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3371
 msgid "Dismiss section error"
-msgstr ""
+msgstr "セクションエラーを閉じる"
 
 #: packages/admin/src/components/Widgets.tsx:127
 msgid "Display a list of recent posts"
-msgstr ""
+msgstr "最近の投稿一覧を表示"
 
 #: packages/admin/src/components/Widgets.tsx:105
 msgid "Display a navigation menu"
@@ -2736,7 +2736,7 @@ msgstr "ナビゲーションメニューを表示"
 
 #: packages/admin/src/components/Widgets.tsx:136
 msgid "Display category list"
-msgstr ""
+msgstr "カテゴリー一覧を表示"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1092
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1154
@@ -2755,7 +2755,7 @@ msgstr "表示サイズ"
 
 #: packages/admin/src/components/Widgets.tsx:144
 msgid "Display tag cloud"
-msgstr ""
+msgstr "タグクラウドを表示"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:356
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:545
@@ -2772,12 +2772,12 @@ msgstr "区切り線"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:35
 msgid "Dockerfile"
-msgstr ""
+msgstr "Dockerfile"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 #: packages/admin/src/components/MediaLibrary.tsx:400
 msgid "Documents"
-msgstr ""
+msgstr "ドキュメント"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:284
 msgid "Domain"
@@ -2812,28 +2812,28 @@ msgstr "下へ"
 #. placeholder {0}: archive.name
 #: packages/admin/src/components/settings/BackupSettings.tsx:304
 msgid "Download {0}"
-msgstr ""
+msgstr "{0}をダウンロード"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:191
 msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
-msgstr ""
+msgstr "サイト全体のバックアップをダウンロードします。すべてのコンテンツ（下書きとゴミ箱を含む）、コレクション、タクソノミー、メニュー、ウィジェット、メディアメタデータ、サイト設定が含まれます。ユーザーアカウントとシークレットは含まれません。"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:195
 msgid "Download backup"
-msgstr ""
+msgstr "バックアップをダウンロード"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:187
 msgid "Download Backup"
-msgstr ""
+msgstr "バックアップをダウンロード"
 
 #: packages/admin/src/components/Settings.tsx:102
 #: packages/admin/src/components/settings/BackupSettings.tsx:144
 msgid "Download backups and schedule automatic backups to storage"
-msgstr ""
+msgstr "バックアップをダウンロードし、ストレージへの自動バックアップを設定します"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:492
 msgid "Download SBOM"
-msgstr ""
+msgstr "SBOMをダウンロード"
 
 #: packages/admin/src/components/WordPressImport.tsx:2126
 msgid "Downloading"
@@ -2855,11 +2855,11 @@ msgstr "下書き"
 
 #: packages/admin/src/components/WordPressImport.tsx:1166
 msgid "Drafts & Private"
-msgstr ""
+msgstr "下書きと非公開"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:427
 msgid "Drag and drop files here"
-msgstr ""
+msgstr "ここにファイルをドラッグ＆ドロップ"
 
 #: packages/admin/src/components/WordPressImport.tsx:1119
 msgid "Drag and drop or click to browse (.xml)"
@@ -2867,43 +2867,43 @@ msgstr "ドラッグ＆ドロップまたはクリックして参照（.xml）"
 
 #: packages/admin/src/components/Widgets.tsx:700
 msgid "Drag here to add"
-msgstr ""
+msgstr "ここにドラッグして追加"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2300
 msgid "Drag to reorder"
-msgstr ""
+msgstr "ドラッグして並べ替え"
 
 #. placeholder {0}: field.label
 #. placeholder {0}: widget.title ?? t`widget`
 #: packages/admin/src/components/ContentTypeEditor.tsx:731
 #: packages/admin/src/components/Widgets.tsx:802
 msgid "Drag to reorder {0}"
-msgstr ""
+msgstr "{0}をドラッグして並べ替え"
 
 #: packages/admin/src/components/SortableContentSettingsSections.tsx:219
 #: packages/admin/src/components/SortableContentSettingsSections.tsx:220
 msgid "Drag to reorder {label}"
-msgstr ""
+msgstr "{label}をドラッグして並べ替え"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:355
 msgid "Drag to reorder block"
-msgstr ""
+msgstr "ブロックをドラッグして並べ替え"
 
 #: packages/admin/src/components/Widgets.tsx:704
 msgid "Drag widgets here to add them"
-msgstr ""
+msgstr "ウィジェットをここにドラッグして追加"
 
 #: packages/admin/src/components/Widgets.tsx:467
 msgid "Drag widgets into an area to add them"
-msgstr ""
+msgstr "ウィジェットをエリアにドラッグして追加"
 
 #: packages/admin/src/components/MediaLibrary.tsx:316
 msgid "Drop files to upload"
-msgstr ""
+msgstr "ドロップしてアップロード"
 
 #: packages/admin/src/components/Widgets.tsx:700
 msgid "Drop to add widget"
-msgstr ""
+msgstr "ドロップしてウィジェットを追加"
 
 #: packages/admin/src/components/WordPressImport.tsx:1588
 msgid "Drop your WordPress export file here"
@@ -2911,7 +2911,7 @@ msgstr "WordPressのエクスポートファイルをここにドロップ"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:309
 msgid "Duplicate"
-msgstr ""
+msgstr "複製"
 
 #: packages/admin/src/components/ContentList.tsx:1224
 msgid "Duplicate {title}"
@@ -2919,11 +2919,11 @@ msgstr "{title}を複製"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr ""
+msgstr "例: application/zip または .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:168
 msgid "e.g. import, blog"
-msgstr ""
+msgstr "例: import、blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:484
 msgid "e.g., CI/CD Pipeline"
@@ -2959,11 +2959,11 @@ msgstr "{0}を編集"
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:756
 msgid "Edit {0} field"
-msgstr ""
+msgstr "{0}フィールドを編集"
 
 #: packages/admin/src/components/ContentEditor.tsx:672
 msgid "Edit {itemLabel}"
-msgstr ""
+msgstr "{itemLabel}を編集"
 
 #: packages/admin/src/components/ContentList.tsx:1216
 msgid "Edit {title}"
@@ -2975,7 +2975,7 @@ msgstr "署名を編集"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "Edit byline field"
-msgstr ""
+msgstr "署名フィールドを編集"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:321
 msgid "Edit Domain"
@@ -2988,11 +2988,11 @@ msgstr "フィールドを編集"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryNode.tsx:178
 msgid "Edit image {0}"
-msgstr ""
+msgstr "画像{0}を編集"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3668
 msgid "Edit link"
-msgstr ""
+msgstr "リンクを編集"
 
 #: packages/admin/src/components/MenuEditor.tsx:573
 msgid "Edit Menu Item"
@@ -3018,7 +3018,7 @@ msgstr "リダイレクト{0}を編集"
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:368
 msgid "Edit URL"
-msgstr ""
+msgstr "URLを編集"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
@@ -3030,11 +3030,11 @@ msgid ""
 "Editor\n"
 "Reporter\n"
 "Photographer"
-msgstr ""
+msgstr "編集者\n記者\n写真家"
 
 #: packages/admin/src/components/WordPressImport.tsx:1044
 msgid "em1.…"
-msgstr ""
+msgstr "em1.…"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:62
 #: packages/admin/src/components/Settings.tsx:95
@@ -3102,7 +3102,7 @@ msgstr "EmDash Exporterプラグインを検出しました！直接インポー
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:160
 msgid "Empty gallery — open settings to add images"
-msgstr ""
+msgstr "空のギャラリー — 設定を開いて画像を追加してください"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
@@ -3110,7 +3110,7 @@ msgstr "有効にする"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:508
 msgid "Enable comments"
-msgstr ""
+msgstr "コメントを有効化"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:87
 msgid "Enable full-text search on this collection"
@@ -3122,7 +3122,7 @@ msgstr "プラグインを有効にする"
 
 #: packages/admin/src/components/PluginManager.tsx:555
 msgid "Enable plugin MCP tools"
-msgstr ""
+msgstr "プラグインのMCPツールを有効化"
 
 #: packages/admin/src/components/Redirects.tsx:513
 msgid "Enable redirect"
@@ -3156,7 +3156,7 @@ msgstr "メールアドレスを入力"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
 msgid "Enter HTML..."
-msgstr ""
+msgstr "HTMLを入力..."
 
 #: packages/admin/src/components/ContentEditor.tsx:1266
 msgid "Enter markdown content..."
@@ -3173,11 +3173,11 @@ msgstr "ターミナルに表示されたコードを入力"
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:123
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:132
 msgid "Enter URL..."
-msgstr ""
+msgstr "URLを入力..."
 
 #: packages/admin/src/components/LoginPage.tsx:327
 msgid "Enter your handle to sign in."
-msgstr ""
+msgstr "ハンドルを入力してログインしてください。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1459
 msgid "Enter your WordPress credentials to import content directly."
@@ -3199,11 +3199,11 @@ msgstr "エラー"
 
 #: packages/admin/src/components/Widgets.tsx:236
 msgid "Error adding widget"
-msgstr ""
+msgstr "ウィジェットの追加エラー"
 
 #: packages/admin/src/components/Widgets.tsx:297
 msgid "Error reordering widgets"
-msgstr ""
+msgstr "ウィジェットの並べ替えエラー"
 
 #: packages/admin/src/components/SectionEditor.tsx:53
 msgid "Error saving section"
@@ -3211,20 +3211,20 @@ msgstr "セクションの保存エラー"
 
 #: packages/admin/src/components/Widgets.tsx:784
 msgid "Error updating widget"
-msgstr ""
+msgstr "ウィジェットの更新エラー"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:596
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
-msgstr ""
+msgstr "このプラグインで公開されたすべてのリリースは撤回されたか、検証できませんでした。後でもう一度確認するか、公開者にお問い合わせください。"
 
 #. placeholder {0}: formData.dateFormat ?? "MMMM d, yyyy"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:327
 msgid "Example: {0} → January 23, 2026"
-msgstr ""
+msgstr "例: {0} → 2026年1月23日"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:285
 msgid "example.com"
-msgstr ""
+msgstr "example.com"
 
 #: packages/admin/src/components/WordPressImport.tsx:2010
 msgid "Exists"
@@ -3236,7 +3236,7 @@ msgstr "集中モードを終了"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4261
 msgid "Exit Spotlight Mode"
-msgstr ""
+msgstr "スポットライトモードを終了"
 
 #: packages/admin/src/components/PluginManager.tsx:506
 msgid "Expand"
@@ -3281,28 +3281,28 @@ msgstr "ドメインの追加に失敗しました"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:175
 msgid "Failed to add passkey"
-msgstr ""
+msgstr "パスキーの追加に失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:413
 msgid "Failed to analyze WordPress site"
-msgstr ""
+msgstr "WordPressサイトの分析に失敗しました"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:54
 msgid "Failed to communicate with plugin"
-msgstr ""
+msgstr "プラグインとの通信に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:196
 msgid "Failed to confirm upload"
-msgstr ""
+msgstr "アップロードの確認に失敗しました"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
-msgstr ""
+msgstr "管理者の作成に失敗しました"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:122
 #: packages/admin/src/lib/api/backups.ts:51
 msgid "Failed to create backup"
-msgstr ""
+msgstr "バックアップの作成に失敗しました"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1135
 msgid "Failed to create byline"
@@ -3310,15 +3310,15 @@ msgstr "署名の作成に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:120
 msgid "Failed to create byline field"
-msgstr ""
+msgstr "署名フィールドの作成に失敗しました"
 
 #: packages/admin/src/routes/byline-schema.tsx:102
 msgid "Failed to create field"
-msgstr ""
+msgstr "フィールドの作成に失敗しました"
 
 #: packages/admin/src/lib/api/sections.ts:88
 msgid "Failed to create section"
-msgstr ""
+msgstr "セクションの作成に失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:1714
 msgid "Failed to create some collections"
@@ -3331,88 +3331,88 @@ msgstr "タームの作成に失敗しました"
 #: packages/admin/src/components/TaxonomySidebar.tsx:475
 #: packages/admin/src/router.tsx:1186
 msgid "Failed to create translation"
-msgstr ""
+msgstr "翻訳の作成に失敗しました"
 
 #: packages/admin/src/router.tsx:447
 #: packages/admin/src/router.tsx:476
 #: packages/admin/src/router.tsx:559
 #: packages/admin/src/router.tsx:1206
 msgid "Failed to delete"
-msgstr ""
+msgstr "削除に失敗しました"
 
 #: packages/admin/src/lib/api/users.ts:345
 msgid "Failed to delete allowed domain"
-msgstr ""
+msgstr "許可ドメインの削除に失敗しました"
 
 #: packages/admin/src/lib/api/backups.ts:58
 msgid "Failed to delete backup"
-msgstr ""
+msgstr "バックアップの削除に失敗しました"
 
 #: packages/admin/src/lib/api/bylines.ts:143
 msgid "Failed to delete byline"
-msgstr ""
+msgstr "署名の削除に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:143
 msgid "Failed to delete byline field"
-msgstr ""
+msgstr "署名フィールドの削除に失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:244
 msgid "Failed to delete collection"
-msgstr ""
+msgstr "コレクションの削除に失敗しました"
 
 #: packages/admin/src/lib/api/comments.ts:111
 #: packages/admin/src/router.tsx:1517
 msgid "Failed to delete comment"
-msgstr ""
+msgstr "コメントの削除に失敗しました"
 
 #: packages/admin/src/lib/api/content.ts:302
 msgid "Failed to delete content"
-msgstr ""
+msgstr "コンテンツの削除に失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:300
 #: packages/admin/src/routes/byline-schema.tsx:138
 msgid "Failed to delete field"
-msgstr ""
+msgstr "フィールドの削除に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:468
 msgid "Failed to delete from provider"
-msgstr ""
+msgstr "プロバイダーからの削除に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:335
 msgid "Failed to delete media"
-msgstr ""
+msgstr "メディアの削除に失敗しました"
 
 #: packages/admin/src/lib/api/menus.ts:163
 msgid "Failed to delete menu"
-msgstr ""
+msgstr "メニューの削除に失敗しました"
 
 #: packages/admin/src/lib/api/menus.ts:217
 msgid "Failed to delete menu item"
-msgstr ""
+msgstr "メニュー項目の削除に失敗しました"
 
 #: packages/admin/src/lib/api/users.ts:256
 msgid "Failed to delete passkey"
-msgstr ""
+msgstr "パスキーの削除に失敗しました"
 
 #: packages/admin/src/lib/api/redirects.ts:111
 msgid "Failed to delete redirect"
-msgstr ""
+msgstr "リダイレクトの削除に失敗しました"
 
 #: packages/admin/src/lib/api/sections.ts:110
 msgid "Failed to delete section"
-msgstr ""
+msgstr "セクションの削除に失敗しました"
 
 #: packages/admin/src/lib/api/taxonomies.ts:221
 msgid "Failed to delete term"
-msgstr ""
+msgstr "用語の削除に失敗しました"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
-msgstr ""
+msgstr "ウィジェットの削除に失敗しました"
 
 #: packages/admin/src/lib/api/widgets.ts:108
 msgid "Failed to delete widget area"
-msgstr ""
+msgstr "ウィジェットエリアの削除に失敗しました"
 
 #: packages/admin/src/components/PluginManager.tsx:120
 #: packages/admin/src/lib/api/plugins.ts:160
@@ -3421,23 +3421,23 @@ msgstr "プラグインの無効化に失敗しました"
 
 #: packages/admin/src/lib/api/search.ts:32
 msgid "Failed to disable search"
-msgstr ""
+msgstr "検索の無効化に失敗しました"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
-msgstr ""
+msgstr "ユーザーの無効化に失敗しました"
 
 #: packages/admin/src/router.tsx:1113
 msgid "Failed to discard changes"
-msgstr ""
+msgstr "変更の破棄に失敗しました"
 
 #: packages/admin/src/components/WelcomeModal.tsx:76
 msgid "Failed to dismiss welcome"
-msgstr ""
+msgstr "ウェルカム画面を閉じられませんでした"
 
 #: packages/admin/src/router.tsx:490
 msgid "Failed to duplicate"
-msgstr ""
+msgstr "複製に失敗しました"
 
 #: packages/admin/src/components/PluginManager.tsx:101
 #: packages/admin/src/lib/api/plugins.ts:146
@@ -3446,98 +3446,98 @@ msgstr "プラグインの有効化に失敗しました"
 
 #: packages/admin/src/lib/api/search.ts:31
 msgid "Failed to enable search"
-msgstr ""
+msgstr "検索の有効化に失敗しました"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
-msgstr ""
+msgstr "ユーザーの有効化に失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:340
 msgid "Failed to execute import"
-msgstr ""
+msgstr "インポートの実行に失敗しました"
 
 #: packages/admin/src/lib/api/client.ts:268
 msgid "Failed to fetch auth mode"
-msgstr ""
+msgstr "認証モードの取得に失敗しました"
 
 #: packages/admin/src/lib/api/backups.ts:37
 msgid "Failed to fetch backup settings"
-msgstr ""
+msgstr "バックアップ設定の取得に失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:192
 #: packages/admin/src/lib/api/schema.ts:196
 msgid "Failed to fetch collection"
-msgstr ""
+msgstr "コレクションの取得に失敗しました"
 
 #: packages/admin/src/lib/api/dashboard.ts:47
 msgid "Failed to fetch dashboard stats"
-msgstr ""
+msgstr "ダッシュボード統計の取得に失敗しました"
 
 #: packages/admin/src/lib/api/email-settings.ts:34
 msgid "Failed to fetch email settings"
-msgstr ""
+msgstr "メール設定の取得に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:140
 msgid "Failed to fetch entry terms"
-msgstr ""
+msgstr "エントリの用語の取得に失敗しました"
 
 #: packages/admin/src/lib/api/client.ts:251
 msgid "Failed to fetch manifest"
-msgstr ""
+msgstr "マニフェストの取得に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:80
 msgid "Failed to fetch media"
-msgstr ""
+msgstr "メディアの取得に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:93
 msgid "Failed to fetch media item"
-msgstr ""
+msgstr "メディア項目の取得に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:401
 msgid "Failed to fetch media providers"
-msgstr ""
+msgstr "メディアプロバイダーの取得に失敗しました"
 
 #: packages/admin/src/lib/api/plugins.ts:70
 #: packages/admin/src/lib/api/plugins.ts:74
 msgid "Failed to fetch plugin"
-msgstr ""
+msgstr "プラグインの取得に失敗しました"
 
 #: packages/admin/src/lib/api/plugins.ts:114
 msgid "Failed to fetch plugin settings"
-msgstr ""
+msgstr "プラグイン設定の取得に失敗しました"
 
 #: packages/admin/src/lib/api/plugins.ts:56
 msgid "Failed to fetch plugins"
-msgstr ""
+msgstr "プラグイン一覧の取得に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:431
 msgid "Failed to fetch provider media"
-msgstr ""
+msgstr "プロバイダーのメディア取得に失敗しました"
 
 #: packages/admin/src/lib/api/content.ts:579
 #: packages/admin/src/lib/api/content.ts:584
 msgid "Failed to fetch revision"
-msgstr ""
+msgstr "リビジョンの取得に失敗しました"
 
 #: packages/admin/src/lib/api/sections.ts:76
 msgid "Failed to fetch section"
-msgstr ""
+msgstr "セクションの取得に失敗しました"
 
 #: packages/admin/src/lib/api/sections.ts:68
 msgid "Failed to fetch sections"
-msgstr ""
+msgstr "セクション一覧の取得に失敗しました"
 
 #: packages/admin/src/lib/api/settings.ts:50
 msgid "Failed to fetch settings"
-msgstr ""
+msgstr "設定の取得に失敗しました"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
-msgstr ""
+msgstr "セットアップ状態の取得に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:124
 msgid "Failed to fetch terms"
-msgstr ""
+msgstr "用語の取得に失敗しました"
 
 #: packages/admin/src/lib/api/current-user.ts:22
 #: packages/admin/src/lib/api/users.ts:88
@@ -3545,7 +3545,7 @@ msgstr ""
 #: packages/admin/src/router.tsx:906
 #: packages/admin/src/router.tsx:1448
 msgid "Failed to fetch user"
-msgstr ""
+msgstr "ユーザーの取得に失敗しました"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:263
 msgid "Failed to generate preview"
@@ -3557,37 +3557,37 @@ msgstr "プレビューURLの生成に失敗しました"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:176
 msgid "Failed to get authentication options"
-msgstr ""
+msgstr "認証オプションの取得に失敗しました"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
 msgid "Failed to get registration options"
-msgstr ""
+msgstr "登録オプションの取得に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:168
 msgid "Failed to get upload URL"
-msgstr ""
+msgstr "アップロードURLの取得に失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:436
 msgid "Failed to import from WordPress"
-msgstr ""
+msgstr "WordPressからのインポートに失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:365
 #: packages/admin/src/lib/api/import.ts:422
 msgid "Failed to import media"
-msgstr ""
+msgstr "メディアのインポートに失敗しました"
 
 #: packages/admin/src/lib/api/marketplace.ts:208
 #: packages/admin/src/lib/api/registry.ts:702
 msgid "Failed to install plugin"
-msgstr ""
+msgstr "プラグインのインストールに失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:98
 msgid "Failed to list byline fields"
-msgstr ""
+msgstr "署名フィールド一覧の取得に失敗しました"
 
 #: packages/admin/src/router.tsx:287
 msgid "Failed to load admin"
-msgstr ""
+msgstr "管理画面の読み込みに失敗しました"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:184
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:185
@@ -3596,12 +3596,12 @@ msgstr "許可ドメインの読み込みに失敗しました"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:165
 msgid "Failed to load backup settings"
-msgstr ""
+msgstr "バックアップ設定の読み込みに失敗しました"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "Failed to load bylines: {0}"
-msgstr ""
+msgstr "署名の読み込みに失敗しました: {0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:80
 #: packages/admin/src/components/settings/EmailSettings.tsx:81
@@ -3610,7 +3610,7 @@ msgstr "メール設定の読み込みに失敗しました"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:465
 msgid "Failed to load image"
-msgstr ""
+msgstr "画像の読み込みに失敗しました"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:123
 msgid "Failed to load passkeys"
@@ -3622,7 +3622,7 @@ msgstr "プラグインの読み込みに失敗しました"
 
 #: packages/admin/src/components/PluginSettings.tsx:146
 msgid "Failed to load plugin settings"
-msgstr ""
+msgstr "プラグイン設定の読み込みに失敗しました"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:149
@@ -3631,7 +3631,7 @@ msgstr "プラグインの読み込みに失敗しました: {0}"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:98
 msgid "Failed to load plugins. The registry aggregator may be unreachable."
-msgstr ""
+msgstr "プラグインを読み込めませんでした。レジストリアグリゲーターに接続できない可能性があります。"
 
 #: packages/admin/src/components/RevisionHistory.tsx:198
 msgid "Failed to load revisions"
@@ -3648,32 +3648,32 @@ msgstr "テーマの読み込みに失敗しました"
 #. placeholder {0}: usersQuery.error.message
 #: packages/admin/src/routes/users.tsx:205
 msgid "Failed to load users: {0}"
-msgstr ""
+msgstr "ユーザーの読み込みに失敗しました: {0}"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:46
 msgid "Failed to load widget"
-msgstr ""
+msgstr "ウィジェットの読み込みに失敗しました"
 
 #: packages/admin/src/router.tsx:1542
 msgid "Failed to perform bulk action"
-msgstr ""
+msgstr "一括操作に失敗しました"
 
 #: packages/admin/src/lib/api/content.ts:345
 msgid "Failed to permanently delete content"
-msgstr ""
+msgstr "コンテンツの完全削除に失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:321
 msgid "Failed to prepare import"
-msgstr ""
+msgstr "インポートの準備に失敗しました"
 
 #: packages/admin/src/router.tsx:515
 #: packages/admin/src/router.tsx:1074
 msgid "Failed to publish"
-msgstr ""
+msgstr "公開に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:106
 msgid "Failed to read byline field usage"
-msgstr ""
+msgstr "署名フィールドの使用状況を読み取れませんでした"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:115
 msgid "Failed to remove domain"
@@ -3690,41 +3690,41 @@ msgstr "パスキーの名前変更に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:156
 msgid "Failed to reorder byline fields"
-msgstr ""
+msgstr "署名フィールドの並べ替えに失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:332
 msgid "Failed to reorder content types"
-msgstr ""
+msgstr "コンテンツタイプの並べ替えに失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:315
 #: packages/admin/src/routes/byline-schema.tsx:152
 msgid "Failed to reorder fields"
-msgstr ""
+msgstr "フィールドの並べ替えに失敗しました"
 
 #: packages/admin/src/lib/api/widgets.ts:158
 msgid "Failed to reorder widgets"
-msgstr ""
+msgstr "ウィジェットの並べ替えに失敗しました"
 
 #: packages/admin/src/router.tsx:462
 msgid "Failed to restore"
-msgstr ""
+msgstr "復元に失敗しました"
 
 #: packages/admin/src/lib/api/content.ts:334
 msgid "Failed to restore content"
-msgstr ""
+msgstr "コンテンツの復元に失敗しました"
 
 #: packages/admin/src/lib/api/content.ts:601
 #: packages/admin/src/lib/api/content.ts:606
 msgid "Failed to restore revision"
-msgstr ""
+msgstr "リビジョンの復元に失敗しました"
 
 #: packages/admin/src/lib/api/api-tokens.ts:99
 msgid "Failed to revoke API token"
-msgstr ""
+msgstr "APIトークンの取り消しに失敗しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:378
 msgid "Failed to rewrite URLs"
-msgstr ""
+msgstr "URLの書き換えに失敗しました"
 
 #: packages/admin/src/router.tsx:714
 #: packages/admin/src/router.tsx:996
@@ -3734,11 +3734,11 @@ msgstr "保存に失敗しました"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:102
 msgid "Failed to save backup settings"
-msgstr ""
+msgstr "バックアップ設定の保存に失敗しました"
 
 #: packages/admin/src/routes/byline-schema.tsx:122
 msgid "Failed to save field"
-msgstr ""
+msgstr "フィールドの保存に失敗しました"
 
 #: packages/admin/src/components/PluginSettings.tsx:74
 #: packages/admin/src/components/settings/GeneralSettings.tsx:77
@@ -3749,7 +3749,7 @@ msgstr "設定の保存に失敗しました"
 
 #: packages/admin/src/router.tsx:1134
 msgid "Failed to schedule"
-msgstr ""
+msgstr "公開予約に失敗しました"
 
 #: packages/admin/src/components/LoginPage.tsx:71
 #: packages/admin/src/components/LoginPage.tsx:76
@@ -3758,7 +3758,7 @@ msgstr "マジックリンクの送信に失敗しました"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
-msgstr ""
+msgstr "復旧リンクの送信に失敗しました"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:44
 #: packages/admin/src/lib/api/email-settings.ts:45
@@ -3767,28 +3767,28 @@ msgstr "テストメールの送信に失敗しました"
 
 #: packages/admin/src/components/SignupPage.tsx:351
 msgid "Failed to send verification email"
-msgstr ""
+msgstr "確認メールの送信に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:159
 msgid "Failed to set entry terms"
-msgstr ""
+msgstr "エントリへの用語設定に失敗しました"
 
 #: packages/admin/src/lib/api/marketplace.ts:249
 #: packages/admin/src/lib/api/registry.ts:858
 msgid "Failed to uninstall plugin"
-msgstr ""
+msgstr "プラグインのアンインストールに失敗しました"
 
 #: packages/admin/src/router.tsx:1092
 msgid "Failed to unpublish"
-msgstr ""
+msgstr "非公開化に失敗しました"
 
 #: packages/admin/src/router.tsx:1155
 msgid "Failed to unschedule"
-msgstr ""
+msgstr "公開予約の解除に失敗しました"
 
 #: packages/admin/src/router.tsx:538
 msgid "Failed to update"
-msgstr ""
+msgstr "更新に失敗しました"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:415
@@ -3797,7 +3797,7 @@ msgstr "{0}の更新に失敗しました"
 
 #: packages/admin/src/lib/api/backups.ts:46
 msgid "Failed to update backup settings"
-msgstr ""
+msgstr "バックアップ設定の更新に失敗しました"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1185
 msgid "Failed to update byline"
@@ -3805,7 +3805,7 @@ msgstr "署名の更新に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:135
 msgid "Failed to update byline field"
-msgstr ""
+msgstr "署名フィールドの更新に失敗しました"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:98
 msgid "Failed to update domain"
@@ -3813,56 +3813,56 @@ msgstr "ドメインの更新に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:352
 msgid "Failed to update media"
-msgstr ""
+msgstr "メディアの更新に失敗しました"
 
 #: packages/admin/src/lib/api/marketplace.ts:232
 #: packages/admin/src/lib/api/registry.ts:776
 msgid "Failed to update plugin"
-msgstr ""
+msgstr "プラグインの更新に失敗しました"
 
 #: packages/admin/src/lib/api/plugins.ts:172
 msgid "Failed to update plugin MCP access"
-msgstr ""
+msgstr "プラグインのMCPアクセス更新に失敗しました"
 
 #: packages/admin/src/lib/api/plugins.ts:133
 msgid "Failed to update plugin settings"
-msgstr ""
+msgstr "プラグイン設定の更新に失敗しました"
 
 #: packages/admin/src/lib/api/sections.ts:100
 msgid "Failed to update section"
-msgstr ""
+msgstr "セクションの更新に失敗しました"
 
 #: packages/admin/src/lib/api/settings.ts:64
 msgid "Failed to update settings"
-msgstr ""
+msgstr "設定の更新に失敗しました"
 
 #: packages/admin/src/router.tsx:1501
 msgid "Failed to update status"
-msgstr ""
+msgstr "ステータスの更新に失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:219
 msgid "Failed to upload file"
-msgstr ""
+msgstr "ファイルのアップロードに失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:286
 msgid "Failed to upload media"
-msgstr ""
+msgstr "メディアのアップロードに失敗しました"
 
 #: packages/admin/src/lib/api/media.ts:456
 msgid "Failed to upload to provider"
-msgstr ""
+msgstr "プロバイダーへのアップロードに失敗しました"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:248
 msgid "Failed to verify authentication"
-msgstr ""
+msgstr "認証の検証に失敗しました"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
 msgid "Failed to verify registration"
-msgstr ""
+msgstr "登録の検証に失敗しました"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:807
 msgid "FAQ"
-msgstr ""
+msgstr "よくある質問"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:251
 #: packages/admin/src/components/settings/GeneralSettings.tsx:258
@@ -3875,7 +3875,7 @@ msgstr "機能"
 
 #: packages/admin/src/components/WordPressImport.tsx:1148
 msgid "Featured Images"
-msgstr ""
+msgstr "アイキャッチ画像"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:455
 #: packages/admin/src/components/ContentTypeList.tsx:187
@@ -3888,11 +3888,11 @@ msgstr "EmDash Exporter APIからコンテンツを取得中。"
 
 #: packages/admin/src/routes/byline-schema.tsx:95
 msgid "Field created"
-msgstr ""
+msgstr "フィールドを作成しました"
 
 #: packages/admin/src/routes/byline-schema.tsx:133
 msgid "Field deleted"
-msgstr ""
+msgstr "フィールドを削除しました"
 
 #: packages/admin/src/components/FieldEditor.tsx:596
 msgid "Field label"
@@ -3908,15 +3908,15 @@ msgstr "フィールドスラッグは作成後に変更できません"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:268
 msgid "Field type cannot be changed after creation."
-msgstr ""
+msgstr "作成後にフィールドタイプを変更することはできません。"
 
 #: packages/admin/src/routes/byline-schema.tsx:115
 msgid "Field updated"
-msgstr ""
+msgstr "フィールドを更新しました"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:596
 msgid "Fields"
-msgstr ""
+msgstr "フィールド"
 
 #: packages/admin/src/components/WordPressImport.tsx:2333
 msgid "Fields created:"
@@ -3951,15 +3951,15 @@ msgstr "ファイルをインポート済み"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:399
 msgid "Files upload as soon as you add them."
-msgstr ""
+msgstr "ファイルは追加するとすぐにアップロードされます。"
 
 #: packages/admin/src/components/ContentList.tsx:887
 msgid "Filter by author"
-msgstr ""
+msgstr "著者で絞り込む"
 
 #: packages/admin/src/components/BylineFilter.tsx:111
 msgid "Filter by byline"
-msgstr ""
+msgstr "署名で絞り込む"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:115
 msgid "Filter by capability"
@@ -3971,33 +3971,33 @@ msgstr "コレクションでフィルタ"
 
 #: packages/admin/src/components/users/UserList.tsx:82
 msgid "Filter by role"
-msgstr ""
+msgstr "ロールで絞り込む"
 
 #: packages/admin/src/components/Sections.tsx:245
 msgid "Filter by source"
-msgstr ""
+msgstr "ソースで絞り込む"
 
 #: packages/admin/src/components/ContentList.tsx:869
 #: packages/admin/src/components/Redirects.tsx:427
 msgid "Filter by status"
-msgstr ""
+msgstr "ステータスで絞り込む"
 
 #: packages/admin/src/components/MediaLibrary.tsx:402
 #: packages/admin/src/components/Redirects.tsx:433
 msgid "Filter by type"
-msgstr ""
+msgstr "種類で絞り込む"
 
 #: packages/admin/src/routes/bylines.tsx:408
 msgid "Filter byline type"
-msgstr ""
+msgstr "署名タイプで絞り込む"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
-msgstr ""
+msgstr "初回コメント投稿者のみ"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:69
 msgid "Fonts"
-msgstr ""
+msgstr "フォント"
 
 #: packages/admin/src/components/WordPressImport.tsx:1398
 msgid "For a complete import including drafts and all content, export from WordPress."
@@ -4009,12 +4009,12 @@ msgstr "最適なインポートのために、以下をインストールして
 
 #: packages/admin/src/components/ContentList.tsx:928
 msgid "From date"
-msgstr ""
+msgstr "開始日"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:164
 #: packages/admin/src/components/WordPressImport.tsx:1155
 msgid "Full"
-msgstr ""
+msgstr "全幅"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -4027,12 +4027,12 @@ msgstr "管理者フルアクセス"
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:171
 #: packages/admin/src/components/PortableTextEditor.tsx:2709
 msgid "Gallery"
-msgstr ""
+msgstr "ギャラリー"
 
 #: packages/admin/src/components/editor/GalleryNode.tsx:207
 #: packages/admin/src/components/editor/GalleryNode.tsx:208
 msgid "Gallery settings"
-msgstr ""
+msgstr "ギャラリー設定"
 
 #: packages/admin/src/components/Settings.tsx:48
 msgid "General"
@@ -4044,7 +4044,7 @@ msgstr "一般設定"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:810
 msgid "Genres"
-msgstr ""
+msgstr "ジャンル"
 
 #: packages/admin/src/components/WelcomeModal.tsx:154
 msgid "Get Started"
@@ -4060,7 +4060,7 @@ msgstr "後で識別しやすいように、このパスキーに名前を付け
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:36
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: packages/admin/src/components/WordPressImport.tsx:2418
 #: packages/admin/src/router.tsx:2277
@@ -4074,7 +4074,7 @@ msgstr "Google認証"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:37
 msgid "GraphQL"
-msgstr ""
+msgstr "GraphQL"
 
 #: packages/admin/src/components/MediaLibrary.tsx:423
 msgid "Grid view"
@@ -4086,15 +4086,15 @@ msgstr "グループ（任意）"
 
 #: packages/admin/src/components/Widgets.tsx:162
 msgid "Group by"
-msgstr ""
+msgstr "グループ化"
 
 #: packages/admin/src/routes/bylines.tsx:555
 msgid "Guest byline"
-msgstr ""
+msgstr "ゲスト署名"
 
 #: packages/admin/src/routes/bylines.tsx:413
 msgid "Guest only"
-msgstr ""
+msgstr "ゲストのみ"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:63
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:32
@@ -4118,24 +4118,24 @@ msgstr "見出し3"
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:35
 #: packages/admin/src/components/PortableTextEditor.tsx:1410
 msgid "Heading 4"
-msgstr ""
+msgstr "見出し4"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:95
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:36
 #: packages/admin/src/components/PortableTextEditor.tsx:1420
 msgid "Heading 5"
-msgstr ""
+msgstr "見出し5"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:103
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:37
 #: packages/admin/src/components/PortableTextEditor.tsx:1430
 msgid "Heading 6"
-msgstr ""
+msgstr "見出し6"
 
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:142
 #: packages/admin/src/components/editor/HeadingDropdownMenu.tsx:158
 msgid "Headings"
-msgstr ""
+msgstr "見出し"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:308
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:497
@@ -4144,11 +4144,11 @@ msgstr "高さ"
 
 #: packages/admin/src/components/Sections.tsx:180
 msgid "Hero Banner"
-msgstr ""
+msgstr "ヒーローバナー"
 
 #: packages/admin/src/components/SectionEditor.tsx:286
 msgid "hero, banner, cta"
-msgstr ""
+msgstr "ヒーロー、バナー、CTA"
 
 #: packages/admin/src/components/SeoPanel.tsx:242
 #: packages/admin/src/components/SeoPanel.tsx:245
@@ -4189,16 +4189,16 @@ msgstr "アプリケーションパスワードの作成方法"
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
 #: packages/admin/src/components/PortableTextEditor.tsx:1480
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
 msgid "HTML source"
-msgstr ""
+msgstr "HTMLソース"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3581
 #: packages/admin/src/components/PortableTextEditor.tsx:4191
 msgid "https://..."
-msgstr ""
+msgstr "https://..."
 
 #: packages/admin/src/components/MenuEditor.tsx:424
 msgid "https://example.com or /about"
@@ -4206,11 +4206,11 @@ msgstr "https://example.com または /about"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:555
 msgid "https://example.com/image.jpg"
-msgstr ""
+msgstr "https://example.com/image.jpg"
 
 #: packages/admin/src/components/WordPressImport.tsx:1089
 msgid "https://yoursite.com"
-msgstr ""
+msgstr "https://yoursite.com"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:243
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:153
@@ -4234,7 +4234,7 @@ msgstr "画像"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:294
 msgid "Image {0}"
-msgstr ""
+msgstr "画像{0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:234
 msgid "Image from media library"
@@ -4244,12 +4244,12 @@ msgstr "メディアライブラリから画像"
 #: packages/admin/src/components/ImageFieldRenderer.tsx:131
 #: packages/admin/src/components/ImageFieldRenderer.tsx:199
 msgid "Image not found"
-msgstr ""
+msgstr "画像が見つかりません"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:208
 #: packages/admin/src/components/editor/ImageNode.tsx:209
 msgid "Image settings"
-msgstr ""
+msgstr "画像設定"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:225
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:410
@@ -4272,7 +4272,7 @@ msgstr "画像URLを更新:"
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:192
 #: packages/admin/src/components/MediaLibrary.tsx:397
 msgid "Images"
-msgstr ""
+msgstr "画像"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:226
 #: packages/admin/src/components/Sidebar.tsx:333
@@ -4344,7 +4344,7 @@ msgstr "コレクション別インポート"
 #. placeholder {0}: wpImportProgress.comments
 #: packages/admin/src/components/WordPressImport.tsx:903
 msgid "Importing comments... {0}"
-msgstr ""
+msgstr "コメントをインポート中... {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:920
 msgid "Importing content..."
@@ -4353,12 +4353,12 @@ msgstr "コンテンツをインポート中..."
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:901
 msgid "Importing content... {0}"
-msgstr ""
+msgstr "コンテンツをインポート中... {0}"
 
 #. placeholder {0}: wpImportProgress.processed
 #: packages/admin/src/components/WordPressImport.tsx:900
 msgid "Importing content... {0} of {totalSelectedPosts}"
-msgstr ""
+msgstr "コンテンツをインポート中... {0}/{totalSelectedPosts}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2139
 msgid "Importing Media"
@@ -4366,11 +4366,11 @@ msgstr "メディアをインポート中"
 
 #: packages/admin/src/components/WordPressImport.tsx:904
 msgid "Importing menus and site settings..."
-msgstr ""
+msgstr "メニューとサイト設定をインポート中..."
 
 #: packages/admin/src/components/BylineFilter.tsx:172
 msgid "Include inferred bylines"
-msgstr ""
+msgstr "推測された署名を含める"
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
@@ -4383,11 +4383,11 @@ msgstr "非互換"
 #: packages/admin/src/components/FieldEditor.tsx:481
 #: packages/admin/src/components/RegistryPluginDetail.tsx:506
 msgid "Indexed"
-msgstr ""
+msgstr "インデックス済み"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4051
 msgid "Inline Code"
-msgstr ""
+msgstr "インラインコード"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:567
 #: packages/admin/src/components/MediaPickerModal.tsx:811
@@ -4397,7 +4397,7 @@ msgstr "挿入"
 #. placeholder {0}: block?.label || ""
 #: packages/admin/src/components/PortableTextEditor.tsx:1905
 msgid "Insert {0}"
-msgstr ""
+msgstr "{0}を挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1461
 msgid "Insert a blockquote"
@@ -4425,20 +4425,20 @@ msgstr "画像を挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2710
 msgid "Insert an image gallery"
-msgstr ""
+msgstr "画像ギャラリーを挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1733
 msgid "Insert block"
-msgstr ""
+msgstr "ブロックを挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4003
 #: packages/admin/src/components/PortableTextEditor.tsx:4013
 msgid "Insert block after current block"
-msgstr ""
+msgstr "現在のブロックの後にブロックを挿入"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:170
 msgid "Insert block below"
-msgstr ""
+msgstr "下にブロックを挿入"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:549
 msgid "Insert from URL"
@@ -4446,20 +4446,20 @@ msgstr "URLから挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4117
 msgid "Insert HTML"
-msgstr ""
+msgstr "HTMLを挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4114
 msgid "Insert Image"
-msgstr ""
+msgstr "画像を挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4161
 #: packages/admin/src/components/PortableTextEditor.tsx:4175
 msgid "Insert Link"
-msgstr ""
+msgstr "リンクを挿入"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1481
 msgid "Insert raw HTML"
-msgstr ""
+msgstr "生のHTMLを挿入"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:58
 msgid "Insert Section"
@@ -4484,11 +4484,11 @@ msgstr "インストールがブロックされました"
 
 #: packages/admin/src/components/WordPressImport.tsx:1039
 msgid "Install the EmDash Exporter plugin on your WordPress site and generate a key under Tools → EmDash Migration."
-msgstr ""
+msgstr "WordPressサイトにEmDash Exporterプラグインをインストールし、［ツール］→［EmDash Migration］でキーを生成してください。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:806
 msgid "Installation"
-msgstr ""
+msgstr "インストール"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:263
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:184
@@ -4517,7 +4517,7 @@ msgstr "整数"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:152
 msgid "Invalid invite link"
-msgstr ""
+msgstr "無効な招待リンク"
 
 #: packages/admin/src/components/ContentEditor.tsx:1562
 msgid "Invalid JSON"
@@ -4529,11 +4529,11 @@ msgstr "無効なリンク"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:241
 msgid "Invite Error"
-msgstr ""
+msgstr "招待エラー"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:150
 msgid "Invite expired"
-msgstr ""
+msgstr "招待の有効期限が切れています"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 msgid "Invite Link Created"
@@ -4546,20 +4546,20 @@ msgstr "ユーザーを招待"
 
 #: packages/admin/src/components/users/UserList.tsx:140
 msgid "Invite your first team member"
-msgstr ""
+msgstr "最初のチームメンバーを招待"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:98
 msgid "Invoke MCP tools from all enabled plugins"
-msgstr ""
+msgstr "有効なすべてのプラグインからMCPツールを呼び出す"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:517
 msgid "Invoke only this plugin's enabled MCP tools"
-msgstr ""
+msgstr "このプラグインで有効なMCPツールのみを呼び出す"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3625
 #: packages/admin/src/components/PortableTextEditor.tsx:4030
 msgid "Italic"
-msgstr ""
+msgstr "斜体"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:2286
@@ -4586,19 +4586,19 @@ msgstr "山田太郎"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:39
 msgid "Java"
-msgstr ""
+msgstr "Java"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:40
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:235
 msgid "Job title"
-msgstr ""
+msgstr "役職"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:246
 msgid "job_title"
-msgstr ""
+msgstr "job_title"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:41
 #: packages/admin/src/components/FieldEditor.tsx:251
@@ -4607,15 +4607,15 @@ msgstr "JSON"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:42
 msgid "JSX"
-msgstr ""
+msgstr "JSX"
 
 #: packages/admin/src/components/WordPressImport.tsx:916
 msgid "Keep this tab open. The import runs in small steps and can be safely re-run if interrupted."
-msgstr ""
+msgstr "このタブを開いたままにしてください。インポートは小さな単位で実行され、中断しても安全に再実行できます。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1014
 msgid "Keep typing to narrow down more bylines."
-msgstr ""
+msgstr "入力を続けて署名をさらに絞り込んでください。"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283
@@ -4625,7 +4625,7 @@ msgstr "キーワード"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:43
 msgid "Kotlin"
-msgstr ""
+msgstr "Kotlin"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:232
 #: packages/admin/src/components/FieldEditor.tsx:437
@@ -4641,11 +4641,11 @@ msgstr "ラベル"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:393
 msgid "Label (Plural)"
-msgstr ""
+msgstr "ラベル（複数形）"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:385
 msgid "Label (Singular)"
-msgstr ""
+msgstr "ラベル（単数形）"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:162
 #: packages/admin/src/components/LoginPage.tsx:347
@@ -4669,7 +4669,7 @@ msgstr "最終ログイン"
 
 #: packages/admin/src/components/users/UserList.tsx:107
 msgid "Last Login"
-msgstr ""
+msgstr "最終ログイン"
 
 #: packages/admin/src/components/Redirects.tsx:227
 msgid "Last seen"
@@ -4691,7 +4691,7 @@ msgstr "最終使用日: {0}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:337
 msgid "Learn more"
-msgstr ""
+msgstr "詳細"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:339
 msgid "Leave blank to use a discoverable passkey."
@@ -4703,7 +4703,7 @@ msgstr "未割り当てのまま"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:160
 msgid "Left"
-msgstr ""
+msgstr "左"
 
 #: packages/admin/src/components/MediaLibrary.tsx:134
 #: packages/admin/src/components/MediaLibrary.tsx:240
@@ -4728,7 +4728,7 @@ msgstr "ライト"
 
 #: packages/admin/src/components/Widgets.tsx:165
 msgid "Limit"
-msgstr ""
+msgstr "上限"
 
 #: packages/admin/src/components/SignupPage.tsx:258
 msgid "Link expired"
@@ -4745,11 +4745,11 @@ msgstr "リンクされたアカウント ({0})"
 
 #: packages/admin/src/routes/bylines.tsx:414
 msgid "Linked only"
-msgstr ""
+msgstr "リンク済みのみ"
 
 #: packages/admin/src/routes/bylines.tsx:506
 msgid "Linked user"
-msgstr ""
+msgstr "リンク済みユーザー"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:171
 msgid "LinkedIn"
@@ -4788,11 +4788,11 @@ msgstr "もっと読み込む"
 
 #: packages/admin/src/router.tsx:2232
 msgid "Loading"
-msgstr ""
+msgstr "読み込み中"
 
 #: packages/admin/src/routes/byline-schema.tsx:257
 msgid "Loading byline fields…"
-msgstr ""
+msgstr "署名フィールドを読み込み中…"
 
 #: packages/admin/src/components/ContentTypeList.tsx:198
 msgid "Loading collections..."
@@ -4805,7 +4805,7 @@ msgstr "コメントを読み込み中..."
 #: packages/admin/src/router.tsx:2234
 #: packages/admin/src/router.tsx:2246
 msgid "Loading configuration..."
-msgstr ""
+msgstr "設定を読み込み中..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:164
 msgid "Loading content..."
@@ -4813,7 +4813,7 @@ msgstr "コンテンツを読み込み中..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3344
 msgid "Loading editor..."
-msgstr ""
+msgstr "エディターを読み込み中..."
 
 #: packages/admin/src/components/MenuEditor.tsx:342
 msgid "Loading menu..."
@@ -4853,7 +4853,7 @@ msgstr "タームを読み込み中..."
 
 #: packages/admin/src/components/Widgets.tsx:372
 msgid "Loading widgets..."
-msgstr ""
+msgstr "ウィジェットを読み込み中..."
 
 #: packages/admin/src/components/ContentList.tsx:627
 #: packages/admin/src/components/ContentList.tsx:724
@@ -4882,7 +4882,7 @@ msgstr "読み込み中..."
 
 #: packages/admin/src/components/BylineFilter.tsx:136
 msgid "Loading…"
-msgstr ""
+msgstr "読み込み中…"
 
 #: packages/admin/src/components/ContentList.tsx:599
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
@@ -4898,7 +4898,7 @@ msgstr "アスペクト比を固定"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:291
 msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
-msgstr ""
+msgstr "保存済みの値があるため、このフィールドはロックされています。変更するには、値またはフィールドを削除してください。"
 
 #: packages/admin/src/components/Header.tsx:109
 msgid "Log out"
@@ -4915,7 +4915,7 @@ msgstr "ロゴとファビコン"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:53
 msgid "Long text"
-msgstr ""
+msgstr "長文テキスト"
 
 #: packages/admin/src/components/FieldEditor.tsx:185
 #: packages/admin/src/components/FieldEditor.tsx:609
@@ -4932,17 +4932,17 @@ msgstr "半角小文字で始まる、半角小文字・数字・アンダース
 
 #: packages/admin/src/components/Widgets.tsx:436
 msgid "Main Sidebar"
-msgstr ""
+msgstr "メインサイドバー"
 
 #: packages/admin/src/lib/api/marketplace.ts:285
 #: packages/admin/src/lib/api/marketplace.ts:293
 msgid "Make network requests"
-msgstr ""
+msgstr "ネットワークリクエストを実行"
 
 #: packages/admin/src/lib/api/marketplace.ts:286
 #: packages/admin/src/lib/api/marketplace.ts:294
 msgid "Make network requests to any host (unrestricted)"
-msgstr ""
+msgstr "任意のホストへネットワークリクエストを実行（制限なし）"
 
 #: packages/admin/src/components/Sidebar.tsx:418
 msgid "Manage"
@@ -4956,11 +4956,11 @@ msgstr "{1}の{0}を管理"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:976
 msgid "Manage bylines in {entryLocale}"
-msgstr ""
+msgstr "{entryLocale}の署名を管理"
 
 #: packages/admin/src/components/Widgets.tsx:390
 msgid "Manage content widgets in your widget areas"
-msgstr ""
+msgstr "ウィジェットエリアのコンテンツウィジェットを管理"
 
 #: packages/admin/src/components/PluginManager.tsx:160
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
@@ -4981,11 +4981,11 @@ msgstr "パスキーと認証の管理"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:317
 msgid "Managed by {providerName}"
-msgstr ""
+msgstr "{providerName}が管理"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:318
 msgid "Managed by an external media provider"
-msgstr ""
+msgstr "外部メディアプロバイダーが管理"
 
 #: packages/admin/src/components/Redirects.tsx:432
 msgid "Manual"
@@ -4998,16 +4998,16 @@ msgstr "著者のマッピング"
 #. placeholder {0}: mapping.wpLogin
 #: packages/admin/src/components/WordPressImport.tsx:2502
 msgid "Map WordPress user {0} to EmDash user"
-msgstr ""
+msgstr "WordPressユーザー{0}をEmDashユーザーに割り当て"
 
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:256
 msgid "Mark {0} as Gone (410)"
-msgstr ""
+msgstr "{0}をGone（410）に設定"
 
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr ""
+msgstr "Gone（410）に設定 — 完全に削除されたことを検索エンジンに通知します"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:502
 msgid "Mark as spam"
@@ -5015,7 +5015,7 @@ msgstr "スパムとしてマーク"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:44
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 #: packages/admin/src/components/PluginManager.tsx:206
 msgid "marketplace"
@@ -5042,11 +5042,11 @@ msgstr "最大値"
 
 #: packages/admin/src/components/Widgets.tsx:147
 msgid "Maximum tags"
-msgstr ""
+msgstr "タグの最大数"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:45
 msgid "MDX"
-msgstr ""
+msgstr "MDX"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2698
 #: packages/admin/src/components/PortableTextEditor.tsx:2713
@@ -5104,7 +5104,7 @@ msgstr "メニュー"
 #. placeholder {1}: translated.locale.toUpperCase()
 #: packages/admin/src/components/MenuEditor.tsx:144
 msgid "Menu \"{0}\" ({1}) created."
-msgstr ""
+msgstr "メニュー「{0}」（{1}）を作成しました。"
 
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:56
@@ -5153,7 +5153,7 @@ msgstr "メニュー ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:82
 msgid "Menus Manage"
-msgstr ""
+msgstr "メニュー管理"
 
 #: packages/admin/src/components/SeoPanel.tsx:199
 #: packages/admin/src/components/SeoPanel.tsx:203
@@ -5174,7 +5174,7 @@ msgstr "メタタイトル、ディスクリプション、ソーシャル画像
 
 #: packages/admin/src/components/WordPressImport.tsx:1051
 msgid "Migration key"
-msgstr ""
+msgstr "移行キー"
 
 #: packages/admin/src/components/FieldEditor.tsx:649
 msgid "Min Items"
@@ -5190,11 +5190,11 @@ msgstr "最小値"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1421
 msgid "Minor section heading"
-msgstr ""
+msgstr "小見出し"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:519
 msgid "Moderation"
-msgstr ""
+msgstr "モデレーション"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
@@ -5206,29 +5206,29 @@ msgstr "コレクションスキーマを変更"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Monthly"
-msgstr ""
+msgstr "月別"
 
 #: packages/admin/src/components/Widgets.tsx:159
 msgid "Monthly/yearly archives"
-msgstr ""
+msgstr "月別/年別アーカイブ"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:184
 msgid "More information about {label}"
-msgstr ""
+msgstr "{label}の詳細情報"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
-msgstr ""
+msgstr "人気順"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:439
 msgid "Move \"{0}\" down"
-msgstr ""
+msgstr "「{0}」を下へ移動"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:429
 msgid "Move \"{0}\" up"
-msgstr ""
+msgstr "「{0}」を上へ移動"
 
 #: packages/admin/src/components/ContentList.tsx:1245
 msgid "Move \"{title}\" to trash? You can restore it later."
@@ -5237,22 +5237,22 @@ msgstr "\"{title}\"をゴミ箱に移動しますか？後で復元できます�
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:251
 msgid "Move {0} down"
-msgstr ""
+msgstr "{0}を下へ移動"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Move {0} down — unavailable, its parent has no translation in this locale"
-msgstr ""
+msgstr "{0}を下へ移動 — 親にこのロケールの翻訳がないため利用できません"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:238
 msgid "Move {0} up"
-msgstr ""
+msgstr "{0}を上へ移動"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:237
 msgid "Move {0} up — unavailable, its parent has no translation in this locale"
-msgstr ""
+msgstr "{0}を上へ移動 — 親にこのロケールの翻訳がないため利用できません"
 
 #: packages/admin/src/components/ContentList.tsx:1236
 msgid "Move {title} to trash"
@@ -5264,7 +5264,7 @@ msgstr "下に移動"
 
 #: packages/admin/src/components/ContentList.tsx:509
 msgid "Move to trash"
-msgstr ""
+msgstr "ゴミ箱に移動"
 
 #: packages/admin/src/components/ContentList.tsx:536
 #: packages/admin/src/components/ContentList.tsx:1258
@@ -5285,11 +5285,11 @@ msgstr "上に移動"
 
 #: packages/admin/src/router.tsx:535
 msgid "Moved {total} items to draft"
-msgstr ""
+msgstr "{total}件のアイテムを下書きに移動しました"
 
 #: packages/admin/src/router.tsx:556
 msgid "Moved {total} items to trash"
-msgstr ""
+msgstr "{total}件のアイテムをゴミ箱に移動しました"
 
 #: packages/admin/src/components/FieldEditor.tsx:221
 msgid "Multi Select"
@@ -5338,11 +5338,11 @@ msgstr "なし"
 
 #: packages/admin/src/router.tsx:1181
 msgid "new"
-msgstr ""
+msgstr "新規"
 
 #: packages/admin/src/routes/bylines.tsx:426
 msgid "New"
-msgstr ""
+msgstr "新規"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:111
 msgid "NEW"
@@ -5355,11 +5355,11 @@ msgstr "新しい{0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:672
 msgid "New {itemLabel}"
-msgstr ""
+msgstr "新しい{itemLabel}"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
-msgstr ""
+msgstr "新しい署名フィールド"
 
 #: packages/admin/src/components/WordPressImport.tsx:1982
 msgid "New collection"
@@ -5372,11 +5372,11 @@ msgstr "新しいコンテンツタイプ"
 
 #: packages/admin/src/routes/byline-schema.tsx:224
 msgid "New field"
-msgstr ""
+msgstr "新しいフィールド"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:122
 msgid "New public routes"
-msgstr ""
+msgstr "新しい公開ルート"
 
 #: packages/admin/src/components/Redirects.tsx:106
 #: packages/admin/src/components/Redirects.tsx:370
@@ -5405,11 +5405,11 @@ msgstr "新しいウィンドウ"
 #: packages/admin/src/components/MarketplaceBrowse.tsx:44
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
 msgid "Newest"
-msgstr ""
+msgstr "新しい順"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:570
 msgid "News"
-msgstr ""
+msgstr "ニュース"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
 msgid "Next"
@@ -5432,7 +5432,7 @@ msgstr "いいえ"
 
 #: packages/admin/src/routes/byline-schema.tsx:420
 msgid "No (shared across translations)"
-msgstr ""
+msgstr "いいえ（翻訳間で共有）"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:576
@@ -5468,24 +5468,24 @@ msgstr "承認済みのコメントはまだありません。"
 
 #: packages/admin/src/components/BylineFilter.tsx:99
 msgid "No byline"
-msgstr ""
+msgstr "署名なし"
 
 #: packages/admin/src/components/BylineFilter.tsx:131
 msgid "No byline assigned"
-msgstr ""
+msgstr "署名が割り当てられていません"
 
 #: packages/admin/src/routes/byline-schema.tsx:291
 msgid "No byline fields yet."
-msgstr ""
+msgstr "署名フィールドはまだありません。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:968
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr ""
+msgstr "{entryLocale}で利用できる署名がありません。このエントリにクレジットを追加する前に、署名ページでこのロケールのバリエーションを作成してください。"
 
 #: packages/admin/src/components/BylineFilter.tsx:139
 #: packages/admin/src/routes/bylines.tsx:452
 msgid "No bylines found"
-msgstr ""
+msgstr "署名が見つかりません"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1076
 msgid "No bylines selected."
@@ -5505,7 +5505,7 @@ msgstr "検索に一致するコメントはありません。"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:82
 msgid "No content"
-msgstr ""
+msgstr "コンテンツなし"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:171
 msgid "No content found"
@@ -5517,7 +5517,7 @@ msgstr "このコレクションにはコンテンツがありません"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:511
 msgid "No content locale is configured, so EmDash stores new content as English (en). Changing the admin language does not change this value."
-msgstr ""
+msgstr "コンテンツのロケールが設定されていないため、EmDashは新しいコンテンツを英語（en）として保存します。管理画面の言語を変更しても、この値は変わりません。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:204
 msgid "No content types yet."
@@ -5525,7 +5525,7 @@ msgstr "コンテンツタイプはまだありません。"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:627
 msgid "No custom fields yet"
-msgstr ""
+msgstr "カスタムフィールドはまだありません"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:275
 msgid "No detailed description available."
@@ -5557,7 +5557,7 @@ msgstr "比較するフィールドがありません"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:482
 msgid "No files added"
-msgstr ""
+msgstr "ファイルが追加されていません"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:213
 msgid "No headings in document"
@@ -5565,15 +5565,15 @@ msgstr "ドキュメントに見出しがありません"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:205
 msgid "No images in this gallery yet."
-msgstr ""
+msgstr "このギャラリーにはまだ画像がありません。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:594
 msgid "No installable releases"
-msgstr ""
+msgstr "インストール可能なリリースがありません"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:193
 msgid "No invite token provided"
-msgstr ""
+msgstr "招待トークンが指定されていません"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2209
 #: packages/admin/src/components/RepeaterField.tsx:165
@@ -5587,20 +5587,20 @@ msgstr "制限なし"
 
 #: packages/admin/src/routes/bylines.tsx:517
 msgid "No linked user"
-msgstr ""
+msgstr "リンク済みユーザーなし"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:171
 msgid "No matches"
-msgstr ""
+msgstr "一致なし"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1011
 msgid "No matching bylines."
-msgstr ""
+msgstr "一致する署名がありません。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:452
 #: packages/admin/src/components/MediaLibrary.tsx:480
 msgid "No matching media"
-msgstr ""
+msgstr "一致するメディアがありません"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:264
 msgid "No matching passkey found for this account."
@@ -5617,7 +5617,7 @@ msgstr "このプロバイダーから利用可能なメディアはありませ
 
 #: packages/admin/src/components/MediaLibrary.tsx:503
 msgid "No media available from this provider."
-msgstr ""
+msgstr "このプロバイダーで利用できるメディアがありません。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:502
 #: packages/admin/src/components/MediaPickerModal.tsx:688
@@ -5639,11 +5639,11 @@ msgstr "下限なし"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:65
 msgid "No moderation (auto-approve all)"
-msgstr ""
+msgstr "モデレーションなし（すべて自動承認）"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "No parent (top level)"
-msgstr ""
+msgstr "親なし（最上位）"
 
 #: packages/admin/src/components/users/UserDetail.tsx:248
 msgid "No passkeys registered"
@@ -5663,11 +5663,11 @@ msgstr "プラグインが見つかりません"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:120
 msgid "No plugins have been published to this registry yet."
-msgstr ""
+msgstr "このレジストリにはまだプラグインが公開されていません。"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:119
 msgid "No plugins match \"{debouncedQuery}\"."
-msgstr ""
+msgstr "「{debouncedQuery}」に一致するプラグインはありません。"
 
 #: packages/admin/src/components/Sections.tsx:343
 msgid "No preview"
@@ -5675,7 +5675,7 @@ msgstr "プレビューなし"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:304
 msgid "No public URL available"
-msgstr ""
+msgstr "利用可能な公開URLがありません"
 
 #: packages/admin/src/components/Dashboard.tsx:354
 msgid "No recent activity"
@@ -5693,7 +5693,7 @@ msgstr "結果なし"
 #: packages/admin/src/components/ContentList.tsx:635
 #: packages/admin/src/components/ContentList.tsx:654
 msgid "No results for \"{activeSearch}\""
-msgstr ""
+msgstr "「{activeSearch}」の結果はありません"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:178
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
@@ -5732,19 +5732,19 @@ msgstr "テーマが見つかりません"
 
 #: packages/admin/src/components/users/UserList.tsx:120
 msgid "No users found matching your filters."
-msgstr ""
+msgstr "フィルターに一致するユーザーが見つかりません。"
 
 #: packages/admin/src/components/users/UserList.tsx:134
 msgid "No users yet."
-msgstr ""
+msgstr "ユーザーはまだいません。"
 
 #: packages/admin/src/components/Widgets.tsx:504
 msgid "No widget areas yet. Create one to get started."
-msgstr ""
+msgstr "ウィジェットエリアはまだありません。作成して始めましょう。"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:159
 msgid "None"
-msgstr ""
+msgstr "なし"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:596
 #: packages/admin/src/components/TaxonomyManager.tsx:605
@@ -5753,12 +5753,12 @@ msgstr "なし（トップレベル）"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:629
 msgid "Not compatible with this environment"
-msgstr ""
+msgstr "この環境には対応していません"
 
 #: packages/admin/src/components/ContentList.tsx:1280
 #: packages/admin/src/components/PluginSettings.tsx:341
 msgid "Not set"
-msgstr ""
+msgstr "未設定"
 
 #: packages/admin/src/components/FieldEditor.tsx:191
 #: packages/admin/src/components/FieldEditor.tsx:610
@@ -5767,7 +5767,7 @@ msgstr "数値"
 
 #: packages/admin/src/components/Widgets.tsx:129
 msgid "Number of posts"
-msgstr ""
+msgstr "投稿数"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:319
 msgid "Number of posts to show per page on list views"
@@ -5781,7 +5781,7 @@ msgstr "番号付きリスト"
 
 #: packages/admin/src/components/WordPressImport.tsx:494
 msgid "OAuth authorization requires HTTPS. Please use manual credentials."
-msgstr ""
+msgstr "OAuth認可にはHTTPSが必要です。手動の認証情報を使用してください。"
 
 #: packages/admin/src/components/SeoImageField.tsx:46
 msgid "OG Image"
@@ -5806,7 +5806,7 @@ msgstr "半角小文字、数字、ハイフンのみ"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:106
 msgid "Only the listed MIME types will be accepted for this field."
-msgstr ""
+msgstr "このフィールドでは一覧にあるMIMEタイプのみ受け付けます。"
 
 #: packages/admin/src/components/SignupPage.tsx:404
 msgid "Oops!"
@@ -5830,11 +5830,11 @@ msgid ""
 "Option 1\n"
 "Option 2\n"
 "Option 3"
-msgstr ""
+msgstr "選択肢1\n選択肢2\n選択肢3"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:385
 msgid "Optional caption"
-msgstr ""
+msgstr "任意のキャプション"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:355
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:544
@@ -5861,7 +5861,7 @@ msgstr "選択肢（1行に1つ）"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:429
 msgid "Or browse files from your computer"
-msgstr ""
+msgstr "またはコンピューターからファイルを選択"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:579
 msgid "or choose from library"
@@ -5873,7 +5873,7 @@ msgstr "または、クリックして参照。WordPressからエクスポート
 
 #: packages/admin/src/components/WordPressImport.tsx:1071
 msgid "or connect by URL"
-msgstr ""
+msgstr "またはURLで接続"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:97
 #: packages/admin/src/components/LoginPage.tsx:263
@@ -5919,7 +5919,7 @@ msgstr "パッケージ"
 
 #: packages/admin/src/router.tsx:2272
 msgid "Page Not Found"
-msgstr ""
+msgstr "ページが見つかりません"
 
 #: packages/admin/src/components/PluginManager.tsx:402
 #: packages/admin/src/components/WordPressImport.tsx:1328
@@ -5942,7 +5942,7 @@ msgstr "リダイレクトループの一部"
 
 #: packages/admin/src/components/WordPressImport.tsx:1153
 msgid "Partial"
-msgstr ""
+msgstr "一部"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:324
 msgid "Pass"
@@ -6008,7 +6008,7 @@ msgstr "パスキーにはHTTPSまたはhttp://localhost（ポート付き）が
 
 #: packages/admin/src/components/WordPressImport.tsx:1037
 msgid "Paste your migration key"
-msgstr ""
+msgstr "移行キーを貼り付け"
 
 #: packages/admin/src/components/Redirects.tsx:225
 msgid "Path"
@@ -6021,16 +6021,16 @@ msgstr "パターン（正規表現）"
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:450
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr ""
+msgstr "URL生成パターン（例: /blog/{0}）"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:446
 msgid "Pattern must include a {0} placeholder"
-msgstr ""
+msgstr "パターンには{0}プレースホルダーが必要です"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:62
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:196
 msgid "pending"
@@ -6058,15 +6058,15 @@ msgstr "権限"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:46
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
-msgstr ""
+msgstr "任意の方法で管理者アカウントを作成してください。"
 
 #: packages/admin/src/components/Widgets.tsx:154
 msgid "Placeholder text"
-msgstr ""
+msgstr "プレースホルダーテキスト"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:311
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
@@ -6076,11 +6076,11 @@ msgstr "プレーン"
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:27
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:120
 msgid "Plain text"
-msgstr ""
+msgstr "プレーンテキスト"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:166
 msgid "Please ask your administrator to send a new invite."
-msgstr ""
+msgstr "管理者に新しい招待を送信するよう依頼してください。"
 
 #: packages/admin/src/components/SetupWizard.tsx:181
 msgid "Please enter a valid email"
@@ -6100,15 +6100,15 @@ msgstr "プラグイン"
 
 #: packages/admin/src/lib/api/plugins.ts:68
 msgid "Plugin \"{pluginId}\" not found"
-msgstr ""
+msgstr "プラグイン「{pluginId}」が見つかりません"
 
 #: packages/admin/src/lib/content-list-columns.tsx:236
 msgid "Plugin column unavailable"
-msgstr ""
+msgstr "プラグイン列を利用できません"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:762
 msgid "Plugin details"
-msgstr ""
+msgstr "プラグインの詳細"
 
 #: packages/admin/src/components/PluginManager.tsx:114
 msgid "Plugin disabled"
@@ -6120,24 +6120,24 @@ msgstr "プラグインを有効にしました"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:89
 msgid "Plugin Error"
-msgstr ""
+msgstr "プラグインエラー"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:37
 msgid "Plugin error ({0})"
-msgstr ""
+msgstr "プラグインエラー（{0}）"
 
 #: packages/admin/src/components/PluginManager.tsx:334
 msgid "Plugin MCP access updated"
-msgstr ""
+msgstr "プラグインのMCPアクセスを更新しました"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:97
 msgid "Plugin MCP Tools"
-msgstr ""
+msgstr "プラグインMCPツール"
 
 #: packages/admin/src/lib/api/marketplace.ts:108
 msgid "Plugin MCP tools require explicit consent"
-msgstr ""
+msgstr "プラグインのMCPツールには明示的な同意が必要です"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:123
 msgid "Plugin not found"
@@ -6145,7 +6145,7 @@ msgstr "プラグインが見つかりません"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:411
 msgid "Plugin not found. The publisher handle or slug may be incorrect."
-msgstr ""
+msgstr "プラグインが見つかりません。公開者のハンドルまたはスラッグが正しくない可能性があります。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1209
 msgid "plugin on your WordPress site."
@@ -6153,11 +6153,11 @@ msgstr "プラグインをWordPressサイトにインストール。"
 
 #: packages/admin/src/components/PluginManager.tsx:483
 msgid "Plugin pages"
-msgstr ""
+msgstr "プラグインページ"
 
 #: packages/admin/src/lib/content-editor-panels.tsx:192
 msgid "Plugin panel unavailable."
-msgstr ""
+msgstr "プラグインパネルを利用できません。"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "Plugin Permissions"
@@ -6165,18 +6165,18 @@ msgstr "プラグインの権限"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:71
 msgid "Plugin Registry"
-msgstr ""
+msgstr "プラグインレジストリ"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginPage.tsx:40
 msgid "Plugin responded with {0}: {text}"
-msgstr ""
+msgstr "プラグインから{0}が返されました: {text}"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:512
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:515
 msgid "Plugin tools: {0}"
-msgstr ""
+msgstr "プラグインツール: {0}"
 
 #: packages/admin/src/components/PluginManager.tsx:323
 msgid "Plugin uninstalled"
@@ -6184,7 +6184,7 @@ msgstr "プラグインをアンインストールしました"
 
 #: packages/admin/src/lib/api/registry.ts:810
 msgid "Plugin update requires re-consent"
-msgstr ""
+msgstr "プラグインの更新には再同意が必要です"
 
 #: packages/admin/src/components/PluginManager.tsx:269
 msgid "Plugin updated"
@@ -6192,7 +6192,7 @@ msgstr "プラグインを更新しました"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
 msgid "Plugin widget error"
-msgstr ""
+msgstr "プラグインウィジェットエラー"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:218
 #: packages/admin/src/components/PluginManager.tsx:139
@@ -6205,7 +6205,7 @@ msgstr "プラグイン"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:327
 msgid "Point-in-Time Restore"
-msgstr ""
+msgstr "ポイントインタイムリストア"
 
 #: packages/admin/src/components/SeoPanel.tsx:220
 msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
@@ -6213,7 +6213,7 @@ msgstr "このページが別のURLの複製の場合、検索エンジンにオ
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:388
 msgid "Post"
-msgstr ""
+msgstr "投稿"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:396
 #: packages/admin/src/components/WordPressImport.tsx:1322
@@ -6222,7 +6222,7 @@ msgstr "投稿"
 
 #: packages/admin/src/components/WordPressImport.tsx:1144
 msgid "Posts & Pages"
-msgstr ""
+msgstr "投稿とページ"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:313
 msgid "Posts Per Page"
@@ -6230,7 +6230,7 @@ msgstr "ページあたりの投稿数"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:478
 msgid "Pre-release"
-msgstr ""
+msgstr "プレリリース"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
@@ -6278,7 +6278,7 @@ msgstr "メインナビゲーション"
 
 #: packages/admin/src/components/ContentStatusBadge.tsx:69
 msgid "Private"
-msgstr ""
+msgstr "非公開"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:167
 msgid "Provider:"
@@ -6294,7 +6294,7 @@ msgstr "公開"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:603
 msgid "Publish date"
-msgstr ""
+msgstr "公開日"
 
 #: packages/admin/src/components/ContentList.tsx:832
 #: packages/admin/src/components/ContentList.tsx:843
@@ -6311,7 +6311,7 @@ msgstr "公開日: {0}"
 
 #: packages/admin/src/router.tsx:512
 msgid "Published {total} items"
-msgstr ""
+msgstr "{total}件のアイテムを公開しました"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
@@ -6319,15 +6319,15 @@ msgstr "公開日時"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:472
 msgid "Published by"
-msgstr ""
+msgstr "公開者"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
-msgstr ""
+msgstr "Python"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:100
 msgid "Queued"
-msgstr ""
+msgstr "待機中"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1084
 msgid "Quick create byline"
@@ -6336,7 +6336,7 @@ msgstr "署名をクイック作成"
 #: packages/admin/src/components/editor/ImageNode.tsx:196
 #: packages/admin/src/components/editor/ImageNode.tsx:197
 msgid "Quick edit alt text"
-msgstr ""
+msgstr "代替テキストをクイック編集"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:111
 #: packages/admin/src/components/PortableTextEditor.tsx:1460
@@ -6346,7 +6346,7 @@ msgstr "引用"
 
 #: packages/admin/src/components/WordPressImport.tsx:1162
 msgid "Raw meta"
-msgstr ""
+msgstr "生のメタデータ"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:68
 msgid "Read collection schemas"
@@ -6362,21 +6362,21 @@ msgstr "メディアファイルを読み取り"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:88
 msgid "Read site settings"
-msgstr ""
+msgstr "サイト設定を読み取る"
 
 #: packages/admin/src/lib/api/marketplace.ts:284
 #: packages/admin/src/lib/api/marketplace.ts:292
 msgid "Read user accounts"
-msgstr ""
+msgstr "ユーザーアカウントを読み取る"
 
 #: packages/admin/src/lib/api/marketplace.ts:279
 #: packages/admin/src/lib/api/marketplace.ts:288
 msgid "Read your content"
-msgstr ""
+msgstr "コンテンツを読み取る"
 
 #: packages/admin/src/lib/api/marketplace.ts:281
 msgid "Read your taxonomies and terms"
-msgstr ""
+msgstr "タクソノミーと用語を読み取る"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:310
 msgid "Reading"
@@ -6392,12 +6392,12 @@ msgstr "最近のアクティビティ"
 
 #: packages/admin/src/components/Widgets.tsx:126
 msgid "Recent Posts"
-msgstr ""
+msgstr "最近の投稿"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:43
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
 msgid "Recently Updated"
-msgstr ""
+msgstr "最近更新"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:107
 msgid "Recipient email"
@@ -6424,7 +6424,7 @@ msgstr "リダイレクト"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4248
 msgid "Redo"
-msgstr ""
+msgstr "やり直す"
 
 #: packages/admin/src/components/FieldEditor.tsx:245
 msgid "Reference"
@@ -6432,11 +6432,11 @@ msgstr "参照"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:269
 msgid "Referenced favicon unavailable."
-msgstr ""
+msgstr "参照先のファビコンを利用できません。"
 
 #: packages/admin/src/components/Dashboard.tsx:125
 msgid "Refresh the page or try again."
-msgstr ""
+msgstr "ページを再読み込みするか、もう一度お試しください。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:156
 msgid "Register"
@@ -6453,7 +6453,7 @@ msgstr "登録済みユーザー"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
 msgid "Registration failed"
-msgstr ""
+msgstr "登録に失敗しました"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
 msgid "Registration was cancelled or timed out. Please try again."
@@ -6461,11 +6461,11 @@ msgstr "登録がキャンセルされたかタイムアウトしました。も
 
 #: packages/admin/src/components/Sidebar.tsx:308
 msgid "Registry"
-msgstr ""
+msgstr "レジストリ"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:610
 msgid "Release is too new to install"
-msgstr ""
+msgstr "リリースが新しすぎるためインストールできません"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
@@ -6492,15 +6492,15 @@ msgstr "{0}を削除"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:145
 msgid "Remove {entry}"
-msgstr ""
+msgstr "{entry}を削除"
 
 #: packages/admin/src/components/ContentEditor.tsx:1720
 msgid "Remove {label}"
-msgstr ""
+msgstr "{label}を削除"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:565
 msgid "Remove assignment"
-msgstr ""
+msgstr "割り当てを削除"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:379
 msgid "Remove Domain"
@@ -6525,7 +6525,7 @@ msgstr "画像を削除"
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:320
 msgid "Remove image {0}"
-msgstr ""
+msgstr "画像{0}を削除"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:197
 msgid "Remove Image?"
@@ -6540,7 +6540,7 @@ msgstr "アイテム{0}を削除"
 #: packages/admin/src/components/PortableTextEditor.tsx:3606
 #: packages/admin/src/components/PortableTextEditor.tsx:3607
 msgid "Remove link"
-msgstr ""
+msgstr "リンクを削除"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:181
 msgid "Remove passkey"
@@ -6579,12 +6579,12 @@ msgstr "パスキーの名前を変更"
 
 #: packages/admin/src/components/ContentTypeList.tsx:174
 msgid "Reorder"
-msgstr ""
+msgstr "並べ替え"
 
 #. placeholder {0}: collection.label
 #: packages/admin/src/components/ContentTypeList.tsx:281
 msgid "Reorder {0}"
-msgstr ""
+msgstr "{0}を並べ替え"
 
 #: packages/admin/src/components/FieldEditor.tsx:269
 msgid "Repeater"
@@ -6596,12 +6596,12 @@ msgstr "繰り返しフィールドグループ"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:162
 msgid "Replace"
-msgstr ""
+msgstr "置き換え"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:363
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:396
 msgid "Replace image"
-msgstr ""
+msgstr "画像を置き換え"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:213
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:248
@@ -6623,11 +6623,11 @@ msgstr "新しいリンクをリクエスト"
 
 #: packages/admin/src/lib/api/client.ts:239
 msgid "Request failed"
-msgstr ""
+msgstr "リクエストに失敗しました"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:430
 msgid "Require a slug before content can be published"
-msgstr ""
+msgstr "コンテンツを公開する前にスラッグを必須にする"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:280
 #: packages/admin/src/components/ContentTypeEditor.tsx:745
@@ -6666,7 +6666,7 @@ msgstr "元に戻す"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4094
 msgid "Restart numbering"
-msgstr ""
+msgstr "番号を振り直す"
 
 #: packages/admin/src/components/RevisionHistory.tsx:238
 msgid "Restore"
@@ -6710,11 +6710,11 @@ msgstr "再試行"
 #. placeholder {0}: row.file.name
 #: packages/admin/src/components/MediaUploadDialog.tsx:145
 msgid "Retry {0}"
-msgstr ""
+msgstr "{0}を再試行"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:497
 msgid "Retry failed"
-msgstr ""
+msgstr "再試行に失敗しました"
 
 #: packages/admin/src/components/Sections.tsx:136
 msgid "Reusable content blocks you can insert into any content"
@@ -6722,11 +6722,11 @@ msgstr "任意のコンテンツに挿入できる再利用可能なコンテン
 
 #: packages/admin/src/router.tsx:1108
 msgid "Reverted to published version"
-msgstr ""
+msgstr "公開済みバージョンに戻しました"
 
 #: packages/admin/src/components/WordPressImport.tsx:724
 msgid "Review"
-msgstr ""
+msgstr "確認"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "Review New Permissions"
@@ -6751,7 +6751,7 @@ msgstr "トークンを取り消す"
 #. placeholder {0}: token.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:392
 msgid "Revoke token {0}"
-msgstr ""
+msgstr "トークン{0}を取り消す"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:414
 msgid "Revoke?"
@@ -6775,7 +6775,7 @@ msgstr "リッチテキストエディタ"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:162
 msgid "Right"
-msgstr ""
+msgstr "右"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:322
@@ -6785,7 +6785,7 @@ msgstr "リスクスコア: {0}/100"
 #: packages/admin/src/components/settings/SeoSettings.tsx:255
 #: packages/admin/src/components/settings/SeoSettings.tsx:258
 msgid "robots.txt"
-msgstr ""
+msgstr "robots.txt"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:164
 #: packages/admin/src/components/users/UserDetail.tsx:169
@@ -6804,22 +6804,22 @@ msgstr "ロールラベル"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:428
 msgid "Routable"
-msgstr ""
+msgstr "ルーティング可能"
 
 #. placeholder {0}: tool.route
 #. placeholder {1}: tool.permission
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:149
 #: packages/admin/src/components/PluginManager.tsx:568
 msgid "Route: {0} · Permission: {1}"
-msgstr ""
+msgstr "ルート: {0} · 権限: {1}"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
-msgstr ""
+msgstr "Ruby"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:49
 msgid "Rust"
-msgstr ""
+msgstr "Rust"
 
 #: packages/admin/src/components/MenuEditor.tsx:430
 #: packages/admin/src/components/MenuEditor.tsx:432
@@ -6844,15 +6844,15 @@ msgstr "保存"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:416
 msgid "Save (Enter)"
-msgstr ""
+msgstr "保存（Enter）"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:265
 msgid "Save alt text"
-msgstr ""
+msgstr "代替テキストを保存"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Save changes"
-msgstr ""
+msgstr "変更を保存"
 
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Save Changes"
@@ -6878,7 +6878,7 @@ msgstr "保存済み"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:116
 msgid "Saved \"{0}\"."
-msgstr ""
+msgstr "「{0}」を保存しました。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1191
 #: packages/admin/src/components/FieldEditor.tsx:689
@@ -6897,16 +6897,16 @@ msgstr "保存中..."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Saving…"
-msgstr ""
+msgstr "保存中…"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:482
 msgid "SBOM"
-msgstr ""
+msgstr "SBOM"
 
 #. placeholder {0}: sbom.format
 #: packages/admin/src/components/RegistryPluginDetail.tsx:480
 msgid "SBOM · {0}"
-msgstr ""
+msgstr "SBOM · {0}"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:571
 msgid "Schedule"
@@ -6933,7 +6933,7 @@ msgstr "公開予約: {0}"
 
 #: packages/admin/src/components/Dashboard.tsx:111
 msgid "Scheduled publishing needs attention"
-msgstr ""
+msgstr "公開予約を確認してください"
 
 #: packages/admin/src/components/WordPressImport.tsx:2322
 msgid "Schema Changes"
@@ -6987,7 +6987,7 @@ msgstr "スクリーンショット"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:50
 msgid "SCSS"
-msgstr ""
+msgstr "SCSS"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 #: packages/admin/src/components/Settings.tsx:140
@@ -7009,25 +7009,25 @@ msgstr "{0}を検索..."
 #: packages/admin/src/components/MediaLibrary.tsx:378
 #: packages/admin/src/components/MediaPickerModal.tsx:626
 msgid "Search by filename..."
-msgstr ""
+msgstr "ファイル名で検索..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
-msgstr ""
+msgstr "名前またはメールアドレスで検索..."
 
 #: packages/admin/src/components/BylineFilter.tsx:121
 #: packages/admin/src/components/ContentSettingsPanel.tsx:985
 #: packages/admin/src/routes/bylines.tsx:401
 msgid "Search bylines"
-msgstr ""
+msgstr "署名を検索"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:984
 msgid "Search bylines to add..."
-msgstr ""
+msgstr "追加する署名を検索..."
 
 #: packages/admin/src/components/BylineFilter.tsx:122
 msgid "Search bylines…"
-msgstr ""
+msgstr "署名を検索…"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:164
 msgid "Search comments"
@@ -7052,7 +7052,7 @@ msgstr "検索エンジン最適化と検証"
 
 #: packages/admin/src/components/Widgets.tsx:152
 msgid "Search form"
-msgstr ""
+msgstr "検索フォーム"
 
 #: packages/admin/src/components/MediaLibrary.tsx:379
 #: packages/admin/src/components/MediaPickerModal.tsx:627
@@ -7066,7 +7066,7 @@ msgstr "ページやコンテンツを検索..."
 #: packages/admin/src/components/MarketplaceBrowse.tsx:103
 #: packages/admin/src/components/RegistryBrowse.tsx:87
 msgid "Search plugins"
-msgstr ""
+msgstr "プラグインを検索"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:99
 #: packages/admin/src/components/RegistryBrowse.tsx:83
@@ -7084,7 +7084,7 @@ msgstr "ソースまたは転送先を検索..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
 msgid "Search themes"
-msgstr ""
+msgstr "テーマを検索"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
 msgid "Search themes..."
@@ -7092,11 +7092,11 @@ msgstr "テーマを検索..."
 
 #: packages/admin/src/components/BylineFilter.tsx:158
 msgid "Search to narrow the list"
-msgstr ""
+msgstr "検索して一覧を絞り込む"
 
 #: packages/admin/src/components/users/UserList.tsx:73
 msgid "Search users"
-msgstr ""
+msgstr "ユーザーを検索"
 
 #: packages/admin/src/components/MediaLibrary.tsx:378
 #: packages/admin/src/components/MediaPickerModal.tsx:626
@@ -7110,7 +7110,7 @@ msgstr "検索可能"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:989
 msgid "Searching..."
-msgstr ""
+msgstr "検索中..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2724
 msgid "Section"
@@ -7186,7 +7186,7 @@ msgstr "セキュリティ監査に合格"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:718
 msgid "Security contacts"
-msgstr ""
+msgstr "セキュリティ連絡先"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:270
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
@@ -7217,15 +7217,15 @@ msgstr "{label}を選択"
 
 #: packages/admin/src/components/ContentList.tsx:1141
 msgid "Select {title}"
-msgstr ""
+msgstr "{title}を選択"
 
 #: packages/admin/src/components/Widgets.tsx:956
 msgid "Select a component..."
-msgstr ""
+msgstr "コンポーネントを選択..."
 
 #: packages/admin/src/components/Widgets.tsx:919
 msgid "Select a menu..."
-msgstr ""
+msgstr "メニューを選択..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:284
 msgid "Select all"
@@ -7233,7 +7233,7 @@ msgstr "すべて選択"
 
 #: packages/admin/src/components/ContentList.tsx:567
 msgid "Select all on this page"
-msgstr ""
+msgstr "このページのすべてを選択"
 
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:457
@@ -7246,7 +7246,7 @@ msgstr "コンテンツを選択"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:284
 msgid "Select Default Social Image"
-msgstr ""
+msgstr "デフォルトのソーシャル画像を選択"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:301
 #: packages/admin/src/components/settings/GeneralSettings.tsx:364
@@ -7255,15 +7255,15 @@ msgstr "ファビコンを選択"
 
 #: packages/admin/src/components/ContentEditor.tsx:1736
 msgid "Select file"
-msgstr ""
+msgstr "ファイルを選択"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:150
 msgid "Select File"
-msgstr ""
+msgstr "ファイルを選択"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3447
 msgid "Select Gallery Images"
-msgstr ""
+msgstr "ギャラリー画像を選択"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:261
 msgid "Select image"
@@ -7282,7 +7282,7 @@ msgstr "ロゴを選択"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
 msgid "Select media"
-msgstr ""
+msgstr "メディアを選択"
 
 #: packages/admin/src/components/SeoImageField.tsx:76
 msgid "Select OG image"
@@ -7304,11 +7304,11 @@ msgstr "選択..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1749
 msgid "Selected {selectedItemTitle}"
-msgstr ""
+msgstr "{selectedItemTitle}を選択中"
 
 #: packages/admin/src/components/ImageFieldRenderer.tsx:116
 msgid "Selected image"
-msgstr ""
+msgstr "選択した画像"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:795
 msgid "Selected:"
@@ -7389,19 +7389,19 @@ msgstr "この画像インスタンスのカスタム表示サイズを設定し
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:146
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:150
 msgid "Set language"
-msgstr ""
+msgstr "言語を設定"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:147
 msgid "Set language (current: {label})"
-msgstr ""
+msgstr "言語を設定（現在: {label}）"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:544
 msgid "Set to 0 to never close comments automatically."
-msgstr ""
+msgstr "0に設定すると、コメントを自動的に閉じません。"
 
 #: packages/admin/src/components/ContentList.tsx:495
 msgid "Set to draft"
-msgstr ""
+msgstr "下書きに設定"
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
@@ -7425,11 +7425,11 @@ msgstr "設定"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:92
 msgid "Settings Manage"
-msgstr ""
+msgstr "設定の管理"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:87
 msgid "Settings Read"
-msgstr ""
+msgstr "設定の閲覧"
 
 #: packages/admin/src/components/PluginSettings.tsx:68
 #: packages/admin/src/components/settings/GeneralSettings.tsx:70
@@ -7438,7 +7438,7 @@ msgstr "設定を保存しました"
 
 #: packages/admin/src/components/SetupWizard.tsx:468
 msgid "Setup failed"
-msgstr ""
+msgstr "セットアップに失敗しました"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
@@ -7446,11 +7446,11 @@ msgstr "招待したユーザーとこのリンクを共有してください"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:294
 msgid "Shared across all translations of the same byline."
-msgstr ""
+msgstr "同じ署名のすべての翻訳で共有されます。"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:52
 msgid "Short text"
-msgstr ""
+msgstr "短いテキスト"
 
 #: packages/admin/src/components/FieldEditor.tsx:179
 #: packages/admin/src/components/FieldEditor.tsx:608
@@ -7459,23 +7459,23 @@ msgstr "短文テキスト"
 
 #: packages/admin/src/components/Widgets.tsx:146
 msgid "Show count"
-msgstr ""
+msgstr "件数を表示"
 
 #: packages/admin/src/components/Widgets.tsx:131
 msgid "Show date"
-msgstr ""
+msgstr "日付を表示"
 
 #: packages/admin/src/components/Widgets.tsx:139
 msgid "Show hierarchy"
-msgstr ""
+msgstr "階層を表示"
 
 #: packages/admin/src/components/Widgets.tsx:138
 msgid "Show post count"
-msgstr ""
+msgstr "投稿数を表示"
 
 #: packages/admin/src/components/Widgets.tsx:130
 msgid "Show thumbnails"
-msgstr ""
+msgstr "サムネイルを表示"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:276
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:283
@@ -7493,7 +7493,7 @@ msgstr "サインイン"
 
 #: packages/admin/src/components/SetupWizard.tsx:355
 msgid "Sign In"
-msgstr ""
+msgstr "サインイン"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:162
 #: packages/admin/src/components/SignupPage.tsx:270
@@ -7509,7 +7509,7 @@ msgstr "サイトにサインイン"
 #: packages/admin/src/components/LoginPage.tsx:233
 #: packages/admin/src/components/SetupWizard.tsx:264
 msgid "Sign in with {0}"
-msgstr ""
+msgstr "{0}でサインイン"
 
 #: packages/admin/src/components/LoginPage.tsx:231
 msgid "Sign in with email"
@@ -7548,7 +7548,7 @@ msgstr "サイト情報"
 
 #: packages/admin/src/components/WordPressImport.tsx:2270
 msgid "site identity applied (title, tagline, logo)"
-msgstr ""
+msgstr "サイト情報を適用しました（タイトル、タグライン、ロゴ）"
 
 #: packages/admin/src/components/Settings.tsx:49
 #: packages/admin/src/components/settings/GeneralSettings.tsx:119
@@ -7579,7 +7579,7 @@ msgstr "サイトURL"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:330
 msgid "Sites on Cloudflare D1 can additionally restore the database to any minute within the last 30 days using D1 Time Travel — always on, no setup required."
-msgstr ""
+msgstr "Cloudflare D1上のサイトではさらに、D1 Time Travelを使用して過去30日以内の任意の時点にデータベースを復元できます。常時有効で、設定は不要です。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:551
 msgid "Size"
@@ -7620,7 +7620,7 @@ msgstr "スラッグをクリップボードにコピーしました"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:251
 msgid "Slugs cannot be changed after the field is created."
-msgstr ""
+msgstr "フィールドの作成後はスラッグを変更できません。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1401
 msgid "Small section heading"
@@ -7628,11 +7628,11 @@ msgstr "小見出し"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1411
 msgid "Smaller section heading"
-msgstr ""
+msgstr "小さめのセクション見出し"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
 msgid "Smallest section heading"
-msgstr ""
+msgstr "最小のセクション見出し"
 
 #: packages/admin/src/components/Settings.tsx:54
 #: packages/admin/src/components/settings/SocialSettings.tsx:89
@@ -7695,15 +7695,15 @@ msgstr "スパム"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4261
 msgid "Spotlight Mode"
-msgstr ""
+msgstr "スポットライトモード"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:64
 msgid "Spreadsheets"
-msgstr ""
+msgstr "スプレッドシート"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:51
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1922
 msgid "Start Import"
@@ -7713,7 +7713,7 @@ msgstr "インポートを開始"
 #: packages/admin/src/components/PortableTextEditor.tsx:2579
 #: packages/admin/src/components/PortableTextEditor.tsx:2580
 msgid "Start writing, or type '/' for commands"
-msgstr ""
+msgstr "入力を開始するか、「/」を入力してコマンドを表示"
 
 #: packages/admin/src/components/ContentList.tsx:592
 #: packages/admin/src/components/ContentSettingsPanel.tsx:517
@@ -7729,24 +7729,24 @@ msgstr "ステータスコード"
 
 #: packages/admin/src/components/Dashboard.tsx:401
 msgid "Status: {status}"
-msgstr ""
+msgstr "ステータス: {status}"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:205
 msgid "Store a daily backup in your site's storage bucket. Old backups are removed automatically."
-msgstr ""
+msgstr "サイトのストレージバケットに日次バックアップを保存します。古いバックアップは自動的に削除されます。"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:270
 msgid "Stored Backups"
-msgstr ""
+msgstr "保存済みバックアップ"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:293
 msgid "Stored per locale — each translation of a byline gets its own value."
-msgstr ""
+msgstr "ロケールごとに保存され、署名の各翻訳には個別の値が設定されます。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3639
 #: packages/admin/src/components/PortableTextEditor.tsx:4044
 msgid "Strikethrough"
-msgstr ""
+msgstr "取り消し線"
 
 #: packages/admin/src/components/WordPressImport.tsx:1752
 msgid "Structure"
@@ -7754,7 +7754,7 @@ msgstr "構造"
 
 #: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Structured"
-msgstr ""
+msgstr "構造化"
 
 #: packages/admin/src/components/FieldEditor.tsx:552
 msgid "Sub-Fields"
@@ -7767,19 +7767,19 @@ msgstr "購読者"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3646
 msgid "Subscript"
-msgstr ""
+msgstr "下付き文字"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3653
 msgid "Superscript"
-msgstr ""
+msgstr "上付き文字"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:52
 msgid "Svelte"
-msgstr ""
+msgstr "Svelte"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:53
 msgid "Swift"
-msgstr ""
+msgstr "Swift"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
@@ -7791,7 +7791,7 @@ msgstr "同期パスキー"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:792
 msgid "System"
-msgstr ""
+msgstr "システム"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
@@ -7799,7 +7799,7 @@ msgstr "システム ({resolvedLabel})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:614
 msgid "System Fields"
-msgstr ""
+msgstr "システムフィールド"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1498
 msgid "Table"
@@ -7807,7 +7807,7 @@ msgstr "テーブル"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3728
 msgid "Table controls"
-msgstr ""
+msgstr "テーブル操作"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:173
 #: packages/admin/src/components/SetupWizard.tsx:127
@@ -7831,7 +7831,7 @@ msgstr "ターゲット"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:354
 msgid "Target locale"
-msgstr ""
+msgstr "翻訳先のロケール"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:706
 #: packages/admin/src/components/TaxonomySidebar.tsx:683
@@ -7840,7 +7840,7 @@ msgstr "タクソノミー"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:77
 msgid "Taxonomies Manage"
-msgstr ""
+msgstr "タクソノミーの管理"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1124
 msgid "Taxonomy created"
@@ -7852,7 +7852,7 @@ msgstr "タクソノミーが見つかりません:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:341
 msgid "Taxonomy: {taxonomyName}"
-msgstr ""
+msgstr "タクソノミー: {taxonomyName}"
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
@@ -7868,7 +7868,7 @@ msgstr "ターム"
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:988
 msgid "Term \"{0}\" created in {1}."
-msgstr ""
+msgstr "{1}に用語「{0}」を作成しました。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:928
 msgid "Term deleted"
@@ -7880,7 +7880,7 @@ msgstr "test@example.com"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3995
 msgid "Text formatting"
-msgstr ""
+msgstr "テキスト書式"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:198
 msgid "The device will not be granted access."
@@ -7917,11 +7917,11 @@ msgstr "サイトの名前。ヘッダーとメタデータに使用されます
 
 #: packages/admin/src/router.tsx:2274
 msgid "The page you're looking for doesn't exist."
-msgstr ""
+msgstr "お探しのページは存在しません。"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
 msgid "The plugin field widget failed to render."
-msgstr ""
+msgstr "プラグインのフィールドウィジェットを表示できませんでした。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:185
 msgid "The public URL of your site (used for canonical links and sitemaps)"
@@ -7929,11 +7929,11 @@ msgstr "サイトの公開URL（正規リンクとサイトマップに使用）
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:192
 msgid "The referenced image is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "参照先の画像は利用できなくなりました。新しい画像を選択するか、参照を削除してください。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:209
 msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "参照先のロゴは利用できなくなりました。新しいロゴを選択するか、参照を削除してください。"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
 msgid "The theme marketplace is empty. Check back later."
@@ -7971,27 +7971,27 @@ msgstr "テーマ"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:141
 msgid "These tools remain disabled after installation until you explicitly enable agent access."
-msgstr ""
+msgstr "これらのツールは、インストール後もエージェントアクセスを明示的に有効にするまで無効のままです。"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:371
 msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
-msgstr ""
+msgstr "このコレクションはコードで定義されています。一部の設定はここでは変更できません。スキーマを変更するには、live.config.tsファイルを編集してください。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3330
 msgid "This content cannot be edited safely"
-msgstr ""
+msgstr "このコンテンツは安全に編集できません"
 
 #: packages/admin/src/components/WordPressImport.tsx:1059
 msgid "This doesn't look like a valid migration key. Generate a new one in the plugin and paste the full string starting with \"em1.\"."
-msgstr ""
+msgstr "有効な移行キーではないようです。プラグインで新しいキーを生成し、「em1.」で始まる文字列全体を貼り付けてください。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3332
 msgid "This field contains unsupported Portable Text marks: <0>{markList}</0>. Remove them through the API before editing or saving this content."
-msgstr ""
+msgstr "このフィールドには、サポートされていないPortable Textマーク <0>{markList}</0> が含まれています。このコンテンツを編集または保存する前に、API経由で削除してください。"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:461
 msgid "This field does not accept {sniffedMime} files."
-msgstr ""
+msgstr "このフィールドでは{sniffedMime}ファイルを受け付けません。"
 
 #: packages/admin/src/components/ContentEditor.tsx:1751
 #: packages/admin/src/components/ImageFieldRenderer.tsx:276
@@ -8008,7 +8008,7 @@ msgstr "これはWordPressサイトです。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:503
 msgid "This is stored with the entry and is separate from your admin language."
-msgstr ""
+msgstr "これはエントリとともに保存され、管理画面の言語とは別に扱われます。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:112
 msgid "This link expires in 7 days and can only be used once."
@@ -8025,11 +8025,11 @@ msgstr "このパスキーはこのデバイスに既に登録されています
 #. placeholder {0}: archiveToDelete?.name ?? ""
 #: packages/admin/src/components/settings/BackupSettings.tsx:351
 msgid "This permanently deletes {0} from storage."
-msgstr ""
+msgstr "ストレージから{0}を完全に削除します。"
 
 #: packages/admin/src/components/PluginSettings.tsx:177
 msgid "This plugin has no configurable settings."
-msgstr ""
+msgstr "このプラグインには設定可能な項目がありません。"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:287
 msgid "This plugin requires no special permissions."
@@ -8037,7 +8037,7 @@ msgstr "このプラグインに特別な権限は不要です。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:579
 msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
-msgstr ""
+msgstr "この公開者は、所有を証明できなかった名前を名乗っており、他者になりすましている可能性があります。インストールは無効です。公開者を知っていて信頼できる場合は、再試行する前に本人確認の設定を修正するよう依頼してください。"
 
 #: packages/admin/src/components/Redirects.tsx:602
 msgid "This redirect rule will be permanently removed."
@@ -8045,16 +8045,16 @@ msgstr "このリダイレクトルールは完全に削除されます。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:631
 msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
-msgstr ""
+msgstr "このリリースには、サイトの現在の環境より新しい環境が必要です。インストールする前にアップグレードしてください。"
 
 #: packages/admin/src/routes/bylines.tsx:623
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr ""
+msgstr "この署名プロフィールを削除します。コンテンツの署名リンクが削除され、代表署名への参照も解除されます。"
 
 #. placeholder {0}: sectionInsertErrorMarks.join(", ")
 #: packages/admin/src/components/PortableTextEditor.tsx:3359
 msgid "This section contains unsupported Portable Text marks: <0>{0}</0>. Update the section before inserting it."
-msgstr ""
+msgstr "このセクションには、サポートされていないPortable Textマーク <0>{0}</0> が含まれています。挿入する前にセクションを更新してください。"
 
 #: packages/admin/src/components/SectionEditor.tsx:298
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
@@ -8066,11 +8066,11 @@ msgstr "このセクションは別のシステムからインポートされま
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:125
 msgid "This update exposes the following routes without authentication:"
-msgstr ""
+msgstr "この更新により、次のルートが認証なしで公開されます:"
 
 #: packages/admin/src/components/Widgets.tsx:715
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
-msgstr ""
+msgstr "ウィジェットエリアとそのすべてのウィジェットを削除します。この操作は取り消せません。"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:276
 msgid "This will grant CLI access with your permissions."
@@ -8133,7 +8133,7 @@ msgstr "タイトル区切り文字"
 
 #: packages/admin/src/components/ContentList.tsx:933
 msgid "to"
-msgstr ""
+msgstr "～"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:483
 msgid "to close"
@@ -8141,7 +8141,7 @@ msgstr "閉じる"
 
 #: packages/admin/src/components/ContentList.tsx:937
 msgid "To date"
-msgstr ""
+msgstr "終了日"
 
 #: packages/admin/src/components/PluginManager.tsx:208
 msgid "to install plugins, or add them to your astro.config.mjs."
@@ -8171,7 +8171,7 @@ msgstr "トークン名"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:54
 msgid "TOML"
-msgstr ""
+msgstr "TOML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1277
 msgid "Tools → Export"
@@ -8184,7 +8184,7 @@ msgstr "コンテンツの変更履歴を追跡"
 #: packages/admin/src/components/BylineFieldEditor.tsx:287
 #: packages/admin/src/routes/byline-schema.tsx:243
 msgid "Translatable"
-msgstr ""
+msgstr "翻訳可能"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:266
 #: packages/admin/src/components/TaxonomyManager.tsx:376
@@ -8195,24 +8195,24 @@ msgstr "翻訳"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:338
 msgid "Translate \"{0}\""
-msgstr ""
+msgstr "「{0}」を翻訳"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:263
 msgid "Translate {0}"
-msgstr ""
+msgstr "{0}を翻訳"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:376
 #: packages/admin/src/components/TranslationsPanel.tsx:104
 msgid "Translating..."
-msgstr ""
+msgstr "翻訳中..."
 
 #: packages/admin/src/components/MenuEditor.tsx:143
 #: packages/admin/src/components/TaxonomyManager.tsx:987
 #: packages/admin/src/components/TaxonomySidebar.tsx:471
 #: packages/admin/src/router.tsx:1180
 msgid "Translation created"
-msgstr ""
+msgstr "翻訳を作成しました"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:684
 #: packages/admin/src/components/TranslationsPanel.tsx:60
@@ -8245,7 +8245,7 @@ msgstr "真偽値のトグル"
 
 #: packages/admin/src/components/MediaLibrary.tsx:456
 msgid "Try a broader media type or clear your filters."
-msgstr ""
+msgstr "メディアタイプを広げるか、フィルターをクリアしてください。"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:691
 msgid "Try a different search term"
@@ -8262,7 +8262,7 @@ msgstr "検索条件やフィルタを変更してみてください。"
 
 #: packages/admin/src/routes/users.tsx:210
 msgid "Try again"
-msgstr ""
+msgstr "もう一度試す"
 
 #: packages/admin/src/components/WordPressImport.tsx:1582
 msgid "Try Again"
@@ -8274,11 +8274,11 @@ msgstr "別のコードを試す"
 
 #: packages/admin/src/components/MediaLibrary.tsx:481
 msgid "Try another filename or clear your search."
-msgstr ""
+msgstr "別のファイル名を試すか、検索をクリアしてください。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:455
 msgid "Try another filename, or clear your search and filters."
-msgstr ""
+msgstr "別のファイル名を試すか、検索とフィルターをクリアしてください。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1286
 #: packages/admin/src/components/WordPressImport.tsx:1408
@@ -8292,11 +8292,11 @@ msgstr "自分のデータで試す"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:55
 msgid "TSX"
-msgstr ""
+msgstr "TSX"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:297
 msgid "Turn into"
-msgstr ""
+msgstr "変換"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:139
 msgid "Twitter"
@@ -8316,7 +8316,7 @@ msgstr "タイプの不一致 ({0})"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:56
 msgid "TypeScript"
-msgstr ""
+msgstr "TypeScript"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:133
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
@@ -8331,11 +8331,11 @@ msgstr "未割り当て"
 #: packages/admin/src/components/PortableTextEditor.tsx:3632
 #: packages/admin/src/components/PortableTextEditor.tsx:4037
 msgid "Underline"
-msgstr ""
+msgstr "下線"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:4241
 msgid "Undo"
-msgstr ""
+msgstr "元に戻す"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:191
 #: packages/admin/src/components/PluginManager.tsx:630
@@ -8387,11 +8387,11 @@ msgstr "無名のパスキー"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:211
 msgid "Unpublish {itemLabel}"
-msgstr ""
+msgstr "{itemLabel}を非公開にする"
 
 #: packages/admin/src/router.tsx:1088
 msgid "Unpublished"
-msgstr ""
+msgstr "非公開"
 
 #: packages/admin/src/components/ContentTypeList.tsx:133
 msgid "Unregistered Content Tables Found"
@@ -8399,7 +8399,7 @@ msgstr "未登録のコンテンツテーブルが見つかりました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:543
 msgid "Unresolved assignment"
-msgstr ""
+msgstr "未解決の割り当て"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:547
 msgid "Unschedule"
@@ -8407,12 +8407,12 @@ msgstr "予約を解除"
 
 #: packages/admin/src/router.tsx:1149
 msgid "Unscheduled"
-msgstr ""
+msgstr "予約なし"
 
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128
 msgid "Unsupported widget element type: {0}"
-msgstr ""
+msgstr "サポートされていないウィジェット要素タイプ: {0}"
 
 #: packages/admin/src/components/Dashboard.tsx:368
 msgid "Untitled"
@@ -8420,16 +8420,16 @@ msgstr "無題"
 
 #: packages/admin/src/components/ContentEditor.tsx:1654
 msgid "Untitled file"
-msgstr ""
+msgstr "無題のファイル"
 
 #: packages/admin/src/components/Widgets.tsx:536
 #: packages/admin/src/components/Widgets.tsx:809
 msgid "Untitled Widget"
-msgstr ""
+msgstr "無題のウィジェット"
 
 #: packages/admin/src/components/PublisherHandle.tsx:145
 msgid "Unverified publisher"
-msgstr ""
+msgstr "未確認の公開者"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1032
 msgid "Up"
@@ -8437,7 +8437,7 @@ msgstr "上へ"
 
 #: packages/admin/src/components/BylineFilter.tsx:164
 msgid "Up to {MAX_SELECTED} bylines can be selected"
-msgstr ""
+msgstr "署名は最大{MAX_SELECTED}件まで選択できます"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:662
 msgid "Update"
@@ -8449,7 +8449,7 @@ msgstr "フィールドを更新"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:621
 msgid "Update publish date"
-msgstr ""
+msgstr "公開日を更新"
 
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
@@ -8458,7 +8458,7 @@ msgstr "{0}の設定を更新"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:93
 msgid "Update site settings"
-msgstr ""
+msgstr "サイト設定を更新"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:544
@@ -8478,7 +8478,7 @@ msgstr "v{0}に更新"
 #: packages/admin/src/components/ContentSettingsPanel.tsx:637
 #: packages/admin/src/components/RegistryPluginDetail.tsx:501
 msgid "Updated"
-msgstr ""
+msgstr "更新済み"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:129
 msgid "Updated At"
@@ -8499,7 +8499,7 @@ msgstr "アップロード"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:152
 msgid "Upload a file to get started"
-msgstr ""
+msgstr "まずファイルをアップロードしてください"
 
 #: packages/admin/src/components/WordPressImport.tsx:1391
 msgid "Upload an export file"
@@ -8516,7 +8516,7 @@ msgstr "メディアのアップロードと削除"
 #: packages/admin/src/lib/api/marketplace.ts:283
 #: packages/admin/src/lib/api/marketplace.ts:291
 msgid "Upload and manage media"
-msgstr ""
+msgstr "メディアをアップロードして管理"
 
 #: packages/admin/src/components/WordPressImport.tsx:1284
 #: packages/admin/src/components/WordPressImport.tsx:1405
@@ -8525,7 +8525,7 @@ msgstr "エクスポートファイルをアップロード"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:96
 msgid "Upload failed"
-msgstr ""
+msgstr "アップロードに失敗しました"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:669
 msgid "Upload failed: {uploadError}"
@@ -8533,11 +8533,11 @@ msgstr "アップロード失敗: {uploadError}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:661
 msgid "Upload file"
-msgstr ""
+msgstr "ファイルをアップロード"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:154
 msgid "Upload File"
-msgstr ""
+msgstr "ファイルをアップロード"
 
 #: packages/admin/src/components/MediaLibrary.tsx:471
 #: packages/admin/src/components/MediaLibrary.tsx:495
@@ -8550,7 +8550,7 @@ msgstr "画像をアップロード"
 
 #: packages/admin/src/components/MediaLibrary.tsx:468
 msgid "Upload images, videos, and documents to keep reusable assets in one place."
-msgstr ""
+msgstr "画像、動画、ドキュメントをアップロードし、再利用できるアセットを1か所で管理します。"
 
 #: packages/admin/src/components/Dashboard.tsx:163
 msgid "Upload Media"
@@ -8558,7 +8558,7 @@ msgstr "メディアをアップロード"
 
 #: packages/admin/src/components/MediaLibrary.tsx:492
 msgid "Upload media to keep reusable assets in one place."
-msgstr ""
+msgstr "メディアをアップロードし、再利用できるアセットを1か所で管理します。"
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:329
@@ -8567,7 +8567,7 @@ msgstr "{0}にアップロード"
 
 #: packages/admin/src/components/MediaUploadDialog.tsx:396
 msgid "Upload to {providerName}"
-msgstr ""
+msgstr "{providerName}にアップロード"
 
 #: packages/admin/src/components/WordPressImport.tsx:1118
 msgid "Upload WordPress export file"
@@ -8599,7 +8599,7 @@ msgstr "URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:438
 msgid "URL Pattern"
-msgstr ""
+msgstr "URLパターン"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:113
 #: packages/admin/src/components/FieldEditor.tsx:258
@@ -8612,7 +8612,7 @@ msgstr "URLに適した識別子（例: \"primary\"、\"footer\"）"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:295
 msgid "URL:"
-msgstr ""
+msgstr "URL:"
 
 #: packages/admin/src/components/Redirects.tsx:111
 msgid "Use [param] or [...rest] in paths for pattern matching."
@@ -8628,7 +8628,7 @@ msgstr "登録済みのパスキーで安全にサインインできます。"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:173
 msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
-msgstr ""
+msgstr "ページに画像がない場合のOpen Graph画像として使用されます。推奨サイズ: 1200×630。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:828
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
@@ -8644,7 +8644,7 @@ msgstr "スクリーンリーダーおよび画像読み込み失敗時に使用
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:409
 msgid "Used in URLs and API endpoints"
-msgstr ""
+msgstr "URLとAPIエンドポイントで使用されます"
 
 #: packages/admin/src/components/SectionEditor.tsx:269
 #: packages/admin/src/components/Sections.tsx:196
@@ -8698,23 +8698,23 @@ msgstr "バリデーション"
 #: packages/admin/src/components/RegistryBrowse.tsx:189
 #: packages/admin/src/components/RegistryPluginDetail.tsx:462
 msgid "Verified publisher"
-msgstr ""
+msgstr "確認済みの公開者"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:461
 msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
-msgstr ""
+msgstr "確認済みの公開者（ラベラー{verifiedLabeller}が確認）"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:452
 msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
-msgstr ""
+msgstr "確認済みの公開者です。ラベラー（{verifiedLabeller}）がこの公開者の本人確認を行いました。"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:453
 msgid "Verified publisher. A labeller has confirmed this publisher's identity."
-msgstr ""
+msgstr "確認済みの公開者です。ラベラーがこの公開者の本人確認を行いました。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:228
 msgid "Verifying your invite..."
-msgstr ""
+msgstr "招待を確認しています..."
 
 #: packages/admin/src/components/SignupPage.tsx:388
 msgid "Verifying your link..."
@@ -8733,12 +8733,12 @@ msgstr "バージョン"
 #. placeholder {0}: release.version
 #: packages/admin/src/components/RegistryPluginDetail.tsx:477
 msgid "Version {0}"
-msgstr ""
+msgstr "バージョン{0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:67
 #: packages/admin/src/components/MediaLibrary.tsx:398
 msgid "Video"
-msgstr ""
+msgstr "動画"
 
 #: packages/admin/src/components/Settings.tsx:96
 #: packages/admin/src/components/settings/EmailSettings.tsx:59
@@ -8763,11 +8763,11 @@ msgstr "サイトを表示"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:676
 msgid "View source"
-msgstr ""
+msgstr "ソースを表示"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:931
 msgid "View the {license} license on spdx.org"
-msgstr ""
+msgstr "spdx.orgで{license}ライセンスを表示"
 
 #: packages/admin/src/components/Redirects.tsx:456
 msgid "Visitors hitting these paths will see an error."
@@ -8775,7 +8775,7 @@ msgstr "これらのパスにアクセスしたユーザーにはエラーが表
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:57
 msgid "Vue"
-msgstr ""
+msgstr "Vue"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
@@ -8793,7 +8793,7 @@ msgstr "{0}のWordPressサイトに接続できませんでした。サイトが
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:577
 msgid "We couldn't verify this publisher's identity"
-msgstr ""
+msgstr "この公開者の本人確認ができませんでした"
 
 #: packages/admin/src/components/WordPressImport.tsx:1084
 msgid "We'll check what import options are available for your site."
@@ -8823,7 +8823,7 @@ msgstr "ウェブサイト"
 
 #: packages/admin/src/routes/bylines.tsx:491
 msgid "Website URL"
-msgstr ""
+msgstr "ウェブサイトURL"
 
 #: packages/admin/src/components/WelcomeModal.tsx:102
 msgid "Welcome to EmDash, {firstName}!"
@@ -8863,64 +8863,64 @@ msgstr "整数"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:121
 msgid "Why can't this be changed?"
-msgstr ""
+msgstr "変更できない理由"
 
 #: packages/admin/src/components/SeoPanel.tsx:221
 msgid "Why is this important for duplicate pages?"
-msgstr ""
+msgstr "重複ページにとって重要な理由"
 
 #: packages/admin/src/components/SeoPanel.tsx:196
 msgid "Why is this important for search result summaries?"
-msgstr ""
+msgstr "検索結果の概要にとって重要な理由"
 
 #: packages/admin/src/components/SeoPanel.tsx:175
 msgid "Why is this important for search result titles?"
-msgstr ""
+msgstr "検索結果のタイトルにとって重要な理由"
 
 #: packages/admin/src/components/SeoPanel.tsx:240
 msgid "Why is this important for search visibility?"
-msgstr ""
+msgstr "検索での表示にとって重要な理由"
 
 #: packages/admin/src/components/SeoImageField.tsx:44
 msgid "Why is this important for social sharing?"
-msgstr ""
+msgstr "ソーシャル共有にとって重要な理由"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:123
 msgid "Why is this important?"
-msgstr ""
+msgstr "重要な理由"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:163
 msgid "Wide"
-msgstr ""
+msgstr "幅広"
 
 #: packages/admin/src/components/Widgets.tsx:802
 #: packages/admin/src/components/Widgets.tsx:817
 msgid "widget"
-msgstr ""
+msgstr "ウィジェット"
 
 #: packages/admin/src/components/Widgets.tsx:232
 msgid "Widget added"
-msgstr ""
+msgstr "ウィジェットを追加しました"
 
 #: packages/admin/src/components/Widgets.tsx:220
 msgid "Widget area created"
-msgstr ""
+msgstr "ウィジェットエリアを作成しました"
 
 #: packages/admin/src/components/Widgets.tsx:645
 msgid "Widget area deleted"
-msgstr ""
+msgstr "ウィジェットエリアを削除しました"
 
 #: packages/admin/src/components/Widgets.tsx:765
 msgid "Widget deleted"
-msgstr ""
+msgstr "ウィジェットを削除しました"
 
 #: packages/admin/src/components/Widgets.tsx:894
 msgid "Widget title"
-msgstr ""
+msgstr "ウィジェットのタイトル"
 
 #: packages/admin/src/components/Widgets.tsx:780
 msgid "Widget updated"
-msgstr ""
+msgstr "ウィジェットを更新しました"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:168
 #: packages/admin/src/components/PluginManager.tsx:408
@@ -8937,7 +8937,7 @@ msgstr "幅"
 
 #: packages/admin/src/components/PluginSettings.tsx:338
 msgid "Will be cleared on save"
-msgstr ""
+msgstr "保存時にクリアされます"
 
 #: packages/admin/src/components/WordPressImport.tsx:2014
 msgid "Will create"
@@ -8953,7 +8953,7 @@ msgstr "メールプロバイダーがない場合、招待リンクは手動で
 
 #: packages/admin/src/components/WordPressImport.tsx:210
 msgid "WordPress authorization was rejected"
-msgstr ""
+msgstr "WordPressの認証が拒否されました"
 
 #: packages/admin/src/components/WordPressImport.tsx:1476
 msgid "WordPress Username"
@@ -8961,11 +8961,11 @@ msgstr "WordPressユーザー名"
 
 #: packages/admin/src/components/ContentList.tsx:473
 msgid "Working on {selectedCount} items…"
-msgstr ""
+msgstr "{selectedCount}件を処理中…"
 
 #: packages/admin/src/components/Widgets.tsx:904
 msgid "Write widget content..."
-msgstr ""
+msgstr "ウィジェットの内容を入力..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1181
 msgid "WXR File"
@@ -8973,19 +8973,19 @@ msgstr "WXRファイル"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:58
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1497
 msgid "xxxx xxxx xxxx xxxx xxxx xxxx"
-msgstr ""
+msgstr "xxxx xxxx xxxx xxxx xxxx xxxx"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:59
 msgid "YAML"
-msgstr ""
+msgstr "YAML"
 
 #: packages/admin/src/components/Widgets.tsx:163
 msgid "Yearly"
-msgstr ""
+msgstr "毎年"
 
 #: packages/admin/src/components/ContentList.tsx:1283
 #: packages/admin/src/components/users/UserDetail.tsx:236
@@ -8996,7 +8996,7 @@ msgstr "はい"
 
 #: packages/admin/src/components/WordPressImport.tsx:1160
 msgid "Yoast/RankMath"
-msgstr ""
+msgstr "Yoast/RankMath"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."
@@ -9012,7 +9012,7 @@ msgstr "コンテンツ、メディア、メニュー、タクソノミーを管
 
 #: packages/admin/src/routes/bylines.tsx:549
 msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
-msgstr ""
+msgstr "上の固定フィールドは引き続き編集できます。保存しても、保存済みのカスタムフィールド値には影響しません。"
 
 #: packages/admin/src/components/WelcomeModal.tsx:50
 msgid "You can view and contribute to the site."
@@ -9028,11 +9028,11 @@ msgstr "ユーザー、設定、すべてのコンテンツを含む、サイト
 
 #: packages/admin/src/routes/byline-schema.tsx:175
 msgid "You need admin permissions to manage byline schema."
-msgstr ""
+msgstr "署名スキーマを管理するには、管理者権限が必要です。"
 
 #: packages/admin/src/router.tsx:1558
 msgid "You need Editor permissions to moderate comments."
-msgstr ""
+msgstr "コメントをモデレートするには、編集者権限が必要です。"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:199
@@ -9046,7 +9046,7 @@ msgstr "このパスキーでサインインできなくなります。この操
 #. placeholder {0}: inviteData.roleName
 #: packages/admin/src/components/InviteAcceptPage.tsx:55
 msgid "You'll be joining as <0>{0}</0>"
-msgstr ""
+msgstr "<0>{0}</0>として参加します"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
@@ -9066,7 +9066,7 @@ msgstr "Cloudflare Accessでサインイン中です"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:53
 msgid "You've been invited!"
-msgstr ""
+msgstr "招待されました！"
 
 #: packages/admin/src/components/SignupPage.tsx:71
 msgid "you@company.com"
@@ -9114,7 +9114,7 @@ msgstr "LinkedInのプロフィールユーザー名"
 #: packages/admin/src/components/MediaLibrary.tsx:467
 #: packages/admin/src/components/MediaLibrary.tsx:491
 msgid "Your media library is empty"
-msgstr ""
+msgstr "メディアライブラリは空です"
 
 #: packages/admin/src/components/SetupWizard.tsx:209
 msgid "Your Name"
@@ -9132,7 +9132,7 @@ msgstr "あなたのロール"
 #. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
 #: packages/admin/src/components/RegistryPluginDetail.tsx:612
 msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
-msgstr ""
+msgstr "サイトの設定により、リリースは公開から少なくとも{0}経過するまでインストールできません。このリリースは後でインストール可能になります。"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:142
 msgid "Your Twitter/X handle (e.g., @username)"
@@ -9140,7 +9140,7 @@ msgstr "Twitter/Xのハンドル名（例: @username）"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:437
 msgid "Your unsaved media changes will be lost."
-msgstr ""
+msgstr "保存していないメディアの変更は失われます。"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:2062

--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -83,7 +83,7 @@ msgstr "{0, plural, one {（#件）} other {（#件）}}"
 #: packages/admin/src/components/BylineFilter.tsx:103
 #: packages/admin/src/components/BylineFilter.tsx:104
 msgid "{0, plural, one {# byline} other {# bylines}}"
-msgstr "{0, plural, one {#件の署名} other {#件の署名}}"
+msgstr "{0, plural, one {#件の執筆者} other {#件の執筆者}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
@@ -181,12 +181,12 @@ msgstr "{0, plural, one {#件スキップ（既に存在）} other {#件スキ�
 #. placeholder {0}: result.taxonomyAssignments
 #: packages/admin/src/components/WordPressImport.tsx:2247
 msgid "{0, plural, one {# taxonomy assignment} other {# taxonomy assignments}}"
-msgstr "{0, plural, one {#件のタクソノミー割り当て} other {#件のタクソノミー割り当て}}"
+msgstr "{0, plural, one {#件の分類項目を割り当て} other {#件の分類項目を割り当て}}"
 
 #. placeholder {0}: result.taxonomiesCreated.length
 #: packages/admin/src/components/WordPressImport.tsx:2239
 msgid "{0, plural, one {# taxonomy created} other {# taxonomies created}}"
-msgstr "{0, plural, one {#件のタクソノミーを作成} other {#件のタクソノミーを作成}}"
+msgstr "{0, plural, one {#件の分類を作成} other {#件の分類を作成}}"
 
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:600
@@ -224,7 +224,7 @@ msgstr "{0}バナー"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:228
 msgid "{0} can't be moved here — its parent has no translation in this locale, so this list isn't the group it belongs to."
-msgstr "{0}はここに移動できません — 親にこのロケールの翻訳がないため、このリストは所属先のグループではありません。"
+msgstr "{0}はここに移動できません — 親項目にこの言語の翻訳がないため、この一覧は所属先のグループではありません。"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1303
@@ -595,7 +595,7 @@ msgstr "サイトの短い説明"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:455
 msgid "A source and target locale are required"
-msgstr "移行元と移行先のロケールが必要です"
+msgstr "翻訳元と翻訳先の言語を選択してください"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:201
 msgid "Accept & Install"
@@ -719,7 +719,7 @@ msgstr "フィールドを追加"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr "「役職」や「代名詞」などのフィールドを追加して、各署名の情報を充実させます。"
+msgstr "「役職」や「代名詞」などの項目を追加して、執筆者情報を充実させます。"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:628
 msgid "Add fields to define the structure of your content"
@@ -883,7 +883,7 @@ msgstr "すべての著者"
 #: packages/admin/src/components/BylineFilter.tsx:101
 #: packages/admin/src/routes/bylines.tsx:412
 msgid "All bylines"
-msgstr "すべての署名"
+msgstr "すべての執筆者"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:110
 msgid "All capabilities"
@@ -959,7 +959,7 @@ msgstr "プラグインのストレージデータも削除"
 
 #: packages/admin/src/components/BylineFilter.tsx:175
 msgid "Also match the byline linked to an entry's author when it has none assigned."
-msgstr "署名が割り当てられていない場合、エントリの著者にリンクされた署名も一致対象にします。"
+msgstr "執筆者が未設定の場合、コンテンツの著者に紐づく執筆者も対象にします。"
 
 #: packages/admin/src/components/editor/GalleryDetailPanel.tsx:376
 #: packages/admin/src/components/editor/ImageNode.tsx:231
@@ -1409,11 +1409,11 @@ msgstr "箇条書きリスト"
 #: packages/admin/src/routes/byline-schema.tsx:218
 #: packages/admin/src/routes/bylines.tsx:383
 msgid "Byline schema"
-msgstr "署名スキーマ"
+msgstr "執筆者情報の項目設定"
 
 #: packages/admin/src/components/Sidebar.tsx:295
 msgid "Byline Schema"
-msgstr "署名スキーマ"
+msgstr "執筆者情報の項目設定"
 
 #: packages/admin/src/components/BylineFilter.tsx:135
 #: packages/admin/src/components/ContentSettingsPanel.tsx:661
@@ -1421,7 +1421,7 @@ msgstr "署名スキーマ"
 #: packages/admin/src/components/Sidebar.tsx:285
 #: packages/admin/src/routes/bylines.tsx:375
 msgid "Bylines"
-msgstr "署名"
+msgstr "執筆者"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
@@ -1908,11 +1908,11 @@ msgstr "コンテンツ"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:499
 msgid "Content locale"
-msgstr "コンテンツのロケール"
+msgstr "コンテンツの言語"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:510
 msgid "Content locale defaults to English"
-msgstr "コンテンツのロケールはデフォルトで英語です"
+msgstr "コンテンツの言語は英語が初期値です"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:47
 msgid "Content Read"
@@ -2025,7 +2025,7 @@ msgstr "WordPressを検出できませんでした"
 
 #: packages/admin/src/routes/byline-schema.tsx:268
 msgid "Couldn't load byline fields."
-msgstr "署名フィールドを読み込めませんでした。"
+msgstr "執筆者情報の項目を読み込めませんでした。"
 
 #: packages/admin/src/routes/bylines.tsx:547
 msgid "Couldn't load custom fields."
@@ -2037,7 +2037,7 @@ msgstr "「{draft}」をMIMEタイプに変換できませんでした。MIMEタ
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1009
 msgid "Couldn't search bylines. Please try again."
-msgstr "署名を検索できませんでした。もう一度お試しください。"
+msgstr "執筆者を検索できませんでした。もう一度お試しください。"
 
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
@@ -2092,7 +2092,7 @@ msgstr "アカウントを作成"
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1089
 #: packages/admin/src/routes/bylines.tsx:476
 msgid "Create byline"
-msgstr "署名を作成"
+msgstr "執筆者を作成"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:575
 msgid "Create Content Type"
@@ -2159,7 +2159,7 @@ msgstr "セクションライブラリでセクションを作成して使用で
 #: packages/admin/src/components/TaxonomyManager.tsx:782
 #: packages/admin/src/components/TaxonomyManager.tsx:873
 msgid "Create Taxonomy"
-msgstr "タクソノミーを作成"
+msgstr "分類を作成"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:238
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:540
@@ -2203,7 +2203,7 @@ msgstr "ナビゲーションメニューの作成、更新、削除"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:78
 msgid "Create, update, and delete taxonomy terms"
-msgstr "タクソノミー用語の作成、更新、削除"
+msgstr "分類分類項目の作成、更新、削除"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:53
 msgid "Create, update, delete content"
@@ -2283,7 +2283,7 @@ msgstr "カスタムセクション"
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "Custom Taxonomies"
-msgstr "カスタムタクソノミー"
+msgstr "独自の分類"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:223
 msgid "Daily automatic backups"
@@ -2354,11 +2354,11 @@ msgstr "デフォルトのソーシャル画像"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:785
 msgid "Define a new taxonomy for classifying content"
-msgstr "コンテンツを分類するための新しいタクソノミーを定義"
+msgstr "コンテンツを整理するための分類を作成"
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr "すべての署名に保存されるカスタムフィールドを定義します — 役職、代名詞、ソーシャルハンドルなど。"
+msgstr "執筆者ごとに保存する追加項目を設定します — 役職、代名詞、SNSアカウントなど。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:118
 msgid "Define the structure of your content"
@@ -2435,11 +2435,11 @@ msgstr "バックアップを削除しますか？"
 
 #: packages/admin/src/routes/byline-schema.tsx:358
 msgid "Delete byline field?"
-msgstr "署名フィールドを削除しますか？"
+msgstr "執筆者情報の項目を削除しますか？"
 
 #: packages/admin/src/routes/bylines.tsx:622
 msgid "Delete Byline?"
-msgstr "署名を削除しますか？"
+msgstr "執筆者を削除しますか？"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3745
 msgid "Delete column"
@@ -2534,7 +2534,7 @@ msgstr "削除済み"
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr "「{0}」を削除すると、すべての署名から{1, plural, one {保存済みの値#件} other {保存済みの値#件}}も削除されます。この操作は取り消せません。"
+msgstr "「{0}」を削除すると、すべての執筆者から{1, plural, one {#件の保存済み値} other {#件の保存済み値}}も削除されます。この操作は取り消せません。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:409
 #: packages/admin/src/components/ContentTypeEditor.tsx:688
@@ -2816,7 +2816,7 @@ msgstr "{0}をダウンロード"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:191
 msgid "Download a complete backup of your site: all content (including drafts and trash), collections, taxonomies, menus, widgets, media metadata, and site settings. User accounts and secrets are never included."
-msgstr "サイト全体のバックアップをダウンロードします。すべてのコンテンツ（下書きとゴミ箱を含む）、コレクション、タクソノミー、メニュー、ウィジェット、メディアメタデータ、サイト設定が含まれます。ユーザーアカウントとシークレットは含まれません。"
+msgstr "サイト全体のバックアップをダウンロードします。すべてのコンテンツ（下書きとゴミ箱を含む）、コレクション、分類、メニュー、ウィジェット、メディアメタデータ、サイト設定が含まれます。ユーザーアカウントとシークレットは含まれません。"
 
 #: packages/admin/src/components/settings/BackupSettings.tsx:195
 msgid "Download backup"
@@ -2971,11 +2971,11 @@ msgstr "{title}を編集"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1151
 msgid "Edit byline"
-msgstr "署名を編集"
+msgstr "執筆者を編集"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "Edit byline field"
-msgstr "署名フィールドを編集"
+msgstr "執筆者情報の項目を編集"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:321
 msgid "Edit Domain"
@@ -3306,11 +3306,11 @@ msgstr "バックアップの作成に失敗しました"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1135
 msgid "Failed to create byline"
-msgstr "署名の作成に失敗しました"
+msgstr "執筆者の作成に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:120
 msgid "Failed to create byline field"
-msgstr "署名フィールドの作成に失敗しました"
+msgstr "執筆者情報の項目の作成に失敗しました"
 
 #: packages/admin/src/routes/byline-schema.tsx:102
 msgid "Failed to create field"
@@ -3326,7 +3326,7 @@ msgstr "一部のコレクションの作成に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:638
 msgid "Failed to create term"
-msgstr "タームの作成に失敗しました"
+msgstr "分類項目の作成に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:475
 #: packages/admin/src/router.tsx:1186
@@ -3350,11 +3350,11 @@ msgstr "バックアップの削除に失敗しました"
 
 #: packages/admin/src/lib/api/bylines.ts:143
 msgid "Failed to delete byline"
-msgstr "署名の削除に失敗しました"
+msgstr "執筆者の削除に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:143
 msgid "Failed to delete byline field"
-msgstr "署名フィールドの削除に失敗しました"
+msgstr "執筆者情報の項目の削除に失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:244
 msgid "Failed to delete collection"
@@ -3404,7 +3404,7 @@ msgstr "セクションの削除に失敗しました"
 
 #: packages/admin/src/lib/api/taxonomies.ts:221
 msgid "Failed to delete term"
-msgstr "用語の削除に失敗しました"
+msgstr "分類項目の削除に失敗しました"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
@@ -3479,7 +3479,7 @@ msgstr "メール設定の取得に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:140
 msgid "Failed to fetch entry terms"
-msgstr "エントリの用語の取得に失敗しました"
+msgstr "コンテンツの分類項目の取得に失敗しました"
 
 #: packages/admin/src/lib/api/client.ts:251
 msgid "Failed to fetch manifest"
@@ -3537,7 +3537,7 @@ msgstr "セットアップ状態の取得に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:124
 msgid "Failed to fetch terms"
-msgstr "用語の取得に失敗しました"
+msgstr "分類項目の取得に失敗しました"
 
 #: packages/admin/src/lib/api/current-user.ts:22
 #: packages/admin/src/lib/api/users.ts:88
@@ -3583,7 +3583,7 @@ msgstr "プラグインのインストールに失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:98
 msgid "Failed to list byline fields"
-msgstr "署名フィールド一覧の取得に失敗しました"
+msgstr "執筆者情報の項目一覧の取得に失敗しました"
 
 #: packages/admin/src/router.tsx:287
 msgid "Failed to load admin"
@@ -3601,7 +3601,7 @@ msgstr "バックアップ設定の読み込みに失敗しました"
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "Failed to load bylines: {0}"
-msgstr "署名の読み込みに失敗しました: {0}"
+msgstr "執筆者の読み込みに失敗しました: {0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:80
 #: packages/admin/src/components/settings/EmailSettings.tsx:81
@@ -3673,7 +3673,7 @@ msgstr "公開に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:106
 msgid "Failed to read byline field usage"
-msgstr "署名フィールドの使用状況を読み取れませんでした"
+msgstr "執筆者情報の項目の使用状況を取得できませんでした"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:115
 msgid "Failed to remove domain"
@@ -3690,7 +3690,7 @@ msgstr "パスキーの名前変更に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:156
 msgid "Failed to reorder byline fields"
-msgstr "署名フィールドの並べ替えに失敗しました"
+msgstr "執筆者情報の項目の並べ替えに失敗しました"
 
 #: packages/admin/src/lib/api/schema.ts:332
 msgid "Failed to reorder content types"
@@ -3771,7 +3771,7 @@ msgstr "確認メールの送信に失敗しました"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:159
 msgid "Failed to set entry terms"
-msgstr "エントリへの用語設定に失敗しました"
+msgstr "コンテンツの分類項目の設定に失敗しました"
 
 #: packages/admin/src/lib/api/marketplace.ts:249
 #: packages/admin/src/lib/api/registry.ts:858
@@ -3801,11 +3801,11 @@ msgstr "バックアップ設定の更新に失敗しました"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1185
 msgid "Failed to update byline"
-msgstr "署名の更新に失敗しました"
+msgstr "執筆者の更新に失敗しました"
 
 #: packages/admin/src/lib/api/byline-fields.ts:135
 msgid "Failed to update byline field"
-msgstr "署名フィールドの更新に失敗しました"
+msgstr "執筆者情報の項目の更新に失敗しました"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:98
 msgid "Failed to update domain"
@@ -3959,7 +3959,7 @@ msgstr "著者で絞り込む"
 
 #: packages/admin/src/components/BylineFilter.tsx:111
 msgid "Filter by byline"
-msgstr "署名で絞り込む"
+msgstr "執筆者で絞り込む"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:115
 msgid "Filter by capability"
@@ -3989,7 +3989,7 @@ msgstr "種類で絞り込む"
 
 #: packages/admin/src/routes/bylines.tsx:408
 msgid "Filter byline type"
-msgstr "署名タイプで絞り込む"
+msgstr "執筆者の種類で絞り込む"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
@@ -4090,7 +4090,7 @@ msgstr "グループ化"
 
 #: packages/admin/src/routes/bylines.tsx:555
 msgid "Guest byline"
-msgstr "ゲスト署名"
+msgstr "ゲスト執筆者"
 
 #: packages/admin/src/routes/bylines.tsx:413
 msgid "Guest only"
@@ -4370,7 +4370,7 @@ msgstr "メニューとサイト設定をインポート中..."
 
 #: packages/admin/src/components/BylineFilter.tsx:172
 msgid "Include inferred bylines"
-msgstr "推測された署名を含める"
+msgstr "著者情報から推定した執筆者を含める"
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
@@ -4615,7 +4615,7 @@ msgstr "このタブを開いたままにしてください。インポートは
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1014
 msgid "Keep typing to narrow down more bylines."
-msgstr "入力を続けて署名をさらに絞り込んでください。"
+msgstr "入力を続けて執筆者をさらに絞り込んでください。"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:283
@@ -4792,7 +4792,7 @@ msgstr "読み込み中"
 
 #: packages/admin/src/routes/byline-schema.tsx:257
 msgid "Loading byline fields…"
-msgstr "署名フィールドを読み込み中…"
+msgstr "執筆者情報の項目を読み込み中…"
 
 #: packages/admin/src/components/ContentTypeList.tsx:198
 msgid "Loading collections..."
@@ -4849,7 +4849,7 @@ msgstr "セットアップを読み込み中..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1054
 msgid "Loading terms..."
-msgstr "タームを読み込み中..."
+msgstr "分類項目を読み込み中..."
 
 #: packages/admin/src/components/Widgets.tsx:372
 msgid "Loading widgets..."
@@ -4887,7 +4887,7 @@ msgstr "読み込み中…"
 #: packages/admin/src/components/ContentList.tsx:599
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
 msgid "Locale"
-msgstr "ロケール"
+msgstr "言語"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:296
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:297
@@ -4956,7 +4956,7 @@ msgstr "{1}の{0}を管理"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:976
 msgid "Manage bylines in {entryLocale}"
-msgstr "{entryLocale}の署名を管理"
+msgstr "{entryLocale}の執筆者を管理"
 
 #: packages/admin/src/components/Widgets.tsx:390
 msgid "Manage content widgets in your widget areas"
@@ -5242,7 +5242,7 @@ msgstr "{0}を下へ移動"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Move {0} down — unavailable, its parent has no translation in this locale"
-msgstr "{0}を下へ移動 — 親にこのロケールの翻訳がないため利用できません"
+msgstr "{0}を下へ移動 — 親項目にこの言語の翻訳がないため利用できません"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:238
@@ -5252,7 +5252,7 @@ msgstr "{0}を上へ移動"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:237
 msgid "Move {0} up — unavailable, its parent has no translation in this locale"
-msgstr "{0}を上へ移動 — 親にこのロケールの翻訳がないため利用できません"
+msgstr "{0}を上へ移動 — 親項目にこの言語の翻訳がないため利用できません"
 
 #: packages/admin/src/components/ContentList.tsx:1236
 msgid "Move {title} to trash"
@@ -5359,7 +5359,7 @@ msgstr "新しい{itemLabel}"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
-msgstr "新しい署名フィールド"
+msgstr "新しい執筆者情報の項目"
 
 #: packages/admin/src/components/WordPressImport.tsx:1982
 msgid "New collection"
@@ -5393,7 +5393,7 @@ msgstr "新しいタブ"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1038
 msgid "New Taxonomy"
-msgstr "新しいタクソノミー"
+msgstr "新しい分類"
 
 #: packages/admin/src/components/MenuEditor.tsx:430
 #: packages/admin/src/components/MenuEditor.tsx:433
@@ -5468,28 +5468,28 @@ msgstr "承認済みのコメントはまだありません。"
 
 #: packages/admin/src/components/BylineFilter.tsx:99
 msgid "No byline"
-msgstr "署名なし"
+msgstr "執筆者なし"
 
 #: packages/admin/src/components/BylineFilter.tsx:131
 msgid "No byline assigned"
-msgstr "署名が割り当てられていません"
+msgstr "執筆者が設定されていません"
 
 #: packages/admin/src/routes/byline-schema.tsx:291
 msgid "No byline fields yet."
-msgstr "署名フィールドはまだありません。"
+msgstr "執筆者情報の項目はまだありません。"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:968
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr "{entryLocale}で利用できる署名がありません。このエントリにクレジットを追加する前に、署名ページでこのロケールのバリエーションを作成してください。"
+msgstr "{entryLocale}で利用できる執筆者がいません。このコンテンツに執筆者を表示する前に、執筆者ページでこの言語の情報を作成してください。"
 
 #: packages/admin/src/components/BylineFilter.tsx:139
 #: packages/admin/src/routes/bylines.tsx:452
 msgid "No bylines found"
-msgstr "署名が見つかりません"
+msgstr "執筆者が見つかりません"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1076
 msgid "No bylines selected."
-msgstr "署名が選択されていません。"
+msgstr "執筆者が選択されていません。"
 
 #: packages/admin/src/components/Dashboard.tsx:275
 msgid "No collections configured"
@@ -5517,7 +5517,7 @@ msgstr "このコレクションにはコンテンツがありません"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:511
 msgid "No content locale is configured, so EmDash stores new content as English (en). Changing the admin language does not change this value."
-msgstr "コンテンツのロケールが設定されていないため、EmDashは新しいコンテンツを英語（en）として保存します。管理画面の言語を変更しても、この値は変わりません。"
+msgstr "コンテンツの言語が設定されていないため、EmDashでは新しいコンテンツを英語（en）として保存します。管理画面の表示言語を変更しても、コンテンツの言語は変わりません。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:204
 msgid "No content types yet."
@@ -5595,7 +5595,7 @@ msgstr "一致なし"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1011
 msgid "No matching bylines."
-msgstr "一致する署名がありません。"
+msgstr "一致する執筆者がありません。"
 
 #: packages/admin/src/components/MediaLibrary.tsx:452
 #: packages/admin/src/components/MediaLibrary.tsx:480
@@ -6331,7 +6331,7 @@ msgstr "待機中"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:1084
 msgid "Quick create byline"
-msgstr "署名をクイック作成"
+msgstr "執筆者をすぐに作成"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:196
 #: packages/admin/src/components/editor/ImageNode.tsx:197
@@ -6376,7 +6376,7 @@ msgstr "コンテンツを読み取る"
 
 #: packages/admin/src/lib/api/marketplace.ts:281
 msgid "Read your taxonomies and terms"
-msgstr "タクソノミーと用語を読み取る"
+msgstr "分類と分類項目を読み取る"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:310
 msgid "Reading"
@@ -7019,15 +7019,15 @@ msgstr "名前またはメールアドレスで検索..."
 #: packages/admin/src/components/ContentSettingsPanel.tsx:985
 #: packages/admin/src/routes/bylines.tsx:401
 msgid "Search bylines"
-msgstr "署名を検索"
+msgstr "執筆者を検索"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:984
 msgid "Search bylines to add..."
-msgstr "追加する署名を検索..."
+msgstr "追加する執筆者を検索..."
 
 #: packages/admin/src/components/BylineFilter.tsx:122
 msgid "Search bylines…"
-msgstr "署名を検索…"
+msgstr "執筆者を検索…"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:164
 msgid "Search comments"
@@ -7446,7 +7446,7 @@ msgstr "招待したユーザーとこのリンクを共有してください"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:294
 msgid "Shared across all translations of the same byline."
-msgstr "同じ署名のすべての翻訳で共有されます。"
+msgstr "同じ執筆者のすべての翻訳で共有されます。"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:52
 msgid "Short text"
@@ -7741,7 +7741,7 @@ msgstr "保存済みバックアップ"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:293
 msgid "Stored per locale — each translation of a byline gets its own value."
-msgstr "ロケールごとに保存され、署名の各翻訳には個別の値が設定されます。"
+msgstr "言語ごとに保存され、執筆者の翻訳ごとに異なる値を設定できます。"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3639
 #: packages/admin/src/components/PortableTextEditor.tsx:4044
@@ -7831,28 +7831,28 @@ msgstr "ターゲット"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:354
 msgid "Target locale"
-msgstr "翻訳先のロケール"
+msgstr "翻訳先の言語"
 
 #: packages/admin/src/components/ContentSettingsPanel.tsx:706
 #: packages/admin/src/components/TaxonomySidebar.tsx:683
 msgid "Taxonomies"
-msgstr "タクソノミー"
+msgstr "分類"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:77
 msgid "Taxonomies Manage"
-msgstr "タクソノミーの管理"
+msgstr "分類の管理"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1124
 msgid "Taxonomy created"
-msgstr "タクソノミーを作成しました"
+msgstr "分類を作成しました"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:1014
 msgid "Taxonomy not found:"
-msgstr "タクソノミーが見つかりません:"
+msgstr "分類が見つかりません:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:341
 msgid "Taxonomy: {taxonomyName}"
-msgstr "タクソノミー: {taxonomyName}"
+msgstr "分類: {taxonomyName}"
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
@@ -7862,17 +7862,17 @@ msgstr "テンプレート:"
 #: packages/admin/src/components/TaxonomyManager.tsx:540
 #: packages/admin/src/components/TaxonomyManager.tsx:1041
 msgid "Term"
-msgstr "ターム"
+msgstr "分類項目"
 
 #. placeholder {0}: term.label
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:988
 msgid "Term \"{0}\" created in {1}."
-msgstr "{1}に用語「{0}」を作成しました。"
+msgstr "{1}に分類項目「{0}」を作成しました。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:928
 msgid "Term deleted"
-msgstr "タームを削除しました"
+msgstr "分類項目を削除しました"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:111
 msgid "test@example.com"
@@ -8049,7 +8049,7 @@ msgstr "このリリースには、サイトの現在の環境より新しい環
 
 #: packages/admin/src/routes/bylines.tsx:623
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr "この署名プロフィールを削除します。コンテンツの署名リンクが削除され、代表署名への参照も解除されます。"
+msgstr "この執筆者プロフィールを削除します。コンテンツとの関連付けと代表執筆者の設定も解除されます。"
 
 #. placeholder {0}: sectionInsertErrorMarks.join(", ")
 #: packages/admin/src/components/PortableTextEditor.tsx:3359
@@ -8437,7 +8437,7 @@ msgstr "上へ"
 
 #: packages/admin/src/components/BylineFilter.tsx:164
 msgid "Up to {MAX_SELECTED} bylines can be selected"
-msgstr "署名は最大{MAX_SELECTED}件まで選択できます"
+msgstr "執筆者は最大{MAX_SELECTED}件まで選択できます"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:662
 msgid "Update"
@@ -8855,7 +8855,7 @@ msgstr "エントリの公開日時"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:842
 msgid "Which content types can use this taxonomy"
-msgstr "このタクソノミーを使用できるコンテンツタイプ"
+msgstr "この分類を使用できるコンテンツタイプ"
 
 #: packages/admin/src/components/FieldEditor.tsx:198
 msgid "Whole number"
@@ -9008,7 +9008,7 @@ msgstr "自分のコンテンツを作成・編集できます。"
 
 #: packages/admin/src/components/WelcomeModal.tsx:48
 msgid "You can manage content, media, menus, and taxonomies."
-msgstr "コンテンツ、メディア、メニュー、タクソノミーを管理できます。"
+msgstr "コンテンツ、メディア、メニュー、分類を管理できます。"
 
 #: packages/admin/src/routes/bylines.tsx:549
 msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
@@ -9028,7 +9028,7 @@ msgstr "ユーザー、設定、すべてのコンテンツを含む、サイト
 
 #: packages/admin/src/routes/byline-schema.tsx:175
 msgid "You need admin permissions to manage byline schema."
-msgstr "署名スキーマを管理するには、管理者権限が必要です。"
+msgstr "執筆者情報の項目を管理するには、管理者権限が必要です。"
 
 #: packages/admin/src/router.tsx:1558
 msgid "You need Editor permissions to moderate comments."


### PR DESCRIPTION
## What does this PR do?

Completes the Japanese (`ja`) admin catalog by translating the 800 remaining empty `msgstr` entries in `packages/admin/src/locales/ja/messages.po`.

It also improves existing terminology so CMS concepts read naturally in Japanese instead of relying on literal transliterations. Examples include:

- taxonomy / term: `分類` / `分類項目`
- byline: `執筆者`
- locale: `言語`
- provider: context-specific terms such as `外部認証サービス`, `メール送信サービス`, and `メディア連携先`
- revision: `版` or `変更履歴`, depending on context
- collection: `コンテンツタイプ`
- user role: `権限` (while byline roles use `役割名`)
- reading time: `約#分で読めます`
- generic item / entry labels: context-specific wording such as `コンテンツ`, `項目`, or a simple `#件`
- unrestricted media fields: plain-language wording that explains both file-format and size settings

The resulting catalog has 1,998/1,998 translated entries, with no empty or fuzzy entries. Interpolation placeholders, ICU plural syntax, and XML-style tags are preserved.

A native Japanese speaker supervised the terminology choices and reviewed the Japanese UI in a deployed EmDash Playground environment. A follow-up review refined reading-time, content-type, permission, media, moderation, activity, and scheduled-publishing terminology. The temporary Cloudflare review environment was deleted after verification, and the refined catalog was re-reviewed in the local Japanese admin UI.

The implementation change is limited to the Japanese catalog. A patch changeset for `@emdash-cms/admin` documents the completed translation for release.

Related issue or discussion: N/A

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (not applicable: catalog-only translation)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (catalog-only translation; source strings were not changed)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md)
- [ ] New features link to an approved Discussion: N/A — this is not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

The initial translation pass and terminology consistency checks were AI-assisted. A native Japanese speaker supervised the wording and reviewed the deployed admin UI before submission.

## Screenshots / test output

- `pnpm locale:compile` — passed
- `pnpm build` — passed
- `pnpm typecheck` — passed across 31 package workspaces
- `pnpm lint:json` — passed with 0 type-aware diagnostics
- `pnpm lint:quick` — passed
- `pnpm format` — passed
- `pnpm changeset status` — passed; `@emdash-cms/admin` is included in the release plan
- Admin Vitest suite — 121 files and 1,502 tests passed
- Catalog validation — 1,998/1,998 translated; 0 empty, 0 fuzzy, 0 ICU argument, branch, or tag mismatches
- Manual review — Japanese admin UI reviewed in a temporary Cloudflare Playground deployment and re-reviewed locally after the terminology refinements
