### PR TITLE
feat(release-service): add Durable Object OAuth client

### DIFF
--- a/apps/release-service/package.json
+++ b/apps/release-service/package.json
@@ -14,6 +14,7 @@
 		"types": "wrangler types"
 	},
 	"dependencies": {
+		"@atcute/identity-resolver": "catalog:",
 		"@atcute/oauth-node-client": "catalog:",
 		"@emdash-cms/registry-lexicons": "workspace:*",
 		"jose": "^6.1.3"

--- a/apps/release-service/src/oauth/custody.ts
+++ b/apps/release-service/src/oauth/custody.ts
@@ -1,0 +1,855 @@
+import type { ActorResolver } from "@atcute/identity-resolver";
+import {
+	CompositeDidDocumentResolver,
+	CompositeHandleResolver,
+	DohJsonHandleResolver,
+	LocalActorResolver,
+	PlcDidDocumentResolver,
+	WebDidDocumentResolver,
+	WellKnownHandleResolver,
+} from "@atcute/identity-resolver";
+import {
+	MemoryStore,
+	OAuthClient,
+	type AuthorizationResult,
+	type AuthorizeTarget,
+	type OAuthClientStores,
+	type OAuthSession,
+	type RestoreOptions,
+	type Store,
+	type StoredSession,
+	type StoredState,
+} from "@atcute/oauth-node-client";
+
+import type { OAuthConfiguration } from "../config.js";
+import {
+	EncryptionError,
+	type EncryptionContext,
+	type EnvelopeEncryption,
+} from "../crypto/encryption.js";
+import type {
+	DelegationReauthorizationReason,
+	DelegationRefreshLease,
+	PublisherDurableObject,
+	StoredDelegation,
+} from "../publisher-do/publisher-do.js";
+
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const BASE64_PADDING_PATTERN = /=+$/;
+const MAX_STATE_LIFETIME_MS = 11 * 60_000;
+const REFRESH_LEASE_MS = 60_000;
+const REFRESH_LOCK_TIMEOUT_MS = 30_000;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+type Did = `did:${string}:${string}`;
+
+export type PublisherOAuthPurpose = "publisher_identity" | "release_delegation";
+
+export interface PublisherOAuthFlowOptions {
+	purpose: PublisherOAuthPurpose;
+	expectedDid: Did;
+	redirectTarget: string;
+}
+
+export interface PublisherOAuthUserState {
+	purpose: PublisherOAuthPurpose;
+	expectedDid: Did;
+	redirectTarget: string;
+}
+
+export type OAuthCustodyErrorCode =
+	| "OAUTH_CLIENT_KEY_UNAVAILABLE"
+	| "OAUTH_CLIENT_AUTH_INVALID"
+	| "OAUTH_SCOPE_INVALID"
+	| "OAUTH_IDENTITY_MISMATCH"
+	| "OAUTH_STATE_INVALID"
+	| "OAUTH_SESSION_INVALID"
+	| "OAUTH_REDIRECT_INVALID"
+	| "OAUTH_DELEGATION_CAS_REQUIRED"
+	| "OAUTH_DELEGATION_UNAVAILABLE"
+	| "OAUTH_REFRESH_LOCK_TIMEOUT";
+
+const ERROR_MESSAGES: Record<OAuthCustodyErrorCode, string> = {
+	OAUTH_CLIENT_KEY_UNAVAILABLE: "OAuth client key is unavailable",
+	OAUTH_CLIENT_AUTH_INVALID: "OAuth client authentication is invalid",
+	OAUTH_SCOPE_INVALID: "OAuth scope is invalid",
+	OAUTH_IDENTITY_MISMATCH: "OAuth identity does not match",
+	OAUTH_STATE_INVALID: "OAuth state is invalid",
+	OAUTH_SESSION_INVALID: "OAuth session is invalid",
+	OAUTH_REDIRECT_INVALID: "OAuth redirect is invalid",
+	OAUTH_DELEGATION_CAS_REQUIRED: "OAuth delegation requires a compare-and-set update",
+	OAUTH_DELEGATION_UNAVAILABLE: "OAuth delegation is unavailable",
+	OAUTH_REFRESH_LOCK_TIMEOUT: "OAuth refresh lock timed out",
+};
+
+export class OAuthCustodyError extends Error {
+	readonly code: OAuthCustodyErrorCode;
+	readonly reauthorizationRequired: boolean;
+
+	constructor(code: OAuthCustodyErrorCode) {
+		super(ERROR_MESSAGES[code]);
+		this.name = "OAuthCustodyError";
+		this.code = code;
+		this.reauthorizationRequired =
+			code === "OAUTH_CLIENT_KEY_UNAVAILABLE" || code === "OAUTH_DELEGATION_UNAVAILABLE";
+	}
+}
+
+interface ActiveRefreshLease extends DelegationRefreshLease {
+	publisherDid: Did;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isDid(value: unknown): value is Did {
+	return typeof value === "string" && value.length <= 2048 && DID_PATTERN.test(value);
+}
+
+function validBoundedString(value: unknown, maxLength: number, minLength = 1): value is string {
+	return typeof value === "string" && value.length >= minLength && value.length <= maxLength;
+}
+
+function isBase64Url(value: unknown, byteLength?: number): value is string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		!BASE64URL_PATTERN.test(value) ||
+		value.length % 4 === 1
+	) {
+		return false;
+	}
+	if (byteLength === undefined) return true;
+	try {
+		const binary = atob(
+			value
+				.replaceAll("-", "+")
+				.replaceAll("_", "/")
+				.padEnd(value.length + ((4 - (value.length % 4)) % 4), "="),
+		);
+		return binary.length === byteLength;
+	} catch {
+		return false;
+	}
+}
+
+function validHttpsOrigin(value: unknown): value is string {
+	if (typeof value !== "string" || value.length === 0 || value.length > 2048) return false;
+	try {
+		const url = new URL(value);
+		return url.protocol === "https:" && url.origin === value;
+	} catch {
+		return false;
+	}
+}
+
+function getClientKeyId(value: { authMethod: StoredState["authMethod"] }): string {
+	if (
+		value.authMethod.method !== "private_key_jwt" ||
+		typeof value.authMethod.kid !== "string" ||
+		value.authMethod.kid.length === 0 ||
+		value.authMethod.kid.length > 128
+	) {
+		throw new OAuthCustodyError("OAUTH_CLIENT_AUTH_INVALID");
+	}
+	return value.authMethod.kid;
+}
+
+function assertDpopKey(value: unknown): asserts value is StoredSession["dpopKey"] {
+	if (
+		!isRecord(value) ||
+		value["kty"] !== "EC" ||
+		value["crv"] !== "P-256" ||
+		value["alg"] !== "ES256" ||
+		!isBase64Url(value["x"], 32) ||
+		!isBase64Url(value["y"], 32) ||
+		!isBase64Url(value["d"], 32) ||
+		(typeof value["kid"] !== "undefined" && typeof value["kid"] !== "string")
+	) {
+		throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+	}
+}
+
+function parseStoredState(value: string): StoredState {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+	}
+	if (
+		!isRecord(parsed) ||
+		!isRecord(parsed["authMethod"]) ||
+		parsed["authMethod"]["method"] !== "private_key_jwt" ||
+		typeof parsed["authMethod"]["kid"] !== "string" ||
+		!validBoundedString(parsed["pkceVerifier"], 128, 43) ||
+		!validHttpsOrigin(parsed["issuer"]) ||
+		typeof parsed["redirectUri"] !== "string" ||
+		(typeof parsed["sub"] !== "undefined" && !isDid(parsed["sub"])) ||
+		typeof parsed["expiresAt"] !== "number" ||
+		!Number.isSafeInteger(parsed["expiresAt"])
+	) {
+		throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+	}
+	try {
+		assertDpopKey(parsed["dpopKey"]);
+	} catch {
+		throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+	}
+	return {
+		dpopKey: parsed["dpopKey"],
+		authMethod: { method: "private_key_jwt", kid: parsed["authMethod"]["kid"] },
+		pkceVerifier: parsed["pkceVerifier"],
+		issuer: parsed["issuer"],
+		redirectUri: parsed["redirectUri"],
+		...(parsed["sub"] ? { sub: parsed["sub"] } : {}),
+		...("userState" in parsed ? { userState: parsed["userState"] } : {}),
+		expiresAt: parsed["expiresAt"],
+	};
+}
+
+function parseStoredSession(value: string): StoredSession {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+	}
+	if (
+		!isRecord(parsed) ||
+		!isRecord(parsed["authMethod"]) ||
+		parsed["authMethod"]["method"] !== "private_key_jwt" ||
+		typeof parsed["authMethod"]["kid"] !== "string" ||
+		!isRecord(parsed["tokenSet"]) ||
+		!validHttpsOrigin(parsed["tokenSet"]["iss"]) ||
+		!isDid(parsed["tokenSet"]["sub"]) ||
+		!validHttpsOrigin(parsed["tokenSet"]["aud"]) ||
+		!validBoundedString(parsed["tokenSet"]["scope"], 4096) ||
+		!validBoundedString(parsed["tokenSet"]["access_token"], 65_536) ||
+		(typeof parsed["tokenSet"]["refresh_token"] !== "undefined" &&
+			!validBoundedString(parsed["tokenSet"]["refresh_token"], 65_536)) ||
+		parsed["tokenSet"]["token_type"] !== "DPoP" ||
+		(typeof parsed["tokenSet"]["expires_at"] !== "undefined" &&
+			!Number.isSafeInteger(parsed["tokenSet"]["expires_at"]))
+	) {
+		throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+	}
+	assertDpopKey(parsed["dpopKey"]);
+	return {
+		dpopKey: parsed["dpopKey"],
+		authMethod: { method: "private_key_jwt", kid: parsed["authMethod"]["kid"] },
+		tokenSet: {
+			iss: parsed["tokenSet"]["iss"],
+			sub: parsed["tokenSet"]["sub"],
+			aud: parsed["tokenSet"]["aud"],
+			scope: parsed["tokenSet"]["scope"],
+			access_token: parsed["tokenSet"]["access_token"],
+			...(parsed["tokenSet"]["refresh_token"]
+				? { refresh_token: parsed["tokenSet"]["refresh_token"] }
+				: {}),
+			...(typeof parsed["tokenSet"]["expires_at"] === "number"
+				? { expires_at: parsed["tokenSet"]["expires_at"] }
+				: {}),
+			token_type: "DPoP",
+		},
+	};
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(BASE64_PADDING_PATTERN, "");
+}
+
+async function hashOpaque(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
+	return encodeBase64Url(new Uint8Array(digest));
+}
+
+export function canonicalizeRedirectTarget(value: string, publicOrigin: string): string {
+	if (typeof value !== "string") throw new OAuthCustodyError("OAUTH_REDIRECT_INVALID");
+	let hasControlCharacter = false;
+	for (let index = 0; index < value.length; index += 1) {
+		const codeUnit = value.charCodeAt(index);
+		if (codeUnit <= 0x1f || codeUnit === 0x7f) {
+			hasControlCharacter = true;
+			break;
+		}
+	}
+	if (
+		!value.startsWith("/") ||
+		value.startsWith("//") ||
+		value.includes("\\") ||
+		hasControlCharacter
+	) {
+		throw new OAuthCustodyError("OAUTH_REDIRECT_INVALID");
+	}
+	try {
+		const url = new URL(value, publicOrigin);
+		if (url.origin !== publicOrigin) throw new OAuthCustodyError("OAUTH_REDIRECT_INVALID");
+		return `${url.pathname}${url.search}${url.hash}`;
+	} catch (error) {
+		if (error instanceof OAuthCustodyError) throw error;
+		throw new OAuthCustodyError("OAUTH_REDIRECT_INVALID");
+	}
+}
+
+function expectedUserState(
+	options: PublisherOAuthFlowOptions,
+	publicOrigin: string,
+): PublisherOAuthUserState {
+	return {
+		purpose: options.purpose,
+		expectedDid: options.expectedDid,
+		redirectTarget: canonicalizeRedirectTarget(options.redirectTarget, publicOrigin),
+	};
+}
+
+function parseUserState(
+	value: unknown,
+	options: PublisherOAuthFlowOptions,
+	publicOrigin: string,
+): PublisherOAuthUserState {
+	const expected = expectedUserState(options, publicOrigin);
+	if (
+		!isRecord(value) ||
+		Object.keys(value).length !== 3 ||
+		value["purpose"] !== expected.purpose ||
+		value["expectedDid"] !== expected.expectedDid ||
+		value["redirectTarget"] !== expected.redirectTarget
+	) {
+		throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+	}
+	return expected;
+}
+
+function transactionEncryptionPurpose(purpose: PublisherOAuthPurpose) {
+	return purpose === "release_delegation"
+		? ("oauth-delegation-transaction" as const)
+		: ("oauth-console-transaction" as const);
+}
+
+class DurableOAuthStateStore implements Store<string, StoredState> {
+	readonly #stub: DurableObjectStub<PublisherDurableObject>;
+	readonly #encryption: EnvelopeEncryption;
+	readonly #oauth: OAuthConfiguration;
+	readonly #options: PublisherOAuthFlowOptions;
+
+	constructor(
+		stub: DurableObjectStub<PublisherDurableObject>,
+		encryption: EnvelopeEncryption,
+		oauth: OAuthConfiguration,
+		options: PublisherOAuthFlowOptions,
+	) {
+		this.#stub = stub;
+		this.#encryption = encryption;
+		this.#oauth = oauth;
+		this.#options = options;
+	}
+
+	async set(rawState: string, state: StoredState): Promise<void> {
+		if (!isBase64Url(rawState) || rawState.length > 128) {
+			throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+		}
+		const now = Date.now();
+		const keyId = getClientKeyId(state);
+		assertClientKeyAvailable(this.#oauth, keyId);
+		assertSeparateDpopKey(this.#oauth, state.dpopKey);
+		if (
+			state.sub !== this.#options.expectedDid ||
+			!validBoundedString(state.pkceVerifier, 128, 43) ||
+			!validHttpsOrigin(state.issuer) ||
+			!this.#oauth.clientMetadata.redirect_uris.includes(state.redirectUri) ||
+			!Number.isSafeInteger(state.expiresAt) ||
+			state.expiresAt <= now ||
+			state.expiresAt > now + MAX_STATE_LIFETIME_MS
+		) {
+			throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+		}
+		const userState = parseUserState(
+			state.userState,
+			this.#options,
+			this.#oauth.clientMetadata.client_uri,
+		);
+		const stateHash = await hashOpaque(rawState);
+		const encrypted = await this.#encryption.encrypt(
+			encoder.encode(JSON.stringify({ ...state, userState })),
+			this.#encryptionContext(stateHash),
+		);
+		const result = await this.#stub.putOAuthState({
+			publisherDid: this.#options.expectedDid,
+			stateHash,
+			encryptedState: encrypted.envelope,
+			encryptionKeyVersion: encrypted.keyVersion,
+			clientKeyId: keyId,
+			redirectTarget: userState.redirectTarget,
+			expiresAt: state.expiresAt,
+		});
+		if (!result.ok) throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+	}
+
+	async get(rawState: string): Promise<StoredState | undefined> {
+		if (!isBase64Url(rawState) || rawState.length > 128) return undefined;
+		const stateHash = await hashOpaque(rawState);
+		const stored = await this.#stub.consumeOAuthState(this.#options.expectedDid, stateHash);
+		if (!stored) return undefined;
+		assertClientKeyAvailable(this.#oauth, stored.clientKeyId);
+		const plaintext = await this.#encryption.decrypt(
+			stored.encryptedState,
+			this.#encryptionContext(stateHash),
+		);
+		const state = parseStoredState(decoder.decode(plaintext));
+		if (
+			getClientKeyId(state) !== stored.clientKeyId ||
+			state.sub !== this.#options.expectedDid ||
+			state.expiresAt !== stored.expiresAt ||
+			!this.#oauth.clientMetadata.redirect_uris.includes(state.redirectUri)
+		) {
+			throw new OAuthCustodyError("OAUTH_STATE_INVALID");
+		}
+		return {
+			...state,
+			userState: parseUserState(
+				state.userState,
+				this.#options,
+				this.#oauth.clientMetadata.client_uri,
+			),
+		};
+	}
+
+	async delete(rawState: string): Promise<void> {
+		if (!isBase64Url(rawState) || rawState.length > 128) return;
+		await this.#stub.consumeOAuthState(this.#options.expectedDid, await hashOpaque(rawState));
+	}
+
+	clear(): Promise<void> {
+		return Promise.reject(new OAuthCustodyError("OAUTH_STATE_INVALID"));
+	}
+
+	#encryptionContext(stateHash: string): EncryptionContext {
+		return {
+			purpose: transactionEncryptionPurpose(this.#options.purpose),
+			objectClass: "PublisherDurableObject",
+			table: "oauth_states",
+			primaryKey: stateHash,
+			ownerDid: this.#options.expectedDid,
+		};
+	}
+}
+
+class PublisherOAuthSessionStore implements Store<Did, StoredSession> {
+	readonly #stub: DurableObjectStub<PublisherDurableObject>;
+	readonly #encryption: EnvelopeEncryption;
+	readonly #oauth: OAuthConfiguration;
+	readonly #options: PublisherOAuthFlowOptions;
+	readonly #identitySessions = new MemoryStore<Did, StoredSession>();
+	#activeLease: ActiveRefreshLease | null = null;
+	#preserveNextDelete = false;
+
+	constructor(
+		stub: DurableObjectStub<PublisherDurableObject>,
+		encryption: EnvelopeEncryption,
+		oauth: OAuthConfiguration,
+		options: PublisherOAuthFlowOptions,
+	) {
+		this.#stub = stub;
+		this.#encryption = encryption;
+		this.#oauth = oauth;
+		this.#options = options;
+	}
+
+	async get(did: Did): Promise<StoredSession | undefined> {
+		this.#assertDid(did);
+		if (this.#options.purpose === "publisher_identity") {
+			return this.#identitySessions.get(did);
+		}
+		const stored = this.#activeLease
+			? await this.#stub.getDelegationForRefresh(
+					this.#activeLease.publisherDid,
+					this.#activeLease.generation,
+					this.#activeLease.token,
+				)
+			: await this.#stub.getDelegation(did);
+		if (!stored || stored.status !== "active" || stored.encryptedSession.length === 0) {
+			return undefined;
+		}
+		try {
+			const session = await this.#decryptSession(stored, did);
+			this.#preserveNextDelete = false;
+			return session;
+		} catch (error) {
+			this.#preserveNextDelete = true;
+			await this.#requireReauthorization(did, stored, error);
+			throw error;
+		}
+	}
+
+	async set(did: Did, session: StoredSession): Promise<void> {
+		this.#assertDid(did);
+		this.#validateSession(did, session);
+		if (this.#options.purpose === "publisher_identity") {
+			this.#identitySessions.set(did, session);
+			return;
+		}
+		const encrypted = await this.#encryptSession(did, session);
+		const fields = {
+			clientKeyId: getClientKeyId(session),
+			encryptedSession: encrypted.envelope,
+			encryptionKeyVersion: encrypted.keyVersion,
+			issuer: session.tokenSet.iss,
+			pdsUrl: session.tokenSet.aud,
+			expiresAt: session.tokenSet.expires_at ?? null,
+			refreshBefore: session.tokenSet.expires_at ?? null,
+		};
+		if (this.#activeLease) {
+			const result = await this.#stub.completeDelegationRefresh({
+				publisherDid: did,
+				generation: this.#activeLease.generation,
+				token: this.#activeLease.token,
+				expectedVersion: this.#activeLease.expectedVersion,
+				...fields,
+			});
+			if (!result.ok) throw new OAuthCustodyError("OAUTH_DELEGATION_CAS_REQUIRED");
+			return;
+		}
+		const existing = await this.#stub.getDelegation(did);
+		if (existing?.status === "active") {
+			throw new OAuthCustodyError("OAUTH_DELEGATION_CAS_REQUIRED");
+		}
+		const result = await this.#stub.putDelegation({
+			publisherDid: did,
+			releaseNsid: this.#oauth.releaseNsid,
+			scope: this.#oauth.releaseScope,
+			...fields,
+			expectedVersion: existing?.stateVersion ?? null,
+		});
+		if (!result.ok) throw new OAuthCustodyError("OAUTH_DELEGATION_CAS_REQUIRED");
+	}
+
+	async delete(did: Did): Promise<void> {
+		this.#assertDid(did);
+		if (this.#options.purpose === "publisher_identity") {
+			this.#identitySessions.delete(did);
+			return;
+		}
+		if (this.#preserveNextDelete) {
+			this.#preserveNextDelete = false;
+			return;
+		}
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const existing = await this.#stub.getDelegation(did);
+			if (!existing || existing.status === "revoked") return;
+			const result = await this.#stub.revokeDelegation(did, existing.stateVersion);
+			if (result.ok) return;
+		}
+		throw new OAuthCustodyError("OAUTH_DELEGATION_CAS_REQUIRED");
+	}
+
+	async clear(): Promise<void> {
+		if (this.#options.purpose === "publisher_identity") {
+			this.#identitySessions.clear();
+			return;
+		}
+		throw new OAuthCustodyError("OAUTH_DELEGATION_CAS_REQUIRED");
+	}
+
+	async requestLock<T>(name: string, callback: () => Promise<T>): Promise<T> {
+		if (this.#options.purpose !== "release_delegation") return callback();
+		if (name !== `oauth-session-${this.#options.expectedDid}` || this.#activeLease) {
+			throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+		}
+		const deadline = Date.now() + REFRESH_LOCK_TIMEOUT_MS;
+		let lease: ActiveRefreshLease | null = null;
+		while (lease === null) {
+			const result = await this.#stub.beginDelegationRefresh(
+				this.#options.expectedDid,
+				REFRESH_LEASE_MS,
+			);
+			if (result.ok) {
+				lease = { ...result.lease, publisherDid: this.#options.expectedDid };
+				break;
+			}
+			if (result.code === "DELEGATION_UNAVAILABLE") {
+				throw new OAuthCustodyError("OAUTH_DELEGATION_UNAVAILABLE");
+			}
+			const now = Date.now();
+			if (now >= deadline) throw new OAuthCustodyError("OAUTH_REFRESH_LOCK_TIMEOUT");
+			await new Promise<void>((resolve) => {
+				setTimeout(resolve, Math.min(250, Math.max(10, result.retryAt - now)));
+			});
+		}
+		this.#activeLease = lease;
+		try {
+			return await callback();
+		} finally {
+			this.#activeLease = null;
+			await this.#stub.releaseDelegationRefresh(lease.publisherDid, lease.generation, lease.token);
+		}
+	}
+
+	#assertDid(did: string): asserts did is Did {
+		if (did !== this.#options.expectedDid || !isDid(did)) {
+			throw new OAuthCustodyError("OAUTH_IDENTITY_MISMATCH");
+		}
+	}
+
+	#validateSession(did: Did, session: StoredSession): void {
+		const expectedScope =
+			this.#options.purpose === "release_delegation" ? this.#oauth.releaseScope : "atproto";
+		assertClientKeyAvailable(this.#oauth, getClientKeyId(session));
+		assertDpopKey(session.dpopKey);
+		assertSeparateDpopKey(this.#oauth, session.dpopKey);
+		if (session.tokenSet.sub !== did) {
+			throw new OAuthCustodyError("OAUTH_IDENTITY_MISMATCH");
+		}
+		if (session.tokenSet.scope !== expectedScope) {
+			throw new OAuthCustodyError("OAUTH_SCOPE_INVALID");
+		}
+		if (
+			session.tokenSet.token_type !== "DPoP" ||
+			!validHttpsOrigin(session.tokenSet.iss) ||
+			!validHttpsOrigin(session.tokenSet.aud) ||
+			!validBoundedString(session.tokenSet.access_token, 65_536) ||
+			(session.tokenSet.refresh_token !== undefined &&
+				!validBoundedString(session.tokenSet.refresh_token, 65_536)) ||
+			(session.tokenSet.expires_at !== undefined &&
+				!Number.isSafeInteger(session.tokenSet.expires_at)) ||
+			(this.#options.purpose === "release_delegation" &&
+				(typeof session.tokenSet.refresh_token !== "string" ||
+					session.tokenSet.refresh_token.length === 0))
+		) {
+			throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+		}
+	}
+
+	async #encryptSession(did: Did, session: StoredSession) {
+		return this.#encryption.encrypt(
+			encoder.encode(JSON.stringify(session)),
+			this.#sessionEncryptionContext(did),
+		);
+	}
+
+	async #decryptSession(stored: StoredDelegation, did: Did): Promise<StoredSession> {
+		if (
+			stored.releaseNsid !== this.#oauth.releaseNsid ||
+			stored.scope !== this.#oauth.releaseScope ||
+			stored.encryptionKeyVersion === null ||
+			stored.issuer === null ||
+			stored.pdsUrl === null
+		) {
+			throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+		}
+		assertClientKeyAvailable(this.#oauth, stored.clientKeyId);
+		const plaintext = await this.#encryption.decrypt(
+			stored.encryptedSession,
+			this.#sessionEncryptionContext(did),
+		);
+		const session = parseStoredSession(decoder.decode(plaintext));
+		this.#validateSession(did, session);
+		if (
+			getClientKeyId(session) !== stored.clientKeyId ||
+			session.tokenSet.iss !== stored.issuer ||
+			session.tokenSet.aud !== stored.pdsUrl ||
+			(session.tokenSet.expires_at ?? null) !== stored.expiresAt
+		) {
+			throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+		}
+		return session;
+	}
+
+	async #requireReauthorization(did: Did, stored: StoredDelegation, error: unknown): Promise<void> {
+		let reason: DelegationReauthorizationReason = "OAUTH_SESSION_INVALID";
+		if (error instanceof OAuthCustodyError && error.code === "OAUTH_CLIENT_KEY_UNAVAILABLE") {
+			reason = "OAUTH_CLIENT_KEY_UNAVAILABLE";
+		} else if (error instanceof EncryptionError && error.code === "ENCRYPTION_KEY_UNAVAILABLE") {
+			reason = "ENCRYPTION_KEY_UNAVAILABLE";
+		}
+		await this.#stub.requireDelegationReauthorization(did, stored.stateVersion, reason);
+	}
+
+	#sessionEncryptionContext(did: Did): EncryptionContext {
+		return {
+			purpose: "oauth-session",
+			objectClass: "PublisherDurableObject",
+			table: "delegation",
+			primaryKey: "1",
+			ownerDid: did,
+		};
+	}
+}
+
+function assertClientKeyAvailable(oauth: OAuthConfiguration, keyId: string): void {
+	if (!oauth.hasAssertionKey(keyId)) {
+		throw new OAuthCustodyError("OAUTH_CLIENT_KEY_UNAVAILABLE");
+	}
+}
+
+function assertSeparateDpopKey(oauth: OAuthConfiguration, dpopKey: StoredSession["dpopKey"]): void {
+	if (
+		dpopKey.kty === "EC" &&
+		oauth.assertionKeys.some(
+			(key) => key.kty === "EC" && key.x === dpopKey.x && key.y === dpopKey.y,
+		)
+	) {
+		throw new OAuthCustodyError("OAUTH_SESSION_INVALID");
+	}
+}
+
+export interface PublisherOAuthStores {
+	stores: OAuthClientStores;
+	requestLock?: <T>(name: string, callback: () => Promise<T>) => Promise<T>;
+	userState: PublisherOAuthUserState;
+}
+
+export function createPublisherOAuthStores(
+	namespace: DurableObjectNamespace<PublisherDurableObject>,
+	encryption: EnvelopeEncryption,
+	oauth: OAuthConfiguration,
+	options: PublisherOAuthFlowOptions,
+): PublisherOAuthStores {
+	if (!isDid(options.expectedDid)) {
+		throw new OAuthCustodyError("OAUTH_IDENTITY_MISMATCH");
+	}
+	const normalizedOptions = {
+		...options,
+		redirectTarget: canonicalizeRedirectTarget(
+			options.redirectTarget,
+			oauth.clientMetadata.client_uri,
+		),
+	};
+	const stub = namespace.getByName(options.expectedDid);
+	const states = new DurableOAuthStateStore(stub, encryption, oauth, normalizedOptions);
+	const sessions = new PublisherOAuthSessionStore(stub, encryption, oauth, normalizedOptions);
+	return {
+		stores: { states, sessions },
+		...(options.purpose === "release_delegation"
+			? { requestLock: sessions.requestLock.bind(sessions) }
+			: {}),
+		userState: expectedUserState(normalizedOptions, oauth.clientMetadata.client_uri),
+	};
+}
+
+export function createWorkerActorResolver(fetchThis: typeof fetch = fetch): ActorResolver {
+	return new LocalActorResolver({
+		handleResolver: new CompositeHandleResolver({
+			methods: {
+				dns: new DohJsonHandleResolver({
+					dohUrl: "https://cloudflare-dns.com/dns-query",
+					fetch: fetchThis,
+				}),
+				http: new WellKnownHandleResolver({ fetch: fetchThis }),
+			},
+		}),
+		didDocumentResolver: new CompositeDidDocumentResolver({
+			methods: {
+				plc: new PlcDidDocumentResolver({ fetch: fetchThis }),
+				web: new WebDidDocumentResolver({ fetch: fetchThis }),
+			},
+		}),
+	});
+}
+
+export interface CreatePublisherOAuthClientOptions {
+	namespace: DurableObjectNamespace<PublisherDurableObject>;
+	encryption: EnvelopeEncryption;
+	oauth: OAuthConfiguration;
+	flow: PublisherOAuthFlowOptions;
+	actorResolver?: ActorResolver;
+	fetch?: typeof globalThis.fetch;
+}
+
+export class PublisherOAuthClient {
+	readonly #client: OAuthClient;
+	readonly #oauth: OAuthConfiguration;
+	readonly #flow: PublisherOAuthFlowOptions;
+	readonly userState: PublisherOAuthUserState;
+
+	constructor(
+		client: OAuthClient,
+		oauth: OAuthConfiguration,
+		flow: PublisherOAuthFlowOptions,
+		userState: PublisherOAuthUserState,
+	) {
+		this.#client = client;
+		this.#oauth = oauth;
+		this.#flow = flow;
+		this.userState = userState;
+	}
+
+	get metadata(): OAuthClient["metadata"] {
+		return this.#client.metadata;
+	}
+
+	get jwks(): OAuthClient["jwks"] {
+		return this.#client.jwks;
+	}
+
+	authorize(
+		target: AuthorizeTarget,
+		options: { signal?: AbortSignal } = {},
+	): Promise<AuthorizationResult> {
+		const scope =
+			this.#flow.purpose === "release_delegation" ? this.#oauth.releaseScope : "atproto";
+		return this.#client.authorize({
+			target,
+			scope,
+			state: this.userState,
+			redirectUri: this.#oauth.clientMetadata.redirect_uris[0],
+			...options,
+		});
+	}
+
+	async callback(params: URLSearchParams): Promise<{
+		session: OAuthSession;
+		state: PublisherOAuthUserState;
+	}> {
+		const result = await this.#client.callback(params, {
+			redirectUri: this.#oauth.clientMetadata.redirect_uris[0],
+		});
+		if (result.session.sub !== this.#flow.expectedDid) {
+			throw new OAuthCustodyError("OAUTH_IDENTITY_MISMATCH");
+		}
+		return {
+			session: result.session,
+			state: parseUserState(result.state, this.#flow, this.#oauth.clientMetadata.client_uri),
+		};
+	}
+
+	restore(options?: RestoreOptions): Promise<OAuthSession> {
+		if (this.#flow.purpose !== "release_delegation") {
+			return Promise.reject(new OAuthCustodyError("OAUTH_DELEGATION_UNAVAILABLE"));
+		}
+		return this.#client.restore(this.#flow.expectedDid, options);
+	}
+
+	revoke(): Promise<void> {
+		if (this.#flow.purpose !== "release_delegation") {
+			return Promise.reject(new OAuthCustodyError("OAUTH_DELEGATION_UNAVAILABLE"));
+		}
+		return this.#client.revoke(this.#flow.expectedDid);
+	}
+}
+
+export function createPublisherOAuthClient(
+	options: CreatePublisherOAuthClientOptions,
+): PublisherOAuthClient {
+	const custody = createPublisherOAuthStores(
+		options.namespace,
+		options.encryption,
+		options.oauth,
+		options.flow,
+	);
+	const fetchThis = options.fetch ?? globalThis.fetch;
+	const client = new OAuthClient({
+		metadata: options.oauth.clientMetadata,
+		keyset: options.oauth.keyset,
+		stores: custody.stores,
+		actorResolver: options.actorResolver ?? createWorkerActorResolver(fetchThis),
+		...(custody.requestLock ? { requestLock: custody.requestLock } : {}),
+		fetch: fetchThis,
+	});
+	return new PublisherOAuthClient(client, options.oauth, options.flow, custody.userState);
+}

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -83,6 +83,15 @@ export type RevokeDelegationResult =
 	| { ok: true; delegation: StoredDelegation }
 	| { ok: false; code: "DELEGATION_CAS_REQUIRED" };
 
