### PR TITLE
fix(admin): replace persistent locale warning with compact help

### DIFF
--- a/.changeset/calm-locale-help.md
+++ b/.changeset/calm-locale-help.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes implicit English locale guidance in the content editor by replacing the persistent warning with compact, accessible help.

--- a/packages/admin/src/components/ContentSettingsPanel.tsx
+++ b/packages/admin/src/components/ContentSettingsPanel.tsx
@@ -1,6 +1,5 @@
 import {
 	Badge,
-	Banner,
 	Button,
 	Dialog,
 	Input,
@@ -9,9 +8,10 @@ import {
 	Loader,
 	Select,
 	Text,
+	Tooltip,
 } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { ArrowSquareOut, Eye, EyeSlash, Trash, Upload, X } from "@phosphor-icons/react";
+import { ArrowSquareOut, Eye, EyeSlash, Info, Trash, Upload, X } from "@phosphor-icons/react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
@@ -494,23 +494,32 @@ export const ContentSettingsPanel = React.memo(function ContentSettingsPanel({
 								placeholder="my-post-slug"
 							/>
 							{contentLocale ? (
-								<div className="space-y-1">
-									<div className="flex flex-wrap items-center gap-2">
-										<Label>{t`Content locale`}</Label>
-										<Badge variant="secondary">{contentLocale.toUpperCase()}</Badge>
-									</div>
-									<p className="text-xs text-kumo-subtle">
-										{t`This is stored with the entry and is separate from your admin language.`}
-									</p>
+								<div className="flex flex-wrap items-center gap-1.5">
+									<Label>{t`Content locale`}</Label>
+									<Badge variant="secondary">{contentLocale.toUpperCase()}</Badge>
+									{usesImplicitEnglish ? (
+										<Tooltip
+											content={
+												<span className="block max-w-64 text-pretty">
+													{t`English is used because no content locale is configured. Content locale is stored with the entry and is separate from your admin language.`}
+												</span>
+											}
+											delay={0}
+											closeDelay={0}
+											render={
+												<Button
+													type="button"
+													variant="ghost"
+													shape="square"
+													size="xs"
+													icon={<Info aria-hidden="true" />}
+													className="text-kumo-subtle hover:text-kumo-default"
+													aria-label={t`Why English is used`}
+												/>
+											}
+										/>
+									) : null}
 								</div>
-							) : null}
-							{usesImplicitEnglish ? (
-								<Banner
-									variant="alert"
-									title={t`Content locale defaults to English`}
-									description={t`No content locale is configured, so EmDash stores new content as English (en). Changing the admin language does not change this value.`}
-									role="alert"
-								/>
 							) : null}
 							<div>
 								<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent } from "@testing-library/react";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
 
 import type { ContentEditorProps } from "../../src/components/ContentEditor";
 import {
@@ -202,37 +203,40 @@ describe("ContentSettingsPanel", () => {
 
 		await expect.element(screen.getByText("Content locale")).toBeInTheDocument();
 		await expect.element(screen.getByText("JA", { exact: true })).toBeInTheDocument();
-		await expect
-			.element(
-				screen.getByText("This is stored with the entry and is separate from your admin language."),
-			)
-			.toBeInTheDocument();
+		expect(screen.getByText(/stored with the entry and is separate/).query()).toBeNull();
+		expect(screen.getByRole("button", { name: "Why English is used" }).query()).toBeNull();
 	});
 
-	it("warns when the stored content locale comes from the implicit English default", async () => {
+	it("keeps implicit English visible through compact help without a persistent warning", async () => {
+		const manifest = { ...TEST_MANIFEST, contentLocale: { defaultLocale: "en", implicit: true } };
 		const screen = await render(
 			<ContentSettingsPanel
-				{...makePanelProps({
-					item: makeItem({ locale: "en" }),
-					i18n: undefined,
-					manifest: {
-						...TEST_MANIFEST,
-						contentLocale: { defaultLocale: "en", implicit: true },
-					},
-				})}
+				{...makePanelProps({ item: makeItem({ locale: "en" }), i18n: undefined, manifest })}
 			/>,
 		);
 
-		await expect
-			.element(screen.getByText("Content locale defaults to English"))
-			.toBeInTheDocument();
-		await expect
-			.element(
-				screen.getByText(
-					"No content locale is configured, so EmDash stores new content as English (en). Changing the admin language does not change this value.",
-				),
-			)
-			.toBeInTheDocument();
+		await expect.element(screen.getByText("EN", { exact: true })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Why English is used" }).query()).not.toBeNull();
+		await screen.rerender(
+			<ContentSettingsPanel
+				{...makePanelProps({ item: null, isNew: true, i18n: undefined, manifest })}
+			/>,
+		);
+		expect(screen.getByText(/stored with the entry and is separate/).query()).toBeNull();
+		const trigger = screen.getByRole("button", { name: "Why English is used" });
+		await expect.element(screen.getByText("EN", { exact: true })).toBeInTheDocument();
+		const explanation =
+			"English is used because no content locale is configured. Content locale is stored with the entry and is separate from your admin language.";
+		const help = screen.getByText(explanation);
+		await userEvent.hover(trigger.element());
+		await expect.element(help).toBeVisible();
+		await userEvent.hover(document.body);
+		await vi.waitFor(() => expect(help.query()).toBeNull());
+		trigger.element().focus();
+		await expect.element(help).toBeVisible();
+		expect(screen.getByRole("alert").query()).toBeNull();
+		await userEvent.tab();
+		await vi.waitFor(() => expect(help.query()).toBeNull());
 	});
 
 	it("shows Scheduled without a Draft companion", async () => {


### PR DESCRIPTION
## What does this PR do?

Replaces the persistent implicit-English warning in the content editor with compact help beside the `EN` locale badge. The native Kumo tooltip matches the existing OG Image help pattern, appears immediately on hover or keyboard focus, and wraps the explanation to a readable four-line measure.

The content locale remains visible, while existing taxonomy fallback badges and unresolved-assignment actions are unchanged.

Closes #2615

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5.6)

## Screenshots / test output

- 58 focused browser tests passed across `ContentSettingsPanel` and `TaxonomySidebar`.
- All package typechecks passed.
- Full type-aware lint and formatting checks passed.
- Manually verified the native tooltip against OG Image help: instant hover/focus behavior, 6px spacing from `EN`, four-line wrapping, and responsive viewport collision handling.
