### PR TITLE
feat(release-service): add publisher application sessions

### DIFF
--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -5,6 +5,7 @@ const HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const MAX_CIPHERTEXT_CHARS = 1_500_000;
 const MAX_REFRESH_LEASE_MS = 5 * 60_000;
+const MAX_PUBLISHER_SESSION_MS = 24 * 60 * 60_000;
 const REFRESH_TOKEN_BYTES = 32;
 const BASE64_PADDING_PATTERN = /=+$/;
 
@@ -15,7 +16,8 @@ export type PublisherStateErrorCode =
 	| "OAUTH_STATE_EXISTS"
 	| "DELEGATION_INVALID"
 	| "DELEGATION_CAS_REQUIRED"
-	| "DELEGATION_UNAVAILABLE";
+	| "DELEGATION_UNAVAILABLE"
+	| "PUBLISHER_SESSION_INVALID";
 
 export class PublisherStateError extends Error {
 	readonly code: PublisherStateErrorCode;
@@ -127,6 +129,46 @@ interface PublisherRow {
 	[key: string]: string | number | ArrayBuffer | null;
 	did: string;
 }
+
+interface PublisherSessionOwnerRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	did: string;
+	status: "active" | "suspended";
+	session_epoch: number;
+}
+
+interface PublisherSessionRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	token_hash: string;
+	csrf_hash: string;
+	session_epoch: number;
+	expires_at: number;
+}
+
+export interface CreatePublisherSessionInput {
+	publisherDid: string;
+	tokenHash: string;
+	csrfHash: string;
+	expiresAt: number;
+	now?: number;
+}
+
+export interface StoredPublisherSession {
+	publisherDid: string;
+	expiresAt: number;
+	sessionEpoch: number;
+}
+
+export type CreatePublisherSessionResult =
+	| { ok: true; session: StoredPublisherSession }
+	| { ok: false; code: "PUBLISHER_SESSION_EXISTS" | "PUBLISHER_SUSPENDED" };
+
+export type ValidatePublisherSessionResult =
+	| { ok: true; session: StoredPublisherSession }
+	| {
+			ok: false;
+			code: "PUBLISHER_SESSION_INVALID" | "PUBLISHER_SESSION_EXPIRED" | "PUBLISHER_SUSPENDED";
+	  };
 
 interface OAuthStateRow {
 	[key: string]: string | number | ArrayBuffer | null;
@@ -276,13 +318,17 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		`);
 	}
 
-	#assertPublisherDid(publisherDid: string): void {
+	#assertPublisherObjectName(publisherDid: string): void {
 		if (!DID_PATTERN.test(publisherDid)) {
 			throw new PublisherStateError("PUBLISHER_DID_INVALID");
 		}
 		if (this.#objectName === undefined || this.#objectName !== publisherDid) {
 			throw new PublisherStateError("PUBLISHER_DID_MISMATCH");
 		}
+	}
+
+	#assertPublisherDid(publisherDid: string): void {
+		this.#assertPublisherObjectName(publisherDid);
 		const existing = this.ctx.storage.sql
 			.exec<PublisherRow>("SELECT did FROM publisher WHERE id = 1")
 			.toArray()[0];
@@ -322,6 +368,147 @@ export class PublisherDurableObject extends DurableObject<Env> {
 
 	initializePublisher(publisherDid: string): void {
 		this.#assertPublisherDid(publisherDid);
+	}
+
+	createPublisherSession(input: CreatePublisherSessionInput): CreatePublisherSessionResult {
+		this.#assertPublisherDid(input.publisherDid);
+		const now = input.now ?? Date.now();
+		if (
+			!TOKEN_PATTERN.test(input.tokenHash) ||
+			!TOKEN_PATTERN.test(input.csrfHash) ||
+			!Number.isSafeInteger(now) ||
+			!Number.isSafeInteger(input.expiresAt) ||
+			input.expiresAt <= now ||
+			input.expiresAt - now > MAX_PUBLISHER_SESSION_MS
+		) {
+			throw new PublisherStateError("PUBLISHER_SESSION_INVALID");
+		}
+		return this.ctx.storage.transactionSync(() => {
+			const owner = this.#readPublisherSessionOwner();
+			if (!owner || owner.status === "suspended") {
+				return { ok: false, code: "PUBLISHER_SUSPENDED" } as const;
+			}
+			const existing = this.ctx.storage.sql
+				.exec<{ token_hash: string }>(
+					"SELECT token_hash FROM publisher_sessions WHERE token_hash = ?",
+					input.tokenHash,
+				)
+				.toArray()[0];
+			if (existing) return { ok: false, code: "PUBLISHER_SESSION_EXISTS" } as const;
+			this.ctx.storage.sql.exec("DELETE FROM publisher_sessions WHERE expires_at <= ?", now);
+			this.ctx.storage.sql.exec(
+				`INSERT INTO publisher_sessions (
+					token_hash, csrf_hash, session_epoch, expires_at, created_at, last_seen_at
+				) VALUES (?, ?, ?, ?, ?, ?)`,
+				input.tokenHash,
+				input.csrfHash,
+				owner.session_epoch,
+				input.expiresAt,
+				now,
+				now,
+			);
+			this.#appendAudit(
+				"publisher-session-created",
+				"publisher",
+				input.publisherDid,
+				input.tokenHash,
+				now,
+			);
+			return {
+				ok: true,
+				session: {
+					publisherDid: input.publisherDid,
+					expiresAt: input.expiresAt,
+					sessionEpoch: owner.session_epoch,
+				},
+			} as const;
+		});
+	}
+
+	validatePublisherSession(
+		publisherDid: string,
+		tokenHash: string,
+		csrfHash: string | null,
+		now = Date.now(),
+	): ValidatePublisherSessionResult {
+		this.#assertPublisherObjectName(publisherDid);
+		if (
+			!TOKEN_PATTERN.test(tokenHash) ||
+			(csrfHash !== null && !TOKEN_PATTERN.test(csrfHash)) ||
+			!Number.isSafeInteger(now)
+		) {
+			return { ok: false, code: "PUBLISHER_SESSION_INVALID" };
+		}
+		return this.ctx.storage.transactionSync(() => {
+			const owner = this.#readPublisherSessionOwner();
+			if (!owner) return { ok: false, code: "PUBLISHER_SESSION_INVALID" } as const;
+			if (owner.status === "suspended") {
+				return { ok: false, code: "PUBLISHER_SUSPENDED" } as const;
+			}
+			const session = this.ctx.storage.sql
+				.exec<PublisherSessionRow>(
+					`SELECT token_hash, csrf_hash, session_epoch, expires_at
+					 FROM publisher_sessions WHERE token_hash = ?`,
+					tokenHash,
+				)
+				.toArray()[0];
+			if (!session || session.session_epoch !== owner.session_epoch) {
+				return { ok: false, code: "PUBLISHER_SESSION_INVALID" } as const;
+			}
+			if (session.expires_at <= now) {
+				this.ctx.storage.sql.exec("DELETE FROM publisher_sessions WHERE token_hash = ?", tokenHash);
+				return { ok: false, code: "PUBLISHER_SESSION_EXPIRED" } as const;
+			}
+			if (csrfHash !== null && session.csrf_hash !== csrfHash) {
+				return { ok: false, code: "PUBLISHER_SESSION_INVALID" } as const;
+			}
+			this.ctx.storage.sql.exec(
+				"UPDATE publisher_sessions SET last_seen_at = ? WHERE token_hash = ?",
+				now,
+				tokenHash,
+			);
+			return {
+				ok: true,
+				session: {
+					publisherDid: owner.did,
+					expiresAt: session.expires_at,
+					sessionEpoch: session.session_epoch,
+				},
+			} as const;
+		});
+	}
+
+	revokePublisherSession(publisherDid: string, tokenHash: string): boolean {
+		this.#assertPublisherObjectName(publisherDid);
+		if (!TOKEN_PATTERN.test(tokenHash)) return false;
+		return this.ctx.storage.transactionSync(() => {
+			const deleted = this.ctx.storage.sql
+				.exec("DELETE FROM publisher_sessions WHERE token_hash = ? RETURNING token_hash", tokenHash)
+				.toArray();
+			if (deleted.length === 0) return false;
+			this.#appendAudit(
+				"publisher-session-revoked",
+				"publisher",
+				publisherDid,
+				tokenHash,
+				Date.now(),
+			);
+			return true;
+		});
+	}
+
+	revokeAllPublisherSessions(publisherDid: string): number | null {
+		this.#assertPublisherObjectName(publisherDid);
+		return this.ctx.storage.transactionSync(() => {
+			const owner = this.#readPublisherSessionOwner();
+			if (!owner) return null;
+			const nextEpoch = owner.session_epoch + 1;
+			const now = Date.now();
+			this.ctx.storage.sql.exec("UPDATE publisher SET session_epoch = ? WHERE id = 1", nextEpoch);
+			this.ctx.storage.sql.exec("DELETE FROM publisher_sessions");
+			this.#appendAudit("publisher-sessions-revoked", "publisher", publisherDid, publisherDid, now);
+			return nextEpoch;
+		});
 	}
 
 	putOAuthState(input: PutOAuthStateInput): PutOAuthStateResult {
@@ -766,6 +953,16 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				 FROM delegation_operations WHERE kind = 'refresh'`,
 			)
 			.one();
