### PR TITLE
feat(media): add image focal points

### DIFF
--- a/.changeset/media-focal-point.md
+++ b/.changeset/media-focal-point.md
@@ -1,0 +1,6 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+---
+
+Adds focal points for local images so cover-cropped thumbnails, galleries, and image components keep the selected subject visible.

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -214,6 +214,20 @@ references remain unchanged.
 
 For fields configured as image or file types, click the field to open the media picker.
 
+## Setting a focal point
+
+A focal point keeps the important part of a local image visible when a card, gallery, or other
+layout crops it to fill a fixed shape.
+
+1. Open **Media**, then select an image from the local library.
+2. Select **Focal point**.
+3. Click or drag the marker onto the important part of the image. You can also use the Arrow keys.
+4. Check the square, landscape, and portrait previews, then select **Save**.
+
+Select **Reset** to remove a custom focal point. The saved point is copied when you select
+the image for a content field or gallery. Content that already uses the image keeps its stored point
+until you select the image again.
+
 ## Displaying Media in Templates
 
 Access media URLs from your content data:
@@ -479,6 +493,8 @@ interface MediaValue {
   mimeType?: string;    // MIME type
   width?: number;       // Image/video width
   height?: number;      // Image/video height
+  focalX?: number;      // Horizontal focal position from 0 to 1
+  focalY?: number;      // Vertical focal position from 0 to 1
   alt?: string;         // Alt text
   meta?: Record<string, unknown>; // Provider-specific metadata
 }

--- a/packages/admin/src/components/FocalPointEditor.tsx
+++ b/packages/admin/src/components/FocalPointEditor.tsx
@@ -1,0 +1,167 @@
+import { useLingui } from "@lingui/react/macro";
+import * as React from "react";
+
+import { getMediaObjectPosition, type MediaFocalPoint } from "../lib/media-utils.js";
+
+interface FocalPointEditorProps {
+	src: string;
+	alt: string;
+	editing: boolean;
+	disabled: boolean;
+	point: MediaFocalPoint | null;
+	descriptionId: string;
+	onChange: (point: MediaFocalPoint) => void;
+	onReadyChange?: (ready: boolean) => void;
+}
+
+const KEY_MOVES: Record<string, [number, number]> = {
+	ArrowLeft: [-1, 0],
+	ArrowRight: [1, 0],
+	ArrowUp: [0, -1],
+	ArrowDown: [0, 1],
+};
+const clamp = (value: number) => Math.min(1, Math.max(0, Math.round(value * 10_000) / 10_000));
+
+export function FocalPointPreviews({ src, point }: Pick<FocalPointEditorProps, "src" | "point">) {
+	const { t } = useLingui();
+	const current = point ?? { focalX: 0.5, focalY: 0.5 };
+	const objectPosition = getMediaObjectPosition(current)!;
+	const previews = [
+		["portrait", t`Portrait`, "aspect-[4/5]"],
+		["square", t`Square`, "aspect-square"],
+		["landscape", t`Landscape`, "aspect-video"],
+	] as const;
+
+	return (
+		<div className="grid w-full grid-cols-3 items-end gap-2" data-testid="focal-preview-group">
+			{previews.map(([id, label, ratio]) => (
+				<figure key={id} className="grid w-full min-w-0 gap-1.5">
+					<div className={`overflow-hidden rounded-lg bg-kumo-tint ring ring-kumo-line ${ratio}`}>
+						<img
+							src={src}
+							alt=""
+							data-testid={`focal-preview-${id}`}
+							className="h-full w-full object-cover"
+							style={{ objectPosition }}
+						/>
+					</div>
+					<figcaption className="truncate text-center text-sm text-kumo-subtle">{label}</figcaption>
+				</figure>
+			))}
+		</div>
+	);
+}
+
+export function FocalPointEditor({
+	src,
+	alt,
+	editing,
+	disabled,
+	point,
+	descriptionId,
+	onChange,
+	onReadyChange,
+}: FocalPointEditorProps) {
+	const { t } = useLingui();
+	const activePointerRef = React.useRef<number | null>(null);
+	const [ready, setReady] = React.useState(false);
+	const [announcement, setAnnouncement] = React.useState("");
+	const current = point ?? { focalX: 0.5, focalY: 0.5 };
+
+	const announce = (next: MediaFocalPoint) =>
+		setAnnouncement(
+			t`Horizontal ${Math.round(next.focalX * 100)}%, vertical ${Math.round(next.focalY * 100)}%`,
+		);
+	const releasePointer = (event: React.PointerEvent<HTMLButtonElement>) => {
+		if (activePointerRef.current !== event.pointerId) return;
+		activePointerRef.current = null;
+		if (
+			event.type !== "lostpointercapture" &&
+			event.currentTarget.hasPointerCapture(event.pointerId)
+		) {
+			event.currentTarget.releasePointerCapture(event.pointerId);
+		}
+	};
+	const handlePointer = (event: React.PointerEvent<HTMLButtonElement>) => {
+		if (event.type === "pointerdown") {
+			if (activePointerRef.current !== null) return;
+			activePointerRef.current = event.pointerId;
+			event.currentTarget.setPointerCapture(event.pointerId);
+		} else if (activePointerRef.current !== event.pointerId) {
+			return;
+		}
+		if (event.type === "pointercancel" || event.type === "lostpointercapture") {
+			return releasePointer(event);
+		}
+		const bounds = event.currentTarget.getBoundingClientRect();
+		if (bounds.width && bounds.height) {
+			const next = {
+				focalX: clamp((event.clientX - bounds.left) / bounds.width),
+				focalY: clamp((event.clientY - bounds.top) / bounds.height),
+			};
+			onChange(next);
+			if (event.type === "pointerup") announce(next);
+		}
+		if (event.type === "pointerup") releasePointer(event);
+	};
+	const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+		const move = KEY_MOVES[event.key];
+		if (!move) return;
+		event.preventDefault();
+		const step = event.shiftKey ? 0.05 : 0.01;
+		const next = {
+			focalX: clamp(current.focalX + move[0] * step),
+			focalY: clamp(current.focalY + move[1] * step),
+		};
+		onChange(next);
+		announce(next);
+	};
+
+	return (
+		<div className="grid gap-4">
+			<div className="flex h-64 items-center justify-center overflow-hidden rounded-xl bg-kumo-tint ring ring-kumo-line md:h-80">
+				<div className="relative inline-flex max-h-full max-w-full">
+					<img
+						src={src}
+						alt={alt}
+						className="block max-h-64 max-w-full object-contain md:max-h-80"
+						draggable={false}
+						onLoad={() => {
+							setReady(true);
+							onReadyChange?.(true);
+						}}
+						onError={() => {
+							setReady(false);
+							onReadyChange?.(false);
+						}}
+					/>
+					{editing && ready && (
+						<button
+							type="button"
+							aria-label={t`Focal point. Use arrow keys to move it.`}
+							aria-describedby={descriptionId}
+							disabled={disabled}
+							className="absolute inset-0 cursor-crosshair touch-none rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-brand"
+							onPointerDown={handlePointer}
+							onPointerMove={handlePointer}
+							onPointerUp={handlePointer}
+							onPointerCancel={handlePointer}
+							onLostPointerCapture={handlePointer}
+							onKeyDown={handleKeyDown}
+						>
+							<span
+								aria-hidden="true"
+								className="absolute h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-kumo-brand ring-2 ring-kumo-base"
+								style={{ left: `${current.focalX * 100}%`, top: `${current.focalY * 100}%` }}
+							/>
+						</button>
+					)}
+				</div>
+			</div>
+
+			<p role="status" aria-live="polite" className="sr-only">
+				{announcement}
+			</p>
+		</div>
+	);
+}

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -14,7 +14,7 @@ import { Image as ImageIcon, ImageBroken, ImageSquare, X } from "@phosphor-icons
 import * as React from "react";
 
 import type { MediaItem } from "../lib/api";
-import { metaString } from "../lib/media-utils";
+import { getMediaObjectPosition, metaString } from "../lib/media-utils";
 import { FieldHelpLabel } from "./FieldHelpLabel.js";
 import { MediaPickerModal } from "./MediaPickerModal";
 