+export type RequireDelegationReauthorizationResult =
+	| { ok: true; delegation: StoredDelegation }
+	| { ok: false; code: "DELEGATION_CAS_REQUIRED" };
+
+export type DelegationReauthorizationReason =
+	| "OAUTH_CLIENT_KEY_UNAVAILABLE"
+	| "OAUTH_SESSION_INVALID"
+	| "ENCRYPTION_KEY_UNAVAILABLE";
+
 export interface DelegationRefreshLease {
 	generation: number;
 	token: string;
@@ -662,6 +671,43 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				now,
 			);
 			return true;
+		});
+	}
+
+	requireDelegationReauthorization(
+		publisherDid: string,
+		expectedVersion: number,
+		reasonCode: DelegationReauthorizationReason,
+	): RequireDelegationReauthorizationResult {
+		this.#assertPublisherDid(publisherDid);
+		if (!validPositiveInteger(expectedVersion)) {
+			throw new PublisherStateError("DELEGATION_INVALID");
+		}
+		return this.ctx.storage.transactionSync(() => {
+			const current = this.#readDelegation();
+			if (!current || current.stateVersion !== expectedVersion || current.status === "revoked") {
+				return { ok: false, code: "DELEGATION_CAS_REQUIRED" } as const;
+			}
+			if (current.status === "reauthorization_required") {
+				return { ok: true, delegation: current } as const;
+			}
+			const now = Date.now();
+			this.ctx.storage.sql.exec(
+				`UPDATE delegation SET
+					status = 'reauthorization_required', state_version = state_version + 1, updated_at = ?
+				 WHERE id = 1`,
+				now,
+			);
+			this.#clearRefreshOperation(now);
+			this.#appendAudit(
+				"delegation-reauthorization-required",
+				"system",
+				"release-service",
+				current.releaseNsid,
+				now,
+				reasonCode,
+			);
+			return { ok: true, delegation: this.#readDelegation()! } as const;
 		});
 	}
 