+	}
+
+	#readPublisherSessionOwner(): PublisherSessionOwnerRow | null {
+		return (
+			this.ctx.storage.sql
+				.exec<PublisherSessionOwnerRow>(
+					"SELECT did, status, session_epoch FROM publisher WHERE id = 1",
+				)
+				.toArray()[0] ?? null
+		);
 	}
 
 	#clearRefreshOperation(now: number): void {

--- a/apps/release-service/src/publisher-session/session.ts
+++ b/apps/release-service/src/publisher-session/session.ts
@@ -1,0 +1,322 @@
+import type { PublisherOAuthPurpose } from "../oauth/custody.js";
+import type {
+	PublisherDurableObject,
+	StoredPublisherSession,
+} from "../publisher-do/publisher-do.js";
+
+const SESSION_COOKIE = "__Host-emdash_publisher_session";
+const CSRF_COOKIE = "__Host-emdash_publisher_csrf";
+const OAUTH_ROUTE_COOKIE = "__Host-emdash_oauth_route";
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const BASE64_PADDING_PATTERN = /=+$/;
+const SESSION_TOKEN_BYTES = 32;
+const SESSION_LIFETIME_MS = 60 * 60_000;
+const OAUTH_ROUTE_LIFETIME_MS = 10 * 60_000;
+const MAX_COOKIE_HEADER_CHARS = 8192;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+type Did = `did:${string}:${string}`;
+
+export type PublisherSessionErrorCode =
+	| "PUBLISHER_SESSION_INVALID"
+	| "PUBLISHER_SESSION_EXPIRED"
+	| "PUBLISHER_SUSPENDED"
+	| "CSRF_INVALID"
+	| "ORIGIN_INVALID";
+
+export class PublisherSessionError extends Error {
+	readonly code: PublisherSessionErrorCode;
+
+	constructor(code: PublisherSessionErrorCode) {
+		super(code);
+		this.name = "PublisherSessionError";
+		this.code = code;
+	}
+}
+
+export interface CreatedPublisherSession {
+	session: StoredPublisherSession;
+	setCookieHeaders: readonly [string, string];
+}
+
+export interface OAuthRouteState {
+	purpose: PublisherOAuthPurpose;
+	expectedDid: Did;
+	redirectTarget: string;
+	stateId: string;
+	expiresAt: number;
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(BASE64_PADDING_PATTERN, "");
+}
+
+function decodeBase64Url(value: unknown): Uint8Array<ArrayBuffer> | null {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		!BASE64URL_PATTERN.test(value) ||
+		value.length % 4 === 1
+	) {
+		return null;
+	}
+	try {
+		const padded = value
+			.replaceAll("-", "+")
+			.replaceAll("_", "/")
+			.padEnd(value.length + ((4 - (value.length % 4)) % 4), "=");
+		const binary = atob(padded);
+		const bytes = new Uint8Array(binary.length);
+		for (let index = 0; index < binary.length; index += 1) {
+			bytes[index] = binary.charCodeAt(index);
+		}
+		return encodeBase64Url(bytes) === value ? bytes : null;
+	} catch {
+		return null;
+	}
+}
+
+function randomToken(): string {
+	return encodeBase64Url(crypto.getRandomValues(new Uint8Array(SESSION_TOKEN_BYTES)));
+}
+
+async function hashOpaque(value: string): Promise<string> {
+	const digest = await hashOpaqueBytes(value);
+	return encodeBase64Url(new Uint8Array(digest));
+}
+
+function hashOpaqueBytes(value: string): Promise<ArrayBuffer> {
+	return crypto.subtle.digest("SHA-256", encoder.encode(value));
+}
+
+function encodeJsonCookie(value: unknown): string {
+	return encodeBase64Url(encoder.encode(JSON.stringify(value)));
+}
+
+function isDid(value: unknown): value is Did {
+	return typeof value === "string" && DID_PATTERN.test(value);
+}
+
+function decodeJsonCookie(value: string): unknown {
+	const bytes = decodeBase64Url(value);
+	if (!bytes || bytes.length > 4096) throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	try {
+		return JSON.parse(decoder.decode(bytes));
+	} catch {
+		throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	}
+}
+
+function parseCookies(request: Request): ReadonlyMap<string, string> {
+	const header = request.headers.get("cookie") ?? "";
+	if (header.length > MAX_COOKIE_HEADER_CHARS) {
+		throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	}
+	const cookies = new Map<string, string>();
+	for (const part of header.split(";")) {
+		const separator = part.indexOf("=");
+		if (separator < 1) continue;
+		const name = part.slice(0, separator).trim();
+		const value = part.slice(separator + 1).trim();
+		if (cookies.has(name)) throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+		cookies.set(name, value);
+	}
+	return cookies;
+}
+
+function serializeCookie(
+	name: string,
+	value: string,
+	options: { httpOnly: boolean; maxAge: number; sameSite?: "Lax" | "Strict" },
+): string {
+	return [
+		`${name}=${value}`,
+		"Path=/",
+		`Max-Age=${options.maxAge}`,
+		"Secure",
+		options.httpOnly ? "HttpOnly" : null,
+		`SameSite=${options.sameSite ?? "Lax"}`,
+	]
+		.filter((part): part is string => part !== null)
+		.join("; ");
+}
+
+function parsePublisherSessionCookie(value: string): { did: Did; token: string } {
+	const parsed = decodeJsonCookie(value);
+	if (
+		!parsed ||
+		typeof parsed !== "object" ||
+		Array.isArray(parsed) ||
+		Object.keys(parsed).length !== 3 ||
+		!("v" in parsed) ||
+		parsed.v !== 1 ||
+		!("did" in parsed) ||
+		!isDid(parsed.did) ||
+		!("token" in parsed) ||
+		typeof parsed.token !== "string" ||
+		!TOKEN_PATTERN.test(parsed.token)
+	) {
+		throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	}
+	return { did: parsed.did, token: parsed.token };
+}
+
+export async function createPublisherApplicationSession(
+	namespace: DurableObjectNamespace<PublisherDurableObject>,
+	publisherDid: Did,
+	now = Date.now(),
+): Promise<CreatedPublisherSession> {
+	if (!DID_PATTERN.test(publisherDid) || !Number.isSafeInteger(now)) {
+		throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	}
+	const token = randomToken();
+	const csrf = randomToken();
+	const expiresAt = now + SESSION_LIFETIME_MS;
+	const result = await namespace.getByName(publisherDid).createPublisherSession({
+		publisherDid,
+		tokenHash: await hashOpaque(token),
+		csrfHash: await hashOpaque(csrf),
+		expiresAt,
+		now,
+	});
+	if (!result.ok) {
+		throw new PublisherSessionError(
+			result.code === "PUBLISHER_SUSPENDED" ? "PUBLISHER_SUSPENDED" : "PUBLISHER_SESSION_INVALID",
+		);
+	}
+	return {
+		session: result.session,
+		setCookieHeaders: [
+			serializeCookie(SESSION_COOKIE, encodeJsonCookie({ v: 1, did: publisherDid, token }), {
+				httpOnly: true,
+				maxAge: SESSION_LIFETIME_MS / 1000,
+			}),
+			serializeCookie(CSRF_COOKIE, csrf, {
+				httpOnly: false,
+				maxAge: SESSION_LIFETIME_MS / 1000,
+				sameSite: "Strict",
+			}),
+		],
+	};
+}
+
+export async function requirePublisherApplicationSession(
+	request: Request,
+	namespace: DurableObjectNamespace<PublisherDurableObject>,
+	publicOrigin: string,
+	options: { requireCsrf?: boolean } = {},
+): Promise<StoredPublisherSession> {
+	const cookies = parseCookies(request);
+	const sessionCookie = cookies.get(SESSION_COOKIE);
+	if (!sessionCookie) throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	const parsed = parsePublisherSessionCookie(sessionCookie);
+	let csrfHash: string | null = null;
+	if (options.requireCsrf) {
+		if (
+			request.headers.get("origin") !== publicOrigin ||
+			request.headers.get("x-emdash-request") !== "1"
+		) {
+			throw new PublisherSessionError("ORIGIN_INVALID");
+		}
+		const csrfCookie = cookies.get(CSRF_COOKIE);
+		const csrfHeader = request.headers.get("x-emdash-csrf");
+		if (!csrfCookie || !csrfHeader || !TOKEN_PATTERN.test(csrfCookie)) {
+			throw new PublisherSessionError("CSRF_INVALID");
+		}
+		const [cookieDigest, headerDigest] = await Promise.all([
+			hashOpaqueBytes(csrfCookie),
+			hashOpaqueBytes(csrfHeader),
+		]);
+		if (!crypto.subtle.timingSafeEqual(cookieDigest, headerDigest)) {
+			throw new PublisherSessionError("CSRF_INVALID");
+		}
+		csrfHash = encodeBase64Url(new Uint8Array(headerDigest));
+	}
+	const result = await namespace
+		.getByName(parsed.did)
+		.validatePublisherSession(parsed.did, await hashOpaque(parsed.token), csrfHash);
+	if (!result.ok) throw new PublisherSessionError(result.code);
+	return result.session;
+}
+
+export function clearPublisherSessionCookies(): readonly [string, string] {
+	return [
+		serializeCookie(SESSION_COOKIE, "", { httpOnly: true, maxAge: 0 }),
+		serializeCookie(CSRF_COOKIE, "", {
+			httpOnly: false,
+			maxAge: 0,
+			sameSite: "Strict",
+		}),
+	];
+}
+
+export function createOAuthRouteCookie(
+	input: Omit<OAuthRouteState, "expiresAt">,
+	now = Date.now(),
+): string {
+	if (
+		!DID_PATTERN.test(input.expectedDid) ||
+		!BASE64URL_PATTERN.test(input.stateId) ||
+		input.stateId.length < 16 ||
+		input.stateId.length > 128 ||
+		!Number.isSafeInteger(now)
+	) {
+		throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	}
+	return serializeCookie(
+		OAUTH_ROUTE_COOKIE,
+		encodeJsonCookie({ v: 1, ...input, expiresAt: now + OAUTH_ROUTE_LIFETIME_MS }),
+		{ httpOnly: true, maxAge: OAUTH_ROUTE_LIFETIME_MS / 1000 },
+	);
+}
+
+export function readOAuthRouteCookie(
+	request: Request,
+	callbackState: string,
+	now = Date.now(),
+): OAuthRouteState {
+	const cookie = parseCookies(request).get(OAUTH_ROUTE_COOKIE);
+	if (!cookie || !BASE64URL_PATTERN.test(callbackState) || !Number.isSafeInteger(now)) {
+		throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	}
+	const parsed = decodeJsonCookie(cookie);
+	if (
+		!parsed ||
+		typeof parsed !== "object" ||
+		Array.isArray(parsed) ||
+		Object.keys(parsed).length !== 6 ||
+		!("v" in parsed) ||
+		parsed.v !== 1 ||
+		!("purpose" in parsed) ||
+		(parsed.purpose !== "publisher_identity" && parsed.purpose !== "release_delegation") ||
+		!("expectedDid" in parsed) ||
+		!isDid(parsed.expectedDid) ||
+		!("redirectTarget" in parsed) ||
+		typeof parsed.redirectTarget !== "string" ||
+		!("stateId" in parsed) ||
+		typeof parsed.stateId !== "string" ||
+		parsed.stateId !== callbackState ||
+		!("expiresAt" in parsed) ||
+		typeof parsed.expiresAt !== "number" ||
+		!Number.isSafeInteger(parsed.expiresAt) ||
+		parsed.expiresAt <= now
+	) {
+		throw new PublisherSessionError("PUBLISHER_SESSION_INVALID");
+	}
+	return {
+		purpose: parsed.purpose,
+		expectedDid: parsed.expectedDid,
+		redirectTarget: parsed.redirectTarget,
+		stateId: parsed.stateId,
+		expiresAt: parsed.expiresAt,
+	};
+}
+
+export function clearOAuthRouteCookie(): string {
+	return serializeCookie(OAUTH_ROUTE_COOKIE, "", { httpOnly: true, maxAge: 0 });
+}

