### PR TITLE
fix(admin): preserve line breaks in table cells

### DIFF
--- a/.changeset/tidy-tables-break.md
+++ b/.changeset/tidy-tables-break.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes line breaks entered in table cells disappearing from saved content.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -614,11 +614,20 @@ function convertPMNode(
 
 						const contentSpans: PortableTextSpan[] = [];
 						const cellMarkDefs: PortableTextMarkDef[] = [];
+						let paragraphCount = 0;
 						for (const paragraph of cellContent) {
 							if (paragraph.type === "paragraph") {
-								const { children, markDefs } = convertInlineContent(paragraph.content || []);
+								if (paragraphCount > 0) {
+									contentSpans.push({
+										_type: "span",
+										_key: generateKey(),
+										text: "\n",
+									});
+								}
+								const { children, markDefs } = convertInlineContent(paragraph.content || [], true);
 								contentSpans.push(...children);
 								cellMarkDefs.push(...markDefs);
+								paragraphCount++;
 							}
 						}
 
@@ -732,7 +741,10 @@ function convertList(
 	return blocks;
 }
 
-function convertInlineContent(nodes: unknown[]): {
+function convertInlineContent(
+	nodes: unknown[],
+	preserveHardBreakBoundary = false,
+): {
 	children: PortableTextSpan[];
 	markDefs: PortableTextMarkDef[];
 } {
@@ -763,7 +775,7 @@ function convertInlineContent(nodes: unknown[]): {
 				marks: marks.length > 0 ? marks : undefined,
 			});
 		} else if (node.type === "hardBreak") {
-			if (children.length > 0) {
+			if (children.length > 0 && !preserveHardBreakBoundary) {
 				const last = children.at(-1);
 				if (last) last.text += "\n";
 			} else {

--- a/packages/admin/tests/components/PortableTextEditor.table.test.ts
+++ b/packages/admin/tests/components/PortableTextEditor.table.test.ts
@@ -238,6 +238,85 @@ describe("Table conversion: PortableText ↔ ProseMirror", () => {
 			expect(table.rows[1].cells[0].content[0].text).toBe("Cell 1");
 		});
 
+		it("preserves line breaks between paragraphs in a table cell", () => {
+			const pmDoc = {
+				type: "doc",
+				content: [
+					{
+						type: "table",
+						content: [
+							{
+								type: "tableRow",
+								content: [
+									{
+										type: "tableCell",
+										content: [
+											{
+												type: "paragraph",
+												content: [
+													{
+														type: "text",
+														text: "First line",
+														marks: [
+															{
+																type: "link",
+																attrs: { href: "https://example.com" },
+															},
+														],
+													},
+												],
+											},
+											{
+												type: "paragraph",
+												content: [{ type: "text", text: "Second line" }],
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+				],
+			};
+
+			const result = _prosemirrorToPortableText(pmDoc);
+			const table = result[0] as {
+				rows: Array<{
+					cells: Array<{
+						content: Array<{ text: string; marks?: string[] }>;
+						markDefs?: Array<{ _key: string; _type: string; href: string }>;
+					}>;
+				}>;
+			};
+			const cell = table.rows[0].cells[0];
+			const spans = cell.content;
+
+			expect(table.rows).toHaveLength(1);
+			expect(spans.map((span) => span.text)).toEqual(["First line", "\n", "Second line"]);
+			expect(cell.markDefs?.[0]).toMatchObject({
+				_key: spans[0].marks?.[0],
+				_type: "link",
+				href: "https://example.com",
+			});
+			expect(spans[1].marks).toBeUndefined();
+
+			const roundTripped = _prosemirrorToPortableText(_portableTextToProsemirror(result));
+			const roundTrippedTable = roundTripped[0] as typeof table;
+			const roundTrippedSpans = roundTrippedTable.rows[0].cells[0].content;
+
+			expect(roundTrippedSpans.map((span) => span.text)).toEqual([
+				"First line",
+				"\n",
+				"Second line",
+			]);
+			expect(roundTrippedTable.rows[0].cells[0].markDefs?.[0]).toMatchObject({
+				_key: roundTrippedSpans[0].marks?.[0],
+				_type: "link",
+				href: "https://example.com",
+			});
+			expect(roundTrippedSpans[1].marks).toBeUndefined();
+		});
+
 		it("converts table with text marks to PT", () => {
 			const pmDoc = {
 				type: "doc",


### PR DESCRIPTION
## What does this PR do?

Pressing Enter in a table cell creates separate TipTap paragraphs. EmDash flattened those paragraphs when converting them to Portable Text, so the saved content lost the line break.

This preserves paragraph boundaries as newline spans and keeps links and marks stable across save/reload cycles.

Closes #2336

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no user-visible strings)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (not applicable: bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6-sol

## Screenshots / test output

No visual change. The full admin suite passes: 122 test files and 1,515 tests.