--- a/apps/release-service/test/oauth-custody.test.ts
+++ b/apps/release-service/test/oauth-custody.test.ts
@@ -1,0 +1,426 @@
+import type { ActorResolver } from "@atcute/identity-resolver";
+import type { StoredSession, StoredState } from "@atcute/oauth-node-client";
+import { reset, runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadConfiguration } from "../src/config.js";
+import {
+	OAuthCustodyError,
+	canonicalizeRedirectTarget,
+	createPublisherOAuthClient,
+	createPublisherOAuthStores,
+} from "../src/oauth/custody.js";
+import { ASSERTION_KEY_1, ASSERTION_KEY_2, TEST_BINDINGS } from "./fixtures/oauth.js";
+
+const DID = "did:plc:publisher" as const;
+const OTHER_DID = "did:plc:other" as const;
+const RAW_STATE = "abcdefghijklmnopqrstuvwx";
+const PKCE_VERIFIER = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+const DPOP_KEY = {
+	kty: "EC",
+	crv: "P-256",
+	alg: "ES256",
+	x: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+	y: "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8",
+	d: "QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl8",
+} as const satisfies StoredSession["dpopKey"];
+
+function state(userState: unknown, overrides: Partial<StoredState> = {}): StoredState {
+	return {
+		dpopKey: DPOP_KEY,
+		authMethod: { method: "private_key_jwt", kid: ASSERTION_KEY_2.kid },
+		pkceVerifier: PKCE_VERIFIER,
+		issuer: "https://authorization.example",
+		redirectUri: "https://release.example.invalid/oauth/callback",
+		sub: DID,
+		userState,
+		expiresAt: Date.now() + 10 * 60_000,
+		...overrides,
+	};
+}
+
+function session(scope: string, overrides: Partial<StoredSession["tokenSet"]> = {}): StoredSession {
+	return {
+		dpopKey: DPOP_KEY,
+		authMethod: { method: "private_key_jwt", kid: ASSERTION_KEY_2.kid },
+		tokenSet: {
+			iss: "https://authorization.example",
+			sub: DID,
+			aud: "https://pds.example",
+			scope: scope as StoredSession["tokenSet"]["scope"],
+			access_token: "access-token-secret",
+			refresh_token: "refresh-token-secret",
+			token_type: "DPoP",
+			expires_at: Date.now() + 60_000,
+			...overrides,
+		},
+	};
+}
+
+afterEach(async () => {
+	await reset();
+});
+
+describe("Durable Object OAuth custody", () => {
+	it("encrypts state, consumes it once, and never persists raw state or PKCE", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const custody = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			{
+				purpose: "release_delegation",
+				expectedDid: DID,
+				redirectTarget: "/publisher/delegation?complete=1",
+			},
+		);
+		await custody.stores.states.set(RAW_STATE, state(custody.userState));
+
+		const persisted = await runInDurableObject(
+			env.PUBLISHER_DO.getByName(DID),
+			(_instance, durableState) =>
+				durableState.storage.sql
+					.exec<{
+						state_hash: string;
+						encrypted_state: string;
+						encryption_key_version: number;
+					}>("SELECT state_hash, encrypted_state, encryption_key_version FROM oauth_states")
+					.one(),
+		);
+		expect(persisted.state_hash).not.toBe(RAW_STATE);
+		expect(persisted.encryption_key_version).toBe(configuration.encryption.currentKeyVersion);
+		expect(JSON.stringify(persisted)).not.toContain(RAW_STATE);
+		expect(JSON.stringify(persisted)).not.toContain(PKCE_VERIFIER);
+		await expect(custody.stores.states.get(RAW_STATE)).resolves.toMatchObject({
+			sub: DID,
+			pkceVerifier: PKCE_VERIFIER,
+			userState: custody.userState,
+		});
+		await expect(custody.stores.states.get(RAW_STATE)).resolves.toBeUndefined();
+	});
+
+	it("fails closed for state identity, redirect, key, and user-state mismatches", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const custody = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			{
+				purpose: "release_delegation",
+				expectedDid: DID,
+				redirectTarget: "/publisher/delegation",
+			},
+		);
+		const cases: StoredState[] = [
+			state(custody.userState, { sub: OTHER_DID }),
+			state(custody.userState, { redirectUri: "https://other.example/callback" }),
+			state(custody.userState, {
+				authMethod: { method: "private_key_jwt", kid: "retired-key" },
+			}),
+			state({ ...custody.userState, redirectTarget: "//evil.example" }),
+		];
+		for (const [index, value] of cases.entries()) {
+			await expect(custody.stores.states.set(`${RAW_STATE}${index}`, value)).rejects.toBeInstanceOf(
+				OAuthCustodyError,
+			);
+		}
+	});
+
+	it("keeps identity-only sessions in request-local memory", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const flow = {
+			purpose: "publisher_identity",
+			expectedDid: DID,
+			redirectTarget: "/publisher",
+		} as const;
+		const first = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			flow,
+		);
+		const identitySession = session("atproto", { refresh_token: undefined });
+		await first.stores.sessions.set(DID, identitySession);
+		await expect(first.stores.sessions.get(DID)).resolves.toEqual(identitySession);
+		const second = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			flow,
+		);
+		await expect(second.stores.sessions.get(DID)).resolves.toBeUndefined();
+		await expect(env.PUBLISHER_DO.getByName(DID).getDelegation(DID)).resolves.toBeNull();
+	});
+
+	it("persists only exact-scope encrypted delegations and rejects replacement", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const custody = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			{
+				purpose: "release_delegation",
+				expectedDid: DID,
+				redirectTarget: "/publisher/delegation",
+			},
+		);
+		const delegatedSession = session(configuration.oauth.releaseScope);
+		await custody.stores.sessions.set(DID, delegatedSession);
+		await expect(custody.stores.sessions.get(DID)).resolves.toEqual(delegatedSession);
+		await expect(custody.stores.sessions.set(DID, delegatedSession)).rejects.toMatchObject({
+			code: "OAUTH_DELEGATION_CAS_REQUIRED",
+		});
+		await expect(custody.stores.sessions.set(DID, session("atproto"))).rejects.toMatchObject({
+			code: "OAUTH_SCOPE_INVALID",
+		});
+
+		const persisted = await runInDurableObject(
+			env.PUBLISHER_DO.getByName(DID),
+			(_instance, durableState) =>
+				durableState.storage.sql
+					.exec<{ encrypted_session: string; scope: string }>(
+						"SELECT encrypted_session, scope FROM delegation WHERE id = 1",
+					)
+					.one(),
+		);
+		expect(persisted.scope).toBe(configuration.oauth.releaseScope);
+		expect(persisted.encrypted_session).not.toContain("access-token-secret");
+		expect(persisted.encrypted_session).not.toContain("refresh-token-secret");
+	});
+
+	it("stores refresh results only through the active generation-bound lease", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const custody = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			{
+				purpose: "release_delegation",
+				expectedDid: DID,
+				redirectTarget: "/publisher/delegation",
+			},
+		);
+		await custody.stores.sessions.set(DID, session(configuration.oauth.releaseScope));
+		expect(custody.requestLock).toBeTypeOf("function");
+		await custody.requestLock?.(`oauth-session-${DID}`, async () => {
+			await expect(custody.stores.sessions.get(DID)).resolves.toBeDefined();
+			await custody.stores.sessions.set(
+				DID,
+				session(configuration.oauth.releaseScope, {
+					access_token: "refreshed-access-secret",
+					refresh_token: "refreshed-refresh-secret",
+					expires_at: Date.now() + 120_000,
+				}),
+			);
+		});
+
+		await expect(custody.stores.sessions.get(DID)).resolves.toMatchObject({
+			tokenSet: {
+				access_token: "refreshed-access-secret",
+				refresh_token: "refreshed-refresh-secret",
+			},
+		});
+		await expect(env.PUBLISHER_DO.getByName(DID).getDelegation(DID)).resolves.toMatchObject({
+			stateVersion: 2,
+		});
+	});
+
+	it("revokes authority and rejects assertion-key reuse as DPoP", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const custody = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			{
+				purpose: "release_delegation",
+				expectedDid: DID,
+				redirectTarget: "/publisher/delegation",
+			},
+		);
+		const reusedKey = {
+			...DPOP_KEY,
+			x: ASSERTION_KEY_1.x,
+			y: ASSERTION_KEY_1.y,
+			d: ASSERTION_KEY_1.d,
+		};
+		await expect(
+			custody.stores.sessions.set(DID, {
+				...session(configuration.oauth.releaseScope),
+				dpopKey: reusedKey,
+			}),
+		).rejects.toMatchObject({ code: "OAUTH_SESSION_INVALID" });
+
+		await custody.stores.sessions.set(DID, session(configuration.oauth.releaseScope));
+		await custody.stores.sessions.delete(DID);
+		await expect(custody.stores.sessions.get(DID)).resolves.toBeUndefined();
+		await expect(env.PUBLISHER_DO.getByName(DID).getDelegation(DID)).resolves.toMatchObject({
+			status: "revoked",
+			encryptedSession: "",
+		});
+	});
+
+	it("requires reauthorization without deleting ciphertext when its assertion key is retired", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const flow = {
+			purpose: "release_delegation",
+			expectedDid: DID,
+			redirectTarget: "/publisher/delegation",
+		} as const;
+		const initial = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			configuration.encryption,
+			configuration.oauth,
+			flow,
+		);
+		await initial.stores.sessions.set(DID, session(configuration.oauth.releaseScope));
+
+		const rotatedConfiguration = await loadConfiguration({
+			...TEST_BINDINGS,
+			OAUTH_ASSERTION_KEYSET: JSON.stringify({
+				active: ASSERTION_KEY_1.kid,
+				keys: [ASSERTION_KEY_1],
+			}),
+		});
+		const afterRetirement = createPublisherOAuthStores(
+			env.PUBLISHER_DO,
+			rotatedConfiguration.encryption,
+			rotatedConfiguration.oauth,
+			flow,
+		);
+		await expect(afterRetirement.stores.sessions.get(DID)).rejects.toMatchObject({
+			code: "OAUTH_CLIENT_KEY_UNAVAILABLE",
+		});
+		await afterRetirement.stores.sessions.delete(DID);
+		await expect(env.PUBLISHER_DO.getByName(DID).getDelegation(DID)).resolves.toMatchObject({
+			status: "reauthorization_required",
+			encryptedSession: expect.stringMatching(/^\{/),
+			stateVersion: 2,
+		});
+	});
+
+	it("builds a confidential client around the Durable Object stores", async () => {
+		const configuration = await loadConfiguration({
+			...TEST_BINDINGS,
+			PUBLIC_ORIGIN: "https://release.example.com",
+			OAUTH_REDIRECT_URIS: '["https://release.example.com/oauth/callback"]',
+		});
+		const result = createPublisherOAuthClient({
+			namespace: env.PUBLISHER_DO,
+			encryption: configuration.encryption,
+			oauth: configuration.oauth,
+			flow: {
+				purpose: "release_delegation",
+				expectedDid: DID,
+				redirectTarget: "/publisher/delegation",
+			},
+		});
+		expect(result.metadata).toMatchObject({
+			client_id: configuration.oauth.clientMetadata.client_id,
+			scope: configuration.oauth.releaseScope,
+			token_endpoint_auth_method: "private_key_jwt",
+		});
+		expect(result.jwks?.keys).toHaveLength(2);
+		expect(result.userState).toEqual({
+			purpose: "release_delegation",
+			expectedDid: DID,
+			redirectTarget: "/publisher/delegation",
+		});
+	});
+
+	it.each([
+		["publisher_identity", "atproto"],
+		["release_delegation", "atproto repo:com.emdashcms.experimental.package.release?action=create"],
+	] as const)("forces the %s authorization scope", async (purpose, expectedScope) => {
+		const configuration = await loadConfiguration({
+			...TEST_BINDINGS,
+			PUBLIC_ORIGIN: "https://release.example.com",
+			OAUTH_REDIRECT_URIS: '["https://release.example.com/oauth/callback"]',
+		});
+		const requests: Array<{ url: string; body: URLSearchParams }> = [];
+		const fetchMock: typeof fetch = async (input, init) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			if (url.pathname === "/.well-known/oauth-protected-resource") {
+				return Response.json({
+					resource: "https://pds.example",
+					authorization_servers: ["https://authorization.example"],
+				});
+			}
+			if (url.pathname === "/.well-known/oauth-authorization-server") {
+				return Response.json({
+					issuer: "https://authorization.example",
+					authorization_endpoint: "https://authorization.example/authorize",
+					token_endpoint: "https://authorization.example/token",
+					pushed_authorization_request_endpoint: "https://authorization.example/par",
+					client_id_metadata_document_supported: true,
+					dpop_signing_alg_values_supported: ["ES256"],
+					response_types_supported: ["code"],
+				});
+			}
+			if (url.pathname === "/par") {
+				const body = new URLSearchParams();
+				if (input instanceof Request) {
+					for (const [key, value] of await input.clone().formData()) {
+						if (typeof value === "string") body.append(key, value);
+					}
+				} else {
+					const rawBody = init?.body;
+					if (typeof rawBody !== "string" && !(rawBody instanceof URLSearchParams)) {
+						throw new Error("Expected a form-encoded OAuth request body");
+					}
+					for (const [key, value] of new URLSearchParams(rawBody)) {
+						body.append(key, value);
+					}
+				}
+				requests.push({ url: url.toString(), body });
+				return Response.json({
+					request_uri: "urn:ietf:params:oauth:request_uri:test",
+					expires_in: 60,
+				});
+			}
+			throw new Error(`Unexpected OAuth request: ${url.toString()}`);
+		};
+		const actorResolver = {
+			async resolve() {
+				return { did: DID, handle: "publisher.example.com", pds: "https://pds.example" };
+			},
+		} satisfies ActorResolver;
+		const client = createPublisherOAuthClient({
+			namespace: env.PUBLISHER_DO,
+			encryption: configuration.encryption,
+			oauth: configuration.oauth,
+			flow: { purpose, expectedDid: DID, redirectTarget: "/publisher" },
+			actorResolver,
+			fetch: fetchMock,
+		});
+
+		const authorization = await client.authorize({ type: "account", identifier: DID });
+		expect(authorization.url.origin).toBe("https://authorization.example");
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.body.get("scope")).toBe(expectedScope);
+		expect(requests[0]?.body.get("scope")).not.toContain("transition:generic");
+		expect(requests[0]?.body.get("redirect_uri")).toBe(
+			"https://release.example.com/oauth/callback",
+		);
+	});
+});
+
+describe("OAuth redirect targets", () => {
+	it.each(["https://evil.example", "//evil.example", "/\\evil", "/path\nnext"])(
+		"rejects %j",
+		(value) => {
+			expect(() =>
+				canonicalizeRedirectTarget(value, "https://release.example.invalid"),
+			).toThrowError(expect.objectContaining({ code: "OAUTH_REDIRECT_INVALID" }));
+		},
+	);
+
+	it("normalizes a same-origin path", () => {
+		expect(
+			canonicalizeRedirectTarget(
+				"/publisher/../publisher?done=1#result",
+				"https://release.example.invalid",
+			),
+		).toBe("/publisher?done=1#result");
+	});
+});