--- a/apps/release-service/test/publisher-do.test.ts
+++ b/apps/release-service/test/publisher-do.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 const DID = "did:plc:publisher";
 const OTHER_DID = "did:plc:other";
 const STATE_HASH = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+const SESSION_TOKEN_HASH = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefg";
+const SESSION_CSRF_HASH = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg";
 const DELEGATION_METADATA = {
 	encryptionKeyVersion: 2,
 	issuer: "https://authorization.example",
@@ -21,6 +23,87 @@ afterEach(async () => {
 });
 
 describe("PublisherDurableObject", () => {
+	it("creates, validates, expires, and revokes hashed publisher sessions", async () => {
+		const stub = publisher();
+		const now = 1_800_000_000_000;
+		await expect(
+			stub.createPublisherSession({
+				publisherDid: DID,
+				tokenHash: SESSION_TOKEN_HASH,
+				csrfHash: SESSION_CSRF_HASH,
+				expiresAt: now + 60_000,
+				now,
+			}),
+		).resolves.toMatchObject({
+			ok: true,
+			session: { publisherDid: DID, expiresAt: now + 60_000, sessionEpoch: 1 },
+		});
+		await expect(
+			stub.createPublisherSession({
+				publisherDid: DID,
+				tokenHash: SESSION_TOKEN_HASH,
+				csrfHash: SESSION_CSRF_HASH,
+				expiresAt: now + 60_000,
+				now,
+			}),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SESSION_EXISTS" });
+		await expect(
+			stub.validatePublisherSession(DID, SESSION_TOKEN_HASH, null, now + 1),
+		).resolves.toMatchObject({ ok: true, session: { publisherDid: DID } });
+		await expect(
+			stub.validatePublisherSession(DID, SESSION_TOKEN_HASH, SESSION_CSRF_HASH, now + 1),
+		).resolves.toMatchObject({ ok: true });
+		await expect(
+			stub.validatePublisherSession(DID, SESSION_TOKEN_HASH, STATE_HASH, now + 1),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SESSION_INVALID" });
+		await expect(
+			stub.validatePublisherSession(DID, SESSION_TOKEN_HASH, null, now + 60_001),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SESSION_EXPIRED" });
+		await expect(
+			stub.validatePublisherSession(DID, SESSION_TOKEN_HASH, null, now + 60_002),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SESSION_INVALID" });
+
+		const secondHash = `${SESSION_TOKEN_HASH.slice(0, -1)}h`;
+		await stub.createPublisherSession({
+			publisherDid: DID,
+			tokenHash: secondHash,
+			csrfHash: SESSION_CSRF_HASH,
+			expiresAt: now + 120_000,
+			now,
+		});
+		await expect(stub.revokePublisherSession(DID, secondHash)).resolves.toBe(true);
+		await expect(stub.revokePublisherSession(DID, secondHash)).resolves.toBe(false);
+	});
+
+	it("invalidates all publisher sessions by epoch and blocks suspended publishers", async () => {
+		const stub = publisher();
+		const now = 1_800_000_000_000;
+		await stub.createPublisherSession({
+			publisherDid: DID,
+			tokenHash: SESSION_TOKEN_HASH,
+			csrfHash: SESSION_CSRF_HASH,
+			expiresAt: now + 60_000,
+			now,
+		});
+		await expect(stub.revokeAllPublisherSessions(DID)).resolves.toBe(2);
+		await expect(
+			stub.validatePublisherSession(DID, SESSION_TOKEN_HASH, null, now + 1),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SESSION_INVALID" });
+
+		await runInDurableObject(stub, (_instance, state) => {
+			state.storage.sql.exec("UPDATE publisher SET status = 'suspended' WHERE id = 1");
+		});
+		await expect(
+			stub.createPublisherSession({
+				publisherDid: DID,
+				tokenHash: SESSION_TOKEN_HASH,
+				csrfHash: SESSION_CSRF_HASH,
+				expiresAt: now + 60_000,
+				now,
+			}),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SUSPENDED" });
+	});
+
 	it("routes and binds one object to one publisher DID", async () => {
 		const stub = publisher();
 		await stub.initializePublisher(DID);

--- a/apps/release-service/test/publisher-session.test.ts
+++ b/apps/release-service/test/publisher-session.test.ts
@@ -1,0 +1,146 @@
+import { reset, runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	PublisherSessionError,
+	clearOAuthRouteCookie,
+	clearPublisherSessionCookies,
+	createOAuthRouteCookie,
+	createPublisherApplicationSession,
+	readOAuthRouteCookie,
+	requirePublisherApplicationSession,
+} from "../src/publisher-session/session.js";
+
+const DID = "did:plc:publisher" as const;
+const ORIGIN = "https://release.example.com";
+
+function cookiePair(setCookie: string): string {
+	return setCookie.split(";", 1)[0] ?? "";
+}
+
+afterEach(async () => {
+	await reset();
+});
+
+describe("publisher application sessions", () => {
+	it("stores only token hashes and validates the HttpOnly session cookie", async () => {
+		const created = await createPublisherApplicationSession(env.PUBLISHER_DO, DID);
+		const [sessionCookie, csrfCookie] = created.setCookieHeaders;
+		expect(sessionCookie).toContain("__Host-emdash_publisher_session=");
+		expect(sessionCookie).toContain("Secure");
+		expect(sessionCookie).toContain("HttpOnly");
+		expect(sessionCookie).toContain("SameSite=Lax");
+		expect(csrfCookie).toContain("__Host-emdash_publisher_csrf=");
+		expect(csrfCookie).not.toContain("HttpOnly");
+
+		const persisted = await runInDurableObject(
+			env.PUBLISHER_DO.getByName(DID),
+			(_instance, state) =>
+				state.storage.sql
+					.exec<{ token_hash: string; csrf_hash: string }>(
+						"SELECT token_hash, csrf_hash FROM publisher_sessions",
+					)
+					.one(),
+		);
+		const rawCookies = created.setCookieHeaders.map(cookiePair).join("; ");
+		expect(rawCookies).not.toContain(persisted.token_hash);
+		expect(rawCookies).not.toContain(persisted.csrf_hash);
+
+		const request = new Request(`${ORIGIN}/v1/publisher`, {
+			headers: { cookie: rawCookies },
+		});
+		await expect(
+			requirePublisherApplicationSession(request, env.PUBLISHER_DO, ORIGIN),
+		).resolves.toMatchObject({ publisherDid: DID, sessionEpoch: 1 });
+	});
+
+	it("requires same-origin double-submit CSRF for state changes", async () => {
+		const created = await createPublisherApplicationSession(env.PUBLISHER_DO, DID);
+		const cookies = created.setCookieHeaders.map(cookiePair).join("; ");
+		const csrf = cookiePair(created.setCookieHeaders[1]).split("=", 2)[1] ?? "";
+		const valid = new Request(`${ORIGIN}/v1/publisher/delegation`, {
+			method: "POST",
+			headers: {
+				cookie: cookies,
+				origin: ORIGIN,
+				"x-emdash-request": "1",
+				"x-emdash-csrf": csrf,
+			},
+		});
+		await expect(
+			requirePublisherApplicationSession(valid, env.PUBLISHER_DO, ORIGIN, {
+				requireCsrf: true,
+			}),
+		).resolves.toMatchObject({ publisherDid: DID });
+
+		for (const headers of [
+			{ origin: "https://evil.example", "x-emdash-request": "1", "x-emdash-csrf": csrf },
+			{ origin: ORIGIN, "x-emdash-request": "1", "x-emdash-csrf": "A".repeat(43) },
+		]) {
+			const request = new Request(`${ORIGIN}/v1/publisher/delegation`, {
+				method: "POST",
+				headers: { cookie: cookies, ...headers },
+			});
+			await expect(
+				requirePublisherApplicationSession(request, env.PUBLISHER_DO, ORIGIN, {
+					requireCsrf: true,
+				}),
+			).rejects.toBeInstanceOf(PublisherSessionError);
+		}
+	});
+
+	it("rejects duplicate or malformed session cookies", async () => {
+		const created = await createPublisherApplicationSession(env.PUBLISHER_DO, DID);
+		const pair = cookiePair(created.setCookieHeaders[0]);
+		for (const cookie of [`${pair}; ${pair}`, "__Host-emdash_publisher_session=not-base64"]) {
+			const request = new Request(`${ORIGIN}/v1/publisher`, { headers: { cookie } });
+			await expect(
+				requirePublisherApplicationSession(request, env.PUBLISHER_DO, ORIGIN),
+			).rejects.toMatchObject({ code: "PUBLISHER_SESSION_INVALID" });
+		}
+	});
+
+	it("emits deletion cookies with the same security attributes", () => {
+		for (const cookie of clearPublisherSessionCookies()) {
+			expect(cookie).toContain("Path=/");
+			expect(cookie).toContain("Max-Age=0");
+			expect(cookie).toContain("Secure");
+		}
+	});
+});
+
+describe("OAuth callback routing cookie", () => {
+	it("round trips an exact state binding and rejects state substitution", () => {
+		const now = 1_800_000_000_000;
+		const setCookie = createOAuthRouteCookie(
+			{
+				purpose: "release_delegation",
+				expectedDid: DID,
+				redirectTarget: "/publisher/delegation",
+				stateId: "abcdefghijklmnopqrstuvwx",
+			},
+			now,
+		);
+		const request = new Request(`${ORIGIN}/oauth/callback`, {
+			headers: { cookie: cookiePair(setCookie) },
+		});
+		expect(readOAuthRouteCookie(request, "abcdefghijklmnopqrstuvwx", now + 1)).toEqual({
+			purpose: "release_delegation",
+			expectedDid: DID,
+			redirectTarget: "/publisher/delegation",
+			stateId: "abcdefghijklmnopqrstuvwx",
+			expiresAt: now + 10 * 60_000,
+		});
+		expect(() => readOAuthRouteCookie(request, "zyxwvutsrqponmlkjihgfedc", now + 1)).toThrow(
+			PublisherSessionError,
+		);
+		expect(() =>
+			readOAuthRouteCookie(request, "abcdefghijklmnopqrstuvwx", now + 10 * 60_000 + 1),
+		).toThrow(PublisherSessionError);
+	});
+
+	it("clears the routing cookie", () => {
+		expect(clearOAuthRouteCookie()).toContain("Max-Age=0");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds short-lived publisher application sessions to each publisher shard. Bearer and CSRF values are persisted only as hashes; cookies use `Secure`, `__Host-`, `HttpOnly` where applicable, SameSite policy, same-origin double-submit CSRF, expiry, session epochs, suspension checks, and bulk revocation.

This is stack layer 7 of 8, based on `feat/drs-oauth-custody-adapter`. Related to RFC #1870 and Discussion #1590.

The eight PRs are one merge unit. This layer is a review boundary, not a supported deployment.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

Admin i18n and a changeset are not applicable; this changes a private Worker app.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Workerd covers hashed persistence, cookie attributes, constant-time CSRF binding, duplicate/malformed cookies, expiry, revocation, session epochs, suspension, and callback-state routing.
- Repository `pnpm typecheck`, `pnpm lint`, and package tests passed on the top stack branch.