@@ -34,6 +34,8 @@ export interface ImageFieldValue {
 	alt?: string;
 	width?: number;
 	height?: number;
+	focalX?: number;
+	focalY?: number;
 	/** LQIP blurhash placeholder (images only) */
 	blurhash?: string;
 	/** LQIP dominant-color placeholder, as a CSS color (images only) */
@@ -97,6 +99,8 @@ export function ImageFieldRenderer({
 			alt: item.alt || "",
 			width: item.width,
 			height: item.height,
+			focalX: item.focalX ?? undefined,
+			focalY: item.focalY ?? undefined,
 			filename: item.filename,
 			mimeType: item.mimeType,
 			// Cache LQIP alongside dimensions so embeds render a placeholder without a
@@ -120,6 +124,8 @@ export function ImageFieldRenderer({
 			: undefined;
 	const mimeType = typeof value === "object" && value.mimeType ? value.mimeType : undefined;
 	const metadata = [dimensions, mimeType].filter(Boolean).join(" · ");
+	const objectPosition =
+		typeof value === "object" && value ? getMediaObjectPosition(value) : undefined;
 
 	const featuredCard = displayUrl ? (
 		<LayerCard className="grid w-full grid-cols-1 rounded-xl p-0 sm:grid-cols-[12rem_minmax(0,1fr)]">
@@ -136,6 +142,7 @@ export function ImageFieldRenderer({
 						src={displayUrl}
 						alt=""
 						className="h-full w-full object-cover"
+						style={{ objectPosition }}
 						onError={() => setImageBroken(true)}
 					/>
 				)}
@@ -225,6 +232,7 @@ export function ImageFieldRenderer({
 							src={displayUrl}
 							alt=""
 							className="max-h-48 min-h-20 rounded-lg border object-cover"
+							style={{ objectPosition }}
 							onError={() => setImageBroken(true)}
 						/>
 						<div className="absolute top-2 end-2 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -12,6 +12,7 @@ import {
 	Dialog,
 	Input,
 	InputArea,
+	Tabs,
 	Tooltip,
 	inputVariants,
 } from "@cloudflare/kumo";
@@ -22,6 +23,7 @@ import {
 	Trash,
 	Calendar,
 	CaretDown,
+	File,
 	HardDrive,
 	LinkSimple,
 	Ruler,
@@ -41,13 +43,22 @@ import {
 	type LocalMediaItem,
 	type MediaFolder,
 	type MediaItem,
+	type MediaUpdateInput,
 } from "../lib/api";
 import { useDebouncedValue, useStableCallback } from "../lib/hooks";
-import { getFileIcon, formatFileSize, metaPlayback } from "../lib/media-utils";
+import {
+	getFileIcon,
+	formatFileSize,
+	metaPlayback,
+	normalizeMediaFocalPoint,
+	type MediaFocalPoint,
+} from "../lib/media-utils";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { DialogError, getMutationError } from "./DialogError.js";
+import { FocalPointEditor, FocalPointPreviews } from "./FocalPointEditor.js";
 
 const CLOSE_FALLBACK_MS = 500;
+type MediaDetailTab = "details" | "edit-image";
 
 interface MediaLocationOption {
 	id: string | null;
@@ -109,8 +120,13 @@ export function MediaDetailPanel({
 	const [selectedFolder, setSelectedFolder] = React.useState<MediaFolder | null>(null);
 	const [locationOpen, setLocationOpen] = React.useState(false);
 	const [locationSearch, setLocationSearch] = React.useState("");
+	const [focalPoint, setFocalPoint] = React.useState<MediaFocalPoint | null>(() =>
+		normalizeMediaFocalPoint(item),
+	);
+	const [activeTab, setActiveTab] = React.useState<MediaDetailTab>("details");
 	const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
 	const [showDiscardConfirm, setShowDiscardConfirm] = React.useState(false);
+	const focalPointDescriptionId = React.useId();
 
 	React.useEffect(() => {
 		if (!open) return;
@@ -128,6 +144,8 @@ export function MediaDetailPanel({
 		setSelectedFolder(null);
 		setLocationOpen(false);
 		setLocationSearch("");
+		setFocalPoint(normalizeMediaFocalPoint(item));
+		setActiveTab("details");
 		setShowDeleteConfirm(false);
 		setShowDiscardConfirm(false);
 	}, [item.id, localItem?.folderId, open]);
@@ -165,14 +183,20 @@ export function MediaDetailPanel({
 		closeFallbackTimerRef.current = window.setTimeout(finishClose, CLOSE_FALLBACK_MS);
 	}, [finishClose, onClose]);
 
+	const originalFocalPoint = normalizeMediaFocalPoint(item);
+	const focalPointChanged =
+		focalPoint?.focalX !== originalFocalPoint?.focalX ||
+		focalPoint?.focalY !== originalFocalPoint?.focalY;
 	const metadataChanged =
-		canEditMetadata && (alt !== (item.alt ?? "") || caption !== (item.caption ?? ""));
+		canEditMetadata &&
+		(alt !== (item.alt ?? "") || caption !== (item.caption ?? "") || focalPointChanged);
 	const locationChanged = canMoveLocation && folderId !== localItem?.folderId;
 	const canEdit = canEditMetadata || canMoveLocation;
 	const hasChanges = metadataChanged || locationChanged;
 	const isConfirmOpen = showDeleteConfirm || showDiscardConfirm;
 	const publicFileUrl =
 		!isProviderAsset && item.url ? new URL(item.url, window.location.origin).href : "";
+	const publicFilePath = publicFileUrl ? new URL(publicFileUrl).pathname : "";
 	const filenameHelp = t`Filename cannot be changed after upload`;
 	const filenameHelpLabel = t`Why can't this be changed?`;
 	const altTextHelp = t`Used by screen readers and when image fails to load`;
@@ -292,8 +316,7 @@ export function MediaDetailPanel({
 	}, [open]);
 
 	const updateMutation = useMutation({
-		mutationFn: (data: { alt?: string; caption?: string; folderId?: string | null }) =>
-			updateMedia(item.id, data),
+		mutationFn: (data: MediaUpdateInput) => updateMedia(item.id, data),
 		onSuccess: () => {
 			if (locationChanged) restoreFocusAfterDeleteRef.current = true;
 			void queryClient.invalidateQueries({ queryKey: ["media"] });
@@ -355,10 +378,17 @@ export function MediaDetailPanel({
 	const handleSave = () => {
 		if (!canEdit || !hasChanges || isBusy || mediaUnavailable || savePendingRef.current) return;
 		savePendingRef.current = true;
-		updateMutation.mutate({
-			...(canEditMetadata ? { alt, caption } : {}),
-			...(locationChanged ? { folderId } : {}),
-		});
+		const changes: MediaUpdateInput = {};
+		if (canEditMetadata) {
+			if (alt !== (item.alt ?? "")) changes.alt = alt;
+			if (caption !== (item.caption ?? "")) changes.caption = caption;
+			if (focalPointChanged) {
+				changes.focalX = focalPoint?.focalX ?? null;
+				changes.focalY = focalPoint?.focalY ?? null;
+			}
+		}
+		if (locationChanged) changes.folderId = folderId;
+		updateMutation.mutate(changes);
 	};
 
 	const handleDelete = () => {
@@ -427,82 +457,146 @@ export function MediaDetailPanel({
 						</Button>
 					</div>
 
+					{canEditMetadata && (
+						<div className="shrink-0 border-b border-kumo-line px-6 py-4 md:px-8">
+							<Tabs
+								variant="segmented"
+								className="max-w-sm"
+								value={activeTab}
+								onValueChange={(value) => {
+									if (value === "details" || value === "edit-image") setActiveTab(value);
+								}}
+								tabs={[
+									{ value: "details", label: t`Details`, className: "flex-1 justify-center" },
+									{
+										value: "edit-image",
+										label: t`Focal point`,
+										className: "flex-1 justify-center",
+									},
+								]}
+							/>
+						</div>
+					)}
+
 					<div
 						className="grid min-h-0 flex-1 grid-cols-1 overflow-y-auto md:grid-cols-2 md:overflow-hidden"
 						data-testid="media-detail-dialog-body"
+						role={canEditMetadata ? "tabpanel" : undefined}
+						aria-label={
+							canEditMetadata ? (activeTab === "details" ? t`Details` : t`Focal point`) : undefined
+						}
 					>
 						<div
 							className="space-y-5 border-b border-kumo-line p-6 md:min-h-0 md:overflow-y-auto md:border-e md:border-b-0 md:p-8"
 							data-testid="media-detail-dialog-preview-column"
 						>
-							<div className="flex h-64 items-center justify-center overflow-hidden rounded-xl border border-kumo-line bg-kumo-tint md:h-80">
-								{isImage ? (
-									<img
-										src={item.url}
-										alt={item.alt || item.filename}
-										className="max-h-full max-w-full object-contain"
-									/>
-								) : isVideo && playback ? (
-									// Streaming: `item.url` is the poster, not the media.
-									<video
-										poster={item.url || undefined}
-										controls
-										preload="metadata"
-										className="max-h-full max-w-full"
-									>
-										{playback.hls && <source src={playback.hls} type="application/x-mpegURL" />}
-										{playback.dash && <source src={playback.dash} type="application/dash+xml" />}
-									</video>
-								) : isVideo ? (
-									// Locally stored video: `item.url` is the file itself.
-									<video
-										src={item.url}
-										controls
-										preload="metadata"
-										className="max-h-full max-w-full"
-									/>
-								) : isAudio ? (
-									<audio src={item.url} controls preload="metadata" className="w-full" />
-								) : (
-									<div className="p-4 text-center">
-										<span className="text-5xl" aria-hidden="true">
-											{getFileIcon(item.mimeType)}
-										</span>
-										<p className="mt-3 text-sm text-kumo-subtle">{item.mimeType}</p>
-									</div>
-								)}
-							</div>
+							{isImage ? (
+								<FocalPointEditor
+									key={`${item.id}:${item.url}`}
+									src={item.url}
+									alt={item.alt || item.filename}
+									editing={activeTab === "edit-image"}
+									disabled={isBusy}
+									point={focalPoint}
+									descriptionId={focalPointDescriptionId}
+									onChange={setFocalPoint}
+								/>
+							) : (
+								<div className="flex h-64 items-center justify-center overflow-hidden rounded-xl bg-kumo-tint ring ring-kumo-line md:h-80">
+									{isVideo && playback ? (
+										<video
+											poster={item.url || undefined}
+											controls
+											preload="metadata"
+											className="max-h-full max-w-full"
+										>
+											{playback.hls && <source src={playback.hls} type="application/x-mpegURL" />}
+											{playback.dash && <source src={playback.dash} type="application/dash+xml" />}
+										</video>
+									) : isVideo ? (
+										<video
+											src={item.url}
+											controls
+											preload="metadata"
+											className="max-h-full max-w-full"
+										/>
+									) : isAudio ? (
+										<audio src={item.url} controls preload="metadata" className="w-full" />
+									) : (
+										<div className="p-4 text-center">
+											<span className="text-5xl" aria-hidden="true">
+												{getFileIcon(item.mimeType)}
+											</span>
+											<p className="mt-3 text-sm text-kumo-subtle">{item.mimeType}</p>
+										</div>
+									)}
+								</div>
+							)}
 
-							<div className="space-y-3" data-testid="media-detail-dialog-file-facts">
-								<div className="flex items-center gap-2 text-sm">
-									<HardDrive className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
-									<span className="text-kumo-subtle">{t`Size:`}</span>
-									<span>{formatFileSize(item.size)}</span>
+							<div
+								className={
+									activeTab === "details"
+										? "grid grid-cols-2 gap-x-6 gap-y-3"
+										: "hidden grid-cols-2 gap-x-6 gap-y-3 md:grid"
+								}
+								data-testid="media-detail-dialog-file-facts"
+								style={{ visibility: activeTab === "details" ? undefined : "hidden" }}
+								aria-hidden={activeTab !== "details"}
+							>
+								<div className="flex min-w-0 items-start gap-2 text-sm">
+									<span className="flex h-lh shrink-0 items-center text-kumo-subtle">
+										<HardDrive className="h-4 w-4" aria-hidden="true" />
+									</span>
+									<p className="flex min-w-0 flex-wrap items-baseline gap-1 leading-5">
+										<span className="text-kumo-subtle">{t`Size:`}</span>
+										<span className="tabular-nums">{formatFileSize(item.size)}</span>
+									</p>
 								</div>
 								{item.width && item.height && (
-									<div className="flex items-center gap-2 text-sm">
-										<Ruler className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
-										<span className="text-kumo-subtle">{t`Dimensions:`}</span>
-										<span>
-											{item.width} × {item.height}
+									<div className="flex min-w-0 items-start gap-2 text-sm">
+										<span className="flex h-lh shrink-0 items-center text-kumo-subtle">
+											<Ruler className="h-4 w-4" aria-hidden="true" />
 										</span>
+										<p className="flex min-w-0 flex-wrap items-baseline gap-1 leading-5">
+											<span className="text-kumo-subtle">{t`Dimensions:`}</span>
+											<span className="tabular-nums">
+												{item.width} × {item.height}
+											</span>
+										</p>
 									</div>
 								)}
 								{!isProviderAsset && (
-									<div className="flex items-center gap-2 text-sm">
-										<Calendar className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
-										<span className="text-kumo-subtle">{t`Uploaded:`}</span>
-										<span>{formatDate(item.createdAt)}</span>
+									<div className="flex min-w-0 items-start gap-2 text-sm">
+										<span className="flex h-lh shrink-0 items-center text-kumo-subtle">
+											<Calendar className="h-4 w-4" aria-hidden="true" />
+										</span>
+										<p className="flex min-w-0 flex-wrap items-baseline gap-1 leading-5">
+											<span className="text-kumo-subtle">{t`Uploaded:`}</span>
+											<span className="tabular-nums">{formatDate(item.createdAt)}</span>
+										</p>
 									</div>
 								)}
-								<div className="flex items-center gap-2 text-sm">
+								<div className="flex min-w-0 items-start gap-2 text-sm">
+									<span className="flex h-lh shrink-0 items-center text-kumo-subtle">
+										<File className="h-4 w-4" aria-hidden="true" />
+									</span>
+									<p className="flex min-w-0 flex-wrap items-baseline gap-1 leading-5">
+										<span className="text-kumo-subtle">{t`Format:`}</span>
+										<span>{formatFileFormat(item.mimeType)}</span>
+									</p>
+								</div>
+								<div
+									className="col-span-full flex min-w-0 items-center gap-2 text-sm"
+									data-testid="media-detail-dialog-file-url"
+								>
 									<LinkSimple className="h-4 w-4 shrink-0 text-kumo-subtle" aria-hidden="true" />
 									<span className="shrink-0 text-kumo-subtle">{t`URL:`}</span>
 									{publicFileUrl ? (
 										<ClipboardText
-											text={publicFileUrl}
+											text={publicFilePath}
+											textToCopy={publicFileUrl}
 											size="sm"
-											className="min-w-0 flex-1"
+											className="w-full min-w-0 max-w-none flex-1"
 											labels={{ copyAction: t`Copy URL` }}
 										/>
 									) : (
@@ -513,10 +607,11 @@ export function MediaDetailPanel({
 						</div>
 
 						<div
-							className="space-y-5 p-6 md:min-h-0 md:overflow-y-auto md:p-8"
+							className="grid gap-5 p-6 md:min-h-0 md:overflow-y-auto md:p-8"
 							data-testid="media-detail-dialog-details-column"
+							style={canEditMetadata ? { gridTemplateAreas: '"panel" "error"' } : undefined}
 						>
-							{isProviderAsset && (
+							{isProviderAsset && activeTab === "details" && (
 								<p className="rounded-lg bg-kumo-tint p-3 text-sm text-kumo-subtle">
 									{providerName
 										? t`Managed by ${providerName}`
@@ -524,7 +619,14 @@ export function MediaDetailPanel({
 								</p>
 							)}
 
-							<div className="space-y-4">
+							<div
+								className={activeTab === "details" ? "space-y-4" : "hidden space-y-4 md:block"}
+								style={{
+									gridArea: canEditMetadata ? "panel" : undefined,
+									visibility: activeTab === "details" ? undefined : "hidden",
+								}}
+								aria-hidden={activeTab !== "details"}
+							>
 								<div className="w-full space-y-2">
 									<div className="flex items-center gap-1.5">
 										<span className="text-sm font-medium text-kumo-default">{t`Filename`}</span>
@@ -708,8 +810,51 @@ export function MediaDetailPanel({
 									</>
 								)}
 							</div>
+							{canEditMetadata && (
+								<div
+									className={
+										activeTab === "edit-image"
+											? "grid content-start gap-6"
+											: "hidden content-start gap-6 md:grid"
+									}
+									style={{
+										gridArea: "panel",
+										visibility: activeTab === "edit-image" ? undefined : "hidden",
+									}}
+									aria-hidden={activeTab !== "edit-image"}
+								>
+									<div className="flex items-start justify-between gap-4">
+										<div className="grid min-w-0 gap-1.5">
+											<h3 className="text-sm font-semibold">{t`Focal point`}</h3>
+											<p id={focalPointDescriptionId} className="text-sm text-kumo-subtle">
+												{t`Choose the part that should remain visible when this image is cropped.`}
+											</p>
+										</div>
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											className="shrink-0"
+											onClick={() => setFocalPoint(null)}
+											disabled={!focalPoint || isBusy}
+										>
+											{t`Reset`}
+										</Button>
+									</div>
+									{activeTab === "edit-image" && (
+										<section className="grid gap-4 border-t border-kumo-line pt-5">
+											<h3 className="text-sm font-semibold">{t`Preview`}</h3>
+											<FocalPointPreviews src={item.url} point={focalPoint} />
+										</section>
+									)}
+								</div>
+							)}
 
-							<DialogError message={updateErrorMessage} />
+							{updateErrorMessage && (
+								<div style={{ gridArea: canEditMetadata ? "error" : undefined }}>
+									<DialogError message={updateErrorMessage} />
+								</div>
+							)}
 						</div>
 					</div>
 
@@ -788,6 +933,10 @@ function formatDate(isoString: string): string {
 		hour: "2-digit",
 		minute: "2-digit",
 	});
+}
+
+function formatFileFormat(mimeType: string): string {
+	return (mimeType.split("/").at(-1)?.split("+")[0] || mimeType).toUpperCase();
 }
 
 function isLocalMediaItem(item: MediaItem): item is LocalMediaItem {

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -62,6 +62,7 @@ import {
 	getFileIcon,
 	formatFileSize,
 	getMediaThumbnailUrl,
+	getMediaObjectPosition,
 	fallbackToOriginalThumbnail,
 	MEDIA_THUMBNAIL_WIDTH,
 	metaNumber,
@@ -1633,6 +1634,7 @@ function MediaGridItem({ item, selected, draggable, isMoving, onClick }: MediaGr
 						alt={item.alt || item.filename}
 						draggable={false}
 						className="h-full w-full object-cover"
+						style={{ objectPosition: getMediaObjectPosition(item) }}
 						onError={(e) => fallbackToOriginalThumbnail(e.currentTarget, item.url)}
 					/>
 				) : (
@@ -1741,6 +1743,7 @@ function MediaListItem({ item, selected, draggable, isMoving, onClick }: MediaLi
 							alt={item.alt || item.filename}
 							draggable={false}
 							className="h-full w-full object-cover"
+							style={{ objectPosition: getMediaObjectPosition(item) }}
 							onError={(e) => fallbackToOriginalThumbnail(e.currentTarget, item.url)}
 						/>
 					) : (

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -30,6 +30,7 @@ import {
 	providerItemToMediaItem,
 	getFileIcon,
 	getMediaThumbnailUrl,
+	getMediaObjectPosition,
 	fallbackToOriginalThumbnail,
 } from "../lib/media-utils";
 import { matchesMimeAllowlist, mimeFromUrl } from "../lib/mime-utils.js";
@@ -871,6 +872,7 @@ function MediaPickerItem({
 						src={displayUrl}
 						alt=""
 						className="h-full w-full object-cover"
+						style={{ objectPosition: getMediaObjectPosition(item) }}
 						onLoad={handleImageLoad}
 						onError={(e) => fallbackToOriginalThumbnail(e.currentTarget, item.url)}
 					/>

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -248,6 +248,8 @@ function sanitizeGalleryImages(value: unknown, withKeys = false): GalleryImage[]
 		if (attrStr(record.caption)) image.caption = attrStr(record.caption);
 		if (typeof record.width === "number") image.width = record.width;
 		if (typeof record.height === "number") image.height = record.height;
+		if (typeof record.focalX === "number") image.focalX = record.focalX;
+		if (typeof record.focalY === "number") image.focalY = record.focalY;
 		if (attrStr(record.blurhash)) image.blurhash = attrStr(record.blurhash);
 		if (attrStr(record.dominantColor)) image.dominantColor = attrStr(record.dominantColor);
 		images.push(image);

--- a/packages/admin/src/components/editor/GalleryDetailPanel.tsx
+++ b/packages/admin/src/components/editor/GalleryDetailPanel.tsx
@@ -17,7 +17,7 @@ import { X, Plus, Trash, ImageSquare } from "@phosphor-icons/react";
 import * as React from "react";
 
 import type { MediaItem } from "../../lib/api";
-import { metaString } from "../../lib/media-utils";
+import { getMediaObjectPosition, metaString } from "../../lib/media-utils";
 import { cn } from "../../lib/utils";
 import { MediaPickerModal } from "../MediaPickerModal";
 import { galleryImageUrl, type GalleryAttributes, type GalleryImage } from "./GalleryNode";
@@ -49,6 +49,8 @@ export function mediaItemToGalleryImage(item: MediaItem): GalleryImage {
 		alt: item.alt || "",
 		width: item.width,
 		height: item.height,
+		focalX: item.focalX ?? undefined,
+		focalY: item.focalY ?? undefined,
 		// Cache LQIP alongside dimensions so the gallery renders a placeholder
 		// without a runtime lookup. Fall back to `meta` for providers that
 		// stash it there — mirrors ImageFieldRenderer's handleSelect.
@@ -148,6 +150,8 @@ export function GalleryDetailPanel({
 							alt: item.alt || "",
 							width: item.width,
 							height: item.height,
+							focalX: item.focalX ?? undefined,
+							focalY: item.focalY ?? undefined,
 							blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
 							dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
 						}
@@ -304,6 +308,7 @@ function SortableGalleryThumb({
 					src={galleryImageUrl(image)}
 					alt={image.alt || ""}
 					className="object-cover w-full h-full"
+					style={{ objectPosition: getMediaObjectPosition(image) }}
 					draggable={false}
 				/>
 			</Button>

--- a/packages/admin/src/components/editor/GalleryNode.tsx
+++ b/packages/admin/src/components/editor/GalleryNode.tsx
@@ -15,6 +15,7 @@ import { Node } from "@tiptap/react";
 import { ReactNodeViewRenderer, NodeViewWrapper } from "@tiptap/react";
 import * as React from "react";
 
+import { getMediaObjectPosition } from "../../lib/media-utils.js";
 import { cn } from "../../lib/utils";
 
 /** One image inside a gallery block — mirrors the Portable Text shape. */
@@ -32,6 +33,8 @@ export interface GalleryImage {
 	caption?: string;
 	width?: number;
 	height?: number;
+	focalX?: number;
+	focalY?: number;
 	/** LQIP blurhash placeholder (images only) */
 	blurhash?: string;
 	/** LQIP dominant-color placeholder, as a CSS color (images only) */
@@ -181,6 +184,7 @@ function GalleryNodeView({
 									src={galleryImageUrl(image)}
 									alt={image.alt || ""}
 									className="w-full aspect-square object-cover rounded-md border"
+									style={{ objectPosition: getMediaObjectPosition(image) }}
 									draggable={false}
 								/>
 							</button>

--- a/packages/admin/src/lib/api/index.ts
+++ b/packages/admin/src/lib/api/index.ts
@@ -62,6 +62,7 @@ export {
 	type LocalMediaItem,
 	type MediaFolder,
 	type MediaFolderListResult,
+	type MediaUpdateInput,
 	type MediaUploadOptions,
 	type MediaProviderCapabilities,
 	type MediaProviderInfo,

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -38,6 +38,8 @@ export interface MediaItem {
 	size: number;
 	width?: number;
 	height?: number;
+	focalX?: number | null;
+	focalY?: number | null;
 	/** LQIP blurhash placeholder (images only) */
 	blurhash?: string;
 	/** LQIP dominant-color placeholder, as a CSS color (images only) */
@@ -427,16 +429,17 @@ export async function deleteMedia(id: string): Promise<void> {
 /**
  * Update media metadata (dimensions, alt text, etc.)
  */
-export async function updateMedia(
-	id: string,
-	input: {
-		alt?: string;
-		caption?: string;
-		width?: number;
-		height?: number;
-		folderId?: string | null;
-	},
-): Promise<LocalMediaItem> {
+export interface MediaUpdateInput {
+	alt?: string;
+	caption?: string;
+	width?: number;
+	height?: number;
+	folderId?: string | null;
+	focalX?: number | null;
+	focalY?: number | null;
+}
+
+export async function updateMedia(id: string, input: MediaUpdateInput): Promise<LocalMediaItem> {
 	const response = await apiFetch(`${API_BASE}/media/${encodeURIComponent(id)}`, {
 		method: "PUT",
 		headers: { "Content-Type": "application/json" },

--- a/packages/admin/src/lib/media-utils.ts
+++ b/packages/admin/src/lib/media-utils.ts
@@ -1,5 +1,32 @@
 import type { MediaItem, MediaProviderItem } from "./api/media.js";
 
+export interface MediaFocalPoint {
+	focalX: number;
+	focalY: number;
+}
+
+function isFocalCoordinate(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+export function normalizeMediaFocalPoint(value: {
+	focalX?: number | null;
+	focalY?: number | null;
+}): MediaFocalPoint | null {
+	const { focalX, focalY } = value;
+	if (!isFocalCoordinate(focalX) || !isFocalCoordinate(focalY)) return null;
+	return { focalX, focalY };
+}
+
+export function getMediaObjectPosition(value: {
+	focalX?: number | null;
+	focalY?: number | null;
+}): string | undefined {
+	const point = normalizeMediaFocalPoint(value);
+	if (!point) return undefined;
+	return `${Math.round(point.focalX * 10_000) / 100}% ${Math.round(point.focalY * 10_000) / 100}%`;
+}
+
 /** Read a string value from an untyped `meta` bag, or undefined. */
 export function metaString(
 	meta: Record<string, unknown> | undefined,

--- a/packages/admin/tests/components/GalleryFocalPoint.test.ts
+++ b/packages/admin/tests/components/GalleryFocalPoint.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from "vitest";
+
+import { mediaItemToGalleryImage } from "../../src/components/editor/GalleryDetailPanel.js";
+
+it("copies a selected media focal point into the gallery snapshot", () => {
+	const image = mediaItemToGalleryImage({
+		id: "media-1",
+		filename: "portrait.jpg",
+		mimeType: "image/jpeg",
+		url: "/_emdash/api/media/file/portrait.jpg",
+		size: 1024,
+		width: 1200,
+		height: 800,
+		focalX: 0.25,
+		focalY: 0.75,
+		createdAt: "2026-08-23T12:00:00.000Z",
+	});
+
+	expect(image).toMatchObject({ focalX: 0.25, focalY: 0.75 });
+});

--- a/packages/admin/tests/components/ImageFieldRenderer.test.tsx
+++ b/packages/admin/tests/components/ImageFieldRenderer.test.tsx
@@ -20,6 +20,8 @@ vi.mock("../../src/components/MediaPickerModal", () => ({
 						size: 31_744,
 						width: 1600,
 						height: 800,
+						focalX: 0.2,
+						focalY: 0.8,
 						alt: "Replacement image",
 						createdAt: "2026-07-23T12:00:00.000Z",
 					})
@@ -38,6 +40,8 @@ const selectedImage: ImageFieldValue = {
 	alt: "Geometric pattern carved into white paper",
 	width: 1200,
 	height: 800,
+	focalX: 0.25,
+	focalY: 0.75,
 	meta: { storageKey: "featured-image.jpg" },
 };
 
@@ -66,6 +70,7 @@ describe("ImageFieldRenderer", () => {
 
 		const image = screen.container.querySelector("img");
 		expect(image).toHaveAttribute("src", "/_emdash/api/media/file/featured-image.jpg");
+		expect(image?.style.objectPosition).toBe("25% 75%");
 	});
 
 	it("falls back cleanly when optional featured-image metadata is missing", async () => {
@@ -121,6 +126,8 @@ describe("ImageFieldRenderer", () => {
 				mimeType: "image/webp",
 				width: 1600,
 				height: 800,
+				focalX: 0.2,
+				focalY: 0.8,
 			}),
 		);
 	});

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -1,10 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { userEvent } from "vitest/browser";
 
 import { MediaDetailPanel } from "../../src/components/MediaDetailPanel";
 import { ApiResponseError, type LocalMediaItem, type MediaItem } from "../../src/lib/api";
 import { render } from "../utils/render.tsx";
+
+const TEST_IMAGE_URL =
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='gray'/%3E%3C/svg%3E";
 
 vi.mock("../../src/lib/api", async () => {
 	const actual = await vi.importActual("../../src/lib/api");
@@ -127,6 +131,19 @@ function renderPanel(props: Partial<React.ComponentProps<typeof MediaDetailPanel
 	);
 }
 
+async function openFocalEditor(screen: Awaited<ReturnType<typeof renderPanel>>) {
+	const editTab = screen.getByRole("tab", { name: "Focal point" }).element();
+	editTab.focus();
+	editTab.click();
+	const surface = screen.getByRole("button", {
+		name: "Focal point. Use arrow keys to move it.",
+	});
+	await expect.element(surface).toBeVisible();
+	surface.element().focus();
+	await expect.element(surface).toHaveFocus();
+	return surface;
+}
+
 describe("MediaDetailPanel", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -153,6 +170,11 @@ describe("MediaDetailPanel", () => {
 		const item = makeImageItem({ width: 1920, height: 1080 });
 		const screen = await renderPanel({ item });
 		await expect.element(screen.getByText("1920 × 1080")).toBeInTheDocument();
+		await expect.element(screen.getByText("JPEG")).toBeInTheDocument();
+		await expect.element(screen.getByText("Size:")).toBeInTheDocument();
+		await expect.element(screen.getByText("Dimensions:")).toBeInTheDocument();
+		await expect.element(screen.getByText("Uploaded:")).toBeInTheDocument();
+		await expect.element(screen.getByText("Format:")).toBeInTheDocument();
 	});
 
 	it("groups the preview, metadata, and actions in an accessible dialog", async () => {
@@ -184,6 +206,17 @@ describe("MediaDetailPanel", () => {
 		await expect.element(screen.getByText("1920 × 1080")).toBeVisible();
 	});
 
+	it("keeps the dialog height stable while switching image tabs", async () => {
+		const screen = await renderPanel({ item: makeImageItem({ url: TEST_IMAGE_URL }) });
+		const dialog = screen.getByRole("dialog", { name: "Media Details" }).element();
+		const detailsHeight = dialog.getBoundingClientRect().height;
+
+		screen.getByRole("tab", { name: "Focal point" }).element().click();
+		await expect.element(screen.getByTestId("focal-preview-square")).toBeVisible();
+
+		expect(dialog.getBoundingClientRect().height).toBe(detailsHeight);
+	});
+
 	it("shows image preview for image mimeTypes", async () => {
 		const item = makeImageItem();
 		const screen = await renderPanel({ item });
@@ -192,11 +225,235 @@ describe("MediaDetailPanel", () => {
 		await expect.element(img).toHaveAttribute("src", item.url);
 	});
 
+	it("separates image details from focal-point editing with tabs", async () => {
+		const screen = await renderPanel({
+			item: makeLocalItem({ url: TEST_IMAGE_URL }),
+			canMoveLocation: true,
+		});
+
+		await expect
+			.element(screen.getByRole("tab", { name: "Details" }))
+			.toHaveAttribute("aria-selected", "true");
+		await expect.element(screen.getByLabelText("Filename")).toBeVisible();
+		await expect
+			.element(screen.getByRole("button", { name: "Focal point. Use arrow keys to move it." }))
+			.not.toBeInTheDocument();
+		expect(screen.getByTestId("focal-preview-square").query()).toBeNull();
+
+		const editTab = screen.getByRole("tab", { name: "Focal point" });
+		editTab.element().focus();
+		editTab.element().click();
+
+		await expect.element(editTab).toHaveFocus();
+		await expect
+			.element(screen.getByRole("button", { name: "Focal point. Use arrow keys to move it." }))
+			.toBeVisible();
+		await expect.element(screen.getByRole("heading", { name: "Preview" })).toBeVisible();
+		const previewGroup = screen.getByTestId("focal-preview-group").element();
+		const portraitPreview = screen.getByTestId("focal-preview-portrait").element();
+		const squarePreview = screen.getByTestId("focal-preview-square").element();
+		const landscapePreview = screen.getByTestId("focal-preview-landscape").element();
+		await expect.element(squarePreview).toBeVisible();
+		expect(
+			Array.from(previewGroup.querySelectorAll("figcaption"), (caption) => caption.textContent),
+		).toEqual(["Portrait", "Square", "Landscape"]);
+		await expect.element(portraitPreview).toBeVisible();
+		await expect.element(landscapePreview).toBeVisible();
+		expect(
+			screen.getByTestId("media-detail-dialog-details-column").element().contains(squarePreview),
+		).toBe(true);
+		expect(
+			screen.getByTestId("media-detail-dialog-preview-column").element().contains(squarePreview),
+		).toBe(false);
+		await expect.element(screen.getByLabelText("Filename")).not.toBeVisible();
+
+		screen.getByRole("tab", { name: "Details" }).element().click();
+		await expect.element(screen.getByLabelText("Filename")).toBeVisible();
+	});
+
+	it("preserves the focal-point draft while switching tabs", async () => {
+		const screen = await renderPanel({
+			item: makeImageItem({ url: TEST_IMAGE_URL, focalX: null, focalY: null }),
+		});
+
+		await openFocalEditor(screen);
+		await userEvent.keyboard("{ArrowRight}");
+		screen.getByRole("tab", { name: "Details" }).element().click();
+		screen.getByRole("tab", { name: "Focal point" }).element().click();
+
+		expect(screen.getByTestId("focal-preview-square").element().style.objectPosition).toBe(
+			"51% 50%",
+		);
+	});
+
+	it("edits the focal point with the keyboard and saves only the focal pair", async () => {
+		const screen = await renderPanel({
+			item: makeImageItem({ url: TEST_IMAGE_URL, focalX: null, focalY: null }),
+		});
+
+		await openFocalEditor(screen);
+		await userEvent.keyboard("{ArrowRight}");
+		await userEvent.keyboard("{Shift>}{ArrowDown}{/Shift}");
+		await expect.element(screen.getByRole("button", { name: "Reset" })).toBeEnabled();
+
+		const squarePreview = screen.getByTestId("focal-preview-square").element();
+		expect(squarePreview.style.objectPosition).toBe("51% 55%");
+		await expect
+			.element(screen.getByRole("status"))
+			.toHaveTextContent("Horizontal 51%, vertical 55%");
+
+		screen.getByRole("button", { name: "Save" }).element().click();
+		await vi.waitFor(() => {
+			expect(updateMedia).toHaveBeenCalledWith("media-1", {
+				focalX: 0.51,
+				focalY: 0.55,
+			});
+		});
+	});
+
+	it("keeps the focal draft visible when saving fails", async () => {
+		vi.mocked(updateMedia).mockRejectedValueOnce(new Error("Update failed"));
+		const screen = await renderPanel({ item: makeImageItem({ url: TEST_IMAGE_URL }) });
+		await openFocalEditor(screen);
+		await userEvent.keyboard("{ArrowRight}");
+		const saveButton = screen.getByRole("button", { name: "Save" });
+		await expect.element(saveButton).toBeEnabled();
+		saveButton.element().click();
+
+		await expect.element(screen.getByText("Update failed")).toBeVisible();
+		expect(screen.getByTestId("focal-preview-square").element().style.objectPosition).toBe(
+			"51% 50%",
+		);
+	});
+
+	it("keeps one active pointer and clears it after cancellation or lost capture", async () => {
+		const screen = await renderPanel({ item: makeImageItem({ url: TEST_IMAGE_URL }) });
+		const surfaceLocator = await openFocalEditor(screen);
+		const surface = surfaceLocator.element();
+		vi.spyOn(surface, "getBoundingClientRect").mockReturnValue({
+			x: 0,
+			y: 0,
+			left: 0,
+			top: 0,
+			right: 100,
+			bottom: 100,
+			width: 100,
+			height: 100,
+			toJSON: () => ({}),
+		});
+		vi.spyOn(surface, "setPointerCapture").mockImplementation(() => {});
+		vi.spyOn(surface, "hasPointerCapture").mockReturnValue(true);
+		const release = vi.spyOn(surface, "releasePointerCapture").mockImplementation(() => {});
+
+		surface.dispatchEvent(
+			new PointerEvent("pointerdown", {
+				bubbles: true,
+				pointerId: 1,
+				clientX: 80,
+				clientY: 20,
+			}),
+		);
+		await vi.waitFor(() => {
+			expect(screen.getByTestId("focal-preview-square").element().style.objectPosition).toBe(
+				"80% 20%",
+			);
+		});
+
+		surface.dispatchEvent(
+			new PointerEvent("pointerdown", {
+				bubbles: true,
+				pointerId: 2,
+				clientX: 10,
+				clientY: 90,
+			}),
+		);
+		await new Promise((resolve) => window.setTimeout(resolve, 0));
+		expect(screen.getByTestId("focal-preview-square").element().style.objectPosition).toBe(
+			"80% 20%",
+		);
+
+		surface.dispatchEvent(new PointerEvent("lostpointercapture", { bubbles: true, pointerId: 1 }));
+		surface.dispatchEvent(
+			new PointerEvent("pointermove", {
+				bubbles: true,
+				pointerId: 1,
+				clientX: 10,
+				clientY: 90,
+			}),
+		);
+		await new Promise((resolve) => window.setTimeout(resolve, 0));
+		expect(screen.getByTestId("focal-preview-square").element().style.objectPosition).toBe(
+			"80% 20%",
+		);
+
+		surface.dispatchEvent(
+			new PointerEvent("pointerdown", {
+				bubbles: true,
+				pointerId: 3,
+				clientX: 30,
+				clientY: 30,
+			}),
+		);
+		await vi.waitFor(() => {
+			expect(screen.getByTestId("focal-preview-square").element().style.objectPosition).toBe(
+				"30% 30%",
+			);
+		});
+		surface.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true, pointerId: 3 }));
+		surface.dispatchEvent(
+			new PointerEvent("pointermove", {
+				bubbles: true,
+				pointerId: 3,
+				clientX: 90,
+				clientY: 90,
+			}),
+		);
+		await new Promise((resolve) => window.setTimeout(resolve, 0));
+		expect(screen.getByTestId("focal-preview-square").element().style.objectPosition).toBe(
+			"30% 30%",
+		);
+		expect(release).toHaveBeenCalledWith(3);
+	});
+
+	it("resets a custom focal point to the centered fallback", async () => {
+		const screen = await renderPanel({
+			item: makeImageItem({ url: TEST_IMAGE_URL, focalX: 0.2, focalY: 0.8 }),
+		});
+		await openFocalEditor(screen);
+		const resetButton = screen.getByRole("button", { name: "Reset" });
+		await expect.element(resetButton).toBeVisible();
+		resetButton.element().click();
+		const saveButton = screen.getByRole("button", { name: "Save" });
+		await expect.element(saveButton).toBeEnabled();
+		saveButton.element().click();
+
+		await vi.waitFor(() => {
+			expect(updateMedia).toHaveBeenCalledWith("media-1", {
+				focalX: null,
+				focalY: null,
+			});
+		});
+	});
+
+	it("does not create unsaved changes by opening Focal point", async () => {
+		const onClose = vi.fn();
+		const screen = await renderPanel({ item: makeImageItem({ url: TEST_IMAGE_URL }), onClose });
+		await openFocalEditor(screen);
+		screen.getByRole("button", { name: "Cancel" }).element().click();
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+		await expect
+			.element(screen.getByText("Discard changes?"), { timeout: 100 })
+			.not.toBeInTheDocument();
+	});
+
 	it("does not show image preview for non-image mimeTypes", async () => {
 		const item = makePdfItem();
 		const screen = await renderPanel({ item });
 		// Should show the mime type text instead of img
 		await expect.element(screen.getByText("application/pdf")).toBeInTheDocument();
+		expect(screen.getByRole("dialog").element().querySelector('[role="tablist"]')).toBeNull();
+		expect(screen.getByText("Focal point").query()).toBeNull();
 	});
 
 	it("alt text input is editable", async () => {
@@ -272,7 +529,6 @@ describe("MediaDetailPanel", () => {
 		await vi.waitFor(() => {
 			expect(updateMedia).toHaveBeenCalledWith("media-1", {
 				alt: "New alt",
-				caption: "Old caption",
 			});
 			expect(onClose).toHaveBeenCalled();
 		});
@@ -332,7 +588,6 @@ describe("MediaDetailPanel", () => {
 		await vi.waitFor(() => {
 			expect(updateMedia).toHaveBeenCalledWith("media-1", {
 				alt: "Shortcut alt",
-				caption: "Old caption",
 			});
 			expect(onClose).toHaveBeenCalled();
 		});
@@ -375,7 +630,6 @@ describe("MediaDetailPanel", () => {
 		await vi.waitFor(() => {
 			expect(updateMedia).toHaveBeenCalledWith("media-1", {
 				alt: "Updated alt",
-				caption: "Photo caption",
 				folderId: "folder-2",
 			});
 		});
@@ -390,7 +644,6 @@ describe("MediaDetailPanel", () => {
 		await vi.waitFor(() => {
 			expect(updateMedia).toHaveBeenCalledWith("media-1", {
 				alt: "Metadata only",
-				caption: "Photo caption",
 			});
 		});
 	});
@@ -635,10 +888,11 @@ describe("MediaDetailPanel", () => {
 	});
 
 	it("does not consume the keyboard save shortcut when nothing can be saved", async () => {
-		await renderPanel({
+		const screen = await renderPanel({
 			item: makeImageItem({ provider: "cloudflare-images" }),
 			providerName: "Cloudflare Images",
 		});
+		expect(screen.getByText("Focal point").query()).toBeNull();
 
 		const event = new KeyboardEvent("keydown", { key: "s", ctrlKey: true, cancelable: true });
 		window.dispatchEvent(event);
@@ -798,17 +1052,20 @@ describe("MediaDetailPanel", () => {
 });
 
 describe("MediaDetailPanel file URL", () => {
-	it("shows the absolute file URL with a Copy URL action", async () => {
+	it("shows a shortened file path while copying the absolute URL", async () => {
+		const clipboardWrite = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
 		const screen = await renderPanel({
 			item: makeImageItem({ url: "/_emdash/api/media/file/01ABC.jpg" }),
 		});
 
-		// Relative local-storage URLs are shown as absolute (origin-resolved)
-		// so they can be pasted anywhere. The Kumo ClipboardText component
-		// renders the value as text and a copy button (labelled "Copy URL").
 		const absolute = new URL("/_emdash/api/media/file/01ABC.jpg", window.location.origin).href;
-		await expect.element(screen.getByText(absolute)).toBeVisible();
-		await expect.element(screen.getByRole("button", { name: /Copy URL/ })).toBeVisible();
+		const displayedPath = screen.getByText("/_emdash/api/media/file/01ABC.jpg").element();
+		expect(displayedPath.textContent).toBe("/_emdash/api/media/file/01ABC.jpg");
+		expect(displayedPath.textContent).not.toContain(window.location.origin);
+		const copyButton = screen.getByRole("button", { name: /Copy URL/ });
+		await expect.element(copyButton).toBeVisible();
+		copyButton.element().click();
+		await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith(absolute));
 	});
 
 	it("does not expose provider preview URLs as public URLs", async () => {

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -781,11 +781,20 @@ describe("MediaLibrary", () => {
 		});
 
 		it("grid items show image thumbnails for image mimeTypes", async () => {
-			const items = [makeMediaItem({ id: "1", filename: "pic.jpg", mimeType: "image/jpeg" })];
+			const items = [
+				makeMediaItem({
+					id: "1",
+					filename: "pic.jpg",
+					mimeType: "image/jpeg",
+					focalX: 0.2,
+					focalY: 0.8,
+				}),
+			];
 			const screen = await renderLibrary({ items });
 			const img = screen.getByAltText("pic.jpg");
 			await expect.element(img).toBeInTheDocument();
 			await expect.element(img).toHaveAttribute("src", "https://example.com/photo.jpg");
+			expect(img.element().style.objectPosition).toBe("20% 80%");
 		});
 	});
 

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -28,6 +28,8 @@ vi.mock("../../src/lib/api", async () => {
 					size: 1024,
 					width: 800,
 					height: 600,
+					focalX: 0.2,
+					focalY: 0.8,
 					createdAt: "2024-01-01",
 				},
 				{
@@ -83,6 +85,11 @@ describe("MediaPickerModal", () => {
 			await expect
 				.element(screen.getByRole("option", { name: "landscape.png" }))
 				.toBeInTheDocument();
+			const image = screen
+				.getByRole("option", { name: "photo.jpg" })
+				.element()
+				.querySelector("img");
+			expect(image?.style.objectPosition).toBe("20% 80%");
 		});
 
 		it("shows the modal title", async () => {

--- a/packages/core/src/api/handlers/media.ts
+++ b/packages/core/src/api/handlers/media.ts
@@ -7,6 +7,7 @@ import type { Kysely } from "kysely";
 import { MediaRepository, type MediaItem } from "../../database/repositories/media.js";
 import { InvalidCursorError } from "../../database/repositories/types.js";
 import type { Database } from "../../database/types.js";
+import { isValidFocalPointUpdate, type FocalPointUpdate } from "../../media/focal-point.js";
 import type { ApiResult } from "../types.js";
 
 const FOREIGN_KEY_VIOLATION_RE = /foreign key constraint failed/i;
@@ -181,8 +182,17 @@ export async function handleMediaUpdate(
 		width?: number;
 		height?: number;
 		folderId?: string | null;
-	},
+	} & FocalPointUpdate,
 ): Promise<ApiResult<MediaResponse>> {
+	if (!isValidFocalPointUpdate(input)) {
+		return {
+			success: false,
+			error: {
+				code: "VALIDATION_ERROR",
+				message: "focalX and focalY must both be valid numbers or both be null",
+			},
+		};
+	}
 	try {
 		const repo = new MediaRepository(db);
 		const item = await repo.update(id, input);

--- a/packages/core/src/api/schemas/media.ts
+++ b/packages/core/src/api/schemas/media.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isValidFocalPointUpdate } from "#media/focal-point.js";
+
 import { cursorPaginationQuery } from "./common.js";
 import { mediaUsageSummarySchema } from "./media-usage.js";
 
@@ -65,6 +67,17 @@ export const mediaUpdateBody = z
 				description:
 					"Assign a media folder ID, or use null or `unfiled` to return the item to the Main library.",
 			}),
+		focalX: z.number().min(0).max(1).nullable().optional(),
+		focalY: z.number().min(0).max(1).nullable().optional(),
+	})
+	.superRefine((value, context) => {
+		if (!isValidFocalPointUpdate(value)) {
+			context.addIssue({
+				code: "custom",
+				message: "focalX and focalY must both be numbers or both be null",
+				path: ["focalX"],
+			});
+		}
 	})
 	.meta({ id: "MediaUpdateBody" });
 
@@ -150,6 +163,8 @@ export const mediaItemSchema = z
 		size: z.number().nullable(),
 		width: z.number().nullable(),
 		height: z.number().nullable(),
+		focalX: z.number().nullable(),
+		focalY: z.number().nullable(),
 		alt: z.string().nullable(),
 		caption: z.string().nullable(),
 		storageKey: z.string(),

--- a/packages/core/src/astro/routes/api/media/[id].ts
+++ b/packages/core/src/astro/routes/api/media/[id].ts
@@ -93,6 +93,8 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 			width: body.width,
 			height: body.height,
 			folderId: body.folderId,
+			focalX: body.focalX,
+			focalY: body.focalY,
 		});
 
 		return unwrapResult(result);

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -403,6 +403,8 @@ export interface EmDashHandlers {
 			width?: number;
 			height?: number;
 			folderId?: string | null;
+			focalX?: number | null;
+			focalY?: number | null;
 		},
 	) => Promise<HandlerResponse>;
 

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -206,8 +206,6 @@ export interface MediaItem {
 /** Result of assigning local media to a folder or the Main library */
 export interface MediaFolderAssignment {
 	id: string;
-	focalX: number | null;
-	focalY: number | null;
 	folderId: string | null;
 }
 
@@ -913,7 +911,7 @@ export class EmDashClient {
 			`/media/${encodeURIComponent(id)}`,
 			{ folderId },
 		);
-		return data.item;
+		return { id: data.item.id, folderId: data.item.folderId };
 	}
 
 	/** Get entry-grouped usage details for a media item */

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -193,6 +193,8 @@ export interface MediaItem {
 	size: number;
 	width?: number;
 	height?: number;
+	focalX?: number | null;
+	focalY?: number | null;
 	alt?: string;
 	caption?: string;
 	createdAt: string;
@@ -204,6 +206,8 @@ export interface MediaItem {
 /** Result of assigning local media to a folder or the Main library */
 export interface MediaFolderAssignment {
 	id: string;
+	focalX: number | null;
+	focalY: number | null;
 	folderId: string | null;
 }
 

--- a/packages/core/src/components/EmDashImage.astro
+++ b/packages/core/src/components/EmDashImage.astro
@@ -28,6 +28,7 @@ import {
 	RESPONSIVE_BREAKPOINTS,
 } from "../media/responsive.js";
 import { getPublicOrigin } from "../api/public-url.js";
+import { focalPointToObjectPosition } from "../media/focal-point.js";
 
 interface Props extends Omit<
 	HTMLAttributes<"img">,
@@ -178,6 +179,7 @@ const blurhash =
 	img?.blurhash ?? (img?.meta?.blurhash as string | undefined);
 const dominantColor =
 	img?.dominantColor ?? (img?.meta?.dominantColor as string | undefined);
+const objectPosition = focalPointToObjectPosition(img?.focalX, img?.focalY);
 
 let placeholderStyle = "";
 if (placeholder && blurhash) {
@@ -186,6 +188,12 @@ if (placeholder && blurhash) {
 } else if (placeholder && dominantColor) {
 	placeholderStyle = `background-color: ${dominantColor};`;
 }
+const generatedStyle = [
+	placeholderStyle,
+	objectPosition ? `object-position: ${objectPosition};` : "",
+]
+	.filter(Boolean)
+	.join(" ");
 
 const imgProps: Record<string, unknown> = {
 	src,
@@ -197,7 +205,7 @@ const imgProps: Record<string, unknown> = {
 	loading: priority ? "eager" : "lazy",
 	fetchpriority: priority ? "high" : undefined,
 	decoding: "async",
-	style: placeholderStyle || undefined,
+	style: generatedStyle || undefined,
 	class: ["emdash-image-media", className].filter(Boolean).join(" "),
 	...attrs,
 };
@@ -215,7 +223,7 @@ const imgProps: Record<string, unknown> = {
 			loading={priority ? "eager" : "lazy"}
 			decoding="async"
 			class={className}
-			style={placeholderStyle || undefined}
+			style={generatedStyle || undefined}
 			{...attrs}
 		/>
 	) : img && src ? (

--- a/packages/core/src/components/Gallery.astro
+++ b/packages/core/src/components/Gallery.astro
@@ -13,6 +13,7 @@ import { getMediaProvider } from "../media/provider-loader.js";
 import { buildRenderMediaUrl } from "../media/url.js";
 import { toAbsoluteMediaUrl, RESPONSIVE_BREAKPOINTS } from "../media/responsive.js";
 import { getPublicOrigin } from "../api/public-url.js";
+import { focalPointToObjectPosition } from "../media/focal-point.js";
 
 export interface Props {
 	node: {
@@ -31,6 +32,8 @@ export interface Props {
 			caption?: string;
 			width?: number;
 			height?: number;
+			focalX?: number;
+			focalY?: number;
 			/** LQIP blurhash placeholder (images only) */
 			blurhash?: string;
 			/** LQIP dominant-color placeholder, as a CSS color (images only) */
@@ -72,6 +75,7 @@ const resolvedImages = await Promise.all(
 	images.map(async (image) => {
 		const { asset, alt = "", width, height } = image;
 		const aspectRatio = width && height ? width / height : undefined;
+		const objectPosition = focalPointToObjectPosition(image.focalX, image.focalY);
 
 		let src = "";
 		let srcset: string | undefined;
@@ -145,6 +149,7 @@ const resolvedImages = await Promise.all(
 			sizes,
 			astroImageSrc,
 			placeholderStyle,
+			objectPosition,
 		};
 	}),
 );
@@ -161,6 +166,7 @@ const resolvedImages = await Promise.all(
 						width={image.width!}
 						height={image.height!}
 						layout="constrained"
+						style={image.objectPosition ? `object-position: ${image.objectPosition};` : undefined}
 					/>
 				) : (
 					<img
@@ -172,6 +178,7 @@ const resolvedImages = await Promise.all(
 						height={image.height}
 						loading="lazy"
 						decoding="async"
+						style={image.objectPosition ? `object-position: ${image.objectPosition};` : undefined}
 					/>
 				)}
 				{image.caption && <figcaption>{image.caption}</figcaption>}

--- a/packages/core/src/content/converters/gallery.ts
+++ b/packages/core/src/content/converters/gallery.ts
@@ -46,6 +46,8 @@ export function sanitizeGalleryImages(
 		if (typeof record.caption === "string" && record.caption) image.caption = record.caption;
 		if (typeof record.width === "number") image.width = record.width;
 		if (typeof record.height === "number") image.height = record.height;
+		if (typeof record.focalX === "number") image.focalX = record.focalX;
+		if (typeof record.focalY === "number") image.focalY = record.focalY;
 		if (typeof record.blurhash === "string" && record.blurhash) image.blurhash = record.blurhash;
 		if (typeof record.dominantColor === "string" && record.dominantColor)
 			image.dominantColor = record.dominantColor;

--- a/packages/core/src/content/converters/types.ts
+++ b/packages/core/src/content/converters/types.ts
@@ -91,6 +91,8 @@ export interface PortableTextGalleryImage {
 	caption?: string;
 	width?: number;
 	height?: number;
+	focalX?: number;
+	focalY?: number;
 	/** LQIP blurhash placeholder (images only) */
 	blurhash?: string;
 	/** LQIP dominant-color placeholder, as a CSS color (images only) */

--- a/packages/core/src/database/migrations/073_media_focal_point.ts
+++ b/packages/core/src/database/migrations/073_media_focal_point.ts
@@ -1,0 +1,57 @@
+import type { Kysely } from "kysely";
+
+import { columnExists } from "../dialect-helpers.js";
+
+const DUPLICATE_COLUMN_RE = /(?:duplicate column|column .* already exists|already exists.*column)/i;
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	await addFocalColumnIfMissing(db, "focal_x", () =>
+		db.schema.alterTable("media").addColumn("focal_x", "real").execute(),
+	);
+	await addFocalColumnIfMissing(db, "focal_y", () =>
+		db.schema.alterTable("media").addColumn("focal_y", "real").execute(),
+	);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	if (await columnExists(db, "media", "focal_y")) {
+		await db.schema.alterTable("media").dropColumn("focal_y").execute();
+	}
+	if (await columnExists(db, "media", "focal_x")) {
+		await db.schema.alterTable("media").dropColumn("focal_x").execute();
+	}
+}
+
+export async function addFocalColumnIfMissing(
+	db: Kysely<unknown>,
+	column: "focal_x" | "focal_y",
+	addColumn: () => Promise<void>,
+): Promise<void> {
+	if (await columnExists(db, "media", column)) return;
+
+	try {
+		await addColumn();
+	} catch (error) {
+		if (DUPLICATE_COLUMN_RE.test(deepErrorMessage(error))) {
+			if (await columnExists(db, "media", column)) return;
+		}
+		throw error;
+	}
+}
+
+function deepErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		const own = error.message ?? "";
+		if (error.cause) {
+			const causeMessage = deepErrorMessage(error.cause);
+			return own ? `${own}: ${causeMessage}` : causeMessage;
+		}
+		return own;
+	}
+	if (typeof error === "string") return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -75,6 +75,7 @@ import * as m069 from "./069_collection_title_date_fields.js";
 import * as m070 from "./070_collection_routable.js";
 import * as m071 from "./071_restore_content_bylines_table.js";
 import * as m072 from "./072_media_folders.js";
+import * as m073 from "./073_media_focal_point.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -148,6 +149,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"070_collection_routable": m070,
 	"071_restore_content_bylines_table": m071,
 	"072_media_folders": m072,
+	"073_media_focal_point": m073,
 });
 
 /** Ordered names from the statically registered migration set. */

--- a/packages/core/src/database/repositories/media.ts
+++ b/packages/core/src/database/repositories/media.ts
@@ -7,6 +7,7 @@ import {
 } from "kysely";
 import { ulid } from "ulidx";
 
+import { normalizeFocalPoint, type FocalPointUpdate } from "../../media/focal-point.js";
 import type { Database, MediaRow } from "../types.js";
 import type { FindManyResult } from "./types.js";
 import { encodeCursor, decodeCursor } from "./types.js";
@@ -54,6 +55,8 @@ export interface MediaItem {
 	size: number | null;
 	width: number | null;
 	height: number | null;
+	focalX: number | null;
+	focalY: number | null;
 	alt: string | null;
 	caption: string | null;
 	storageKey: string;
@@ -94,7 +97,7 @@ export interface FindManyMediaOptions {
 	folderId?: string | null;
 }
 
-export interface UpdateMediaInput {
+export interface UpdateMediaInput extends FocalPointUpdate {
 	alt?: string;
 	caption?: string;
 	width?: number;
@@ -134,6 +137,8 @@ export class MediaRepository {
 			size: input.size ?? null,
 			width: input.width ?? null,
 			height: input.height ?? null,
+			focal_x: null,
+			focal_y: null,
 			alt: input.alt ?? null,
 			caption: input.caption ?? null,
 			storage_key: input.storageKey,
@@ -463,6 +468,10 @@ export class MediaRepository {
 		if (input.width !== undefined) updates.width = input.width;
 		if (input.height !== undefined) updates.height = input.height;
 		if (input.folderId !== undefined) updates.folder_id = input.folderId;
+		if (input.focalX !== undefined && input.focalY !== undefined) {
+			updates.focal_x = input.focalX;
+			updates.focal_y = input.focalY;
+		}
 
 		if (Object.keys(updates).length > 0) {
 			await this.db.updateTable("media").set(updates).where("id", "=", id).execute();
@@ -559,6 +568,7 @@ export class MediaRepository {
 	 * Convert database row to MediaItem
 	 */
 	private rowToItem(row: MediaRow): MediaItem {
+		const focalPoint = normalizeFocalPoint(row.focal_x, row.focal_y);
 		return {
 			id: row.id,
 			filename: row.filename,
@@ -566,6 +576,8 @@ export class MediaRepository {
 			size: row.size,
 			width: row.width,
 			height: row.height,
+			focalX: focalPoint?.focalX ?? null,
+			focalY: focalPoint?.focalY ?? null,
 			alt: row.alt,
 			caption: row.caption,
 			storageKey: row.storage_key,

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -67,6 +67,8 @@ export interface MediaTable {
 	size: number | null;
 	width: number | null;
 	height: number | null;
+	focal_x: number | null;
+	focal_y: number | null;
 	alt: string | null;
 	caption: string | null;
 	storage_key: string;
@@ -693,6 +695,8 @@ export type MediaRow = {
 	size: number | null;
 	width: number | null;
 	height: number | null;
+	focal_x: number | null;
+	focal_y: number | null;
 	alt: string | null;
 	caption: string | null;
 	storage_key: string;

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -3527,6 +3527,8 @@ export class EmDashRuntime {
 			width?: number;
 			height?: number;
 			folderId?: string | null;
+			focalX?: number | null;
+			focalY?: number | null;
 		},
 	) {
 		const result = await handleMediaUpdate(this.db, id, input);

--- a/packages/core/src/media/focal-point.ts
+++ b/packages/core/src/media/focal-point.ts
@@ -1,0 +1,37 @@
+export interface FocalPoint {
+	focalX: number;
+	focalY: number;
+}
+
+export interface FocalPointUpdate {
+	focalX?: number | null;
+	focalY?: number | null;
+}
+
+function isFocalCoordinate(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+export function normalizeFocalPoint(focalX: unknown, focalY: unknown): FocalPoint | null {
+	if (!isFocalCoordinate(focalX) || !isFocalCoordinate(focalY)) return null;
+	return { focalX, focalY };
+}
+
+export function isValidFocalPointUpdate(input: FocalPointUpdate): boolean {
+	const hasX = input.focalX !== undefined;
+	const hasY = input.focalY !== undefined;
+	if (!hasX && !hasY) return true;
+	if (!hasX || !hasY) return false;
+	if (input.focalX === null || input.focalY === null) {
+		return input.focalX === null && input.focalY === null;
+	}
+	return normalizeFocalPoint(input.focalX, input.focalY) !== null;
+}
+
+export function focalPointToObjectPosition(focalX: unknown, focalY: unknown): string | undefined {
+	const point = normalizeFocalPoint(focalX, focalY);
+	if (!point) return undefined;
+	const x = Math.round(point.focalX * 10_000) / 100;
+	const y = Math.round(point.focalY * 10_000) / 100;
+	return `${x}% ${y}%`;
+}

--- a/packages/core/src/media/local-runtime.ts
+++ b/packages/core/src/media/local-runtime.ts
@@ -73,6 +73,8 @@ export const createMediaProvider: CreateMediaProviderFn<LocalMediaRuntimeConfig>
 					size: item.size ?? undefined,
 					width: item.width ?? undefined,
 					height: item.height ?? undefined,
+					focalX: item.focalX ?? undefined,
+					focalY: item.focalY ?? undefined,
 					blurhash: item.blurhash ?? undefined,
 					dominantColor: item.dominantColor ?? undefined,
 					alt: item.alt ?? undefined,
@@ -99,6 +101,8 @@ export const createMediaProvider: CreateMediaProviderFn<LocalMediaRuntimeConfig>
 				size: item.size ?? undefined,
 				width: item.width ?? undefined,
 				height: item.height ?? undefined,
+				focalX: item.focalX ?? undefined,
+				focalY: item.focalY ?? undefined,
 				blurhash: item.blurhash ?? undefined,
 				dominantColor: item.dominantColor ?? undefined,
 				alt: item.alt ?? undefined,
@@ -225,6 +229,8 @@ export function repoItemToProviderItem(item: {
 	size: number | null;
 	width: number | null;
 	height: number | null;
+	focalX?: number | null;
+	focalY?: number | null;
 	alt: string | null;
 	caption: string | null;
 	storageKey: string;
@@ -238,6 +244,8 @@ export function repoItemToProviderItem(item: {
 		size: item.size ?? undefined,
 		width: item.width ?? undefined,
 		height: item.height ?? undefined,
+		focalX: item.focalX ?? undefined,
+		focalY: item.focalY ?? undefined,
 		blurhash: item.blurhash ?? undefined,
 		dominantColor: item.dominantColor ?? undefined,
 		alt: item.alt ?? undefined,

--- a/packages/core/src/media/normalize.ts
+++ b/packages/core/src/media/normalize.ts
@@ -9,6 +9,7 @@
  * the provider's `get()` method.
  */
 
+import { normalizeFocalPoint } from "./focal-point.js";
 import type { MediaProvider, MediaProviderItem, MediaValue } from "./types.js";
 
 export const INTERNAL_MEDIA_PREFIX = "/_emdash/api/media/file/";
@@ -138,6 +139,7 @@ async function resolveInternalUrl(
 		return { provider: "external", id: "", src: url };
 	}
 
+	const focalPoint = normalizeFocalPoint(item.focalX, item.focalY);
 	return {
 		provider: "local",
 		id: item.id,
@@ -145,6 +147,7 @@ async function resolveInternalUrl(
 		mimeType: item.mimeType,
 		width: item.width,
 		height: item.height,
+		...focalPoint,
 		blurhash: item.blurhash,
 		dominantColor: item.dominantColor,
 		alt: item.alt,
@@ -169,6 +172,7 @@ async function resolveLocalId(
 
 	if (!item) return null;
 
+	const focalPoint = normalizeFocalPoint(item.focalX, item.focalY);
 	return {
 		provider: "local",
 		id: item.id,
@@ -176,6 +180,7 @@ async function resolveLocalId(
 		mimeType: item.mimeType,
 		width: item.width,
 		height: item.height,
+		...focalPoint,
 		blurhash: item.blurhash,
 		dominantColor: item.dominantColor,
 		alt: item.alt,
@@ -234,6 +239,11 @@ function recordToMediaValue(obj: Record<string, unknown>): MediaValue {
 	if (typeof obj.mimeType === "string") result.mimeType = obj.mimeType;
 	if (typeof obj.width === "number") result.width = obj.width;
 	if (typeof obj.height === "number") result.height = obj.height;
+	const focalPoint = normalizeFocalPoint(obj.focalX, obj.focalY);
+	if (focalPoint) {
+		result.focalX = focalPoint.focalX;
+		result.focalY = focalPoint.focalY;
+	}
 	if (typeof obj.blurhash === "string") result.blurhash = obj.blurhash;
 	if (typeof obj.dominantColor === "string") result.dominantColor = obj.dominantColor;
 	if (typeof obj.alt === "string") result.alt = obj.alt;

--- a/packages/core/src/media/types.ts
+++ b/packages/core/src/media/types.ts
@@ -6,6 +6,8 @@
  * alongside the built-in local media library.
  */
 
+import { normalizeFocalPoint } from "./focal-point.js";
+
 /**
  * Serializable media provider configuration descriptor
  * Returned by provider config functions (e.g., unsplash(), mux())
@@ -85,6 +87,9 @@ export interface MediaProviderItem {
 	/** Dimensions (for images/video) */
 	width?: number;
 	height?: number;
+	/** Default focal point for cover-cropped displays */
+	focalX?: number;
+	focalY?: number;
 	/** LQIP blurhash placeholder (images only) */
 	blurhash?: string;
 	/** LQIP dominant-color placeholder, as a CSS color (images only) */
@@ -264,6 +269,9 @@ export interface MediaValue {
 	mimeType?: string;
 	width?: number;
 	height?: number;
+	/** Default focal point copied when the media item is selected */
+	focalX?: number;
+	focalY?: number;
 	/** Cached LQIP blurhash placeholder (images only) */
 	blurhash?: string;
 	/** Cached LQIP dominant-color placeholder, as a CSS color (images only) */
@@ -278,6 +286,7 @@ export interface MediaValue {
  * Convert a MediaProviderItem to a MediaValue for storage
  */
 export function mediaItemToValue(providerId: string, item: MediaProviderItem): MediaValue {
+	const focalPoint = normalizeFocalPoint(item.focalX, item.focalY);
 	return {
 		provider: providerId,
 		id: item.id,
@@ -285,6 +294,7 @@ export function mediaItemToValue(providerId: string, item: MediaProviderItem): M
 		mimeType: item.mimeType,
 		width: item.width,
 		height: item.height,
+		...focalPoint,
 		blurhash: item.blurhash,
 		dominantColor: item.dominantColor,
 		alt: item.alt,

--- a/packages/core/tests/integration/database/media-focal-point.test.ts
+++ b/packages/core/tests/integration/database/media-focal-point.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { MediaRepository } from "../../../src/database/repositories/media.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("MediaRepository focal point", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("stores and resets the focal point without changing other metadata", async () => {
+		const repo = new MediaRepository(ctx.db);
+		const created = await repo.create({
+			filename: "portrait.jpg",
+			mimeType: "image/jpeg",
+			storageKey: "portrait.jpg",
+			alt: "Portrait",
+		});
+
+		expect(created).toMatchObject({ focalX: null, focalY: null });
+
+		const focused = await repo.update(created.id, { focalX: 0, focalY: 1 });
+		expect(focused).toMatchObject({
+			focalX: 0,
+			focalY: 1,
+			alt: "Portrait",
+		});
+		const listed = await repo.findMany();
+		expect(listed.items).toMatchObject([{ id: created.id, focalX: 0, focalY: 1 }]);
+
+		const reset = await repo.update(created.id, { focalX: null, focalY: null });
+		expect(reset).toMatchObject({ focalX: null, focalY: null, alt: "Portrait" });
+	});
+
+	it("normalizes a malformed stored pair to the centered fallback", async () => {
+		const repo = new MediaRepository(ctx.db);
+		const created = await repo.create({
+			filename: "portrait.jpg",
+			mimeType: "image/jpeg",
+			storageKey: "portrait.jpg",
+		});
+		await ctx.db
+			.updateTable("media")
+			.set({ focal_x: 0.4, focal_y: null })
+			.where("id", "=", created.id)
+			.execute();
+
+		expect(await repo.findById(created.id)).toMatchObject({ focalX: null, focalY: null });
+	});
+});

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -186,6 +186,7 @@ describe("Database Migrations (Integration)", () => {
 			"070_collection_routable",
 			"071_restore_content_bylines_table",
 			"072_media_folders",
+			"073_media_focal_point",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/repro/focal-point-render.render.test.ts
+++ b/packages/core/tests/repro/focal-point-render.render.test.ts
@@ -1,0 +1,87 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { expect, it } from "vitest";
+
+import EmDashImage from "../../src/components/EmDashImage.astro";
+import Gallery from "../../src/components/Gallery.astro";
+
+const locals = {
+	emdash: { getPublicMediaUrl: (key: string) => `/_emdash/api/media/file/${key}` },
+};
+
+it("applies a media snapshot focal point to the public Image component", async () => {
+	const container = await AstroContainer.create();
+	const html = await container.renderToString(EmDashImage, {
+		props: {
+			image: {
+				id: "media-1",
+				src: "https://example.com/portrait.jpg",
+				focalX: 0.25,
+				focalY: 0.75,
+			},
+			class: "cover-image",
+		},
+		locals,
+	});
+
+	expect(html).toContain("object-position: 25% 75%");
+});
+
+it("lets an explicit Image style override the stored focal point", async () => {
+	const container = await AstroContainer.create();
+	const html = await container.renderToString(EmDashImage, {
+		props: {
+			image: {
+				id: "media-1",
+				src: "https://example.com/portrait.jpg",
+				focalX: 0.25,
+				focalY: 0.75,
+			},
+			style: "object-position: 10% 20%;",
+		},
+		locals,
+	});
+
+	expect(html).toContain("object-position: 10% 20%");
+	expect(html).not.toContain("object-position: 25% 75%");
+});
+
+it("ignores an incomplete content focal point", async () => {
+	const container = await AstroContainer.create();
+	const html = await container.renderToString(EmDashImage, {
+		props: {
+			image: {
+				id: "media-1",
+				src: "https://example.com/portrait.jpg",
+				focalX: 0.25,
+			},
+		},
+		locals,
+	});
+
+	expect(html).not.toContain("object-position");
+});
+
+it("applies each gallery image focal point to its square crop", async () => {
+	const container = await AstroContainer.create();
+	const html = await container.renderToString(Gallery, {
+		props: {
+			node: {
+				_type: "gallery",
+				_key: "gallery-1",
+				images: [
+					{
+						_type: "image",
+						_key: "image-1",
+						asset: { _ref: "media-1", url: "/_emdash/api/media/file/portrait.jpg" },
+						alt: "Portrait",
+						focalX: 0.2,
+						focalY: 0.8,
+					},
+				],
+			},
+		},
+		locals,
+	});
+
+	expect(html).toContain("object-position: 20% 80%");
+});

--- a/packages/core/tests/unit/api/media-focal-point.test.ts
+++ b/packages/core/tests/unit/api/media-focal-point.test.ts
@@ -1,0 +1,59 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleMediaUpdate } from "../../../src/api/handlers/media.js";
+import { mediaUpdateBody } from "../../../src/api/schemas/media.js";
+import { MediaRepository } from "../../../src/database/repositories/media.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("media focal-point updates", () => {
+	let db: Kysely<Database>;
+	let mediaId: string;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		const item = await new MediaRepository(db).create({
+			filename: "portrait.jpg",
+			mimeType: "image/jpeg",
+			storageKey: "portrait.jpg",
+			alt: "Original alt",
+		});
+		mediaId = item.id;
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it.each([
+		{ focalX: 0.5 },
+		{ focalX: null, focalY: 0.5 },
+		{ focalX: -0.1, focalY: 0.5 },
+		{ focalX: 0.5, focalY: 1.1 },
+		{ focalX: Number.POSITIVE_INFINITY, focalY: 0.5 },
+	])("rejects an invalid pair without applying other metadata: %j", async (input) => {
+		const result = await handleMediaUpdate(db, mediaId, { ...input, alt: "Changed alt" });
+		expect(result).toMatchObject({
+			success: false,
+			error: { code: "VALIDATION_ERROR" },
+		});
+
+		const stored = await new MediaRepository(db).findById(mediaId);
+		expect(stored).toMatchObject({ alt: "Original alt", focalX: null, focalY: null });
+	});
+
+	it("accepts a complete pair and reset through the request schema", () => {
+		expect(mediaUpdateBody.safeParse({ focalX: 0, focalY: 1 }).success).toBe(true);
+		expect(mediaUpdateBody.safeParse({ focalX: null, focalY: null }).success).toBe(true);
+		expect(mediaUpdateBody.safeParse({ focalX: 0.5 }).success).toBe(false);
+	});
+
+	it("updates a valid pair through the handler", async () => {
+		const result = await handleMediaUpdate(db, mediaId, { focalX: 0.25, focalY: 0.75 });
+		expect(result).toMatchObject({
+			success: true,
+			data: { item: { focalX: 0.25, focalY: 0.75 } },
+		});
+	});
+});

--- a/packages/core/tests/unit/api/media-usage-summary.test.ts
+++ b/packages/core/tests/unit/api/media-usage-summary.test.ts
@@ -567,6 +567,8 @@ function mediaItemFixture(): MediaItem {
 		size: null,
 		width: null,
 		height: null,
+		focalX: null,
+		focalY: null,
 		alt: null,
 		caption: null,
 		storageKey: "hero.png",

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -759,7 +759,9 @@ describe("EmDashClient", () => {
 				}
 				if (req.method === "DELETE") return jsonResponse({ deleted: true });
 				if (url.pathname.endsWith("/media/media%2Fone")) {
-					return jsonResponse({ item: { id: "media/one", folderId: null } });
+					return jsonResponse({
+						item: { id: "media/one", folderId: null, focalX: 0.25, focalY: 0.75 },
+					});
 				}
 				return jsonResponse({ item: { id: "folder/one", name: "Updated" } });
 			};
@@ -784,7 +786,12 @@ describe("EmDashClient", () => {
 			expect(created).toEqual({ id: "folder/one", name: "Updated" });
 			expect(updated).toEqual({ id: "folder/one", name: "Updated" });
 			expect(fetched).toEqual({ id: "folder/one", name: "One" });
-			expect(media).toEqual({ id: "media/one", folderId: null });
+			expect(media).toEqual({
+				id: "media/one",
+				folderId: null,
+				focalX: 0.25,
+				focalY: 0.75,
+			});
 			expect(Object.fromEntries(requests[0]?.url.searchParams ?? [])).toEqual({
 				limit: "25",
 				cursor: "after / folder",

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -786,12 +786,7 @@ describe("EmDashClient", () => {
 			expect(created).toEqual({ id: "folder/one", name: "Updated" });
 			expect(updated).toEqual({ id: "folder/one", name: "Updated" });
 			expect(fetched).toEqual({ id: "folder/one", name: "One" });
-			expect(media).toEqual({
-				id: "media/one",
-				folderId: null,
-				focalX: 0.25,
-				focalY: 0.75,
-			});
+			expect(media).toEqual({ id: "media/one", folderId: null });
 			expect(Object.fromEntries(requests[0]?.url.searchParams ?? [])).toEqual({
 				limit: "25",
 				cursor: "after / folder",

--- a/packages/core/tests/unit/converters/gallery-round-trip.test.ts
+++ b/packages/core/tests/unit/converters/gallery-round-trip.test.ts
@@ -16,6 +16,8 @@ const gallery: PortableTextGalleryBlock = {
 			caption: "A local image",
 			width: 800,
 			height: 600,
+			focalX: 0.25,
+			focalY: 0.75,
 		},
 		{
 			_type: "image",
@@ -55,6 +57,8 @@ describe("gallery block round-trip (core converters)", () => {
 			caption: "A local image",
 			width: 800,
 			height: 600,
+			focalX: 0.25,
+			focalY: 0.75,
 		});
 		expect(first._key).toBeDefined();
 		expect(second).toMatchObject({

--- a/packages/core/tests/unit/database/migrations/073_media_focal_point.test.ts
+++ b/packages/core/tests/unit/database/migrations/073_media_focal_point.test.ts
@@ -1,0 +1,30 @@
+import BetterSqlite3 from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { addFocalColumnIfMissing } from "../../../../src/database/migrations/073_media_focal_point.js";
+
+describe("073_media_focal_point migration", () => {
+	let db: Kysely<Record<string, never>> | undefined;
+
+	afterEach(async () => {
+		await db?.destroy();
+	});
+
+	it("accepts a duplicate-column error when a concurrent migrator added the column", async () => {
+		const sqlite = new BetterSqlite3(":memory:");
+		sqlite.exec("CREATE TABLE media (id TEXT PRIMARY KEY)");
+		db = new Kysely<Record<string, never>>({
+			dialect: new SqliteDialect({ database: sqlite }),
+		});
+
+		await expect(
+			addFocalColumnIfMissing(db, "focal_x", async () => {
+				await db!.schema.alterTable("media").addColumn("focal_x", "real").execute();
+				throw new Error("migration failed", {
+					cause: new Error("duplicate column name: focal_x"),
+				});
+			}),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/core/tests/unit/media/focal-point-normalize.test.ts
+++ b/packages/core/tests/unit/media/focal-point-normalize.test.ts
@@ -1,0 +1,52 @@
+import { expect, it, vi } from "vitest";
+
+import { normalizeMediaValue } from "../../../src/media/normalize.js";
+import type { MediaProvider, MediaProviderItem } from "../../../src/media/types.js";
+
+function provider(item: MediaProviderItem | null): MediaProvider {
+	return {
+		list: vi.fn().mockResolvedValue({ items: [] }),
+		get: vi.fn().mockResolvedValue(item),
+		getEmbed: vi.fn().mockReturnValue({ type: "image", src: "/test" }),
+	};
+}
+
+it("copies the focal point when resolving a bare local media ID", async () => {
+	const local = provider({
+		id: "01ABC",
+		filename: "photo.jpg",
+		mimeType: "image/jpeg",
+		width: 1200,
+		height: 800,
+		focalX: 0.25,
+		focalY: 0.75,
+		meta: { storageKey: "01ABC.jpg" },
+	});
+
+	const result = await normalizeMediaValue("01ABC", (id) => (id === "local" ? local : undefined));
+
+	expect(result).toMatchObject({ focalX: 0.25, focalY: 0.75 });
+});
+
+it("preserves a focal point in a complete content snapshot without a provider lookup", async () => {
+	const local = provider(null);
+	const result = await normalizeMediaValue(
+		{
+			provider: "local",
+			id: "01ABC",
+			filename: "photo.jpg",
+			mimeType: "image/jpeg",
+			width: 1200,
+			height: 800,
+			focalX: 0.2,
+			focalY: 0.8,
+			blurhash: "snapshot-hash",
+			dominantColor: "#112233",
+			meta: { storageKey: "01ABC.jpg" },
+		},
+		(id) => (id === "local" ? local : undefined),
+	);
+
+	expect(local.get).not.toHaveBeenCalled();
+	expect(result).toMatchObject({ focalX: 0.2, focalY: 0.8 });
+});


### PR DESCRIPTION
## What does this PR do?

Adds focal points for local images. Editors can set the important part of an image from the Media Details dialog, compare square, landscape, and portrait crops, and keep that subject visible in cover-cropped thumbnails, image fields, galleries, and `EmDashImage`.

The dialog uses native Kumo segmented tabs for **Details** and **Edit image**. Folder Location remains under Details, the crop previews sit beside the editor on desktop, and the dialog keeps a stable height while switching tabs.

This is PR 4/4 in the native media stack and is stacked directly on #2586:

1. #2582 — numbered Media Library pagination
2. #2584 — flat folder API foundation
3. #2586 — flat folder admin UI
4. This PR — focal points

Related discussion: https://github.com/emdash-cms/emdash/discussions/990

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes for the affected admin and core packages
- [x] `pnpm lint` passes with 0 type-aware diagnostics
- [x] Targeted tests pass for the affected admin, API, database, client, migration, snapshot, and rendering behavior
- [x] `pnpm format` has been run and the full formatting check passes
- [x] I have added/updated tests for my changes
- [x] User-visible strings in the admin UI are wrapped for translation. No `messages.po` files are included.
- [x] I have added and reviewed the user-facing changeset
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/990

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5), reviewed with GPT-5.6 Terra xhigh

## Screenshots / test output

- Type-aware lint: 0 diagnostics.
- Admin focused browser suite: 131 tests passed.
- Core focused suite: 88 tests passed.
- Focused migration and concurrent-migrator suite: 31 tests passed.
- Admin and core typechecks passed.
- Full formatting check passed.
- Browser-verified Details/Edit image switching, focal click and keyboard editing, folder Location preservation, stable dialog height, dark mode, 390px layout, and Arabic RTL.
- Persistent adversarial review converged with no findings.

PostgreSQL and D1 were not available locally; SQLite and the existing migration-race fixture passed.