--- a/apps/release-service/test/oauth-custody.test.ts
+++ b/apps/release-service/test/oauth-custody.test.ts
@@ -274,6 +274,7 @@ describe("Durable Object OAuth custody", () => {
 			flow,
 		);
 		await initial.stores.sessions.set(DID, session(configuration.oauth.releaseScope));
+		const beforeRetirement = await env.PUBLISHER_DO.getByName(DID).getDelegation(DID);
 
 		const rotatedConfiguration = await loadConfiguration({
 			...TEST_BINDINGS,
@@ -292,11 +293,12 @@ describe("Durable Object OAuth custody", () => {
 			code: "OAUTH_CLIENT_KEY_UNAVAILABLE",
 		});
 		await afterRetirement.stores.sessions.delete(DID);
-		await expect(env.PUBLISHER_DO.getByName(DID).getDelegation(DID)).resolves.toMatchObject({
+		const afterRetirementDelegation = await env.PUBLISHER_DO.getByName(DID).getDelegation(DID);
+		expect(afterRetirementDelegation).toMatchObject({
 			status: "reauthorization_required",
-			encryptedSession: expect.stringMatching(/^\{/),
 			stateVersion: 2,
 		});
+		expect(afterRetirementDelegation?.encryptedSession).toBe(beforeRetirement?.encryptedSession);
 	});
 
 	it("builds a confidential client around the Durable Object stores", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
 
   apps/release-service:
     dependencies:
+      '@atcute/identity-resolver':
+        specifier: 'catalog:'
+        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/oauth-node-client':
         specifier: 'catalog:'
         version: 2.0.0(@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)


### PR DESCRIPTION
## What does this PR do?

Adds the confidential AT Protocol OAuth client backed by the publisher Durable Object. It encrypts and consumes authorization state, keeps identity-only sessions request-local, stores only exact create-only release delegations, serializes refresh through generation-bound leases, and transitions unreadable authority to reauthorization-required without deleting recovery ciphertext.

This is stack layer 6 of 8, based on `feat/drs-publisher-refresh-operations`. Related to RFC #1870 and Discussion #1590.

The eight PRs are one merge unit. This layer is a review boundary, not a supported deployment.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

Admin i18n and a changeset are not applicable; this changes a private Worker app.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Workerd covers encrypted one-shot state, exact identity/scope/redirect/key matching, DPoP/assertion key separation, identity-session non-persistence, delegated refresh, revocation, and both forced PAR scopes with no broad fallback.
- Repository `pnpm typecheck`, `pnpm lint`, and package tests passed on the top stack branch.
